### PR TITLE
Resources library

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -22,6 +22,7 @@ const pageRoutes = [
   { heading: 'Equipment', path: '/profile/equipment' },
   { heading: 'Health Tracking', path: '/profile/injuries' },
   { heading: 'Resources', path: '/profile/resources' },
+  { heading: 'McGill Big 3', path: '/profile/resources/mcgill-big-3' },
   { heading: 'Settings', path: '/settings' },
 ] as const;
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,9 +10,9 @@ import { HabitsPage } from '@/pages/habits';
 import { InjuriesPage } from '@/pages/injuries';
 import { InjuryDetailPage } from '@/pages/injury-detail';
 import { JournalPage } from '@/pages/journal';
-import { ProfileResourcesPage } from '@/pages/profile-resources';
 import { NutritionPage } from '@/pages/nutrition';
 import { ProfilePage } from '@/pages/profile';
+import { ResourcesPage } from '@/pages/resources';
 import { SettingsPage } from '@/pages/settings';
 import { ActiveWorkoutPage } from '@/pages/active-workout';
 import { WorkoutSessionDetailPage } from '@/pages/workout-session-detail';
@@ -39,7 +39,7 @@ function AppRoutes() {
         <Route element={<EquipmentRoutePage />} path="/profile/equipment" />
         <Route element={<InjuriesPage />} path="/profile/injuries" />
         <Route element={<InjuryDetailPage />} path="/profile/injuries/:conditionId" />
-        <Route element={<ProfileResourcesPage />} path="/profile/resources" />
+        <Route element={<ResourcesPage />} path="/profile/resources" />
         <Route element={<SettingsPage />} path="/settings" />
       </Routes>
     </AppLayout>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,7 @@ import { InjuryDetailPage } from '@/pages/injury-detail';
 import { JournalPage } from '@/pages/journal';
 import { NutritionPage } from '@/pages/nutrition';
 import { ProfilePage } from '@/pages/profile';
+import { ResourceDetailPage } from '@/pages/resource-detail';
 import { ResourcesPage } from '@/pages/resources';
 import { SettingsPage } from '@/pages/settings';
 import { ActiveWorkoutPage } from '@/pages/active-workout';
@@ -40,6 +41,7 @@ function AppRoutes() {
         <Route element={<InjuriesPage />} path="/profile/injuries" />
         <Route element={<InjuryDetailPage />} path="/profile/injuries/:conditionId" />
         <Route element={<ResourcesPage />} path="/profile/resources" />
+        <Route element={<ResourceDetailPage />} path="/profile/resources/:resourceId" />
         <Route element={<SettingsPage />} path="/settings" />
       </Routes>
     </AppLayout>

--- a/apps/web/src/features/resources/components/resource-detail.test.tsx
+++ b/apps/web/src/features/resources/components/resource-detail.test.tsx
@@ -9,6 +9,7 @@ import { ResourceDetail } from './resource-detail';
 describe('ResourceDetail', () => {
   it('renders the full resource detail layout for a populated resource', () => {
     const resource = mockResources.find((item) => item.id === 'mcgill-big-3');
+    if (!resource) throw new Error('mcgill-big-3 missing from mockResources');
 
     render(
       <MemoryRouter>
@@ -16,7 +17,7 @@ describe('ResourceDetail', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole('link', { name: '← Back to Resources' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Back to Resources' })).toHaveAttribute(
       'href',
       '/profile/resources',
     );

--- a/apps/web/src/features/resources/components/resource-detail.test.tsx
+++ b/apps/web/src/features/resources/components/resource-detail.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { mockResources } from '..';
+import type { Resource } from '../types';
+import { ResourceDetail } from './resource-detail';
+
+describe('ResourceDetail', () => {
+  it('renders the full resource detail layout for a populated resource', () => {
+    const resource = mockResources.find((item) => item.id === 'mcgill-big-3');
+
+    render(
+      <MemoryRouter>
+        <ResourceDetail resource={resource} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('link', { name: '← Back to Resources' })).toHaveAttribute(
+      'href',
+      '/profile/resources',
+    );
+    expect(screen.getByRole('heading', { name: 'McGill Big 3' })).toBeInTheDocument();
+    expect(screen.getByText('Program')).toBeInTheDocument();
+    expect(screen.getByText('Dr. Stuart McGill')).toBeInTheDocument();
+    expect(screen.getByText('spine health')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Key Principles & Methods' })).toBeInTheDocument();
+    expect(screen.getByText('Modified curl-up')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Exercises from this Resource' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Bird Dog' })).toHaveAttribute(
+      'href',
+      '/workouts?view=exercises&exercise=bird-dog',
+    );
+    expect(screen.getByRole('heading', { name: 'Related Health Protocols' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View condition' })).toHaveAttribute(
+      'href',
+      '/profile/injuries/lower-back-disc-herniation',
+    );
+    expect(screen.getByText('Upload Resource Document')).toBeInTheDocument();
+    expect(screen.getByText('Coming Soon')).toBeInTheDocument();
+    expect(screen.getByText('PDF, EPUB, TXT')).toBeInTheDocument();
+  });
+
+  it('renders empty-state copy for missing linked items', () => {
+    const resource: Resource = {
+      ...mockResources[0],
+      linkedExercises: [],
+      linkedProtocols: [],
+    };
+
+    render(
+      <MemoryRouter>
+        <ResourceDetail resource={resource} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('No linked exercises')).toBeInTheDocument();
+    expect(screen.getByText('No linked protocols')).toBeInTheDocument();
+  });
+
+  it('renders a not-found state when the resource lookup fails', () => {
+    render(
+      <MemoryRouter>
+        <ResourceDetail />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Resource not found' })).toBeInTheDocument();
+    expect(
+      screen.getByText('The requested resource is not available in the current prototype library.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/resources/components/resource-detail.tsx
+++ b/apps/web/src/features/resources/components/resource-detail.tsx
@@ -161,7 +161,7 @@ export function ResourceDetail({ resource }: ResourceDetailProps) {
                               buttonVariants({ size: 'sm', variant: 'ghost' }),
                               'w-fit px-0 text-primary hover:text-primary',
                             )}
-                            to={buildConditionDetailPath(protocol.conditionName)}
+                            to={buildConditionDetailPath(protocol.conditionSlug)}
                           >
                             View condition
                           </Link>

--- a/apps/web/src/features/resources/components/resource-detail.tsx
+++ b/apps/web/src/features/resources/components/resource-detail.tsx
@@ -23,7 +23,7 @@ export function ResourceDetail({ resource }: ResourceDetailProps) {
       <section className="mx-auto flex w-full max-w-4xl flex-col gap-6 pb-10">
         <Button
           asChild
-          className="w-fit px-0 text-muted hover:text-foreground"
+          className="w-fit px-0 text-muted-foreground hover:text-foreground"
           size="sm"
           variant="ghost"
         >
@@ -46,7 +46,7 @@ export function ResourceDetail({ resource }: ResourceDetailProps) {
     <section className="mx-auto flex w-full max-w-5xl flex-col gap-6 pb-10">
       <Button
         asChild
-        className="w-fit px-0 text-muted hover:text-foreground"
+        className="w-fit px-0 text-muted-foreground hover:text-foreground"
         size="sm"
         variant="ghost"
       >
@@ -102,7 +102,7 @@ export function ResourceDetail({ resource }: ResourceDetailProps) {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <ol className="space-y-3 pl-5 text-sm leading-7 text-foreground marker:font-semibold marker:text-primary">
+            <ol className="list-decimal space-y-3 pl-5 text-sm leading-7 text-foreground marker:font-semibold marker:text-primary">
               {resource.principles.map((principle) => (
                 <li key={principle}>{principle}</li>
               ))}

--- a/apps/web/src/features/resources/components/resource-detail.tsx
+++ b/apps/web/src/features/resources/components/resource-detail.tsx
@@ -1,0 +1,207 @@
+import { FileUp } from 'lucide-react';
+import { Link } from 'react-router';
+
+import { Badge } from '@/components/ui/badge';
+import { Button, buttonVariants } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+import {
+  buildConditionDetailPath,
+  resourceTypeBadgeClasses,
+  resourceTypeLabels,
+} from '../lib/resource-ui';
+import type { Resource } from '../types';
+
+type ResourceDetailProps = {
+  resource?: Resource;
+};
+
+export function ResourceDetail({ resource }: ResourceDetailProps) {
+  if (!resource) {
+    return (
+      <section className="mx-auto flex w-full max-w-4xl flex-col gap-6 pb-10">
+        <Button
+          asChild
+          className="w-fit px-0 text-muted hover:text-foreground"
+          size="sm"
+          variant="ghost"
+        >
+          <Link to="/profile/resources">← Back to Resources</Link>
+        </Button>
+
+        <Card>
+          <CardHeader className="space-y-2">
+            <h1 className="text-2xl font-semibold text-foreground">Resource not found</h1>
+            <CardDescription>
+              The requested resource is not available in the current prototype library.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mx-auto flex w-full max-w-5xl flex-col gap-6 pb-10">
+      <Button
+        asChild
+        className="w-fit px-0 text-muted hover:text-foreground"
+        size="sm"
+        variant="ghost"
+      >
+        <Link to="/profile/resources">← Back to Resources</Link>
+      </Button>
+
+      <Card className="overflow-hidden border-border/70 bg-card/90 py-0">
+        <div className="space-y-5 bg-linear-to-br from-secondary via-card to-card px-6 py-6 sm:px-8">
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-3">
+              <Badge
+                className={cn(
+                  'px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em]',
+                  resourceTypeBadgeClasses[resource.type],
+                )}
+                variant="outline"
+              >
+                {resourceTypeLabels[resource.type]}
+              </Badge>
+              <p className="text-sm font-medium text-muted-foreground">{resource.author}</p>
+            </div>
+
+            <div className="space-y-3">
+              <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+                {resource.title}
+              </h1>
+              <p className="max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
+                {resource.description}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            {resource.tags.map((tag) => (
+              <Badge
+                className="border-border/80 bg-background/80 px-2.5 py-1 text-[0.72rem] font-medium text-muted-foreground"
+                key={tag}
+                variant="outline"
+              >
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      </Card>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
+        <Card className="gap-4">
+          <CardHeader className="space-y-2">
+            <h2 className="text-xl font-semibold text-foreground">Key Principles &amp; Methods</h2>
+            <CardDescription>
+              Core ideas captured from this resource for quick review.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ol className="space-y-3 pl-5 text-sm leading-7 text-foreground marker:font-semibold marker:text-primary">
+              {resource.principles.map((principle) => (
+                <li key={principle}>{principle}</li>
+              ))}
+            </ol>
+          </CardContent>
+        </Card>
+
+        <div className="flex flex-col gap-6">
+          <Card className="gap-4">
+            <CardHeader className="space-y-2">
+              <h2 className="text-xl font-semibold text-foreground">
+                Exercises from this Resource
+              </h2>
+            </CardHeader>
+            <CardContent>
+              {resource.linkedExercises.length > 0 ? (
+                <div className="flex flex-wrap gap-3">
+                  {resource.linkedExercises.map((exercise) => (
+                    <Link
+                      className={cn(
+                        buttonVariants({ size: 'sm', variant: 'outline' }),
+                        'rounded-full border-border bg-background/70 text-sm font-medium',
+                      )}
+                      key={exercise.id}
+                      to={`/workouts?view=exercises&exercise=${exercise.id}`}
+                    >
+                      {exercise.name}
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">No linked exercises</p>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="gap-4">
+            <CardHeader className="space-y-2">
+              <h2 className="text-xl font-semibold text-foreground">Related Health Protocols</h2>
+            </CardHeader>
+            <CardContent>
+              {resource.linkedProtocols.length > 0 ? (
+                <div className="space-y-3">
+                  {resource.linkedProtocols.map((protocol) => (
+                    <div
+                      className="flex flex-col gap-2 rounded-2xl border border-border/70 bg-secondary/35 p-4 sm:flex-row sm:items-center sm:justify-between"
+                      key={protocol.id}
+                    >
+                      <div className="space-y-1">
+                        <p className="font-medium text-foreground">{protocol.name}</p>
+                        <p className="text-sm text-muted-foreground">{protocol.conditionName}</p>
+                      </div>
+                      <Link
+                        className={cn(
+                          buttonVariants({ size: 'sm', variant: 'ghost' }),
+                          'w-fit px-0 text-primary hover:text-primary',
+                        )}
+                        to={buildConditionDetailPath(protocol.conditionName)}
+                      >
+                        View condition
+                      </Link>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">No linked protocols</p>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="gap-4">
+            <CardHeader className="space-y-2">
+              <h2 className="text-xl font-semibold text-foreground">Document Upload</h2>
+              <CardDescription>
+                Keep the source material attached to this reference.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div
+                aria-disabled="true"
+                className="relative rounded-2xl border-2 border-dashed border-border/70 bg-secondary/25 p-6 opacity-65 grayscale"
+              >
+                <Badge className="absolute right-3 top-3" variant="secondary">
+                  Coming Soon
+                </Badge>
+                <div className="flex flex-col items-center gap-3 text-center">
+                  <div className="rounded-full border border-border/70 bg-background/80 p-3">
+                    <FileUp aria-hidden="true" className="size-5 text-muted-foreground" />
+                  </div>
+                  <div className="space-y-1">
+                    <p className="font-medium text-foreground">Upload Resource Document</p>
+                    <p className="text-sm text-muted-foreground">PDF, EPUB, TXT</p>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/resources/components/resource-detail.tsx
+++ b/apps/web/src/features/resources/components/resource-detail.tsx
@@ -1,4 +1,4 @@
-import { FileUp } from 'lucide-react';
+import { ArrowLeft, FileUp } from 'lucide-react';
 import { Link } from 'react-router';
 
 import { Badge } from '@/components/ui/badge';
@@ -18,18 +18,26 @@ type ResourceDetailProps = {
 };
 
 export function ResourceDetail({ resource }: ResourceDetailProps) {
-  if (!resource) {
-    return (
-      <section className="mx-auto flex w-full max-w-4xl flex-col gap-6 pb-10">
-        <Button
-          asChild
-          className="w-fit px-0 text-muted-foreground hover:text-foreground"
-          size="sm"
-          variant="ghost"
-        >
-          <Link to="/profile/resources">← Back to Resources</Link>
-        </Button>
+  return (
+    <section
+      className={cn(
+        'mx-auto flex w-full flex-col gap-6 pb-10',
+        resource ? 'max-w-5xl' : 'max-w-4xl',
+      )}
+    >
+      <Button
+        asChild
+        className="w-fit gap-2 px-0 text-muted-foreground hover:text-foreground"
+        size="sm"
+        variant="ghost"
+      >
+        <Link to="/profile/resources">
+          <ArrowLeft aria-hidden="true" className="size-4" />
+          Back to Resources
+        </Link>
+      </Button>
 
+      {!resource ? (
         <Card>
           <CardHeader className="space-y-2">
             <h1 className="text-2xl font-semibold text-foreground">Resource not found</h1>
@@ -38,170 +46,165 @@ export function ResourceDetail({ resource }: ResourceDetailProps) {
             </CardDescription>
           </CardHeader>
         </Card>
-      </section>
-    );
-  }
-
-  return (
-    <section className="mx-auto flex w-full max-w-5xl flex-col gap-6 pb-10">
-      <Button
-        asChild
-        className="w-fit px-0 text-muted-foreground hover:text-foreground"
-        size="sm"
-        variant="ghost"
-      >
-        <Link to="/profile/resources">← Back to Resources</Link>
-      </Button>
-
-      <Card className="overflow-hidden border-border/70 bg-card/90 py-0">
-        <div className="space-y-5 bg-linear-to-br from-secondary via-card to-card px-6 py-6 sm:px-8">
-          <div className="space-y-3">
-            <div className="flex flex-wrap items-center gap-3">
-              <Badge
-                className={cn(
-                  'px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em]',
-                  resourceTypeBadgeClasses[resource.type],
-                )}
-                variant="outline"
-              >
-                {resourceTypeLabels[resource.type]}
-              </Badge>
-              <p className="text-sm font-medium text-muted-foreground">{resource.author}</p>
-            </div>
-
-            <div className="space-y-3">
-              <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
-                {resource.title}
-              </h1>
-              <p className="max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
-                {resource.description}
-              </p>
-            </div>
-          </div>
-
-          <div className="flex flex-wrap gap-2">
-            {resource.tags.map((tag) => (
-              <Badge
-                className="border-border/80 bg-background/80 px-2.5 py-1 text-[0.72rem] font-medium text-muted-foreground"
-                key={tag}
-                variant="outline"
-              >
-                {tag}
-              </Badge>
-            ))}
-          </div>
-        </div>
-      </Card>
-
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
-        <Card className="gap-4">
-          <CardHeader className="space-y-2">
-            <h2 className="text-xl font-semibold text-foreground">Key Principles &amp; Methods</h2>
-            <CardDescription>
-              Core ideas captured from this resource for quick review.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <ol className="list-decimal space-y-3 pl-5 text-sm leading-7 text-foreground marker:font-semibold marker:text-primary">
-              {resource.principles.map((principle) => (
-                <li key={principle}>{principle}</li>
-              ))}
-            </ol>
-          </CardContent>
-        </Card>
-
-        <div className="flex flex-col gap-6">
-          <Card className="gap-4">
-            <CardHeader className="space-y-2">
-              <h2 className="text-xl font-semibold text-foreground">
-                Exercises from this Resource
-              </h2>
-            </CardHeader>
-            <CardContent>
-              {resource.linkedExercises.length > 0 ? (
-                <div className="flex flex-wrap gap-3">
-                  {resource.linkedExercises.map((exercise) => (
-                    <Link
-                      className={cn(
-                        buttonVariants({ size: 'sm', variant: 'outline' }),
-                        'rounded-full border-border bg-background/70 text-sm font-medium',
-                      )}
-                      key={exercise.id}
-                      to={`/workouts?view=exercises&exercise=${exercise.id}`}
-                    >
-                      {exercise.name}
-                    </Link>
-                  ))}
+      ) : (
+        <>
+          <Card className="overflow-hidden border-border/70 bg-card/90 py-0">
+            <div className="space-y-5 bg-linear-to-br from-secondary via-card to-card px-6 py-6 sm:px-8">
+              <div className="space-y-3">
+                <div className="flex flex-wrap items-center gap-3">
+                  <Badge
+                    className={cn(
+                      'px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em]',
+                      resourceTypeBadgeClasses[resource.type],
+                    )}
+                    variant="outline"
+                  >
+                    {resourceTypeLabels[resource.type]}
+                  </Badge>
+                  <p className="text-sm font-medium text-muted-foreground">{resource.author}</p>
                 </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">No linked exercises</p>
-              )}
-            </CardContent>
-          </Card>
 
-          <Card className="gap-4">
-            <CardHeader className="space-y-2">
-              <h2 className="text-xl font-semibold text-foreground">Related Health Protocols</h2>
-            </CardHeader>
-            <CardContent>
-              {resource.linkedProtocols.length > 0 ? (
                 <div className="space-y-3">
-                  {resource.linkedProtocols.map((protocol) => (
-                    <div
-                      className="flex flex-col gap-2 rounded-2xl border border-border/70 bg-secondary/35 p-4 sm:flex-row sm:items-center sm:justify-between"
-                      key={protocol.id}
-                    >
-                      <div className="space-y-1">
-                        <p className="font-medium text-foreground">{protocol.name}</p>
-                        <p className="text-sm text-muted-foreground">{protocol.conditionName}</p>
-                      </div>
-                      <Link
-                        className={cn(
-                          buttonVariants({ size: 'sm', variant: 'ghost' }),
-                          'w-fit px-0 text-primary hover:text-primary',
-                        )}
-                        to={buildConditionDetailPath(protocol.conditionName)}
-                      >
-                        View condition
-                      </Link>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">No linked protocols</p>
-              )}
-            </CardContent>
-          </Card>
-
-          <Card className="gap-4">
-            <CardHeader className="space-y-2">
-              <h2 className="text-xl font-semibold text-foreground">Document Upload</h2>
-              <CardDescription>
-                Keep the source material attached to this reference.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div
-                aria-disabled="true"
-                className="relative rounded-2xl border-2 border-dashed border-border/70 bg-secondary/25 p-6 opacity-65 grayscale"
-              >
-                <Badge className="absolute right-3 top-3" variant="secondary">
-                  Coming Soon
-                </Badge>
-                <div className="flex flex-col items-center gap-3 text-center">
-                  <div className="rounded-full border border-border/70 bg-background/80 p-3">
-                    <FileUp aria-hidden="true" className="size-5 text-muted-foreground" />
-                  </div>
-                  <div className="space-y-1">
-                    <p className="font-medium text-foreground">Upload Resource Document</p>
-                    <p className="text-sm text-muted-foreground">PDF, EPUB, TXT</p>
-                  </div>
+                  <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+                    {resource.title}
+                  </h1>
+                  <p className="max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
+                    {resource.description}
+                  </p>
                 </div>
               </div>
-            </CardContent>
+
+              <div className="flex flex-wrap gap-2">
+                {resource.tags.map((tag) => (
+                  <Badge
+                    className="border-border/80 bg-background/80 px-2.5 py-1 text-[0.72rem] font-medium text-muted-foreground"
+                    key={tag}
+                    variant="outline"
+                  >
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            </div>
           </Card>
-        </div>
-      </div>
+
+          <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
+            <Card className="gap-4">
+              <CardHeader className="space-y-2">
+                <h2 className="text-xl font-semibold text-foreground">
+                  Key Principles &amp; Methods
+                </h2>
+                <CardDescription>
+                  Core ideas captured from this resource for quick review.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ol className="list-decimal space-y-3 pl-5 text-sm leading-7 text-foreground marker:font-semibold marker:text-primary">
+                  {resource.principles.map((principle) => (
+                    <li key={principle}>{principle}</li>
+                  ))}
+                </ol>
+              </CardContent>
+            </Card>
+
+            <div className="flex flex-col gap-6">
+              <Card className="gap-4">
+                <CardHeader className="space-y-2">
+                  <h2 className="text-xl font-semibold text-foreground">
+                    Exercises from this Resource
+                  </h2>
+                </CardHeader>
+                <CardContent>
+                  {resource.linkedExercises.length > 0 ? (
+                    <div className="flex flex-wrap gap-3">
+                      {resource.linkedExercises.map((exercise) => (
+                        <Link
+                          className={cn(
+                            buttonVariants({ size: 'sm', variant: 'outline' }),
+                            'rounded-full border-border bg-background/70 text-sm font-medium',
+                          )}
+                          key={exercise.id}
+                          to={`/workouts?view=exercises&exercise=${exercise.id}`}
+                        >
+                          {exercise.name}
+                        </Link>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">No linked exercises</p>
+                  )}
+                </CardContent>
+              </Card>
+
+              <Card className="gap-4">
+                <CardHeader className="space-y-2">
+                  <h2 className="text-xl font-semibold text-foreground">
+                    Related Health Protocols
+                  </h2>
+                </CardHeader>
+                <CardContent>
+                  {resource.linkedProtocols.length > 0 ? (
+                    <div className="space-y-3">
+                      {resource.linkedProtocols.map((protocol) => (
+                        <div
+                          className="flex flex-col gap-2 rounded-2xl border border-border/70 bg-secondary/35 p-4 sm:flex-row sm:items-center sm:justify-between"
+                          key={protocol.id}
+                        >
+                          <div className="space-y-1">
+                            <p className="font-medium text-foreground">{protocol.name}</p>
+                            <p className="text-sm text-muted-foreground">
+                              {protocol.conditionName}
+                            </p>
+                          </div>
+                          <Link
+                            className={cn(
+                              buttonVariants({ size: 'sm', variant: 'ghost' }),
+                              'w-fit px-0 text-primary hover:text-primary',
+                            )}
+                            to={buildConditionDetailPath(protocol.conditionName)}
+                          >
+                            View condition
+                          </Link>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">No linked protocols</p>
+                  )}
+                </CardContent>
+              </Card>
+
+              <Card className="gap-4">
+                <CardHeader className="space-y-2">
+                  <h2 className="text-xl font-semibold text-foreground">Document Upload</h2>
+                  <CardDescription>
+                    Keep the source material attached to this reference.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div
+                    aria-disabled="true"
+                    className="relative rounded-2xl border-2 border-dashed border-border/70 bg-secondary/25 p-6 opacity-65 grayscale"
+                  >
+                    <Badge className="absolute right-3 top-3" variant="secondary">
+                      Coming Soon
+                    </Badge>
+                    <div className="flex flex-col items-center gap-3 text-center">
+                      <div className="rounded-full border border-border/70 bg-background/80 p-3">
+                        <FileUp aria-hidden="true" className="size-5 text-muted-foreground" />
+                      </div>
+                      <div className="space-y-1">
+                        <p className="font-medium text-foreground">Upload Resource Document</p>
+                        <p className="text-sm text-muted-foreground">PDF, EPUB, TXT</p>
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        </>
+      )}
     </section>
   );
 }

--- a/apps/web/src/features/resources/components/resource-grid.test.tsx
+++ b/apps/web/src/features/resources/components/resource-grid.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useParams } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { mockResources } from '..';
+import { ResourceGrid } from './resource-grid';
+
+describe('ResourceGrid', () => {
+  it('filters resources by type and search query, then navigates to the detail route', () => {
+    render(
+      <MemoryRouter initialEntries={['/profile/resources']}>
+        <Routes>
+          <Route element={<ResourceGrid resources={mockResources} />} path="/profile/resources" />
+          <Route element={<ResourceRouteProbe />} path="/profile/resources/:resourceId" />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Resources' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to Profile' })).toHaveAttribute(
+      'href',
+      '/profile',
+    );
+    expect(screen.getAllByRole('link', { name: /^Open / })).toHaveLength(mockResources.length);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Books' }));
+    expect(screen.getByRole('link', { name: 'Open Starting Strength' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Open McGill Big 3' })).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Search'), {
+      target: { value: 'barbell' },
+    });
+    expect(screen.getByRole('link', { name: 'Open Starting Strength' })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Search'), {
+      target: { value: 'mobility' },
+    });
+    expect(screen.getByText('No resources found')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'All' }));
+    expect(screen.getByRole('link', { name: 'Open Strength Side' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('link', { name: 'Open Strength Side' }));
+    expect(screen.getByRole('heading', { name: 'Resource strength-side' })).toBeInTheDocument();
+  });
+});
+
+function ResourceRouteProbe() {
+  const { resourceId } = useParams();
+
+  return <h1>{`Resource ${resourceId}`}</h1>;
+}

--- a/apps/web/src/features/resources/components/resource-grid.test.tsx
+++ b/apps/web/src/features/resources/components/resource-grid.test.tsx
@@ -23,7 +23,7 @@ describe('ResourceGrid', () => {
     );
     expect(screen.getAllByRole('link', { name: /^Open / })).toHaveLength(mockResources.length);
 
-    fireEvent.click(screen.getByRole('tab', { name: 'Books' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Books' }));
     expect(screen.getByRole('link', { name: 'Open Starting Strength' })).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Open McGill Big 3' })).not.toBeInTheDocument();
 
@@ -37,7 +37,7 @@ describe('ResourceGrid', () => {
     });
     expect(screen.getByText('No resources found')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('tab', { name: 'All' }));
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
     expect(screen.getByRole('link', { name: 'Open Strength Side' })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('link', { name: 'Open Strength Side' }));

--- a/apps/web/src/features/resources/components/resource-grid.tsx
+++ b/apps/web/src/features/resources/components/resource-grid.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { ArrowLeft, Search } from 'lucide-react';
 import { Link } from 'react-router';
 
@@ -24,27 +24,32 @@ const FILTER_OPTIONS: Array<{ label: string; value: ResourceFilter }> = [
   { label: 'Creators', value: 'creator' },
 ];
 
+const MAX_VISIBLE_TAGS = 4;
+
 export function ResourceGrid({ resources }: ResourceGridProps) {
   const [activeFilter, setActiveFilter] = useState<ResourceFilter>('all');
   const [searchQuery, setSearchQuery] = useState('');
 
-  const normalizedQuery = searchQuery.trim().toLowerCase();
-  const filteredResources = resources.filter((resource) => {
-    const matchesType = activeFilter === 'all' || resource.type === activeFilter;
-    const matchesSearch =
-      normalizedQuery.length === 0 ||
-      resource.title.toLowerCase().includes(normalizedQuery) ||
-      resource.tags.some((tag) => tag.toLowerCase().includes(normalizedQuery));
+  const filteredResources = useMemo(() => {
+    const normalizedQuery = searchQuery.trim().toLowerCase();
 
-    return matchesType && matchesSearch;
-  });
+    return resources.filter((resource) => {
+      const matchesType = activeFilter === 'all' || resource.type === activeFilter;
+      const matchesSearch =
+        normalizedQuery.length === 0 ||
+        resource.title.toLowerCase().includes(normalizedQuery) ||
+        resource.tags.some((tag) => tag.toLowerCase().includes(normalizedQuery));
+
+      return matchesType && matchesSearch;
+    });
+  }, [activeFilter, resources, searchQuery]);
 
   return (
     <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 pb-10">
       <header className="space-y-4">
         <Button
           asChild
-          className="w-fit gap-2 px-0 text-muted hover:text-foreground"
+          className="w-fit gap-2 px-0 text-muted-foreground hover:text-foreground"
           size="sm"
           variant="ghost"
         >
@@ -58,7 +63,7 @@ export function ResourceGrid({ resources }: ResourceGridProps) {
           <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
             <div className="space-y-1">
               <h1 className="text-3xl font-semibold text-primary">Resources</h1>
-              <p className="max-w-3xl text-sm text-muted">
+              <p className="max-w-3xl text-sm text-muted-foreground">
                 Browse saved programs, books, and creators with quick tag search and type filters.
               </p>
             </div>
@@ -91,21 +96,16 @@ export function ResourceGrid({ resources }: ResourceGridProps) {
             </div>
           </div>
 
-          <div
-            aria-label="Resource types"
-            className="flex gap-2 overflow-x-auto pb-1"
-            role="tablist"
-          >
+          <div aria-label="Resource types" className="flex gap-2 overflow-x-auto pb-1">
             {FILTER_OPTIONS.map((option) => {
               const isActive = option.value === activeFilter;
 
               return (
                 <Button
-                  aria-selected={isActive}
+                  aria-pressed={isActive}
                   className="rounded-full"
                   key={option.value}
                   onClick={() => setActiveFilter(option.value)}
-                  role="tab"
                   size="sm"
                   type="button"
                   variant={isActive ? 'default' : 'ghost'}
@@ -121,7 +121,7 @@ export function ResourceGrid({ resources }: ResourceGridProps) {
       {filteredResources.length > 0 ? (
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {filteredResources.map((resource) => {
-            const visibleTags = resource.tags.slice(0, 4);
+            const visibleTags = resource.tags.slice(0, MAX_VISIBLE_TAGS);
             const hiddenTagCount = resource.tags.length - visibleTags.length;
 
             return (
@@ -152,7 +152,7 @@ export function ResourceGrid({ resources }: ResourceGridProps) {
                   </CardHeader>
 
                   <CardContent className="space-y-4 pb-5">
-                    <p className="overflow-hidden text-sm leading-6 text-muted-foreground [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2]">
+                    <p className="line-clamp-2 text-sm leading-6 text-muted-foreground">
                       {resource.description}
                     </p>
 

--- a/apps/web/src/features/resources/components/resource-grid.tsx
+++ b/apps/web/src/features/resources/components/resource-grid.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 
+import { resourceTypeBadgeClasses, resourceTypeLabels } from '../lib/resource-ui';
 import type { Resource, ResourceType } from '../types';
 
 type ResourceGridProps = {
@@ -22,20 +23,6 @@ const FILTER_OPTIONS: Array<{ label: string; value: ResourceFilter }> = [
   { label: 'Books', value: 'book' },
   { label: 'Creators', value: 'creator' },
 ];
-
-const typeBadgeClasses: Record<ResourceType, string> = {
-  program:
-    'border-transparent bg-violet-200 text-violet-950 dark:bg-violet-500/20 dark:text-violet-300',
-  book: 'border-transparent bg-sky-200 text-sky-950 dark:bg-sky-500/20 dark:text-sky-300',
-  creator:
-    'border-transparent bg-emerald-200 text-emerald-950 dark:bg-emerald-500/20 dark:text-emerald-300',
-};
-
-const typeLabels: Record<ResourceType, string> = {
-  program: 'Program',
-  book: 'Book',
-  creator: 'Creator',
-};
 
 export function ResourceGrid({ resources }: ResourceGridProps) {
   const [activeFilter, setActiveFilter] = useState<ResourceFilter>('all');
@@ -150,11 +137,11 @@ export function ResourceGrid({ resources }: ResourceGridProps) {
                       <Badge
                         className={cn(
                           'cursor-pointer px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em]',
-                          typeBadgeClasses[resource.type],
+                          resourceTypeBadgeClasses[resource.type],
                         )}
                         variant="outline"
                       >
-                        {typeLabels[resource.type]}
+                        {resourceTypeLabels[resource.type]}
                       </Badge>
                     </div>
 

--- a/apps/web/src/features/resources/components/resource-grid.tsx
+++ b/apps/web/src/features/resources/components/resource-grid.tsx
@@ -1,0 +1,209 @@
+import { useState } from 'react';
+import { ArrowLeft, Search } from 'lucide-react';
+import { Link } from 'react-router';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+import type { Resource, ResourceType } from '../types';
+
+type ResourceGridProps = {
+  resources: Resource[];
+};
+
+type ResourceFilter = 'all' | ResourceType;
+
+const FILTER_OPTIONS: Array<{ label: string; value: ResourceFilter }> = [
+  { label: 'All', value: 'all' },
+  { label: 'Programs', value: 'program' },
+  { label: 'Books', value: 'book' },
+  { label: 'Creators', value: 'creator' },
+];
+
+const typeBadgeClasses: Record<ResourceType, string> = {
+  program:
+    'border-transparent bg-violet-200 text-violet-950 dark:bg-violet-500/20 dark:text-violet-300',
+  book: 'border-transparent bg-sky-200 text-sky-950 dark:bg-sky-500/20 dark:text-sky-300',
+  creator:
+    'border-transparent bg-emerald-200 text-emerald-950 dark:bg-emerald-500/20 dark:text-emerald-300',
+};
+
+const typeLabels: Record<ResourceType, string> = {
+  program: 'Program',
+  book: 'Book',
+  creator: 'Creator',
+};
+
+export function ResourceGrid({ resources }: ResourceGridProps) {
+  const [activeFilter, setActiveFilter] = useState<ResourceFilter>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const filteredResources = resources.filter((resource) => {
+    const matchesType = activeFilter === 'all' || resource.type === activeFilter;
+    const matchesSearch =
+      normalizedQuery.length === 0 ||
+      resource.title.toLowerCase().includes(normalizedQuery) ||
+      resource.tags.some((tag) => tag.toLowerCase().includes(normalizedQuery));
+
+    return matchesType && matchesSearch;
+  });
+
+  return (
+    <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 pb-10">
+      <header className="space-y-4">
+        <Button
+          asChild
+          className="w-fit gap-2 px-0 text-muted hover:text-foreground"
+          size="sm"
+          variant="ghost"
+        >
+          <Link to="/profile">
+            <ArrowLeft aria-hidden="true" className="size-4" />
+            Back to Profile
+          </Link>
+        </Button>
+
+        <div className="space-y-2">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div className="space-y-1">
+              <h1 className="text-3xl font-semibold text-primary">Resources</h1>
+              <p className="max-w-3xl text-sm text-muted">
+                Browse saved programs, books, and creators with quick tag search and type filters.
+              </p>
+            </div>
+            <p className="text-sm font-medium text-muted-foreground">
+              {`${filteredResources.length} resource${filteredResources.length === 1 ? '' : 's'}`}
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <Card className="gap-4 border-border/70 bg-card/80 py-4">
+        <CardContent className="space-y-4 px-4 sm:px-6">
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-foreground" htmlFor="resource-search">
+              Search
+            </label>
+            <div className="relative">
+              <Search
+                aria-hidden="true"
+                className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+              />
+              <Input
+                className="border-border bg-background/70 pl-9"
+                id="resource-search"
+                onChange={(event) => setSearchQuery(event.target.value)}
+                placeholder="Search titles or tags"
+                type="search"
+                value={searchQuery}
+              />
+            </div>
+          </div>
+
+          <div
+            aria-label="Resource types"
+            className="flex gap-2 overflow-x-auto pb-1"
+            role="tablist"
+          >
+            {FILTER_OPTIONS.map((option) => {
+              const isActive = option.value === activeFilter;
+
+              return (
+                <Button
+                  aria-selected={isActive}
+                  className="rounded-full"
+                  key={option.value}
+                  onClick={() => setActiveFilter(option.value)}
+                  role="tab"
+                  size="sm"
+                  type="button"
+                  variant={isActive ? 'default' : 'ghost'}
+                >
+                  {option.label}
+                </Button>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+
+      {filteredResources.length > 0 ? (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {filteredResources.map((resource) => {
+            const visibleTags = resource.tags.slice(0, 4);
+            const hiddenTagCount = resource.tags.length - visibleTags.length;
+
+            return (
+              <Link
+                aria-label={`Open ${resource.title}`}
+                className="block cursor-pointer rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                key={resource.id}
+                to={`/profile/resources/${resource.id}`}
+              >
+                <Card className="h-full gap-4 py-0 transition-transform duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md">
+                  <CardHeader className="gap-3 py-5">
+                    <div className="flex items-center justify-between gap-3">
+                      <Badge
+                        className={cn(
+                          'cursor-pointer px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em]',
+                          typeBadgeClasses[resource.type],
+                        )}
+                        variant="outline"
+                      >
+                        {typeLabels[resource.type]}
+                      </Badge>
+                    </div>
+
+                    <div className="space-y-1">
+                      <CardTitle className="text-xl text-foreground">{resource.title}</CardTitle>
+                      <CardDescription>{resource.author}</CardDescription>
+                    </div>
+                  </CardHeader>
+
+                  <CardContent className="space-y-4 pb-5">
+                    <p className="overflow-hidden text-sm leading-6 text-muted-foreground [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2]">
+                      {resource.description}
+                    </p>
+
+                    <div className="flex flex-wrap gap-2">
+                      {visibleTags.map((tag) => (
+                        <Badge
+                          className="cursor-pointer border-border/80 bg-secondary/65 px-2.5 py-1 text-[0.68rem] font-medium text-muted-foreground"
+                          key={tag}
+                          variant="outline"
+                        >
+                          {tag}
+                        </Badge>
+                      ))}
+                      {hiddenTagCount > 0 ? (
+                        <Badge
+                          className="cursor-pointer border-dashed border-border/80 bg-background/70 px-2.5 py-1 text-[0.68rem] font-medium text-muted-foreground"
+                          variant="outline"
+                        >
+                          {`+${hiddenTagCount}`}
+                        </Badge>
+                      ) : null}
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            );
+          })}
+        </div>
+      ) : (
+        <Card className="border-dashed border-border/80 bg-card/60">
+          <CardHeader className="gap-2">
+            <CardTitle>No resources found</CardTitle>
+            <CardDescription>
+              Adjust the search term or switch the type filter to see more results.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/features/resources/index.ts
+++ b/apps/web/src/features/resources/index.ts
@@ -1,4 +1,5 @@
 export { ResourceDetail } from './components/resource-detail';
 export { ResourceGrid } from './components/resource-grid';
+// TODO: remove when replaced by TanStack Query hooks
 export { mockResources } from './lib/mock-data';
 export type { LinkedExercise, LinkedProtocol, Resource, ResourceType } from './types';

--- a/apps/web/src/features/resources/index.ts
+++ b/apps/web/src/features/resources/index.ts
@@ -1,0 +1,2 @@
+export { mockResources } from './lib/mock-data';
+export type { LinkedExercise, LinkedProtocol, Resource, ResourceType } from './types';

--- a/apps/web/src/features/resources/index.ts
+++ b/apps/web/src/features/resources/index.ts
@@ -1,2 +1,3 @@
+export { ResourceGrid } from './components/resource-grid';
 export { mockResources } from './lib/mock-data';
 export type { LinkedExercise, LinkedProtocol, Resource, ResourceType } from './types';

--- a/apps/web/src/features/resources/index.ts
+++ b/apps/web/src/features/resources/index.ts
@@ -1,3 +1,4 @@
+export { ResourceDetail } from './components/resource-detail';
 export { ResourceGrid } from './components/resource-grid';
 export { mockResources } from './lib/mock-data';
 export type { LinkedExercise, LinkedProtocol, Resource, ResourceType } from './types';

--- a/apps/web/src/features/resources/lib/mock-data.ts
+++ b/apps/web/src/features/resources/lib/mock-data.ts
@@ -1,0 +1,110 @@
+import type { Resource } from '../types';
+
+export const mockResources: Resource[] = [
+  {
+    id: 'atg-knees-over-toes-guy',
+    title: 'ATG (Knees Over Toes Guy)',
+    type: 'creator',
+    author: 'Ben Patrick',
+    description:
+      'Joint-focused training methodology centered on rebuilding knees, ankles, and hips with progressive full-range loading.',
+    tags: ['joint health', 'knee rehab', 'longevity'],
+    principles: [
+      'Tibialis raises for knee protection',
+      'Full ROM strength through stretching',
+      'Backward walking for knee health',
+    ],
+    linkedExercises: [
+      { id: 'tibialis-raises', name: 'Tibialis Raises' },
+      { id: 'spanish-squats', name: 'Spanish Squats' },
+      { id: 'split-squats', name: 'Split Squats' },
+      { id: 'calf-raises', name: 'Calf Raises' },
+    ],
+    linkedProtocols: [],
+  },
+  {
+    id: 'strength-side',
+    title: 'Strength Side',
+    type: 'creator',
+    author: 'Josh Hash',
+    description:
+      'Movement practice blending calisthenics, mobility, and playful strength progressions to improve control through larger ranges.',
+    tags: ['movement quality', 'calisthenics', 'mobility'],
+    principles: ['Ground movement flows', 'L-sit progression', 'Pancake flexibility'],
+    linkedExercises: [
+      { id: 'l-sit', name: 'L-Sit' },
+      { id: 'pancake-stretch', name: 'Pancake Stretch' },
+      { id: 'ground-movement-flow', name: 'Ground Movement Flow' },
+    ],
+    linkedProtocols: [],
+  },
+  {
+    id: 'starting-strength',
+    title: 'Starting Strength',
+    type: 'book',
+    author: 'Mark Rippetoe',
+    description:
+      'Foundational barbell training text focused on teaching efficient mechanics and simple novice progression.',
+    tags: ['barbell', 'strength', 'compound lifts'],
+    principles: ['Linear progression', 'Compound barbell movements', 'Progressive overload'],
+    linkedExercises: [
+      { id: 'high-bar-back-squat', name: 'High-Bar Back Squat' },
+      { id: 'barbell-bench-press', name: 'Barbell Bench Press' },
+      { id: 'romanian-deadlift', name: 'Romanian Deadlift' },
+    ],
+    linkedProtocols: [],
+  },
+  {
+    id: 'mcgill-big-3',
+    title: 'McGill Big 3',
+    type: 'program',
+    author: 'Dr. Stuart McGill',
+    description:
+      'Spine-sparing core stability sequence used to improve trunk stiffness and reduce symptom flare-ups during rehab.',
+    tags: ['spine health', 'core', 'rehabilitation'],
+    principles: ['Modified curl-up', 'Side plank', 'Bird dog'],
+    linkedExercises: [
+      { id: 'modified-curl-up', name: 'Modified Curl-Up' },
+      { id: 'side-plank', name: 'Side Plank' },
+      { id: 'bird-dog', name: 'Bird Dog' },
+    ],
+    linkedProtocols: [
+      {
+        id: 'lower-back-disc-herniation-mcgill-big-3',
+        name: 'McGill Big 3',
+        conditionName: 'Lower Back Disc Herniation',
+      },
+    ],
+  },
+  {
+    id: 'reverse-pyramid-training',
+    title: 'Reverse Pyramid Training',
+    type: 'program',
+    author: 'Martin Berkhan',
+    description:
+      'A high-intensity lifting structure that prioritizes the heaviest set first, then reduces load as fatigue builds.',
+    tags: ['hypertrophy', 'efficiency', 'strength'],
+    principles: ['Start heavy, drop weight each set', 'Low volume, high intensity'],
+    linkedExercises: [
+      { id: 'incline-dumbbell-press', name: 'Incline Dumbbell Press' },
+      { id: 'lat-pulldown', name: 'Lat Pulldown' },
+      { id: 'leg-press', name: 'Leg Press' },
+    ],
+    linkedProtocols: [],
+  },
+  {
+    id: 'yoga-with-adriene',
+    title: 'Yoga with Adriene',
+    type: 'creator',
+    author: 'Adriene Mishler',
+    description:
+      'Accessible yoga instruction emphasizing consistency, breathing, and low-pressure mobility work for recovery days.',
+    tags: ['yoga', 'flexibility', 'mindfulness'],
+    principles: ['Find what feels good', 'Breath-led movement'],
+    linkedExercises: [
+      { id: 'couch-stretch', name: 'Couch Stretch' },
+      { id: 'worlds-greatest-stretch', name: "World's Greatest Stretch" },
+    ],
+    linkedProtocols: [],
+  },
+];

--- a/apps/web/src/features/resources/lib/mock-data.ts
+++ b/apps/web/src/features/resources/lib/mock-data.ts
@@ -73,6 +73,7 @@ export const mockResources: Resource[] = [
         id: 'lower-back-disc-herniation-mcgill-big-3',
         name: 'McGill Big 3',
         conditionName: 'Lower Back Disc Herniation',
+        conditionSlug: 'lower-back-disc-herniation',
       },
     ],
   },

--- a/apps/web/src/features/resources/lib/resource-ui.ts
+++ b/apps/web/src/features/resources/lib/resource-ui.ts
@@ -14,13 +14,6 @@ export const resourceTypeLabels: Record<ResourceType, string> = {
   creator: 'Creator',
 };
 
-// TODO: Replace this derived slug with a stored route id/slug when injury detail routes are backed by real data.
-export function buildConditionDetailPath(conditionName: string) {
-  const slug = conditionName
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-
-  return `/profile/injuries/${slug}`;
+export function buildConditionDetailPath(conditionSlug: string) {
+  return `/profile/injuries/${conditionSlug}`;
 }

--- a/apps/web/src/features/resources/lib/resource-ui.ts
+++ b/apps/web/src/features/resources/lib/resource-ui.ts
@@ -14,6 +14,7 @@ export const resourceTypeLabels: Record<ResourceType, string> = {
   creator: 'Creator',
 };
 
+// TODO: Replace this derived slug with a stored route id/slug when injury detail routes are backed by real data.
 export function buildConditionDetailPath(conditionName: string) {
   const slug = conditionName
     .trim()

--- a/apps/web/src/features/resources/lib/resource-ui.ts
+++ b/apps/web/src/features/resources/lib/resource-ui.ts
@@ -1,0 +1,25 @@
+import type { ResourceType } from '../types';
+
+export const resourceTypeBadgeClasses: Record<ResourceType, string> = {
+  program:
+    'border-transparent bg-violet-200 text-violet-950 dark:bg-violet-500/20 dark:text-violet-300',
+  book: 'border-transparent bg-sky-200 text-sky-950 dark:bg-sky-500/20 dark:text-sky-300',
+  creator:
+    'border-transparent bg-emerald-200 text-emerald-950 dark:bg-emerald-500/20 dark:text-emerald-300',
+};
+
+export const resourceTypeLabels: Record<ResourceType, string> = {
+  program: 'Program',
+  book: 'Book',
+  creator: 'Creator',
+};
+
+export function buildConditionDetailPath(conditionName: string) {
+  const slug = conditionName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return `/profile/injuries/${slug}`;
+}

--- a/apps/web/src/features/resources/types.ts
+++ b/apps/web/src/features/resources/types.ts
@@ -1,0 +1,24 @@
+export type ResourceType = 'program' | 'book' | 'creator';
+
+export type LinkedExercise = {
+  id: string;
+  name: string;
+};
+
+export type LinkedProtocol = {
+  id: string;
+  name: string;
+  conditionName: string;
+};
+
+export type Resource = {
+  id: string;
+  title: string;
+  type: ResourceType;
+  author: string;
+  description: string;
+  tags: string[];
+  principles: string[];
+  linkedExercises: LinkedExercise[];
+  linkedProtocols: LinkedProtocol[];
+};

--- a/apps/web/src/features/resources/types.ts
+++ b/apps/web/src/features/resources/types.ts
@@ -9,6 +9,7 @@ export type LinkedProtocol = {
   id: string;
   name: string;
   conditionName: string;
+  conditionSlug: string;
 };
 
 export type Resource = {

--- a/apps/web/src/pages/resource-detail.tsx
+++ b/apps/web/src/pages/resource-detail.tsx
@@ -1,0 +1,10 @@
+import { useParams } from 'react-router';
+
+import { mockResources, ResourceDetail } from '@/features/resources';
+
+export function ResourceDetailPage() {
+  const { resourceId = '' } = useParams();
+  const resource = mockResources.find((item) => item.id === resourceId);
+
+  return <ResourceDetail resource={resource} />;
+}

--- a/apps/web/src/pages/resources.tsx
+++ b/apps/web/src/pages/resources.tsx
@@ -1,0 +1,5 @@
+import { ResourceGrid, mockResources } from '@/features/resources';
+
+export function ResourcesPage() {
+  return <ResourceGrid resources={mockResources} />;
+}


### PR DESCRIPTION
## Summary
This PR adds the Phase 1b resources library prototype to the web app so reviewers can navigate a concrete reference experience before backend APIs exist. It introduces a profile-scoped resources index with mock programs, books, and creators, plus a detail page that surfaces principles, linked exercises, and related health protocols. The goal is to make the resources feature feel connected to the rest of the prototype, especially workouts and injury tracking, while keeping the implementation intentionally mock-data driven. It also adds focused UI tests for filtering, routing, empty states, and not-found handling.

## Key Changes
- Added new routes for `/profile/resources` and `/profile/resources/:resourceId`
- Created a resources feature module with typed resource models and shared UI helpers
- Added mock resource data for programs, books, and creators, including tags, principles, linked exercises, and linked protocols
- Built a resource grid view with:
  - type filter tabs for programs, books, and creators
  - search across resource titles and tags
  - card-based navigation into resource detail pages
- Built a resource detail view with:
  - back navigation to the resources index
  - resource type badge, author, description, and tags
  - principles list
  - linked exercise deep links into workouts
  - related protocol links into injury detail routes
  - disabled document upload placeholder for a future phase
- Extended route-level app tests and added dedicated tests for the grid and detail components

## Technical Notes
- All content is prototype-only mock data; there is no API integration or persistence in this PR.
- The feature is isolated under `apps/web/src/features/resources/` to match the existing feature-based frontend structure.
- `buildConditionDetailPath` generates injury detail links from protocol condition names, so reviewers should pay attention to that slugging assumption if route naming changes later.
- The detail page explicitly handles three states: populated resource, empty linked sections, and missing resource ID.
- The upload area is intentionally present but disabled to establish the future interaction without implying that file handling exists yet.

## Commits

- `9a18b76 feat(web): add resource detail page`
- `7856a6e feat(web): add resources library grid`
- `ae4b773 feat(web): add resources mock data`

## Tasks

- **Resources mock data: programs, books, creators with principles and linked exercises**: Create mock data for ATG, Strength Side, Starting Strength, etc. with principles, tags, and linked exercises
- **Resource grid with type filter and search**: Card grid of resources with type badges (Program/Book/Creator), tag display, type filter tabs, search by name/tag
- **Resource detail page with principles, linked exercises, upload placeholder**: Detail page showing overview, key principles list, linked exercises/protocols, and disabled document upload area

## Diff Stats

```
apps/web/src/App.test.tsx                          |   3 +
 apps/web/src/App.tsx                               |   5 +
 .../resources/components/resource-detail.test.tsx  |  75 ++++++++
 .../resources/components/resource-detail.tsx       | 207 +++++++++++++++++++++
 .../resources/components/resource-grid.test.tsx    |  52 ++++++
 .../resources/components/resource-grid.tsx         | 196 +++++++++++++++++++
 apps/web/src/features/resources/index.ts           |   4 +
 apps/web/src/features/resources/lib/mock-data.ts   | 110 +++++++++++
 apps/web/src/features/resources/lib/resource-ui.ts |  25 +++
 apps/web/src/features/resources/types.ts           |  24 +++
 apps/web/src/pages/resource-detail.tsx             |  10 +
 apps/web/src/pages/resources.tsx                   |   5 +
 12 files changed, 716 insertions(+)
```