### PR TITLE
Journal feed + entity linking

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@ import { DashboardPage } from '@/pages/dashboard';
 import { DesignSystemPage } from '@/pages/design-system';
 import { EquipmentRoutePage } from '@/pages/equipment';
 import { FoodsPage } from '@/pages/foods';
+import { JournalEntryPage } from '@/pages/journal-entry';
 import { HabitsPage } from '@/pages/habits';
 import { JournalPage } from '@/pages/journal';
 import { ProfileInjuriesPage } from '@/pages/profile-injuries';
@@ -32,6 +33,7 @@ function AppRoutes() {
         <Route element={<ActivityPage />} path="/activity" />
         <Route element={<FoodsPage />} path="/foods" />
         <Route element={<JournalPage />} path="/journal" />
+        <Route element={<JournalEntryPage />} path="/journal/:entryId" />
         <Route element={<ProfilePage />} path="/profile" />
         <Route element={<EquipmentRoutePage />} path="/profile/equipment" />
         <Route element={<ProfileInjuriesPage />} path="/profile/injuries" />

--- a/apps/web/src/features/journal/components/entity-chip.tsx
+++ b/apps/web/src/features/journal/components/entity-chip.tsx
@@ -13,10 +13,10 @@ const iconByType: Record<LinkedEntityType, typeof Dumbbell> = {
   workout: Dumbbell,
 };
 
-const hrefByType: Partial<Record<LinkedEntityType, string>> = {
-  activity: '/activity',
-  habit: '/habits',
-  workout: '/workouts',
+const hrefByType: Partial<Record<LinkedEntityType, (entity: LinkedEntity) => string>> = {
+  activity: () => '/activity',
+  habit: () => '/habits',
+  workout: (entity) => `/workouts/template/${entity.id}`,
 };
 
 type EntityChipProps = {
@@ -25,7 +25,7 @@ type EntityChipProps = {
 
 export function EntityChip({ entity }: EntityChipProps) {
   const Icon = iconByType[entity.type];
-  const href = hrefByType[entity.type];
+  const href = hrefByType[entity.type]?.(entity);
   const content = (
     <>
       <Icon aria-hidden="true" className="size-3.5" />
@@ -50,7 +50,7 @@ export function EntityChip({ entity }: EntityChipProps) {
   return (
     <Badge
       className={cn(
-        'cursor-pointer rounded-full border-border/70 bg-background/75 px-3 py-1 text-xs font-medium text-muted shadow-sm',
+        'rounded-full border-border/70 bg-background/75 px-3 py-1 text-xs font-medium text-muted shadow-sm',
       )}
       variant="outline"
     >

--- a/apps/web/src/features/journal/components/entity-chip.tsx
+++ b/apps/web/src/features/journal/components/entity-chip.tsx
@@ -16,6 +16,8 @@ const iconByType: Record<LinkedEntityType, typeof Dumbbell> = {
 const hrefByType: Partial<Record<LinkedEntityType, (entity: LinkedEntity) => string>> = {
   activity: () => '/activity',
   habit: () => '/habits',
+  // Links to the workout template route. When API data lands, confirm whether
+  // journal-linked workout IDs refer to sessions or templates and update if needed.
   workout: (entity) => `/workouts/template/${entity.id}`,
 };
 

--- a/apps/web/src/features/journal/components/entity-chip.tsx
+++ b/apps/web/src/features/journal/components/entity-chip.tsx
@@ -1,0 +1,60 @@
+import { Activity, Dumbbell, Heart, ListChecks } from 'lucide-react';
+import { Link } from 'react-router';
+
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+import type { LinkedEntity, LinkedEntityType } from '../types';
+
+const iconByType: Record<LinkedEntityType, typeof Dumbbell> = {
+  activity: Activity,
+  habit: ListChecks,
+  injury: Heart,
+  workout: Dumbbell,
+};
+
+const hrefByType: Partial<Record<LinkedEntityType, string>> = {
+  activity: '/activity',
+  habit: '/habits',
+  workout: '/workouts',
+};
+
+type EntityChipProps = {
+  entity: LinkedEntity;
+};
+
+export function EntityChip({ entity }: EntityChipProps) {
+  const Icon = iconByType[entity.type];
+  const href = hrefByType[entity.type];
+  const content = (
+    <>
+      <Icon aria-hidden="true" className="size-3.5" />
+      <span>{entity.name}</span>
+    </>
+  );
+
+  if (href) {
+    return (
+      <Badge
+        asChild
+        className={cn(
+          'cursor-pointer rounded-full border-border/70 bg-background/75 px-3 py-1 text-xs font-medium text-muted shadow-sm transition-colors hover:border-primary/40 hover:bg-card hover:text-foreground',
+        )}
+        variant="outline"
+      >
+        <Link to={href}>{content}</Link>
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge
+      className={cn(
+        'cursor-pointer rounded-full border-border/70 bg-background/75 px-3 py-1 text-xs font-medium text-muted shadow-sm',
+      )}
+      variant="outline"
+    >
+      {content}
+    </Badge>
+  );
+}

--- a/apps/web/src/features/journal/components/journal-entry-detail.tsx
+++ b/apps/web/src/features/journal/components/journal-entry-detail.tsx
@@ -1,0 +1,100 @@
+import { ArrowLeft, Sparkles } from 'lucide-react';
+import { Link } from 'react-router';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+import { formatEntryType, formatJournalEntryDate } from '../lib/formatters';
+import { renderJournalMarkdown } from '../lib/markdown';
+import { journalBadgeClassesByType } from '../lib/presentation';
+import type { JournalEntry } from '../types';
+import { EntityChip } from './entity-chip';
+
+type JournalEntryDetailProps = {
+  entry: JournalEntry;
+};
+
+export function JournalEntryDetail({ entry }: JournalEntryDetailProps) {
+  return (
+    <section className="space-y-6">
+      <Button asChild className="gap-2" size="sm" variant="ghost">
+        <Link to="/journal">
+          <ArrowLeft aria-hidden="true" className="size-4" />
+          Back to Journal
+        </Link>
+      </Button>
+
+      <Card className="gap-4 overflow-hidden border-transparent bg-card/80 py-0">
+        <div className="space-y-4 bg-[var(--color-accent-cream)] px-6 py-6 text-on-cream dark:border-b dark:border-border dark:bg-card dark:text-foreground">
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge
+                className={cn(
+                  'cursor-default px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.16em]',
+                  journalBadgeClassesByType[entry.type],
+                )}
+                variant="secondary"
+              >
+                {formatEntryType(entry.type)}
+              </Badge>
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] opacity-70 dark:text-muted dark:opacity-100">
+                {formatJournalEntryDate(entry.date)}
+              </p>
+              <Badge
+                className="border-white/45 bg-white/55 dark:border-border dark:bg-secondary"
+                variant="outline"
+              >
+                Created by {entry.createdBy}
+              </Badge>
+            </div>
+
+            <div className="space-y-2">
+              <h1 className="text-3xl font-semibold tracking-tight text-foreground dark:text-foreground">
+                {entry.title}
+              </h1>
+              <p className="max-w-3xl text-sm opacity-80 sm:text-base dark:text-muted dark:opacity-100">
+                Full journal entry with linked training context and supporting notes.
+              </p>
+            </div>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <CardHeader className="gap-2">
+          <CardTitle>Entry Content</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div
+            className={cn(
+              'max-w-3xl space-y-4 text-sm leading-7 text-foreground',
+              '[&_br]:block [&_br]:content-[""] [&_h2]:mt-1 [&_h2]:text-2xl [&_h2]:font-semibold [&_h2]:tracking-tight',
+              '[&_h3]:mt-5 [&_h3]:text-lg [&_h3]:font-semibold',
+              '[&_p]:text-muted [&_strong]:font-semibold [&_strong]:text-foreground',
+              '[&_ul]:space-y-2 [&_ul]:pl-5 [&_li]:list-disc [&_li]:text-muted',
+            )}
+            dangerouslySetInnerHTML={{ __html: renderJournalMarkdown(entry.content) }}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="gap-2">
+          <CardTitle className="flex items-center gap-2">
+            <Sparkles aria-hidden="true" className="size-5 text-primary" />
+            Linked To
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap gap-2">
+            {entry.linkedEntities.map((entity) => (
+              <EntityChip entity={entity} key={`${entry.id}-${entity.type}-${entity.id}`} />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/apps/web/src/features/journal/components/journal-entry-detail.tsx
+++ b/apps/web/src/features/journal/components/journal-entry-detail.tsx
@@ -99,7 +99,7 @@ export function JournalEntryDetail({ entry }: JournalEntryDetailProps) {
           <CardContent>
             <div className="flex flex-wrap gap-2">
               {entry.linkedEntities.map((entity) => (
-                <EntityChip entity={entity} key={`${entry.id}-${entity.type}-${entity.id}`} />
+                <EntityChip entity={entity} key={`${entity.type}-${entity.id}`} />
               ))}
             </div>
           </CardContent>

--- a/apps/web/src/features/journal/components/journal-entry-detail.tsx
+++ b/apps/web/src/features/journal/components/journal-entry-detail.tsx
@@ -6,7 +6,11 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 
-import { formatEntryType, formatJournalEntryDate } from '../lib/formatters';
+import {
+  formatEntryType,
+  formatJournalEntryDate,
+  getJournalEntrySubtitle,
+} from '../lib/formatters';
 import { renderJournalMarkdown } from '../lib/markdown';
 import { journalBadgeClassesByType } from '../lib/presentation';
 import type { JournalEntry } from '../types';
@@ -17,6 +21,8 @@ type JournalEntryDetailProps = {
 };
 
 export function JournalEntryDetail({ entry }: JournalEntryDetailProps) {
+  const hasLinkedEntities = entry.linkedEntities.length > 0;
+
   return (
     <section className="space-y-6">
       <Button asChild className="gap-2" size="sm" variant="ghost">
@@ -55,7 +61,7 @@ export function JournalEntryDetail({ entry }: JournalEntryDetailProps) {
                 {entry.title}
               </h1>
               <p className="max-w-3xl text-sm opacity-80 sm:text-base dark:text-muted dark:opacity-100">
-                Full journal entry with linked training context and supporting notes.
+                {getJournalEntrySubtitle(entry.type)}
               </p>
             </div>
           </div>
@@ -71,6 +77,8 @@ export function JournalEntryDetail({ entry }: JournalEntryDetailProps) {
             className={cn(
               'max-w-3xl space-y-4 text-sm leading-7 text-foreground',
               '[&_br]:block [&_br]:content-[""] [&_h2]:mt-1 [&_h2]:text-2xl [&_h2]:font-semibold [&_h2]:tracking-tight',
+              '[&_code]:rounded-sm [&_code]:bg-secondary/80 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.9em] [&_code]:text-foreground',
+              '[&_em]:font-medium [&_em]:italic [&_em]:text-foreground',
               '[&_h3]:mt-5 [&_h3]:text-lg [&_h3]:font-semibold',
               '[&_p]:text-muted [&_strong]:font-semibold [&_strong]:text-foreground',
               '[&_ul]:space-y-2 [&_ul]:pl-5 [&_li]:list-disc [&_li]:text-muted',
@@ -80,21 +88,23 @@ export function JournalEntryDetail({ entry }: JournalEntryDetailProps) {
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader className="gap-2">
-          <CardTitle className="flex items-center gap-2">
-            <Sparkles aria-hidden="true" className="size-5 text-primary" />
-            Linked To
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex flex-wrap gap-2">
-            {entry.linkedEntities.map((entity) => (
-              <EntityChip entity={entity} key={`${entry.id}-${entity.type}-${entity.id}`} />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+      {hasLinkedEntities && (
+        <Card>
+          <CardHeader className="gap-2">
+            <CardTitle className="flex items-center gap-2">
+              <Sparkles aria-hidden="true" className="size-5 text-primary" />
+              Linked To
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap gap-2">
+              {entry.linkedEntities.map((entity) => (
+                <EntityChip entity={entity} key={`${entry.id}-${entity.type}-${entity.id}`} />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
     </section>
   );
 }

--- a/apps/web/src/features/journal/components/journal-feed.tsx
+++ b/apps/web/src/features/journal/components/journal-feed.tsx
@@ -1,76 +1,50 @@
+import { Link } from 'react-router';
+
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 
+import { formatEntryType, formatJournalEntryDate, getJournalEntryPreview } from '../lib/formatters';
 import { mockJournalEntries } from '../lib/mock-data';
-import type { JournalEntryType } from '../types';
+import { journalBadgeClassesByType } from '../lib/presentation';
 import { EntityChip } from './entity-chip';
-
-const entryDateFormatter = new Intl.DateTimeFormat('en-US', {
-  day: 'numeric',
-  month: 'short',
-  year: 'numeric',
-});
-
-const badgeClassesByType: Record<JournalEntryType, string> = {
-  'injury-update':
-    'border-transparent bg-red-200 text-red-950 dark:bg-red-500/20 dark:text-red-300',
-  milestone:
-    'border-transparent bg-amber-200 text-amber-950 dark:bg-amber-500/20 dark:text-amber-300',
-  observation:
-    'border-transparent bg-sky-200 text-sky-950 dark:bg-sky-500/20 dark:text-sky-300',
-  'post-workout':
-    'border-transparent bg-[var(--color-accent-mint)] text-[var(--color-on-accent)] dark:bg-emerald-500/20 dark:text-emerald-300',
-  'weekly-summary':
-    'border-transparent bg-violet-200 text-violet-950 dark:bg-violet-500/20 dark:text-violet-300',
-};
-
-function formatJournalEntryDate(date: string) {
-  return entryDateFormatter.format(new Date(`${date}T12:00:00`));
-}
-
-function formatEntryType(type: JournalEntryType) {
-  return type.replaceAll('-', ' ');
-}
-
-function getPreview(content: string, maxLength = 132) {
-  const normalized = content
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-    .replace(/[#>*_`-]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-
-  if (normalized.length <= maxLength) {
-    return normalized;
-  }
-
-  const truncated = normalized.slice(0, maxLength);
-  const safeSlice = truncated.includes(' ') ? truncated.slice(0, truncated.lastIndexOf(' ')) : truncated;
-
-  return `${safeSlice.trimEnd()}...`;
-}
 
 const entriesNewestFirst = [...mockJournalEntries].sort((left, right) =>
   right.date.localeCompare(left.date),
 );
 
-export function JournalFeed() {
+type JournalFeedProps = {
+  getEntryHref?: (entryId: string) => string;
+};
+
+export function JournalFeed({ getEntryHref }: JournalFeedProps) {
   return (
     <div aria-label="Journal feed" className="space-y-4">
       {entriesNewestFirst.map((entry) => (
         <Card
           key={entry.id}
-          className="overflow-hidden border-border/70 bg-card/95 shadow-sm"
+          className={cn(
+            'group relative overflow-hidden border-border/70 bg-card/95 shadow-sm',
+            getEntryHref && 'transition-colors hover:border-primary/35',
+          )}
           data-slot="journal-entry-card"
         >
-          <CardHeader className="gap-4 pb-4">
+          {getEntryHref && (
+            <Link
+              aria-label={`Open journal entry ${entry.title}`}
+              className="absolute inset-0 rounded-[inherit] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+              to={getEntryHref(entry.id)}
+            />
+          )}
+
+          <CardHeader className="pointer-events-none relative gap-4 pb-4">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div className="space-y-3">
                 <div className="flex flex-wrap items-center gap-2">
                   <Badge
                     className={cn(
                       'cursor-default px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.16em]',
-                      badgeClassesByType[entry.type],
+                      journalBadgeClassesByType[entry.type],
                     )}
                     variant="secondary"
                   >
@@ -82,7 +56,7 @@ export function JournalFeed() {
                 </div>
                 <CardTitle
                   aria-level={2}
-                  className="text-xl leading-tight text-foreground"
+                  className="text-xl leading-tight text-foreground transition-colors group-hover:text-primary"
                   role="heading"
                 >
                   {entry.title}
@@ -90,9 +64,11 @@ export function JournalFeed() {
               </div>
             </div>
           </CardHeader>
-          <CardContent className="space-y-4 pt-0">
-            <p className="max-w-3xl text-sm leading-6 text-muted">{getPreview(entry.content)}</p>
-            <div className="flex flex-wrap gap-2">
+          <CardContent className="pointer-events-none relative space-y-4 pt-0">
+            <p className="max-w-3xl text-sm leading-6 text-muted">
+              {getJournalEntryPreview(entry.content)}
+            </p>
+            <div className="pointer-events-auto flex flex-wrap gap-2">
               {entry.linkedEntities.map((entity) => (
                 <EntityChip entity={entity} key={`${entry.id}-${entity.type}-${entity.id}`} />
               ))}

--- a/apps/web/src/features/journal/components/journal-feed.tsx
+++ b/apps/web/src/features/journal/components/journal-feed.tsx
@@ -19,7 +19,7 @@ type JournalFeedProps = {
 
 export function JournalFeed({ getEntryHref }: JournalFeedProps) {
   return (
-    <div aria-label="Journal feed" className="space-y-4">
+    <div aria-label="Journal feed" className="space-y-4" role="list">
       {entriesNewestFirst.map((entry) => (
         <Card
           key={entry.id}
@@ -28,6 +28,7 @@ export function JournalFeed({ getEntryHref }: JournalFeedProps) {
             getEntryHref && 'transition-colors hover:border-primary/35',
           )}
           data-slot="journal-entry-card"
+          role="listitem"
         >
           {getEntryHref && (
             <Link

--- a/apps/web/src/features/journal/components/journal-feed.tsx
+++ b/apps/web/src/features/journal/components/journal-feed.tsx
@@ -1,82 +1,204 @@
+import { useState } from 'react';
 import { Link } from 'react-router';
 
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 
 import { formatEntryType, formatJournalEntryDate, getJournalEntryPreview } from '../lib/formatters';
+import {
+  filterJournalEntries,
+  journalEntityFilterOptions,
+  journalTypeFilterOptions,
+  sortJournalEntriesNewestFirst,
+  type JournalEntityFilter,
+  type JournalFilterOption,
+  type JournalTypeFilter,
+} from '../lib/filters';
 import { mockJournalEntries } from '../lib/mock-data';
 import { journalBadgeClassesByType } from '../lib/presentation';
 import { EntityChip } from './entity-chip';
 
-const entriesNewestFirst = [...mockJournalEntries].sort((left, right) =>
-  right.date.localeCompare(left.date),
-);
+const entriesNewestFirst = sortJournalEntriesNewestFirst(mockJournalEntries);
 
 type JournalFeedProps = {
   getEntryHref?: (entryId: string) => string;
 };
 
 export function JournalFeed({ getEntryHref }: JournalFeedProps) {
-  return (
-    <div aria-label="Journal feed" className="space-y-4" role="list">
-      {entriesNewestFirst.map((entry) => (
-        <Card
-          key={entry.id}
-          className={cn(
-            'group relative overflow-hidden border-border/70 bg-card/95 shadow-sm',
-            getEntryHref && 'transition-colors hover:border-primary/35',
-          )}
-          data-slot="journal-entry-card"
-          role="listitem"
-        >
-          {getEntryHref && (
-            <Link
-              aria-label={`Open journal entry ${entry.title}`}
-              className="absolute inset-0 rounded-[inherit] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-              to={getEntryHref(entry.id)}
-            />
-          )}
+  const [typeFilter, setTypeFilter] = useState<JournalTypeFilter>('all');
+  const [entityFilter, setEntityFilter] = useState<JournalEntityFilter>('all');
 
-          <CardHeader className="pointer-events-none relative gap-4 pb-4">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div className="space-y-3">
-                <div className="flex flex-wrap items-center gap-2">
-                  <Badge
-                    className={cn(
-                      'cursor-default px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.16em]',
-                      journalBadgeClassesByType[entry.type],
-                    )}
-                    variant="secondary"
-                  >
-                    {formatEntryType(entry.type)}
-                  </Badge>
-                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted">
-                    {formatJournalEntryDate(entry.date)}
-                  </p>
+  const filteredEntries = filterJournalEntries(entriesNewestFirst, {
+    entityFilter,
+    typeFilter,
+  });
+  const hasActiveFilters = entityFilter !== 'all' || typeFilter !== 'all';
+
+  return (
+    <div className="space-y-5">
+      <Card className="border-border/70 bg-card/80 shadow-sm">
+        <CardContent className="space-y-4 p-4 sm:p-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted">
+                Feed Filters
+              </p>
+              <p className="text-sm text-muted">
+                Showing {filteredEntries.length} of {entriesNewestFirst.length} entries
+              </p>
+            </div>
+            {hasActiveFilters && (
+              <Button
+                className="w-full sm:w-auto"
+                size="sm"
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setTypeFilter('all');
+                  setEntityFilter('all');
+                }}
+              >
+                Reset filters
+              </Button>
+            )}
+          </div>
+
+          <FilterRow
+            label="Type"
+            options={journalTypeFilterOptions}
+            selectedValue={typeFilter}
+            onSelect={setTypeFilter}
+          />
+          <FilterRow
+            label="Linked entity"
+            options={journalEntityFilterOptions}
+            selectedValue={entityFilter}
+            onSelect={setEntityFilter}
+          />
+        </CardContent>
+      </Card>
+
+      <div aria-label="Journal feed" className="space-y-4" role="list">
+        {filteredEntries.length === 0 ? (
+          <Card
+            className="border-dashed border-border/70 bg-card/95 shadow-sm"
+            data-slot="journal-empty-state"
+            role="listitem"
+          >
+            <CardContent className="py-8 text-center text-sm text-muted">
+              No journal entries match the current filters.
+            </CardContent>
+          </Card>
+        ) : (
+          filteredEntries.map((entry) => (
+            <Card
+              key={entry.id}
+              className={cn(
+                'group relative overflow-hidden border-border/70 bg-card/95 shadow-sm',
+                getEntryHref && 'transition-colors hover:border-primary/35',
+              )}
+              data-slot="journal-entry-card"
+              role="listitem"
+            >
+              {getEntryHref && (
+                <Link
+                  aria-label={`Open journal entry ${entry.title}`}
+                  className="absolute inset-0 rounded-[inherit] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                  to={getEntryHref(entry.id)}
+                />
+              )}
+
+              <CardHeader className="pointer-events-none relative gap-4 pb-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="space-y-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge
+                        className={cn(
+                          'cursor-default px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.16em]',
+                          journalBadgeClassesByType[entry.type],
+                        )}
+                        variant="secondary"
+                      >
+                        {formatEntryType(entry.type)}
+                      </Badge>
+                      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted">
+                        {formatJournalEntryDate(entry.date)}
+                      </p>
+                    </div>
+                    <CardTitle
+                      aria-level={2}
+                      className="text-xl leading-tight text-foreground transition-colors group-hover:text-primary"
+                      role="heading"
+                    >
+                      {entry.title}
+                    </CardTitle>
+                  </div>
                 </div>
-                <CardTitle
-                  aria-level={2}
-                  className="text-xl leading-tight text-foreground transition-colors group-hover:text-primary"
-                  role="heading"
-                >
-                  {entry.title}
-                </CardTitle>
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent className="pointer-events-none relative space-y-4 pt-0">
-            <p className="max-w-3xl text-sm leading-6 text-muted">
-              {getJournalEntryPreview(entry.content)}
-            </p>
-            <div className="pointer-events-auto flex flex-wrap gap-2">
-              {entry.linkedEntities.map((entity) => (
-                <EntityChip entity={entity} key={`${entry.id}-${entity.type}-${entity.id}`} />
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      ))}
+              </CardHeader>
+              <CardContent className="pointer-events-none relative space-y-4 pt-0">
+                <p className="max-w-3xl text-sm leading-6 text-muted">
+                  {getJournalEntryPreview(entry.content)}
+                </p>
+                <div className="pointer-events-auto flex flex-wrap gap-2">
+                  {entry.linkedEntities.map((entity) => (
+                    <EntityChip entity={entity} key={`${entry.id}-${entity.type}-${entity.id}`} />
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+type FilterRowProps<T extends string> = {
+  label: string;
+  onSelect: (value: T) => void;
+  options: JournalFilterOption<T>[];
+  selectedValue: T;
+};
+
+function FilterRow<T extends string>({
+  label,
+  onSelect,
+  options,
+  selectedValue,
+}: FilterRowProps<T>) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted">{label}</p>
+      </div>
+      <div
+        aria-label={`${label} filter`}
+        className="flex gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        role="toolbar"
+      >
+        {options.map((option) => {
+          const isActive = option.value === selectedValue;
+
+          return (
+            <button
+              key={option.value}
+              aria-pressed={isActive}
+              className={cn(
+                'cursor-pointer whitespace-nowrap rounded-full border px-3.5 py-2 text-sm font-medium transition-colors',
+                isActive
+                  ? 'border-transparent bg-[var(--color-accent-mint)] text-[var(--color-on-accent)] shadow-sm'
+                  : 'border-border/70 bg-background/70 text-muted hover:border-primary/35 hover:text-foreground',
+              )}
+              type="button"
+              onClick={() => onSelect(option.value)}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/journal/components/journal-feed.tsx
+++ b/apps/web/src/features/journal/components/journal-feed.tsx
@@ -143,7 +143,7 @@ export function JournalFeed({ getEntryHref }: JournalFeedProps) {
                 </p>
                 <div className="pointer-events-auto flex flex-wrap gap-2">
                   {entry.linkedEntities.map((entity) => (
-                    <EntityChip entity={entity} key={`${entry.id}-${entity.type}-${entity.id}`} />
+                    <EntityChip entity={entity} key={`${entity.type}-${entity.id}`} />
                   ))}
                 </div>
               </CardContent>

--- a/apps/web/src/features/journal/components/journal-feed.tsx
+++ b/apps/web/src/features/journal/components/journal-feed.tsx
@@ -1,0 +1,105 @@
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+import { mockJournalEntries } from '../lib/mock-data';
+import type { JournalEntryType } from '../types';
+import { EntityChip } from './entity-chip';
+
+const entryDateFormatter = new Intl.DateTimeFormat('en-US', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+});
+
+const badgeClassesByType: Record<JournalEntryType, string> = {
+  'injury-update':
+    'border-transparent bg-red-200 text-red-950 dark:bg-red-500/20 dark:text-red-300',
+  milestone:
+    'border-transparent bg-amber-200 text-amber-950 dark:bg-amber-500/20 dark:text-amber-300',
+  observation:
+    'border-transparent bg-sky-200 text-sky-950 dark:bg-sky-500/20 dark:text-sky-300',
+  'post-workout':
+    'border-transparent bg-[var(--color-accent-mint)] text-[var(--color-on-accent)] dark:bg-emerald-500/20 dark:text-emerald-300',
+  'weekly-summary':
+    'border-transparent bg-violet-200 text-violet-950 dark:bg-violet-500/20 dark:text-violet-300',
+};
+
+function formatJournalEntryDate(date: string) {
+  return entryDateFormatter.format(new Date(`${date}T12:00:00`));
+}
+
+function formatEntryType(type: JournalEntryType) {
+  return type.replaceAll('-', ' ');
+}
+
+function getPreview(content: string, maxLength = 132) {
+  const normalized = content
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[#>*_`-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  const truncated = normalized.slice(0, maxLength);
+  const safeSlice = truncated.includes(' ') ? truncated.slice(0, truncated.lastIndexOf(' ')) : truncated;
+
+  return `${safeSlice.trimEnd()}...`;
+}
+
+const entriesNewestFirst = [...mockJournalEntries].sort((left, right) =>
+  right.date.localeCompare(left.date),
+);
+
+export function JournalFeed() {
+  return (
+    <div aria-label="Journal feed" className="space-y-4">
+      {entriesNewestFirst.map((entry) => (
+        <Card
+          key={entry.id}
+          className="overflow-hidden border-border/70 bg-card/95 shadow-sm"
+          data-slot="journal-entry-card"
+        >
+          <CardHeader className="gap-4 pb-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge
+                    className={cn(
+                      'cursor-default px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.16em]',
+                      badgeClassesByType[entry.type],
+                    )}
+                    variant="secondary"
+                  >
+                    {formatEntryType(entry.type)}
+                  </Badge>
+                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted">
+                    {formatJournalEntryDate(entry.date)}
+                  </p>
+                </div>
+                <CardTitle
+                  aria-level={2}
+                  className="text-xl leading-tight text-foreground"
+                  role="heading"
+                >
+                  {entry.title}
+                </CardTitle>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4 pt-0">
+            <p className="max-w-3xl text-sm leading-6 text-muted">{getPreview(entry.content)}</p>
+            <div className="flex flex-wrap gap-2">
+              {entry.linkedEntities.map((entity) => (
+                <EntityChip entity={entity} key={`${entry.id}-${entity.type}-${entity.id}`} />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/journal/index.ts
+++ b/apps/web/src/features/journal/index.ts
@@ -1,4 +1,5 @@
 export { EntityChip } from './components/entity-chip';
 export { JournalFeed } from './components/journal-feed';
+export { JournalEntryDetail } from './components/journal-entry-detail';
 export { mockJournalEntries } from './lib/mock-data';
 export type { JournalEntry, JournalEntryType, LinkedEntity, LinkedEntityType } from './types';

--- a/apps/web/src/features/journal/index.ts
+++ b/apps/web/src/features/journal/index.ts
@@ -1,2 +1,4 @@
+export { EntityChip } from './components/entity-chip';
+export { JournalFeed } from './components/journal-feed';
 export { mockJournalEntries } from './lib/mock-data';
 export type { JournalEntry, JournalEntryType, LinkedEntity, LinkedEntityType } from './types';

--- a/apps/web/src/features/journal/index.ts
+++ b/apps/web/src/features/journal/index.ts
@@ -1,5 +1,6 @@
 export { EntityChip } from './components/entity-chip';
 export { JournalFeed } from './components/journal-feed';
 export { JournalEntryDetail } from './components/journal-entry-detail';
+// TODO: remove this export when journal entries are query-backed; pages should use hooks, not static data.
 export { mockJournalEntries } from './lib/mock-data';
 export type { JournalEntry, JournalEntryType, LinkedEntity, LinkedEntityType } from './types';

--- a/apps/web/src/features/journal/index.ts
+++ b/apps/web/src/features/journal/index.ts
@@ -1,0 +1,2 @@
+export { mockJournalEntries } from './lib/mock-data';
+export type { JournalEntry, JournalEntryType, LinkedEntity, LinkedEntityType } from './types';

--- a/apps/web/src/features/journal/lib/filters.ts
+++ b/apps/web/src/features/journal/lib/filters.ts
@@ -1,0 +1,49 @@
+import type { JournalEntry, JournalEntryType, LinkedEntityType } from '../types';
+
+export type JournalTypeFilter = 'all' | JournalEntryType;
+export type JournalEntityFilter = 'all' | LinkedEntityType;
+
+export type JournalFilterOption<T extends string> = {
+  label: string;
+  value: T;
+};
+
+export const journalTypeFilterOptions: JournalFilterOption<JournalTypeFilter>[] = [
+  { label: 'All', value: 'all' },
+  { label: 'Post-Workout', value: 'post-workout' },
+  { label: 'Milestone', value: 'milestone' },
+  { label: 'Observation', value: 'observation' },
+  { label: 'Weekly Summary', value: 'weekly-summary' },
+  { label: 'Injury Update', value: 'injury-update' },
+];
+
+export const journalEntityFilterOptions: JournalFilterOption<JournalEntityFilter>[] = [
+  { label: 'All', value: 'all' },
+  { label: 'Workouts', value: 'workout' },
+  { label: 'Activities', value: 'activity' },
+  { label: 'Habits', value: 'habit' },
+  { label: 'Injuries', value: 'injury' },
+];
+
+export function sortJournalEntriesNewestFirst(entries: JournalEntry[]) {
+  return [...entries].sort((left, right) => right.date.localeCompare(left.date));
+}
+
+type FilterJournalEntriesArgs = {
+  entityFilter: JournalEntityFilter;
+  typeFilter: JournalTypeFilter;
+};
+
+export function filterJournalEntries(
+  entries: JournalEntry[],
+  { entityFilter, typeFilter }: FilterJournalEntriesArgs,
+) {
+  return entries.filter((entry) => {
+    const matchesType = typeFilter === 'all' || entry.type === typeFilter;
+    const matchesEntity =
+      entityFilter === 'all' ||
+      entry.linkedEntities.some((linkedEntity) => linkedEntity.type === entityFilter);
+
+    return matchesType && matchesEntity;
+  });
+}

--- a/apps/web/src/features/journal/lib/formatters.ts
+++ b/apps/web/src/features/journal/lib/formatters.ts
@@ -1,0 +1,34 @@
+import type { JournalEntryType } from '../types';
+
+const entryDateFormatter = new Intl.DateTimeFormat('en-US', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+});
+
+export function formatJournalEntryDate(date: string) {
+  return entryDateFormatter.format(new Date(`${date}T12:00:00`));
+}
+
+export function formatEntryType(type: JournalEntryType) {
+  return type.replaceAll('-', ' ');
+}
+
+export function getJournalEntryPreview(content: string, maxLength = 132) {
+  const normalized = content
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[#>*_`-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  const truncated = normalized.slice(0, maxLength);
+  const safeSlice = truncated.includes(' ')
+    ? truncated.slice(0, truncated.lastIndexOf(' '))
+    : truncated;
+
+  return `${safeSlice.trimEnd()}...`;
+}

--- a/apps/web/src/features/journal/lib/formatters.ts
+++ b/apps/web/src/features/journal/lib/formatters.ts
@@ -29,7 +29,7 @@ export function getJournalEntrySubtitle(type: JournalEntryType) {
 export function getJournalEntryPreview(content: string, maxLength = 132) {
   const normalized = content
     .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-    .replace(/[#>*_`-]+/g, ' ')
+    .replace(/[#>*_`]+/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 

--- a/apps/web/src/features/journal/lib/formatters.ts
+++ b/apps/web/src/features/journal/lib/formatters.ts
@@ -14,6 +14,18 @@ export function formatEntryType(type: JournalEntryType) {
   return type.replaceAll('-', ' ');
 }
 
+const detailSubtitleByType: Record<JournalEntryType, string> = {
+  'post-workout': 'Detailed session debrief with linked training and recovery context.',
+  milestone: 'Milestone recap tying the win back to the work that drove it.',
+  observation: 'Observation log capturing trends, signals, and linked context.',
+  'weekly-summary': 'Weekly recap connecting standout sessions, recovery, and next steps.',
+  'injury-update': 'Injury status update with rehab notes, guardrails, and linked context.',
+};
+
+export function getJournalEntrySubtitle(type: JournalEntryType) {
+  return detailSubtitleByType[type];
+}
+
 export function getJournalEntryPreview(content: string, maxLength = 132) {
   const normalized = content
     .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')

--- a/apps/web/src/features/journal/lib/markdown.ts
+++ b/apps/web/src/features/journal/lib/markdown.ts
@@ -1,0 +1,76 @@
+function escapeHtml(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function formatInlineMarkdown(value: string) {
+  return escapeHtml(value).replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+}
+
+export function renderJournalMarkdown(content: string) {
+  const blocks: string[] = [];
+  const paragraphLines: string[] = [];
+  const listItems: string[] = [];
+
+  const flushParagraph = () => {
+    if (paragraphLines.length === 0) {
+      return;
+    }
+
+    blocks.push(`<p>${paragraphLines.map(formatInlineMarkdown).join('<br />')}</p>`);
+    paragraphLines.length = 0;
+  };
+
+  const flushList = () => {
+    if (listItems.length === 0) {
+      return;
+    }
+
+    blocks.push(
+      `<ul>${listItems.map((item) => `<li>${formatInlineMarkdown(item)}</li>`).join('')}</ul>`,
+    );
+    listItems.length = 0;
+  };
+
+  for (const rawLine of content.trim().split('\n')) {
+    const line = rawLine.trim();
+
+    if (!line) {
+      flushParagraph();
+      flushList();
+      continue;
+    }
+
+    if (line.startsWith('### ')) {
+      flushParagraph();
+      flushList();
+      blocks.push(`<h3>${formatInlineMarkdown(line.slice(4))}</h3>`);
+      continue;
+    }
+
+    if (line.startsWith('## ')) {
+      flushParagraph();
+      flushList();
+      blocks.push(`<h2>${formatInlineMarkdown(line.slice(3))}</h2>`);
+      continue;
+    }
+
+    if (line.startsWith('- ')) {
+      flushParagraph();
+      listItems.push(line.slice(2));
+      continue;
+    }
+
+    flushList();
+    paragraphLines.push(line);
+  }
+
+  flushParagraph();
+  flushList();
+
+  return blocks.join('');
+}

--- a/apps/web/src/features/journal/lib/markdown.ts
+++ b/apps/web/src/features/journal/lib/markdown.ts
@@ -48,6 +48,9 @@ export function renderJournalMarkdown(content: string) {
       continue;
     }
 
+    // Check h3 before h2 so that "### " doesn't partially match "## ".
+    // h1 ("# ") is intentionally unsupported because the entry title
+    // already occupies that heading level in the detail view.
     if (line.startsWith('### ')) {
       flushParagraph();
       flushList();

--- a/apps/web/src/features/journal/lib/markdown.ts
+++ b/apps/web/src/features/journal/lib/markdown.ts
@@ -8,7 +8,10 @@ function escapeHtml(value: string) {
 }
 
 function formatInlineMarkdown(value: string) {
-  return escapeHtml(value).replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  return escapeHtml(value)
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/(^|[^*])\*([^*\n]+)\*(?!\*)/g, '$1<em>$2</em>');
 }
 
 export function renderJournalMarkdown(content: string) {

--- a/apps/web/src/features/journal/lib/mock-data.ts
+++ b/apps/web/src/features/journal/lib/mock-data.ts
@@ -1,0 +1,273 @@
+import type { JournalEntry, LinkedEntity } from '../types';
+
+const workouts = {
+  fullBody: {
+    id: 'full-body',
+    name: 'Full Body',
+    type: 'workout',
+  },
+  lowerQuadDominant: {
+    id: 'lower-quad-dominant',
+    name: 'Lower Quad-Dominant',
+    type: 'workout',
+  },
+  upperPush: {
+    id: 'upper-push',
+    name: 'Upper Push',
+    type: 'workout',
+  },
+} satisfies Record<string, LinkedEntity>;
+
+const activities = {
+  eveningWalk: {
+    id: 'activity-evening-zone-2-walk',
+    name: 'Evening Zone 2 Walk',
+    type: 'activity',
+  },
+  recoveryBike: {
+    id: 'activity-recovery-bike-spin',
+    name: 'Recovery Bike Spin',
+    type: 'activity',
+  },
+  tibialisCircuit: {
+    id: 'activity-tibialis-circuit',
+    name: 'Tibialis and Foot Prep Circuit',
+    type: 'activity',
+  },
+} satisfies Record<string, LinkedEntity>;
+
+const habits = {
+  hydrate: {
+    id: 'hydrate',
+    name: 'Hydrate',
+    type: 'habit',
+  },
+  mobility: {
+    id: 'mobility',
+    name: 'Mobility warm-up',
+    type: 'habit',
+  },
+  protein: {
+    id: 'protein',
+    name: 'Protein goal',
+    type: 'habit',
+  },
+  sleep: {
+    id: 'sleep',
+    name: 'Sleep',
+    type: 'habit',
+  },
+  vitamins: {
+    id: 'vitamins',
+    name: 'Take vitamins',
+    type: 'habit',
+  },
+} satisfies Record<string, LinkedEntity>;
+
+const injuries = {
+  leftAchilles: {
+    id: 'injury-left-achilles-insertion',
+    name: 'Left Achilles insertion',
+    type: 'injury',
+  },
+  rightKnee: {
+    id: 'injury-right-patellar-tendon',
+    name: 'Right patellar tendon irritation',
+    type: 'injury',
+  },
+  rightShoulder: {
+    id: 'injury-right-shoulder-slap',
+    name: 'Right shoulder SLAP rehab',
+    type: 'injury',
+  },
+} satisfies Record<string, LinkedEntity>;
+
+export const mockJournalEntries: JournalEntry[] = [
+  {
+    id: 'journal-shoulder-slap-clearance',
+    date: '2026-03-06',
+    title: 'Shoulder SLAP Clearance',
+    type: 'injury-update',
+    content: `## Clearance update
+
+**Sports med check-in:** cleared to reintroduce overhead work at a moderate RPE as long as the first working set stays pain-free.
+
+### What changed
+- Internal rotation tolerance was better than the last appointment.
+- Clicking is now occasional instead of showing up every pressing session.
+- I can use a controlled eccentric without feeling the shoulder shift.
+
+### Guardrails for the next block
+- Keep the first overhead press set at **RPE 6-7**.
+- Pair every upper session with band external rotations before the first compound set.
+- Stop the set if pain rises above **2/10** or if range shortens rep to rep.`,
+    linkedEntities: [injuries.rightShoulder, habits.mobility],
+    createdBy: 'user',
+  },
+  {
+    id: 'journal-upper-a-session-notes',
+    date: '2026-03-05',
+    title: 'Upper A Session Notes',
+    type: 'post-workout',
+    content: `## Coach notes
+
+**Session focus:** keep incline press progression moving while protecting the right shoulder.
+
+### Wins
+- Bar path on incline dumbbell press stayed cleaner than last week.
+- Scap position held up well once the warm-up band work was finished.
+- Tempo stayed honest even after the top set climbed.
+
+### Next adjustments
+- Keep elbows about **30-45 degrees** off the torso on the first two sets.
+- Add a one-count pause at the bottom if shoulder tension returns.
+- Triceps pushdowns can move up next week if pressing recovery still feels normal.`,
+    linkedEntities: [workouts.upperPush, injuries.rightShoulder],
+    createdBy: 'agent',
+  },
+  {
+    id: 'journal-knee-feeling-better',
+    date: '2026-03-04',
+    title: 'Knee feeling better after 2 weeks of tibialis work',
+    type: 'observation',
+    content: `## Trend
+
+**Noticeable improvement:** stairs are almost pain-free in the morning and the knee is warming up faster before squats.
+
+### Signals worth keeping
+- The tibialis raises seem to cut down the stiff first few reps.
+- Split squat depth is coming back without the usual tug under the kneecap.
+- The ankle feels more stable when I stay consistent with the foot prep circuit.
+
+### Keep doing
+- Tibialis circuit before lower sessions.
+- A short mobility check on non-lifting days.
+- Track whether the knee still improves when squat load goes up next week.`,
+    linkedEntities: [injuries.rightKnee, activities.tibialisCircuit],
+    createdBy: 'user',
+  },
+  {
+    id: 'journal-incline-press-pr',
+    date: '2026-03-03',
+    title: 'Hit 55lb Incline Press PR',
+    type: 'milestone',
+    content: `## Personal record
+
+Moved the top set to **55 lb dumbbells** for a clean set of 8. This is the first time the load moved up without the shoulder getting cranky afterward.
+
+### Why it mattered
+- Warm-up sequencing was better than the last two push sessions.
+- Sleep was solid for three nights in a row.
+- I stayed patient on the eccentric instead of rushing the first rep.
+
+### Next target
+- Repeat the load and own all working sets before chasing another jump.`,
+    linkedEntities: [workouts.upperPush, habits.sleep],
+    createdBy: 'user',
+  },
+  {
+    id: 'journal-week-12-training-summary',
+    date: '2026-03-02',
+    title: 'Week 12 Training Summary',
+    type: 'weekly-summary',
+    content: `## Week 12 snapshot
+
+**Theme:** solid training week with enough recovery to push load on both upper and lower sessions.
+
+### Highlights
+- Pressing volume went up without aggravating the shoulder.
+- Quad work felt more stable, especially in the second half of the session.
+- Bench and squat both showed better position under fatigue.
+
+### Watch next week
+- Keep hydration up before lower days.
+- Do not stack hard conditioning on the day before squat work.
+- Continue logging soreness by region instead of just saying "felt tight."`,
+    linkedEntities: [workouts.upperPush, workouts.lowerQuadDominant, workouts.fullBody],
+    createdBy: 'agent',
+  },
+  {
+    id: 'journal-recovery-walk-observation',
+    date: '2026-03-01',
+    title: 'Outdoor walk kept recovery high between lower sessions',
+    type: 'observation',
+    content: `## Recovery note
+
+The longer evening walk seemed to make the next morning feel better rather than more fatigued.
+
+### What I noticed
+- Legs felt looser after dinner and less heavy the following morning.
+- Sleep onset was quicker on the same day as the walk.
+- Appetite stayed steadier, which made the protein target easier to hit.
+
+### Repeatable version
+- Keep the pace conversational.
+- Cap it around **35-45 minutes**.
+- Use it on high-stress days instead of adding more gym work.`,
+    linkedEntities: [activities.eveningWalk, habits.sleep, habits.protein],
+    createdBy: 'user',
+  },
+  {
+    id: 'journal-lower-session-pacing-notes',
+    date: '2026-02-28',
+    title: 'Lower Session Pacing Notes',
+    type: 'post-workout',
+    content: `## Post-session review
+
+**Big win:** squat positions improved when the first two warm-up jumps stayed smaller.
+
+### Form notes
+- The knee tracked cleaner when I let the ankle move instead of sitting back early.
+- Bulgarian split squats were much smoother with a slower descent.
+- Leg press depth stayed consistent when I did not rush the turnaround.
+
+### For the next lower day
+- Add one more ramp set before the first top squat set.
+- Keep rest periods at **2-3 minutes** for the bilateral work.
+- Finish with a short tibialis circuit if the knee feels sticky coming out of the rack.`,
+    linkedEntities: [workouts.lowerQuadDominant, injuries.rightKnee],
+    createdBy: 'agent',
+  },
+  {
+    id: 'journal-sleep-consistency-milestone',
+    date: '2026-02-26',
+    title: 'Seven straight nights over 8 hours',
+    type: 'milestone',
+    content: `## Recovery milestone
+
+Closed out a full week with **8+ hours** every night, and the difference showed up immediately in training readiness.
+
+### Outcomes
+- Morning soreness came down faster.
+- Upper body pressing felt more coordinated.
+- Cravings were lower, which made meals easier to keep on plan.
+
+### What helped
+- Water and vitamins were done earlier in the day.
+- Screens were off before bed most nights.
+- The walk after dinner made it easier to wind down.`,
+    linkedEntities: [habits.sleep, habits.hydrate, habits.vitamins],
+    createdBy: 'user',
+  },
+  {
+    id: 'journal-achilles-bike-update',
+    date: '2026-02-22',
+    title: 'Easy bike flush settled Achilles stiffness',
+    type: 'injury-update',
+    content: `## Injury check
+
+The Achilles was stiff first thing in the morning, but a very easy spin loosened it up without the rebound soreness I usually get from extra walking.
+
+### Helpful details
+- Low resistance worked better than trying to "open it up" with a harder effort.
+- Cadence above **85 rpm** felt smoother than pushing torque.
+- Heel raises afterward were tolerable and did not spike symptoms.
+
+### Plan
+- Use the bike flush the day after full-body sessions.
+- Keep calf loading separate from the spin.
+- Recheck whether the morning stiffness stays under **3/10** this weekend.`,
+    linkedEntities: [injuries.leftAchilles, activities.recoveryBike],
+    createdBy: 'agent',
+  },
+];

--- a/apps/web/src/features/journal/lib/presentation.ts
+++ b/apps/web/src/features/journal/lib/presentation.ts
@@ -1,0 +1,13 @@
+import type { JournalEntryType } from '../types';
+
+export const journalBadgeClassesByType: Record<JournalEntryType, string> = {
+  'injury-update':
+    'border-transparent bg-red-200 text-red-950 dark:bg-red-500/20 dark:text-red-300',
+  milestone:
+    'border-transparent bg-amber-200 text-amber-950 dark:bg-amber-500/20 dark:text-amber-300',
+  observation: 'border-transparent bg-sky-200 text-sky-950 dark:bg-sky-500/20 dark:text-sky-300',
+  'post-workout':
+    'border-transparent bg-[var(--color-accent-mint)] text-[var(--color-on-accent)] dark:bg-emerald-500/20 dark:text-emerald-300',
+  'weekly-summary':
+    'border-transparent bg-violet-200 text-violet-950 dark:bg-violet-500/20 dark:text-violet-300',
+};

--- a/apps/web/src/features/journal/types.ts
+++ b/apps/web/src/features/journal/types.ts
@@ -1,0 +1,24 @@
+export type JournalEntryType =
+  | 'post-workout'
+  | 'milestone'
+  | 'observation'
+  | 'weekly-summary'
+  | 'injury-update';
+
+export type LinkedEntityType = 'workout' | 'activity' | 'habit' | 'injury';
+
+export interface LinkedEntity {
+  type: LinkedEntityType;
+  id: string;
+  name: string;
+}
+
+export interface JournalEntry {
+  id: string;
+  date: string;
+  title: string;
+  type: JournalEntryType;
+  content: string;
+  linkedEntities: LinkedEntity[];
+  createdBy: 'agent' | 'user';
+}

--- a/apps/web/src/pages/journal-entry.test.tsx
+++ b/apps/web/src/pages/journal-entry.test.tsx
@@ -2,6 +2,9 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
+import { JournalEntryDetail } from '@/features/journal';
+import type { JournalEntry } from '@/features/journal';
+
 import { JournalEntryPage } from './journal-entry';
 
 function renderWithRoute(entryId: string) {
@@ -34,6 +37,9 @@ describe('JournalEntryPage', () => {
     expect(screen.getByText('post workout')).toBeInTheDocument();
     expect(screen.getByText('Mar 5, 2026')).toBeInTheDocument();
     expect(screen.getByText('Created by agent')).toBeInTheDocument();
+    expect(
+      screen.getByText('Detailed session debrief with linked training and recovery context.'),
+    ).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 2, name: 'Coach notes' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 3, name: 'Wins' })).toBeInTheDocument();
     expect(screen.getByText(/Session focus:/)).toBeInTheDocument();
@@ -46,5 +52,28 @@ describe('JournalEntryPage', () => {
       'href',
       '/workouts/template/upper-push',
     );
+  });
+
+  it('omits the linked entities card when an entry has no related entities', () => {
+    const entry: JournalEntry = {
+      id: 'journal-empty-links',
+      date: '2026-03-06',
+      title: 'Standalone note',
+      type: 'observation',
+      content: 'A quick standalone update.',
+      linkedEntities: [],
+      createdBy: 'user',
+    };
+
+    render(
+      <MemoryRouter>
+        <JournalEntryDetail entry={entry} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText('Linked To')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Observation log capturing trends, signals, and linked context.'),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/journal-entry.test.tsx
+++ b/apps/web/src/pages/journal-entry.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { JournalEntryPage } from './journal-entry';
+
+function renderWithRoute(entryId: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/journal/${entryId}`]}>
+      <Routes>
+        <Route element={<JournalEntryPage />} path="/journal/:entryId" />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('JournalEntryPage', () => {
+  it('renders not-found state for an unknown entryId', () => {
+    renderWithRoute('missing-entry');
+
+    expect(screen.getByRole('heading', { name: 'Journal entry not found' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to Journal' })).toHaveAttribute(
+      'href',
+      '/journal',
+    );
+  });
+
+  it('renders full entry content and linked entities for a valid entry', () => {
+    renderWithRoute('journal-upper-a-session-notes');
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Upper A Session Notes' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('post workout')).toBeInTheDocument();
+    expect(screen.getByText('Mar 5, 2026')).toBeInTheDocument();
+    expect(screen.getByText('Created by agent')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Coach notes' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: 'Wins' })).toBeInTheDocument();
+    expect(screen.getByText(/Session focus:/)).toBeInTheDocument();
+    expect(screen.getByText('Linked To')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to Journal' })).toHaveAttribute(
+      'href',
+      '/journal',
+    );
+    expect(screen.getByRole('link', { name: 'Upper Push' })).toHaveAttribute(
+      'href',
+      '/workouts/template/upper-push',
+    );
+  });
+});

--- a/apps/web/src/pages/journal-entry.tsx
+++ b/apps/web/src/pages/journal-entry.tsx
@@ -1,0 +1,30 @@
+import { Link, useParams } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { JournalEntryDetail, mockJournalEntries } from '@/features/journal';
+
+export function JournalEntryPage() {
+  const { entryId = '' } = useParams();
+  const entry = mockJournalEntries.find((candidate) => candidate.id === entryId);
+
+  if (!entry) {
+    return (
+      <Card>
+        <CardHeader className="space-y-2">
+          <h1 className="text-2xl font-semibold text-foreground">Journal entry not found</h1>
+          <p className="text-sm text-muted">
+            The requested journal entry is not available in the current prototype data.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <Button asChild className="w-full sm:w-auto">
+            <Link to="/journal">Back to Journal</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return <JournalEntryDetail entry={entry} />;
+}

--- a/apps/web/src/pages/journal.test.tsx
+++ b/apps/web/src/pages/journal.test.tsx
@@ -1,68 +1,59 @@
 import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
+import { mockJournalEntries } from '@/features/journal';
 import { JournalPage } from '@/pages/journal';
 
-const sampleEntries = [
-  {
-    contentPreview:
-      'Noticed a significant boost in morning energy after switching to earlier bedtime and keeping caffeine before noon.',
-    date: 'February 16, 2026',
-    title: 'Feeling More Energetic',
-    type: 'observation',
-  },
-  {
-    contentPreview:
-      'Ran my first 5K today in 28:32. Started training 8 weeks ago and finally felt confident pushing the last kilometer.',
-    date: 'February 28, 2026',
-    title: 'First 5K Completed!',
-    type: 'milestone',
-  },
-  {
-    contentPreview:
-      'Consistent with all habits this week. Weight trending down slightly, workouts felt steady, and recovery improved by Friday.',
-    date: 'March 2, 2026',
-    title: 'Week 12 Summary',
-    type: 'weekly_summary',
-  },
-] as const;
-
 describe('JournalPage', () => {
-  it('renders the coming soon state with sample entries', () => {
-    render(<JournalPage />);
+  it('renders the chronological feed with badges, previews, and entity chips', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <JournalPage />
+      </MemoryRouter>,
+    );
 
     expect(screen.getByRole('heading', { name: 'Journal' })).toBeInTheDocument();
-    expect(screen.getByText('Coming Soon')).toBeInTheDocument();
     expect(
-      screen.getByText('Track your health observations, milestones, and weekly reflections.'),
+      screen.getByText(
+        'Review coaching notes, milestones, observations, and injury updates in one chronological feed.',
+      ),
     ).toBeInTheDocument();
 
-    sampleEntries.forEach((entry) => {
-      const cardHeading = screen.getByRole('heading', { name: entry.title });
-      const card = cardHeading.closest('[data-slot="card"]');
+    const cardTitles = screen
+      .getAllByRole('heading', { level: 2 })
+      .map((heading) => heading.textContent);
+    expect(cardTitles).toEqual(mockJournalEntries.map((entry) => entry.title));
 
-      expect(card).not.toBeNull();
-      expect(within(card as HTMLElement).getByText(entry.type)).toBeInTheDocument();
-      expect(within(card as HTMLElement).getByText(entry.date)).toBeInTheDocument();
-      expect(within(card as HTMLElement).getByText(entry.contentPreview)).toBeInTheDocument();
-      expect(card).toHaveClass('border-dashed');
-      expect(card).toHaveClass('opacity-90');
-    });
+    const cards = container.querySelectorAll('[data-slot="journal-entry-card"]');
+    expect(cards).toHaveLength(mockJournalEntries.length);
+
+    const firstCard = cards[0] as HTMLElement;
+    expect(within(firstCard).getByText('injury update')).toBeInTheDocument();
+    expect(within(firstCard).getByText('Mar 6, 2026')).toBeInTheDocument();
+    expect(
+      within(firstCard).getByText(/Sports med check in: cleared to reintroduce overhead work/i),
+    ).toHaveTextContent(/\.\.\.$/);
+    expect(within(firstCard).getByRole('link', { name: 'Mobility warm-up' })).toHaveAttribute(
+      'href',
+      '/habits',
+    );
+    expect(
+      within(firstCard).getByText('Right shoulder SLAP rehab').closest('[data-slot="badge"]'),
+    ).toBeInTheDocument();
   });
 
-  it('uses distinct badge colors with explicit dark text on accent surfaces', () => {
-    render(<JournalPage />);
+  it('uses the required color mapping for each journal type badge', () => {
+    render(
+      <MemoryRouter>
+        <JournalPage />
+      </MemoryRouter>,
+    );
 
-    const observationBadge = screen.getByText('observation');
-    const milestoneBadge = screen.getByText('milestone');
-    const weeklySummaryBadge = screen.getByText('weekly_summary');
-
-    expect(observationBadge).toHaveClass('bg-[var(--color-accent-cream)]');
-    expect(milestoneBadge).toHaveClass('bg-[var(--color-accent-mint)]');
-    expect(weeklySummaryBadge).toHaveClass('bg-[var(--color-accent-pink)]');
-
-    expect(observationBadge).toHaveClass('text-on-cream');
-    expect(milestoneBadge).toHaveClass('text-on-mint');
-    expect(weeklySummaryBadge).toHaveClass('text-on-pink');
+    expect(screen.getAllByText('post workout')[0]).toHaveClass('bg-[var(--color-accent-mint)]');
+    expect(screen.getAllByText('milestone')[0]).toHaveClass('bg-amber-200');
+    expect(screen.getAllByText('observation')[0]).toHaveClass('bg-sky-200');
+    expect(screen.getByText('weekly summary')).toHaveClass('bg-violet-200');
+    expect(screen.getAllByText('injury update')[0]).toHaveClass('bg-red-200');
   });
 });

--- a/apps/web/src/pages/journal.test.tsx
+++ b/apps/web/src/pages/journal.test.tsx
@@ -48,7 +48,7 @@ describe('JournalPage', () => {
     expect(within(firstCard).getByText('injury update')).toBeInTheDocument();
     expect(within(firstCard).getByText('Mar 6, 2026')).toBeInTheDocument();
     expect(
-      within(firstCard).getByText(/Sports med check in: cleared to reintroduce overhead work/i),
+      within(firstCard).getByText(/Sports med check-?in: cleared to reintroduce overhead work/i),
     ).toHaveTextContent(/\.\.\.$/);
     expect(within(firstCard).getByRole('link', { name: 'Mobility warm-up' })).toHaveAttribute(
       'href',

--- a/apps/web/src/pages/journal.test.tsx
+++ b/apps/web/src/pages/journal.test.tsx
@@ -23,12 +23,19 @@ describe('JournalPage', () => {
     const cardTitles = screen
       .getAllByRole('heading', { level: 2 })
       .map((heading) => heading.textContent);
-    expect(cardTitles).toEqual(mockJournalEntries.map((entry) => entry.title));
+    expect(cardTitles).toEqual(
+      [...mockJournalEntries]
+        .sort((left, right) => right.date.localeCompare(left.date))
+        .map((entry) => entry.title),
+    );
 
     const cards = container.querySelectorAll('[data-slot="journal-entry-card"]');
     expect(cards).toHaveLength(mockJournalEntries.length);
 
     const firstCard = cards[0] as HTMLElement;
+    expect(
+      within(firstCard).getByRole('link', { name: 'Open journal entry Shoulder SLAP Clearance' }),
+    ).toHaveAttribute('href', '/journal/journal-shoulder-slap-clearance');
     expect(within(firstCard).getByText('injury update')).toBeInTheDocument();
     expect(within(firstCard).getByText('Mar 6, 2026')).toBeInTheDocument();
     expect(
@@ -55,5 +62,17 @@ describe('JournalPage', () => {
     expect(screen.getAllByText('observation')[0]).toHaveClass('bg-sky-200');
     expect(screen.getByText('weekly summary')).toHaveClass('bg-violet-200');
     expect(screen.getAllByText('injury update')[0]).toHaveClass('bg-red-200');
+  });
+
+  it('links workout entity chips to the workout template detail route', () => {
+    render(
+      <MemoryRouter>
+        <JournalPage />
+      </MemoryRouter>,
+    );
+
+    for (const link of screen.getAllByRole('link', { name: 'Upper Push' })) {
+      expect(link).toHaveAttribute('href', '/workouts/template/upper-push');
+    }
   });
 });

--- a/apps/web/src/pages/journal.test.tsx
+++ b/apps/web/src/pages/journal.test.tsx
@@ -19,6 +19,7 @@ describe('JournalPage', () => {
         'Review coaching notes, milestones, observations, and injury updates in one chronological feed.',
       ),
     ).toBeInTheDocument();
+    expect(screen.getByRole('list', { name: 'Journal feed' })).toBeInTheDocument();
 
     const cardTitles = screen
       .getAllByRole('heading', { level: 2 })

--- a/apps/web/src/pages/journal.test.tsx
+++ b/apps/web/src/pages/journal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
@@ -19,7 +19,15 @@ describe('JournalPage', () => {
         'Review coaching notes, milestones, observations, and injury updates in one chronological feed.',
       ),
     ).toBeInTheDocument();
+    expect(screen.getByRole('toolbar', { name: 'Type filter' })).toBeInTheDocument();
+    expect(screen.getByRole('toolbar', { name: 'Linked entity filter' })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `Showing ${mockJournalEntries.length} of ${mockJournalEntries.length} entries`,
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByRole('list', { name: 'Journal feed' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Reset filters' })).not.toBeInTheDocument();
 
     const cardTitles = screen
       .getAllByRole('heading', { level: 2 })
@@ -75,5 +83,44 @@ describe('JournalPage', () => {
     for (const link of screen.getAllByRole('link', { name: 'Upper Push' })) {
       expect(link).toHaveAttribute('href', '/workouts/template/upper-push');
     }
+  });
+
+  it('filters entries by type and linked entity with AND logic and resets back to all entries', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <JournalPage />
+      </MemoryRouter>,
+    );
+
+    const injuryUpdateFilter = screen.getByRole('button', { name: 'Injury Update' });
+    const activitiesFilter = screen.getByRole('button', { name: 'Activities' });
+
+    fireEvent.click(injuryUpdateFilter);
+
+    expect(injuryUpdateFilter).toHaveAttribute('aria-pressed', 'true');
+    expect(injuryUpdateFilter).toHaveClass('bg-[var(--color-accent-mint)]');
+    expect(screen.getByText('Showing 2 of 9 entries')).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('heading', { level: 2 }).map((heading) => heading.textContent),
+    ).toEqual(['Shoulder SLAP Clearance', 'Easy bike flush settled Achilles stiffness']);
+
+    fireEvent.click(activitiesFilter);
+
+    expect(activitiesFilter).toHaveAttribute('aria-pressed', 'true');
+    expect(activitiesFilter).toHaveClass('bg-[var(--color-accent-mint)]');
+    expect(screen.getByText('Showing 1 of 9 entries')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Easy bike flush settled Achilles stiffness' }),
+    ).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="journal-entry-card"]')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Reset filters' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset filters' }));
+
+    expect(screen.getByText('Showing 9 of 9 entries')).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="journal-entry-card"]')).toHaveLength(
+      mockJournalEntries.length,
+    );
+    expect(screen.queryByRole('button', { name: 'Reset filters' })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/journal.test.tsx
+++ b/apps/web/src/pages/journal.test.tsx
@@ -48,7 +48,7 @@ describe('JournalPage', () => {
     expect(within(firstCard).getByText('injury update')).toBeInTheDocument();
     expect(within(firstCard).getByText('Mar 6, 2026')).toBeInTheDocument();
     expect(
-      within(firstCard).getByText(/Sports med check-?in: cleared to reintroduce overhead work/i),
+      within(firstCard).getByText(/Sports med check-in: cleared to reintroduce overhead work/i),
     ).toHaveTextContent(/\.\.\.$/);
     expect(within(firstCard).getByRole('link', { name: 'Mobility warm-up' })).toHaveAttribute(
       'href',

--- a/apps/web/src/pages/journal.tsx
+++ b/apps/web/src/pages/journal.tsx
@@ -1,61 +1,6 @@
 import { BookOpen } from 'lucide-react';
 
-import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { cn } from '@/lib/utils';
-
-type JournalEntryType = 'milestone' | 'observation' | 'weekly_summary';
-
-type JournalSampleEntry = {
-  contentPreview: string;
-  date: string;
-  title: string;
-  type: JournalEntryType;
-};
-
-const entryDateFormatter = new Intl.DateTimeFormat('en-US', {
-  day: 'numeric',
-  month: 'long',
-  year: 'numeric',
-});
-
-const badgeClassesByType: Record<JournalEntryType, string> = {
-  milestone:
-    'border-transparent bg-[var(--color-accent-mint)] text-on-mint dark:bg-emerald-500/20 dark:text-emerald-400',
-  observation:
-    'border-transparent bg-[var(--color-accent-cream)] text-on-cream dark:bg-amber-500/20 dark:text-amber-400',
-  weekly_summary:
-    'border-transparent bg-[var(--color-accent-pink)] text-on-pink dark:bg-pink-500/20 dark:text-pink-400',
-};
-
-const journalSampleEntries: JournalSampleEntry[] = [
-  {
-    contentPreview:
-      'Noticed a significant boost in morning energy after switching to earlier bedtime and keeping caffeine before noon.',
-    date: '2026-02-16',
-    title: 'Feeling More Energetic',
-    type: 'observation',
-  },
-  {
-    contentPreview:
-      'Ran my first 5K today in 28:32. Started training 8 weeks ago and finally felt confident pushing the last kilometer.',
-    date: '2026-02-28',
-    title: 'First 5K Completed!',
-    type: 'milestone',
-  },
-  {
-    contentPreview:
-      'Consistent with all habits this week. Weight trending down slightly, workouts felt steady, and recovery improved by Friday.',
-    date: '2026-03-02',
-    title: 'Week 12 Summary',
-    type: 'weekly_summary',
-  },
-];
-
-function formatJournalEntryDate(date: string) {
-  // Parse date-only strings at noon local time to avoid timezone shifts when formatting preview content.
-  return entryDateFormatter.format(new Date(`${date}T12:00:00`));
-}
+import { JournalFeed } from '@/features/journal';
 
 export function JournalPage() {
   return (
@@ -67,54 +12,14 @@ export function JournalPage() {
           </div>
           <div className="space-y-2">
             <h1 className="text-3xl font-semibold text-primary">Journal</h1>
-            <div className="space-y-1">
-              <p className="text-lg font-medium text-foreground">Coming Soon</p>
-              <p className="max-w-2xl text-sm text-muted">
-                Track your health observations, milestones, and weekly reflections.
-              </p>
-            </div>
+            <p className="max-w-2xl text-sm text-muted">
+              Review coaching notes, milestones, observations, and injury updates in one
+              chronological feed.
+            </p>
           </div>
         </div>
       </header>
-
-      <div className="space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted">
-          Preview entries
-        </p>
-        <div className="grid gap-4 xl:grid-cols-3">
-          {journalSampleEntries.map((entry) => (
-            <Card
-              key={`${entry.date}-${entry.title}`}
-              className="border-dashed bg-card/70 opacity-90"
-            >
-              <CardHeader className="gap-3">
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <Badge
-                    className={cn(
-                      'cursor-default px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em]',
-                      badgeClassesByType[entry.type],
-                    )}
-                    variant="secondary"
-                  >
-                    {entry.type}
-                  </Badge>
-                  <CardDescription className="text-xs font-medium uppercase tracking-[0.14em]">
-                    {formatJournalEntryDate(entry.date)}
-                  </CardDescription>
-                </div>
-                <CardTitle aria-level={2} className="text-xl text-foreground" role="heading">
-                  {entry.title}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="max-h-[4.5rem] overflow-hidden text-sm leading-6 text-muted">
-                  {entry.contentPreview}
-                </p>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      </div>
+      <JournalFeed />
     </section>
   );
 }

--- a/apps/web/src/pages/journal.tsx
+++ b/apps/web/src/pages/journal.tsx
@@ -19,7 +19,7 @@ export function JournalPage() {
           </div>
         </div>
       </header>
-      <JournalFeed />
+      <JournalFeed getEntryHref={(entryId) => `/journal/${entryId}`} />
     </section>
   );
 }


### PR DESCRIPTION
## Summary

This PR builds the journal prototype for Phase 1b by replacing the placeholder journal page with a usable feed and adding a dedicated journal entry detail view. It introduces mock journal data across multiple entry types, then layers on type and linked-entity filtering so reviewers can exercise the feed the way future real data will need to work. The detail page expands entries into full markdown-rendered notes and preserves navigation to related workouts, habits, and activities where routes already exist. The goal is to establish the journal interaction model now, with enough structure to plug into backend APIs later without reworking the page architecture.

## Key Changes

- Replaced the simplified journal page implementation with a reusable `journal` feature module under `apps/web/src/features/journal/`
- Added rich mock journal entries covering post-workout, milestone, observation, weekly summary, and injury update entry types
- Added a journal feed UI with:
  - newest-first ordering
  - type filters
  - linked entity filters
  - empty state when filters return no matches
  - preview text, type badges, and linked entity chips on each card
- Added a new journal entry detail route at `/journal/:entryId`
- Built a dedicated detail view that shows full entry content, metadata, and linked entities
- Added entity chips with iconography and contextual navigation for supported linked entity types
- Added lightweight journal-specific formatting and filtering utilities to keep presentation logic out of page components
- Added a custom markdown renderer for prototype content so mock entries can include headings, emphasis, code, lists, and paragraph breaks
- Added/updated page tests to cover journal feed behavior and the new entry detail page

## Technical Notes

- Journal data is still fully mock-driven; the new feature module is structured so the feed/detail components can later swap from static imports to query-backed data with minimal UI churn.
- Linked entity navigation is intentionally partial right now: workouts, habits, and activities route to existing prototype surfaces where possible, while unsupported entity types still render as non-link chips rather than broken links.
- The markdown renderer is intentionally small and scoped to known mock-content patterns. It escapes HTML before applying limited formatting, which keeps the prototype safe while avoiding a heavier markdown dependency at this stage.
- Reviewers should pay attention to the route assumptions in `EntityChip` and the current workout link shape (`/workouts/template/:id`), since that contract will matter once linked entities are backed by real IDs and API responses.

## Commits

- `fe8a8f8 feat(web): add journal feed filters`
- `1c5f797 fix(web): address journal detail review feedback`
- `df5b5e5 feat(web): add journal entry detail page`
- `a12a73a feat(web): build journal feed`
- `d036154 chore: finalize journal mock data review fixes`
- `6ab6a33 feat(web): add journal mock data`

## Tasks

- **Journal mock data with types and linked entities**: Create mock journal entries with post-workout, milestone, observation, weekly-summary, injury-update types and linked entity references
- **Journal feed with type badges and entity chips**: Chronological entry list with color-coded type badges, preview text, and linked entity chips
- **Journal entry detail page with linked entities**: Full entry detail with markdown content rendering and clickable linked entity chips
- **Journal filtering by type and linked entity**: Add filter controls for entry type and linked entity type on journal feed

## Diff Stats

```
apps/web/src/App.tsx                               |   2 +
 .../features/journal/components/entity-chip.tsx    |  60 +++++
 .../journal/components/journal-entry-detail.tsx    | 110 +++++++++
 .../features/journal/components/journal-feed.tsx   | 204 +++++++++++++++
 apps/web/src/features/journal/index.ts             |   5 +
 apps/web/src/features/journal/lib/filters.ts       |  49 ++++
 apps/web/src/features/journal/lib/formatters.ts    |  46 ++++
 apps/web/src/features/journal/lib/markdown.ts      |  79 ++++++
 apps/web/src/features/journal/lib/mock-data.ts     | 273 +++++++++++++++++++++
 apps/web/src/features/journal/lib/presentation.ts  |  13 +
 apps/web/src/features/journal/types.ts             |  24 ++
 apps/web/src/pages/journal-entry.test.tsx          |  79 ++++++
 apps/web/src/pages/journal-entry.tsx               |  30 +++
 apps/web/src/pages/journal.test.tsx                | 160 ++++++++----
 apps/web/src/pages/journal.tsx                     | 107 +-------
 15 files changed, 1089 insertions(+), 152 deletions(-)
```