### PR TITLE
Injuries & ailments tracking

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -20,7 +20,7 @@ const pageRoutes = [
   { heading: 'Journal', path: '/journal' },
   { heading: 'Profile', path: '/profile' },
   { heading: 'Equipment', path: '/profile/equipment' },
-  { heading: 'Injuries', path: '/profile/injuries' },
+  { heading: 'Health Tracking', path: '/profile/injuries' },
   { heading: 'Resources', path: '/profile/resources' },
   { heading: 'Settings', path: '/settings' },
 ] as const;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,8 +7,8 @@ import { EquipmentRoutePage } from '@/pages/equipment';
 import { FoodsPage } from '@/pages/foods';
 import { JournalEntryPage } from '@/pages/journal-entry';
 import { HabitsPage } from '@/pages/habits';
+import { InjuriesPage } from '@/pages/injuries';
 import { JournalPage } from '@/pages/journal';
-import { ProfileInjuriesPage } from '@/pages/profile-injuries';
 import { ProfileResourcesPage } from '@/pages/profile-resources';
 import { NutritionPage } from '@/pages/nutrition';
 import { ProfilePage } from '@/pages/profile';
@@ -36,7 +36,8 @@ function AppRoutes() {
         <Route element={<JournalEntryPage />} path="/journal/:entryId" />
         <Route element={<ProfilePage />} path="/profile" />
         <Route element={<EquipmentRoutePage />} path="/profile/equipment" />
-        <Route element={<ProfileInjuriesPage />} path="/profile/injuries" />
+        <Route element={<InjuriesPage />} path="/profile/injuries" />
+        <Route element={<InjuriesPage />} path="/profile/injuries/:conditionId" />
         <Route element={<ProfileResourcesPage />} path="/profile/resources" />
         <Route element={<SettingsPage />} path="/settings" />
       </Routes>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -8,6 +8,7 @@ import { FoodsPage } from '@/pages/foods';
 import { JournalEntryPage } from '@/pages/journal-entry';
 import { HabitsPage } from '@/pages/habits';
 import { InjuriesPage } from '@/pages/injuries';
+import { InjuryDetailPage } from '@/pages/injury-detail';
 import { JournalPage } from '@/pages/journal';
 import { ProfileResourcesPage } from '@/pages/profile-resources';
 import { NutritionPage } from '@/pages/nutrition';
@@ -37,7 +38,7 @@ function AppRoutes() {
         <Route element={<ProfilePage />} path="/profile" />
         <Route element={<EquipmentRoutePage />} path="/profile/equipment" />
         <Route element={<InjuriesPage />} path="/profile/injuries" />
-        <Route element={<InjuriesPage />} path="/profile/injuries/:conditionId" />
+        <Route element={<InjuryDetailPage />} path="/profile/injuries/:conditionId" />
         <Route element={<ProfileResourcesPage />} path="/profile/resources" />
         <Route element={<SettingsPage />} path="/settings" />
       </Routes>

--- a/apps/web/src/features/injuries/components/condition-detail.tsx
+++ b/apps/web/src/features/injuries/components/condition-detail.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ProtocolList } from './protocol-list';
 import type {
   ConditionStatus,
   HealthCondition,
@@ -220,6 +221,8 @@ export function ConditionDetail({ condition }: ConditionDetailProps) {
           </ol>
         </CardContent>
       </Card>
+
+      <ProtocolList protocols={condition.protocols} />
 
       <Card className="py-6 shadow-sm">
         <CardHeader className="gap-2">

--- a/apps/web/src/features/injuries/components/condition-detail.tsx
+++ b/apps/web/src/features/injuries/components/condition-detail.tsx
@@ -1,0 +1,263 @@
+import { ArrowLeftIcon, CalendarDaysIcon, MapPinIcon } from 'lucide-react';
+import { Link } from 'react-router';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import type {
+  ConditionStatus,
+  HealthCondition,
+  LinkedJournalEntryType,
+  TimelineEventType,
+} from '../types';
+
+type ConditionDetailProps = {
+  condition: HealthCondition;
+};
+
+const fullDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+const STATUS_META: Record<
+  ConditionStatus,
+  {
+    badgeClassName: string;
+    label: string;
+  }
+> = {
+  active: {
+    badgeClassName:
+      'border-transparent bg-destructive text-white dark:bg-destructive/70 dark:text-white',
+    label: 'Active',
+  },
+  monitoring: {
+    badgeClassName:
+      'border-transparent bg-amber-200 text-amber-950 dark:bg-amber-500/20 dark:text-amber-300',
+    label: 'Monitoring',
+  },
+  resolved: {
+    badgeClassName:
+      'border-transparent bg-emerald-200 text-emerald-950 dark:bg-emerald-500/20 dark:text-emerald-300',
+    label: 'Resolved',
+  },
+};
+
+const TIMELINE_META: Record<
+  TimelineEventType,
+  {
+    badgeClassName: string;
+    dotClassName: string;
+    label: string;
+  }
+> = {
+  onset: {
+    badgeClassName:
+      'border-transparent bg-rose-200 text-rose-950 dark:bg-rose-500/20 dark:text-rose-300',
+    dotClassName: 'bg-rose-500 ring-4 ring-rose-500/15',
+    label: 'Onset',
+  },
+  flare: {
+    badgeClassName:
+      'border-transparent bg-orange-200 text-orange-950 dark:bg-orange-500/20 dark:text-orange-300',
+    dotClassName: 'bg-orange-500 ring-4 ring-orange-500/15',
+    label: 'Flare',
+  },
+  improvement: {
+    badgeClassName:
+      'border-transparent bg-emerald-200 text-emerald-950 dark:bg-emerald-500/20 dark:text-emerald-300',
+    dotClassName: 'bg-emerald-500 ring-4 ring-emerald-500/15',
+    label: 'Improvement',
+  },
+  treatment: {
+    badgeClassName:
+      'border-transparent bg-sky-200 text-sky-950 dark:bg-sky-500/20 dark:text-sky-300',
+    dotClassName: 'bg-sky-500 ring-4 ring-sky-500/15',
+    label: 'Treatment',
+  },
+  milestone: {
+    badgeClassName:
+      'border-transparent bg-[var(--color-accent-cream)] text-[var(--color-on-accent)] dark:bg-yellow-500/20 dark:text-yellow-300',
+    dotClassName: 'bg-yellow-500 ring-4 ring-yellow-500/15',
+    label: 'Milestone',
+  },
+};
+
+const JOURNAL_META: Record<
+  LinkedJournalEntryType,
+  {
+    badgeClassName: string;
+    label: string;
+  }
+> = {
+  milestone: {
+    badgeClassName:
+      'border-transparent bg-[var(--color-accent-mint)] text-[var(--color-on-accent)] dark:bg-emerald-500/20 dark:text-emerald-300',
+    label: 'Milestone',
+  },
+  observation: {
+    badgeClassName:
+      'border-transparent bg-[var(--color-accent-cream)] text-[var(--color-on-accent)] dark:bg-amber-500/20 dark:text-amber-300',
+    label: 'Observation',
+  },
+  weekly_summary: {
+    badgeClassName:
+      'border-transparent bg-[var(--color-accent-pink)] text-[var(--color-on-accent)] dark:bg-pink-500/20 dark:text-pink-300',
+    label: 'Weekly Summary',
+  },
+};
+
+function parseDate(date: string) {
+  return new Date(`${date}T12:00:00`);
+}
+
+function formatDate(date: string) {
+  return fullDateFormatter.format(parseDate(date));
+}
+
+function sortByNewest<T extends { date: string }>(items: T[]) {
+  return [...items].sort(
+    (left, right) => parseDate(right.date).getTime() - parseDate(left.date).getTime(),
+  );
+}
+
+export function ConditionDetail({ condition }: ConditionDetailProps) {
+  const timeline = sortByNewest(condition.timeline);
+  const linkedEntries = sortByNewest(condition.linkedJournalEntries);
+
+  return (
+    <section className="mx-auto flex w-full max-w-5xl flex-col gap-6 pb-10">
+      <Button asChild className="w-fit gap-2" size="sm" variant="ghost">
+        <Link to="/profile/injuries">
+          <ArrowLeftIcon aria-hidden="true" className="size-4" />
+          Back to Health Tracking
+        </Link>
+      </Button>
+
+      <Card className="overflow-hidden border-transparent bg-gradient-to-br from-[var(--color-accent-pink)]/35 via-card to-[var(--color-accent-cream)]/45 py-0 shadow-sm dark:border-border/60 dark:from-secondary dark:via-card dark:to-secondary">
+        <CardHeader className="gap-5 border-b border-border/50 py-7">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div className="space-y-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                Condition overview
+              </p>
+              <div className="space-y-2">
+                <CardTitle className="text-3xl font-semibold tracking-tight text-primary sm:text-4xl">
+                  {condition.name}
+                </CardTitle>
+                <CardDescription className="max-w-3xl text-sm leading-6 text-muted-foreground sm:text-base">
+                  {condition.description}
+                </CardDescription>
+              </div>
+            </div>
+
+            <Badge className={STATUS_META[condition.status].badgeClassName}>
+              {STATUS_META[condition.status].label}
+            </Badge>
+          </div>
+        </CardHeader>
+
+        <CardContent className="grid gap-3 px-6 py-5 sm:grid-cols-2">
+          <div className="rounded-2xl border border-border/60 bg-background/80 px-4 py-4 shadow-sm">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+              Body area
+            </p>
+            <div className="mt-3 flex items-center gap-2 text-sm font-medium text-foreground">
+              <MapPinIcon aria-hidden="true" className="size-4 text-muted-foreground" />
+              {condition.bodyArea}
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-border/60 bg-background/80 px-4 py-4 shadow-sm">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+              Onset date
+            </p>
+            <div className="mt-3 flex items-center gap-2 text-sm font-medium text-foreground">
+              <CalendarDaysIcon aria-hidden="true" className="size-4 text-muted-foreground" />
+              {formatDate(condition.onsetDate)}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="py-6 shadow-sm">
+        <CardHeader className="gap-2">
+          <CardTitle className="text-2xl text-foreground">Timeline</CardTitle>
+          <CardDescription>
+            Most recent changes first to keep the current recovery picture visible.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ol className="relative space-y-5 border-l border-border/70 pl-6">
+            {timeline.map((item) => (
+              <li className="relative space-y-3" key={`${item.date}-${item.type}-${item.event}`}>
+                <span
+                  aria-hidden="true"
+                  className={`absolute -left-[1.95rem] top-1.5 size-3 rounded-full ${TIMELINE_META[item.type].dotClassName}`}
+                />
+                <div className="flex flex-col gap-3 rounded-2xl border border-border/60 bg-card/80 p-4 shadow-sm">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="space-y-1">
+                      <p className="text-sm font-semibold text-foreground">
+                        {formatDate(item.date)}
+                      </p>
+                      <p className="text-sm leading-6 text-foreground">{item.event}</p>
+                    </div>
+                    <Badge className={TIMELINE_META[item.type].badgeClassName}>
+                      {TIMELINE_META[item.type].label}
+                    </Badge>
+                  </div>
+                  {item.notes ? (
+                    <p className="rounded-xl bg-background/80 px-3 py-2 text-sm leading-6 text-muted-foreground">
+                      {item.notes}
+                    </p>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ol>
+        </CardContent>
+      </Card>
+
+      <Card className="py-6 shadow-sm">
+        <CardHeader className="gap-2">
+          <CardTitle className="text-2xl text-foreground">Related Journal Entries</CardTitle>
+          <CardDescription>
+            Linked reflections, flare notes, and milestone updates for this condition.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {linkedEntries.length > 0 ? (
+            <div className="grid gap-3">
+              {linkedEntries.map((entry) => (
+                <Link className="block cursor-pointer" key={entry.id} to={`/journal/${entry.id}`}>
+                  <article className="rounded-2xl border border-border/60 bg-card/80 p-4 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="space-y-1">
+                        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                          {formatDate(entry.date)}
+                        </p>
+                        <h3 className="text-sm font-semibold text-foreground sm:text-base">
+                          {entry.title}
+                        </h3>
+                      </div>
+                      <Badge className={JOURNAL_META[entry.type].badgeClassName}>
+                        {JOURNAL_META[entry.type].label}
+                      </Badge>
+                    </div>
+                  </article>
+                </Link>
+              ))}
+            </div>
+          ) : (
+            <p className="rounded-2xl border border-dashed border-border/70 bg-background/70 px-4 py-5 text-sm text-muted-foreground">
+              No journal entries linked to this condition
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/apps/web/src/features/injuries/components/condition-detail.tsx
+++ b/apps/web/src/features/injuries/components/condition-detail.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { ProtocolList } from './protocol-list';
+import { SeverityChart } from './severity-chart';
 import type {
   ConditionStatus,
   HealthCondition,
@@ -223,6 +224,8 @@ export function ConditionDetail({ condition }: ConditionDetailProps) {
       </Card>
 
       <ProtocolList protocols={condition.protocols} />
+
+      <SeverityChart severityHistory={condition.severityHistory} timeline={condition.timeline} />
 
       <Card className="py-6 shadow-sm">
         <CardHeader className="gap-2">

--- a/apps/web/src/features/injuries/components/condition-detail.tsx
+++ b/apps/web/src/features/injuries/components/condition-detail.tsx
@@ -194,7 +194,7 @@ export function ConditionDetail({ condition }: ConditionDetailProps) {
         <CardContent>
           <ol className="relative space-y-5 border-l border-border/70 pl-6">
             {timeline.map((item) => (
-              <li className="relative space-y-3" key={`${item.date}-${item.type}-${item.event}`}>
+              <li className="relative space-y-3" key={item.id}>
                 <span
                   aria-hidden="true"
                   className={`absolute -left-[1.95rem] top-1.5 size-3 rounded-full ${TIMELINE_META[item.type].dotClassName}`}

--- a/apps/web/src/features/injuries/components/conditions-list.tsx
+++ b/apps/web/src/features/injuries/components/conditions-list.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type CSSProperties, type FormEvent } from 'react';
+import { useMemo, useState, type CSSProperties, type FormEvent } from 'react';
 import { ArrowLeftIcon, ArrowUpDownIcon, CalendarDaysIcon, ClipboardPlusIcon } from 'lucide-react';
 import { Link } from 'react-router';
 
@@ -23,13 +23,11 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import { cn } from '@/lib/utils';
 import { mockHealthConditions } from '../lib/mock-data';
 import type { ConditionStatus, HealthCondition } from '../types';
 
 type ConditionsListProps = {
   conditions?: HealthCondition[];
-  selectedConditionId?: string;
 };
 
 type ConditionSortOption = 'status' | 'onset-date';
@@ -47,6 +45,8 @@ const STATUS_ORDER: Record<ConditionStatus, number> = {
   monitoring: 1,
   resolved: 2,
 };
+
+const CONDITION_STATUSES = ['active', 'monitoring', 'resolved'] as const;
 
 const SORT_OPTIONS: Array<{ description: string; label: string; value: ConditionSortOption }> = [
   {
@@ -143,26 +143,27 @@ function formatConditionSummary(conditions: HealthCondition[]) {
   return `${conditions.length} ${conditionLabel} (${counts.active} ${STATUS_META.active.summaryLabel}, ${counts.monitoring} ${STATUS_META.monitoring.summaryLabel}, ${counts.resolved} ${STATUS_META.resolved.summaryLabel})`;
 }
 
+function parseDate(date: string) {
+  return new Date(`${date}T12:00:00`);
+}
+
 function sortConditions(conditions: HealthCondition[], sortBy: ConditionSortOption) {
   return [...conditions].sort((left, right) => {
-    if (sortBy === 'status') {
-      const statusDifference = STATUS_ORDER[left.status] - STATUS_ORDER[right.status];
+    const statusDifference = STATUS_ORDER[left.status] - STATUS_ORDER[right.status];
+    const onsetDifference =
+      parseDate(right.onsetDate).getTime() - parseDate(left.onsetDate).getTime();
 
+    if (sortBy === 'status') {
       if (statusDifference !== 0) {
         return statusDifference;
       }
-    }
-
-    const onsetDifference =
-      new Date(right.onsetDate).getTime() - new Date(left.onsetDate).getTime();
-
-    if (onsetDifference !== 0) {
-      return onsetDifference;
-    }
-
-    if (sortBy === 'onset-date') {
-      const statusDifference = STATUS_ORDER[left.status] - STATUS_ORDER[right.status];
-
+      if (onsetDifference !== 0) {
+        return onsetDifference;
+      }
+    } else {
+      if (onsetDifference !== 0) {
+        return onsetDifference;
+      }
       if (statusDifference !== 0) {
         return statusDifference;
       }
@@ -172,23 +173,21 @@ function sortConditions(conditions: HealthCondition[], sortBy: ConditionSortOpti
   });
 }
 
-export function ConditionsList({
-  conditions = mockHealthConditions,
-  selectedConditionId,
-}: ConditionsListProps) {
-  const [localConditions, setLocalConditions] = useState<HealthCondition[]>(() => conditions);
+export function ConditionsList({ conditions = mockHealthConditions }: ConditionsListProps) {
+  const [addedConditions, setAddedConditions] = useState<HealthCondition[]>([]);
   const [sortBy, setSortBy] = useState<ConditionSortOption>('status');
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
   const [draftCondition, setDraftCondition] = useState<ConditionDraft>(() => getDefaultDraft());
 
-  useEffect(() => {
-    setLocalConditions(conditions);
-  }, [conditions]);
-
-  const visibleConditions = sortConditions(localConditions, sortBy);
-  const conditionCounts = getConditionCounts(localConditions);
-  const selectedCondition =
-    visibleConditions.find((condition) => condition.id === selectedConditionId) ?? null;
+  const allConditions = useMemo(
+    () => [...addedConditions, ...conditions],
+    [addedConditions, conditions],
+  );
+  const visibleConditions = useMemo(
+    () => sortConditions(allConditions, sortBy),
+    [allConditions, sortBy],
+  );
+  const conditionCounts = useMemo(() => getConditionCounts(allConditions), [allConditions]);
 
   function updateDraft<K extends keyof ConditionDraft>(field: K, value: ConditionDraft[K]) {
     setDraftCondition((currentDraft) => ({
@@ -213,7 +212,7 @@ export function ConditionsList({
       return;
     }
 
-    setLocalConditions((currentConditions) => [
+    setAddedConditions((currentConditions) => [
       {
         id: createConditionId(name),
         name,
@@ -274,7 +273,7 @@ export function ConditionsList({
             <div className="space-y-2">
               <CardTitle className="text-xl text-foreground">Condition overview</CardTitle>
               <CardDescription className="max-w-2xl text-sm text-muted-foreground">
-                {formatConditionSummary(localConditions)}
+                {formatConditionSummary(allConditions)}
               </CardDescription>
             </div>
 
@@ -308,7 +307,7 @@ export function ConditionsList({
         </CardHeader>
 
         <CardContent className="grid gap-3 px-6 py-5 sm:grid-cols-3">
-          {(['active', 'monitoring', 'resolved'] as const).map((status) => {
+          {CONDITION_STATUSES.map((status) => {
             return (
               <div
                 className="rounded-2xl border border-border/60 bg-background/75 px-4 py-3 shadow-sm backdrop-blur"
@@ -335,51 +334,11 @@ export function ConditionsList({
         </CardContent>
       </Card>
 
-      {selectedCondition ? (
-        <Card className="gap-3 border-primary/35 bg-primary/5 py-5 shadow-sm">
-          <CardHeader className="gap-2">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <div className="space-y-1">
-                <CardTitle className="text-lg text-foreground">{selectedCondition.name}</CardTitle>
-                <CardDescription>
-                  Route selected:{' '}
-                  <span className="font-medium text-foreground">{selectedCondition.bodyArea}</span>
-                </CardDescription>
-              </div>
-              <Badge className={STATUS_META[selectedCondition.status].badgeClassName}>
-                {STATUS_META[selectedCondition.status].label}
-              </Badge>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-3 pt-0">
-            <p className="text-sm text-muted-foreground">
-              The detail route is active for this condition. This task keeps the list experience in
-              place and highlights the selected record until the full detail page lands.
-            </p>
-            <Button asChild className="w-fit" size="sm" variant="outline">
-              <Link to="/profile/injuries">Back to all conditions</Link>
-            </Button>
-          </CardContent>
-        </Card>
-      ) : null}
-
       <div className="grid gap-4 lg:grid-cols-2">
         {visibleConditions.map((condition) => {
-          const isSelected = condition.id === selectedConditionId;
-
           return (
-            <Link
-              aria-current={isSelected ? 'page' : undefined}
-              className="block cursor-pointer"
-              key={condition.id}
-              to={`/profile/injuries/${condition.id}`}
-            >
-              <Card
-                className={cn(
-                  'h-full gap-4 py-5 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md focus-within:border-primary/50',
-                  isSelected && 'border-primary/60 bg-primary/5 shadow-md ring-2 ring-primary/15',
-                )}
-              >
+            <Link className="block cursor-pointer" key={condition.id} to={`/profile/injuries/${condition.id}`}>
+              <Card className="h-full gap-4 py-5 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md focus-within:border-primary/50">
                 <CardHeader className="gap-3">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="space-y-3">

--- a/apps/web/src/features/injuries/components/conditions-list.tsx
+++ b/apps/web/src/features/injuries/components/conditions-list.tsx
@@ -1,0 +1,517 @@
+import { useEffect, useState, type CSSProperties, type FormEvent } from 'react';
+import { ArrowLeftIcon, ArrowUpDownIcon, CalendarDaysIcon, ClipboardPlusIcon } from 'lucide-react';
+import { Link } from 'react-router';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+import { mockHealthConditions } from '../lib/mock-data';
+import type { ConditionStatus, HealthCondition } from '../types';
+
+type ConditionsListProps = {
+  conditions?: HealthCondition[];
+  selectedConditionId?: string;
+};
+
+type ConditionSortOption = 'status' | 'onset-date';
+
+type ConditionDraft = {
+  bodyArea: string;
+  description: string;
+  name: string;
+  onsetDate: string;
+  status: ConditionStatus;
+};
+
+const STATUS_ORDER: Record<ConditionStatus, number> = {
+  active: 0,
+  monitoring: 1,
+  resolved: 2,
+};
+
+const SORT_OPTIONS: Array<{ description: string; label: string; value: ConditionSortOption }> = [
+  {
+    description: 'Active first, then monitoring and resolved.',
+    label: 'Status',
+    value: 'status',
+  },
+  {
+    description: 'Newest onset date first.',
+    label: 'Onset date',
+    value: 'onset-date',
+  },
+];
+
+const STATUS_META: Record<
+  ConditionStatus,
+  {
+    badgeClassName: string;
+    label: string;
+    summaryLabel: string;
+  }
+> = {
+  active: {
+    badgeClassName:
+      'border-transparent bg-destructive text-white dark:bg-destructive/70 dark:text-white',
+    label: 'Active',
+    summaryLabel: 'active',
+  },
+  monitoring: {
+    badgeClassName:
+      'border-transparent bg-amber-200 text-amber-950 dark:bg-amber-500/20 dark:text-amber-300',
+    label: 'Monitoring',
+    summaryLabel: 'monitoring',
+  },
+  resolved: {
+    badgeClassName:
+      'border-transparent bg-emerald-200 text-emerald-950 dark:bg-emerald-500/20 dark:text-emerald-300',
+    label: 'Resolved',
+    summaryLabel: 'resolved',
+  },
+};
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+const lineClampStyle: CSSProperties = {
+  display: '-webkit-box',
+  overflow: 'hidden',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: 2,
+};
+
+function getDefaultDraft(): ConditionDraft {
+  return {
+    bodyArea: '',
+    description: '',
+    name: '',
+    onsetDate: new Date().toISOString().slice(0, 10),
+    status: 'monitoring',
+  };
+}
+
+function createConditionId(name: string) {
+  const baseSlug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return `${baseSlug || 'condition'}-${Date.now().toString(36)}`;
+}
+
+function getConditionCounts(conditions: HealthCondition[]) {
+  return conditions.reduce(
+    (counts, condition) => {
+      counts[condition.status] += 1;
+      return counts;
+    },
+    {
+      active: 0,
+      monitoring: 0,
+      resolved: 0,
+    },
+  );
+}
+
+function formatConditionSummary(conditions: HealthCondition[]) {
+  const counts = getConditionCounts(conditions);
+  const conditionLabel = conditions.length === 1 ? 'condition' : 'conditions';
+
+  return `${conditions.length} ${conditionLabel} (${counts.active} ${STATUS_META.active.summaryLabel}, ${counts.monitoring} ${STATUS_META.monitoring.summaryLabel}, ${counts.resolved} ${STATUS_META.resolved.summaryLabel})`;
+}
+
+function sortConditions(conditions: HealthCondition[], sortBy: ConditionSortOption) {
+  return [...conditions].sort((left, right) => {
+    if (sortBy === 'status') {
+      const statusDifference = STATUS_ORDER[left.status] - STATUS_ORDER[right.status];
+
+      if (statusDifference !== 0) {
+        return statusDifference;
+      }
+    }
+
+    const onsetDifference =
+      new Date(right.onsetDate).getTime() - new Date(left.onsetDate).getTime();
+
+    if (onsetDifference !== 0) {
+      return onsetDifference;
+    }
+
+    if (sortBy === 'onset-date') {
+      const statusDifference = STATUS_ORDER[left.status] - STATUS_ORDER[right.status];
+
+      if (statusDifference !== 0) {
+        return statusDifference;
+      }
+    }
+
+    return left.name.localeCompare(right.name);
+  });
+}
+
+export function ConditionsList({
+  conditions = mockHealthConditions,
+  selectedConditionId,
+}: ConditionsListProps) {
+  const [localConditions, setLocalConditions] = useState<HealthCondition[]>(() => conditions);
+  const [sortBy, setSortBy] = useState<ConditionSortOption>('status');
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+  const [draftCondition, setDraftCondition] = useState<ConditionDraft>(() => getDefaultDraft());
+
+  useEffect(() => {
+    setLocalConditions(conditions);
+  }, [conditions]);
+
+  const visibleConditions = sortConditions(localConditions, sortBy);
+  const conditionCounts = getConditionCounts(localConditions);
+  const selectedCondition =
+    visibleConditions.find((condition) => condition.id === selectedConditionId) ?? null;
+
+  function updateDraft<K extends keyof ConditionDraft>(field: K, value: ConditionDraft[K]) {
+    setDraftCondition((currentDraft) => ({
+      ...currentDraft,
+      [field]: value,
+    }));
+  }
+
+  function closeDialog() {
+    setIsAddDialogOpen(false);
+    setDraftCondition(getDefaultDraft());
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const name = draftCondition.name.trim();
+    const bodyArea = draftCondition.bodyArea.trim();
+    const description = draftCondition.description.trim();
+
+    if (!name || !bodyArea || !draftCondition.onsetDate || !description) {
+      return;
+    }
+
+    setLocalConditions((currentConditions) => [
+      {
+        id: createConditionId(name),
+        name,
+        bodyArea,
+        status: draftCondition.status,
+        onsetDate: draftCondition.onsetDate,
+        description,
+        timeline: [],
+        protocols: [],
+        linkedJournalEntries: [],
+        severityHistory: [],
+      },
+      ...currentConditions,
+    ]);
+
+    closeDialog();
+  }
+
+  return (
+    <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 pb-10">
+      <header className="flex flex-col gap-4">
+        <Button asChild className="w-fit gap-2" size="sm" variant="ghost">
+          <Link to="/profile">
+            <ArrowLeftIcon aria-hidden="true" className="size-4" />
+            Profile
+          </Link>
+        </Button>
+
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+              Recovery and readiness
+            </p>
+            <div className="space-y-2">
+              <h1 className="text-3xl font-semibold tracking-tight text-primary sm:text-4xl">
+                Health Tracking
+              </h1>
+              <p className="max-w-3xl text-sm text-muted-foreground sm:text-base">
+                Keep the current condition list visible, sort the recovery picture quickly, and
+                capture new issues without leaving the prototype flow.
+              </p>
+            </div>
+          </div>
+
+          <Button
+            className="gap-2 self-start lg:self-auto"
+            onClick={() => setIsAddDialogOpen(true)}
+          >
+            <ClipboardPlusIcon aria-hidden="true" className="size-4" />
+            Add Condition
+          </Button>
+        </div>
+      </header>
+
+      <Card className="gap-5 overflow-hidden border-transparent bg-gradient-to-br from-[var(--color-accent-pink)]/40 via-card to-[var(--color-accent-cream)]/45 py-0 shadow-sm dark:border-border/60 dark:from-secondary dark:via-card dark:to-secondary">
+        <CardHeader className="gap-4 border-b border-border/50 py-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-2">
+              <CardTitle className="text-xl text-foreground">Condition overview</CardTitle>
+              <CardDescription className="max-w-2xl text-sm text-muted-foreground">
+                {formatConditionSummary(localConditions)}
+              </CardDescription>
+            </div>
+
+            <div className="w-full max-w-xs space-y-2">
+              <Label className="text-sm font-medium text-foreground" htmlFor="condition-sort">
+                Sort conditions
+              </Label>
+              <Select
+                onValueChange={(value) => setSortBy(value as ConditionSortOption)}
+                value={sortBy}
+              >
+                <SelectTrigger aria-label="Sort conditions" id="condition-sort">
+                  <div className="flex items-center gap-2">
+                    <ArrowUpDownIcon aria-hidden="true" className="size-4 text-muted-foreground" />
+                    <SelectValue />
+                  </div>
+                </SelectTrigger>
+                <SelectContent>
+                  {SORT_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                {SORT_OPTIONS.find((option) => option.value === sortBy)?.description}
+              </p>
+            </div>
+          </div>
+        </CardHeader>
+
+        <CardContent className="grid gap-3 px-6 py-5 sm:grid-cols-3">
+          {(['active', 'monitoring', 'resolved'] as const).map((status) => {
+            return (
+              <div
+                className="rounded-2xl border border-border/60 bg-background/75 px-4 py-3 shadow-sm backdrop-blur"
+                key={status}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <Badge className={STATUS_META[status].badgeClassName}>
+                    {STATUS_META[status].label}
+                  </Badge>
+                  <span className="text-2xl font-semibold text-foreground">
+                    {conditionCounts[status]}
+                  </span>
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  {status === 'active'
+                    ? 'Needs current training adjustments or symptom management.'
+                    : status === 'monitoring'
+                      ? 'Stable enough to watch, but still worth tracking.'
+                      : 'Resolved enough to keep as historical context.'}
+                </p>
+              </div>
+            );
+          })}
+        </CardContent>
+      </Card>
+
+      {selectedCondition ? (
+        <Card className="gap-3 border-primary/35 bg-primary/5 py-5 shadow-sm">
+          <CardHeader className="gap-2">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="space-y-1">
+                <CardTitle className="text-lg text-foreground">{selectedCondition.name}</CardTitle>
+                <CardDescription>
+                  Route selected:{' '}
+                  <span className="font-medium text-foreground">{selectedCondition.bodyArea}</span>
+                </CardDescription>
+              </div>
+              <Badge className={STATUS_META[selectedCondition.status].badgeClassName}>
+                {STATUS_META[selectedCondition.status].label}
+              </Badge>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-3 pt-0">
+            <p className="text-sm text-muted-foreground">
+              The detail route is active for this condition. This task keeps the list experience in
+              place and highlights the selected record until the full detail page lands.
+            </p>
+            <Button asChild className="w-fit" size="sm" variant="outline">
+              <Link to="/profile/injuries">Back to all conditions</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {visibleConditions.map((condition) => {
+          const isSelected = condition.id === selectedConditionId;
+
+          return (
+            <Link
+              aria-current={isSelected ? 'page' : undefined}
+              className="block cursor-pointer"
+              key={condition.id}
+              to={`/profile/injuries/${condition.id}`}
+            >
+              <Card
+                className={cn(
+                  'h-full gap-4 py-5 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md focus-within:border-primary/50',
+                  isSelected && 'border-primary/60 bg-primary/5 shadow-md ring-2 ring-primary/15',
+                )}
+              >
+                <CardHeader className="gap-3">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="space-y-3">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge className={STATUS_META[condition.status].badgeClassName}>
+                          {STATUS_META[condition.status].label}
+                        </Badge>
+                        <span className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                          {condition.bodyArea}
+                        </span>
+                      </div>
+
+                      <div className="space-y-1">
+                        <CardTitle
+                          aria-level={3}
+                          className="text-xl text-foreground"
+                          role="heading"
+                        >
+                          {condition.name}
+                        </CardTitle>
+                        <CardDescription className="flex items-center gap-2 text-sm">
+                          <CalendarDaysIcon aria-hidden="true" className="size-4" />
+                          Onset {dateFormatter.format(new Date(condition.onsetDate))}
+                        </CardDescription>
+                      </div>
+                    </div>
+
+                    <span className="rounded-full border border-border/70 bg-background/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                      Open
+                    </span>
+                  </div>
+                </CardHeader>
+
+                <CardContent className="space-y-3 pt-0">
+                  <p className="text-sm leading-6 text-muted-foreground" style={lineClampStyle}>
+                    {condition.description}
+                  </p>
+                </CardContent>
+              </Card>
+            </Link>
+          );
+        })}
+      </div>
+
+      <Dialog
+        onOpenChange={(open) => (open ? setIsAddDialogOpen(true) : closeDialog())}
+        open={isAddDialogOpen}
+      >
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Add Condition</DialogTitle>
+            <DialogDescription>
+              Create a new locally tracked condition with the core details needed for the list view.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form className="grid gap-4" onSubmit={handleSubmit}>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="space-y-2">
+                <span className="text-sm font-medium text-foreground">Name</span>
+                <Input
+                  aria-label="Condition name"
+                  onChange={(event) => updateDraft('name', event.target.value)}
+                  placeholder="Lumbar strain"
+                  required
+                  value={draftCondition.name}
+                />
+              </label>
+
+              <label className="space-y-2">
+                <span className="text-sm font-medium text-foreground">Body area</span>
+                <Input
+                  aria-label="Body area"
+                  onChange={(event) => updateDraft('bodyArea', event.target.value)}
+                  placeholder="Lower back"
+                  required
+                  value={draftCondition.bodyArea}
+                />
+              </label>
+
+              <label className="space-y-2">
+                <span className="text-sm font-medium text-foreground">Status</span>
+                <Select
+                  onValueChange={(value) => updateDraft('status', value as ConditionStatus)}
+                  value={draftCondition.status}
+                >
+                  <SelectTrigger aria-label="Condition status">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(['active', 'monitoring', 'resolved'] as const).map((status) => (
+                      <SelectItem key={status} value={status}>
+                        {STATUS_META[status].label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </label>
+
+              <label className="space-y-2">
+                <span className="text-sm font-medium text-foreground">Onset date</span>
+                <Input
+                  aria-label="Onset date"
+                  onChange={(event) => updateDraft('onsetDate', event.target.value)}
+                  required
+                  type="date"
+                  value={draftCondition.onsetDate}
+                />
+              </label>
+            </div>
+
+            <label className="space-y-2">
+              <span className="text-sm font-medium text-foreground">Description</span>
+              <Textarea
+                aria-label="Condition description"
+                className="min-h-28"
+                onChange={(event) => updateDraft('description', event.target.value)}
+                placeholder="Brief note about symptoms, triggers, or what changed."
+                required
+                value={draftCondition.description}
+              />
+            </label>
+
+            <DialogFooter>
+              <Button onClick={closeDialog} type="button" variant="outline">
+                Cancel
+              </Button>
+              <Button type="submit">Save Condition</Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}

--- a/apps/web/src/features/injuries/components/protocol-list.tsx
+++ b/apps/web/src/features/injuries/components/protocol-list.tsx
@@ -1,0 +1,384 @@
+import { useEffect, useState, type FormEvent } from 'react';
+import { CalendarDaysIcon, ClipboardPlusIcon } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import type { Protocol, ProtocolStatus } from '../types';
+
+type ProtocolListProps = {
+  protocols: Protocol[];
+};
+
+type ProtocolDraft = {
+  name: string;
+  notes: string;
+  startDate: string;
+  status: ProtocolStatus;
+};
+
+const fullDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+const PROTOCOL_STATUS_ORDER: Record<ProtocolStatus, number> = {
+  active: 0,
+  completed: 1,
+  discontinued: 2,
+};
+
+const PROTOCOL_STATUS_META: Record<
+  ProtocolStatus,
+  {
+    badgeClassName: string;
+    label: string;
+  }
+> = {
+  active: {
+    badgeClassName:
+      'border-transparent bg-emerald-200 text-emerald-950 dark:bg-emerald-500/20 dark:text-emerald-300',
+    label: 'Active',
+  },
+  completed: {
+    badgeClassName:
+      'border-transparent bg-sky-200 text-sky-950 dark:bg-sky-500/20 dark:text-sky-300',
+    label: 'Completed',
+  },
+  discontinued: {
+    badgeClassName:
+      'border-transparent bg-slate-200 text-slate-950 dark:bg-slate-500/20 dark:text-slate-300',
+    label: 'Discontinued',
+  },
+};
+
+function getTodayDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function getDefaultDraft(): ProtocolDraft {
+  return {
+    name: '',
+    notes: '',
+    startDate: getTodayDate(),
+    status: 'active',
+  };
+}
+
+function parseDate(date: string) {
+  return new Date(`${date}T12:00:00`);
+}
+
+function formatDate(date: string) {
+  return fullDateFormatter.format(parseDate(date));
+}
+
+function createProtocolId(name: string) {
+  const baseSlug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return `${baseSlug || 'protocol'}-${Date.now().toString(36)}`;
+}
+
+function getProtocolSortDate(protocol: Protocol) {
+  if (protocol.status === 'active') {
+    return protocol.startDate;
+  }
+
+  return protocol.endDate ?? protocol.startDate;
+}
+
+function sortProtocols(protocols: Protocol[]) {
+  return [...protocols].sort((left, right) => {
+    const statusDifference =
+      PROTOCOL_STATUS_ORDER[left.status] - PROTOCOL_STATUS_ORDER[right.status];
+
+    if (statusDifference !== 0) {
+      return statusDifference;
+    }
+
+    const dateDifference =
+      parseDate(getProtocolSortDate(right)).getTime() -
+      parseDate(getProtocolSortDate(left)).getTime();
+
+    if (dateDifference !== 0) {
+      return dateDifference;
+    }
+
+    return left.name.localeCompare(right.name);
+  });
+}
+
+export function ProtocolList({ protocols }: ProtocolListProps) {
+  const [localProtocols, setLocalProtocols] = useState<Protocol[]>(() => protocols);
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+  const [draftProtocol, setDraftProtocol] = useState<ProtocolDraft>(() => getDefaultDraft());
+
+  useEffect(() => {
+    setLocalProtocols(protocols);
+  }, [protocols]);
+
+  const visibleProtocols = sortProtocols(localProtocols);
+
+  function updateDraft<K extends keyof ProtocolDraft>(field: K, value: ProtocolDraft[K]) {
+    setDraftProtocol((currentDraft) => ({
+      ...currentDraft,
+      [field]: value,
+    }));
+  }
+
+  function closeDialog() {
+    setIsAddDialogOpen(false);
+    setDraftProtocol(getDefaultDraft());
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const name = draftProtocol.name.trim();
+    const notes = draftProtocol.notes.trim();
+
+    if (!name || !draftProtocol.startDate) {
+      return;
+    }
+
+    setLocalProtocols((currentProtocols) => [
+      ...currentProtocols,
+      {
+        id: createProtocolId(name),
+        name,
+        notes,
+        startDate: draftProtocol.startDate,
+        status: draftProtocol.status,
+        endDate: draftProtocol.status === 'active' ? undefined : draftProtocol.startDate,
+      },
+    ]);
+
+    closeDialog();
+  }
+
+  function handleStatusChange(protocolId: string, nextStatus: ProtocolStatus) {
+    const today = getTodayDate();
+
+    setLocalProtocols((currentProtocols) =>
+      currentProtocols.map((protocol) => {
+        if (protocol.id !== protocolId || protocol.status === nextStatus) {
+          return protocol;
+        }
+
+        return {
+          ...protocol,
+          status: nextStatus,
+          endDate: nextStatus === 'active' ? undefined : (protocol.endDate ?? today),
+        };
+      }),
+    );
+  }
+
+  return (
+    <>
+      <Card className="py-6 shadow-sm">
+        <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-2">
+            <CardTitle className="text-2xl text-foreground">Protocols & Treatments</CardTitle>
+            <CardDescription className="max-w-2xl">
+              Track which therapies, drills, and training modifications are still in play versus
+              which ones were completed or dropped.
+            </CardDescription>
+          </div>
+
+          <Button className="gap-2 self-start" onClick={() => setIsAddDialogOpen(true)}>
+            <ClipboardPlusIcon aria-hidden="true" className="size-4" />
+            Add Protocol
+          </Button>
+        </CardHeader>
+
+        <CardContent>
+          {visibleProtocols.length > 0 ? (
+            <div className="grid gap-3">
+              {visibleProtocols.map((protocol) => (
+                <article
+                  className="grid gap-4 rounded-2xl border border-border/60 bg-card/80 p-4 shadow-sm"
+                  key={protocol.id}
+                >
+                  <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="space-y-3">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h3 className="text-base font-semibold text-foreground">{protocol.name}</h3>
+                        <Badge className={PROTOCOL_STATUS_META[protocol.status].badgeClassName}>
+                          {PROTOCOL_STATUS_META[protocol.status].label}
+                        </Badge>
+                      </div>
+
+                      <div className="flex flex-wrap gap-2">
+                        <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground">
+                          <CalendarDaysIcon
+                            aria-hidden="true"
+                            className="size-3.5 text-muted-foreground"
+                          />
+                          Started {formatDate(protocol.startDate)}
+                        </span>
+
+                        {protocol.endDate ? (
+                          <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground">
+                            <CalendarDaysIcon
+                              aria-hidden="true"
+                              className="size-3.5 text-muted-foreground"
+                            />
+                            Ended {formatDate(protocol.endDate)}
+                          </span>
+                        ) : null}
+                      </div>
+                    </div>
+
+                    <div className="w-full max-w-full space-y-2 lg:max-w-[12rem]">
+                      <Label
+                        className="text-xs font-semibold uppercase tracking-[0.16em]"
+                        htmlFor={`protocol-status-${protocol.id}`}
+                      >
+                        Status
+                      </Label>
+                      <Select
+                        onValueChange={(value) =>
+                          handleStatusChange(protocol.id, value as ProtocolStatus)
+                        }
+                        value={protocol.status}
+                      >
+                        <SelectTrigger
+                          aria-label={`Update protocol status for ${protocol.name}`}
+                          id={`protocol-status-${protocol.id}`}
+                        >
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {(['active', 'completed', 'discontinued'] as const).map((status) => (
+                            <SelectItem key={status} value={status}>
+                              {PROTOCOL_STATUS_META[status].label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+
+                  {protocol.notes ? (
+                    <p className="rounded-xl bg-background/80 px-3 py-2 text-sm leading-6 text-muted-foreground">
+                      {protocol.notes}
+                    </p>
+                  ) : null}
+                </article>
+              ))}
+            </div>
+          ) : (
+            <p className="rounded-2xl border border-dashed border-border/70 bg-background/70 px-4 py-5 text-sm text-muted-foreground">
+              No protocols logged yet. Add the first therapy, drill, or training modification to
+              start tracking it locally.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog
+        onOpenChange={(open) => (open ? setIsAddDialogOpen(true) : closeDialog())}
+        open={isAddDialogOpen}
+      >
+        <DialogContent className="sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Add Protocol</DialogTitle>
+            <DialogDescription>
+              Capture a therapy, exercise, or training modification for this condition.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form className="grid gap-4" onSubmit={handleSubmit}>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2 sm:col-span-2">
+                <Label htmlFor="protocol-name">Protocol name</Label>
+                <Input
+                  aria-label="Protocol name"
+                  id="protocol-name"
+                  onChange={(event) => updateDraft('name', event.target.value)}
+                  placeholder="Spanish squats"
+                  required
+                  value={draftProtocol.name}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="protocol-status">Status</Label>
+                <Select
+                  onValueChange={(value) => updateDraft('status', value as ProtocolStatus)}
+                  value={draftProtocol.status}
+                >
+                  <SelectTrigger aria-label="Protocol status" id="protocol-status">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(['active', 'completed', 'discontinued'] as const).map((status) => (
+                      <SelectItem key={status} value={status}>
+                        {PROTOCOL_STATUS_META[status].label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="protocol-start-date">Start date</Label>
+                <Input
+                  aria-label="Protocol start date"
+                  id="protocol-start-date"
+                  onChange={(event) => updateDraft('startDate', event.target.value)}
+                  required
+                  type="date"
+                  value={draftProtocol.startDate}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="protocol-notes">Notes</Label>
+              <Textarea
+                aria-label="Protocol notes"
+                className="min-h-28"
+                id="protocol-notes"
+                onChange={(event) => updateDraft('notes', event.target.value)}
+                placeholder="What changed, how it helps, or when to use it."
+                value={draftProtocol.notes}
+              />
+            </div>
+
+            <DialogFooter>
+              <Button onClick={closeDialog} type="button" variant="outline">
+                Cancel
+              </Button>
+              <Button type="submit">Save Protocol</Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/features/injuries/components/protocol-list.tsx
+++ b/apps/web/src/features/injuries/components/protocol-list.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FormEvent } from 'react';
+import { useMemo, useState, type FormEvent } from 'react';
 import { CalendarDaysIcon, ClipboardPlusIcon } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
@@ -35,6 +35,8 @@ type ProtocolDraft = {
   status: ProtocolStatus;
 };
 
+type ProtocolStatusOverride = Pick<Protocol, 'endDate' | 'status'>;
+
 const fullDateFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'long',
   day: 'numeric',
@@ -46,6 +48,8 @@ const PROTOCOL_STATUS_ORDER: Record<ProtocolStatus, number> = {
   completed: 1,
   discontinued: 2,
 };
+
+const PROTOCOL_STATUSES = ['active', 'completed', 'discontinued'] as const;
 
 const PROTOCOL_STATUS_META: Record<
   ProtocolStatus,
@@ -132,15 +136,27 @@ function sortProtocols(protocols: Protocol[]) {
 }
 
 export function ProtocolList({ protocols }: ProtocolListProps) {
-  const [localProtocols, setLocalProtocols] = useState<Protocol[]>(() => protocols);
+  const [addedProtocols, setAddedProtocols] = useState<Protocol[]>([]);
+  const [protocolStatusById, setProtocolStatusById] = useState<
+    Record<string, ProtocolStatusOverride>
+  >({});
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
   const [draftProtocol, setDraftProtocol] = useState<ProtocolDraft>(() => getDefaultDraft());
 
-  useEffect(() => {
-    setLocalProtocols(protocols);
-  }, [protocols]);
+  const allProtocols = useMemo(
+    () =>
+      [...protocols, ...addedProtocols].map((protocol) => {
+        const statusOverride = protocolStatusById[protocol.id];
 
-  const visibleProtocols = sortProtocols(localProtocols);
+        return statusOverride ? { ...protocol, ...statusOverride } : protocol;
+      }),
+    [protocols, addedProtocols, protocolStatusById],
+  );
+  const protocolLookup = useMemo(
+    () => new Map(allProtocols.map((protocol) => [protocol.id, protocol])),
+    [allProtocols],
+  );
+  const visibleProtocols = useMemo(() => sortProtocols(allProtocols), [allProtocols]);
 
   function updateDraft<K extends keyof ProtocolDraft>(field: K, value: ProtocolDraft[K]) {
     setDraftProtocol((currentDraft) => ({
@@ -164,7 +180,7 @@ export function ProtocolList({ protocols }: ProtocolListProps) {
       return;
     }
 
-    setLocalProtocols((currentProtocols) => [
+    setAddedProtocols((currentProtocols) => [
       ...currentProtocols,
       {
         id: createProtocolId(name),
@@ -172,7 +188,7 @@ export function ProtocolList({ protocols }: ProtocolListProps) {
         notes,
         startDate: draftProtocol.startDate,
         status: draftProtocol.status,
-        endDate: draftProtocol.status === 'active' ? undefined : draftProtocol.startDate,
+        endDate: draftProtocol.status === 'active' ? undefined : getTodayDate(),
       },
     ]);
 
@@ -180,21 +196,21 @@ export function ProtocolList({ protocols }: ProtocolListProps) {
   }
 
   function handleStatusChange(protocolId: string, nextStatus: ProtocolStatus) {
+    const protocol = protocolLookup.get(protocolId);
+
+    if (!protocol || protocol.status === nextStatus) {
+      return;
+    }
+
     const today = getTodayDate();
 
-    setLocalProtocols((currentProtocols) =>
-      currentProtocols.map((protocol) => {
-        if (protocol.id !== protocolId || protocol.status === nextStatus) {
-          return protocol;
-        }
-
-        return {
-          ...protocol,
-          status: nextStatus,
-          endDate: nextStatus === 'active' ? undefined : (protocol.endDate ?? today),
-        };
-      }),
-    );
+    setProtocolStatusById((currentStatuses) => ({
+      ...currentStatuses,
+      [protocolId]: {
+        status: nextStatus,
+        endDate: nextStatus === 'active' ? undefined : (protocol.endDate ?? today),
+      },
+    }));
   }
 
   return (
@@ -273,7 +289,7 @@ export function ProtocolList({ protocols }: ProtocolListProps) {
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                          {(['active', 'completed', 'discontinued'] as const).map((status) => (
+                          {PROTOCOL_STATUSES.map((status) => (
                             <SelectItem key={status} value={status}>
                               {PROTOCOL_STATUS_META[status].label}
                             </SelectItem>
@@ -336,7 +352,7 @@ export function ProtocolList({ protocols }: ProtocolListProps) {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {(['active', 'completed', 'discontinued'] as const).map((status) => (
+                    {PROTOCOL_STATUSES.map((status) => (
                       <SelectItem key={status} value={status}>
                         {PROTOCOL_STATUS_META[status].label}
                       </SelectItem>

--- a/apps/web/src/features/injuries/components/severity-chart.test.tsx
+++ b/apps/web/src/features/injuries/components/severity-chart.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { SeverityPoint, TimelineEvent } from '../types';
+import type { HealthCondition } from '../types';
 import { SeverityChart } from './severity-chart';
 
 vi.mock('recharts', async () => {
@@ -27,23 +27,37 @@ vi.mock('recharts', async () => {
 });
 
 describe('SeverityChart', () => {
-  const severityHistory: SeverityPoint[] = [
-    { date: '2025-01-01', value: 6 },
-    { date: '2025-01-10', value: 3 },
-  ];
-
-  const timeline: TimelineEvent[] = [
-    {
-      id: 'shoulder-flare-2025-01-05',
-      date: '2025-01-05',
-      event: 'Pain spiked after a heavy pressing day.',
-      type: 'flare',
-      notes: 'Backed off pressing volume for the rest of the week.',
-    },
-  ];
+  const condition: HealthCondition = {
+    id: 'test-condition',
+    bodyArea: 'Right Shoulder',
+    description: 'Minimal inline fixture for the severity chart tests.',
+    linkedJournalEntries: [],
+    name: 'Test Condition',
+    onsetDate: '2025-01-01',
+    protocols: [],
+    severityHistory: [
+      { date: '2025-01-01', value: 6 },
+      { date: '2025-01-10', value: 3 },
+    ],
+    status: 'active',
+    timeline: [
+      {
+        id: 'shoulder-flare-2025-01-05',
+        date: '2025-01-05',
+        event: 'Pain spiked after a heavy pressing day.',
+        type: 'flare',
+        notes: 'Backed off pressing volume for the rest of the week.',
+      },
+    ],
+  };
 
   it('renders a responsive chart with event markers and hover details', () => {
-    const { container } = render(<SeverityChart severityHistory={severityHistory} timeline={timeline} />);
+    const { container } = render(
+      <SeverityChart
+        severityHistory={condition.severityHistory}
+        timeline={condition.timeline}
+      />,
+    );
 
     expect(screen.getByText('Pain / Severity Over Time')).toBeInTheDocument();
     expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
@@ -60,7 +74,12 @@ describe('SeverityChart', () => {
   });
 
   it('shows a fallback when fewer than two severity data points are available', () => {
-    render(<SeverityChart severityHistory={[severityHistory[0]]} timeline={timeline} />);
+    render(
+      <SeverityChart
+        severityHistory={[condition.severityHistory[0]]}
+        timeline={condition.timeline}
+      />,
+    );
 
     expect(
       screen.getByText('Not enough data to show a trend yet. Add at least two severity check-ins.'),

--- a/apps/web/src/features/injuries/components/severity-chart.test.tsx
+++ b/apps/web/src/features/injuries/components/severity-chart.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { mockHealthConditions } from '../lib/mock-data';
+import type { SeverityPoint, TimelineEvent } from '../types';
 import { SeverityChart } from './severity-chart';
 
 vi.mock('recharts', async () => {
@@ -27,38 +27,44 @@ vi.mock('recharts', async () => {
 });
 
 describe('SeverityChart', () => {
+  const severityHistory: SeverityPoint[] = [
+    { date: '2025-01-01', value: 6 },
+    { date: '2025-01-10', value: 3 },
+  ];
+
+  const timeline: TimelineEvent[] = [
+    {
+      id: 'shoulder-flare-2025-01-05',
+      date: '2025-01-05',
+      event: 'Pain spiked after a heavy pressing day.',
+      type: 'flare',
+      notes: 'Backed off pressing volume for the rest of the week.',
+    },
+  ];
+
   it('renders a responsive chart with event markers and hover details', () => {
-    const condition = mockHealthConditions[0];
-    const { container } = render(
-      <SeverityChart severityHistory={condition.severityHistory} timeline={condition.timeline} />,
-    );
+    const { container } = render(<SeverityChart severityHistory={severityHistory} timeline={timeline} />);
 
     expect(screen.getByText('Pain / Severity Over Time')).toBeInTheDocument();
     expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
     expect(screen.getByRole('img', { name: 'Pain / Severity Over Time chart' })).toBeInTheDocument();
 
     const eventMarkers = container.querySelectorAll('[data-slot="severity-event-marker"]');
-    expect(eventMarkers).toHaveLength(condition.timeline.length);
+    expect(eventMarkers).toHaveLength(1);
 
     fireEvent.focus(eventMarkers[0] as Element);
 
     expect(screen.getByRole('tooltip')).toBeInTheDocument();
-    expect(screen.getByText('March 18, 2025')).toBeInTheDocument();
-    expect(
-      screen.getByText('Sharp anterior shoulder pain showed up during the top set of incline dumbbell press.'),
-    ).toBeInTheDocument();
-
+    expect(screen.getByText('January 5, 2025')).toBeInTheDocument();
+    expect(screen.getByText('Pain spiked after a heavy pressing day.')).toBeInTheDocument();
   });
 
   it('shows a fallback when fewer than two severity data points are available', () => {
-    render(
-      <SeverityChart
-        severityHistory={[mockHealthConditions[0].severityHistory[0]]}
-        timeline={mockHealthConditions[0].timeline}
-      />,
-    );
+    render(<SeverityChart severityHistory={[severityHistory[0]]} timeline={timeline} />);
 
-    expect(screen.getByText('Not enough data to show a trend yet. Add at least two severity check-ins.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Not enough data to show a trend yet. Add at least two severity check-ins.'),
+    ).toBeInTheDocument();
     expect(screen.queryByTestId('responsive-container')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/injuries/components/severity-chart.test.tsx
+++ b/apps/web/src/features/injuries/components/severity-chart.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { mockHealthConditions } from '../lib/mock-data';
+import { SeverityChart } from './severity-chart';
+
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<typeof import('recharts')>('recharts');
+  const React = await vi.importActual<typeof import('react')>('react');
+
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="responsive-container">
+        {React.isValidElement(children)
+          ? React.cloneElement(
+              children as React.ReactElement<{ height?: number; width?: number }>,
+              {
+                height: 320,
+                width: 640,
+              },
+            )
+          : children}
+      </div>
+    ),
+  };
+});
+
+describe('SeverityChart', () => {
+  it('renders a responsive chart with event markers and hover details', () => {
+    const condition = mockHealthConditions[0];
+    const { container } = render(
+      <SeverityChart severityHistory={condition.severityHistory} timeline={condition.timeline} />,
+    );
+
+    expect(screen.getByText('Pain / Severity Over Time')).toBeInTheDocument();
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Pain / Severity Over Time chart' })).toBeInTheDocument();
+
+    const eventMarkers = container.querySelectorAll('[data-slot="severity-event-marker"]');
+    expect(eventMarkers).toHaveLength(condition.timeline.length);
+
+    fireEvent.focus(eventMarkers[0] as Element);
+
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    expect(screen.getByText('March 18, 2025')).toBeInTheDocument();
+    expect(
+      screen.getByText('Sharp anterior shoulder pain showed up during the top set of incline dumbbell press.'),
+    ).toBeInTheDocument();
+
+  });
+
+  it('shows a fallback when fewer than two severity data points are available', () => {
+    render(
+      <SeverityChart
+        severityHistory={[mockHealthConditions[0].severityHistory[0]]}
+        timeline={mockHealthConditions[0].timeline}
+      />,
+    );
+
+    expect(screen.getByText('Not enough data to show a trend yet. Add at least two severity check-ins.')).toBeInTheDocument();
+    expect(screen.queryByTestId('responsive-container')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/injuries/components/severity-chart.tsx
+++ b/apps/web/src/features/injuries/components/severity-chart.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from 'react';
+import { useCallback, useId, useState } from 'react';
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer, XAxis, YAxis } from 'recharts';
 
 import { Badge } from '@/components/ui/badge';
@@ -125,7 +125,9 @@ function interpolateSeverity(
       const progress =
         (timestamp - currentPoint.timestamp) / (nextPoint.timestamp - currentPoint.timestamp);
 
-      return Number((currentPoint.value + (nextPoint.value - currentPoint.value) * progress).toFixed(2));
+      return Math.round(
+        (currentPoint.value + (nextPoint.value - currentPoint.value) * progress) * 100,
+      ) / 100;
     }
   }
 
@@ -182,7 +184,7 @@ function EventTooltip({ hoveredEvent }: { hoveredEvent: HoveredEventState }) {
       </p>
       <div className="mt-2 grid gap-2">
         {hoveredEvent.datum.events.map((event) => (
-          <div className="space-y-1" key={`${event.date}-${event.type}-${event.event}`}>
+          <div className="space-y-1" key={event.id}>
             <Badge
               className="border-transparent"
               style={{
@@ -206,6 +208,52 @@ function EventTooltip({ hoveredEvent }: { hoveredEvent: HoveredEventState }) {
 export function SeverityChart({ severityHistory, timeline }: SeverityChartProps) {
   const chartId = useId();
   const [hoveredEvent, setHoveredEvent] = useState<HoveredEventState | null>(null);
+  const renderEventDot = useCallback(
+    ({ cx, cy, payload }: EventMarkerDotProps) => {
+      if (
+        typeof cx !== 'number' ||
+        typeof cy !== 'number' ||
+        !payload?.primaryEventType ||
+        payload.events.length === 0
+      ) {
+        return null;
+      }
+
+      const eventMeta = EVENT_META[payload.primaryEventType];
+
+      return (
+        <g>
+          <circle
+            aria-label={`${eventMeta.label} event on ${formatFullDate(payload.date)}`}
+            className="cursor-pointer outline-none"
+            cx={cx}
+            cy={cy}
+            data-slot="severity-event-marker"
+            fill={eventMeta.dotFill}
+            onBlur={() => setHoveredEvent(null)}
+            onFocus={() => setHoveredEvent({ datum: payload, x: cx, y: cy })}
+            onMouseEnter={() => setHoveredEvent({ datum: payload, x: cx, y: cy })}
+            onMouseLeave={() => setHoveredEvent(null)}
+            r={6}
+            stroke={eventMeta.dotStroke}
+            strokeWidth={2}
+            tabIndex={0}
+          />
+          <circle
+            cx={cx}
+            cy={cy}
+            fill="none"
+            pointerEvents="none"
+            r={10}
+            stroke={eventMeta.dotFill}
+            strokeOpacity={0.2}
+            strokeWidth={6}
+          />
+        </g>
+      );
+    },
+    [setHoveredEvent],
+  );
 
   if (severityHistory.length < 2) {
     return (
@@ -227,50 +275,6 @@ export function SeverityChart({ severityHistory, timeline }: SeverityChartProps)
 
   const data = buildChartData(severityHistory, timeline);
   const gradientId = `severity-gradient-${chartId.replace(/:/g, '-')}`;
-
-  const renderEventDot = ({ cx, cy, payload }: EventMarkerDotProps) => {
-    if (
-      typeof cx !== 'number' ||
-      typeof cy !== 'number' ||
-      !payload?.primaryEventType ||
-      payload.events.length === 0
-    ) {
-      return null;
-    }
-
-    const eventMeta = EVENT_META[payload.primaryEventType];
-
-    return (
-      <g>
-        <circle
-          aria-label={`${eventMeta.label} event on ${formatFullDate(payload.date)}`}
-          className="cursor-pointer outline-none"
-          cx={cx}
-          cy={cy}
-          data-slot="severity-event-marker"
-          fill={eventMeta.dotFill}
-          onBlur={() => setHoveredEvent(null)}
-          onFocus={() => setHoveredEvent({ datum: payload, x: cx, y: cy })}
-          onMouseEnter={() => setHoveredEvent({ datum: payload, x: cx, y: cy })}
-          onMouseLeave={() => setHoveredEvent(null)}
-          r={6}
-          stroke={eventMeta.dotStroke}
-          strokeWidth={2}
-          tabIndex={0}
-        />
-        <circle
-          cx={cx}
-          cy={cy}
-          fill="none"
-          pointerEvents="none"
-          r={10}
-          stroke={eventMeta.dotFill}
-          strokeOpacity={0.2}
-          strokeWidth={6}
-        />
-      </g>
-    );
-  };
 
   return (
     <Card className="py-6 shadow-sm">

--- a/apps/web/src/features/injuries/components/severity-chart.tsx
+++ b/apps/web/src/features/injuries/components/severity-chart.tsx
@@ -1,0 +1,357 @@
+import { useId, useState } from 'react';
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, XAxis, YAxis } from 'recharts';
+
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import type { SeverityPoint, TimelineEvent, TimelineEventType } from '../types';
+
+type SeverityChartProps = {
+  severityHistory: SeverityPoint[];
+  timeline: TimelineEvent[];
+};
+
+type SeverityChartDatum = {
+  date: string;
+  events: TimelineEvent[];
+  primaryEventType?: TimelineEventType;
+  timestamp: number;
+  value: number;
+};
+
+type EventMarkerDotProps = {
+  cx?: number;
+  cy?: number;
+  payload?: SeverityChartDatum;
+};
+
+type HoveredEventState = {
+  datum: SeverityChartDatum;
+  x: number;
+  y: number;
+};
+
+const shortDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+});
+
+const fullDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+const EVENT_META: Record<
+  TimelineEventType,
+  {
+    badgeTextColor: string;
+    dotFill: string;
+    dotStroke: string;
+    label: string;
+  }
+> = {
+  onset: {
+    badgeTextColor: '#ffffff',
+    dotFill: 'var(--color-destructive)',
+    dotStroke: 'color-mix(in srgb, var(--color-destructive) 30%, var(--color-card))',
+    label: 'Onset',
+  },
+  flare: {
+    badgeTextColor: 'var(--color-on-cream)',
+    dotFill: 'color-mix(in srgb, var(--color-destructive) 68%, var(--color-accent-cream))',
+    dotStroke: 'color-mix(in srgb, var(--color-destructive) 28%, var(--color-card))',
+    label: 'Flare',
+  },
+  improvement: {
+    badgeTextColor: 'var(--color-on-mint)',
+    dotFill: 'var(--color-accent-mint)',
+    dotStroke: 'var(--color-on-mint)',
+    label: 'Improvement',
+  },
+  treatment: {
+    badgeTextColor: '#ffffff',
+    dotFill: 'var(--color-primary)',
+    dotStroke: 'color-mix(in srgb, var(--color-primary) 35%, var(--color-card))',
+    label: 'Treatment',
+  },
+  milestone: {
+    badgeTextColor: 'var(--color-on-cream)',
+    dotFill: 'var(--color-accent-cream)',
+    dotStroke: 'var(--color-on-cream)',
+    label: 'Milestone',
+  },
+};
+
+function parseDate(date: string) {
+  return new Date(`${date}T12:00:00`);
+}
+
+function toTimestamp(date: string) {
+  return parseDate(date).getTime();
+}
+
+function formatFullDate(date: string) {
+  return fullDateFormatter.format(parseDate(date));
+}
+
+function interpolateSeverity(
+  history: Array<{ timestamp: number; value: number }>,
+  timestamp: number,
+): number {
+  const firstPoint = history[0];
+  const lastPoint = history.at(-1);
+
+  if (!firstPoint || !lastPoint) {
+    return 0;
+  }
+
+  if (timestamp <= firstPoint.timestamp) {
+    return firstPoint.value;
+  }
+
+  if (timestamp >= lastPoint.timestamp) {
+    return lastPoint.value;
+  }
+
+  for (let index = 0; index < history.length - 1; index += 1) {
+    const currentPoint = history[index];
+    const nextPoint = history[index + 1];
+
+    if (timestamp === currentPoint.timestamp) {
+      return currentPoint.value;
+    }
+
+    if (timestamp < nextPoint.timestamp) {
+      const progress =
+        (timestamp - currentPoint.timestamp) / (nextPoint.timestamp - currentPoint.timestamp);
+
+      return Number((currentPoint.value + (nextPoint.value - currentPoint.value) * progress).toFixed(2));
+    }
+  }
+
+  return lastPoint.value;
+}
+
+function buildChartData(severityHistory: SeverityPoint[], timeline: TimelineEvent[]): SeverityChartDatum[] {
+  const sortedHistory = [...severityHistory].sort(
+    (left, right) => toTimestamp(left.date) - toTimestamp(right.date),
+  );
+  const historyByDate = new Map(sortedHistory.map((entry) => [entry.date, entry.value]));
+  const eventMap = new Map<string, TimelineEvent[]>();
+
+  for (const item of timeline) {
+    const existingEvents = eventMap.get(item.date) ?? [];
+    eventMap.set(item.date, [...existingEvents, item]);
+  }
+
+  const severitySeries = sortedHistory.map((entry) => ({
+    timestamp: toTimestamp(entry.date),
+    value: entry.value,
+  }));
+  const dates = Array.from(new Set([...historyByDate.keys(), ...eventMap.keys()])).sort(
+    (left, right) => toTimestamp(left) - toTimestamp(right),
+  );
+
+  return dates.map((date) => {
+    const events = eventMap.get(date) ?? [];
+    const timestamp = toTimestamp(date);
+
+    return {
+      date,
+      events,
+      primaryEventType: events[0]?.type,
+      timestamp,
+      value: historyByDate.get(date) ?? interpolateSeverity(severitySeries, timestamp),
+    };
+  });
+}
+
+function EventTooltip({ hoveredEvent }: { hoveredEvent: HoveredEventState }) {
+  return (
+    <div
+      className="pointer-events-none absolute z-10 max-w-xs rounded-2xl border border-border/70 bg-card/95 px-3 py-3 shadow-lg backdrop-blur"
+      role="tooltip"
+      style={{
+        left: hoveredEvent.x,
+        top: hoveredEvent.y - 16,
+        transform: 'translate(-50%, -100%)',
+      }}
+    >
+      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+        {formatFullDate(hoveredEvent.datum.date)}
+      </p>
+      <div className="mt-2 grid gap-2">
+        {hoveredEvent.datum.events.map((event) => (
+          <div className="space-y-1" key={`${event.date}-${event.type}-${event.event}`}>
+            <Badge
+              className="border-transparent"
+              style={{
+                backgroundColor: EVENT_META[event.type].dotFill,
+                color: EVENT_META[event.type].badgeTextColor,
+              }}
+            >
+              {EVENT_META[event.type].label}
+            </Badge>
+            <p className="text-sm font-medium leading-5 text-foreground">{event.event}</p>
+            {event.notes ? (
+              <p className="text-xs leading-5 text-muted-foreground">{event.notes}</p>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function SeverityChart({ severityHistory, timeline }: SeverityChartProps) {
+  const chartId = useId();
+  const [hoveredEvent, setHoveredEvent] = useState<HoveredEventState | null>(null);
+
+  if (severityHistory.length < 2) {
+    return (
+      <Card className="py-6 shadow-sm">
+        <CardHeader className="gap-2">
+          <CardTitle className="text-2xl text-foreground">Pain / Severity Over Time</CardTitle>
+          <CardDescription>
+            Severity is tracked on a 1-10 scale, where 10 is the worst.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="rounded-2xl border border-dashed border-border/70 bg-background/70 px-4 py-5 text-sm text-muted-foreground">
+            Not enough data to show a trend yet. Add at least two severity check-ins.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const data = buildChartData(severityHistory, timeline);
+  const gradientId = `severity-gradient-${chartId.replace(/:/g, '-')}`;
+
+  const renderEventDot = ({ cx, cy, payload }: EventMarkerDotProps) => {
+    if (
+      typeof cx !== 'number' ||
+      typeof cy !== 'number' ||
+      !payload?.primaryEventType ||
+      payload.events.length === 0
+    ) {
+      return null;
+    }
+
+    const eventMeta = EVENT_META[payload.primaryEventType];
+
+    return (
+      <g>
+        <circle
+          aria-label={`${eventMeta.label} event on ${formatFullDate(payload.date)}`}
+          className="cursor-pointer outline-none"
+          cx={cx}
+          cy={cy}
+          data-slot="severity-event-marker"
+          fill={eventMeta.dotFill}
+          onBlur={() => setHoveredEvent(null)}
+          onFocus={() => setHoveredEvent({ datum: payload, x: cx, y: cy })}
+          onMouseEnter={() => setHoveredEvent({ datum: payload, x: cx, y: cy })}
+          onMouseLeave={() => setHoveredEvent(null)}
+          r={6}
+          stroke={eventMeta.dotStroke}
+          strokeWidth={2}
+          tabIndex={0}
+        />
+        <circle
+          cx={cx}
+          cy={cy}
+          fill="none"
+          pointerEvents="none"
+          r={10}
+          stroke={eventMeta.dotFill}
+          strokeOpacity={0.2}
+          strokeWidth={6}
+        />
+      </g>
+    );
+  };
+
+  return (
+    <Card className="py-6 shadow-sm">
+      <CardHeader className="gap-2">
+        <CardTitle className="text-2xl text-foreground">Pain / Severity Over Time</CardTitle>
+        <CardDescription>
+          Severity is tracked on a 1-10 scale, where 10 is the worst. Markers line up with
+          key recovery events.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="relative">
+          {hoveredEvent ? <EventTooltip hoveredEvent={hoveredEvent} /> : null}
+
+          <div
+            aria-label="Pain / Severity Over Time chart"
+            className="aspect-[16/9] w-full"
+            data-slot="severity-chart"
+            role="img"
+          >
+            <ResponsiveContainer height="100%" width="100%">
+              <AreaChart
+                data={data}
+                margin={{ bottom: 8, left: 4, right: 12, top: 16 }}
+                onMouseLeave={() => setHoveredEvent(null)}
+              >
+                <defs>
+                  <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
+                    <stop offset="0%" stopColor="var(--color-destructive)" stopOpacity={0.34} />
+                    <stop offset="100%" stopColor="var(--color-accent-mint)" stopOpacity={0.1} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid
+                  opacity={0.35}
+                  stroke="var(--color-border)"
+                  strokeDasharray="4 4"
+                  vertical={false}
+                />
+                <XAxis
+                  axisLine={false}
+                  dataKey="timestamp"
+                  domain={['dataMin', 'dataMax']}
+                  minTickGap={28}
+                  scale="time"
+                  tick={{ fill: 'var(--color-muted)', fontSize: 12 }}
+                  tickFormatter={(value: number) => shortDateFormatter.format(new Date(value))}
+                  tickLine={false}
+                  type="number"
+                />
+                <YAxis
+                  allowDecimals={false}
+                  axisLine={false}
+                  domain={[1, 10]}
+                  label={{
+                    angle: -90,
+                    fill: 'var(--color-muted)',
+                    position: 'insideLeft',
+                    style: { textAnchor: 'middle' },
+                    value: 'Severity',
+                  }}
+                  tick={{ fill: 'var(--color-muted)', fontSize: 12 }}
+                  tickLine={false}
+                  ticks={[1, 3, 5, 7, 10]}
+                  width={46}
+                />
+                <Area
+                  dataKey="value"
+                  dot={renderEventDot}
+                  fill={`url(#${gradientId})`}
+                  isAnimationActive={false}
+                  stroke="var(--color-primary)"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={3}
+                  type="linear"
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/features/injuries/index.ts
+++ b/apps/web/src/features/injuries/index.ts
@@ -1,9 +1,11 @@
+export { ConditionDetail } from './components/condition-detail';
 export { ConditionsList } from './components/conditions-list';
 export { mockHealthConditions } from './lib/mock-data';
 export type {
   ConditionStatus,
   HealthCondition,
   LinkedJournalEntry,
+  LinkedJournalEntryType,
   Protocol,
   ProtocolStatus,
   SeverityPoint,

--- a/apps/web/src/features/injuries/index.ts
+++ b/apps/web/src/features/injuries/index.ts
@@ -1,0 +1,11 @@
+export { mockHealthConditions } from './lib/mock-data';
+export type {
+  ConditionStatus,
+  HealthCondition,
+  LinkedJournalEntry,
+  Protocol,
+  ProtocolStatus,
+  SeverityPoint,
+  TimelineEvent,
+  TimelineEventType,
+} from './types';

--- a/apps/web/src/features/injuries/index.ts
+++ b/apps/web/src/features/injuries/index.ts
@@ -1,3 +1,4 @@
+export { ConditionsList } from './components/conditions-list';
 export { mockHealthConditions } from './lib/mock-data';
 export type {
   ConditionStatus,

--- a/apps/web/src/features/injuries/index.ts
+++ b/apps/web/src/features/injuries/index.ts
@@ -1,5 +1,6 @@
 export { ConditionDetail } from './components/condition-detail';
 export { ConditionsList } from './components/conditions-list';
+export { SeverityChart } from './components/severity-chart';
 export { mockHealthConditions } from './lib/mock-data';
 export type {
   ConditionStatus,

--- a/apps/web/src/features/injuries/lib/mock-data.ts
+++ b/apps/web/src/features/injuries/lib/mock-data.ts
@@ -100,16 +100,19 @@ export const mockHealthConditions: HealthCondition[] = [
         id: 'journal-upper-2025-03-18',
         title: 'Upper body session shut down by sharp shoulder pain',
         date: '2025-03-18',
+        type: 'observation',
       },
       {
         id: 'journal-pt-2025-06-11',
         title: 'PT notes: pressing finally feels stable again',
         date: '2025-06-11',
+        type: 'observation',
       },
       {
         id: 'journal-clearance-2026-01-12',
         title: 'Shoulder clearance and return-to-normal pressing',
         date: '2026-01-12',
+        type: 'milestone',
       },
     ],
     severityHistory: [
@@ -215,16 +218,19 @@ export const mockHealthConditions: HealthCondition[] = [
         id: 'journal-knees-2025-06-03',
         title: 'Quad day notes: knees ache on every warmup set',
         date: '2025-06-03',
+        type: 'observation',
       },
       {
         id: 'journal-knees-2025-08-14',
         title: 'Basketball weekend triggered another knee flare',
         date: '2025-08-14',
+        type: 'observation',
       },
       {
         id: 'journal-knees-2025-12-02',
         title: 'Knees stable enough to treat as managed, not acute',
         date: '2025-12-02',
+        type: 'weekly_summary',
       },
     ],
     severityHistory: [
@@ -330,16 +336,19 @@ export const mockHealthConditions: HealthCondition[] = [
         id: 'journal-back-2025-09-18',
         title: 'Heavy pull day turned into low-back spasm management',
         date: '2025-09-18',
+        type: 'observation',
       },
       {
         id: 'journal-back-2025-11-12',
         title: 'Sitting all week brought the back pain back',
         date: '2025-11-12',
+        type: 'weekly_summary',
       },
       {
         id: 'journal-back-2026-02-03',
         title: 'Back still active, but training feels more predictable now',
         date: '2026-02-03',
+        type: 'milestone',
       },
     ],
     severityHistory: [
@@ -437,16 +446,19 @@ export const mockHealthConditions: HealthCondition[] = [
         id: 'journal-feet-2025-07-05',
         title: 'Morning heel pain is now affecting conditioning',
         date: '2025-07-05',
+        type: 'observation',
       },
       {
         id: 'journal-feet-2025-08-28',
         title: 'Long weekend on concrete brought the foot pain back',
         date: '2025-08-28',
+        type: 'observation',
       },
       {
         id: 'journal-feet-2026-01-18',
         title: 'Feet improving enough to treat this as maintenance',
         date: '2026-01-18',
+        type: 'milestone',
       },
     ],
     severityHistory: [

--- a/apps/web/src/features/injuries/lib/mock-data.ts
+++ b/apps/web/src/features/injuries/lib/mock-data.ts
@@ -1,0 +1,463 @@
+import type { HealthCondition } from '../types';
+
+export const mockHealthConditions: HealthCondition[] = [
+  {
+    id: 'shoulder-slap-tear-right',
+    name: 'Shoulder SLAP Tear (Right)',
+    bodyArea: 'Right Shoulder',
+    status: 'resolved',
+    onsetDate: '2025-03-18',
+    description:
+      'Right shoulder labrum irritation that escalated during heavy pressing and overhead work, then gradually resolved with physical therapy, scapular stability work, and temporary pressing modifications.',
+    timeline: [
+      {
+        date: '2025-03-18',
+        event:
+          'Sharp anterior shoulder pain showed up during the top set of incline dumbbell press.',
+        type: 'onset',
+        notes: 'Pain was worst at lockout and when lowering with elbows flared.',
+      },
+      {
+        date: '2025-04-02',
+        event: 'Sports medicine consult flagged a probable SLAP tear and biceps anchor irritation.',
+        type: 'treatment',
+        notes: 'Plan was conservative rehab before considering imaging or injections.',
+      },
+      {
+        date: '2025-04-10',
+        event: 'Physical therapy started with scapular control drills and cuff endurance work.',
+        type: 'treatment',
+        notes: 'Initial home program centered on pain-free range and posture cleanup.',
+      },
+      {
+        date: '2025-04-14',
+        event: 'All barbell and overhead pressing was swapped to neutral-grip dumbbell variations.',
+        type: 'milestone',
+        notes: 'Volume stayed in, but pressing intensity was cut sharply for six weeks.',
+      },
+      {
+        date: '2025-06-11',
+        event: 'Bench and incline pressing became mostly pain-free with controlled tempo.',
+        type: 'improvement',
+        notes: 'Still avoided maximal loading and deep stretch positions.',
+      },
+      {
+        date: '2025-08-21',
+        event: 'Short flare-up after pushing a high-volume chest day too aggressively.',
+        type: 'flare',
+        notes: 'Symptoms settled after one lighter week and extra PT work.',
+      },
+      {
+        date: '2025-11-15',
+        event: 'Returned to full pressing range without next-day soreness.',
+        type: 'improvement',
+        notes: 'Face pulls and scap retractions stayed in the warmup through the end of the year.',
+      },
+      {
+        date: '2026-01-12',
+        event: 'Cleared from rehab and marked resolved after several symptom-free weeks.',
+        type: 'milestone',
+        notes: 'Still keeping a shoulder primer before upper-body sessions.',
+      },
+    ],
+    protocols: [
+      {
+        id: 'shoulder-face-pulls',
+        name: 'Face pulls',
+        status: 'completed',
+        startDate: '2025-04-10',
+        endDate: '2025-12-20',
+        notes: 'Used as a high-rep finisher and warmup staple to keep the shoulder centered.',
+      },
+      {
+        id: 'shoulder-scapular-retractions',
+        name: 'Scapular retractions',
+        status: 'completed',
+        startDate: '2025-04-10',
+        endDate: '2025-11-15',
+        notes: 'Performed between upper-body sets to rebuild scapular control.',
+      },
+      {
+        id: 'shoulder-pt-sessions',
+        name: 'Physical therapy sessions',
+        status: 'completed',
+        startDate: '2025-04-10',
+        endDate: '2025-09-05',
+        notes: 'Weekly PT progressed from pain management into return-to-pressing strength work.',
+      },
+      {
+        id: 'shoulder-pressing-modifications',
+        name: 'Pressing modifications',
+        status: 'completed',
+        startDate: '2025-04-14',
+        endDate: '2025-11-15',
+        notes:
+          'Neutral-grip pressing, reduced ROM, and slower eccentrics prevented repeated irritation.',
+      },
+    ],
+    linkedJournalEntries: [
+      {
+        id: 'journal-upper-2025-03-18',
+        title: 'Upper body session shut down by sharp shoulder pain',
+        date: '2025-03-18',
+      },
+      {
+        id: 'journal-pt-2025-06-11',
+        title: 'PT notes: pressing finally feels stable again',
+        date: '2025-06-11',
+      },
+      {
+        id: 'journal-clearance-2026-01-12',
+        title: 'Shoulder clearance and return-to-normal pressing',
+        date: '2026-01-12',
+      },
+    ],
+    severityHistory: [
+      { date: '2025-03-18', value: 7 },
+      { date: '2025-04-02', value: 7 },
+      { date: '2025-04-24', value: 6 },
+      { date: '2025-05-22', value: 5 },
+      { date: '2025-06-19', value: 4 },
+      { date: '2025-08-21', value: 5 },
+      { date: '2025-09-18', value: 3 },
+      { date: '2025-11-15', value: 2 },
+      { date: '2026-01-12', value: 1 },
+    ],
+  },
+  {
+    id: 'patellar-tendon-issues',
+    name: 'Patellar Tendon Issues',
+    bodyArea: 'Both Knees',
+    status: 'monitoring',
+    onsetDate: '2025-06-03',
+    description:
+      'Bilateral patellar tendon irritation that spikes with aggressive squat progressions, sprint work, and jumping volume. Symptoms are manageable but still require ongoing prep and load control.',
+    timeline: [
+      {
+        date: '2025-06-03',
+        event:
+          'Front-of-knee pain started after a dense block of squats, split squats, and sprints.',
+        type: 'onset',
+        notes: 'Descending stairs and the first warmup sets were the worst triggers.',
+      },
+      {
+        date: '2025-06-10',
+        event: 'Swapped to slower eccentrics and removed jumps from lower-body accessories.',
+        type: 'treatment',
+        notes: 'Immediate goal was to calm tendon irritation without dropping all leg training.',
+      },
+      {
+        date: '2025-06-18',
+        event: 'Spanish squats were added before leg sessions and on off days.',
+        type: 'treatment',
+        notes: 'These consistently reduced pain during the first loaded knee flexion patterns.',
+      },
+      {
+        date: '2025-07-09',
+        event: 'Symptoms improved enough to reintroduce machine leg work and split squats.',
+        type: 'improvement',
+        notes: 'Kept ROM honest and avoided fast rebounds out of the hole.',
+      },
+      {
+        date: '2025-08-14',
+        event: 'Knees flared after a hard weekend of basketball and high-volume walking lunges.',
+        type: 'flare',
+        notes: 'Left side felt worse than right for about a week.',
+      },
+      {
+        date: '2025-09-05',
+        event: 'Tibialis raises and slant board stretching became part of the daily warmup.',
+        type: 'treatment',
+        notes: 'Ankles and lower-leg stiffness were contributing more than expected.',
+      },
+      {
+        date: '2025-12-02',
+        event: 'Moved from rehab mode into ongoing monitoring with stable training tolerance.',
+        type: 'milestone',
+        notes: 'Still need to cap sprint and jump exposure when volume is already high.',
+      },
+    ],
+    protocols: [
+      {
+        id: 'knee-spanish-squats',
+        name: 'Spanish squats',
+        status: 'active',
+        startDate: '2025-06-18',
+        notes: 'Primary analgesic drill before squats, split squats, and conditioning.',
+      },
+      {
+        id: 'knee-tibialis-raises',
+        name: 'Tibialis raises',
+        status: 'active',
+        startDate: '2025-09-05',
+        notes:
+          'Used daily to improve lower-leg tolerance and reduce stress concentration at the knee.',
+      },
+      {
+        id: 'knee-slant-board-stretches',
+        name: 'Slant board stretches',
+        status: 'active',
+        startDate: '2025-09-05',
+        notes: 'Done after training and on rest days to keep ankle dorsiflexion from regressing.',
+      },
+      {
+        id: 'knee-plyometric-block',
+        name: 'High-impact plyometric block',
+        status: 'discontinued',
+        startDate: '2025-07-28',
+        endDate: '2025-08-14',
+        notes:
+          'Dropped when repeated jumping aggravated the tendons faster than recovery could keep up.',
+      },
+    ],
+    linkedJournalEntries: [
+      {
+        id: 'journal-knees-2025-06-03',
+        title: 'Quad day notes: knees ache on every warmup set',
+        date: '2025-06-03',
+      },
+      {
+        id: 'journal-knees-2025-08-14',
+        title: 'Basketball weekend triggered another knee flare',
+        date: '2025-08-14',
+      },
+      {
+        id: 'journal-knees-2025-12-02',
+        title: 'Knees stable enough to treat as managed, not acute',
+        date: '2025-12-02',
+      },
+    ],
+    severityHistory: [
+      { date: '2025-06-03', value: 5 },
+      { date: '2025-06-18', value: 4 },
+      { date: '2025-07-02', value: 3 },
+      { date: '2025-07-23', value: 4 },
+      { date: '2025-08-14', value: 5 },
+      { date: '2025-09-05', value: 4 },
+      { date: '2025-10-01', value: 3 },
+      { date: '2025-11-06', value: 4 },
+      { date: '2025-12-02', value: 3 },
+    ],
+  },
+  {
+    id: 'lower-back-disc-herniation',
+    name: 'Lower Back Disc Herniation',
+    bodyArea: 'Lumbar Spine',
+    status: 'active',
+    onsetDate: '2025-09-18',
+    description:
+      'Lumbar disc irritation with occasional referral into the glute after fatigue-heavy pulling and prolonged sitting. Improved from the initial acute phase, but still actively managed with spine-sparing training.',
+    timeline: [
+      {
+        date: '2025-09-18',
+        event:
+          'Low back tightened sharply after a heavy pull and stayed irritated through the next morning.',
+        type: 'onset',
+        notes: 'Pain was worse with bending, sitting, and getting in or out of the car.',
+      },
+      {
+        date: '2025-09-22',
+        event:
+          'Stopped loading squats, deadlifts, and any movements that stacked spinal compression.',
+        type: 'treatment',
+        notes: 'Training pivoted toward supported rows, split squats, sled work, and machines.',
+      },
+      {
+        date: '2025-09-29',
+        event: 'Started McGill Big 3 progression and strict brace-focused warmups.',
+        type: 'treatment',
+        notes: 'Daily consistency mattered more than trying to progress difficulty quickly.',
+      },
+      {
+        date: '2025-10-17',
+        event: 'Symptoms improved enough to tolerate longer walks and easier hinge patterns.',
+        type: 'improvement',
+        notes: 'Still avoiding fatigue that caused lumbar flexion under load.',
+      },
+      {
+        date: '2025-11-12',
+        event: 'Flare after a long drive and too much sitting during a busy work week.',
+        type: 'flare',
+        notes: 'Pain centralized again after two lighter sessions and frequent walking breaks.',
+      },
+      {
+        date: '2025-12-08',
+        event: 'Couch stretch and hip-opening work reduced the constant low-back guarding.',
+        type: 'improvement',
+        notes: 'Hip flexor tightness was feeding into an overextended standing position.',
+      },
+      {
+        date: '2026-02-03',
+        event: 'Still marked active but stable enough for careful training progression.',
+        type: 'milestone',
+        notes: 'No return yet to barbell axial loading or high-fatigue spinal flexion work.',
+      },
+    ],
+    protocols: [
+      {
+        id: 'back-mcgill-big-3',
+        name: 'McGill Big 3',
+        status: 'active',
+        startDate: '2025-09-29',
+        notes: 'Daily spine-stability circuit to maintain tolerance without provoking symptoms.',
+      },
+      {
+        id: 'back-couch-stretch',
+        name: 'Couch stretch',
+        status: 'active',
+        startDate: '2025-12-08',
+        notes: 'Used to reduce anterior hip tightness that was increasing lumbar extension bias.',
+      },
+      {
+        id: 'back-no-spinal-compression',
+        name: 'No spinal compression loading',
+        status: 'active',
+        startDate: '2025-09-22',
+        notes:
+          'No back squats, heavy deadlifts, or overhead loading until symptoms remain steady longer.',
+      },
+      {
+        id: 'back-loaded-flexion-work',
+        name: 'Loaded lumbar flexion work',
+        status: 'discontinued',
+        startDate: '2025-09-18',
+        endDate: '2025-09-22',
+        notes: 'Removed immediately because it predictably reproduced symptoms.',
+      },
+    ],
+    linkedJournalEntries: [
+      {
+        id: 'journal-back-2025-09-18',
+        title: 'Heavy pull day turned into low-back spasm management',
+        date: '2025-09-18',
+      },
+      {
+        id: 'journal-back-2025-11-12',
+        title: 'Sitting all week brought the back pain back',
+        date: '2025-11-12',
+      },
+      {
+        id: 'journal-back-2026-02-03',
+        title: 'Back still active, but training feels more predictable now',
+        date: '2026-02-03',
+      },
+    ],
+    severityHistory: [
+      { date: '2025-09-18', value: 6 },
+      { date: '2025-09-22', value: 5 },
+      { date: '2025-09-29', value: 5 },
+      { date: '2025-10-17', value: 4 },
+      { date: '2025-11-12', value: 5 },
+      { date: '2025-12-08', value: 4 },
+      { date: '2026-01-07', value: 4 },
+      { date: '2026-02-03', value: 4 },
+    ],
+  },
+  {
+    id: 'foot-pain-plantar-fasciitis',
+    name: 'Foot Pain / Plantar Fasciitis',
+    bodyArea: 'Both Feet',
+    status: 'monitoring',
+    onsetDate: '2025-07-05',
+    description:
+      'Heel and arch pain that built up from steps, standing, and conditioning volume. The condition is improving, but daily lower-leg work and footwear choices still matter.',
+    timeline: [
+      {
+        date: '2025-07-05',
+        event:
+          'First-step heel pain showed up after a stretch of high daily step counts and incline walking.',
+        type: 'onset',
+        notes: 'Morning stiffness and post-workout standing were the main symptoms.',
+      },
+      {
+        date: '2025-07-14',
+        event: 'Conditioning volume was reduced and calf mobility work was added after sessions.',
+        type: 'treatment',
+        notes: 'Incline treadmill work was the fastest trigger at that point.',
+      },
+      {
+        date: '2025-08-01',
+        event: 'Daily tibialis raises started to build ankle and foot tolerance.',
+        type: 'treatment',
+        notes: 'Foot discomfort decreased when these were done consistently.',
+      },
+      {
+        date: '2025-08-28',
+        event: 'Short flare after several long days on concrete with minimal recovery.',
+        type: 'flare',
+        notes: 'Pain was still milder than the original onset week.',
+      },
+      {
+        date: '2025-09-19',
+        event: 'Supportive insoles made longer walks and errands much more manageable.',
+        type: 'improvement',
+        notes: 'This was enough to bring daily pain down even before training changes.',
+      },
+      {
+        date: '2025-11-07',
+        event: 'Morning pain dropped noticeably and conditioning tolerance improved.',
+        type: 'improvement',
+        notes: 'Walking is mostly fine as long as calf work stays consistent.',
+      },
+      {
+        date: '2026-01-18',
+        event: 'Condition moved into monitoring with only occasional tightness after long days.',
+        type: 'milestone',
+        notes: 'Still keeping the lower-leg routine because symptoms return when it drops off.',
+      },
+    ],
+    protocols: [
+      {
+        id: 'feet-tibialis-raises',
+        name: 'Tibialis raises daily',
+        status: 'active',
+        startDate: '2025-08-01',
+        notes:
+          'Daily anterior lower-leg work improved dorsiflexion control and reduced foot fatigue.',
+      },
+      {
+        id: 'feet-calf-stretches',
+        name: 'Calf stretches',
+        status: 'active',
+        startDate: '2025-07-14',
+        notes:
+          'Performed after training and before long walking days to reduce arch and heel tension.',
+      },
+      {
+        id: 'feet-supportive-insoles',
+        name: 'Supportive insoles',
+        status: 'completed',
+        startDate: '2025-09-19',
+        endDate: '2026-01-18',
+        notes: 'Temporary support bridged the gap while tissue tolerance was building back up.',
+      },
+    ],
+    linkedJournalEntries: [
+      {
+        id: 'journal-feet-2025-07-05',
+        title: 'Morning heel pain is now affecting conditioning',
+        date: '2025-07-05',
+      },
+      {
+        id: 'journal-feet-2025-08-28',
+        title: 'Long weekend on concrete brought the foot pain back',
+        date: '2025-08-28',
+      },
+      {
+        id: 'journal-feet-2026-01-18',
+        title: 'Feet improving enough to treat this as maintenance',
+        date: '2026-01-18',
+      },
+    ],
+    severityHistory: [
+      { date: '2025-07-05', value: 6 },
+      { date: '2025-07-14', value: 5 },
+      { date: '2025-08-01', value: 5 },
+      { date: '2025-08-28', value: 6 },
+      { date: '2025-09-19', value: 4 },
+      { date: '2025-10-10', value: 4 },
+      { date: '2025-11-07', value: 3 },
+      { date: '2026-01-18', value: 3 },
+    ],
+  },
+];

--- a/apps/web/src/features/injuries/lib/mock-data.ts
+++ b/apps/web/src/features/injuries/lib/mock-data.ts
@@ -11,6 +11,7 @@ export const mockHealthConditions: HealthCondition[] = [
       'Right shoulder labrum irritation that escalated during heavy pressing and overhead work, then gradually resolved with physical therapy, scapular stability work, and temporary pressing modifications.',
     timeline: [
       {
+        id: 'shoulder-onset-2025-03-18',
         date: '2025-03-18',
         event:
           'Sharp anterior shoulder pain showed up during the top set of incline dumbbell press.',
@@ -18,42 +19,49 @@ export const mockHealthConditions: HealthCondition[] = [
         notes: 'Pain was worst at lockout and when lowering with elbows flared.',
       },
       {
+        id: 'shoulder-treatment-2025-04-02',
         date: '2025-04-02',
         event: 'Sports medicine consult flagged a probable SLAP tear and biceps anchor irritation.',
         type: 'treatment',
         notes: 'Plan was conservative rehab before considering imaging or injections.',
       },
       {
+        id: 'shoulder-treatment-2025-04-10',
         date: '2025-04-10',
         event: 'Physical therapy started with scapular control drills and cuff endurance work.',
         type: 'treatment',
         notes: 'Initial home program centered on pain-free range and posture cleanup.',
       },
       {
+        id: 'shoulder-milestone-2025-04-14',
         date: '2025-04-14',
         event: 'All barbell and overhead pressing was swapped to neutral-grip dumbbell variations.',
         type: 'milestone',
         notes: 'Volume stayed in, but pressing intensity was cut sharply for six weeks.',
       },
       {
+        id: 'shoulder-improvement-2025-06-11',
         date: '2025-06-11',
         event: 'Bench and incline pressing became mostly pain-free with controlled tempo.',
         type: 'improvement',
         notes: 'Still avoided maximal loading and deep stretch positions.',
       },
       {
+        id: 'shoulder-flare-2025-08-21',
         date: '2025-08-21',
         event: 'Short flare-up after pushing a high-volume chest day too aggressively.',
         type: 'flare',
         notes: 'Symptoms settled after one lighter week and extra PT work.',
       },
       {
+        id: 'shoulder-improvement-2025-11-15',
         date: '2025-11-15',
         event: 'Returned to full pressing range without next-day soreness.',
         type: 'improvement',
         notes: 'Face pulls and scap retractions stayed in the warmup through the end of the year.',
       },
       {
+        id: 'shoulder-milestone-2026-01-12',
         date: '2026-01-12',
         event: 'Cleared from rehab and marked resolved after several symptom-free weeks.',
         type: 'milestone',
@@ -137,6 +145,7 @@ export const mockHealthConditions: HealthCondition[] = [
       'Bilateral patellar tendon irritation that spikes with aggressive squat progressions, sprint work, and jumping volume. Symptoms are manageable but still require ongoing prep and load control.',
     timeline: [
       {
+        id: 'knees-onset-2025-06-03',
         date: '2025-06-03',
         event:
           'Front-of-knee pain started after a dense block of squats, split squats, and sprints.',
@@ -144,36 +153,42 @@ export const mockHealthConditions: HealthCondition[] = [
         notes: 'Descending stairs and the first warmup sets were the worst triggers.',
       },
       {
+        id: 'knees-treatment-2025-06-10',
         date: '2025-06-10',
         event: 'Swapped to slower eccentrics and removed jumps from lower-body accessories.',
         type: 'treatment',
         notes: 'Immediate goal was to calm tendon irritation without dropping all leg training.',
       },
       {
+        id: 'knees-treatment-2025-06-18',
         date: '2025-06-18',
         event: 'Spanish squats were added before leg sessions and on off days.',
         type: 'treatment',
         notes: 'These consistently reduced pain during the first loaded knee flexion patterns.',
       },
       {
+        id: 'knees-improvement-2025-07-09',
         date: '2025-07-09',
         event: 'Symptoms improved enough to reintroduce machine leg work and split squats.',
         type: 'improvement',
         notes: 'Kept ROM honest and avoided fast rebounds out of the hole.',
       },
       {
+        id: 'knees-flare-2025-08-14',
         date: '2025-08-14',
         event: 'Knees flared after a hard weekend of basketball and high-volume walking lunges.',
         type: 'flare',
         notes: 'Left side felt worse than right for about a week.',
       },
       {
+        id: 'knees-treatment-2025-09-05',
         date: '2025-09-05',
         event: 'Tibialis raises and slant board stretching became part of the daily warmup.',
         type: 'treatment',
         notes: 'Ankles and lower-leg stiffness were contributing more than expected.',
       },
       {
+        id: 'knees-milestone-2025-12-02',
         date: '2025-12-02',
         event: 'Moved from rehab mode into ongoing monitoring with stable training tolerance.',
         type: 'milestone',
@@ -255,6 +270,7 @@ export const mockHealthConditions: HealthCondition[] = [
       'Lumbar disc irritation with occasional referral into the glute after fatigue-heavy pulling and prolonged sitting. Improved from the initial acute phase, but still actively managed with spine-sparing training.',
     timeline: [
       {
+        id: 'back-onset-2025-09-18',
         date: '2025-09-18',
         event:
           'Low back tightened sharply after a heavy pull and stayed irritated through the next morning.',
@@ -262,6 +278,7 @@ export const mockHealthConditions: HealthCondition[] = [
         notes: 'Pain was worse with bending, sitting, and getting in or out of the car.',
       },
       {
+        id: 'back-treatment-2025-09-22',
         date: '2025-09-22',
         event:
           'Stopped loading squats, deadlifts, and any movements that stacked spinal compression.',
@@ -269,30 +286,35 @@ export const mockHealthConditions: HealthCondition[] = [
         notes: 'Training pivoted toward supported rows, split squats, sled work, and machines.',
       },
       {
+        id: 'back-treatment-2025-09-29',
         date: '2025-09-29',
         event: 'Started McGill Big 3 progression and strict brace-focused warmups.',
         type: 'treatment',
         notes: 'Daily consistency mattered more than trying to progress difficulty quickly.',
       },
       {
+        id: 'back-improvement-2025-10-17',
         date: '2025-10-17',
         event: 'Symptoms improved enough to tolerate longer walks and easier hinge patterns.',
         type: 'improvement',
         notes: 'Still avoiding fatigue that caused lumbar flexion under load.',
       },
       {
+        id: 'back-flare-2025-11-12',
         date: '2025-11-12',
         event: 'Flare after a long drive and too much sitting during a busy work week.',
         type: 'flare',
         notes: 'Pain centralized again after two lighter sessions and frequent walking breaks.',
       },
       {
+        id: 'back-improvement-2025-12-08',
         date: '2025-12-08',
         event: 'Couch stretch and hip-opening work reduced the constant low-back guarding.',
         type: 'improvement',
         notes: 'Hip flexor tightness was feeding into an overextended standing position.',
       },
       {
+        id: 'back-milestone-2026-02-03',
         date: '2026-02-03',
         event: 'Still marked active but stable enough for careful training progression.',
         type: 'milestone',
@@ -372,6 +394,7 @@ export const mockHealthConditions: HealthCondition[] = [
       'Heel and arch pain that built up from steps, standing, and conditioning volume. The condition is improving, but daily lower-leg work and footwear choices still matter.',
     timeline: [
       {
+        id: 'feet-onset-2025-07-05',
         date: '2025-07-05',
         event:
           'First-step heel pain showed up after a stretch of high daily step counts and incline walking.',
@@ -379,36 +402,42 @@ export const mockHealthConditions: HealthCondition[] = [
         notes: 'Morning stiffness and post-workout standing were the main symptoms.',
       },
       {
+        id: 'feet-treatment-2025-07-14',
         date: '2025-07-14',
         event: 'Conditioning volume was reduced and calf mobility work was added after sessions.',
         type: 'treatment',
         notes: 'Incline treadmill work was the fastest trigger at that point.',
       },
       {
+        id: 'feet-treatment-2025-08-01',
         date: '2025-08-01',
         event: 'Daily tibialis raises started to build ankle and foot tolerance.',
         type: 'treatment',
         notes: 'Foot discomfort decreased when these were done consistently.',
       },
       {
+        id: 'feet-flare-2025-08-28',
         date: '2025-08-28',
         event: 'Short flare after several long days on concrete with minimal recovery.',
         type: 'flare',
         notes: 'Pain was still milder than the original onset week.',
       },
       {
+        id: 'feet-improvement-2025-09-19',
         date: '2025-09-19',
         event: 'Supportive insoles made longer walks and errands much more manageable.',
         type: 'improvement',
         notes: 'This was enough to bring daily pain down even before training changes.',
       },
       {
+        id: 'feet-improvement-2025-11-07',
         date: '2025-11-07',
         event: 'Morning pain dropped noticeably and conditioning tolerance improved.',
         type: 'improvement',
         notes: 'Walking is mostly fine as long as calf work stays consistent.',
       },
       {
+        id: 'feet-milestone-2026-01-18',
         date: '2026-01-18',
         event: 'Condition moved into monitoring with only occasional tightness after long days.',
         type: 'milestone',

--- a/apps/web/src/features/injuries/types.ts
+++ b/apps/web/src/features/injuries/types.ts
@@ -3,6 +3,7 @@ export type ConditionStatus = 'active' | 'monitoring' | 'resolved';
 export type TimelineEventType = 'onset' | 'flare' | 'improvement' | 'treatment' | 'milestone';
 
 export type TimelineEvent = {
+  id: string;
   date: string;
   event: string;
   type: TimelineEventType;

--- a/apps/web/src/features/injuries/types.ts
+++ b/apps/web/src/features/injuries/types.ts
@@ -1,0 +1,45 @@
+export type ConditionStatus = 'active' | 'monitoring' | 'resolved';
+
+export type TimelineEventType = 'onset' | 'flare' | 'improvement' | 'treatment' | 'milestone';
+
+export type TimelineEvent = {
+  date: string;
+  event: string;
+  type: TimelineEventType;
+  notes?: string;
+};
+
+export type ProtocolStatus = 'active' | 'discontinued' | 'completed';
+
+export type Protocol = {
+  id: string;
+  name: string;
+  status: ProtocolStatus;
+  startDate: string;
+  endDate?: string;
+  notes: string;
+};
+
+export type LinkedJournalEntry = {
+  id: string;
+  title: string;
+  date: string;
+};
+
+export type SeverityPoint = {
+  date: string;
+  value: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+};
+
+export type HealthCondition = {
+  id: string;
+  name: string;
+  bodyArea: string;
+  status: ConditionStatus;
+  onsetDate: string;
+  description: string;
+  timeline: TimelineEvent[];
+  protocols: Protocol[];
+  linkedJournalEntries: LinkedJournalEntry[];
+  severityHistory: SeverityPoint[];
+};

--- a/apps/web/src/features/injuries/types.ts
+++ b/apps/web/src/features/injuries/types.ts
@@ -20,10 +20,13 @@ export type Protocol = {
   notes: string;
 };
 
+export type LinkedJournalEntryType = 'milestone' | 'observation' | 'weekly_summary';
+
 export type LinkedJournalEntry = {
   id: string;
   title: string;
   date: string;
+  type: LinkedJournalEntryType;
 };
 
 export type SeverityPoint = {

--- a/apps/web/src/pages/injuries.tsx
+++ b/apps/web/src/pages/injuries.tsx
@@ -1,9 +1,5 @@
-import { useParams } from 'react-router';
-
 import { ConditionsList } from '@/features/injuries';
 
 export function InjuriesPage() {
-  const { conditionId } = useParams();
-
-  return <ConditionsList selectedConditionId={conditionId} />;
+  return <ConditionsList />;
 }

--- a/apps/web/src/pages/injuries.tsx
+++ b/apps/web/src/pages/injuries.tsx
@@ -1,0 +1,9 @@
+import { useParams } from 'react-router';
+
+import { ConditionsList } from '@/features/injuries';
+
+export function InjuriesPage() {
+  const { conditionId } = useParams();
+
+  return <ConditionsList selectedConditionId={conditionId} />;
+}

--- a/apps/web/src/pages/injury-detail.tsx
+++ b/apps/web/src/pages/injury-detail.tsx
@@ -1,0 +1,40 @@
+import { ArrowLeftIcon } from 'lucide-react';
+import { Link, useParams } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ConditionDetail, mockHealthConditions } from '@/features/injuries';
+
+export function InjuryDetailPage() {
+  const { conditionId } = useParams();
+  const condition = mockHealthConditions.find((item) => item.id === conditionId);
+
+  if (!condition) {
+    return (
+      <section className="mx-auto flex w-full max-w-3xl flex-col gap-6 pb-10">
+        <Button asChild className="w-fit gap-2" size="sm" variant="ghost">
+          <Link to="/profile/injuries">
+            <ArrowLeftIcon aria-hidden="true" className="size-4" />
+            Back to Health Tracking
+          </Link>
+        </Button>
+
+        <Card className="py-6 shadow-sm">
+          <CardHeader className="gap-2">
+            <CardTitle className="text-2xl text-foreground">Condition not found</CardTitle>
+            <CardDescription>
+              The requested condition ID is not present in the mock injuries dataset.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Return to the health tracking list and pick one of the available conditions.
+            </p>
+          </CardContent>
+        </Card>
+      </section>
+    );
+  }
+
+  return <ConditionDetail condition={condition} />;
+}


### PR DESCRIPTION
## Summary

This PR adds the injuries and ailments prototype for Phase 1b, turning the profile health-tracking area into a browsable conditions list with linked detail pages. It introduces realistic mock condition data and surfaces the core recovery context reviewers need to evaluate the UX: status, onset, timeline events, protocols, related journal entries, and symptom severity over time. The goal is to make injury management feel like a first-class workflow in the prototype, not a placeholder, while staying fully frontend-only ahead of Phase 2 APIs. It also wires the new `/profile/injuries` routes into the app so the list and detail flows can be reviewed end to end.

## Key Changes

- Added injuries mock data covering multiple conditions with timelines, protocols, linked journal entries, and severity history.
- Added a health tracking list page at `/profile/injuries` with:
  - status-based overview cards
  - sort controls for status vs. onset date
  - condition cards linking into detail pages
  - a local “Add Condition” dialog for prototype-level creation
- Added condition detail pages at `/profile/injuries/:conditionId` with:
  - overview metadata for body area, onset date, and status
  - reverse-chronological timeline of recovery events
  - protocol tracking with status and notes
  - linked journal entry cards
  - a severity trend chart with event markers
- Added a reusable protocol list component and a severity chart component for the detail experience.
- Added test coverage for the severity chart component.
- Wired new routes into [`apps/web/src/App.tsx`](/Users/derek/GitProjects/pulse-fitness-app/apps/web/src/App.tsx), including `/profile` as the entry path for profile-related navigation in this phase.

## Technical Notes

- This is still a prototype-only implementation: all condition data is mock data, and the add-condition flow updates local component state only. There is no backend persistence, shared schema, or API integration in this PR.
- The list/detail split is intentionally route-driven so the injury workflow matches the navigation shape planned for the broader Profile hub work.
- Reviewers should pay attention to the information density on the detail page, especially the timeline, protocol status presentation, and severity chart readability, since those are the main UX risks in this slice.
- The new journal links assume linked-entry navigation as part of the wider Phase 1b prototype flow; they are present to validate cross-entity connection patterns rather than backend-backed relationships.

## Commits

- `1bf0162 feat(web): add condition severity chart`
- `26c6314 feat(web): add injury protocol tracking`
- `4f0d88a feat(web): add injury condition detail page`
- `2ee86ee feat(web): add injuries conditions list page`
- `79de13c feat(web): add injuries mock data`

## Tasks

- **Injuries mock data with conditions, timelines, protocols, severity history**: Create mock data for health conditions (SLAP tear, patellar tendon, disc herniation) with full timeline events, protocols, linked journal entries, severity data
- **Conditions list with status badges and add condition flow**: Conditions list page with active/monitoring/resolved status badges, body area, sort controls, and add new condition form
- **Condition detail: overview, timeline, linked journal entries**: Condition detail page with overview section, chronological timeline of events, and linked journal entry cards
- **Condition detail: protocols section with status tracking**: Protocols section showing tried therapies/exercises with active/discontinued/completed status and notes
- **Condition detail: improvement/regression chart with event markers**: Recharts AreaChart showing severity over time with dot markers for timeline events (flare-ups, treatments, milestones)

## Diff Stats

```
apps/web/src/App.tsx                               |   5 +
 .../injuries/components/condition-detail.tsx       | 269 +++++++++++
 .../injuries/components/conditions-list.tsx        | 517 +++++++++++++++++++++
 .../features/injuries/components/protocol-list.tsx | 384 +++++++++++++++
 .../injuries/components/severity-chart.test.tsx    |  64 +++
 .../injuries/components/severity-chart.tsx         | 357 ++++++++++++++
 apps/web/src/features/injuries/index.ts            |  15 +
 apps/web/src/features/injuries/lib/mock-data.ts    | 475 +++++++++++++++++++
 apps/web/src/features/injuries/types.ts            |  48 ++
 apps/web/src/pages/injuries.tsx                    |   5 +
 apps/web/src/pages/injury-detail.tsx               |  40 ++
 11 files changed, 2179 insertions(+)
```