### PR TITLE
Activity page prototype

### DIFF
--- a/apps/web/src/features/activity/components/activity-form.tsx
+++ b/apps/web/src/features/activity/components/activity-form.tsx
@@ -16,11 +16,8 @@ import { Textarea } from '@/components/ui/textarea';
 import { toDateKey } from '@/lib/date-utils';
 import { cn } from '@/lib/utils';
 
-import {
-  activityTypeOptions,
-  getActivityTypeIcon,
-  getActivityTypeLabel,
-} from '../lib/mock-data';
+import { activityTypeOptions, getActivityTypeIcon, getActivityTypeLabel } from '../lib/mock-data';
+import { formatDuration } from '../lib/format';
 import type { Activity, ActivityType } from '../types';
 
 type ActivityFormProps = {
@@ -46,21 +43,6 @@ const activityNameSuggestions: Record<ActivityType, string> = {
   hiking: 'Local Trail Hike',
   other: 'Movement Session',
 };
-
-function formatDurationPreview(minutes: number) {
-  const hours = Math.floor(minutes / 60);
-  const remainingMinutes = minutes % 60;
-
-  if (hours > 0 && remainingMinutes > 0) {
-    return `${hours}h ${remainingMinutes}min`;
-  }
-
-  if (hours > 0) {
-    return `${hours}h`;
-  }
-
-  return `${minutes} min`;
-}
 
 function createDefaultFormState(): ActivityFormState {
   return {
@@ -125,10 +107,10 @@ export function ActivityForm({ className, onSubmit }: ActivityFormProps) {
     onSubmit({
       date: formState.date,
       durationMinutes: parsedDuration,
-      id: `activity-local-${Date.now()}`,
+      id: `activity-local-${crypto.randomUUID()}`,
       linkedJournalEntries: [],
       name: activityName,
-      notes,
+      notes: notes.length > 0 ? notes : undefined,
       type: formState.type,
     });
 
@@ -137,7 +119,7 @@ export function ActivityForm({ className, onSubmit }: ActivityFormProps) {
   };
 
   const selectedTypeLabel = getActivityTypeLabel(formState.type);
-  const durationPreview = hasValidDuration ? formatDurationPreview(parsedDuration) : null;
+  const durationPreview = hasValidDuration ? formatDuration(parsedDuration) : null;
 
   return (
     <div className={cn('space-y-3', className)}>

--- a/apps/web/src/features/activity/components/activity-form.tsx
+++ b/apps/web/src/features/activity/components/activity-form.tsx
@@ -1,0 +1,279 @@
+import { type FormEvent, useState } from 'react';
+import { CalendarDays, CheckCircle2, Clock3, Plus } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { toDateKey } from '@/lib/date-utils';
+import { cn } from '@/lib/utils';
+
+import {
+  activityTypeOptions,
+  getActivityTypeIcon,
+  getActivityTypeLabel,
+} from '../lib/mock-data';
+import type { Activity, ActivityType } from '../types';
+
+type ActivityFormProps = {
+  className?: string;
+  onSubmit: (activity: Activity) => void;
+};
+
+type ActivityFormState = {
+  date: string;
+  durationMinutes: string;
+  name: string;
+  notes: string;
+  type: ActivityType;
+};
+
+const activityNameSuggestions: Record<ActivityType, string> = {
+  walking: 'Morning Walk',
+  running: 'Zone 2 Run',
+  stretching: 'Recovery Stretch',
+  yoga: 'Evening Yoga Flow',
+  cycling: 'Neighborhood Ride',
+  swimming: 'Recovery Swim',
+  hiking: 'Local Trail Hike',
+  other: 'Movement Session',
+};
+
+function formatDurationPreview(minutes: number) {
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  if (hours > 0 && remainingMinutes > 0) {
+    return `${hours}h ${remainingMinutes}min`;
+  }
+
+  if (hours > 0) {
+    return `${hours}h`;
+  }
+
+  return `${minutes} min`;
+}
+
+function createDefaultFormState(): ActivityFormState {
+  return {
+    date: toDateKey(new Date()),
+    durationMinutes: '',
+    name: activityNameSuggestions.walking,
+    notes: '',
+    type: 'walking',
+  };
+}
+
+export function ActivityForm({ className, onSubmit }: ActivityFormProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [formState, setFormState] = useState<ActivityFormState>(createDefaultFormState);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const parsedDuration = Number(formState.durationMinutes);
+  const hasValidDuration =
+    formState.durationMinutes.trim().length > 0 &&
+    Number.isFinite(parsedDuration) &&
+    parsedDuration > 0;
+  const isSubmitDisabled =
+    formState.name.trim().length === 0 || formState.date.trim().length === 0 || !hasValidDuration;
+
+  const resetForm = () => {
+    setFormState(createDefaultFormState());
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+
+    if (!open) {
+      resetForm();
+    }
+  };
+
+  const handleTypeChange = (nextType: ActivityType) => {
+    setFormState((current) => {
+      const previousSuggestion = activityNameSuggestions[current.type];
+      const nextSuggestion = activityNameSuggestions[nextType];
+      const shouldReplaceName =
+        current.name.trim().length === 0 || current.name === previousSuggestion;
+
+      return {
+        ...current,
+        name: shouldReplaceName ? nextSuggestion : current.name,
+        type: nextType,
+      };
+    });
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isSubmitDisabled) {
+      return;
+    }
+
+    const activityName = formState.name.trim();
+    const notes = formState.notes.trim();
+
+    onSubmit({
+      date: formState.date,
+      durationMinutes: parsedDuration,
+      id: `activity-local-${Date.now()}`,
+      linkedJournalEntries: [],
+      name: activityName,
+      notes,
+      type: formState.type,
+    });
+
+    setSuccessMessage(`Logged "${activityName}" to the local activity list.`);
+    handleOpenChange(false);
+  };
+
+  const selectedTypeLabel = getActivityTypeLabel(formState.type);
+  const durationPreview = hasValidDuration ? formatDurationPreview(parsedDuration) : null;
+
+  return (
+    <div className={cn('space-y-3', className)}>
+      <Button onClick={() => setIsOpen(true)} type="button">
+        <Plus aria-hidden="true" className="size-4" />
+        Add Activity
+      </Button>
+
+      {successMessage ? (
+        <div
+          aria-live="polite"
+          className="flex items-start gap-3 rounded-2xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-950 dark:text-emerald-300"
+        >
+          <CheckCircle2 aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
+          <p>{successMessage}</p>
+        </div>
+      ) : null}
+
+      <Dialog onOpenChange={handleOpenChange} open={isOpen}>
+        <DialogContent className="max-h-[calc(100vh-2rem)] overflow-y-auto sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Log a new activity</DialogTitle>
+            <DialogDescription>
+              Add a movement session to the local prototype list. This does not persist yet.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form className="space-y-5" onSubmit={handleSubmit}>
+            <div className="space-y-3">
+              <Label>Type</Label>
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                {activityTypeOptions.map((type) => {
+                  const ActivityTypeIcon = getActivityTypeIcon(type);
+                  const isSelected = formState.type === type;
+
+                  return (
+                    <Button
+                      key={type}
+                      aria-pressed={isSelected}
+                      className={cn(
+                        'h-auto justify-start rounded-2xl px-3 py-3 text-left',
+                        isSelected &&
+                          'border-primary bg-primary text-primary-foreground hover:bg-primary/90',
+                      )}
+                      onClick={() => handleTypeChange(type)}
+                      type="button"
+                      variant={isSelected ? 'default' : 'outline'}
+                    >
+                      <ActivityTypeIcon aria-hidden="true" className="size-4" />
+                      {getActivityTypeLabel(type)}
+                    </Button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2 sm:col-span-2">
+                <Label htmlFor="activity-name">Name</Label>
+                <Input
+                  id="activity-name"
+                  onChange={(event) =>
+                    setFormState((current) => ({ ...current, name: event.target.value }))
+                  }
+                  placeholder={activityNameSuggestions[formState.type]}
+                  value={formState.name}
+                />
+                <p className="text-xs text-muted">
+                  Suggested for {selectedTypeLabel.toLowerCase()}. You can edit this before saving.
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="activity-duration">Duration</Label>
+                <Input
+                  id="activity-duration"
+                  inputMode="numeric"
+                  min="1"
+                  onChange={(event) =>
+                    setFormState((current) => ({
+                      ...current,
+                      durationMinutes: event.target.value,
+                    }))
+                  }
+                  placeholder="30"
+                  type="number"
+                  value={formState.durationMinutes}
+                />
+                <p className="flex items-center gap-1.5 text-xs text-muted">
+                  <Clock3 aria-hidden="true" className="size-3.5" />
+                  {durationPreview
+                    ? `Preview: ${durationPreview}`
+                    : 'Enter minutes to preview the formatted duration.'}
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="activity-date">Date</Label>
+                <Input
+                  id="activity-date"
+                  onChange={(event) =>
+                    setFormState((current) => ({ ...current, date: event.target.value }))
+                  }
+                  type="date"
+                  value={formState.date}
+                />
+                <p className="flex items-center gap-1.5 text-xs text-muted">
+                  <CalendarDays aria-hidden="true" className="size-3.5" />
+                  Defaults to today for quick logging.
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="activity-notes">Notes</Label>
+              <Textarea
+                id="activity-notes"
+                onChange={(event) =>
+                  setFormState((current) => ({ ...current, notes: event.target.value }))
+                }
+                placeholder="Optional context about pace, recovery, terrain, or how it felt."
+                value={formState.notes}
+              />
+            </div>
+
+            <DialogFooter>
+              <Button onClick={() => handleOpenChange(false)} type="button" variant="outline">
+                Cancel
+              </Button>
+              <Button disabled={isSubmitDisabled} type="submit">
+                Log Activity
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/features/activity/components/activity-list.test.tsx
+++ b/apps/web/src/features/activity/components/activity-list.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ActivityList } from '@/features/activity';
+
+describe('ActivityList', () => {
+  it('formats longer durations using hours and minutes', () => {
+    render(<ActivityList />);
+
+    expect(screen.getByText('1h 30min')).toBeInTheDocument();
+    expect(screen.getByText('45 min')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when a filter has no matching activities', () => {
+    render(
+      <ActivityList
+        activities={[
+          {
+            id: 'activity-one',
+            date: '2026-03-05',
+            durationMinutes: 20,
+            linkedJournalEntries: [],
+            name: 'Easy Walk',
+            notes: 'Flat neighborhood loop.',
+            type: 'walking',
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Yoga' }));
+
+    expect(screen.getByText('No activities match this filter.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Try a different activity type to view the rest of the mock log.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/activity/components/activity-list.test.tsx
+++ b/apps/web/src/features/activity/components/activity-list.test.tsx
@@ -5,7 +5,29 @@ import { ActivityList } from '@/features/activity';
 
 describe('ActivityList', () => {
   it('formats longer durations using hours and minutes', () => {
-    render(<ActivityList />);
+    render(
+      <ActivityList
+        activities={[
+          {
+            id: 'activity-hike',
+            date: '2026-03-05',
+            durationMinutes: 90,
+            linkedJournalEntries: [],
+            name: 'Trail Session',
+            notes: 'Rolling climbs with easy descents.',
+            type: 'hiking',
+          },
+          {
+            id: 'activity-yoga',
+            date: '2026-03-04',
+            durationMinutes: 45,
+            linkedJournalEntries: [],
+            name: 'Morning Flow',
+            type: 'yoga',
+          },
+        ]}
+      />,
+    );
 
     expect(screen.getByText('1h 30min')).toBeInTheDocument();
     expect(screen.getByText('45 min')).toBeInTheDocument();
@@ -32,7 +54,7 @@ describe('ActivityList', () => {
 
     expect(screen.getByText('No activities match this filter.')).toBeInTheDocument();
     expect(
-      screen.getByText('Try a different activity type to view the rest of the mock log.'),
+      screen.getByText('Try a different activity type to view the rest of the activity log.'),
     ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/activity/components/activity-list.tsx
+++ b/apps/web/src/features/activity/components/activity-list.tsx
@@ -47,18 +47,13 @@ function formatDuration(minutes: number) {
   return `${minutes} min`;
 }
 
-function sortActivitiesByDate(activities: Activity[]) {
-  return [...activities].sort((left, right) => right.date.localeCompare(left.date));
-}
-
 export function ActivityList({ activities = mockActivities }: ActivityListProps) {
   const [selectedType, setSelectedType] = useState<ActivityFilter>('all');
 
-  const sortedActivities = sortActivitiesByDate(activities);
   const filteredActivities =
     selectedType === 'all'
-      ? sortedActivities
-      : sortedActivities.filter((activity) => activity.type === selectedType);
+      ? activities
+      : activities.filter((activity) => activity.type === selectedType);
 
   return (
     <div className="space-y-5">
@@ -148,11 +143,13 @@ export function ActivityList({ activities = mockActivities }: ActivityListProps)
                           <h2 className="text-lg font-semibold text-foreground sm:text-xl">
                             {activity.name}
                           </h2>
-                          <p className="max-w-3xl text-sm leading-6 text-muted">
-                            <span className="block max-h-[3rem] overflow-hidden">
-                              {activity.notes}
-                            </span>
-                          </p>
+                          {activity.notes ? (
+                            <p className="max-w-3xl text-sm leading-6 text-muted">
+                              <span className="block max-h-[3rem] overflow-hidden">
+                                {activity.notes}
+                              </span>
+                            </p>
+                          ) : null}
                         </div>
                       </div>
                     </div>

--- a/apps/web/src/features/activity/components/activity-list.tsx
+++ b/apps/web/src/features/activity/components/activity-list.tsx
@@ -1,0 +1,209 @@
+import { useState } from 'react';
+import { BookOpen, CalendarDays, Clock3, SlidersHorizontal } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { parseDateKey } from '@/lib/date-utils';
+import { cn } from '@/lib/utils';
+
+import {
+  activityTypeOptions,
+  getActivityTypeBadgeClasses,
+  getActivityTypeIcon,
+  getActivityTypeLabel,
+  mockActivities,
+} from '../lib/mock-data';
+import type { Activity, ActivityType } from '../types';
+
+type ActivityListProps = {
+  activities?: Activity[];
+};
+
+type ActivityFilter = 'all' | ActivityType;
+
+const activityDateFormatter = new Intl.DateTimeFormat('en-US', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+});
+
+function formatActivityDate(date: string) {
+  return activityDateFormatter.format(parseDateKey(date));
+}
+
+function formatDuration(minutes: number) {
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  if (hours > 0 && remainingMinutes > 0) {
+    return `${hours}h ${remainingMinutes}min`;
+  }
+
+  if (hours > 0) {
+    return `${hours}h`;
+  }
+
+  return `${minutes} min`;
+}
+
+function sortActivitiesByDate(activities: Activity[]) {
+  return [...activities].sort((left, right) => right.date.localeCompare(left.date));
+}
+
+export function ActivityList({ activities = mockActivities }: ActivityListProps) {
+  const [selectedType, setSelectedType] = useState<ActivityFilter>('all');
+
+  const sortedActivities = sortActivitiesByDate(activities);
+  const filteredActivities =
+    selectedType === 'all'
+      ? sortedActivities
+      : sortedActivities.filter((activity) => activity.type === selectedType);
+
+  return (
+    <div className="space-y-5">
+      <div className="space-y-3">
+        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted">
+          <SlidersHorizontal aria-hidden="true" className="size-3.5" />
+          Type filter
+        </div>
+        <div className="-mx-4 overflow-x-auto px-4 sm:mx-0 sm:px-0">
+          <div className="flex min-w-max gap-2 pb-1">
+            <Button
+              aria-pressed={selectedType === 'all'}
+              className={cn(
+                'shrink-0 rounded-full border px-4',
+                selectedType === 'all'
+                  ? 'border-primary bg-primary text-primary-foreground hover:bg-primary/90'
+                  : 'border-border/70 bg-card/80 text-muted hover:bg-secondary hover:text-foreground',
+              )}
+              onClick={() => setSelectedType('all')}
+              size="sm"
+              variant="ghost"
+            >
+              All
+            </Button>
+            {activityTypeOptions.map((type) => {
+              const ActivityTypeIcon = getActivityTypeIcon(type);
+
+              return (
+                <Button
+                  key={type}
+                  aria-pressed={selectedType === type}
+                  className={cn(
+                    'shrink-0 rounded-full border px-4',
+                    selectedType === type
+                      ? 'border-primary bg-primary text-primary-foreground hover:bg-primary/90'
+                      : 'border-border/70 bg-card/80 text-muted hover:bg-secondary hover:text-foreground',
+                  )}
+                  onClick={() => setSelectedType(type)}
+                  size="sm"
+                  variant="ghost"
+                >
+                  <ActivityTypeIcon aria-hidden="true" className="size-4" />
+                  {getActivityTypeLabel(type)}
+                </Button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {filteredActivities.length === 0 ? (
+        <Card className="border-dashed bg-card/70 py-0">
+          <CardContent className="px-5 py-6 sm:px-6">
+            <p className="text-sm font-medium text-foreground">No activities match this filter.</p>
+            <p className="mt-1 text-sm text-muted">
+              Try a different activity type to view the rest of the mock log.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-4">
+          {filteredActivities.map((activity) => {
+            const ActivityTypeIcon = getActivityTypeIcon(activity.type);
+
+            return (
+              <Card key={activity.id} className="gap-0 border-border/70 bg-card/95 py-0">
+                <CardContent className="space-y-4 px-5 py-5 sm:px-6">
+                  <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="flex items-start gap-3">
+                      <div className="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-border/60 bg-secondary/80 text-primary shadow-sm">
+                        <ActivityTypeIcon aria-hidden="true" className="size-5" />
+                      </div>
+                      <div className="space-y-3">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge
+                            className={cn(
+                              'cursor-default gap-1.5 px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em]',
+                              getActivityTypeBadgeClasses(activity.type),
+                            )}
+                            variant="secondary"
+                          >
+                            <ActivityTypeIcon aria-hidden="true" className="size-3.5" />
+                            {getActivityTypeLabel(activity.type)}
+                          </Badge>
+                        </div>
+                        <div className="space-y-2">
+                          <h2 className="text-lg font-semibold text-foreground sm:text-xl">
+                            {activity.name}
+                          </h2>
+                          <p className="max-w-3xl text-sm leading-6 text-muted">
+                            <span className="block max-h-[3rem] overflow-hidden">
+                              {activity.notes}
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="grid gap-3 sm:grid-cols-2 lg:min-w-72">
+                      <div className="rounded-2xl border border-border/60 bg-background/75 px-3.5 py-3">
+                        <p className="flex items-center gap-1.5 text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-muted">
+                          <Clock3 aria-hidden="true" className="size-3.5" />
+                          Duration
+                        </p>
+                        <p className="mt-2 text-lg font-semibold text-foreground">
+                          {formatDuration(activity.durationMinutes)}
+                        </p>
+                      </div>
+                      <div className="rounded-2xl border border-border/60 bg-background/75 px-3.5 py-3">
+                        <p className="flex items-center gap-1.5 text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-muted">
+                          <CalendarDays aria-hidden="true" className="size-3.5" />
+                          Date
+                        </p>
+                        <p className="mt-2 text-lg font-semibold text-foreground">
+                          {formatActivityDate(activity.date)}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  {activity.linkedJournalEntries.length > 0 ? (
+                    <div className="space-y-2 border-t border-border/60 pt-4">
+                      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted">
+                        Linked journal
+                      </p>
+                      <div className="flex flex-wrap gap-2">
+                        {activity.linkedJournalEntries.map((entry) => (
+                          <Badge
+                            key={entry.id}
+                            className="cursor-default gap-1.5 rounded-full border-border/70 bg-background/80 px-3 py-1 text-xs font-medium text-muted"
+                            variant="outline"
+                          >
+                            <BookOpen aria-hidden="true" className="size-3.5" />
+                            {entry.title}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/activity/components/activity-list.tsx
+++ b/apps/web/src/features/activity/components/activity-list.tsx
@@ -12,12 +12,12 @@ import {
   getActivityTypeBadgeClasses,
   getActivityTypeIcon,
   getActivityTypeLabel,
-  mockActivities,
 } from '../lib/mock-data';
+import { formatDuration } from '../lib/format';
 import type { Activity, ActivityType } from '../types';
 
 type ActivityListProps = {
-  activities?: Activity[];
+  activities: Activity[];
 };
 
 type ActivityFilter = 'all' | ActivityType;
@@ -32,22 +32,7 @@ function formatActivityDate(date: string) {
   return activityDateFormatter.format(parseDateKey(date));
 }
 
-function formatDuration(minutes: number) {
-  const hours = Math.floor(minutes / 60);
-  const remainingMinutes = minutes % 60;
-
-  if (hours > 0 && remainingMinutes > 0) {
-    return `${hours}h ${remainingMinutes}min`;
-  }
-
-  if (hours > 0) {
-    return `${hours}h`;
-  }
-
-  return `${minutes} min`;
-}
-
-export function ActivityList({ activities = mockActivities }: ActivityListProps) {
+export function ActivityList({ activities }: ActivityListProps) {
   const [selectedType, setSelectedType] = useState<ActivityFilter>('all');
 
   const filteredActivities =
@@ -109,7 +94,7 @@ export function ActivityList({ activities = mockActivities }: ActivityListProps)
           <CardContent className="px-5 py-6 sm:px-6">
             <p className="text-sm font-medium text-foreground">No activities match this filter.</p>
             <p className="mt-1 text-sm text-muted">
-              Try a different activity type to view the rest of the mock log.
+              Try a different activity type to view the rest of the activity log.
             </p>
           </CardContent>
         </Card>
@@ -144,10 +129,8 @@ export function ActivityList({ activities = mockActivities }: ActivityListProps)
                             {activity.name}
                           </h2>
                           {activity.notes ? (
-                            <p className="max-w-3xl text-sm leading-6 text-muted">
-                              <span className="block max-h-[3rem] overflow-hidden">
-                                {activity.notes}
-                              </span>
+                            <p className="max-w-3xl text-sm leading-6 text-muted line-clamp-2">
+                              {activity.notes}
                             </p>
                           ) : null}
                         </div>

--- a/apps/web/src/features/activity/index.ts
+++ b/apps/web/src/features/activity/index.ts
@@ -7,4 +7,5 @@ export {
   getActivityTypeLabel,
   mockActivities,
 } from './lib/mock-data';
+export { sortActivitiesByDateDesc } from './lib/sort';
 export type { Activity, ActivityJournalEntryReference, ActivityType } from './types';

--- a/apps/web/src/features/activity/index.ts
+++ b/apps/web/src/features/activity/index.ts
@@ -1,3 +1,4 @@
+export { ActivityList } from './components/activity-list';
 export {
   activityTypeOptions,
   getActivityTypeBadgeClasses,

--- a/apps/web/src/features/activity/index.ts
+++ b/apps/web/src/features/activity/index.ts
@@ -1,0 +1,8 @@
+export {
+  activityTypeOptions,
+  getActivityTypeBadgeClasses,
+  getActivityTypeIcon,
+  getActivityTypeLabel,
+  mockActivities,
+} from './lib/mock-data';
+export type { Activity, ActivityJournalEntryReference, ActivityType } from './types';

--- a/apps/web/src/features/activity/index.ts
+++ b/apps/web/src/features/activity/index.ts
@@ -1,3 +1,4 @@
+export { ActivityForm } from './components/activity-form';
 export { ActivityList } from './components/activity-list';
 export {
   activityTypeOptions,

--- a/apps/web/src/features/activity/lib/format.ts
+++ b/apps/web/src/features/activity/lib/format.ts
@@ -1,0 +1,14 @@
+export function formatDuration(minutes: number) {
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  if (hours > 0 && remainingMinutes > 0) {
+    return `${hours}h ${remainingMinutes}min`;
+  }
+
+  if (hours > 0) {
+    return `${hours}h`;
+  }
+
+  return `${minutes} min`;
+}

--- a/apps/web/src/features/activity/lib/mock-data.test.ts
+++ b/apps/web/src/features/activity/lib/mock-data.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  activityTypeOptions,
+  getActivityTypeBadgeClasses,
+  getActivityTypeIcon,
+  getActivityTypeLabel,
+  mockActivities,
+} from '@/features/activity';
+
+describe('activity mock data', () => {
+  it('provides 10-12 realistic activities spanning multiple weeks', () => {
+    expect(mockActivities).toHaveLength(11);
+    expect(mockActivities[0]?.date).toBe('2026-03-04');
+    expect(mockActivities.at(-1)?.date).toBe('2026-02-17');
+
+    expect(mockActivities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ durationMinutes: 30, name: 'Morning Walk', type: 'walking' }),
+        expect.objectContaining({ durationMinutes: 20, name: 'Evening Walk', type: 'walking' }),
+        expect.objectContaining({
+          durationMinutes: 15,
+          name: 'Morning Stretch Routine',
+          type: 'stretching',
+        }),
+        expect.objectContaining({
+          durationMinutes: 20,
+          name: 'Hip Opener Flow',
+          type: 'stretching',
+        }),
+        expect.objectContaining({ durationMinutes: 45, name: 'Yoga with Adriene', type: 'yoga' }),
+        expect.objectContaining({ durationMinutes: 25, name: 'Zone 2 Run', type: 'running' }),
+        expect.objectContaining({ durationMinutes: 30, name: 'Peloton Ride', type: 'cycling' }),
+        expect.objectContaining({
+          durationMinutes: 90,
+          name: 'Trail Hike - Blue Ridge',
+          type: 'hiking',
+        }),
+      ]),
+    );
+  });
+
+  it('links some activities back to journal previews', () => {
+    const linkedActivities = mockActivities.filter(
+      (activity) => activity.linkedJournalEntries.length > 0,
+    );
+
+    expect(linkedActivities.length).toBeGreaterThanOrEqual(5);
+    expect(linkedActivities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          linkedJournalEntries: expect.arrayContaining([
+            expect.objectContaining({ title: 'Feeling More Energetic' }),
+          ]),
+        }),
+        expect.objectContaining({
+          linkedJournalEntries: expect.arrayContaining([
+            expect.objectContaining({ title: 'First 5K Completed!' }),
+          ]),
+        }),
+      ]),
+    );
+  });
+
+  it('exposes icon, color, and label helpers for every activity type', () => {
+    activityTypeOptions.forEach((type) => {
+      expect(getActivityTypeIcon(type)).toBeTruthy();
+      expect(getActivityTypeBadgeClasses(type)).toContain('border-transparent');
+      expect(getActivityTypeLabel(type)).toMatch(/[A-Z]/);
+    });
+  });
+});

--- a/apps/web/src/features/activity/lib/mock-data.test.ts
+++ b/apps/web/src/features/activity/lib/mock-data.test.ts
@@ -87,7 +87,7 @@ describe('activity mock data', () => {
     activityTypeOptions.forEach((type) => {
       expect(getActivityTypeIcon(type)).toBe(expectedIcons[type]);
       expect(getActivityTypeBadgeClasses(type)).toContain('border-transparent');
-      expect(getActivityTypeLabel(type)).toMatch(/[A-Z]/);
+      expect(getActivityTypeLabel(type)).toMatch(/^[A-Z][a-z]/);
     });
   });
 });

--- a/apps/web/src/features/activity/lib/mock-data.test.ts
+++ b/apps/web/src/features/activity/lib/mock-data.test.ts
@@ -1,4 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import {
+  Bike,
+  Flower2,
+  Footprints,
+  MoreHorizontal,
+  Mountain,
+  StretchHorizontal,
+  Timer,
+  Waves,
+} from 'lucide-react';
 
 import {
   activityTypeOptions,
@@ -63,8 +73,19 @@ describe('activity mock data', () => {
   });
 
   it('exposes icon, color, and label helpers for every activity type', () => {
+    const expectedIcons = {
+      cycling: Bike,
+      hiking: Mountain,
+      other: MoreHorizontal,
+      running: Timer,
+      stretching: StretchHorizontal,
+      swimming: Waves,
+      walking: Footprints,
+      yoga: Flower2,
+    } as const;
+
     activityTypeOptions.forEach((type) => {
-      expect(getActivityTypeIcon(type)).toBeTruthy();
+      expect(getActivityTypeIcon(type)).toBe(expectedIcons[type]);
       expect(getActivityTypeBadgeClasses(type)).toContain('border-transparent');
       expect(getActivityTypeLabel(type)).toMatch(/[A-Z]/);
     });

--- a/apps/web/src/features/activity/lib/mock-data.ts
+++ b/apps/web/src/features/activity/lib/mock-data.ts
@@ -1,0 +1,225 @@
+import type { LucideIcon } from 'lucide-react';
+import {
+  Activity as ActivityIcon,
+  Bike,
+  CircleEllipsis,
+  Footprints,
+  Mountain,
+  Move,
+  PersonStanding,
+  Waves,
+} from 'lucide-react';
+
+import type { Activity, ActivityType } from '../types';
+
+type ActivityTypeMetadata = {
+  badgeClassName: string;
+  icon: LucideIcon;
+  label: string;
+};
+
+const activityTypeMetadata: Record<ActivityType, ActivityTypeMetadata> = {
+  walking: {
+    badgeClassName:
+      'border-transparent bg-emerald-200 text-emerald-950 dark:bg-emerald-500/20 dark:text-emerald-400',
+    icon: Footprints,
+    label: 'Walking',
+  },
+  running: {
+    badgeClassName:
+      'border-transparent bg-rose-200 text-rose-950 dark:bg-rose-500/20 dark:text-rose-400',
+    icon: ActivityIcon,
+    label: 'Running',
+  },
+  stretching: {
+    badgeClassName:
+      'border-transparent bg-sky-200 text-sky-950 dark:bg-sky-500/20 dark:text-sky-400',
+    icon: Move,
+    label: 'Stretching',
+  },
+  yoga: {
+    badgeClassName:
+      'border-transparent bg-violet-200 text-violet-950 dark:bg-violet-500/20 dark:text-violet-400',
+    icon: PersonStanding,
+    label: 'Yoga',
+  },
+  cycling: {
+    badgeClassName:
+      'border-transparent bg-amber-200 text-amber-950 dark:bg-amber-500/20 dark:text-amber-400',
+    icon: Bike,
+    label: 'Cycling',
+  },
+  swimming: {
+    badgeClassName:
+      'border-transparent bg-cyan-200 text-cyan-950 dark:bg-cyan-500/20 dark:text-cyan-400',
+    icon: Waves,
+    label: 'Swimming',
+  },
+  hiking: {
+    badgeClassName:
+      'border-transparent bg-lime-200 text-lime-950 dark:bg-lime-500/20 dark:text-lime-400',
+    icon: Mountain,
+    label: 'Hiking',
+  },
+  other: {
+    badgeClassName:
+      'border-transparent bg-slate-200 text-slate-950 dark:bg-slate-500/20 dark:text-slate-300',
+    icon: CircleEllipsis,
+    label: 'Other',
+  },
+};
+
+export const activityTypeOptions: ActivityType[] = [
+  'walking',
+  'running',
+  'stretching',
+  'yoga',
+  'cycling',
+  'swimming',
+  'hiking',
+  'other',
+];
+
+export const mockActivities: Activity[] = [
+  {
+    id: 'activity-peloton-ride-2026-03-04',
+    date: '2026-03-04',
+    type: 'cycling',
+    name: 'Peloton Ride',
+    durationMinutes: 30,
+    notes: 'Low-impact ride with a steady Zone 2 effort before breakfast.',
+    linkedJournalEntries: [
+      {
+        id: 'journal-week-12-summary',
+        title: 'Week 12 Summary',
+      },
+    ],
+  },
+  {
+    id: 'activity-evening-walk-2026-03-03',
+    date: '2026-03-03',
+    type: 'walking',
+    name: 'Evening Walk',
+    durationMinutes: 20,
+    notes: 'Easy neighborhood loop to unwind after dinner.',
+    linkedJournalEntries: [],
+  },
+  {
+    id: 'activity-hip-opener-flow-2026-03-02',
+    date: '2026-03-02',
+    type: 'stretching',
+    name: 'Hip Opener Flow',
+    durationMinutes: 20,
+    notes: 'Focused on hips, calves, and thoracic rotation after leg day.',
+    linkedJournalEntries: [
+      {
+        id: 'journal-week-12-summary',
+        title: 'Week 12 Summary',
+      },
+    ],
+  },
+  {
+    id: 'activity-blue-ridge-hike-2026-03-01',
+    date: '2026-03-01',
+    type: 'hiking',
+    name: 'Trail Hike - Blue Ridge',
+    durationMinutes: 90,
+    notes: 'Rolling trail loop with a few steep climbs and plenty of recovery stops.',
+    linkedJournalEntries: [
+      {
+        id: 'journal-week-12-summary',
+        title: 'Week 12 Summary',
+      },
+    ],
+  },
+  {
+    id: 'activity-zone-2-run-2026-02-28',
+    date: '2026-02-28',
+    type: 'running',
+    name: 'Zone 2 Run',
+    durationMinutes: 25,
+    notes: 'Kept pace conversational and finished with a controlled final kilometer.',
+    linkedJournalEntries: [
+      {
+        id: 'journal-first-5k-completed',
+        title: 'First 5K Completed!',
+      },
+    ],
+  },
+  {
+    id: 'activity-yoga-with-adriene-2026-02-27',
+    date: '2026-02-27',
+    type: 'yoga',
+    name: 'Yoga with Adriene',
+    durationMinutes: 45,
+    notes: 'Full-body flow with balance work and a long cooldown on the mat.',
+    linkedJournalEntries: [],
+  },
+  {
+    id: 'activity-morning-walk-2026-02-25',
+    date: '2026-02-25',
+    type: 'walking',
+    name: 'Morning Walk',
+    durationMinutes: 30,
+    notes: 'Brisk walk before work with a few short hills to raise heart rate.',
+    linkedJournalEntries: [
+      {
+        id: 'journal-feeling-more-energetic',
+        title: 'Feeling More Energetic',
+      },
+    ],
+  },
+  {
+    id: 'activity-morning-stretch-routine-2026-02-23',
+    date: '2026-02-23',
+    type: 'stretching',
+    name: 'Morning Stretch Routine',
+    durationMinutes: 15,
+    notes: 'Quick hamstring, shoulder, and ankle mobility circuit before sitting down to work.',
+    linkedJournalEntries: [],
+  },
+  {
+    id: 'activity-recovery-swim-2026-02-21',
+    date: '2026-02-21',
+    type: 'swimming',
+    name: 'Recovery Swim',
+    durationMinutes: 35,
+    notes: 'Easy laps with pull-buoy work to keep effort light and smooth.',
+    linkedJournalEntries: [],
+  },
+  {
+    id: 'activity-neighborhood-bike-2026-02-19',
+    date: '2026-02-19',
+    type: 'cycling',
+    name: 'Neighborhood Spin',
+    durationMinutes: 40,
+    notes: 'Casual outdoor ride with a few cadence pushes on the flat sections.',
+    linkedJournalEntries: [],
+  },
+  {
+    id: 'activity-sauna-mobility-2026-02-17',
+    date: '2026-02-17',
+    type: 'other',
+    name: 'Sauna + Mobility Circuit',
+    durationMinutes: 25,
+    notes: 'Alternated light mobility drills with short sauna rounds for recovery.',
+    linkedJournalEntries: [
+      {
+        id: 'journal-feeling-more-energetic',
+        title: 'Feeling More Energetic',
+      },
+    ],
+  },
+];
+
+export function getActivityTypeBadgeClasses(type: ActivityType) {
+  return activityTypeMetadata[type].badgeClassName;
+}
+
+export function getActivityTypeIcon(type: ActivityType) {
+  return activityTypeMetadata[type].icon;
+}
+
+export function getActivityTypeLabel(type: ActivityType) {
+  return activityTypeMetadata[type].label;
+}

--- a/apps/web/src/features/activity/lib/mock-data.ts
+++ b/apps/web/src/features/activity/lib/mock-data.ts
@@ -1,12 +1,12 @@
 import type { LucideIcon } from 'lucide-react';
 import {
-  Activity as ActivityIcon,
   Bike,
-  CircleEllipsis,
+  Flower2,
   Footprints,
   Mountain,
-  Move,
-  PersonStanding,
+  MoreHorizontal,
+  StretchHorizontal,
+  Timer,
   Waves,
 } from 'lucide-react';
 
@@ -28,19 +28,19 @@ const activityTypeMetadata: Record<ActivityType, ActivityTypeMetadata> = {
   running: {
     badgeClassName:
       'border-transparent bg-rose-200 text-rose-950 dark:bg-rose-500/20 dark:text-rose-400',
-    icon: ActivityIcon,
+    icon: Timer,
     label: 'Running',
   },
   stretching: {
     badgeClassName:
       'border-transparent bg-sky-200 text-sky-950 dark:bg-sky-500/20 dark:text-sky-400',
-    icon: Move,
+    icon: StretchHorizontal,
     label: 'Stretching',
   },
   yoga: {
     badgeClassName:
       'border-transparent bg-violet-200 text-violet-950 dark:bg-violet-500/20 dark:text-violet-400',
-    icon: PersonStanding,
+    icon: Flower2,
     label: 'Yoga',
   },
   cycling: {
@@ -64,7 +64,7 @@ const activityTypeMetadata: Record<ActivityType, ActivityTypeMetadata> = {
   other: {
     badgeClassName:
       'border-transparent bg-slate-200 text-slate-950 dark:bg-slate-500/20 dark:text-slate-300',
-    icon: CircleEllipsis,
+    icon: MoreHorizontal,
     label: 'Other',
   },
 };

--- a/apps/web/src/features/activity/lib/sort.ts
+++ b/apps/web/src/features/activity/lib/sort.ts
@@ -1,0 +1,5 @@
+import type { Activity } from '../types';
+
+export function sortActivitiesByDateDesc(activities: Activity[]) {
+  return [...activities].sort((left, right) => right.date.localeCompare(left.date));
+}

--- a/apps/web/src/features/activity/types.ts
+++ b/apps/web/src/features/activity/types.ts
@@ -1,0 +1,24 @@
+export type ActivityType =
+  | 'walking'
+  | 'running'
+  | 'stretching'
+  | 'yoga'
+  | 'cycling'
+  | 'swimming'
+  | 'hiking'
+  | 'other';
+
+export type ActivityJournalEntryReference = {
+  id: string;
+  title: string;
+};
+
+export type Activity = {
+  id: string;
+  date: string;
+  type: ActivityType;
+  name: string;
+  durationMinutes: number;
+  notes: string;
+  linkedJournalEntries: ActivityJournalEntryReference[];
+};

--- a/apps/web/src/features/activity/types.ts
+++ b/apps/web/src/features/activity/types.ts
@@ -19,6 +19,6 @@ export type Activity = {
   type: ActivityType;
   name: string;
   durationMinutes: number;
-  notes: string;
+  notes?: string;
   linkedJournalEntries: ActivityJournalEntryReference[];
 };

--- a/apps/web/src/pages/activity.test.tsx
+++ b/apps/web/src/pages/activity.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import { mockActivities } from '@/features/activity';
+import { toDateKey } from '@/lib/date-utils';
 import { ActivityPage } from '@/pages/activity';
 
 const sortedActivities = [...mockActivities].sort((left, right) =>
@@ -66,5 +67,90 @@ describe('ActivityPage', () => {
     expect(allFilter).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByRole('heading', { name: 'Peloton Ride' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Morning Walk' })).toBeInTheDocument();
+  });
+
+  it('opens the add activity form with smart defaults and previews', () => {
+    render(<ActivityPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Activity' }));
+
+    const dialog = screen.getByRole('dialog');
+    const nameInput = within(dialog).getByLabelText('Name');
+    const durationInput = within(dialog).getByLabelText('Duration');
+    const dateInput = within(dialog).getByLabelText('Date');
+
+    expect(within(dialog).getByRole('heading', { name: 'Log a new activity' })).toBeInTheDocument();
+    expect(nameInput).toHaveValue('Morning Walk');
+    expect(dateInput).toHaveValue(toDateKey(new Date()));
+    expect(
+      within(dialog).getByText('Enter minutes to preview the formatted duration.'),
+    ).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Running' }));
+
+    expect(nameInput).toHaveValue('Zone 2 Run');
+
+    fireEvent.change(durationInput, { target: { value: '90' } });
+
+    expect(within(dialog).getByText('Preview: 1h 30min')).toBeInTheDocument();
+  });
+
+  it('prepends a submitted activity to the list and shows a success message', () => {
+    render(<ActivityPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Activity' }));
+
+    const dialog = screen.getByRole('dialog');
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Yoga' }));
+    fireEvent.change(within(dialog).getByLabelText('Name'), {
+      target: { value: 'Sunrise Mobility Flow' },
+    });
+    fireEvent.change(within(dialog).getByLabelText('Duration'), {
+      target: { value: '75' },
+    });
+    fireEvent.change(within(dialog).getByLabelText('Notes'), {
+      target: { value: 'Focused on hips, hamstrings, and mid-back rotation.' },
+    });
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Log Activity' }));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Logged "Sunrise Mobility Flow" to the local activity list.'),
+    ).toBeInTheDocument();
+
+    const activityHeadings = screen.getAllByRole('heading', { level: 2 });
+
+    expect(activityHeadings).toHaveLength(mockActivities.length + 1);
+    expect(activityHeadings[0]).toHaveTextContent('Sunrise Mobility Flow');
+
+    const newActivityCard = activityHeadings[0].closest('[data-slot="card"]');
+
+    expect(newActivityCard).not.toBeNull();
+    expect(within(newActivityCard as HTMLElement).getByText('1h 15min')).toBeInTheDocument();
+    expect(
+      within(newActivityCard as HTMLElement).getByText(
+        'Focused on hips, hamstrings, and mid-back rotation.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('closes the form without adding an activity when cancelled', () => {
+    render(<ActivityPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Activity' }));
+
+    const dialog = screen.getByRole('dialog');
+
+    fireEvent.change(within(dialog).getByLabelText('Name'), {
+      target: { value: 'Should Not Save' },
+    });
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Should Not Save' })).not.toBeInTheDocument();
+    expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(mockActivities.length);
   });
 });

--- a/apps/web/src/pages/activity.test.tsx
+++ b/apps/web/src/pages/activity.test.tsx
@@ -1,13 +1,11 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { mockActivities } from '@/features/activity';
+import { mockActivities, sortActivitiesByDateDesc } from '@/features/activity';
 import { toDateKey } from '@/lib/date-utils';
 import { ActivityPage } from '@/pages/activity';
 
-const sortedActivities = [...mockActivities].sort((left, right) =>
-  right.date.localeCompare(left.date),
-);
+const sortedActivities = sortActivitiesByDateDesc(mockActivities);
 
 describe('ActivityPage', () => {
   it('renders the activity list sorted newest first with formatted metadata', () => {
@@ -134,6 +132,43 @@ describe('ActivityPage', () => {
         'Focused on hips, hamstrings, and mid-back rotation.',
       ),
     ).toBeInTheDocument();
+  });
+
+  it('keeps the list in date order when a past activity is submitted', () => {
+    render(<ActivityPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Activity' }));
+
+    const dialog = screen.getByRole('dialog');
+
+    fireEvent.change(within(dialog).getByLabelText('Name'), {
+      target: { value: 'Backfilled Recovery Walk' },
+    });
+    fireEvent.change(within(dialog).getByLabelText('Duration'), {
+      target: { value: '35' },
+    });
+    fireEvent.change(within(dialog).getByLabelText('Date'), {
+      target: { value: '2026-02-26' },
+    });
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Log Activity' }));
+
+    const activityHeadings = screen.getAllByRole('heading', { level: 2 });
+
+    expect(activityHeadings.map((heading) => heading.textContent)).toEqual([
+      'Peloton Ride',
+      'Evening Walk',
+      'Hip Opener Flow',
+      'Trail Hike - Blue Ridge',
+      'Zone 2 Run',
+      'Yoga with Adriene',
+      'Backfilled Recovery Walk',
+      'Morning Walk',
+      'Morning Stretch Routine',
+      'Recovery Swim',
+      'Neighborhood Spin',
+      'Sauna + Mobility Circuit',
+    ]);
   });
 
   it('closes the form without adding an activity when cancelled', () => {

--- a/apps/web/src/pages/activity.test.tsx
+++ b/apps/web/src/pages/activity.test.tsx
@@ -1,52 +1,70 @@
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { getActivityTypeLabel, mockActivities } from '@/features/activity';
+import { mockActivities } from '@/features/activity';
 import { ActivityPage } from '@/pages/activity';
 
-const previewActivities = mockActivities.slice(0, 3);
+const sortedActivities = [...mockActivities].sort((left, right) =>
+  right.date.localeCompare(left.date),
+);
 
 describe('ActivityPage', () => {
-  it('renders the coming soon state with sample activity cards', () => {
+  it('renders the activity list sorted newest first with formatted metadata', () => {
     render(<ActivityPage />);
 
     expect(screen.getByRole('heading', { name: 'Activity' })).toBeInTheDocument();
-    expect(screen.getByText('Coming Soon')).toBeInTheDocument();
     expect(
-      screen.getByText('Log walks, stretching, yoga, and other movement activities.'),
+      screen.getByText(
+        /Review recent movement sessions outside structured workouts, with quick filtering by activity type and linked journal context\./,
+      ),
     ).toBeInTheDocument();
 
-    previewActivities.forEach((activity) => {
-      const cardHeading = screen.getByRole('heading', { name: activity.name });
-      const card = cardHeading.closest('[data-slot="card"]');
+    const activityHeadings = screen.getAllByRole('heading', { level: 2 });
 
-      expect(card).not.toBeNull();
-      expect(
-        within(card as HTMLElement).getByText(getActivityTypeLabel(activity.type)),
-      ).toBeInTheDocument();
-      expect(
-        within(card as HTMLElement).getByText(`${activity.durationMinutes} min`),
-      ).toBeInTheDocument();
-      expect(within(card as HTMLElement).getByText(activity.notes)).toBeInTheDocument();
-      expect(within(card as HTMLElement).getByText('Preview')).toBeInTheDocument();
-      expect(card).toHaveClass('border-dashed');
-      expect(card).toHaveClass('opacity-85');
-    });
+    expect(activityHeadings.map((heading) => heading.textContent)).toEqual(
+      sortedActivities.map((activity) => activity.name),
+    );
+
+    const pelotonCard = screen
+      .getByRole('heading', { name: 'Peloton Ride' })
+      .closest('[data-slot="card"]');
+    const eveningWalkCard = screen
+      .getByRole('heading', { name: 'Evening Walk' })
+      .closest('[data-slot="card"]');
+
+    expect(pelotonCard).not.toBeNull();
+    expect(eveningWalkCard).not.toBeNull();
+    expect(within(pelotonCard as HTMLElement).getByText('30 min')).toBeInTheDocument();
+    expect(within(pelotonCard as HTMLElement).getByText('Mar 4, 2026')).toBeInTheDocument();
+    expect(
+      within(pelotonCard as HTMLElement).getByText(
+        'Low-impact ride with a steady Zone 2 effort before breakfast.',
+      ),
+    ).toBeInTheDocument();
+    expect(within(pelotonCard as HTMLElement).getByText('Linked journal')).toBeInTheDocument();
+    expect(within(pelotonCard as HTMLElement).getByText('Week 12 Summary')).toBeInTheDocument();
+    expect(
+      within(eveningWalkCard as HTMLElement).queryByText('Linked journal'),
+    ).not.toBeInTheDocument();
   });
 
-  it('uses distinct badge colors with explicit dark text on accent surfaces', () => {
+  it('filters the activity cards by type', () => {
     render(<ActivityPage />);
 
-    const cyclingBadge = screen.getByText('Cycling');
-    const walkingBadge = screen.getByText('Walking');
-    const stretchingBadge = screen.getByText('Stretching');
+    const runningFilter = screen.getByRole('button', { name: 'Running' });
+    const allFilter = screen.getByRole('button', { name: 'All' });
 
-    expect(cyclingBadge).toHaveClass('bg-amber-200');
-    expect(walkingBadge).toHaveClass('bg-emerald-200');
-    expect(stretchingBadge).toHaveClass('bg-sky-200');
+    fireEvent.click(runningFilter);
 
-    expect(cyclingBadge).toHaveClass('text-amber-950');
-    expect(walkingBadge).toHaveClass('text-emerald-950');
-    expect(stretchingBadge).toHaveClass('text-sky-950');
+    expect(runningFilter).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('heading', { name: 'Zone 2 Run' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Peloton Ride' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Morning Walk' })).not.toBeInTheDocument();
+
+    fireEvent.click(allFilter);
+
+    expect(allFilter).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('heading', { name: 'Peloton Ride' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Morning Walk' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/activity.test.tsx
+++ b/apps/web/src/pages/activity.test.tsx
@@ -1,28 +1,10 @@
 import { render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
+import { getActivityTypeLabel, mockActivities } from '@/features/activity';
 import { ActivityPage } from '@/pages/activity';
 
-const sampleActivities = [
-  {
-    description: 'Mobility session',
-    duration: '20 min',
-    note: 'Morning mobility routine - hip openers and shoulder work',
-    type: 'Stretching',
-  },
-  {
-    description: 'Outdoor walk',
-    duration: '45 min',
-    note: 'Afternoon walk around the park, 3.2 km',
-    type: 'Walking',
-  },
-  {
-    description: 'Vinyasa flow',
-    duration: '30 min',
-    note: 'Vinyasa flow session, focused on balance poses',
-    type: 'Yoga',
-  },
-] as const;
+const previewActivities = mockActivities.slice(0, 3);
 
 describe('ActivityPage', () => {
   it('renders the coming soon state with sample activity cards', () => {
@@ -34,14 +16,18 @@ describe('ActivityPage', () => {
       screen.getByText('Log walks, stretching, yoga, and other movement activities.'),
     ).toBeInTheDocument();
 
-    sampleActivities.forEach((activity) => {
-      const cardHeading = screen.getByRole('heading', { name: activity.description });
+    previewActivities.forEach((activity) => {
+      const cardHeading = screen.getByRole('heading', { name: activity.name });
       const card = cardHeading.closest('[data-slot="card"]');
 
       expect(card).not.toBeNull();
-      expect(within(card as HTMLElement).getByText(activity.type)).toBeInTheDocument();
-      expect(within(card as HTMLElement).getByText(activity.duration)).toBeInTheDocument();
-      expect(within(card as HTMLElement).getByText(activity.note)).toBeInTheDocument();
+      expect(
+        within(card as HTMLElement).getByText(getActivityTypeLabel(activity.type)),
+      ).toBeInTheDocument();
+      expect(
+        within(card as HTMLElement).getByText(`${activity.durationMinutes} min`),
+      ).toBeInTheDocument();
+      expect(within(card as HTMLElement).getByText(activity.notes)).toBeInTheDocument();
       expect(within(card as HTMLElement).getByText('Preview')).toBeInTheDocument();
       expect(card).toHaveClass('border-dashed');
       expect(card).toHaveClass('opacity-85');
@@ -51,16 +37,16 @@ describe('ActivityPage', () => {
   it('uses distinct badge colors with explicit dark text on accent surfaces', () => {
     render(<ActivityPage />);
 
-    const stretchingBadge = screen.getByText('Stretching');
+    const cyclingBadge = screen.getByText('Cycling');
     const walkingBadge = screen.getByText('Walking');
-    const yogaBadge = screen.getByText('Yoga');
+    const stretchingBadge = screen.getByText('Stretching');
 
-    expect(stretchingBadge).toHaveClass('bg-sky-200');
+    expect(cyclingBadge).toHaveClass('bg-amber-200');
     expect(walkingBadge).toHaveClass('bg-emerald-200');
-    expect(yogaBadge).toHaveClass('bg-violet-200');
+    expect(stretchingBadge).toHaveClass('bg-sky-200');
 
-    expect(stretchingBadge).toHaveClass('text-sky-950');
+    expect(cyclingBadge).toHaveClass('text-amber-950');
     expect(walkingBadge).toHaveClass('text-emerald-950');
-    expect(yogaBadge).toHaveClass('text-violet-950');
+    expect(stretchingBadge).toHaveClass('text-sky-950');
   });
 });

--- a/apps/web/src/pages/activity.tsx
+++ b/apps/web/src/pages/activity.tsx
@@ -1,16 +1,6 @@
 import { Activity as ActivityGlyph } from 'lucide-react';
 
-import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card';
-import {
-  getActivityTypeBadgeClasses,
-  getActivityTypeIcon,
-  getActivityTypeLabel,
-  mockActivities,
-} from '@/features/activity';
-import { cn } from '@/lib/utils';
-
-const previewActivities = mockActivities.slice(0, 3);
+import { ActivityList, mockActivities } from '@/features/activity';
 
 export function ActivityPage() {
   return (
@@ -22,73 +12,15 @@ export function ActivityPage() {
           </div>
           <div className="space-y-2">
             <h1 className="text-3xl font-semibold text-primary">Activity</h1>
-            <div className="space-y-1">
-              <p className="text-lg font-medium text-foreground">Coming Soon</p>
-              <p className="max-w-2xl text-sm text-muted">
-                Log walks, stretching, yoga, and other movement activities.
-              </p>
-            </div>
+            <p className="max-w-2xl text-sm text-muted">
+              Review recent movement sessions outside structured workouts, with quick filtering by
+              activity type and linked journal context.
+            </p>
           </div>
         </div>
       </header>
 
-      <div className="space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted">
-          Preview activities
-        </p>
-        <div className="grid gap-4 xl:grid-cols-3">
-          {previewActivities.map((activity) => {
-            const ActivityTypeIcon = getActivityTypeIcon(activity.type);
-
-            return (
-              <Card key={activity.id} className="border-dashed bg-card/70 opacity-85">
-                <CardHeader className="gap-4">
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div className="space-y-3">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <Badge
-                          className={cn(
-                            'cursor-default inline-flex items-center gap-1.5 px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em]',
-                            getActivityTypeBadgeClasses(activity.type),
-                          )}
-                          variant="secondary"
-                        >
-                          <ActivityTypeIcon aria-hidden="true" className="size-3.5" />
-                          {getActivityTypeLabel(activity.type)}
-                        </Badge>
-                        <Badge
-                          className="cursor-default border-border/80 bg-background/80 text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-muted"
-                          variant="outline"
-                        >
-                          Preview
-                        </Badge>
-                      </div>
-                      <div className="space-y-1">
-                        <h2 className="text-xl font-semibold text-foreground">{activity.name}</h2>
-                        <CardDescription>{activity.notes}</CardDescription>
-                      </div>
-                    </div>
-                    <div className="min-w-20 rounded-xl bg-secondary/70 px-3 py-2 text-right">
-                      <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted">
-                        Duration
-                      </p>
-                      <p className="text-2xl font-semibold text-foreground">
-                        {activity.durationMinutes} min
-                      </p>
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent className="pt-0">
-                  <p className="text-sm leading-6 text-muted">
-                    Future entries will capture the activity type, time spent, and optional context
-                    about how the session felt.
-                  </p>
-                </CardContent>
-              </Card>
-            );
-          })}
-        </div>
-      </div>
+      <ActivityList activities={mockActivities} />
     </section>
   );
 }

--- a/apps/web/src/pages/activity.tsx
+++ b/apps/web/src/pages/activity.tsx
@@ -1,8 +1,12 @@
+import { useState } from 'react';
 import { Activity as ActivityGlyph } from 'lucide-react';
 
-import { ActivityList, mockActivities } from '@/features/activity';
+import { ActivityForm, ActivityList, mockActivities } from '@/features/activity';
+import type { Activity } from '@/features/activity';
 
 export function ActivityPage() {
+  const [activities, setActivities] = useState<Activity[]>(mockActivities);
+
   return (
     <section className="space-y-6">
       <header className="space-y-4">
@@ -20,7 +24,9 @@ export function ActivityPage() {
         </div>
       </header>
 
-      <ActivityList activities={mockActivities} />
+      <ActivityForm onSubmit={(activity) => setActivities((current) => [activity, ...current])} />
+
+      <ActivityList activities={activities} />
     </section>
   );
 }

--- a/apps/web/src/pages/activity.tsx
+++ b/apps/web/src/pages/activity.tsx
@@ -1,11 +1,18 @@
 import { useState } from 'react';
 import { Activity as ActivityGlyph } from 'lucide-react';
 
-import { ActivityForm, ActivityList, mockActivities } from '@/features/activity';
+import {
+  ActivityForm,
+  ActivityList,
+  mockActivities,
+  sortActivitiesByDateDesc,
+} from '@/features/activity';
 import type { Activity } from '@/features/activity';
 
 export function ActivityPage() {
-  const [activities, setActivities] = useState<Activity[]>(mockActivities);
+  const [activities, setActivities] = useState<Activity[]>(() =>
+    sortActivitiesByDateDesc(mockActivities),
+  );
 
   return (
     <section className="space-y-6">
@@ -24,7 +31,11 @@ export function ActivityPage() {
         </div>
       </header>
 
-      <ActivityForm onSubmit={(activity) => setActivities((current) => [activity, ...current])} />
+      <ActivityForm
+        onSubmit={(activity) =>
+          setActivities((current) => sortActivitiesByDateDesc([...current, activity]))
+        }
+      />
 
       <ActivityList activities={activities} />
     </section>

--- a/apps/web/src/pages/activity.tsx
+++ b/apps/web/src/pages/activity.tsx
@@ -1,45 +1,16 @@
-import { Activity } from 'lucide-react';
+import { Activity as ActivityGlyph } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card';
+import {
+  getActivityTypeBadgeClasses,
+  getActivityTypeIcon,
+  getActivityTypeLabel,
+  mockActivities,
+} from '@/features/activity';
 import { cn } from '@/lib/utils';
 
-type ActivityType = 'Stretching' | 'Walking' | 'Yoga';
-
-type ActivityPreview = {
-  description: string;
-  duration: string;
-  note?: string;
-  type: ActivityType;
-};
-
-const badgeClassesByType: Record<ActivityType, string> = {
-  Stretching: 'border-transparent bg-sky-200 text-sky-950 dark:bg-sky-500/20 dark:text-sky-400',
-  Walking:
-    'border-transparent bg-emerald-200 text-emerald-950 dark:bg-emerald-500/20 dark:text-emerald-400',
-  Yoga: 'border-transparent bg-violet-200 text-violet-950 dark:bg-violet-500/20 dark:text-violet-400',
-};
-
-const sampleActivities: ActivityPreview[] = [
-  {
-    description: 'Mobility session',
-    duration: '20 min',
-    note: 'Morning mobility routine - hip openers and shoulder work',
-    type: 'Stretching',
-  },
-  {
-    description: 'Outdoor walk',
-    duration: '45 min',
-    note: 'Afternoon walk around the park, 3.2 km',
-    type: 'Walking',
-  },
-  {
-    description: 'Vinyasa flow',
-    duration: '30 min',
-    note: 'Vinyasa flow session, focused on balance poses',
-    type: 'Yoga',
-  },
-];
+const previewActivities = mockActivities.slice(0, 3);
 
 export function ActivityPage() {
   return (
@@ -47,7 +18,7 @@ export function ActivityPage() {
       <header className="space-y-4">
         <div className="flex items-start gap-3">
           <div className="rounded-2xl bg-[var(--color-accent-mint)] p-3 text-on-mint shadow-sm dark:bg-emerald-500/20 dark:text-emerald-400">
-            <Activity aria-hidden="true" className="size-6" />
+            <ActivityGlyph aria-hidden="true" className="size-6" />
           </div>
           <div className="space-y-2">
             <h1 className="text-3xl font-semibold text-primary">Activity</h1>
@@ -66,56 +37,56 @@ export function ActivityPage() {
           Preview activities
         </p>
         <div className="grid gap-4 xl:grid-cols-3">
-          {sampleActivities.map((activity) => (
-            <Card
-              key={`${activity.type}-${activity.duration}`}
-              className="border-dashed bg-card/70 opacity-85"
-            >
-              <CardHeader className="gap-4">
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div className="space-y-3">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Badge
-                        className={cn(
-                          'cursor-default px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em]',
-                          badgeClassesByType[activity.type],
-                        )}
-                        variant="secondary"
-                      >
-                        {activity.type}
-                      </Badge>
-                      <Badge
-                        className="cursor-default border-border/80 bg-background/80 text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-muted"
-                        variant="outline"
-                      >
-                        Preview
-                      </Badge>
+          {previewActivities.map((activity) => {
+            const ActivityTypeIcon = getActivityTypeIcon(activity.type);
+
+            return (
+              <Card key={activity.id} className="border-dashed bg-card/70 opacity-85">
+                <CardHeader className="gap-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="space-y-3">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge
+                          className={cn(
+                            'cursor-default inline-flex items-center gap-1.5 px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em]',
+                            getActivityTypeBadgeClasses(activity.type),
+                          )}
+                          variant="secondary"
+                        >
+                          <ActivityTypeIcon aria-hidden="true" className="size-3.5" />
+                          {getActivityTypeLabel(activity.type)}
+                        </Badge>
+                        <Badge
+                          className="cursor-default border-border/80 bg-background/80 text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-muted"
+                          variant="outline"
+                        >
+                          Preview
+                        </Badge>
+                      </div>
+                      <div className="space-y-1">
+                        <h2 className="text-xl font-semibold text-foreground">{activity.name}</h2>
+                        <CardDescription>{activity.notes}</CardDescription>
+                      </div>
                     </div>
-                    <div className="space-y-1">
-                      <h2 className="text-xl font-semibold text-foreground">
-                        {activity.description}
-                      </h2>
-                      <CardDescription>
-                        {activity.note ?? 'Sample activity note coming soon.'}
-                      </CardDescription>
+                    <div className="min-w-20 rounded-xl bg-secondary/70 px-3 py-2 text-right">
+                      <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+                        Duration
+                      </p>
+                      <p className="text-2xl font-semibold text-foreground">
+                        {activity.durationMinutes} min
+                      </p>
                     </div>
                   </div>
-                  <div className="min-w-20 rounded-xl bg-secondary/70 px-3 py-2 text-right">
-                    <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted">
-                      Duration
-                    </p>
-                    <p className="text-2xl font-semibold text-foreground">{activity.duration}</p>
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent className="pt-0">
-                <p className="text-sm leading-6 text-muted">
-                  Future entries will capture the activity type, time spent, and optional context
-                  about how the session felt.
-                </p>
-              </CardContent>
-            </Card>
-          ))}
+                </CardHeader>
+                <CardContent className="pt-0">
+                  <p className="text-sm leading-6 text-muted">
+                    Future entries will capture the activity type, time spent, and optional context
+                    about how the session felt.
+                  </p>
+                </CardContent>
+              </Card>
+            );
+          })}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

This PR turns the Activity page from a placeholder into a usable prototype for phase 1b. It introduces a mock-backed activity log with realistic entries, type-based filtering, linked journal references, and an inline logging flow so reviewers can evaluate the full UI pattern before backend APIs exist. The new page is designed to match the rest of the prototype system: card-based presentation, lightweight state, and clear affordances for browsing and adding entries. It also adds focused tests around the new activity data helpers and the core list behaviors.

## Key Changes

- Replaced the previous placeholder Activity page with a prototype built around reusable `activity` feature components.
- Added `mockActivities` plus shared helpers for activity labels, icons, badge styles, and type options to keep display logic centralized.
- Implemented a card-based `ActivityList` that shows activity type, date, formatted duration, notes, and linked journal entry chips.
- Added client-side type filtering with an explicit empty state when no activities match the selected filter.
- Added an `ActivityForm` dialog for mock activity logging with type selection, suggested names, duration/date inputs, optional notes, and success feedback.
- Exported the activity feature surface through `apps/web/src/features/activity/index.ts` so the page and tests can consume a single module boundary.
- Added tests covering mock data shape, type metadata helpers, duration formatting, and filtered empty-state behavior.

## Technical Notes

- This is still prototype-only UI: new activities are appended to the local page state and do not persist or call any API.
- Activity types are modeled as shared feature-level metadata in `mock-data.ts`; reviewers should pay attention to this pattern because it intentionally keeps icon/label/badge decisions out of the rendering components.
- The form uses lightweight local React state rather than React Hook Form because this flow is mock-only and has minimal validation requirements; that will likely change once persistence and shared schemas are introduced.
- Duration formatting logic exists in both the list and form preview paths with similar rules; if the activity domain grows, that formatting should probably move into a shared utility.
- Tests are aimed at prototype stability rather than exhaustive behavior, so the main review focus should be whether the UI/data shape matches the intended phase 1b activity logging experience.

## Commits

- `cec4e48 test(web): cover activity logging flow`
- `536c5e6 feat(web): add activity list with type filter, duration, and inline form`
- `449f4ff feat(web): add activity list cards`
- `1998fb8 feat(web): add activity mock data`

## Tasks

- **Activity mock data with types and linked journal entries**: Create mock activities (walking, stretching, yoga, etc.) with durations and linked journal references
- **Activity list with type icons, duration, and filter**: Card-based activity list with type icons, duration display, date, filter by type, linked journal chips
- **Activity logging form (mock submit)**: Add activity form with type selector, duration, date picker, notes (mock data only)

## Diff Stats

```
.../features/activity/components/activity-form.tsx | 279 +++++++++++++++++++++
 .../activity/components/activity-list.test.tsx     |  38 +++
 .../features/activity/components/activity-list.tsx | 206 +++++++++++++++
 apps/web/src/features/activity/index.ts            |  10 +
 .../src/features/activity/lib/mock-data.test.ts    |  93 +++++++
 apps/web/src/features/activity/lib/mock-data.ts    | 225 +++++++++++++++++
 apps/web/src/features/activity/types.ts            |  24 ++
 apps/web/src/pages/activity.test.tsx               | 180 +++++++++----
 apps/web/src/pages/activity.tsx                    | 119 ++-------
 9 files changed, 1024 insertions(+), 150 deletions(-)
```