### PR TITLE
Foods API + frontend wiring

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { authRoutes } from './routes/auth/index.js';
 import { agentTokenRoutes } from './routes/agent-tokens/index.js';
+import { foodsRoutes } from './routes/foods/index.js';
 
 const DEV_JWT_SECRET = 'pulse-dev-jwt-secret';
 
@@ -29,6 +30,7 @@ export const buildServer = () => {
   app.get('/health', async () => ({ status: 'ok' }));
   app.register(authRoutes, { prefix: '/api/v1/auth' });
   app.register(agentTokenRoutes, { prefix: '/api/v1/agent-tokens' });
+  app.register(foodsRoutes, { prefix: '/api/v1/foods' });
 
   return app;
 };

--- a/apps/api/src/routes/foods/index.test.ts
+++ b/apps/api/src/routes/foods/index.test.ts
@@ -1,0 +1,330 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildServer } from '../../index.js';
+import { createFood, deleteFood, listFoods, updateFood } from './store.js';
+
+vi.mock('./store.js', () => ({
+  createFood: vi.fn(),
+  deleteFood: vi.fn(),
+  listFoods: vi.fn(),
+  updateFood: vi.fn(),
+}));
+
+const createAuthorizationHeader = (token: string) => ({
+  authorization: `Bearer ${token}`,
+});
+
+const buildFood = (
+  overrides?: Partial<{
+    id: string;
+    userId: string;
+    name: string;
+    brand: string | null;
+    servingSize: string | null;
+    servingGrams: number | null;
+    calories: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+    fiber: number | null;
+    sugar: number | null;
+    verified: boolean;
+    source: string | null;
+    notes: string | null;
+    lastUsedAt: number | null;
+    createdAt: number;
+    updatedAt: number;
+  }>,
+) => ({
+  id: 'food-1',
+  userId: 'user-1',
+  name: 'Greek Yogurt',
+  brand: 'Fage 0%',
+  servingSize: '170 g',
+  servingGrams: 170,
+  calories: 90,
+  protein: 18,
+  carbs: 5,
+  fat: 0,
+  fiber: null,
+  sugar: 5,
+  verified: true,
+  source: 'Manufacturer label',
+  notes: null,
+  lastUsedAt: null,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_001,
+  ...overrides,
+});
+
+describe('foods routes', () => {
+  beforeEach(() => {
+    vi.mocked(createFood).mockReset();
+    vi.mocked(deleteFood).mockReset();
+    vi.mocked(listFoods).mockReset();
+    vi.mocked(updateFood).mockReset();
+    process.env.JWT_SECRET = 'test-foods-secret';
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  it('creates a food for the authenticated user', async () => {
+    vi.mocked(createFood).mockImplementation(async (input) => buildFood({ id: input.id }));
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/v1/foods',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          name: ' Greek Yogurt ',
+          brand: ' Fage 0% ',
+          servingSize: ' 170 g ',
+          calories: 90,
+          protein: 18,
+          carbs: 5,
+          fat: 0,
+          verified: true,
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(response.json()).toEqual({
+        data: buildFood({
+          id: (response.json() as { data: { id: string } }).data.id,
+        }),
+      });
+      expect(vi.mocked(createFood)).toHaveBeenCalledWith({
+        id: expect.any(String),
+        userId: 'user-1',
+        name: 'Greek Yogurt',
+        brand: 'Fage 0%',
+        servingSize: '170 g',
+        calories: 90,
+        protein: 18,
+        carbs: 5,
+        fat: 0,
+        verified: true,
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('lists foods with parsed search, sort, and pagination params', async () => {
+    vi.mocked(listFoods).mockResolvedValue({
+      foods: [buildFood()],
+      total: 3,
+    });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/foods?q=%20yogurt%20&sort=protein&page=2&limit=1',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: [buildFood()],
+        meta: {
+          page: 2,
+          limit: 1,
+          total: 3,
+        },
+      });
+      expect(vi.mocked(listFoods)).toHaveBeenCalledWith('user-1', {
+        q: 'yogurt',
+        sort: 'protein',
+        page: 2,
+        limit: 1,
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects invalid food payloads and query parameters', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const [createResponse, queryResponse] = await Promise.all([
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/foods',
+          headers: createAuthorizationHeader(authToken),
+          payload: {
+            name: '   ',
+            calories: 90,
+            protein: 18,
+            carbs: 5,
+            fat: 0,
+          },
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/foods?sort=calories&page=0',
+          headers: createAuthorizationHeader(authToken),
+        }),
+      ]);
+
+      expect(createResponse.statusCode).toBe(400);
+      expect(createResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid food payload',
+        },
+      });
+
+      expect(queryResponse.statusCode).toBe(400);
+      expect(queryResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid food query parameters',
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('requires authentication for all food endpoints', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const requests = await Promise.all([
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/foods',
+          payload: {
+            name: 'Greek Yogurt',
+            calories: 90,
+            protein: 18,
+            carbs: 5,
+            fat: 0,
+          },
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/foods',
+        }),
+        app.inject({
+          method: 'PUT',
+          url: '/api/v1/foods/food-1',
+          payload: {
+            notes: 'Updated',
+          },
+        }),
+        app.inject({
+          method: 'DELETE',
+          url: '/api/v1/foods/food-1',
+        }),
+      ]);
+
+      for (const response of requests) {
+        expect(response.statusCode).toBe(401);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'UNAUTHORIZED',
+            message: 'Authentication required',
+          },
+        });
+      }
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('updates and deletes only when the food exists in the authenticated scope', async () => {
+    vi.mocked(updateFood)
+      .mockResolvedValueOnce(buildFood({ notes: 'Updated note', brand: null }))
+      .mockResolvedValueOnce(undefined);
+    vi.mocked(deleteFood).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+
+      const updateResponse = await app.inject({
+        method: 'PUT',
+        url: '/api/v1/foods/food-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          notes: ' Updated note ',
+          brand: null,
+        },
+      });
+
+      expect(updateResponse.statusCode).toBe(200);
+      expect(updateResponse.json()).toEqual({
+        data: buildFood({ notes: 'Updated note', brand: null }),
+      });
+      expect(vi.mocked(updateFood)).toHaveBeenNthCalledWith(1, 'food-1', 'user-1', {
+        notes: 'Updated note',
+        brand: null,
+      });
+
+      const missingUpdateResponse = await app.inject({
+        method: 'PUT',
+        url: '/api/v1/foods/missing-food',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          notes: 'Updated note',
+        },
+      });
+
+      expect(missingUpdateResponse.statusCode).toBe(404);
+      expect(missingUpdateResponse.json()).toEqual({
+        error: {
+          code: 'FOOD_NOT_FOUND',
+          message: 'Food not found',
+        },
+      });
+
+      const deleteResponse = await app.inject({
+        method: 'DELETE',
+        url: '/api/v1/foods/food-1',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(deleteResponse.statusCode).toBe(200);
+      expect(deleteResponse.json()).toEqual({
+        data: {
+          success: true,
+        },
+      });
+      expect(vi.mocked(deleteFood)).toHaveBeenNthCalledWith(1, 'food-1', 'user-1');
+
+      const missingDeleteResponse = await app.inject({
+        method: 'DELETE',
+        url: '/api/v1/foods/missing-food',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(missingDeleteResponse.statusCode).toBe(404);
+      expect(missingDeleteResponse.json()).toEqual({
+        error: {
+          code: 'FOOD_NOT_FOUND',
+          message: 'Food not found',
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apps/api/src/routes/foods/index.ts
+++ b/apps/api/src/routes/foods/index.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from 'node:crypto';
+
+import { createFoodInputSchema, foodQueryParamsSchema, updateFoodInputSchema } from '@pulse/shared';
+import type { FastifyPluginAsync } from 'fastify';
+
+import { sendError } from '../../lib/reply.js';
+import { requireAuth } from '../../middleware/auth.js';
+
+import { createFood, deleteFood, listFoods, updateFood } from './store.js';
+
+export const foodsRoutes: FastifyPluginAsync = async (app) => {
+  app.addHook('onRequest', requireAuth);
+
+  app.post('/', async (request, reply) => {
+    const parsedBody = createFoodInputSchema.safeParse(request.body);
+    if (!parsedBody.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid food payload');
+    }
+
+    const food = await createFood({
+      id: randomUUID(),
+      userId: request.userId,
+      ...parsedBody.data,
+    });
+
+    return reply.code(201).send({
+      data: food,
+    });
+  });
+
+  app.get('/', async (request, reply) => {
+    const parsedQuery = foodQueryParamsSchema.safeParse(request.query);
+    if (!parsedQuery.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid food query parameters');
+    }
+
+    const result = await listFoods(request.userId, parsedQuery.data);
+
+    return reply.send({
+      data: result.foods,
+      meta: {
+        page: parsedQuery.data.page,
+        limit: parsedQuery.data.limit,
+        total: result.total,
+      },
+    });
+  });
+
+  app.put<{ Params: { id: string } }>('/:id', async (request, reply) => {
+    const parsedBody = updateFoodInputSchema.safeParse(request.body);
+    if (!parsedBody.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid food payload');
+    }
+
+    const food = await updateFood(request.params.id, request.userId, parsedBody.data);
+    if (!food) {
+      return sendError(reply, 404, 'FOOD_NOT_FOUND', 'Food not found');
+    }
+
+    return reply.send({
+      data: food,
+    });
+  });
+
+  app.delete<{ Params: { id: string } }>('/:id', async (request, reply) => {
+    const deleted = await deleteFood(request.params.id, request.userId);
+    if (!deleted) {
+      return sendError(reply, 404, 'FOOD_NOT_FOUND', 'Food not found');
+    }
+
+    return reply.send({
+      data: {
+        success: true,
+      },
+    });
+  });
+};

--- a/apps/api/src/routes/foods/store.test.ts
+++ b/apps/api/src/routes/foods/store.test.ts
@@ -18,6 +18,7 @@ const dbState = vi.hoisted(() => ({
   }>,
   insertValues: [] as unknown[],
   updateSets: [] as unknown[],
+  updateWhereCalls: [] as unknown[],
   deleteWhereCalls: [] as unknown[],
   insertRunResult: { changes: 1 },
   updateRunResult: { changes: 1 },
@@ -27,12 +28,47 @@ const dbState = vi.hoisted(() => ({
     this.selectBuilders = [];
     this.insertValues = [];
     this.updateSets = [];
+    this.updateWhereCalls = [];
     this.deleteWhereCalls = [];
     this.insertRunResult = { changes: 1 };
     this.updateRunResult = { changes: 1 };
     this.deleteRunResult = { changes: 1 };
   },
 }));
+
+const flattenSql = (value: unknown): string => {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  if (!value || typeof value !== 'object') {
+    return '';
+  }
+
+  if ('name' in value && typeof value.name === 'string') {
+    return value.name;
+  }
+
+  if ('value' in value) {
+    if (Array.isArray(value.value)) {
+      return value.value.map(flattenSql).join('');
+    }
+
+    if (
+      typeof value.value === 'string' ||
+      typeof value.value === 'number' ||
+      typeof value.value === 'boolean'
+    ) {
+      return String(value.value);
+    }
+  }
+
+  if ('queryChunks' in value && Array.isArray(value.queryChunks)) {
+    return value.queryChunks.map(flattenSql).join('');
+  }
+
+  return '';
+};
 
 const createSelectBuilder = (result: SelectResultConfig) => {
   const builder = {
@@ -73,9 +109,13 @@ vi.mock('../../db/index.js', () => ({
         dbState.updateSets.push(values);
 
         return {
-          where: vi.fn(() => ({
-            run: vi.fn(() => dbState.updateRunResult),
-          })),
+          where: vi.fn((whereClause: unknown) => {
+            dbState.updateWhereCalls.push(whereClause);
+
+            return {
+              run: vi.fn(() => dbState.updateRunResult),
+            };
+          }),
         };
       }),
     })),
@@ -200,7 +240,7 @@ describe('foods store', () => {
     const { listFoods } = await import('./store.js');
 
     const result = await listFoods('user-1', {
-      q: 'ghost',
+      q: '50%_off',
       sort: 'protein',
       page: 2,
       limit: 1,
@@ -221,6 +261,10 @@ describe('foods store', () => {
     expect(dbState.selectBuilders[0].limit).toHaveBeenCalledWith(1);
     expect(dbState.selectBuilders[0].offset).toHaveBeenCalledWith(1);
     expect(dbState.selectBuilders[1].get).toHaveBeenCalledOnce();
+
+    const whereClauseText = flattenSql(dbState.selectBuilders[0].where.mock.calls[0]?.[0]);
+    expect(whereClauseText).toContain('%50\\%\\_off%');
+    expect(whereClauseText.toLowerCase()).toContain("escape '\\'");
   });
 
   it('supports recent sorting without pagination errors when the query is absent', async () => {
@@ -329,7 +373,7 @@ describe('foods store', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('deletes foods by scope and updates lastUsedAt timestamps', async () => {
+  it('deletes foods by scope and scopes lastUsedAt updates to the user', async () => {
     const { deleteFood, updateFoodLastUsedAt } = await import('./store.js');
 
     await expect(deleteFood('food-1', 'user-1')).resolves.toBe(true);
@@ -338,10 +382,13 @@ describe('foods store', () => {
     dbState.deleteRunResult = { changes: 0 };
     await expect(deleteFood('food-1', 'user-2')).resolves.toBe(false);
 
-    await updateFoodLastUsedAt('food-1', 1_700_000_300_000);
+    await updateFoodLastUsedAt('food-1', 'user-1', 1_700_000_300_000);
 
     expect(dbState.updateSets.at(-1)).toEqual({
       lastUsedAt: 1_700_000_300_000,
     });
+    const updateWhereText = flattenSql(dbState.updateWhereCalls.at(-1));
+    expect(updateWhereText).toContain('id = food-1');
+    expect(updateWhereText).toContain('user_id = user-1');
   });
 });

--- a/apps/api/src/routes/foods/store.test.ts
+++ b/apps/api/src/routes/foods/store.test.ts
@@ -1,0 +1,347 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type SelectResultConfig = {
+  all?: unknown[];
+  get?: unknown;
+};
+
+const dbState = vi.hoisted(() => ({
+  selectResults: [] as SelectResultConfig[],
+  selectBuilders: [] as Array<{
+    from: ReturnType<typeof vi.fn>;
+    where: ReturnType<typeof vi.fn>;
+    orderBy: ReturnType<typeof vi.fn>;
+    limit: ReturnType<typeof vi.fn>;
+    offset: ReturnType<typeof vi.fn>;
+    all: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+  }>,
+  insertValues: [] as unknown[],
+  updateSets: [] as unknown[],
+  deleteWhereCalls: [] as unknown[],
+  insertRunResult: { changes: 1 },
+  updateRunResult: { changes: 1 },
+  deleteRunResult: { changes: 1 },
+  reset() {
+    this.selectResults = [];
+    this.selectBuilders = [];
+    this.insertValues = [];
+    this.updateSets = [];
+    this.deleteWhereCalls = [];
+    this.insertRunResult = { changes: 1 };
+    this.updateRunResult = { changes: 1 };
+    this.deleteRunResult = { changes: 1 };
+  },
+}));
+
+const createSelectBuilder = (result: SelectResultConfig) => {
+  const builder = {
+    from: vi.fn(),
+    where: vi.fn(),
+    orderBy: vi.fn(),
+    limit: vi.fn(),
+    offset: vi.fn(),
+    all: vi.fn(() => result.all ?? []),
+    get: vi.fn(() => result.get),
+  };
+
+  builder.from.mockReturnValue(builder);
+  builder.where.mockReturnValue(builder);
+  builder.orderBy.mockReturnValue(builder);
+  builder.limit.mockReturnValue(builder);
+  builder.offset.mockReturnValue(builder);
+
+  dbState.selectBuilders.push(builder);
+
+  return builder;
+};
+
+vi.mock('../../db/index.js', () => ({
+  db: {
+    select: vi.fn(() => createSelectBuilder(dbState.selectResults.shift() ?? {})),
+    insert: vi.fn(() => ({
+      values: vi.fn((values: unknown) => {
+        dbState.insertValues.push(values);
+
+        return {
+          run: vi.fn(() => dbState.insertRunResult),
+        };
+      }),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((values: unknown) => {
+        dbState.updateSets.push(values);
+
+        return {
+          where: vi.fn(() => ({
+            run: vi.fn(() => dbState.updateRunResult),
+          })),
+        };
+      }),
+    })),
+    delete: vi.fn(() => ({
+      where: vi.fn((whereClause: unknown) => {
+        dbState.deleteWhereCalls.push(whereClause);
+
+        return {
+          run: vi.fn(() => dbState.deleteRunResult),
+        };
+      }),
+    })),
+  },
+}));
+
+describe('foods store', () => {
+  beforeEach(() => {
+    dbState.reset();
+  });
+
+  it('creates a food and normalizes omitted optional fields to null', async () => {
+    dbState.selectResults.push({
+      get: {
+        id: 'food-1',
+        userId: 'user-1',
+        name: 'Greek Yogurt',
+        brand: null,
+        servingSize: null,
+        servingGrams: null,
+        calories: 90,
+        protein: 18,
+        carbs: 5,
+        fat: 0,
+        fiber: null,
+        sugar: null,
+        verified: true,
+        source: null,
+        notes: null,
+        lastUsedAt: null,
+        createdAt: 1_700_000_000_000,
+        updatedAt: 1_700_000_000_001,
+      },
+    });
+
+    const { createFood } = await import('./store.js');
+
+    const created = await createFood({
+      id: 'food-1',
+      userId: 'user-1',
+      name: 'Greek Yogurt',
+      calories: 90,
+      protein: 18,
+      carbs: 5,
+      fat: 0,
+      verified: true,
+    });
+
+    expect(created).toMatchObject({
+      id: 'food-1',
+      brand: null,
+      servingSize: null,
+      servingGrams: null,
+      fiber: null,
+      sugar: null,
+      source: null,
+      notes: null,
+    });
+    expect(dbState.insertValues).toEqual([
+      {
+        id: 'food-1',
+        userId: 'user-1',
+        name: 'Greek Yogurt',
+        brand: null,
+        servingSize: null,
+        servingGrams: null,
+        calories: 90,
+        protein: 18,
+        carbs: 5,
+        fat: 0,
+        fiber: null,
+        sugar: null,
+        verified: true,
+        source: null,
+        notes: null,
+      },
+    ]);
+  });
+
+  it('returns paginated foods and performs separate row and total queries', async () => {
+    dbState.selectResults.push(
+      {
+        all: [
+          {
+            id: 'food-2',
+            userId: 'user-1',
+            name: 'Protein Cereal',
+            brand: 'Ghost',
+            servingSize: '1 cup',
+            servingGrams: null,
+            calories: 180,
+            protein: 20,
+            carbs: 15,
+            fat: 3,
+            fiber: null,
+            sugar: null,
+            verified: false,
+            source: null,
+            notes: null,
+            lastUsedAt: null,
+            createdAt: 1,
+            updatedAt: 2,
+          },
+        ],
+      },
+      {
+        get: {
+          total: 3,
+        },
+      },
+    );
+
+    const { listFoods } = await import('./store.js');
+
+    const result = await listFoods('user-1', {
+      q: 'ghost',
+      sort: 'protein',
+      page: 2,
+      limit: 1,
+    });
+
+    expect(result).toEqual({
+      foods: [
+        expect.objectContaining({
+          id: 'food-2',
+          name: 'Protein Cereal',
+        }),
+      ],
+      total: 3,
+    });
+    expect(dbState.selectBuilders).toHaveLength(2);
+    expect(dbState.selectBuilders[0].where).toHaveBeenCalledOnce();
+    expect(dbState.selectBuilders[0].orderBy).toHaveBeenCalledOnce();
+    expect(dbState.selectBuilders[0].limit).toHaveBeenCalledWith(1);
+    expect(dbState.selectBuilders[0].offset).toHaveBeenCalledWith(1);
+    expect(dbState.selectBuilders[1].get).toHaveBeenCalledOnce();
+  });
+
+  it('supports recent sorting without pagination errors when the query is absent', async () => {
+    dbState.selectResults.push(
+      {
+        all: [
+          {
+            id: 'food-new',
+            userId: 'user-1',
+            name: 'New Food',
+            brand: null,
+            servingSize: null,
+            servingGrams: null,
+            calories: 100,
+            protein: 10,
+            carbs: 10,
+            fat: 2,
+            fiber: null,
+            sugar: null,
+            verified: false,
+            source: null,
+            notes: null,
+            lastUsedAt: 200,
+            createdAt: 1,
+            updatedAt: 2,
+          },
+        ],
+      },
+      {
+        get: {
+          total: 1,
+        },
+      },
+    );
+
+    const { listFoods } = await import('./store.js');
+
+    const result = await listFoods('user-1', {
+      sort: 'recent',
+      page: 1,
+      limit: 10,
+    });
+
+    expect(result.foods[0]).toMatchObject({
+      id: 'food-new',
+      lastUsedAt: 200,
+    });
+    expect(dbState.selectBuilders[0].where).toHaveBeenCalledOnce();
+    expect(dbState.selectBuilders[0].orderBy).toHaveBeenCalledOnce();
+    expect(dbState.selectBuilders[0].limit).toHaveBeenCalledWith(10);
+    expect(dbState.selectBuilders[0].offset).toHaveBeenCalledWith(0);
+  });
+
+  it('updates foods within scope and returns undefined when no row changed', async () => {
+    dbState.selectResults.push({
+      get: {
+        id: 'food-1',
+        userId: 'user-1',
+        name: 'Chicken Breast',
+        brand: null,
+        servingSize: '4 oz',
+        servingGrams: 112,
+        calories: 187,
+        protein: 35,
+        carbs: 0,
+        fat: 4,
+        fiber: null,
+        sugar: null,
+        verified: true,
+        source: 'USDA',
+        notes: 'Updated note',
+        lastUsedAt: null,
+        createdAt: 1,
+        updatedAt: 2,
+      },
+    });
+
+    const { updateFood } = await import('./store.js');
+
+    const updated = await updateFood('food-1', 'user-1', {
+      brand: null,
+      notes: 'Updated note',
+      verified: true,
+    });
+
+    expect(updated).toMatchObject({
+      id: 'food-1',
+      brand: null,
+      notes: 'Updated note',
+      verified: true,
+    });
+    expect(dbState.updateSets).toHaveLength(1);
+    expect(dbState.updateSets[0]).toMatchObject({
+      brand: null,
+      notes: 'Updated note',
+      verified: true,
+    });
+    expect(dbState.updateSets[0]).toHaveProperty('updatedAt');
+
+    dbState.updateRunResult = { changes: 0 };
+
+    await expect(
+      updateFood('food-1', 'user-2', {
+        name: 'Unauthorized rename',
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('deletes foods by scope and updates lastUsedAt timestamps', async () => {
+    const { deleteFood, updateFoodLastUsedAt } = await import('./store.js');
+
+    await expect(deleteFood('food-1', 'user-1')).resolves.toBe(true);
+    expect(dbState.deleteWhereCalls).toHaveLength(1);
+
+    dbState.deleteRunResult = { changes: 0 };
+    await expect(deleteFood('food-1', 'user-2')).resolves.toBe(false);
+
+    await updateFoodLastUsedAt('food-1', 1_700_000_300_000);
+
+    expect(dbState.updateSets.at(-1)).toEqual({
+      lastUsedAt: 1_700_000_300_000,
+    });
+  });
+});

--- a/apps/api/src/routes/foods/store.ts
+++ b/apps/api/src/routes/foods/store.ts
@@ -1,0 +1,274 @@
+import { and, count, eq, sql, type SQL } from 'drizzle-orm';
+import type {
+  CreateFoodInput,
+  Food,
+  FoodQueryParams,
+  FoodSort,
+  UpdateFoodInput,
+} from '@pulse/shared';
+
+import { foods } from '../../db/schema/index.js';
+
+export type FoodRecord = Food;
+
+export type CreateFoodRecordInput = {
+  id: string;
+  userId: string;
+} & CreateFoodInput;
+
+export type FoodListResult = {
+  foods: FoodRecord[];
+  total: number;
+};
+
+const foodSelection = {
+  id: foods.id,
+  userId: foods.userId,
+  name: foods.name,
+  brand: foods.brand,
+  servingSize: foods.servingSize,
+  servingGrams: foods.servingGrams,
+  calories: foods.calories,
+  protein: foods.protein,
+  carbs: foods.carbs,
+  fat: foods.fat,
+  fiber: foods.fiber,
+  sugar: foods.sugar,
+  verified: foods.verified,
+  source: foods.source,
+  notes: foods.notes,
+  lastUsedAt: foods.lastUsedAt,
+  createdAt: foods.createdAt,
+  updatedAt: foods.updatedAt,
+};
+
+const toNullable = <T>(value: T | undefined): T | null => value ?? null;
+
+const buildFoodFilters = (userId: string, query?: string) => {
+  const filters: SQL<unknown>[] = [eq(foods.userId, userId)];
+
+  if (query) {
+    const pattern = `%${query.toLowerCase()}%`;
+
+    filters.push(
+      sql`(
+        lower(${foods.name}) like ${pattern}
+        or lower(coalesce(${foods.brand}, '')) like ${pattern}
+      )`,
+    );
+  }
+
+  return filters.length === 1 ? filters[0] : and(...filters);
+};
+
+const buildFoodSort = (sort: FoodSort) => {
+  switch (sort) {
+    case 'recent':
+      return sql`case when ${foods.lastUsedAt} is null then 1 else 0 end asc, ${foods.lastUsedAt} desc, lower(${foods.name}) asc`;
+    case 'protein':
+      return sql`${foods.protein} desc, lower(${foods.name}) asc`;
+    case 'name':
+    default:
+      return sql`lower(${foods.name}) asc, lower(coalesce(${foods.brand}, '')) asc`;
+  }
+};
+
+const getFoodById = async (id: string, userId: string): Promise<FoodRecord | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  return db
+    .select(foodSelection)
+    .from(foods)
+    .where(and(eq(foods.id, id), eq(foods.userId, userId)))
+    .limit(1)
+    .get();
+};
+
+export const createFood = async ({
+  id,
+  userId,
+  name,
+  brand,
+  servingSize,
+  servingGrams,
+  calories,
+  protein,
+  carbs,
+  fat,
+  fiber,
+  sugar,
+  verified,
+  source,
+  notes,
+}: CreateFoodRecordInput): Promise<FoodRecord> => {
+  const { db } = await import('../../db/index.js');
+
+  const result = db
+    .insert(foods)
+    .values({
+      id,
+      userId,
+      name,
+      brand: toNullable(brand),
+      servingSize: toNullable(servingSize),
+      servingGrams: toNullable(servingGrams),
+      calories,
+      protein,
+      carbs,
+      fat,
+      fiber: toNullable(fiber),
+      sugar: toNullable(sugar),
+      verified,
+      source: toNullable(source),
+      notes: toNullable(notes),
+    })
+    .run();
+
+  if (result.changes !== 1) {
+    throw new Error('Failed to persist food');
+  }
+
+  const food = await getFoodById(id, userId);
+  if (!food) {
+    throw new Error('Failed to load created food');
+  }
+
+  return food;
+};
+
+export const listFoods = async (
+  userId: string,
+  { q, sort, page, limit }: FoodQueryParams,
+): Promise<FoodListResult> => {
+  const { db } = await import('../../db/index.js');
+
+  const filters = buildFoodFilters(userId, q);
+  const offset = (page - 1) * limit;
+
+  const foodRows = db
+    .select(foodSelection)
+    .from(foods)
+    .where(filters)
+    .orderBy(buildFoodSort(sort))
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  const totalRow = db
+    .select({
+      total: count(),
+    })
+    .from(foods)
+    .where(filters)
+    .get();
+
+  return {
+    foods: foodRows,
+    total: totalRow?.total ?? 0,
+  };
+};
+
+export const updateFood = async (
+  id: string,
+  userId: string,
+  updates: UpdateFoodInput,
+): Promise<FoodRecord | undefined> => {
+  const { db } = await import('../../db/index.js');
+  const nextValues: Partial<typeof foods.$inferInsert> & { updatedAt: number } = {
+    updatedAt: Date.now(),
+  };
+
+  if (updates.name !== undefined) {
+    nextValues.name = updates.name;
+  }
+
+  if ('brand' in updates) {
+    nextValues.brand = toNullable(updates.brand);
+  }
+
+  if ('servingSize' in updates) {
+    nextValues.servingSize = toNullable(updates.servingSize);
+  }
+
+  if ('servingGrams' in updates) {
+    nextValues.servingGrams = toNullable(updates.servingGrams);
+  }
+
+  if (updates.calories !== undefined) {
+    nextValues.calories = updates.calories;
+  }
+
+  if (updates.protein !== undefined) {
+    nextValues.protein = updates.protein;
+  }
+
+  if (updates.carbs !== undefined) {
+    nextValues.carbs = updates.carbs;
+  }
+
+  if (updates.fat !== undefined) {
+    nextValues.fat = updates.fat;
+  }
+
+  if ('fiber' in updates) {
+    nextValues.fiber = toNullable(updates.fiber);
+  }
+
+  if ('sugar' in updates) {
+    nextValues.sugar = toNullable(updates.sugar);
+  }
+
+  if (updates.verified !== undefined) {
+    nextValues.verified = updates.verified;
+  }
+
+  if ('source' in updates) {
+    nextValues.source = toNullable(updates.source);
+  }
+
+  if ('notes' in updates) {
+    nextValues.notes = toNullable(updates.notes);
+  }
+
+  const result = db
+    .update(foods)
+    .set(nextValues)
+    .where(and(eq(foods.id, id), eq(foods.userId, userId)))
+    .run();
+
+  if (result.changes !== 1) {
+    return undefined;
+  }
+
+  return getFoodById(id, userId);
+};
+
+export const deleteFood = async (id: string, userId: string): Promise<boolean> => {
+  const { db } = await import('../../db/index.js');
+
+  const result = db
+    .delete(foods)
+    .where(and(eq(foods.id, id), eq(foods.userId, userId)))
+    .run();
+
+  return result.changes === 1;
+};
+
+export const updateFoodLastUsedAt = async (
+  foodId: string,
+  lastUsedAt = Date.now(),
+): Promise<void> => {
+  const { db } = await import('../../db/index.js');
+
+  const result = db
+    .update(foods)
+    .set({
+      lastUsedAt,
+    })
+    .where(eq(foods.id, foodId))
+    .run();
+
+  if (result.changes !== 1) {
+    throw new Error('Failed to update food last used timestamp');
+  }
+};

--- a/apps/api/src/routes/foods/store.ts
+++ b/apps/api/src/routes/foods/store.ts
@@ -43,17 +43,18 @@ const foodSelection = {
 };
 
 const toNullable = <T>(value: T | undefined): T | null => value ?? null;
+const escapeLikePattern = (value: string) => value.toLowerCase().replace(/[%_\\]/g, '\\$&');
 
 const buildFoodFilters = (userId: string, query?: string) => {
   const filters: SQL<unknown>[] = [eq(foods.userId, userId)];
 
   if (query) {
-    const pattern = `%${query.toLowerCase()}%`;
+    const pattern = `%${escapeLikePattern(query)}%`;
 
     filters.push(
       sql`(
-        lower(${foods.name}) like ${pattern}
-        or lower(coalesce(${foods.brand}, '')) like ${pattern}
+        lower(${foods.name}) like ${pattern} escape '\\'
+        or lower(coalesce(${foods.brand}, '')) like ${pattern} escape '\\'
       )`,
     );
   }
@@ -256,6 +257,7 @@ export const deleteFood = async (id: string, userId: string): Promise<boolean> =
 
 export const updateFoodLastUsedAt = async (
   foodId: string,
+  userId: string,
   lastUsedAt = Date.now(),
 ): Promise<void> => {
   const { db } = await import('../../db/index.js');
@@ -265,7 +267,7 @@ export const updateFoodLastUsedAt = async (
     .set({
       lastUsedAt,
     })
-    .where(eq(foods.id, foodId))
+    .where(and(eq(foods.id, foodId), eq(foods.userId, userId)))
     .run();
 
   if (result.changes !== 1) {

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,9 +1,11 @@
+import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it } from 'vitest';
 import App from '@/App';
 import { ThemeProvider } from '@/components/theme-provider';
 import { workoutCompletedSessions } from '@/features/workouts';
 import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
+import { createAppQueryClient } from '@/lib/query-client';
 import { useAuthStore } from '@/store/auth-store';
 
 const sessionId = workoutCompletedSessions[0]?.id ?? 'session-upper-push-2026-03-02';
@@ -45,10 +47,14 @@ const navRoutes = [
 ] as const;
 
 function renderApp() {
+  const queryClient = createAppQueryClient();
+
   return render(
-    <ThemeProvider>
-      <App />
-    </ThemeProvider>,
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
+    </QueryClientProvider>,
   );
 }
 
@@ -82,6 +88,7 @@ function setAuthenticatedState() {
 
 describe('App', () => {
   beforeEach(() => {
+    createAppQueryClient().clear();
     window.localStorage.removeItem('pulse-theme');
     document.documentElement.classList.remove('dark');
     document.documentElement.classList.remove('theme-midnight');

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,10 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router';
 import { GuestRoute } from '@/components/auth/guest-route';
 import { ProtectedRoute } from '@/components/auth/protected-route';
 import { AppLayout } from '@/components/layout/app-layout';
+import { createAppQueryClient } from '@/lib/query-client';
 import { ActivityPage } from '@/pages/activity';
 import { DashboardPage } from '@/pages/dashboard';
 import { DesignSystemPage } from '@/pages/design-system';
@@ -76,10 +79,14 @@ function AppRoutes() {
 }
 
 function App() {
+  const [queryClient] = useState(() => createAppQueryClient());
+
   return (
-    <BrowserRouter>
-      <AppRoutes />
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <AppRoutes />
+      </BrowserRouter>
+    </QueryClientProvider>
   );
 }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,10 +1,7 @@
-import { QueryClientProvider } from '@tanstack/react-query';
-import { useState } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router';
 import { GuestRoute } from '@/components/auth/guest-route';
 import { ProtectedRoute } from '@/components/auth/protected-route';
 import { AppLayout } from '@/components/layout/app-layout';
-import { createAppQueryClient } from '@/lib/query-client';
 import { ActivityPage } from '@/pages/activity';
 import { DashboardPage } from '@/pages/dashboard';
 import { DesignSystemPage } from '@/pages/design-system';
@@ -79,14 +76,10 @@ function AppRoutes() {
 }
 
 function App() {
-  const [queryClient] = useState(() => createAppQueryClient());
-
   return (
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <AppRoutes />
-      </BrowserRouter>
-    </QueryClientProvider>
+    <BrowserRouter>
+      <AppRoutes />
+    </BrowserRouter>
   );
 }
 

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Slot } from 'radix-ui';

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Slot } from 'radix-ui';

--- a/apps/web/src/features/dashboard/components/macro-rings.tsx
+++ b/apps/web/src/features/dashboard/components/macro-rings.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { ProgressRing } from '@/components/ui/progress-ring';
@@ -108,7 +109,11 @@ export function MacroRings({ snapshot = mockDailySnapshot }: MacroRingsProps) {
           );
 
           return (
-            <div className="flex flex-col items-center gap-2" data-slot="macro-ring-item" key={macro.key}>
+            <div
+              className="flex flex-col items-center gap-2"
+              data-slot="macro-ring-item"
+              key={macro.key}
+            >
               <div className="w-full max-w-[106px] px-1">
                 <ProgressRing
                   aria-label={`${macro.label} progress`}

--- a/apps/web/src/features/dashboard/components/snapshot-cards.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { StatCard, type StatTrend } from '@/components/ui/stat-card';
 import { accentCardStyles } from '@/lib/accent-card-styles';
 import { mockDailySnapshot, type DailySnapshot } from '@/lib/mock-data/dashboard';

--- a/apps/web/src/features/foods/api/foods.test.tsx
+++ b/apps/web/src/features/foods/api/foods.test.tsx
@@ -54,10 +54,12 @@ function createWrapper() {
 
 describe('foods api hooks', () => {
   beforeEach(() => {
+    createAppQueryClient().clear();
     window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
   });
 
   afterEach(() => {
+    createAppQueryClient().clear();
     window.localStorage.clear();
     vi.unstubAllGlobals();
   });

--- a/apps/web/src/features/foods/api/foods.test.tsx
+++ b/apps/web/src/features/foods/api/foods.test.tsx
@@ -1,0 +1,188 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import type { Food } from '@pulse/shared';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDeleteFood, useFoods, type FoodListResponse } from '@/features/foods/api/foods';
+import { foodKeys } from '@/features/foods/api/keys';
+import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
+import { createAppQueryClient } from '@/lib/query-client';
+
+function createDeferredResponse() {
+  let resolve: (value: Response) => void = () => {};
+
+  const promise = new Promise<Response>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
+}
+
+function createFood(id: string, name: string): Food {
+  return {
+    id,
+    userId: 'user-1',
+    name,
+    brand: null,
+    servingSize: '1 serving',
+    servingGrams: null,
+    calories: 100,
+    protein: 10,
+    carbs: 10,
+    fat: 5,
+    fiber: null,
+    sugar: null,
+    verified: false,
+    source: null,
+    notes: null,
+    lastUsedAt: null,
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+  };
+}
+
+function createWrapper() {
+  const queryClient = createAppQueryClient();
+
+  return {
+    queryClient,
+    wrapper({ children }: PropsWithChildren) {
+      return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    },
+  };
+}
+
+describe('foods api hooks', () => {
+  beforeEach(() => {
+    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the list query key and request params for foods fetches', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [createFood('food-1', 'Chicken Breast')],
+            meta: {
+              page: 2,
+              limit: 5,
+              total: 12,
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { queryClient, wrapper } = createWrapper();
+    const { result } = renderHook(
+      () =>
+        useFoods({
+          q: 'chicken',
+          sort: 'protein',
+          page: 2,
+          limit: 5,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.data[0]?.name).toBe('Chicken Breast');
+    expect(result.current.data?.meta.total).toBe(12);
+    expect(
+      queryClient.getQueryState(
+        foodKeys.list({
+          q: 'chicken',
+          sort: 'protein',
+          page: 2,
+          limit: 5,
+        }),
+      ),
+    ).toBeDefined();
+
+    const firstRequest = (
+      fetchMock.mock.calls as unknown as Array<[RequestInfo | URL, RequestInit?]>
+    ).at(0)?.[0];
+    if (!firstRequest) {
+      throw new Error('Expected at least one foods request');
+    }
+    const request = new URL(String(firstRequest), 'http://localhost');
+    expect(request.pathname).toBe('/api/v1/foods');
+    expect(request.searchParams.get('q')).toBe('chicken');
+    expect(request.searchParams.get('sort')).toBe('protein');
+    expect(request.searchParams.get('page')).toBe('2');
+    expect(request.searchParams.get('limit')).toBe('5');
+  });
+
+  it('rolls back optimistic deletes when the API returns an error', async () => {
+    const deferredDelete = createDeferredResponse();
+    const fetchMock = vi.fn(() => deferredDelete.promise);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { queryClient, wrapper } = createWrapper();
+    const initialData: FoodListResponse = {
+      data: [createFood('food-1', 'Chicken Breast'), createFood('food-2', 'Greek Yogurt')],
+      meta: {
+        page: 1,
+        limit: 12,
+        total: 2,
+      },
+    };
+
+    queryClient.setQueryData(foodKeys.list({ page: 1, limit: 12, sort: 'name' }), initialData);
+
+    const { result } = renderHook(() => useDeleteFood(), { wrapper });
+
+    act(() => {
+      result.current.mutate('food-1');
+    });
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<FoodListResponse>(
+          foodKeys.list({ page: 1, limit: 12, sort: 'name' }),
+        )?.data,
+      ).toHaveLength(1);
+    });
+
+    deferredDelete.resolve(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 'DELETE_FAILED',
+            message: 'Delete failed',
+          },
+        }),
+        {
+          status: 500,
+          headers: {
+            'content-type': 'application/json',
+          },
+        },
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(
+      queryClient.getQueryData<FoodListResponse>(
+        foodKeys.list({ page: 1, limit: 12, sort: 'name' }),
+      ),
+    ).toEqual(initialData);
+  });
+});

--- a/apps/web/src/features/foods/api/foods.ts
+++ b/apps/web/src/features/foods/api/foods.ts
@@ -81,14 +81,14 @@ export function useUpdateFood() {
 
   return useMutation({
     mutationFn: ({ id, updates }: { id: string; updates: UpdateFoodInput }) => putFood(id, updates),
-    onSuccess: (updatedFood) => {
+    onSuccess: async (updatedFood) => {
       patchFoodListCache(queryClient, (current) => ({
         ...current,
         data: current.data.map((food) => (food.id === updatedFood.id ? updatedFood : food)),
       }));
 
       queryClient.setQueryData(foodKeys.detail(updatedFood.id), updatedFood);
-      return queryClient.invalidateQueries({
+      await queryClient.invalidateQueries({
         queryKey: foodKeys.list(),
       });
     },

--- a/apps/web/src/features/foods/api/foods.ts
+++ b/apps/web/src/features/foods/api/foods.ts
@@ -1,0 +1,155 @@
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { QueryClient, QueryKey } from '@tanstack/react-query';
+import type { Food, FoodQueryParams, UpdateFoodInput } from '@pulse/shared';
+import { apiRequest, apiRequestWithMeta } from '@/lib/api-client';
+import { foodKeys } from './keys';
+
+type FoodListResponse = {
+  data: Food[];
+  meta: {
+    page: number;
+    limit: number;
+    total: number;
+  };
+};
+
+function buildFoodsQueryString(params: FoodQueryParams) {
+  const searchParams = new URLSearchParams();
+
+  if (params.q) {
+    searchParams.set('q', params.q);
+  }
+
+  searchParams.set('sort', params.sort);
+  searchParams.set('page', String(params.page));
+  searchParams.set('limit', String(params.limit));
+
+  return searchParams.toString();
+}
+
+async function fetchFoods(params: FoodQueryParams, signal?: AbortSignal) {
+  const query = buildFoodsQueryString(params);
+
+  return apiRequestWithMeta<Food[], FoodListResponse['meta']>(`/api/v1/foods?${query}`, {
+    method: 'GET',
+    signal,
+  });
+}
+
+async function putFood(id: string, updates: UpdateFoodInput) {
+  return apiRequest<Food>(`/api/v1/foods/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(updates),
+  });
+}
+
+async function removeFood(id: string) {
+  return apiRequest<{ success: true }>(`/api/v1/foods/${id}`, {
+    method: 'DELETE',
+  });
+}
+
+function patchFoodListCache(
+  queryClient: QueryClient,
+  updater: (current: FoodListResponse) => FoodListResponse,
+) {
+  const queries = queryClient.getQueriesData<FoodListResponse>({
+    queryKey: foodKeys.list(),
+  });
+
+  queries.forEach(([queryKey, value]) => {
+    if (!value) {
+      return;
+    }
+
+    queryClient.setQueryData(queryKey, updater(value));
+  });
+
+  return queries;
+}
+
+export function useFoods(params: FoodQueryParams) {
+  return useQuery({
+    queryKey: foodKeys.list(params),
+    queryFn: ({ signal }) => fetchFoods(params, signal),
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useUpdateFood() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, updates }: { id: string; updates: UpdateFoodInput }) => putFood(id, updates),
+    onSuccess: (updatedFood) => {
+      patchFoodListCache(queryClient, (current) => ({
+        ...current,
+        data: current.data.map((food) => (food.id === updatedFood.id ? updatedFood : food)),
+      }));
+
+      queryClient.setQueryData(foodKeys.detail(updatedFood.id), updatedFood);
+      return queryClient.invalidateQueries({
+        queryKey: foodKeys.list(),
+      });
+    },
+  });
+}
+
+export function useDeleteFood() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await removeFood(id);
+      return id;
+    },
+    onMutate: async (foodId) => {
+      await queryClient.cancelQueries({
+        queryKey: foodKeys.list(),
+      });
+
+      const previousLists = queryClient.getQueriesData<FoodListResponse>({
+        queryKey: foodKeys.list(),
+      });
+
+      previousLists.forEach(([queryKey, value]) => {
+        if (!value) {
+          return;
+        }
+
+        queryClient.setQueryData<FoodListResponse>(queryKey, {
+          ...value,
+          data: value.data.filter((food) => food.id !== foodId),
+          meta: {
+            ...value.meta,
+            total: Math.max(0, value.meta.total - 1),
+          },
+        });
+      });
+
+      queryClient.removeQueries({
+        queryKey: foodKeys.detail(foodId),
+      });
+
+      return {
+        previousLists,
+      };
+    },
+    onError: (_error, _foodId, context) => {
+      context?.previousLists.forEach(([queryKey, value]) => {
+        queryClient.setQueryData(queryKey as QueryKey, value);
+      });
+    },
+    onSettled: (_data, _error, foodId) =>
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: foodKeys.list(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: foodKeys.detail(foodId),
+        }),
+      ]),
+  });
+}
+
+export type { FoodListResponse };

--- a/apps/web/src/features/foods/api/keys.ts
+++ b/apps/web/src/features/foods/api/keys.ts
@@ -1,0 +1,19 @@
+import type { FoodQueryParams } from '@pulse/shared';
+
+function normalizeListParams(params?: Partial<FoodQueryParams>) {
+  return {
+    limit: params?.limit ?? null,
+    page: params?.page ?? null,
+    q: params?.q ?? null,
+    sort: params?.sort ?? null,
+  };
+}
+
+export const foodKeys = {
+  all: ['foods'] as const,
+  list: (params?: Partial<FoodQueryParams>) =>
+    params
+      ? (['foods', 'list', normalizeListParams(params)] as const)
+      : (['foods', 'list'] as const),
+  detail: (id: string) => ['foods', 'detail', id] as const,
+};

--- a/apps/web/src/features/foods/components/food-list.test.tsx
+++ b/apps/web/src/features/foods/components/food-list.test.tsx
@@ -278,10 +278,12 @@ const paginatedFoods = [
 
 describe('FoodList', () => {
   beforeEach(() => {
+    createAppQueryClient().clear();
     window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
   });
 
   afterEach(() => {
+    createAppQueryClient().clear();
     window.localStorage.clear();
     vi.unstubAllGlobals();
   });

--- a/apps/web/src/features/foods/components/food-list.test.tsx
+++ b/apps/web/src/features/foods/components/food-list.test.tsx
@@ -70,7 +70,14 @@ function sortFoods(foods: Food[], sort: string) {
   return copy.sort((left, right) => left.name.localeCompare(right.name));
 }
 
-function createFoodsApiMock(initialFoods: Food[], options?: { failDeleteForId?: string }) {
+function createFoodsApiMock(
+  initialFoods: Food[],
+  options?: {
+    deferredUpdateForId?: string;
+    deferredUpdateResponse?: Promise<Response>;
+    failDeleteForId?: string;
+  },
+) {
   let foods = [...initialFoods];
 
   const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -122,6 +129,10 @@ function createFoodsApiMock(initialFoods: Food[], options?: { failDeleteForId?: 
             },
           },
         );
+      }
+
+      if (options?.deferredUpdateForId === id && options.deferredUpdateResponse) {
+        return options.deferredUpdateResponse;
       }
 
       foods[index] = {
@@ -402,6 +413,53 @@ describe('FoodList', () => {
 
     lastUrl = new URL(String(api.fetchMock.mock.calls.at(-1)?.[0]), 'http://localhost');
     expect(lastUrl.pathname).toBe('/api/v1/foods');
+  });
+
+  it('keeps the inline editor open if a pending save blurs before the API fails', async () => {
+    const deferredUpdate = createDeferredResponse();
+    const api = createFoodsApiMock(paginatedFoods, {
+      deferredUpdateForId: 'food-13',
+      deferredUpdateResponse: deferredUpdate.promise,
+    });
+    vi.stubGlobal('fetch', api.fetchMock);
+
+    renderFoodList();
+
+    expect(await screen.findByRole('heading', { level: 3, name: '2% Milk' })).toBeInTheDocument();
+
+    selectSortOption('Highest Protein');
+    expect(await screen.findByRole('button', { name: 'Whey Protein' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Whey Protein' }));
+    const editInput = await screen.findByRole('textbox', { name: 'Edit Whey Protein name' });
+
+    fireEvent.change(editInput, { target: { value: 'Casein Protein' } });
+    fireEvent.submit(editInput.closest('form') as HTMLFormElement);
+    fireEvent.blur(editInput);
+
+    deferredUpdate.resolve(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 'UPDATE_FAILED',
+            message: 'Update failed',
+          },
+        }),
+        {
+          status: 500,
+          headers: {
+            'content-type': 'application/json',
+          },
+        },
+      ),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Update failed')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('textbox', { name: 'Edit Whey Protein name' })).toHaveValue(
+      'Casein Protein',
+    );
   });
 
   it('removes foods optimistically and keeps the total count in sync', async () => {

--- a/apps/web/src/features/foods/components/food-list.test.tsx
+++ b/apps/web/src/features/foods/components/food-list.test.tsx
@@ -341,8 +341,10 @@ describe('FoodList', () => {
 
     renderFoodList();
 
-    expect(await screen.findByRole('heading', { level: 3, name: '2% Milk' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: 'Spinach' })).toBeInTheDocument();
     expect(api.fetchMock).toHaveBeenCalledTimes(1);
+    const initialUrl = new URL(String(api.fetchMock.mock.calls.at(0)?.[0]), 'http://localhost');
+    expect(initialUrl.searchParams.get('sort')).toBe('recent');
 
     fireEvent.change(screen.getByRole('searchbox', { name: 'Search foods' }), {
       target: { value: 'fair' },
@@ -374,7 +376,9 @@ describe('FoodList', () => {
 
     renderFoodList();
 
-    expect(await screen.findByRole('heading', { level: 3, name: '2% Milk' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: 'Spinach' })).toBeInTheDocument();
+    const initialUrl = new URL(String(api.fetchMock.mock.calls.at(0)?.[0]), 'http://localhost');
+    expect(initialUrl.searchParams.get('sort')).toBe('recent');
 
     selectSortOption('Highest Protein');
 
@@ -427,7 +431,7 @@ describe('FoodList', () => {
 
     renderFoodList();
 
-    expect(await screen.findByRole('heading', { level: 3, name: '2% Milk' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: 'Spinach' })).toBeInTheDocument();
 
     selectSortOption('Highest Protein');
     expect(await screen.findByRole('button', { name: 'Whey Protein' })).toBeInTheDocument();
@@ -470,7 +474,7 @@ describe('FoodList', () => {
 
     renderFoodList();
 
-    expect(await screen.findByRole('heading', { level: 3, name: '2% Milk' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: 'Spinach' })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete Broccoli' }));
     expect(screen.getByText('Are you sure you want to remove Broccoli?')).toBeInTheDocument();

--- a/apps/web/src/features/foods/components/food-list.test.tsx
+++ b/apps/web/src/features/foods/components/food-list.test.tsx
@@ -1,9 +1,185 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import type { Food } from '@pulse/shared';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FoodList } from '@/features/foods/components/food-list';
+import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
+import { createAppQueryClient } from '@/lib/query-client';
 
-function getVisibleFoodNames() {
-  return screen.getAllByRole('heading', { level: 3 }).map((heading) => heading.textContent);
+function createDeferredResponse() {
+  let resolve: (value: Response) => void = () => {};
+
+  const promise = new Promise<Response>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
+}
+
+function createFood(id: string, name: string, overrides: Partial<Food> = {}): Food {
+  return {
+    id,
+    userId: 'user-1',
+    name,
+    brand: null,
+    servingSize: '1 serving',
+    servingGrams: null,
+    calories: 100,
+    protein: 10,
+    carbs: 10,
+    fat: 5,
+    fiber: null,
+    sugar: null,
+    verified: true,
+    source: 'USDA',
+    notes: null,
+    lastUsedAt: Date.parse('2026-03-05T12:00:00.000Z'),
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+function sortFoods(foods: Food[], sort: string) {
+  const copy = [...foods];
+
+  if (sort === 'recent') {
+    return copy.sort((left, right) => {
+      if (left.lastUsedAt === null && right.lastUsedAt === null) {
+        return left.name.localeCompare(right.name);
+      }
+
+      if (left.lastUsedAt === null) {
+        return 1;
+      }
+
+      if (right.lastUsedAt === null) {
+        return -1;
+      }
+
+      return right.lastUsedAt - left.lastUsedAt || left.name.localeCompare(right.name);
+    });
+  }
+
+  if (sort === 'protein') {
+    return copy.sort(
+      (left, right) => right.protein - left.protein || left.name.localeCompare(right.name),
+    );
+  }
+
+  return copy.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function createFoodsApiMock(initialFoods: Food[], options?: { failDeleteForId?: string }) {
+  let foods = [...initialFoods];
+
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(typeof input === 'string' ? input : input.toString(), 'http://localhost');
+    const method = init?.method ?? 'GET';
+
+    if (url.pathname === '/api/v1/foods' && method === 'GET') {
+      const q = url.searchParams.get('q')?.toLowerCase() ?? '';
+      const sort = url.searchParams.get('sort') ?? 'name';
+      const page = Number(url.searchParams.get('page') ?? '1');
+      const limit = Number(url.searchParams.get('limit') ?? '12');
+      const filteredFoods = foods.filter((food) =>
+        [food.name, food.brand ?? ''].some((value) => value.toLowerCase().includes(q)),
+      );
+      const sortedFoods = sortFoods(filteredFoods, sort);
+      const startIndex = (page - 1) * limit;
+      const data = sortedFoods.slice(startIndex, startIndex + limit);
+
+      return new Response(
+        JSON.stringify({
+          data,
+          meta: {
+            page,
+            limit,
+            total: filteredFoods.length,
+          },
+        }),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        },
+      );
+    }
+
+    if (url.pathname.startsWith('/api/v1/foods/') && method === 'PUT') {
+      const id = url.pathname.split('/').at(-1) ?? '';
+      const body = JSON.parse(String(init?.body ?? '{}')) as Partial<Food>;
+      const index = foods.findIndex((food) => food.id === id);
+
+      if (index === -1) {
+        return new Response(
+          JSON.stringify({ error: { code: 'FOOD_NOT_FOUND', message: 'Missing' } }),
+          {
+            status: 404,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        );
+      }
+
+      foods[index] = {
+        ...foods[index],
+        ...body,
+        updatedAt: foods[index].updatedAt + 1,
+      };
+
+      return new Response(JSON.stringify({ data: foods[index] }), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+    }
+
+    if (url.pathname.startsWith('/api/v1/foods/') && method === 'DELETE') {
+      const id = url.pathname.split('/').at(-1) ?? '';
+
+      if (options?.failDeleteForId === id) {
+        return new Response(
+          JSON.stringify({ error: { code: 'DELETE_FAILED', message: 'Delete failed' } }),
+          {
+            status: 500,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        );
+      }
+
+      foods = foods.filter((food) => food.id !== id);
+
+      return new Response(JSON.stringify({ data: { success: true } }), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+    }
+
+    throw new Error(`Unhandled request: ${method} ${url.pathname}${url.search}`);
+  });
+
+  return {
+    fetchMock,
+    getFoods: () => foods,
+  };
+}
+
+function renderFoodList() {
+  const queryClient = createAppQueryClient();
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <FoodList now={new Date('2026-03-06T12:00:00.000Z')} />
+    </QueryClientProvider>,
+  );
 }
 
 function selectSortOption(optionLabel: string) {
@@ -13,176 +189,239 @@ function selectSortOption(optionLabel: string) {
   fireEvent.click(screen.getByText(optionLabel));
 }
 
+const paginatedFoods = [
+  createFood('food-1', '2% Milk', {
+    brand: 'Fairlife',
+    protein: 13,
+    servingSize: '1 cup',
+    servingGrams: 240,
+    lastUsedAt: Date.parse('2026-03-04T07:10:00.000Z'),
+  }),
+  createFood('food-2', 'Almonds', {
+    protein: 6,
+    lastUsedAt: Date.parse('2026-03-03T20:20:00.000Z'),
+  }),
+  createFood('food-3', 'Apple', {
+    verified: false,
+    source: null,
+    protein: 0,
+    lastUsedAt: Date.parse('2026-03-02T12:15:00.000Z'),
+  }),
+  createFood('food-4', 'Atlantic Salmon', {
+    protein: 31,
+    calories: 290,
+    fat: 17,
+    carbs: 0,
+    lastUsedAt: Date.parse('2026-03-05T18:40:00.000Z'),
+  }),
+  createFood('food-5', 'Avocado', {
+    protein: 2,
+    fat: 11,
+    lastUsedAt: Date.parse('2026-03-01T12:15:00.000Z'),
+  }),
+  createFood('food-6', 'Banana', {
+    protein: 1,
+    carbs: 27,
+    lastUsedAt: Date.parse('2026-03-05T07:15:00.000Z'),
+  }),
+  createFood('food-7', 'Broccoli', {
+    protein: 3,
+    lastUsedAt: Date.parse('2026-03-05T12:30:00.000Z'),
+  }),
+  createFood('food-8', 'Chicken Breast', {
+    protein: 35,
+    carbs: 0,
+    fat: 4,
+    lastUsedAt: Date.parse('2026-03-05T12:30:00.000Z'),
+  }),
+  createFood('food-9', 'Greek Yogurt', {
+    brand: 'Fage 0%',
+    protein: 18,
+    lastUsedAt: Date.parse('2026-03-05T15:30:00.000Z'),
+  }),
+  createFood('food-10', 'Ground Beef 90/10', {
+    protein: 23,
+    fat: 11,
+    lastUsedAt: Date.parse('2026-03-03T18:30:00.000Z'),
+  }),
+  createFood('food-11', 'Olive Oil', {
+    protein: 0,
+    carbs: 0,
+    fat: 14,
+    lastUsedAt: Date.parse('2026-03-04T18:45:00.000Z'),
+  }),
+  createFood('food-12', 'Spinach', {
+    protein: 3,
+    lastUsedAt: Date.parse('2026-03-05T16:45:00.000Z'),
+  }),
+  createFood('food-13', 'Whey Protein', {
+    brand: 'Optimum Nutrition Gold Standard',
+    protein: 24,
+    carbs: 3,
+    fat: 1,
+    calories: 120,
+    servingSize: '1 scoop',
+    lastUsedAt: Date.parse('2026-03-05T16:45:00.000Z'),
+  }),
+];
+
 describe('FoodList', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-03-06T12:00:00'));
+    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
   });
 
   afterEach(() => {
-    vi.useRealTimers();
+    window.localStorage.clear();
+    vi.unstubAllGlobals();
   });
 
-  it('renders food cards with serving info, macros, verified badges, and last-used text', () => {
-    render(<FoodList />);
+  it('shows loading placeholders, then renders the first server page with pagination', async () => {
+    const deferredFoods = createDeferredResponse();
+    const delayedFetch = vi.fn((input: RequestInfo | URL) => {
+      const url = new URL(typeof input === 'string' ? input : input.toString(), 'http://localhost');
 
-    const wheyProteinCard = screen.getByText('Whey Protein').closest('[data-slot="card"]');
-    const cheddarCard = screen.getByText('Cheddar Cheese').closest('[data-slot="card"]');
+      if (url.pathname === '/api/v1/foods') {
+        return deferredFoods.promise;
+      }
 
-    expect(wheyProteinCard).not.toBeNull();
-    expect(cheddarCard).not.toBeNull();
-
-    if (!wheyProteinCard || !cheddarCard) {
-      throw new Error('Expected food cards to render');
-    }
-
-    expect(screen.getAllByText('Verified').length).toBeGreaterThan(0);
-    expect(wheyProteinCard).toHaveTextContent('Optimum Nutrition Gold Standard');
-    expect(wheyProteinCard).toHaveTextContent('Serving: 1 scoop');
-    expect(wheyProteinCard).toHaveTextContent('Last used: 1 day ago');
-    expect(wheyProteinCard).toHaveTextContent('120 cal');
-    expect(wheyProteinCard).toHaveTextContent('24g');
-    expect(wheyProteinCard).toHaveTextContent('3g');
-    expect(wheyProteinCard).toHaveTextContent('1g');
-    expect(cheddarCard).toHaveTextContent('Last used: Never');
-  });
-
-  it('filters foods in real time by name or brand', () => {
-    render(<FoodList />);
-
-    fireEvent.change(screen.getByRole('searchbox', { name: 'Search foods' }), {
-      target: { value: 'fairlife' },
+      throw new Error(`Unhandled request ${url.pathname}`);
     });
 
-    expect(screen.getByText('2% Milk')).toBeInTheDocument();
-    expect(screen.queryByText('Chicken Breast')).not.toBeInTheDocument();
-    expect(screen.getByText('Showing 1 of 20 foods')).toBeInTheDocument();
+    vi.stubGlobal('fetch', delayedFetch);
+
+    const view = renderFoodList();
+
+    expect(screen.getByText('Showing 0 of 0 foods')).toBeInTheDocument();
+    expect(screen.queryAllByRole('article')).toHaveLength(0);
+    expect(view.container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+
+    deferredFoods.resolve(
+      new Response(
+        JSON.stringify({
+          data: paginatedFoods.slice(0, 12),
+          meta: {
+            page: 1,
+            limit: 12,
+            total: paginatedFoods.length,
+          },
+        }),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        },
+      ),
+    );
+
+    expect(await screen.findByRole('button', { name: '2% Milk' })).toBeInTheDocument();
+    expect(screen.getByText('Serving: 1 cup (240 g)')).toBeInTheDocument();
+    expect(screen.getAllByText('Last used: 2 days ago').length).toBeGreaterThan(0);
+    expect(screen.getByText('Showing 12 of 13 foods')).toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+    expect(screen.getAllByText('Verified').length).toBeGreaterThan(0);
   });
 
-  it('sorts foods alphabetically by default', () => {
-    render(<FoodList />);
+  it('debounces search and sends the query to the foods API', async () => {
+    const api = createFoodsApiMock(paginatedFoods);
+    vi.stubGlobal('fetch', api.fetchMock);
 
-    expect(getVisibleFoodNames().slice(0, 5)).toEqual([
-      '2% Milk',
-      'Almonds',
-      'Apple',
-      'Atlantic Salmon',
-      'Avocado',
-    ]);
+    renderFoodList();
+
+    expect(await screen.findByRole('heading', { level: 3, name: '2% Milk' })).toBeInTheDocument();
+    expect(api.fetchMock).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search foods' }), {
+      target: { value: 'fair' },
+    });
+
+    await new Promise((resolve) => window.setTimeout(resolve, 150));
+
+    expect(api.fetchMock).toHaveBeenCalledTimes(1);
+
+    await waitFor(
+      () => {
+        expect(api.fetchMock).toHaveBeenCalledTimes(2);
+      },
+      { timeout: 1000 },
+    );
+    expect(await screen.findByRole('heading', { level: 3, name: '2% Milk' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { level: 3, name: 'Chicken Breast' }),
+    ).not.toBeInTheDocument();
+
+    const lastUrl = new URL(String(api.fetchMock.mock.calls.at(-1)?.[0]), 'http://localhost');
+    expect(lastUrl.searchParams.get('q')).toBe('fair');
+    expect(lastUrl.searchParams.get('page')).toBe('1');
   });
 
-  it('sorts foods by recency with null last-used dates at the end', () => {
-    render(<FoodList />);
+  it('changes server sort, paginates, and saves inline edits through the API', async () => {
+    const api = createFoodsApiMock(paginatedFoods);
+    vi.stubGlobal('fetch', api.fetchMock);
 
-    selectSortOption('Most Recent');
+    renderFoodList();
 
-    const visibleNames = getVisibleFoodNames();
-
-    expect(visibleNames[0]).toBe('Atlantic Salmon');
-    expect(visibleNames[1]).toBe('Spinach');
-    expect(visibleNames.at(-1)).toBe('Cheddar Cheese');
-  });
-
-  it('sorts foods by highest protein first', () => {
-    render(<FoodList />);
+    expect(await screen.findByRole('heading', { level: 3, name: '2% Milk' })).toBeInTheDocument();
 
     selectSortOption('Highest Protein');
 
-    expect(getVisibleFoodNames().slice(0, 4)).toEqual([
-      'Chicken Breast',
-      'Atlantic Salmon',
-      'Whey Protein',
-      'Ground Beef 90/10',
-    ]);
-  });
+    expect(await screen.findByRole('button', { name: 'Whey Protein' })).toBeInTheDocument();
 
-  it('toggles sort direction for the current sort option', () => {
-    render(<FoodList />);
+    let lastUrl = new URL(String(api.fetchMock.mock.calls.at(-1)?.[0]), 'http://localhost');
+    expect(lastUrl.searchParams.get('sort')).toBe('protein');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Toggle sort direction' }));
-
-    expect(getVisibleFoodNames().slice(0, 5)).toEqual([
-      'Whole Wheat Bread',
-      'White Rice',
-      'Whey Protein',
-      'Sweet Potato',
-      'Spinach',
-    ]);
-
-    selectSortOption('Most Recent');
-    fireEvent.click(screen.getByRole('button', { name: 'Toggle sort direction' }));
-
-    expect(getVisibleFoodNames()[0]).toBe('Avocado');
-    expect(getVisibleFoodNames().at(-1)).toBe('Cheddar Cheese');
-  });
-
-  it('saves an inline food-name edit on Enter and reapplies the active search filter', () => {
-    render(<FoodList />);
-
-    fireEvent.change(screen.getByRole('searchbox', { name: 'Search foods' }), {
-      target: { value: 'whey' },
-    });
     fireEvent.click(screen.getByRole('button', { name: 'Whey Protein' }));
-
-    const editInput = screen.getByRole('textbox', { name: 'Edit Whey Protein name' });
+    const editInput = await screen.findByRole('textbox', { name: 'Edit Whey Protein name' });
 
     fireEvent.change(editInput, { target: { value: 'Casein Protein' } });
     fireEvent.submit(editInput.closest('form') as HTMLFormElement);
 
-    expect(screen.getByText('No foods found')).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { level: 3, name: 'Whey Protein' })).not.toBeInTheDocument();
-    expect(screen.getByText('Showing 0 of 20 foods')).toBeInTheDocument();
-  });
-
-  it('cancels inline editing on Escape and on outside focus changes', () => {
-    render(<FoodList />);
-
-    fireEvent.click(screen.getByRole('button', { name: 'Greek Yogurt' }));
-
-    const escapeInput = screen.getByRole('textbox', { name: 'Edit Greek Yogurt name' });
-    fireEvent.change(escapeInput, { target: { value: 'Skyr Yogurt' } });
-    fireEvent.keyDown(escapeInput, { key: 'Escape' });
-
-    expect(screen.getByRole('button', { name: 'Greek Yogurt' })).toBeInTheDocument();
-    expect(screen.queryByDisplayValue('Skyr Yogurt')).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Apple' }));
-
-    const blurInput = screen.getByRole('textbox', { name: 'Edit Apple name' });
-    fireEvent.change(blurInput, { target: { value: 'Honeycrisp Apple' } });
-    fireEvent.blur(blurInput);
-
-    expect(screen.getByRole('button', { name: 'Apple' })).toBeInTheDocument();
-    expect(screen.queryByDisplayValue('Honeycrisp Apple')).not.toBeInTheDocument();
-  });
-
-  it('confirms deletion with the food name and removes the food from local state', () => {
-    render(<FoodList />);
-
-    fireEvent.change(screen.getByRole('searchbox', { name: 'Search foods' }), {
-      target: { value: 'spinach' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Delete Spinach' }));
-
     expect(
-      screen.getByText('Are you sure you want to remove Spinach?'),
+      await screen.findByRole('heading', { level: 3, name: 'Casein Protein' }),
     ).toBeInTheDocument();
+    expect(api.getFoods().find((food) => food.id === 'food-13')?.name).toBe('Casein Protein');
+
+    selectSortOption('Alphabetical');
+    await waitFor(() => {
+      const requestUrl = new URL(String(api.fetchMock.mock.calls.at(-1)?.[0]), 'http://localhost');
+
+      expect(requestUrl.searchParams.get('sort')).toBe('name');
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('Refreshing foods…')).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole('heading', { level: 3, name: '2% Milk' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => {
+      const requestUrl = new URL(String(api.fetchMock.mock.calls.at(-1)?.[0]), 'http://localhost');
+
+      expect(requestUrl.searchParams.get('page')).toBe('2');
+    });
+    expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
+
+    lastUrl = new URL(String(api.fetchMock.mock.calls.at(-1)?.[0]), 'http://localhost');
+    expect(lastUrl.pathname).toBe('/api/v1/foods');
+  });
+
+  it('removes foods optimistically and keeps the total count in sync', async () => {
+    const api = createFoodsApiMock(paginatedFoods);
+    vi.stubGlobal('fetch', api.fetchMock);
+
+    renderFoodList();
+
+    expect(await screen.findByRole('heading', { level: 3, name: '2% Milk' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Broccoli' }));
+    expect(screen.getByText('Are you sure you want to remove Broccoli?')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
 
-    expect(screen.queryByRole('heading', { level: 3, name: 'Spinach' })).not.toBeInTheDocument();
-    expect(screen.getByText('No foods found')).toBeInTheDocument();
-    expect(screen.getByText('Showing 0 of 19 foods')).toBeInTheDocument();
-  });
-
-  it('shows an empty state when the search yields no matches', () => {
-    render(<FoodList />);
-
-    fireEvent.change(screen.getByRole('searchbox', { name: 'Search foods' }), {
-      target: { value: 'dragonfruit jerky' },
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { level: 3, name: 'Broccoli' })).not.toBeInTheDocument();
     });
-
-    expect(screen.getByText('No foods found')).toBeInTheDocument();
-    expect(screen.getByText('Showing 0 of 20 foods')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Showing 12 of 12 foods')).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/features/foods/components/food-list.tsx
+++ b/apps/web/src/features/foods/components/food-list.tsx
@@ -1,4 +1,5 @@
-import { ArrowUpDownIcon, CheckCircle2Icon, SearchIcon, Trash2Icon } from 'lucide-react';
+import { CheckCircle2Icon, SearchIcon, Trash2Icon } from 'lucide-react';
+import type { Food, FoodSort } from '@pulse/shared';
 import { useEffect, useState } from 'react';
 import {
   AlertDialog,
@@ -22,41 +23,38 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useDeleteFood, useFoods, useUpdateFood } from '@/features/foods/api/foods';
 import { accentCardStyles } from '@/lib/accent-card-styles';
-import { mockFoods, type Food } from '@/lib/mock-data/foods';
 
 type FoodListProps = {
-  foods?: Food[];
   now?: Date;
+  pageSize?: number;
 };
 
-type FoodSortOption = 'alphabetical' | 'highest-protein' | 'most-recent';
-type FoodSortDirection = 'ascending' | 'descending';
+type PendingDeleteFood = Pick<Food, 'id' | 'name'>;
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
+const SEARCH_DEBOUNCE_MS = 300;
+const DEFAULT_PAGE_SIZE = 12;
 
-const SORT_OPTIONS: Array<{ label: string; value: FoodSortOption }> = [
-  { label: 'Alphabetical', value: 'alphabetical' },
-  { label: 'Most Recent', value: 'most-recent' },
-  { label: 'Highest Protein', value: 'highest-protein' },
+const SORT_OPTIONS: Array<{ label: string; value: FoodSort }> = [
+  { label: 'Alphabetical', value: 'name' },
+  { label: 'Most Recent', value: 'recent' },
+  { label: 'Highest Protein', value: 'protein' },
 ];
-
-function getDefaultSortDirection(sortBy: FoodSortOption): FoodSortDirection {
-  return sortBy === 'alphabetical' ? 'ascending' : 'descending';
-}
 
 function startOfDay(date: Date) {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }
 
-function getDaysAgo(lastUsedAt: string, now: Date) {
+function getDaysAgo(lastUsedAt: number, now: Date) {
   const lastUsedDate = new Date(lastUsedAt);
   const diffMs = startOfDay(now).getTime() - startOfDay(lastUsedDate).getTime();
 
   return Math.max(0, Math.floor(diffMs / MS_PER_DAY));
 }
 
-function formatLastUsed(lastUsedAt: string | null, now: Date) {
+function formatLastUsed(lastUsedAt: number | null, now: Date) {
   if (!lastUsedAt) {
     return 'Last used: Never';
   }
@@ -68,67 +66,86 @@ function formatLastUsed(lastUsedAt: string | null, now: Date) {
 }
 
 function formatServing(food: Food) {
-  return `${food.servingSize} ${food.servingUnit}`;
+  if (food.servingSize && food.servingGrams !== null) {
+    return `${food.servingSize} (${food.servingGrams} g)`;
+  }
+
+  if (food.servingSize) {
+    return food.servingSize;
+  }
+
+  if (food.servingGrams !== null) {
+    return `${food.servingGrams} g`;
+  }
+
+  return 'Not provided';
 }
 
-function sortFoods(foods: Food[], sortBy: FoodSortOption, sortDirection: FoodSortDirection) {
-  const sortedFoods = [...foods];
-
-  if (sortBy === 'most-recent') {
-    return sortedFoods.sort((a, b) => {
-      if (!a.lastUsedAt && !b.lastUsedAt) {
-        return a.name.localeCompare(b.name);
-      }
-
-      if (!a.lastUsedAt) {
-        return 1;
-      }
-
-      if (!b.lastUsedAt) {
-        return -1;
-      }
-
-      const dateDiff = new Date(a.lastUsedAt).getTime() - new Date(b.lastUsedAt).getTime();
-
-      if (dateDiff !== 0) {
-        return sortDirection === 'ascending' ? dateDiff : -dateDiff;
-      }
-
-      return a.name.localeCompare(b.name);
-    });
-  }
-
-  if (sortBy === 'highest-protein') {
-    return sortedFoods.sort((a, b) => {
-      const proteinDiff = a.protein - b.protein;
-
-      if (proteinDiff !== 0) {
-        return sortDirection === 'ascending' ? proteinDiff : -proteinDiff;
-      }
-
-      return a.name.localeCompare(b.name);
-    });
-  }
-
-  return sortedFoods.sort((a, b) =>
-    sortDirection === 'ascending' ? a.name.localeCompare(b.name) : b.name.localeCompare(a.name),
+function FoodCardSkeleton() {
+  return (
+    <Card className="gap-4 border-border bg-card py-5 shadow-none">
+      <CardHeader className="gap-3 px-5 sm:px-6">
+        <div className="space-y-3">
+          <div className="h-5 w-40 animate-pulse rounded bg-muted/70" />
+          <div className="h-4 w-28 animate-pulse rounded bg-muted/60" />
+          <div className="h-4 w-48 animate-pulse rounded bg-muted/60" />
+        </div>
+      </CardHeader>
+      <CardContent className="px-5 sm:px-6">
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div
+              key={index}
+              className="h-16 animate-pulse rounded-lg border border-border/70 bg-background/70"
+            />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 
-export function FoodList({ foods = mockFoods, now = new Date() }: FoodListProps) {
-  const [localFoods, setLocalFoods] = useState<Food[]>(() => foods);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [sortBy, setSortBy] = useState<FoodSortOption>('alphabetical');
-  const [sortDirection, setSortDirection] = useState<FoodSortDirection>(() =>
-    getDefaultSortDirection('alphabetical'),
-  );
+export function FoodList({ now = new Date(), pageSize = DEFAULT_PAGE_SIZE }: FoodListProps) {
+  const [searchInput, setSearchInput] = useState('');
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
+  const [sortBy, setSortBy] = useState<FoodSort>('name');
+  const [page, setPage] = useState(1);
   const [editingFoodId, setEditingFoodId] = useState<string | null>(null);
   const [draftFoodName, setDraftFoodName] = useState('');
-  const [foodPendingDeleteId, setFoodPendingDeleteId] = useState<string | null>(null);
+  const [foodPendingDelete, setFoodPendingDelete] = useState<PendingDeleteFood | null>(null);
 
   useEffect(() => {
-    setLocalFoods(foods);
-  }, [foods]);
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedSearchQuery(searchInput.trim());
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [searchInput]);
+
+  const foodsQuery = useFoods({
+    q: debouncedSearchQuery || undefined,
+    sort: sortBy,
+    page,
+    limit: pageSize,
+  });
+  const updateFood = useUpdateFood();
+  const deleteFood = useDeleteFood();
+
+  const foods = foodsQuery.data?.data ?? [];
+  const totalFoods = foodsQuery.data?.meta.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(totalFoods / pageSize));
+  const updateErrorMessage =
+    updateFood.isError && updateFood.error instanceof Error ? updateFood.error.message : null;
+  const deleteErrorMessage =
+    deleteFood.isError && deleteFood.error instanceof Error ? deleteFood.error.message : null;
+
+  useEffect(() => {
+    if (page > totalPages) {
+      setPage(totalPages);
+    }
+  }, [page, totalPages]);
 
   function beginEditing(food: Food) {
     setEditingFoodId(food.id);
@@ -140,46 +157,52 @@ export function FoodList({ foods = mockFoods, now = new Date() }: FoodListProps)
     setDraftFoodName('');
   }
 
-  function saveEditing() {
+  async function saveEditing() {
     if (!editingFoodId) {
       return;
     }
 
     const nextName = draftFoodName.trim();
-
     if (!nextName) {
       cancelEditing();
       return;
     }
 
-    setLocalFoods((currentFoods) =>
-      currentFoods.map((food) => (food.id === editingFoodId ? { ...food, name: nextName } : food)),
-    );
-    cancelEditing();
+    const currentFood = foods.find((food) => food.id === editingFoodId);
+    if (!currentFood || currentFood.name === nextName) {
+      cancelEditing();
+      return;
+    }
+
+    try {
+      await updateFood.mutateAsync({
+        id: editingFoodId,
+        updates: {
+          name: nextName,
+        },
+      });
+      cancelEditing();
+    } catch {
+      return;
+    }
   }
 
-  function removeFood(foodId: string) {
-    setLocalFoods((currentFoods) => currentFoods.filter((food) => food.id !== foodId));
-
+  async function confirmDelete(foodId: string) {
     if (editingFoodId === foodId) {
       cancelEditing();
     }
 
-    setFoodPendingDeleteId(null);
+    setFoodPendingDelete(null);
+
+    try {
+      await deleteFood.mutateAsync(foodId);
+    } catch {
+      return;
+    }
   }
 
-  const normalizedQuery = searchQuery.trim().toLowerCase();
-  const filteredFoods = localFoods.filter((food) => {
-    if (!normalizedQuery) {
-      return true;
-    }
-
-    return [food.name, food.brand ?? ''].some((value) =>
-      value.toLowerCase().includes(normalizedQuery),
-    );
-  });
-  const visibleFoods = sortFoods(filteredFoods, sortBy, sortDirection);
-  const foodPendingDelete = localFoods.find((food) => food.id === foodPendingDeleteId) ?? null;
+  const isInitialLoading = foodsQuery.isPending;
+  const isRefreshing = foodsQuery.isFetching && !foodsQuery.isPending;
 
   return (
     <div className="space-y-4">
@@ -187,12 +210,12 @@ export function FoodList({ foods = mockFoods, now = new Date() }: FoodListProps)
         <CardHeader className="gap-1 px-5 sm:px-6">
           <CardTitle className="text-xl">Search your foods database</CardTitle>
           <CardDescription className="text-sm opacity-70 dark:text-muted dark:opacity-100">
-            Filter by food name or brand, then switch between alphabetical, recency, and
-            protein-focused views with reversible sort direction.
+            Search by food name or brand, then switch between alphabetical, recency, and
+            protein-focused views.
           </CardDescription>
         </CardHeader>
 
-        <CardContent className="grid gap-3 px-5 sm:grid-cols-[minmax(0,1fr)_13rem_10rem] sm:px-6">
+        <CardContent className="grid gap-3 px-5 sm:grid-cols-[minmax(0,1fr)_13rem] sm:px-6">
           <label className="space-y-2">
             <span className="text-sm font-medium text-on-cream dark:text-foreground">
               Search foods
@@ -202,10 +225,13 @@ export function FoodList({ foods = mockFoods, now = new Date() }: FoodListProps)
               <Input
                 aria-label="Search foods"
                 className="border-black/10 bg-white/80 pl-9 text-on-cream placeholder:text-gray-500 dark:border-border dark:bg-background dark:text-foreground dark:placeholder:text-muted"
-                onChange={(event) => setSearchQuery(event.target.value)}
+                onChange={(event) => {
+                  setSearchInput(event.target.value);
+                  setPage(1);
+                }}
                 placeholder="Chicken, Fairlife, oats..."
                 type="search"
-                value={searchQuery}
+                value={searchInput}
               />
             </div>
           </label>
@@ -214,10 +240,8 @@ export function FoodList({ foods = mockFoods, now = new Date() }: FoodListProps)
             <span className="text-sm font-medium text-on-cream dark:text-foreground">Sort by</span>
             <Select
               onValueChange={(value) => {
-                const nextSortBy = value as FoodSortOption;
-
-                setSortBy(nextSortBy);
-                setSortDirection(getDefaultSortDirection(nextSortBy));
+                setSortBy(value as FoodSort);
+                setPage(1);
               }}
               value={sortBy}
             >
@@ -236,180 +260,229 @@ export function FoodList({ foods = mockFoods, now = new Date() }: FoodListProps)
               </SelectContent>
             </Select>
           </label>
-
-          <div className="space-y-2">
-            <span className="text-sm font-medium text-on-cream dark:text-foreground">
-              Direction
-            </span>
-            <Button
-              aria-label="Toggle sort direction"
-              aria-pressed={sortDirection === 'descending'}
-              className="w-full border-black/10 bg-white/80 text-on-cream hover:bg-white/90 dark:border-border dark:bg-background dark:text-foreground dark:hover:bg-secondary"
-              onClick={() =>
-                setSortDirection((currentDirection) =>
-                  currentDirection === 'ascending' ? 'descending' : 'ascending',
-                )
-              }
-              type="button"
-              variant="outline"
-            >
-              <ArrowUpDownIcon className="size-4" />
-              {sortDirection === 'ascending' ? 'Ascending' : 'Descending'}
-            </Button>
-          </div>
         </CardContent>
 
         <CardContent className="px-5 pt-0 sm:px-6">
-          <p className="text-sm text-muted">
-            Showing {visibleFoods.length} of {localFoods.length} foods
-          </p>
+          <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-muted">
+            <p>
+              Showing {foods.length} of {totalFoods} foods
+            </p>
+            {isRefreshing ? <p>Refreshing foods…</p> : null}
+          </div>
+          {updateErrorMessage ? (
+            <p className="mt-2 text-sm text-destructive">{updateErrorMessage}</p>
+          ) : null}
+          {deleteErrorMessage ? (
+            <p className="mt-2 text-sm text-destructive">{deleteErrorMessage}</p>
+          ) : null}
         </CardContent>
       </Card>
 
-      {visibleFoods.length === 0 ? (
+      {foodsQuery.isError ? (
+        <Card className="gap-3 border-dashed py-8 text-center shadow-none">
+          <CardHeader className="gap-1 px-5 sm:px-6">
+            <CardTitle className="text-lg">Unable to load foods</CardTitle>
+            <CardDescription>
+              {foodsQuery.error instanceof Error
+                ? foodsQuery.error.message
+                : 'The foods API request failed.'}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : isInitialLoading ? (
+        <div className="grid gap-4 lg:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <FoodCardSkeleton key={index} />
+          ))}
+        </div>
+      ) : foods.length === 0 ? (
         <Card className="gap-3 border-dashed py-8 text-center shadow-none">
           <CardHeader className="gap-1 px-5 sm:px-6">
             <CardTitle className="text-lg">No foods found</CardTitle>
             <CardDescription>
-              Try a broader search term or switch the sort to see the full mock database again.
+              {debouncedSearchQuery
+                ? `No saved foods matched “${debouncedSearchQuery}”. Try another search term.`
+                : 'No foods have been saved yet.'}
             </CardDescription>
           </CardHeader>
         </Card>
       ) : (
-        <div className="grid gap-4 lg:grid-cols-2">
-          {visibleFoods.map((food) => (
-            <Card
-              key={food.id}
-              className="gap-4 border-border bg-card py-5 shadow-none"
-              role="article"
-            >
-              <CardHeader className="gap-3 px-5 sm:px-6">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="space-y-1">
-                    {editingFoodId === food.id ? (
-                      <form
-                        className="space-y-2"
-                        onSubmit={(event) => {
-                          event.preventDefault();
-                          saveEditing();
-                        }}
-                      >
-                        <Input
-                          aria-label={`Edit ${food.name} name`}
-                          autoFocus
-                          className="h-9"
-                          onBlur={cancelEditing}
-                          onChange={(event) => setDraftFoodName(event.target.value)}
-                          onKeyDown={(event) => {
-                            if (event.key === 'Escape') {
+        <>
+          <div className="grid gap-4 lg:grid-cols-2">
+            {foods.map((food) => {
+              const isUpdatingFood = updateFood.isPending && updateFood.variables?.id === food.id;
+              const isDeletingFood = deleteFood.isPending && deleteFood.variables === food.id;
+
+              return (
+                <Card
+                  key={food.id}
+                  className="gap-4 border-border bg-card py-5 shadow-none"
+                  role="article"
+                >
+                  <CardHeader className="gap-3 px-5 sm:px-6">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="space-y-1">
+                        {editingFoodId === food.id ? (
+                          <form
+                            className="space-y-2"
+                            onSubmit={(event) => {
                               event.preventDefault();
-                              cancelEditing();
-                            }
-                          }}
-                          value={draftFoodName}
-                        />
-                        <p className="text-xs text-muted-foreground">
-                          Press Enter to save or Escape to cancel.
-                        </p>
-                      </form>
-                    ) : (
-                      <CardTitle aria-level={3} className="text-lg" role="heading">
-                        <button
-                          className="cursor-pointer text-left transition-colors hover:text-primary"
-                          onClick={() => beginEditing(food)}
+                              void saveEditing();
+                            }}
+                          >
+                            <Input
+                              aria-label={`Edit ${food.name} name`}
+                              autoFocus
+                              className="h-9"
+                              disabled={isUpdatingFood}
+                              onBlur={cancelEditing}
+                              onChange={(event) => setDraftFoodName(event.target.value)}
+                              onKeyDown={(event) => {
+                                if (event.key === 'Escape') {
+                                  event.preventDefault();
+                                  cancelEditing();
+                                }
+                              }}
+                              value={draftFoodName}
+                            />
+                            <p className="text-xs text-muted-foreground">
+                              {isUpdatingFood
+                                ? 'Saving changes…'
+                                : 'Press Enter to save or Escape to cancel.'}
+                            </p>
+                          </form>
+                        ) : (
+                          <CardTitle aria-level={3} className="text-lg" role="heading">
+                            <button
+                              className="cursor-pointer text-left transition-colors hover:text-primary"
+                              onClick={() => beginEditing(food)}
+                              type="button"
+                            >
+                              {food.name}
+                            </button>
+                          </CardTitle>
+                        )}
+                        {food.brand ? <CardDescription>{food.brand}</CardDescription> : null}
+                      </div>
+
+                      <div className="flex items-start gap-2">
+                        {food.verified ? (
+                          <TooltipProvider>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Badge className="bg-emerald-100 text-emerald-800 hover:bg-emerald-100 dark:bg-emerald-500/15 dark:text-emerald-400 dark:hover:bg-emerald-500/15">
+                                  <CheckCircle2Icon className="size-3.5" />
+                                  Verified
+                                </Badge>
+                              </TooltipTrigger>
+                              <TooltipContent side="top">
+                                {food.source ? `Source: ${food.source}` : 'Verified nutrition data'}
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        ) : null}
+
+                        <Button
+                          aria-label={`Delete ${food.name}`}
+                          className="text-muted-foreground hover:text-destructive"
+                          disabled={isDeletingFood}
+                          onClick={() =>
+                            setFoodPendingDelete({
+                              id: food.id,
+                              name: food.name,
+                            })
+                          }
+                          size="icon-xs"
                           type="button"
+                          variant="ghost"
                         >
-                          {food.name}
-                        </button>
-                      </CardTitle>
-                    )}
-                    {food.brand ? <CardDescription>{food.brand}</CardDescription> : null}
-                  </div>
+                          <Trash2Icon className="size-3.5" />
+                        </Button>
+                      </div>
+                    </div>
 
-                  <div className="flex items-start gap-2">
-                    {food.verified ? (
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Badge className="bg-emerald-100 text-emerald-800 hover:bg-emerald-100 dark:bg-emerald-500/15 dark:text-emerald-400 dark:hover:bg-emerald-500/15">
-                              <CheckCircle2Icon className="size-3.5" />
-                              Verified
-                            </Badge>
-                          </TooltipTrigger>
-                          <TooltipContent side="top">
-                            {food.verifiedSource
-                              ? `Source: ${food.verifiedSource}`
-                              : 'Verified nutrition data'}
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    ) : null}
+                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+                      <span>Serving: {formatServing(food)}</span>
+                      <span aria-hidden="true">•</span>
+                      <span>{formatLastUsed(food.lastUsedAt, now)}</span>
+                    </div>
+                  </CardHeader>
 
-                    <Button
-                      aria-label={`Delete ${food.name}`}
-                      className="text-muted-foreground hover:text-destructive"
-                      onClick={() => setFoodPendingDeleteId(food.id)}
-                      size="icon-xs"
-                      type="button"
-                      variant="ghost"
-                    >
-                      <Trash2Icon className="size-3.5" />
-                    </Button>
-                  </div>
-                </div>
+                  <CardContent className="px-5 sm:px-6">
+                    <dl className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                      <div className="rounded-lg border border-border/70 bg-background/70 px-3 py-2">
+                        <dt className="text-xs font-medium tracking-[0.16em] text-muted-foreground uppercase">
+                          Calories
+                        </dt>
+                        <dd className="mt-1 text-sm font-semibold text-foreground">
+                          {food.calories} cal
+                        </dd>
+                      </div>
 
-                <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
-                  <span>Serving: {formatServing(food)}</span>
-                  <span aria-hidden="true">•</span>
-                  <span>{formatLastUsed(food.lastUsedAt, now)}</span>
-                </div>
-              </CardHeader>
+                      <div className="rounded-lg border border-border/70 bg-background/70 px-3 py-2">
+                        <dt className="text-xs font-medium tracking-[0.16em] text-muted-foreground uppercase">
+                          Protein
+                        </dt>
+                        <dd className="mt-1 text-sm font-semibold text-foreground">
+                          {food.protein}g
+                        </dd>
+                      </div>
 
-              <CardContent className="px-5 sm:px-6">
-                <dl className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-                  <div className="rounded-lg border border-border/70 bg-background/70 px-3 py-2">
-                    <dt className="text-xs font-medium tracking-[0.16em] text-muted-foreground uppercase">
-                      Calories
-                    </dt>
-                    <dd className="mt-1 text-sm font-semibold text-foreground">
-                      {food.calories} cal
-                    </dd>
-                  </div>
+                      <div className="rounded-lg border border-border/70 bg-background/70 px-3 py-2">
+                        <dt className="text-xs font-medium tracking-[0.16em] text-muted-foreground uppercase">
+                          Carbs
+                        </dt>
+                        <dd className="mt-1 text-sm font-semibold text-foreground">
+                          {food.carbs}g
+                        </dd>
+                      </div>
 
-                  <div className="rounded-lg border border-border/70 bg-background/70 px-3 py-2">
-                    <dt className="text-xs font-medium tracking-[0.16em] text-muted-foreground uppercase">
-                      Protein
-                    </dt>
-                    <dd className="mt-1 text-sm font-semibold text-foreground">{food.protein}g</dd>
-                  </div>
+                      <div className="rounded-lg border border-border/70 bg-background/70 px-3 py-2">
+                        <dt className="text-xs font-medium tracking-[0.16em] text-muted-foreground uppercase">
+                          Fat
+                        </dt>
+                        <dd className="mt-1 text-sm font-semibold text-foreground">{food.fat}g</dd>
+                      </div>
+                    </dl>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
 
-                  <div className="rounded-lg border border-border/70 bg-background/70 px-3 py-2">
-                    <dt className="text-xs font-medium tracking-[0.16em] text-muted-foreground uppercase">
-                      Carbs
-                    </dt>
-                    <dd className="mt-1 text-sm font-semibold text-foreground">{food.carbs}g</dd>
-                  </div>
-
-                  <div className="rounded-lg border border-border/70 bg-background/70 px-3 py-2">
-                    <dt className="text-xs font-medium tracking-[0.16em] text-muted-foreground uppercase">
-                      Fat
-                    </dt>
-                    <dd className="mt-1 text-sm font-semibold text-foreground">{food.fat}g</dd>
-                  </div>
-                </dl>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+          {totalFoods > pageSize ? (
+            <div className="flex items-center justify-between gap-3">
+              <Button
+                disabled={page === 1 || foodsQuery.isFetching}
+                onClick={() => setPage((currentPage) => Math.max(1, currentPage - 1))}
+                type="button"
+                variant="outline"
+              >
+                Previous
+              </Button>
+              <p className="text-sm text-muted-foreground">
+                Page {page} of {totalPages}
+              </p>
+              <Button
+                disabled={page >= totalPages || foodsQuery.isFetching}
+                onClick={() => setPage((currentPage) => Math.min(totalPages, currentPage + 1))}
+                type="button"
+                variant="outline"
+              >
+                Next
+              </Button>
+            </div>
+          ) : null}
+        </>
       )}
 
       <AlertDialog
         onOpenChange={(open) => {
           if (!open) {
-            setFoodPendingDeleteId(null);
+            setFoodPendingDelete(null);
           }
         }}
-        open={foodPendingDeleteId !== null}
+        open={foodPendingDelete !== null}
       >
         <AlertDialogContent>
           <AlertDialogHeader>
@@ -425,7 +498,7 @@ export function FoodList({ foods = mockFoods, now = new Date() }: FoodListProps)
             <AlertDialogAction
               onClick={() => {
                 if (foodPendingDelete) {
-                  removeFood(foodPendingDelete.id);
+                  void confirmDelete(foodPendingDelete.id);
                 }
               }}
               type="button"

--- a/apps/web/src/features/foods/components/food-list.tsx
+++ b/apps/web/src/features/foods/components/food-list.tsx
@@ -108,7 +108,7 @@ function FoodCardSkeleton() {
 export function FoodList({ now = new Date(), pageSize = DEFAULT_PAGE_SIZE }: FoodListProps) {
   const [searchInput, setSearchInput] = useState('');
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
-  const [sortBy, setSortBy] = useState<FoodSort>('name');
+  const [sortBy, setSortBy] = useState<FoodSort>('recent');
   const [page, setPage] = useState(1);
   const [editingFoodId, setEditingFoodId] = useState<string | null>(null);
   const [draftFoodName, setDraftFoodName] = useState('');

--- a/apps/web/src/features/foods/components/food-list.tsx
+++ b/apps/web/src/features/foods/components/food-list.tsx
@@ -1,6 +1,6 @@
 import { CheckCircle2Icon, SearchIcon, Trash2Icon } from 'lucide-react';
 import type { Food, FoodSort } from '@pulse/shared';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -114,6 +114,7 @@ export function FoodList({ now = new Date(), pageSize = DEFAULT_PAGE_SIZE }: Foo
   const [draftFoodName, setDraftFoodName] = useState('');
   const [isSavingEdit, setIsSavingEdit] = useState(false);
   const [foodPendingDelete, setFoodPendingDelete] = useState<PendingDeleteFood | null>(null);
+  const editCancelledRef = useRef(false);
 
   useEffect(() => {
     const timeoutId = window.setTimeout(() => {
@@ -152,11 +153,13 @@ export function FoodList({ now = new Date(), pageSize = DEFAULT_PAGE_SIZE }: Foo
   }, [page, totalPages]);
 
   function beginEditing(food: Food) {
+    editCancelledRef.current = false;
     setEditingFoodId(food.id);
     setDraftFoodName(food.name);
   }
 
   function cancelEditing() {
+    editCancelledRef.current = true;
     setEditingFoodId(null);
     setDraftFoodName('');
     setIsSavingEdit(false);
@@ -344,8 +347,8 @@ export function FoodList({ now = new Date(), pageSize = DEFAULT_PAGE_SIZE }: Foo
                               className="h-9"
                               aria-disabled={isUpdatingFood}
                               onBlur={() => {
-                                if (!isUpdatingFood) {
-                                  cancelEditing();
+                                if (!isUpdatingFood && !editCancelledRef.current) {
+                                  void saveEditing();
                                 }
                               }}
                               onChange={(event) => setDraftFoodName(event.target.value)}
@@ -361,7 +364,7 @@ export function FoodList({ now = new Date(), pageSize = DEFAULT_PAGE_SIZE }: Foo
                             <p className="text-xs text-muted-foreground">
                               {isUpdatingFood
                                 ? 'Saving changes…'
-                                : 'Press Enter to save or Escape to cancel.'}
+                                : 'Press Enter or click away to save, Escape to cancel.'}
                             </p>
                           </form>
                         ) : (

--- a/apps/web/src/features/foods/components/food-list.tsx
+++ b/apps/web/src/features/foods/components/food-list.tsx
@@ -112,6 +112,7 @@ export function FoodList({ now = new Date(), pageSize = DEFAULT_PAGE_SIZE }: Foo
   const [page, setPage] = useState(1);
   const [editingFoodId, setEditingFoodId] = useState<string | null>(null);
   const [draftFoodName, setDraftFoodName] = useState('');
+  const [isSavingEdit, setIsSavingEdit] = useState(false);
   const [foodPendingDelete, setFoodPendingDelete] = useState<PendingDeleteFood | null>(null);
 
   useEffect(() => {
@@ -140,6 +141,9 @@ export function FoodList({ now = new Date(), pageSize = DEFAULT_PAGE_SIZE }: Foo
     updateFood.isError && updateFood.error instanceof Error ? updateFood.error.message : null;
   const deleteErrorMessage =
     deleteFood.isError && deleteFood.error instanceof Error ? deleteFood.error.message : null;
+  const isEditingFoodPending =
+    isSavingEdit ||
+    (editingFoodId !== null && updateFood.isPending && updateFood.variables?.id === editingFoodId);
 
   useEffect(() => {
     if (page > totalPages) {
@@ -155,10 +159,11 @@ export function FoodList({ now = new Date(), pageSize = DEFAULT_PAGE_SIZE }: Foo
   function cancelEditing() {
     setEditingFoodId(null);
     setDraftFoodName('');
+    setIsSavingEdit(false);
   }
 
   async function saveEditing() {
-    if (!editingFoodId) {
+    if (!editingFoodId || isEditingFoodPending) {
       return;
     }
 
@@ -175,6 +180,7 @@ export function FoodList({ now = new Date(), pageSize = DEFAULT_PAGE_SIZE }: Foo
     }
 
     try {
+      setIsSavingEdit(true);
       await updateFood.mutateAsync({
         id: editingFoodId,
         updates: {
@@ -184,6 +190,8 @@ export function FoodList({ now = new Date(), pageSize = DEFAULT_PAGE_SIZE }: Foo
       cancelEditing();
     } catch {
       return;
+    } finally {
+      setIsSavingEdit(false);
     }
   }
 
@@ -334,8 +342,12 @@ export function FoodList({ now = new Date(), pageSize = DEFAULT_PAGE_SIZE }: Foo
                               aria-label={`Edit ${food.name} name`}
                               autoFocus
                               className="h-9"
-                              disabled={isUpdatingFood}
-                              onBlur={cancelEditing}
+                              aria-disabled={isUpdatingFood}
+                              onBlur={() => {
+                                if (!isUpdatingFood) {
+                                  cancelEditing();
+                                }
+                              }}
                               onChange={(event) => setDraftFoodName(event.target.value)}
                               onKeyDown={(event) => {
                                 if (event.key === 'Escape') {
@@ -343,6 +355,7 @@ export function FoodList({ now = new Date(), pageSize = DEFAULT_PAGE_SIZE }: Foo
                                   cancelEditing();
                                 }
                               }}
+                              readOnly={isUpdatingFood}
                               value={draftFoodName}
                             />
                             <p className="text-xs text-muted-foreground">

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -12,6 +12,12 @@ export default defineConfig({
   },
   server: {
     host: true,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+    },
   },
   test: {
     include: ['src/**/*.{test,spec}.{ts,tsx}'],

--- a/docs/agents/foods-api.md
+++ b/docs/agents/foods-api.md
@@ -1,0 +1,163 @@
+# Foods API — Agent Guide
+
+How to create, list, update, and delete foods in a user's personal food database via the Pulse API.
+
+## Authentication
+
+All foods endpoints require auth via the `Authorization` header. Two schemes are supported:
+
+- **JWT** (user sessions): `Authorization: Bearer <jwt_token>`
+- **AgentToken** (agent integrations): `Authorization: AgentToken <token>`
+
+### Getting a JWT token (dev)
+
+The frontend auto-logs in as the `pulse-dev` user. To get a token manually:
+
+```bash
+# Register (first time)
+curl -s -X POST http://localhost:3001/api/v1/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"username": "pulse-dev", "password": "pulse-dev-password", "name": "Pulse Dev"}'
+
+# Login (subsequent)
+curl -s -X POST http://localhost:3001/api/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username": "pulse-dev", "password": "pulse-dev-password"}'
+```
+
+Both return `{ data: { token: "<jwt>", user: { ... } } }`. Use the token in subsequent requests.
+
+## Endpoints
+
+Base URL: `http://localhost:3001/api/v1/foods`
+
+### Create a food — `POST /api/v1/foods`
+
+Returns `201` with `{ data: Food }`.
+
+```bash
+curl -s -X POST http://localhost:3001/api/v1/foods \
+  -H 'Authorization: Bearer <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "Chicken Breast (grilled)",
+    "brand": null,
+    "servingSize": "4 oz",
+    "servingGrams": 113,
+    "calories": 187,
+    "protein": 35,
+    "carbs": 0,
+    "fat": 4,
+    "fiber": null,
+    "sugar": null,
+    "verified": true,
+    "source": "USDA",
+    "notes": null
+  }'
+```
+
+**Required fields:** `name`, `calories`, `protein`, `carbs`, `fat`
+
+**Optional fields:** `brand`, `servingSize`, `servingGrams`, `fiber`, `sugar`, `verified` (defaults `false`), `source`, `notes`
+
+**Constraints:**
+
+- `name`: 1–255 chars, trimmed
+- `servingSize`: max 100 chars
+- `servingGrams`: must be positive
+- `calories`, `protein`, `carbs`, `fat`: non-negative numbers
+- `fiber`, `sugar`: non-negative when provided
+- `source`: max 255 chars
+- `notes`: max 2000 chars
+
+### List foods — `GET /api/v1/foods`
+
+Returns `200` with `{ data: Food[], meta: { page, limit, total } }`.
+
+```bash
+# All foods, alphabetical
+curl -s 'http://localhost:3001/api/v1/foods?sort=name' \
+  -H 'Authorization: Bearer <token>'
+
+# Search by name/brand
+curl -s 'http://localhost:3001/api/v1/foods?q=chicken&sort=name' \
+  -H 'Authorization: Bearer <token>'
+
+# High protein foods
+curl -s 'http://localhost:3001/api/v1/foods?sort=protein&limit=10' \
+  -H 'Authorization: Bearer <token>'
+```
+
+**Query params:**
+
+| Param   | Default | Description                              |
+| ------- | ------- | ---------------------------------------- |
+| `q`     | —       | Search name and brand (case-insensitive) |
+| `sort`  | `name`  | `name`, `recent`, or `protein`           |
+| `page`  | `1`     | Page number (min 1)                      |
+| `limit` | `50`    | Items per page (1–100)                   |
+
+**Sort modes:**
+
+- `name` — alphabetical (case-insensitive)
+- `recent` — by `lastUsedAt` descending (nulls last), then name
+- `protein` — by protein descending, then name
+
+### Update a food — `PUT /api/v1/foods/:id`
+
+Returns `200` with `{ data: Food }`. All fields are optional but at least one must be provided.
+
+```bash
+curl -s -X PUT 'http://localhost:3001/api/v1/foods/<food-id>' \
+  -H 'Authorization: Bearer <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{"calories": 95, "notes": "Updated from nutrition label"}'
+```
+
+Returns `404` with `FOOD_NOT_FOUND` if the food doesn't exist or belongs to another user.
+
+### Delete a food — `DELETE /api/v1/foods/:id`
+
+Returns `200` with `{ data: { success: true } }`.
+
+```bash
+curl -s -X DELETE 'http://localhost:3001/api/v1/foods/<food-id>' \
+  -H 'Authorization: Bearer <token>'
+```
+
+Returns `404` with `FOOD_NOT_FOUND` if not found.
+
+## Food Object
+
+```json
+{
+  "id": "uuid",
+  "userId": "uuid",
+  "name": "Greek Yogurt",
+  "brand": "Fage 0%",
+  "servingSize": "170 g",
+  "servingGrams": 170,
+  "calories": 90,
+  "protein": 18,
+  "carbs": 5,
+  "fat": 0,
+  "fiber": 0,
+  "sugar": 5,
+  "verified": true,
+  "source": "Manufacturer label",
+  "notes": null,
+  "lastUsedAt": null,
+  "createdAt": 1772936869000,
+  "updatedAt": 1772936869000
+}
+```
+
+Timestamps are Unix epoch in milliseconds. `lastUsedAt` is updated separately when a food is used in a meal entry — agents should not set it during creation.
+
+## Key Source Files
+
+- **Routes:** `apps/api/src/routes/foods/index.ts`
+- **Store (DB queries):** `apps/api/src/routes/foods/store.ts`
+- **Zod schemas:** `packages/shared/src/schemas/foods.ts`
+- **DB schema:** `apps/api/src/db/schema/foods.ts`
+- **Tests:** `apps/api/src/routes/foods/index.test.ts`, `store.test.ts`

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,6 +7,7 @@ export * from './schemas/entity-links.js';
 export * from './schemas/equipment.js';
 export * from './schemas/health-conditions.js';
 export * from './schemas/journal.js';
+export * from './schemas/foods.js';
 export * from './schemas/resources.js';
 
 export const userSchema = z.object({

--- a/packages/shared/src/schemas/foods.test.ts
+++ b/packages/shared/src/schemas/foods.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createFoodInputSchema,
+  foodQueryParamsSchema,
+  foodSchema,
+  type Food,
+  type FoodQueryParams,
+  type UpdateFoodInput,
+  updateFoodInputSchema,
+} from './foods';
+
+describe('foodSchema', () => {
+  it('parses a valid persisted food record', () => {
+    const payload = foodSchema.parse({
+      id: 'food-1',
+      userId: 'user-1',
+      name: ' Greek Yogurt ',
+      brand: 'Fage',
+      servingSize: '170 g',
+      servingGrams: 170,
+      calories: 90,
+      protein: 18,
+      carbs: 5,
+      fat: 0,
+      fiber: null,
+      sugar: 5,
+      verified: true,
+      source: 'Manufacturer label',
+      notes: null,
+      lastUsedAt: 1_700_000_000_000,
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_001,
+    });
+
+    expect(payload.name).toBe('Greek Yogurt');
+  });
+
+  it('infers the Food type from the schema', () => {
+    const payload: Food = {
+      id: 'food-2',
+      userId: 'user-1',
+      name: 'Chicken Breast',
+      brand: null,
+      servingSize: '4 oz',
+      servingGrams: 112,
+      calories: 187,
+      protein: 35,
+      carbs: 0,
+      fat: 4,
+      fiber: null,
+      sugar: null,
+      verified: true,
+      source: 'USDA',
+      notes: null,
+      lastUsedAt: null,
+      createdAt: 1,
+      updatedAt: 2,
+    };
+
+    expect(payload.name).toBe('Chicken Breast');
+  });
+});
+
+describe('createFoodInputSchema', () => {
+  it('trims strings and defaults verified to false', () => {
+    const payload = createFoodInputSchema.parse({
+      name: ' Greek Yogurt ',
+      brand: ' Fage 0% ',
+      servingSize: ' 170 g ',
+      calories: 90,
+      protein: 18,
+      carbs: 5,
+      fat: 0,
+      notes: ' High protein snack ',
+    });
+
+    expect(payload).toEqual({
+      name: 'Greek Yogurt',
+      brand: 'Fage 0%',
+      servingSize: '170 g',
+      calories: 90,
+      protein: 18,
+      carbs: 5,
+      fat: 0,
+      notes: 'High protein snack',
+      verified: false,
+    });
+  });
+
+  it('rejects blank names and negative nutrition values', () => {
+    expect(() =>
+      createFoodInputSchema.parse({
+        name: '   ',
+        calories: -1,
+        protein: 18,
+        carbs: 5,
+        fat: 0,
+      }),
+    ).toThrow();
+  });
+});
+
+describe('updateFoodInputSchema', () => {
+  it('accepts partial updates', () => {
+    const payload: UpdateFoodInput = updateFoodInputSchema.parse({
+      brand: ' Chobani ',
+      verified: true,
+    });
+
+    expect(payload).toEqual({
+      brand: 'Chobani',
+      verified: true,
+    });
+  });
+
+  it('rejects empty update payloads', () => {
+    expect(() => updateFoodInputSchema.parse({})).toThrow();
+  });
+});
+
+describe('foodQueryParamsSchema', () => {
+  it('coerces pagination params and trims the search query', () => {
+    const payload = foodQueryParamsSchema.parse({
+      q: '  yogurt ',
+      sort: 'protein',
+      page: '2',
+      limit: '25',
+    });
+
+    expect(payload).toEqual({
+      q: 'yogurt',
+      sort: 'protein',
+      page: 2,
+      limit: 25,
+    });
+  });
+
+  it('defaults omitted params and treats blank q as undefined', () => {
+    const payload: FoodQueryParams = foodQueryParamsSchema.parse({
+      q: '   ',
+    });
+
+    expect(payload).toEqual({
+      q: undefined,
+      sort: 'name',
+      page: 1,
+      limit: 50,
+    });
+  });
+
+  it('rejects invalid sort and page values', () => {
+    expect(() =>
+      foodQueryParamsSchema.parse({
+        sort: 'calories',
+        page: '0',
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/shared/src/schemas/foods.ts
+++ b/packages/shared/src/schemas/foods.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+
+const requiredText = (maxLength = 255) => z.string().trim().min(1).max(maxLength);
+const optionalNullableText = (maxLength = 255) => requiredText(maxLength).nullable().optional();
+const nonnegativeNumber = z.number().nonnegative();
+const optionalNullablePositiveNumber = z.number().positive().nullable().optional();
+const optionalNullableNonnegativeNumber = z.number().nonnegative().nullable().optional();
+
+const optionalQueryText = z.preprocess((value) => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}, z.string().max(255).optional());
+
+export const foodSortSchema = z.enum(['name', 'recent', 'protein']);
+
+export const foodSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  name: requiredText(),
+  brand: z.string().nullable(),
+  servingSize: z.string().nullable(),
+  servingGrams: z.number().positive().nullable(),
+  calories: nonnegativeNumber,
+  protein: nonnegativeNumber,
+  carbs: nonnegativeNumber,
+  fat: nonnegativeNumber,
+  fiber: nonnegativeNumber.nullable(),
+  sugar: nonnegativeNumber.nullable(),
+  verified: z.boolean(),
+  source: z.string().nullable(),
+  notes: z.string().nullable(),
+  lastUsedAt: z.number().int().nullable(),
+  createdAt: z.number().int(),
+  updatedAt: z.number().int(),
+});
+
+const foodMutationFieldsSchema = z.object({
+  name: requiredText(),
+  brand: optionalNullableText(),
+  servingSize: optionalNullableText(100),
+  servingGrams: optionalNullablePositiveNumber,
+  calories: nonnegativeNumber,
+  protein: nonnegativeNumber,
+  carbs: nonnegativeNumber,
+  fat: nonnegativeNumber,
+  fiber: optionalNullableNonnegativeNumber,
+  sugar: optionalNullableNonnegativeNumber,
+  verified: z.boolean(),
+  source: optionalNullableText(),
+  notes: optionalNullableText(2000),
+});
+
+export const createFoodInputSchema = foodMutationFieldsSchema.extend({
+  verified: z.boolean().optional().default(false),
+});
+
+export const updateFoodInputSchema = foodMutationFieldsSchema
+  .partial()
+  .refine((value) => Object.keys(value).length > 0, 'At least one field must be provided');
+
+export const foodQueryParamsSchema = z.object({
+  q: optionalQueryText,
+  sort: foodSortSchema.default('name'),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+});
+
+export type Food = z.infer<typeof foodSchema>;
+export type FoodSort = z.infer<typeof foodSortSchema>;
+export type CreateFoodInput = z.infer<typeof createFoodInputSchema>;
+export type UpdateFoodInput = z.infer<typeof updateFoodInputSchema>;
+export type FoodQueryParams = z.infer<typeof foodQueryParamsSchema>;


### PR DESCRIPTION
## Summary

This PR turns the Foods feature into a real end-to-end product surface by replacing mock frontend data with authenticated API-backed CRUD flows. On the backend, it adds `/api/v1/foods` routes for creating, listing, updating, and deleting foods, with search, sorting, pagination, and per-user access control. On the frontend, the foods page is now wired to those endpoints through TanStack Query and a shared API client, so search, edit, and delete actions operate against persisted data instead of local mocks. It also adds shared food schemas and broader test coverage to keep request validation, API behavior, and UI interactions aligned.

## Key Changes

- Added authenticated Foods API routes under `/api/v1/foods` for create, list, update, and delete operations.
- Implemented foods store logic with user-scoped queries, pagination, name/brand search, and sorting by name, protein, or recency.
- Added `lastUsedAt` update support in the foods store to support recency-based matching and ordering.
- Introduced shared food Zod schemas/types in `@pulse/shared` for create, update, and query validation.
- Replaced mock foods page data with TanStack Query-powered API integration in the web app.
- Added a shared web API client and query client support for authenticated requests and cache management.
- Updated foods UI tests and added backend route/store tests plus shared schema tests.

## Technical Notes

- All foods endpoints are protected by JWT auth and every data operation is explicitly scoped by `userId`; reviewers should pay particular attention to the update/delete/list paths to confirm no cross-user access is possible.
- Request bodies and query params are validated with shared Zod schemas before hitting persistence, which keeps frontend/backend contracts consistent and standardizes validation failures.
- The foods list query performs separate row and total-count lookups to support pagination metadata cleanly; sorting and search behavior are covered in tests.
- Optional food fields are normalized to `null` at the store layer so the API returns a stable shape instead of mixing `undefined` and `null`.
- Frontend wiring depends on the new API client and React Query setup, so reviewers may want to look at cache invalidation behavior around create/update/delete flows and how auth tokens are supplied in tests.

## Commits

- `d306acb fix(web): address foods review feedback`
- `35254e0 feat(web): connect foods page to foods API`
- `4a1adaf feat(api): add foods CRUD endpoints`

## Tasks

- **Foods CRUD API with search + recency**: CRUD + search by name/brand, update lastUsedAt on use, pagination
- **Wire foods database view to API**: Replace mock data with TanStack Query, connect search/edit/delete to API

## Diff Stats

```
apps/api/src/index.ts                              |   2 +
 apps/api/src/routes/foods/index.test.ts            | 330 ++++++++++++
 apps/api/src/routes/foods/index.ts                 |  77 +++
 apps/api/src/routes/foods/store.test.ts            | 347 +++++++++++++
 apps/api/src/routes/foods/store.ts                 | 274 ++++++++++
 apps/web/package.json                              |   1 +
 apps/web/src/App.test.tsx                          |  30 +-
 apps/web/src/App.tsx                               |  13 +-
 apps/web/src/components/ui/badge.tsx               |   1 +
 apps/web/src/components/ui/button.tsx              |   1 +
 .../features/dashboard/components/macro-rings.tsx  |   7 +-
 .../dashboard/components/snapshot-cards.tsx        |   1 +
 apps/web/src/features/foods/api/foods.test.tsx     | 188 +++++++
 apps/web/src/features/foods/api/foods.ts           | 155 ++++++
 apps/web/src/features/foods/api/keys.ts            |  19 +
 .../features/foods/components/food-list.test.tsx   | 543 ++++++++++++++-----
 .../src/features/foods/components/food-list.tsx    | 578 ++++++++++++---------
 apps/web/src/lib/api-client.test.ts                | 107 ++++
 apps/web/src/lib/api-client.ts                     | 256 +++++++++
 apps/web/src/lib/query-client.ts                   |  13 +
 apps/web/vite.config.ts                            |   6 +
 packages/shared/src/index.ts                       |   1 +
 packages/shared/src/schemas/foods.test.ts          | 160 ++++++
 packages/shared/src/schemas/foods.ts               |  76 +++
 pnpm-lock.yaml                                     |  18 +
 25 files changed, 2830 insertions(+), 374 deletions(-)
```