### PR TITLE
Habits API + frontend wiring

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { authRoutes } from './routes/auth/index.js';
 import { agentTokenRoutes } from './routes/agent-tokens/index.js';
+import { habitEntryRoutes } from './routes/habit-entries/index.js';
 import { habitRoutes } from './routes/habits/index.js';
 
 const DEV_JWT_SECRET = 'pulse-dev-jwt-secret';
@@ -31,6 +32,7 @@ export const buildServer = () => {
   app.register(authRoutes, { prefix: '/api/v1/auth' });
   app.register(agentTokenRoutes, { prefix: '/api/v1/agent-tokens' });
   app.register(habitRoutes, { prefix: '/api/v1/habits' });
+  app.register(habitEntryRoutes, { prefix: '/api/v1' });
 
   return app;
 };

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { authRoutes } from './routes/auth/index.js';
 import { agentTokenRoutes } from './routes/agent-tokens/index.js';
-import { habitEntryRoutes } from './routes/habit-entries/index.js';
+import { habitEntryCollectionRoutes } from './routes/habit-entries/index.js';
 import { habitRoutes } from './routes/habits/index.js';
 
 const DEV_JWT_SECRET = 'pulse-dev-jwt-secret';
@@ -32,7 +32,7 @@ export const buildServer = () => {
   app.register(authRoutes, { prefix: '/api/v1/auth' });
   app.register(agentTokenRoutes, { prefix: '/api/v1/agent-tokens' });
   app.register(habitRoutes, { prefix: '/api/v1/habits' });
-  app.register(habitEntryRoutes, { prefix: '/api/v1' });
+  app.register(habitEntryCollectionRoutes, { prefix: '/api/v1/habit-entries' });
 
   return app;
 };

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { authRoutes } from './routes/auth/index.js';
 import { agentTokenRoutes } from './routes/agent-tokens/index.js';
+import { habitRoutes } from './routes/habits/index.js';
 
 const DEV_JWT_SECRET = 'pulse-dev-jwt-secret';
 
@@ -29,6 +30,7 @@ export const buildServer = () => {
   app.get('/health', async () => ({ status: 'ok' }));
   app.register(authRoutes, { prefix: '/api/v1/auth' });
   app.register(agentTokenRoutes, { prefix: '/api/v1/agent-tokens' });
+  app.register(habitRoutes, { prefix: '/api/v1/habits' });
 
   return app;
 };

--- a/apps/api/src/routes/auth/store.ts
+++ b/apps/api/src/routes/auth/store.ts
@@ -1,6 +1,8 @@
+import { randomUUID } from 'node:crypto';
+
 import { eq } from 'drizzle-orm';
 
-import { users } from '../../db/schema/index.js';
+import { habits, users } from '../../db/schema/index.js';
 
 export type AuthUserRecord = {
   id: string;
@@ -15,6 +17,36 @@ type CreateUserInput = {
   name?: string;
   passwordHash: string;
 };
+
+const starterHabitDefinitions: Array<{
+  emoji: string;
+  name: string;
+  target: number | null;
+  trackingType: 'boolean' | 'numeric' | 'time';
+  unit: string | null;
+}> = [
+  {
+    emoji: '💧',
+    name: 'Hydrate',
+    trackingType: 'numeric',
+    target: 8,
+    unit: 'glasses',
+  },
+  {
+    emoji: '💊',
+    name: 'Take vitamins',
+    trackingType: 'boolean',
+    target: null,
+    unit: null,
+  },
+  {
+    emoji: '😴',
+    name: 'Sleep',
+    trackingType: 'time',
+    target: 8,
+    unit: 'hours',
+  },
+];
 
 export const findUserByUsername = async (username: string): Promise<AuthUserRecord | undefined> => {
   const { db } = await import('../../db/index.js');
@@ -40,15 +72,40 @@ export const createUser = async ({
 }: CreateUserInput): Promise<Omit<AuthUserRecord, 'passwordHash'>> => {
   const { db } = await import('../../db/index.js');
 
-  const result = db
-    .insert(users)
-    .values({
-      id,
-      username,
-      name,
-      passwordHash,
-    })
-    .run();
+  const result = db.transaction((tx) => {
+    const userInsertResult = tx
+      .insert(users)
+      .values({
+        id,
+        username,
+        name,
+        passwordHash,
+      })
+      .run();
+
+    if (userInsertResult.changes !== 1) {
+      throw new Error('Failed to persist auth user');
+    }
+
+    const starterHabits = starterHabitDefinitions.map((habit, index) => ({
+      id: randomUUID(),
+      userId: id,
+      name: habit.name,
+      emoji: habit.emoji,
+      trackingType: habit.trackingType,
+      target: habit.target,
+      unit: habit.unit,
+      sortOrder: index,
+      active: true,
+    }));
+
+    const habitInsertResult = tx.insert(habits).values(starterHabits).run();
+    if (habitInsertResult.changes !== starterHabits.length) {
+      throw new Error('Failed to persist starter habits');
+    }
+
+    return userInsertResult;
+  });
 
   if (result.changes !== 1) {
     throw new Error('Failed to persist auth user');

--- a/apps/api/src/routes/habit-entries/index.test.ts
+++ b/apps/api/src/routes/habit-entries/index.test.ts
@@ -1,0 +1,484 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildServer } from '../../index.js';
+import { findHabitById } from '../habits/store.js';
+
+import {
+  listHabitEntriesByDateRange,
+  listHabitEntriesForHabitByDateRange,
+  updateHabitEntry,
+  upsertHabitEntry,
+} from './store.js';
+
+vi.mock('../habits/store.js', () => ({
+  findHabitById: vi.fn(),
+}));
+
+vi.mock('./store.js', () => ({
+  listHabitEntriesByDateRange: vi.fn(),
+  listHabitEntriesForHabitByDateRange: vi.fn(),
+  updateHabitEntry: vi.fn(),
+  upsertHabitEntry: vi.fn(),
+}));
+
+const createAuthorizationHeader = (token: string) => ({
+  authorization: `Bearer ${token}`,
+});
+
+describe('habit entry routes', () => {
+  beforeEach(() => {
+    vi.mocked(findHabitById).mockReset();
+    vi.mocked(listHabitEntriesByDateRange).mockReset();
+    vi.mocked(listHabitEntriesForHabitByDateRange).mockReset();
+    vi.mocked(updateHabitEntry).mockReset();
+    vi.mocked(upsertHabitEntry).mockReset();
+    process.env.JWT_SECRET = 'test-habit-entry-secret';
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  it('upserts a habit entry for a habit within the authenticated user scope', async () => {
+    vi.mocked(findHabitById).mockResolvedValue({
+      id: 'habit-1',
+      userId: 'user-1',
+      name: 'Water',
+      emoji: '💧',
+      trackingType: 'numeric',
+      target: 8,
+      unit: 'glasses',
+      sortOrder: 0,
+      active: true,
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_000,
+    });
+    vi.mocked(upsertHabitEntry).mockImplementation(async ({ id, habitId, userId, date }) => ({
+      id,
+      habitId,
+      userId,
+      date,
+      completed: true,
+      value: 8,
+      createdAt: 1_700_000_100_000,
+    }));
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/v1/habits/habit-1/entries',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          date: '2026-03-07',
+          completed: true,
+          value: 8,
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+
+      const payload = response.json() as {
+        data: {
+          id: string;
+          habitId: string;
+          userId: string;
+          date: string;
+          completed: boolean;
+          value: number | null;
+          createdAt: number;
+        };
+      };
+
+      expect(payload.data).toMatchObject({
+        habitId: 'habit-1',
+        userId: 'user-1',
+        date: '2026-03-07',
+        completed: true,
+        value: 8,
+        createdAt: 1_700_000_100_000,
+      });
+      expect(payload.data.id).toBeTruthy();
+      expect(vi.mocked(findHabitById)).toHaveBeenCalledWith('habit-1', 'user-1');
+      expect(vi.mocked(upsertHabitEntry)).toHaveBeenCalledWith({
+        id: payload.data.id,
+        habitId: 'habit-1',
+        userId: 'user-1',
+        date: '2026-03-07',
+        completed: true,
+        value: 8,
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('lists all habit entries for the authenticated user within a date range', async () => {
+    vi.mocked(listHabitEntriesByDateRange).mockResolvedValue([
+      {
+        id: 'entry-1',
+        habitId: 'habit-1',
+        userId: 'user-1',
+        date: '2026-03-06',
+        completed: true,
+        value: null,
+        createdAt: 1_700_000_000_000,
+      },
+      {
+        id: 'entry-2',
+        habitId: 'habit-2',
+        userId: 'user-1',
+        date: '2026-03-07',
+        completed: true,
+        value: 8,
+        createdAt: 1_700_000_100_000,
+      },
+    ]);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/habit-entries?from=2026-03-01&to=2026-03-07',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: [
+          {
+            id: 'entry-1',
+            habitId: 'habit-1',
+            userId: 'user-1',
+            date: '2026-03-06',
+            completed: true,
+            value: null,
+            createdAt: 1_700_000_000_000,
+          },
+          {
+            id: 'entry-2',
+            habitId: 'habit-2',
+            userId: 'user-1',
+            date: '2026-03-07',
+            completed: true,
+            value: 8,
+            createdAt: 1_700_000_100_000,
+          },
+        ],
+      });
+      expect(vi.mocked(listHabitEntriesByDateRange)).toHaveBeenCalledWith(
+        'user-1',
+        '2026-03-01',
+        '2026-03-07',
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('lists entries for a specific habit only when that habit belongs to the user', async () => {
+    vi.mocked(findHabitById).mockResolvedValue({
+      id: 'habit-1',
+      userId: 'user-1',
+      name: 'Meditate',
+      emoji: null,
+      trackingType: 'boolean',
+      target: null,
+      unit: null,
+      sortOrder: 0,
+      active: true,
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_000,
+    });
+    vi.mocked(listHabitEntriesForHabitByDateRange).mockResolvedValue([
+      {
+        id: 'entry-1',
+        habitId: 'habit-1',
+        userId: 'user-1',
+        date: '2026-03-05',
+        completed: true,
+        value: null,
+        createdAt: 1_700_000_000_000,
+      },
+    ]);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/habits/habit-1/entries?from=2026-03-01&to=2026-03-07',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: [
+          {
+            id: 'entry-1',
+            habitId: 'habit-1',
+            userId: 'user-1',
+            date: '2026-03-05',
+            completed: true,
+            value: null,
+            createdAt: 1_700_000_000_000,
+          },
+        ],
+      });
+      expect(vi.mocked(listHabitEntriesForHabitByDateRange)).toHaveBeenCalledWith(
+        'habit-1',
+        'user-1',
+        '2026-03-01',
+        '2026-03-07',
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('patches an existing habit entry within the authenticated user scope', async () => {
+    vi.mocked(updateHabitEntry).mockResolvedValue({
+      id: 'entry-1',
+      habitId: 'habit-1',
+      userId: 'user-1',
+      date: '2026-03-07',
+      completed: false,
+      value: 6,
+      createdAt: 1_700_000_000_000,
+    });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/habit-entries/entry-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          completed: false,
+          value: 6,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: {
+          id: 'entry-1',
+          habitId: 'habit-1',
+          userId: 'user-1',
+          date: '2026-03-07',
+          completed: false,
+          value: 6,
+          createdAt: 1_700_000_000_000,
+        },
+      });
+      expect(vi.mocked(updateHabitEntry)).toHaveBeenCalledWith('entry-1', 'user-1', {
+        completed: false,
+        value: 6,
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns not found when posting or querying entries for a habit outside the user scope', async () => {
+    vi.mocked(findHabitById).mockResolvedValue(undefined);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const [createResponse, listResponse] = await Promise.all([
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/habits/habit-1/entries',
+          headers: createAuthorizationHeader(authToken),
+          payload: {
+            date: '2026-03-07',
+            completed: true,
+          },
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/habits/habit-1/entries?from=2026-03-01&to=2026-03-07',
+          headers: createAuthorizationHeader(authToken),
+        }),
+      ]);
+
+      expect(createResponse.statusCode).toBe(404);
+      expect(createResponse.json()).toEqual({
+        error: {
+          code: 'HABIT_NOT_FOUND',
+          message: 'Habit not found',
+        },
+      });
+      expect(listResponse.statusCode).toBe(404);
+      expect(listResponse.json()).toEqual({
+        error: {
+          code: 'HABIT_NOT_FOUND',
+          message: 'Habit not found',
+        },
+      });
+      expect(vi.mocked(upsertHabitEntry)).not.toHaveBeenCalled();
+      expect(vi.mocked(listHabitEntriesForHabitByDateRange)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns not found when patching an entry outside the user scope', async () => {
+    vi.mocked(updateHabitEntry).mockResolvedValue(undefined);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/habit-entries/entry-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          completed: true,
+        },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'HABIT_ENTRY_NOT_FOUND',
+          message: 'Habit entry not found',
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('requires authentication for every habit entry endpoint', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const responses = await Promise.all([
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/habits/habit-1/entries',
+          payload: {
+            date: '2026-03-07',
+            completed: true,
+          },
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/habit-entries?from=2026-03-01&to=2026-03-07',
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/habits/habit-1/entries?from=2026-03-01&to=2026-03-07',
+        }),
+        app.inject({
+          method: 'PATCH',
+          url: '/api/v1/habit-entries/entry-1',
+          payload: {
+            completed: true,
+          },
+        }),
+      ]);
+
+      for (const response of responses) {
+        expect(response.statusCode).toBe(401);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'UNAUTHORIZED',
+            message: 'Authentication required',
+          },
+        });
+      }
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects invalid payloads and query params', async () => {
+    vi.mocked(findHabitById).mockResolvedValue({
+      id: 'habit-1',
+      userId: 'user-1',
+      name: 'Water',
+      emoji: '💧',
+      trackingType: 'numeric',
+      target: 8,
+      unit: 'glasses',
+      sortOrder: 0,
+      active: true,
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_000,
+    });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const [createResponse, listResponse, patchResponse] = await Promise.all([
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/habits/habit-1/entries',
+          headers: createAuthorizationHeader(authToken),
+          payload: {
+            date: '03/07/2026',
+            completed: true,
+          },
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/habit-entries?from=2026-03-08&to=2026-03-07',
+          headers: createAuthorizationHeader(authToken),
+        }),
+        app.inject({
+          method: 'PATCH',
+          url: '/api/v1/habit-entries/entry-1',
+          headers: createAuthorizationHeader(authToken),
+          payload: {},
+        }),
+      ]);
+
+      expect(createResponse.statusCode).toBe(400);
+      expect(createResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid habit entry payload',
+        },
+      });
+      expect(listResponse.statusCode).toBe(400);
+      expect(listResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid habit entry query params',
+        },
+      });
+      expect(patchResponse.statusCode).toBe(400);
+      expect(patchResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid habit entry payload',
+        },
+      });
+      expect(vi.mocked(upsertHabitEntry)).not.toHaveBeenCalled();
+      expect(vi.mocked(updateHabitEntry)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apps/api/src/routes/habit-entries/index.ts
+++ b/apps/api/src/routes/habit-entries/index.ts
@@ -27,10 +27,8 @@ const sendHabitNotFound = (reply: Parameters<typeof sendError>[0]) =>
 const sendHabitEntryNotFound = (reply: Parameters<typeof sendError>[0]) =>
   sendError(reply, 404, 'HABIT_ENTRY_NOT_FOUND', 'Habit entry not found');
 
-export const habitEntryRoutes: FastifyPluginAsync = async (app) => {
-  app.addHook('onRequest', requireAuth);
-
-  app.post<{ Params: { id: string } }>('/habits/:id/entries', async (request, reply) => {
+export const habitEntryNestedRoutes: FastifyPluginAsync = async (app) => {
+  app.post<{ Params: { id: string } }>('/:id/entries', async (request, reply) => {
     const habitId = parseId(request.params.id);
     if (!habitId) {
       return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit id');
@@ -58,24 +56,7 @@ export const habitEntryRoutes: FastifyPluginAsync = async (app) => {
     });
   });
 
-  app.get('/habit-entries', async (request, reply) => {
-    const parsedQuery = habitEntryQueryParamsSchema.safeParse(request.query);
-    if (!parsedQuery.success) {
-      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit entry query params');
-    }
-
-    const entries = await listHabitEntriesByDateRange(
-      request.userId,
-      parsedQuery.data.from,
-      parsedQuery.data.to,
-    );
-
-    return reply.send({
-      data: entries,
-    });
-  });
-
-  app.get<{ Params: { id: string } }>('/habits/:id/entries', async (request, reply) => {
+  app.get<{ Params: { id: string } }>('/:id/entries', async (request, reply) => {
     const habitId = parseId(request.params.id);
     if (!habitId) {
       return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit id');
@@ -102,8 +83,29 @@ export const habitEntryRoutes: FastifyPluginAsync = async (app) => {
       data: entries,
     });
   });
+};
 
-  app.patch<{ Params: { id: string } }>('/habit-entries/:id', async (request, reply) => {
+export const habitEntryCollectionRoutes: FastifyPluginAsync = async (app) => {
+  app.addHook('onRequest', requireAuth);
+
+  app.get('/', async (request, reply) => {
+    const parsedQuery = habitEntryQueryParamsSchema.safeParse(request.query);
+    if (!parsedQuery.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit entry query params');
+    }
+
+    const entries = await listHabitEntriesByDateRange(
+      request.userId,
+      parsedQuery.data.from,
+      parsedQuery.data.to,
+    );
+
+    return reply.send({
+      data: entries,
+    });
+  });
+
+  app.patch<{ Params: { id: string } }>('/:id', async (request, reply) => {
     const entryId = parseId(request.params.id);
     if (!entryId) {
       return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit entry id');

--- a/apps/api/src/routes/habit-entries/index.ts
+++ b/apps/api/src/routes/habit-entries/index.ts
@@ -1,0 +1,126 @@
+import { randomUUID } from 'node:crypto';
+
+import {
+  createHabitEntryInputSchema,
+  habitEntryQueryParamsSchema,
+  updateHabitEntryInputSchema,
+} from '@pulse/shared';
+import type { FastifyPluginAsync } from 'fastify';
+
+import { sendError } from '../../lib/reply.js';
+import { requireAuth } from '../../middleware/auth.js';
+import { findHabitById } from '../habits/store.js';
+
+import {
+  updateHabitEntry,
+  upsertHabitEntry,
+  listHabitEntriesByDateRange,
+  listHabitEntriesForHabitByDateRange,
+} from './store.js';
+
+const parseId = (value: unknown) =>
+  typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+
+const sendHabitNotFound = (reply: Parameters<typeof sendError>[0]) =>
+  sendError(reply, 404, 'HABIT_NOT_FOUND', 'Habit not found');
+
+const sendHabitEntryNotFound = (reply: Parameters<typeof sendError>[0]) =>
+  sendError(reply, 404, 'HABIT_ENTRY_NOT_FOUND', 'Habit entry not found');
+
+export const habitEntryRoutes: FastifyPluginAsync = async (app) => {
+  app.addHook('onRequest', requireAuth);
+
+  app.post<{ Params: { id: string } }>('/habits/:id/entries', async (request, reply) => {
+    const habitId = parseId(request.params.id);
+    if (!habitId) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit id');
+    }
+
+    const parsedBody = createHabitEntryInputSchema.safeParse(request.body);
+    if (!parsedBody.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit entry payload');
+    }
+
+    const habit = await findHabitById(habitId, request.userId);
+    if (!habit) {
+      return sendHabitNotFound(reply);
+    }
+
+    const entry = await upsertHabitEntry({
+      id: randomUUID(),
+      habitId,
+      userId: request.userId,
+      ...parsedBody.data,
+    });
+
+    return reply.code(201).send({
+      data: entry,
+    });
+  });
+
+  app.get('/habit-entries', async (request, reply) => {
+    const parsedQuery = habitEntryQueryParamsSchema.safeParse(request.query);
+    if (!parsedQuery.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit entry query params');
+    }
+
+    const entries = await listHabitEntriesByDateRange(
+      request.userId,
+      parsedQuery.data.from,
+      parsedQuery.data.to,
+    );
+
+    return reply.send({
+      data: entries,
+    });
+  });
+
+  app.get<{ Params: { id: string } }>('/habits/:id/entries', async (request, reply) => {
+    const habitId = parseId(request.params.id);
+    if (!habitId) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit id');
+    }
+
+    const parsedQuery = habitEntryQueryParamsSchema.safeParse(request.query);
+    if (!parsedQuery.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit entry query params');
+    }
+
+    const habit = await findHabitById(habitId, request.userId);
+    if (!habit) {
+      return sendHabitNotFound(reply);
+    }
+
+    const entries = await listHabitEntriesForHabitByDateRange(
+      habitId,
+      request.userId,
+      parsedQuery.data.from,
+      parsedQuery.data.to,
+    );
+
+    return reply.send({
+      data: entries,
+    });
+  });
+
+  app.patch<{ Params: { id: string } }>('/habit-entries/:id', async (request, reply) => {
+    const entryId = parseId(request.params.id);
+    if (!entryId) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit entry id');
+    }
+
+    const parsedBody = updateHabitEntryInputSchema.safeParse(request.body);
+    if (!parsedBody.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit entry payload');
+    }
+
+    const entry = await updateHabitEntry(entryId, request.userId, parsedBody.data);
+    if (!entry) {
+      return sendHabitEntryNotFound(reply);
+    }
+
+    return reply.send({
+      data: entry,
+    });
+  });
+};

--- a/apps/api/src/routes/habit-entries/store.test.ts
+++ b/apps/api/src/routes/habit-entries/store.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testState = vi.hoisted(() => {
+  const getQueue: unknown[] = [];
+  const allQueue: unknown[] = [];
+  const insertValues: unknown[] = [];
+  const updateSets: unknown[] = [];
+  const insertRunResults: Array<{ changes: number }> = [];
+  const updateRunResults: Array<{ changes: number }> = [];
+
+  const db = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => ({
+            get: vi.fn(() => getQueue.shift()),
+          })),
+          orderBy: vi.fn(() => ({
+            all: vi.fn(() => allQueue.shift() ?? []),
+          })),
+          get: vi.fn(() => getQueue.shift()),
+          all: vi.fn(() => allQueue.shift() ?? []),
+        })),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn((values: unknown) => {
+        insertValues.push(values);
+
+        return {
+          run: vi.fn(() => insertRunResults.shift() ?? { changes: 1 }),
+        };
+      }),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((values: unknown) => {
+        updateSets.push(values);
+
+        return {
+          where: vi.fn(() => ({
+            run: vi.fn(() => updateRunResults.shift() ?? { changes: 1 }),
+          })),
+        };
+      }),
+    })),
+  };
+
+  return {
+    db,
+    getQueue,
+    allQueue,
+    insertValues,
+    updateSets,
+    insertRunResults,
+    updateRunResults,
+    reset() {
+      getQueue.length = 0;
+      allQueue.length = 0;
+      insertValues.length = 0;
+      updateSets.length = 0;
+      insertRunResults.length = 0;
+      updateRunResults.length = 0;
+      db.select.mockClear();
+      db.insert.mockClear();
+      db.update.mockClear();
+    },
+  };
+});
+
+vi.mock('../../db/index.js', () => ({
+  db: testState.db,
+}));
+
+describe('habit entry store', () => {
+  beforeEach(() => {
+    testState.reset();
+  });
+
+  it('inserts a new habit entry when no entry exists for the habit and date', async () => {
+    const { upsertHabitEntry } = await import('./store.js');
+
+    testState.getQueue.push(undefined, {
+      id: 'entry-1',
+      habitId: 'habit-1',
+      userId: 'user-1',
+      date: '2026-03-07',
+      completed: true,
+      value: 8,
+      createdAt: 1_700_000_000_000,
+    });
+
+    const entry = await upsertHabitEntry({
+      id: 'entry-1',
+      habitId: 'habit-1',
+      userId: 'user-1',
+      date: '2026-03-07',
+      completed: true,
+      value: 8,
+    });
+
+    expect(entry).toEqual({
+      id: 'entry-1',
+      habitId: 'habit-1',
+      userId: 'user-1',
+      date: '2026-03-07',
+      completed: true,
+      value: 8,
+      createdAt: 1_700_000_000_000,
+    });
+    expect(testState.db.insert).toHaveBeenCalledOnce();
+    expect(testState.db.update).not.toHaveBeenCalled();
+    expect(testState.insertValues).toEqual([
+      {
+        id: 'entry-1',
+        habitId: 'habit-1',
+        userId: 'user-1',
+        date: '2026-03-07',
+        completed: true,
+        value: 8,
+      },
+    ]);
+  });
+
+  it('updates an existing habit entry instead of inserting a duplicate for the same habit and date', async () => {
+    const { upsertHabitEntry } = await import('./store.js');
+
+    testState.getQueue.push(
+      {
+        id: 'entry-1',
+        habitId: 'habit-1',
+        userId: 'user-1',
+        date: '2026-03-07',
+        completed: true,
+        value: 8,
+        createdAt: 1_700_000_000_000,
+      },
+      {
+        id: 'entry-1',
+        habitId: 'habit-1',
+        userId: 'user-1',
+        date: '2026-03-07',
+        completed: false,
+        value: null,
+        createdAt: 1_700_000_000_000,
+      },
+    );
+
+    const entry = await upsertHabitEntry({
+      id: 'entry-2',
+      habitId: 'habit-1',
+      userId: 'user-1',
+      date: '2026-03-07',
+      completed: false,
+    });
+
+    expect(entry).toEqual({
+      id: 'entry-1',
+      habitId: 'habit-1',
+      userId: 'user-1',
+      date: '2026-03-07',
+      completed: false,
+      value: null,
+      createdAt: 1_700_000_000_000,
+    });
+    expect(testState.db.update).toHaveBeenCalledOnce();
+    expect(testState.db.insert).not.toHaveBeenCalled();
+    expect(testState.updateSets).toEqual([
+      {
+        completed: false,
+        value: null,
+      },
+    ]);
+  });
+
+  it('returns the updated entry after a scoped patch update', async () => {
+    const { updateHabitEntry } = await import('./store.js');
+
+    testState.getQueue.push({
+      id: 'entry-1',
+      habitId: 'habit-1',
+      userId: 'user-1',
+      date: '2026-03-07',
+      completed: false,
+      value: 6,
+      createdAt: 1_700_000_000_000,
+    });
+
+    const entry = await updateHabitEntry('entry-1', 'user-1', {
+      completed: false,
+      value: 6,
+    });
+
+    expect(entry).toEqual({
+      id: 'entry-1',
+      habitId: 'habit-1',
+      userId: 'user-1',
+      date: '2026-03-07',
+      completed: false,
+      value: 6,
+      createdAt: 1_700_000_000_000,
+    });
+    expect(testState.updateSets).toEqual([
+      {
+        completed: false,
+        value: 6,
+      },
+    ]);
+  });
+
+  it('returns undefined when a scoped patch update does not affect a row', async () => {
+    const { updateHabitEntry } = await import('./store.js');
+
+    testState.updateRunResults.push({ changes: 0 });
+
+    const entry = await updateHabitEntry('entry-1', 'user-1', {
+      completed: true,
+    });
+
+    expect(entry).toBeUndefined();
+  });
+});

--- a/apps/api/src/routes/habit-entries/store.test.ts
+++ b/apps/api/src/routes/habit-entries/store.test.ts
@@ -4,6 +4,7 @@ const testState = vi.hoisted(() => {
   const getQueue: unknown[] = [];
   const allQueue: unknown[] = [];
   const insertValues: unknown[] = [];
+  const upsertConfigs: unknown[] = [];
   const updateSets: unknown[] = [];
   const insertRunResults: Array<{ changes: number }> = [];
   const updateRunResults: Array<{ changes: number }> = [];
@@ -28,7 +29,13 @@ const testState = vi.hoisted(() => {
         insertValues.push(values);
 
         return {
-          run: vi.fn(() => insertRunResults.shift() ?? { changes: 1 }),
+          onConflictDoUpdate: vi.fn((config: unknown) => {
+            upsertConfigs.push(config);
+
+            return {
+              run: vi.fn(() => insertRunResults.shift() ?? { changes: 1 }),
+            };
+          }),
         };
       }),
     })),
@@ -50,6 +57,7 @@ const testState = vi.hoisted(() => {
     getQueue,
     allQueue,
     insertValues,
+    upsertConfigs,
     updateSets,
     insertRunResults,
     updateRunResults,
@@ -57,6 +65,7 @@ const testState = vi.hoisted(() => {
       getQueue.length = 0;
       allQueue.length = 0;
       insertValues.length = 0;
+      upsertConfigs.length = 0;
       updateSets.length = 0;
       insertRunResults.length = 0;
       updateRunResults.length = 0;
@@ -79,7 +88,7 @@ describe('habit entry store', () => {
   it('inserts a new habit entry when no entry exists for the habit and date', async () => {
     const { upsertHabitEntry } = await import('./store.js');
 
-    testState.getQueue.push(undefined, {
+    testState.getQueue.push({
       id: 'entry-1',
       habitId: 'habit-1',
       userId: 'user-1',
@@ -119,31 +128,28 @@ describe('habit entry store', () => {
         value: 8,
       },
     ]);
+    expect(testState.upsertConfigs).toEqual([
+      expect.objectContaining({
+        set: {
+          completed: true,
+          value: 8,
+        },
+      }),
+    ]);
   });
 
-  it('updates an existing habit entry instead of inserting a duplicate for the same habit and date', async () => {
+  it('upserts an existing habit entry without issuing a separate update statement', async () => {
     const { upsertHabitEntry } = await import('./store.js');
 
-    testState.getQueue.push(
-      {
-        id: 'entry-1',
-        habitId: 'habit-1',
-        userId: 'user-1',
-        date: '2026-03-07',
-        completed: true,
-        value: 8,
-        createdAt: 1_700_000_000_000,
-      },
-      {
-        id: 'entry-1',
-        habitId: 'habit-1',
-        userId: 'user-1',
-        date: '2026-03-07',
-        completed: false,
-        value: null,
-        createdAt: 1_700_000_000_000,
-      },
-    );
+    testState.getQueue.push({
+      id: 'entry-1',
+      habitId: 'habit-1',
+      userId: 'user-1',
+      date: '2026-03-07',
+      completed: false,
+      value: null,
+      createdAt: 1_700_000_000_000,
+    });
 
     const entry = await upsertHabitEntry({
       id: 'entry-2',
@@ -162,13 +168,25 @@ describe('habit entry store', () => {
       value: null,
       createdAt: 1_700_000_000_000,
     });
-    expect(testState.db.update).toHaveBeenCalledOnce();
-    expect(testState.db.insert).not.toHaveBeenCalled();
-    expect(testState.updateSets).toEqual([
+    expect(testState.db.insert).toHaveBeenCalledOnce();
+    expect(testState.db.update).not.toHaveBeenCalled();
+    expect(testState.insertValues).toEqual([
       {
+        id: 'entry-2',
+        habitId: 'habit-1',
+        userId: 'user-1',
+        date: '2026-03-07',
         completed: false,
         value: null,
       },
+    ]);
+    expect(testState.upsertConfigs).toEqual([
+      expect.objectContaining({
+        set: {
+          completed: false,
+          value: null,
+        },
+      }),
     ]);
   });
 

--- a/apps/api/src/routes/habit-entries/store.ts
+++ b/apps/api/src/routes/habit-entries/store.ts
@@ -1,0 +1,180 @@
+import { and, asc, between, eq } from 'drizzle-orm';
+import type { HabitEntry, UpdateHabitEntryInput } from '@pulse/shared';
+
+import { habitEntries } from '../../db/schema/index.js';
+
+type HabitEntryRecord = HabitEntry;
+
+type UpsertHabitEntryInput = {
+  id: string;
+  habitId: string;
+  userId: string;
+  date: string;
+  completed: boolean;
+  value?: number;
+};
+
+const habitEntrySelection = {
+  id: habitEntries.id,
+  habitId: habitEntries.habitId,
+  userId: habitEntries.userId,
+  date: habitEntries.date,
+  completed: habitEntries.completed,
+  value: habitEntries.value,
+  createdAt: habitEntries.createdAt,
+};
+
+export const findHabitEntryById = async (
+  id: string,
+  userId: string,
+): Promise<HabitEntryRecord | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  return db
+    .select(habitEntrySelection)
+    .from(habitEntries)
+    .where(and(eq(habitEntries.id, id), eq(habitEntries.userId, userId)))
+    .limit(1)
+    .get();
+};
+
+export const findHabitEntryByHabitAndDate = async (
+  habitId: string,
+  userId: string,
+  date: string,
+): Promise<HabitEntryRecord | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  return db
+    .select(habitEntrySelection)
+    .from(habitEntries)
+    .where(
+      and(
+        eq(habitEntries.habitId, habitId),
+        eq(habitEntries.userId, userId),
+        eq(habitEntries.date, date),
+      ),
+    )
+    .limit(1)
+    .get();
+};
+
+export const upsertHabitEntry = async ({
+  id,
+  habitId,
+  userId,
+  date,
+  completed,
+  value,
+}: UpsertHabitEntryInput): Promise<HabitEntryRecord> => {
+  const { db } = await import('../../db/index.js');
+
+  const existingEntry = await findHabitEntryByHabitAndDate(habitId, userId, date);
+
+  if (existingEntry) {
+    const result = db
+      .update(habitEntries)
+      .set({
+        completed,
+        value: value ?? null,
+      })
+      .where(and(eq(habitEntries.id, existingEntry.id), eq(habitEntries.userId, userId)))
+      .run();
+
+    if (result.changes !== 1) {
+      throw new Error('Failed to update habit entry');
+    }
+
+    const updatedEntry = await findHabitEntryById(existingEntry.id, userId);
+    if (!updatedEntry) {
+      throw new Error('Failed to load updated habit entry');
+    }
+
+    return updatedEntry;
+  }
+
+  const result = db
+    .insert(habitEntries)
+    .values({
+      id,
+      habitId,
+      userId,
+      date,
+      completed,
+      value: value ?? null,
+    })
+    .run();
+
+  if (result.changes !== 1) {
+    throw new Error('Failed to persist habit entry');
+  }
+
+  const entry = await findHabitEntryById(id, userId);
+  if (!entry) {
+    throw new Error('Failed to load created habit entry');
+  }
+
+  return entry;
+};
+
+export const listHabitEntriesByDateRange = async (
+  userId: string,
+  from: string,
+  to: string,
+): Promise<HabitEntryRecord[]> => {
+  const { db } = await import('../../db/index.js');
+
+  return db
+    .select(habitEntrySelection)
+    .from(habitEntries)
+    .where(and(eq(habitEntries.userId, userId), between(habitEntries.date, from, to)))
+    .orderBy(asc(habitEntries.date), asc(habitEntries.createdAt), asc(habitEntries.id))
+    .all();
+};
+
+export const listHabitEntriesForHabitByDateRange = async (
+  habitId: string,
+  userId: string,
+  from: string,
+  to: string,
+): Promise<HabitEntryRecord[]> => {
+  const { db } = await import('../../db/index.js');
+
+  return db
+    .select(habitEntrySelection)
+    .from(habitEntries)
+    .where(
+      and(
+        eq(habitEntries.habitId, habitId),
+        eq(habitEntries.userId, userId),
+        between(habitEntries.date, from, to),
+      ),
+    )
+    .orderBy(asc(habitEntries.date), asc(habitEntries.createdAt), asc(habitEntries.id))
+    .all();
+};
+
+export const updateHabitEntry = async (
+  id: string,
+  userId: string,
+  updates: UpdateHabitEntryInput,
+): Promise<HabitEntryRecord | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  const values = {
+    ...(updates.completed !== undefined ? { completed: updates.completed } : {}),
+    ...(updates.value !== undefined ? { value: updates.value } : {}),
+  };
+
+  const result = db
+    .update(habitEntries)
+    .set(values)
+    .where(and(eq(habitEntries.id, id), eq(habitEntries.userId, userId)))
+    .run();
+
+  if (result.changes !== 1) {
+    return undefined;
+  }
+
+  return findHabitEntryById(id, userId);
+};

--- a/apps/api/src/routes/habit-entries/store.ts
+++ b/apps/api/src/routes/habit-entries/store.ts
@@ -69,32 +69,7 @@ export const upsertHabitEntry = async ({
 }: UpsertHabitEntryInput): Promise<HabitEntryRecord> => {
   const { db } = await import('../../db/index.js');
 
-  const existingEntry = await findHabitEntryByHabitAndDate(habitId, userId, date);
-
-  if (existingEntry) {
-    const result = db
-      .update(habitEntries)
-      .set({
-        completed,
-        value: value ?? null,
-      })
-      .where(and(eq(habitEntries.id, existingEntry.id), eq(habitEntries.userId, userId)))
-      .run();
-
-    if (result.changes !== 1) {
-      throw new Error('Failed to update habit entry');
-    }
-
-    const updatedEntry = await findHabitEntryById(existingEntry.id, userId);
-    if (!updatedEntry) {
-      throw new Error('Failed to load updated habit entry');
-    }
-
-    return updatedEntry;
-  }
-
-  const result = db
-    .insert(habitEntries)
+  db.insert(habitEntries)
     .values({
       id,
       habitId,
@@ -103,15 +78,18 @@ export const upsertHabitEntry = async ({
       completed,
       value: value ?? null,
     })
+    .onConflictDoUpdate({
+      target: [habitEntries.habitId, habitEntries.date],
+      set: {
+        completed,
+        value: value ?? null,
+      },
+    })
     .run();
 
-  if (result.changes !== 1) {
-    throw new Error('Failed to persist habit entry');
-  }
-
-  const entry = await findHabitEntryById(id, userId);
+  const entry = await findHabitEntryByHabitAndDate(habitId, userId, date);
   if (!entry) {
-    throw new Error('Failed to load created habit entry');
+    throw new Error('Failed to load upserted habit entry');
   }
 
   return entry;

--- a/apps/api/src/routes/habits/index.test.ts
+++ b/apps/api/src/routes/habits/index.test.ts
@@ -1,0 +1,454 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildServer } from '../../index.js';
+import {
+  createHabit,
+  findHabitById,
+  getNextHabitSortOrder,
+  listActiveHabits,
+  reorderHabits,
+  softDeleteHabit,
+  updateHabit,
+} from './store.js';
+
+vi.mock('./store.js', () => ({
+  createHabit: vi.fn(),
+  findHabitById: vi.fn(),
+  getNextHabitSortOrder: vi.fn(),
+  listActiveHabits: vi.fn(),
+  reorderHabits: vi.fn(),
+  softDeleteHabit: vi.fn(),
+  updateHabit: vi.fn(),
+}));
+
+const createAuthorizationHeader = (token: string) => ({
+  authorization: `Bearer ${token}`,
+});
+
+describe('habit routes', () => {
+  beforeEach(() => {
+    vi.mocked(createHabit).mockReset();
+    vi.mocked(findHabitById).mockReset();
+    vi.mocked(getNextHabitSortOrder).mockReset();
+    vi.mocked(listActiveHabits).mockReset();
+    vi.mocked(reorderHabits).mockReset();
+    vi.mocked(softDeleteHabit).mockReset();
+    vi.mocked(updateHabit).mockReset();
+    process.env.JWT_SECRET = 'test-habit-secret';
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  it('creates a habit for the authenticated user with the next sort order', async () => {
+    vi.mocked(getNextHabitSortOrder).mockResolvedValue(3);
+    vi.mocked(createHabit).mockImplementation(async (input) => ({
+      ...input,
+      emoji: input.emoji ?? null,
+      target: input.target ?? null,
+      unit: input.unit ?? null,
+      active: true,
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_000,
+    }));
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/v1/habits',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          name: ' Water ',
+          emoji: ' 💧 ',
+          trackingType: 'numeric',
+          target: 8,
+          unit: ' glasses ',
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+
+      const payload = response.json() as {
+        data: {
+          id: string;
+          userId: string;
+          name: string;
+          emoji: string | null;
+          trackingType: string;
+          target: number | null;
+          unit: string | null;
+          sortOrder: number;
+          active: boolean;
+        };
+      };
+
+      expect(payload.data).toMatchObject({
+        userId: 'user-1',
+        name: 'Water',
+        emoji: '💧',
+        trackingType: 'numeric',
+        target: 8,
+        unit: 'glasses',
+        sortOrder: 3,
+        active: true,
+      });
+      expect(payload.data.id).toBeTruthy();
+      expect(vi.mocked(getNextHabitSortOrder)).toHaveBeenCalledWith('user-1');
+      expect(vi.mocked(createHabit)).toHaveBeenCalledWith({
+        id: payload.data.id,
+        userId: 'user-1',
+        name: 'Water',
+        emoji: '💧',
+        trackingType: 'numeric',
+        target: 8,
+        unit: 'glasses',
+        sortOrder: 3,
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('lists the authenticated users active habits sorted by sort order', async () => {
+    vi.mocked(listActiveHabits).mockResolvedValue([
+      {
+        id: 'habit-2',
+        userId: 'user-1',
+        name: 'Water',
+        emoji: '💧',
+        trackingType: 'numeric',
+        target: 8,
+        unit: 'glasses',
+        sortOrder: 0,
+        active: true,
+        createdAt: 1_700_000_000_000,
+        updatedAt: 1_700_000_000_000,
+      },
+      {
+        id: 'habit-1',
+        userId: 'user-1',
+        name: 'Sleep',
+        emoji: '😴',
+        trackingType: 'time',
+        target: 8,
+        unit: 'hours',
+        sortOrder: 1,
+        active: true,
+        createdAt: 1_700_000_100_000,
+        updatedAt: 1_700_000_100_000,
+      },
+    ]);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/habits',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: [
+          {
+            id: 'habit-2',
+            userId: 'user-1',
+            name: 'Water',
+            emoji: '💧',
+            trackingType: 'numeric',
+            target: 8,
+            unit: 'glasses',
+            sortOrder: 0,
+            active: true,
+            createdAt: 1_700_000_000_000,
+            updatedAt: 1_700_000_000_000,
+          },
+          {
+            id: 'habit-1',
+            userId: 'user-1',
+            name: 'Sleep',
+            emoji: '😴',
+            trackingType: 'time',
+            target: 8,
+            unit: 'hours',
+            sortOrder: 1,
+            active: true,
+            createdAt: 1_700_000_100_000,
+            updatedAt: 1_700_000_100_000,
+          },
+        ],
+      });
+      expect(vi.mocked(listActiveHabits)).toHaveBeenCalledWith('user-1');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('updates a habit only when it belongs to the authenticated user', async () => {
+    vi.mocked(findHabitById).mockResolvedValue({
+      id: 'habit-1',
+      userId: 'user-1',
+      name: 'Sleep',
+      emoji: '😴',
+      trackingType: 'time',
+      target: 8,
+      unit: 'hours',
+      sortOrder: 1,
+      active: true,
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_000,
+    });
+    vi.mocked(updateHabit).mockResolvedValue({
+      id: 'habit-1',
+      userId: 'user-1',
+      name: 'Evening sleep',
+      emoji: '😴',
+      trackingType: 'time',
+      target: 8.5,
+      unit: 'hours',
+      sortOrder: 1,
+      active: true,
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_100_000,
+    });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/v1/habits/habit-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          name: ' Evening sleep ',
+          target: 8.5,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: {
+          id: 'habit-1',
+          userId: 'user-1',
+          name: 'Evening sleep',
+          emoji: '😴',
+          trackingType: 'time',
+          target: 8.5,
+          unit: 'hours',
+          sortOrder: 1,
+          active: true,
+          createdAt: 1_700_000_000_000,
+          updatedAt: 1_700_000_100_000,
+        },
+      });
+      expect(vi.mocked(findHabitById)).toHaveBeenCalledWith('habit-1', 'user-1');
+      expect(vi.mocked(updateHabit)).toHaveBeenCalledWith('habit-1', 'user-1', {
+        name: 'Evening sleep',
+        target: 8.5,
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns not found when updating a habit outside the user scope', async () => {
+    vi.mocked(findHabitById).mockResolvedValue(undefined);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/v1/habits/habit-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          name: 'Water',
+        },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'HABIT_NOT_FOUND',
+          message: 'Habit not found',
+        },
+      });
+      expect(vi.mocked(updateHabit)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('soft deletes a habit within the authenticated user scope', async () => {
+    vi.mocked(softDeleteHabit).mockResolvedValue(true);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/v1/habits/habit-1',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: {
+          success: true,
+        },
+      });
+      expect(vi.mocked(softDeleteHabit)).toHaveBeenCalledWith('habit-1', 'user-1');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('reorders habits when every id belongs to the authenticated user', async () => {
+    vi.mocked(reorderHabits).mockResolvedValue(true);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/habits/reorder',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          items: [
+            { id: 'habit-1', sortOrder: 1 },
+            { id: 'habit-2', sortOrder: 0 },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: {
+          success: true,
+        },
+      });
+      expect(vi.mocked(reorderHabits)).toHaveBeenCalledWith('user-1', [
+        { id: 'habit-1', sortOrder: 1 },
+        { id: 'habit-2', sortOrder: 0 },
+      ]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('requires authentication for every habits endpoint', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const responses = await Promise.all([
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/habits',
+          payload: {
+            name: 'Water',
+            trackingType: 'boolean',
+          },
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/habits',
+        }),
+        app.inject({
+          method: 'PUT',
+          url: '/api/v1/habits/habit-1',
+          payload: {
+            name: 'Water',
+          },
+        }),
+        app.inject({
+          method: 'DELETE',
+          url: '/api/v1/habits/habit-1',
+        }),
+        app.inject({
+          method: 'PATCH',
+          url: '/api/v1/habits/reorder',
+          payload: {
+            items: [{ id: 'habit-1', sortOrder: 0 }],
+          },
+        }),
+      ]);
+
+      for (const response of responses) {
+        expect(response.statusCode).toBe(401);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'UNAUTHORIZED',
+            message: 'Authentication required',
+          },
+        });
+      }
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects invalid create and reorder payloads', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const [createResponse, reorderResponse] = await Promise.all([
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/habits',
+          headers: createAuthorizationHeader(authToken),
+          payload: {
+            name: 'Water',
+            trackingType: 'numeric',
+          },
+        }),
+        app.inject({
+          method: 'PATCH',
+          url: '/api/v1/habits/reorder',
+          headers: createAuthorizationHeader(authToken),
+          payload: {
+            items: [
+              { id: 'habit-1', sortOrder: 0 },
+              { id: 'habit-1', sortOrder: 1 },
+            ],
+          },
+        }),
+      ]);
+
+      expect(createResponse.statusCode).toBe(400);
+      expect(createResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid habit payload',
+        },
+      });
+      expect(reorderResponse.statusCode).toBe(400);
+      expect(reorderResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid reorder payload',
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apps/api/src/routes/habits/index.test.ts
+++ b/apps/api/src/routes/habits/index.test.ts
@@ -254,7 +254,10 @@ describe('habit routes', () => {
       expect(vi.mocked(findHabitById)).toHaveBeenCalledWith('habit-1', 'user-1');
       expect(vi.mocked(updateHabit)).toHaveBeenCalledWith('habit-1', 'user-1', {
         name: 'Evening sleep',
+        emoji: '😴',
+        trackingType: 'time',
         target: 8.5,
+        unit: 'hours',
       });
     } finally {
       await app.close();

--- a/apps/api/src/routes/habits/index.ts
+++ b/apps/api/src/routes/habits/index.ts
@@ -9,6 +9,7 @@ import type { FastifyPluginAsync } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
 import { requireAuth } from '../../middleware/auth.js';
+import { habitEntryNestedRoutes } from '../habit-entries/index.js';
 
 import {
   createHabit,
@@ -20,9 +21,6 @@ import {
   updateHabit,
 } from './store.js';
 
-const pickDefined = <T>(value: T | undefined, fallback: T): T =>
-  value === undefined ? fallback : value;
-
 const habitParamsSchema = {
   id: (value: unknown) =>
     typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined,
@@ -33,6 +31,7 @@ const sendNotFound = (reply: Parameters<typeof sendError>[0]) =>
 
 export const habitRoutes: FastifyPluginAsync = async (app) => {
   app.addHook('onRequest', requireAuth);
+  app.register(habitEntryNestedRoutes);
 
   app.post('/', async (request, reply) => {
     const parsedBody = createHabitInputSchema.safeParse(request.body);
@@ -78,18 +77,21 @@ export const habitRoutes: FastifyPluginAsync = async (app) => {
     }
 
     const mergedHabitInput = createHabitInputSchema.safeParse({
-      name: pickDefined(parsedBody.data.name, existingHabit.name),
-      emoji: pickDefined(parsedBody.data.emoji, existingHabit.emoji),
-      trackingType: pickDefined(parsedBody.data.trackingType, existingHabit.trackingType),
-      target: pickDefined(parsedBody.data.target, existingHabit.target),
-      unit: pickDefined(parsedBody.data.unit, existingHabit.unit),
+      name: parsedBody.data.name === undefined ? existingHabit.name : parsedBody.data.name,
+      emoji: parsedBody.data.emoji === undefined ? existingHabit.emoji : parsedBody.data.emoji,
+      trackingType:
+        parsedBody.data.trackingType === undefined
+          ? existingHabit.trackingType
+          : parsedBody.data.trackingType,
+      target: parsedBody.data.target === undefined ? existingHabit.target : parsedBody.data.target,
+      unit: parsedBody.data.unit === undefined ? existingHabit.unit : parsedBody.data.unit,
     });
 
     if (!mergedHabitInput.success) {
       return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit payload');
     }
 
-    const habit = await updateHabit(habitId, request.userId, parsedBody.data);
+    const habit = await updateHabit(habitId, request.userId, mergedHabitInput.data);
     if (!habit) {
       return sendNotFound(reply);
     }

--- a/apps/api/src/routes/habits/index.ts
+++ b/apps/api/src/routes/habits/index.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from 'node:crypto';
+
+import {
+  createHabitInputSchema,
+  reorderHabitsInputSchema,
+  updateHabitInputSchema,
+} from '@pulse/shared';
+import type { FastifyPluginAsync } from 'fastify';
+
+import { sendError } from '../../lib/reply.js';
+import { requireAuth } from '../../middleware/auth.js';
+
+import {
+  createHabit,
+  findHabitById,
+  getNextHabitSortOrder,
+  listActiveHabits,
+  reorderHabits,
+  softDeleteHabit,
+  updateHabit,
+} from './store.js';
+
+const pickDefined = <T>(value: T | undefined, fallback: T): T =>
+  value === undefined ? fallback : value;
+
+const habitParamsSchema = {
+  id: (value: unknown) =>
+    typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined,
+};
+
+const sendNotFound = (reply: Parameters<typeof sendError>[0]) =>
+  sendError(reply, 404, 'HABIT_NOT_FOUND', 'Habit not found');
+
+export const habitRoutes: FastifyPluginAsync = async (app) => {
+  app.addHook('onRequest', requireAuth);
+
+  app.post('/', async (request, reply) => {
+    const parsedBody = createHabitInputSchema.safeParse(request.body);
+    if (!parsedBody.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit payload');
+    }
+
+    const sortOrder = await getNextHabitSortOrder(request.userId);
+    const habit = await createHabit({
+      id: randomUUID(),
+      userId: request.userId,
+      sortOrder,
+      ...parsedBody.data,
+    });
+
+    return reply.code(201).send({
+      data: habit,
+    });
+  });
+
+  app.get('/', async (request, reply) => {
+    const habits = await listActiveHabits(request.userId);
+
+    return reply.send({
+      data: habits,
+    });
+  });
+
+  app.put<{ Params: { id: string } }>('/:id', async (request, reply) => {
+    const habitId = habitParamsSchema.id(request.params.id);
+    if (!habitId) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit id');
+    }
+
+    const parsedBody = updateHabitInputSchema.safeParse(request.body);
+    if (!parsedBody.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit payload');
+    }
+
+    const existingHabit = await findHabitById(habitId, request.userId);
+    if (!existingHabit) {
+      return sendNotFound(reply);
+    }
+
+    const mergedHabitInput = createHabitInputSchema.safeParse({
+      name: pickDefined(parsedBody.data.name, existingHabit.name),
+      emoji: pickDefined(parsedBody.data.emoji, existingHabit.emoji),
+      trackingType: pickDefined(parsedBody.data.trackingType, existingHabit.trackingType),
+      target: pickDefined(parsedBody.data.target, existingHabit.target),
+      unit: pickDefined(parsedBody.data.unit, existingHabit.unit),
+    });
+
+    if (!mergedHabitInput.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit payload');
+    }
+
+    const habit = await updateHabit(habitId, request.userId, parsedBody.data);
+    if (!habit) {
+      return sendNotFound(reply);
+    }
+
+    return reply.send({
+      data: habit,
+    });
+  });
+
+  app.delete<{ Params: { id: string } }>('/:id', async (request, reply) => {
+    const habitId = habitParamsSchema.id(request.params.id);
+    if (!habitId) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit id');
+    }
+
+    const deleted = await softDeleteHabit(habitId, request.userId);
+    if (!deleted) {
+      return sendNotFound(reply);
+    }
+
+    return reply.send({
+      data: {
+        success: true,
+      },
+    });
+  });
+
+  app.patch('/reorder', async (request, reply) => {
+    const parsedBody = reorderHabitsInputSchema.safeParse(request.body);
+    if (!parsedBody.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid reorder payload');
+    }
+
+    const reordered = await reorderHabits(request.userId, parsedBody.data.items);
+    if (!reordered) {
+      return sendNotFound(reply);
+    }
+
+    return reply.send({
+      data: {
+        success: true,
+      },
+    });
+  });
+};

--- a/apps/api/src/routes/habits/store.ts
+++ b/apps/api/src/routes/habits/store.ts
@@ -1,5 +1,5 @@
 import { and, asc, eq, inArray, sql } from 'drizzle-orm';
-import type { CreateHabitInput, Habit, UpdateHabitInput } from '@pulse/shared';
+import type { CreateHabitInput, Habit } from '@pulse/shared';
 
 import { habits } from '../../db/schema/index.js';
 
@@ -106,21 +106,19 @@ export const findHabitById = async (
 export const updateHabit = async (
   id: string,
   userId: string,
-  updates: UpdateHabitInput,
+  updates: CreateHabitInput,
 ): Promise<HabitRecord | undefined> => {
   const { db } = await import('../../db/index.js');
 
-  const values = {
-    ...(updates.name !== undefined ? { name: updates.name } : {}),
-    ...(updates.emoji !== undefined ? { emoji: updates.emoji } : {}),
-    ...(updates.trackingType !== undefined ? { trackingType: updates.trackingType } : {}),
-    ...(updates.target !== undefined ? { target: updates.target } : {}),
-    ...(updates.unit !== undefined ? { unit: updates.unit } : {}),
-  };
-
   const result = db
     .update(habits)
-    .set(values)
+    .set({
+      name: updates.name,
+      emoji: updates.emoji ?? null,
+      trackingType: updates.trackingType,
+      target: updates.target ?? null,
+      unit: updates.unit ?? null,
+    })
     .where(and(eq(habits.id, id), eq(habits.userId, userId)))
     .run();
 
@@ -153,21 +151,24 @@ export const reorderHabits = async (
   const existingHabits = db
     .select({ id: habits.id })
     .from(habits)
-    .where(and(eq(habits.userId, userId), inArray(habits.id, ids)))
+    .where(and(eq(habits.userId, userId), eq(habits.active, true), inArray(habits.id, ids)))
     .all();
 
   if (existingHabits.length !== ids.length) {
     return false;
   }
 
-  db.transaction((tx) => {
-    for (const item of items) {
-      tx.update(habits)
-        .set({ sortOrder: item.sortOrder })
-        .where(and(eq(habits.id, item.id), eq(habits.userId, userId)))
-        .run();
-    }
-  });
+  const sortOrderCases = sql.join(
+    items.map((item) => sql`when ${habits.id} = ${item.id} then ${item.sortOrder}`),
+    sql.raw(' '),
+  );
+
+  db.update(habits)
+    .set({
+      sortOrder: sql<number>`case ${sortOrderCases} else ${habits.sortOrder} end`,
+    })
+    .where(and(eq(habits.userId, userId), eq(habits.active, true), inArray(habits.id, ids)))
+    .run();
 
   return true;
 };

--- a/apps/api/src/routes/habits/store.ts
+++ b/apps/api/src/routes/habits/store.ts
@@ -1,0 +1,173 @@
+import { and, asc, eq, inArray, sql } from 'drizzle-orm';
+import type { CreateHabitInput, Habit, UpdateHabitInput } from '@pulse/shared';
+
+import { habits } from '../../db/schema/index.js';
+
+type HabitRecord = Habit;
+
+type CreateHabitRecordInput = CreateHabitInput & {
+  id: string;
+  userId: string;
+  sortOrder: number;
+};
+
+const habitSelection = {
+  id: habits.id,
+  userId: habits.userId,
+  name: habits.name,
+  emoji: habits.emoji,
+  trackingType: habits.trackingType,
+  target: habits.target,
+  unit: habits.unit,
+  sortOrder: habits.sortOrder,
+  active: habits.active,
+  createdAt: habits.createdAt,
+  updatedAt: habits.updatedAt,
+};
+
+export const getNextHabitSortOrder = async (userId: string): Promise<number> => {
+  const { db } = await import('../../db/index.js');
+
+  const result = db
+    .select({
+      maxSortOrder: sql<number>`coalesce(max(${habits.sortOrder}), -1)`,
+    })
+    .from(habits)
+    .where(eq(habits.userId, userId))
+    .get();
+
+  return (result?.maxSortOrder ?? -1) + 1;
+};
+
+export const createHabit = async ({
+  id,
+  userId,
+  name,
+  emoji,
+  trackingType,
+  target,
+  unit,
+  sortOrder,
+}: CreateHabitRecordInput): Promise<HabitRecord> => {
+  const { db } = await import('../../db/index.js');
+
+  const result = db
+    .insert(habits)
+    .values({
+      id,
+      userId,
+      name,
+      emoji: emoji ?? null,
+      trackingType,
+      target: target ?? null,
+      unit: unit ?? null,
+      sortOrder,
+      active: true,
+    })
+    .run();
+
+  if (result.changes !== 1) {
+    throw new Error('Failed to persist habit');
+  }
+
+  const habit = await findHabitById(id, userId);
+  if (!habit) {
+    throw new Error('Failed to load created habit');
+  }
+
+  return habit;
+};
+
+export const listActiveHabits = async (userId: string): Promise<HabitRecord[]> => {
+  const { db } = await import('../../db/index.js');
+
+  return db
+    .select(habitSelection)
+    .from(habits)
+    .where(and(eq(habits.userId, userId), eq(habits.active, true)))
+    .orderBy(asc(habits.sortOrder), asc(habits.createdAt))
+    .all();
+};
+
+export const findHabitById = async (
+  id: string,
+  userId: string,
+): Promise<HabitRecord | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  return db
+    .select(habitSelection)
+    .from(habits)
+    .where(and(eq(habits.id, id), eq(habits.userId, userId)))
+    .limit(1)
+    .get();
+};
+
+export const updateHabit = async (
+  id: string,
+  userId: string,
+  updates: UpdateHabitInput,
+): Promise<HabitRecord | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  const values = {
+    ...(updates.name !== undefined ? { name: updates.name } : {}),
+    ...(updates.emoji !== undefined ? { emoji: updates.emoji } : {}),
+    ...(updates.trackingType !== undefined ? { trackingType: updates.trackingType } : {}),
+    ...(updates.target !== undefined ? { target: updates.target } : {}),
+    ...(updates.unit !== undefined ? { unit: updates.unit } : {}),
+  };
+
+  const result = db
+    .update(habits)
+    .set(values)
+    .where(and(eq(habits.id, id), eq(habits.userId, userId)))
+    .run();
+
+  if (result.changes !== 1) {
+    return undefined;
+  }
+
+  return findHabitById(id, userId);
+};
+
+export const softDeleteHabit = async (id: string, userId: string): Promise<boolean> => {
+  const { db } = await import('../../db/index.js');
+
+  const result = db
+    .update(habits)
+    .set({ active: false })
+    .where(and(eq(habits.id, id), eq(habits.userId, userId)))
+    .run();
+
+  return result.changes === 1;
+};
+
+export const reorderHabits = async (
+  userId: string,
+  items: Array<{ id: string; sortOrder: number }>,
+): Promise<boolean> => {
+  const { db } = await import('../../db/index.js');
+
+  const ids = items.map((item) => item.id);
+  const existingHabits = db
+    .select({ id: habits.id })
+    .from(habits)
+    .where(and(eq(habits.userId, userId), inArray(habits.id, ids)))
+    .all();
+
+  if (existingHabits.length !== ids.length) {
+    return false;
+  }
+
+  db.transaction((tx) => {
+    for (const item of items) {
+      tx.update(habits)
+        .set({ sortOrder: item.sortOrder })
+        .where(and(eq(habits.id, item.id), eq(habits.userId, userId)))
+        .run();
+    }
+  });
+
+  return true;
+};

--- a/apps/web/e2e/habits.spec.ts
+++ b/apps/web/e2e/habits.spec.ts
@@ -1,0 +1,102 @@
+import { expect, request, test, type Page } from '@playwright/test';
+
+const authTokenStorageKey = 'pulse-auth-token';
+const apiBaseURL = process.env.API_BASE_URL ?? 'http://127.0.0.1:3001';
+
+const testUsername = `habits-e2e-${Date.now()}`;
+const testPassword = 'super-secret-password';
+
+let authToken = '';
+
+async function seedTestUser() {
+  const apiContext = await request.newContext({ baseURL: apiBaseURL });
+
+  try {
+    const response = await apiContext.post('/api/v1/auth/register', {
+      data: {
+        password: testPassword,
+        username: testUsername,
+      },
+    });
+    expect(response.ok()).toBeTruthy();
+
+    const payload = (await response.json()) as {
+      data: {
+        token: string;
+      };
+    };
+
+    authToken = payload.data.token;
+  } finally {
+    await apiContext.dispose();
+  }
+}
+
+async function authenticatePage(page: Page) {
+  await page.addInitScript(
+    ([storageKey, token]) => {
+      window.localStorage.setItem(storageKey, token);
+    },
+    [authTokenStorageKey, authToken] as const,
+  );
+}
+
+test.describe.serial('habits flow', () => {
+  test.beforeAll(async () => {
+    await seedTestUser();
+  });
+
+  test('creates a boolean habit from settings', async ({ page }) => {
+    await authenticatePage(page);
+    await page.goto('/settings');
+
+    await page.getByRole('button', { name: 'Add habit' }).first().click();
+    await page.getByLabel('Habit name').fill('Meditate');
+    await page.getByLabel('Tracking type').selectOption('boolean');
+    await page.getByRole('button', { exact: true, name: 'Save' }).click();
+
+    await expect(page.getByRole('heading', { level: 3, name: 'Meditate' })).toBeVisible();
+  });
+
+  test('tracks a boolean habit and reflects it on the dashboard', async ({ page }) => {
+    await authenticatePage(page);
+    await page.goto('/habits');
+
+    const meditateCheckbox = page.getByLabel('Meditate');
+
+    await meditateCheckbox.click();
+    await expect(meditateCheckbox).toHaveAttribute('data-state', 'checked');
+
+    await page.reload();
+    await expect(page.getByLabel('Meditate')).toHaveAttribute('data-state', 'checked');
+
+    await page.goto('/');
+    await expect(page.getByText('1 / 1 complete')).toBeVisible();
+    await expect(page.getByText('100%')).toBeVisible();
+    await expect(page.getByLabel(/Meditate \d{4}-\d{2}-\d{2} Completed/)).toBeVisible();
+  });
+
+  test('creates and tracks a numeric habit', async ({ page }) => {
+    await authenticatePage(page);
+    await page.goto('/settings');
+
+    await page.getByRole('button', { name: 'Add habit' }).first().click();
+    await page.getByLabel('Habit name').fill('Water (glasses)');
+    await page.getByLabel('Tracking type').selectOption('numeric');
+    await page.getByLabel('Target').fill('8');
+    await page.getByLabel('Unit').fill('glasses');
+    await page.getByRole('button', { exact: true, name: 'Save' }).click();
+
+    await expect(page.getByRole('heading', { level: 3, name: 'Water (glasses)' })).toBeVisible();
+
+    await page.goto('/habits');
+
+    const waterInput = page.getByLabel('Water (glasses)');
+
+    await waterInput.fill('6');
+    await waterInput.blur();
+
+    await expect(page.getByText('6 / 8 glasses', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('75%', { exact: true }).first()).toBeVisible();
+  });
+});

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-test('page loads and shows Hello Pulse', async ({ page }) => {
+test('page loads and shows dashboard', async ({ page }) => {
   await page.goto('/');
-  await expect(page.locator('h1')).toContainText('Hello Pulse');
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
 });

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,6 +1,10 @@
+import path from 'node:path';
 import { defineConfig, devices } from '@playwright/test';
 
-const baseURL = process.env.BASE_URL || 'http://localhost:5173';
+const baseURL = process.env.BASE_URL || 'http://127.0.0.1:4173';
+const apiBaseURL = process.env.API_BASE_URL || 'http://127.0.0.1:3001';
+const e2eDatabasePath =
+  process.env.E2E_DATABASE_URL || path.resolve(__dirname, '../../data/pulse-e2e.db');
 
 export default defineConfig({
   testDir: './e2e',
@@ -16,9 +20,18 @@ export default defineConfig({
       },
     },
   ],
-  webServer: {
-    command: 'pnpm dev',
-    url: baseURL,
-    reuseExistingServer: !process.env.CI,
-  },
+  webServer: [
+    {
+      command: `DATABASE_URL=${e2eDatabasePath} pnpm --filter api dev`,
+      cwd: path.resolve(__dirname, '../..'),
+      reuseExistingServer: !process.env.CI,
+      url: `${apiBaseURL}/health`,
+    },
+    {
+      command: 'pnpm dev --host 127.0.0.1 --port 4173',
+      cwd: __dirname,
+      reuseExistingServer: !process.env.CI,
+      url: baseURL,
+    },
+  ],
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,10 @@
+import { useState } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Route, Routes } from 'react-router';
 import { GuestRoute } from '@/components/auth/guest-route';
 import { ProtectedRoute } from '@/components/auth/protected-route';
 import { AppLayout } from '@/components/layout/app-layout';
+import { createAppQueryClient } from '@/lib/query-client';
 import { ActivityPage } from '@/pages/activity';
 import { DashboardPage } from '@/pages/dashboard';
 import { DesignSystemPage } from '@/pages/design-system';
@@ -76,10 +79,14 @@ function AppRoutes() {
 }
 
 function App() {
+  const [queryClient] = useState(() => createAppQueryClient());
+
   return (
-    <BrowserRouter>
-      <AppRoutes />
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <AppRoutes />
+      </BrowserRouter>
+    </QueryClientProvider>
   );
 }
 

--- a/apps/web/src/__tests__/components/daily-habits.test.tsx
+++ b/apps/web/src/__tests__/components/daily-habits.test.tsx
@@ -210,6 +210,16 @@ describe('DailyHabits', () => {
     });
   });
 
+  it('reflects numeric progress from draft input before blur', () => {
+    render(<DailyHabits />);
+
+    const input = screen.getByRole('spinbutton', { name: 'Hydrate' });
+    fireEvent.change(input, { target: { value: '8' } });
+
+    expect(screen.getAllByText('8 / 8 glasses')).toHaveLength(2);
+    expect(screen.getByText('100%')).toBeInTheDocument();
+  });
+
   it('creates a numeric or time entry through the upsert mutation when none exists yet', () => {
     render(<DailyHabits />);
 

--- a/apps/web/src/__tests__/components/daily-habits.test.tsx
+++ b/apps/web/src/__tests__/components/daily-habits.test.tsx
@@ -1,92 +1,229 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { Habit, HabitEntry } from '@pulse/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DailyHabits } from '@/features/habits';
-import type { DailyHabit } from '@/features/habits';
+import {
+  useHabitEntries,
+  useHabits,
+  useToggleHabit,
+  useUpdateHabitEntry,
+} from '@/features/habits/api/habits';
 
-const habits: DailyHabit[] = [
+vi.mock('@/features/habits/api/habits', () => ({
+  useHabitEntries: vi.fn(),
+  useHabits: vi.fn(),
+  useToggleHabit: vi.fn(),
+  useUpdateHabitEntry: vi.fn(),
+}));
+
+const mockedUseHabits = vi.mocked(useHabits);
+const mockedUseHabitEntries = vi.mocked(useHabitEntries);
+const mockedUseToggleHabit = vi.mocked(useToggleHabit);
+const mockedUseUpdateHabitEntry = vi.mocked(useUpdateHabitEntry);
+
+const toggleMutate = vi.fn();
+const updateMutate = vi.fn();
+
+const habits: Habit[] = [
   {
-    id: 'mobility',
+    id: 'habit-mobility',
+    userId: 'user-1',
     name: 'Mobility',
     emoji: '🧘',
     trackingType: 'boolean',
     target: null,
     unit: null,
-    todayValue: false,
+    sortOrder: 0,
+    active: true,
+    createdAt: 1,
+    updatedAt: 1,
   },
   {
-    id: 'hydrate',
+    id: 'habit-hydrate',
+    userId: 'user-1',
     name: 'Hydrate',
     emoji: '💧',
     trackingType: 'numeric',
     target: 8,
     unit: 'glasses',
-    todayValue: 6,
+    sortOrder: 1,
+    active: true,
+    createdAt: 1,
+    updatedAt: 1,
   },
   {
-    id: 'sleep',
+    id: 'habit-sleep',
+    userId: 'user-1',
     name: 'Sleep',
     emoji: '😴',
     trackingType: 'time',
     target: 8,
     unit: 'hours',
-    todayValue: 7,
+    sortOrder: 2,
+    active: true,
+    createdAt: 1,
+    updatedAt: 1,
   },
 ];
 
-function getHabitCard(name: string) {
-  const card = screen.getByRole('heading', { name }).closest('[data-slot="card"]');
+const entries: HabitEntry[] = [
+  {
+    id: 'entry-mobility',
+    habitId: 'habit-mobility',
+    userId: 'user-1',
+    date: '2026-03-07',
+    completed: false,
+    value: null,
+    createdAt: 10,
+  },
+  {
+    id: 'entry-hydrate',
+    habitId: 'habit-hydrate',
+    userId: 'user-1',
+    date: '2026-03-07',
+    completed: false,
+    value: 6,
+    createdAt: 11,
+  },
+];
 
-  if (!(card instanceof HTMLElement)) {
-    throw new Error(`Habit card not found for ${name}.`);
-  }
+function mockUseHabitsResult(overrides: Partial<ReturnType<typeof useHabits>> = {}) {
+  mockedUseHabits.mockReturnValue({
+    data: habits,
+    error: null,
+    isError: false,
+    isPending: false,
+    refetch: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useHabits>);
+}
 
-  return card;
+function mockUseHabitEntriesResult(overrides: Partial<ReturnType<typeof useHabitEntries>> = {}) {
+  mockedUseHabitEntries.mockReturnValue({
+    data: entries,
+    error: null,
+    isError: false,
+    isPending: false,
+    refetch: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useHabitEntries>);
 }
 
 describe('DailyHabits', () => {
-  it('renders all provided habits with their tracking-type controls', () => {
-    render(<DailyHabits habits={habits} />);
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-07T12:00:00'));
 
-    expect(screen.getByText('Mobility')).toBeInTheDocument();
-    expect(screen.getByText('Hydrate')).toBeInTheDocument();
-    expect(screen.getByText('Sleep')).toBeInTheDocument();
+    toggleMutate.mockReset();
+    updateMutate.mockReset();
+
+    mockUseHabitsResult();
+    mockUseHabitEntriesResult();
+
+    mockedUseToggleHabit.mockReturnValue({
+      isPending: false,
+      mutate: toggleMutate,
+      variables: undefined,
+    } as unknown as ReturnType<typeof useToggleHabit>);
+    mockedUseUpdateHabitEntry.mockReturnValue({
+      isPending: false,
+      mutate: updateMutate,
+      variables: undefined,
+    } as unknown as ReturnType<typeof useUpdateHabitEntry>);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows a loading skeleton while habit queries are pending', () => {
+    mockUseHabitsResult({ isPending: true });
+    mockUseHabitEntriesResult({ isPending: true });
+
+    render(<DailyHabits />);
+
+    expect(screen.getByText("Loading today's habits.")).toBeInTheDocument();
+  });
+
+  it('shows an error state and retries both queries when loading fails', () => {
+    const refetchHabits = vi.fn();
+    const refetchEntries = vi.fn();
+
+    mockUseHabitsResult({
+      error: new Error('Habits API unavailable'),
+      isError: true,
+      refetch: refetchHabits,
+    });
+    mockUseHabitEntriesResult({
+      error: new Error('Entries API unavailable'),
+      isError: true,
+      refetch: refetchEntries,
+    });
+
+    render(<DailyHabits />);
+
+    expect(screen.getByText('Habits API unavailable')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+
+    expect(refetchHabits).toHaveBeenCalledTimes(1);
+    expect(refetchEntries).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders habits with the correct controls and current progress', () => {
+    render(<DailyHabits />);
+
     expect(screen.getByRole('checkbox', { name: 'Mobility' })).toBeInTheDocument();
-    expect(screen.getByRole('spinbutton', { name: 'Hydrate' })).toBeInTheDocument();
-    expect(screen.getByRole('spinbutton', { name: 'Sleep' })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: 'Hydrate' })).toHaveValue(6);
+    expect(screen.getByRole('spinbutton', { name: 'Sleep' })).toHaveValue(null);
+    expect(screen.getByText('0 of 3 habits complete')).toBeInTheDocument();
   });
 
-  it('toggles a boolean habit when the checkbox is clicked', () => {
-    render(<DailyHabits habits={habits} />);
+  it('toggles boolean habits through the upsert mutation', () => {
+    render(<DailyHabits />);
 
-    const checkbox = screen.getByRole('checkbox', { name: 'Mobility' });
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Mobility' }));
 
-    expect(checkbox).not.toBeChecked();
-
-    fireEvent.click(checkbox);
-
-    expect(checkbox).toBeChecked();
-    expect(screen.getByText('1 of 3 habits complete')).toBeInTheDocument();
-    expect(within(getHabitCard('Mobility')).getByText('Done')).toBeInTheDocument();
-  });
-
-  it('updates numeric habits when a number is entered', () => {
-    render(<DailyHabits habits={habits} />);
-
-    fireEvent.change(screen.getByRole('spinbutton', { name: 'Hydrate' }), {
-      target: { value: '8' },
+    expect(toggleMutate).toHaveBeenCalledWith({
+      completed: true,
+      date: '2026-03-07',
+      entryId: 'entry-mobility',
+      habitId: 'habit-mobility',
     });
-
-    expect(within(getHabitCard('Hydrate')).getAllByText('8 / 8 glasses')).toHaveLength(2);
   });
 
-  it('updates duration habits when a duration is entered', () => {
-    render(<DailyHabits habits={habits} />);
+  it('patches an existing numeric entry when the value is changed', () => {
+    render(<DailyHabits />);
 
-    fireEvent.change(screen.getByRole('spinbutton', { name: 'Sleep' }), {
-      target: { value: '8.5' },
+    const input = screen.getByRole('spinbutton', { name: 'Hydrate' });
+
+    fireEvent.change(input, { target: { value: '8' } });
+    fireEvent.blur(input);
+
+    expect(updateMutate).toHaveBeenCalledWith({
+      completed: true,
+      date: '2026-03-07',
+      habitId: 'habit-hydrate',
+      id: 'entry-hydrate',
+      value: 8,
     });
+  });
 
-    expect(within(getHabitCard('Sleep')).getAllByText('8.5 / 8 hours')).toHaveLength(2);
+  it('creates a numeric or time entry through the upsert mutation when none exists yet', () => {
+    render(<DailyHabits />);
+
+    const input = screen.getByRole('spinbutton', { name: 'Sleep' });
+
+    fireEvent.change(input, { target: { value: '8.5' } });
+    fireEvent.blur(input);
+
+    expect(toggleMutate).toHaveBeenCalledWith({
+      completed: true,
+      date: '2026-03-07',
+      entryId: null,
+      habitId: 'habit-sleep',
+      value: 8.5,
+    });
   });
 });

--- a/apps/web/src/features/dashboard/components/habit-chain.test.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.test.tsx
@@ -1,3 +1,4 @@
+import type { Habit, HabitEntry } from '@pulse/shared';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
@@ -23,9 +24,43 @@ const getHabitByIndex = (index: number) => {
   return habit;
 };
 
+const habitRecords: Habit[] = mockHabits.map((habit, index) => ({
+  id: habit.id,
+  userId: 'user-1',
+  name: habit.name,
+  emoji: null,
+  trackingType: 'boolean',
+  target: null,
+  unit: null,
+  sortOrder: index,
+  active: true,
+  createdAt: 1_700_000_000_000 + index,
+  updatedAt: 1_700_000_000_000 + index,
+}));
+
+const habitEntryRecords: HabitEntry[] = mockHabits.flatMap((habit, habitIndex) =>
+  habit.entries.map((entry, entryIndex) => ({
+    id: `${habit.id}-${entry.date}`,
+    habitId: habit.id,
+    userId: 'user-1',
+    date: entry.date,
+    completed: entry.completed,
+    value: null,
+    createdAt: 1_700_000_000_000 + habitIndex * 100 + entryIndex,
+  })),
+);
+
 describe('HabitChain', () => {
-  it('renders all habits by default with 30 day squares each', () => {
+  it('renders an empty state when no habits are provided', () => {
     const { container } = render(<HabitChain />);
+
+    expect(screen.getByText('No matching habits.')).toBeInTheDocument();
+    const allSquares = container.querySelectorAll('[data-slot="habit-chain-day"]');
+    expect(allSquares).toHaveLength(0);
+  });
+
+  it('renders all habits with 30 day squares each when API data is provided', () => {
+    const { container } = render(<HabitChain habits={habitRecords} entries={habitEntryRecords} />);
 
     mockHabits.forEach((habit) => {
       expect(screen.getByRole('heading', { name: habit.name })).toBeInTheDocument();
@@ -38,7 +73,9 @@ describe('HabitChain', () => {
 
   it('renders squares in oldest-to-newest order and highlights today', () => {
     const habit = getHabitByIndex(0);
-    const { container } = render(<HabitChain habitIds={[habit.id]} />);
+    const { container } = render(
+      <HabitChain entries={habitEntryRecords} habitIds={[habit.id]} habits={habitRecords} />,
+    );
 
     const squares = container.querySelectorAll('[data-slot="habit-chain-day"]');
     const firstEntry = habit.entries[0];
@@ -52,19 +89,25 @@ describe('HabitChain', () => {
     expect(squares[0]).toHaveAttribute('data-date', firstEntry.date);
     expect(squares[29]).toHaveAttribute('data-date', lastEntry.date);
 
-    const todaySquares = container.querySelectorAll('[data-slot="habit-chain-day"][data-today="true"]');
+    const todaySquares = container.querySelectorAll(
+      '[data-slot="habit-chain-day"][data-today="true"]',
+    );
     expect(todaySquares).toHaveLength(1);
     expect(todaySquares[0]).toHaveClass('border-[var(--color-primary)]');
   });
 
   it('uses mint squares for completed days and gray squares for missed days', () => {
     const habit = getHabitByIndex(0);
-    const { container } = render(<HabitChain habitIds={[habit.id]} />);
+    const { container } = render(
+      <HabitChain entries={habitEntryRecords} habitIds={[habit.id]} habits={habitRecords} />,
+    );
 
     const completedSquare = container.querySelector(
       '[data-slot="habit-chain-day"][data-completed="true"]',
     );
-    const missedSquare = container.querySelector('[data-slot="habit-chain-day"][data-completed="false"]');
+    const missedSquare = container.querySelector(
+      '[data-slot="habit-chain-day"][data-completed="false"]',
+    );
 
     expect(completedSquare).toHaveClass('bg-[var(--color-accent-mint)]');
     expect(missedSquare).toHaveClass('bg-[var(--color-muted)]/40');
@@ -73,11 +116,15 @@ describe('HabitChain', () => {
   it('filters habits with habitIds', () => {
     const selectedHabits = [getHabitByIndex(1), getHabitByIndex(3)];
     const selectedHabitIds = selectedHabits.map((habit) => habit.id);
-    const { container } = render(<HabitChain habitIds={selectedHabitIds} />);
+    const { container } = render(
+      <HabitChain entries={habitEntryRecords} habitIds={selectedHabitIds} habits={habitRecords} />,
+    );
 
     expect(screen.getByRole('heading', { name: selectedHabits[0].name })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: selectedHabits[1].name })).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: getHabitByIndex(0).name })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: getHabitByIndex(0).name }),
+    ).not.toBeInTheDocument();
 
     const squares = container.querySelectorAll('[data-slot="habit-chain-day"]');
     expect(squares).toHaveLength(60);
@@ -85,7 +132,9 @@ describe('HabitChain', () => {
 
   it('assigns a date tooltip label to each day square', () => {
     const habit = getHabitByIndex(0);
-    const { container } = render(<HabitChain habitIds={[habit.id]} />);
+    const { container } = render(
+      <HabitChain entries={habitEntryRecords} habitIds={[habit.id]} habits={habitRecords} />,
+    );
 
     const firstSquare = container.querySelector('[data-slot="habit-chain-day"]');
     const date = firstSquare?.getAttribute('data-date');
@@ -99,7 +148,13 @@ describe('HabitChain', () => {
   });
 
   it('renders an empty state when no habits match the filter', () => {
-    render(<HabitChain habitIds={['habit-does-not-exist']} />);
+    render(
+      <HabitChain
+        entries={habitEntryRecords}
+        habitIds={['habit-does-not-exist']}
+        habits={habitRecords}
+      />,
+    );
 
     expect(screen.getByText('No matching habits.')).toBeInTheDocument();
   });

--- a/apps/web/src/features/dashboard/components/habit-chain.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.tsx
@@ -4,7 +4,6 @@ import { Flame } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { addDays, formatDateKey, getToday, toDateKey } from '@/lib/date';
-import { type Habit, mockHabits } from '@/lib/mock-data/dashboard';
 import { cn } from '@/lib/utils';
 
 type HabitChainProps = {
@@ -61,23 +60,23 @@ const getVisibleHabits = (habits: HabitChainHabit[], habitIds?: string[]) => {
 };
 
 const buildHabitChainHabits = (
-  habits: HabitRecord[] | undefined,
-  entries: HabitEntryRecord[] | undefined,
-): HabitChainHabit[] | null => {
-  if (!habits || !entries) {
-    return null;
-  }
+  habits: HabitRecord[],
+  entries: HabitEntryRecord[],
+): HabitChainHabit[] => {
+  const entriesByHabit = new Map<string, Map<string, boolean>>();
+
+  entries.forEach((entry) => {
+    const entriesByDate = entriesByHabit.get(entry.habitId) ?? new Map<string, boolean>();
+    entriesByDate.set(entry.date, entry.completed);
+    entriesByHabit.set(entry.habitId, entriesByDate);
+  });
 
   const dates = Array.from({ length: DAYS_TO_DISPLAY }, (_, index) =>
     toDateKey(addDays(getToday(), index - (DAYS_TO_DISPLAY - 1))),
   );
 
   return habits.map((habit) => {
-    const entriesByDate = new Map(
-      entries
-        .filter((entry) => entry.habitId === habit.id)
-        .map((entry) => [entry.date, entry.completed] as const),
-    );
+    const entriesByDate = entriesByHabit.get(habit.id) ?? new Map<string, boolean>();
     const completedEntries = dates.map((date) => ({
       completed: entriesByDate.get(date) ?? false,
       date,
@@ -92,17 +91,8 @@ const buildHabitChainHabits = (
   });
 };
 
-const getFallbackHabits = (): HabitChainHabit[] => {
-  return mockHabits.map((habit: Habit) => ({
-    currentStreak: habit.currentStreak,
-    entries: habit.entries,
-    id: habit.id,
-    name: habit.name,
-  }));
-};
-
-export function HabitChain({ habitIds, habits, entries }: HabitChainProps) {
-  const resolvedHabits = buildHabitChainHabits(habits, entries) ?? getFallbackHabits();
+export function HabitChain({ habitIds, habits = [], entries = [] }: HabitChainProps) {
+  const resolvedHabits = buildHabitChainHabits(habits, entries);
   const visibleHabits = getVisibleHabits(resolvedHabits, habitIds);
   const todayKey = formatDateKey(getToday());
 

--- a/apps/web/src/features/dashboard/components/habit-chain.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.tsx
@@ -1,13 +1,28 @@
+import type { Habit as HabitRecord, HabitEntry as HabitEntryRecord } from '@pulse/shared';
 import { Flame } from 'lucide-react';
 
 import { Card, CardContent } from '@/components/ui/card';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { formatDateKey, getToday } from '@/lib/date';
+import { addDays, formatDateKey, getToday, toDateKey } from '@/lib/date';
 import { type Habit, mockHabits } from '@/lib/mock-data/dashboard';
 import { cn } from '@/lib/utils';
 
 type HabitChainProps = {
   habitIds?: string[];
+  habits?: HabitRecord[];
+  entries?: HabitEntryRecord[];
+};
+
+type HabitChainEntry = {
+  completed: boolean;
+  date: string;
+};
+
+type HabitChainHabit = {
+  currentStreak: number;
+  entries: HabitChainEntry[];
+  id: string;
+  name: string;
 };
 
 const DAYS_TO_DISPLAY = 30;
@@ -22,81 +37,131 @@ const formatDateLabel = (date: string): string => {
   return dateFormatter.format(new Date(`${date}T00:00:00`));
 };
 
-const getVisibleHabits = (habitIds?: string[]): Habit[] => {
+const getCurrentStreak = (entries: HabitChainEntry[]) => {
+  let streak = 0;
+
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    if (!entries[index]?.completed) {
+      break;
+    }
+
+    streak += 1;
+  }
+
+  return streak;
+};
+
+const getVisibleHabits = (habits: HabitChainHabit[], habitIds?: string[]) => {
   if (!habitIds || habitIds.length === 0) {
-    return mockHabits;
+    return habits;
   }
 
   const allowedIds = new Set(habitIds);
-  return mockHabits.filter((habit) => allowedIds.has(habit.id));
+  return habits.filter((habit) => allowedIds.has(habit.id));
 };
 
-export function HabitChain({ habitIds }: HabitChainProps) {
-  const habits = getVisibleHabits(habitIds);
+const buildHabitChainHabits = (
+  habits: HabitRecord[] | undefined,
+  entries: HabitEntryRecord[] | undefined,
+): HabitChainHabit[] | null => {
+  if (!habits || !entries) {
+    return null;
+  }
+
+  const dates = Array.from({ length: DAYS_TO_DISPLAY }, (_, index) =>
+    toDateKey(addDays(getToday(), index - (DAYS_TO_DISPLAY - 1))),
+  );
+
+  return habits.map((habit) => {
+    const entriesByDate = new Map(
+      entries
+        .filter((entry) => entry.habitId === habit.id)
+        .map((entry) => [entry.date, entry.completed] as const),
+    );
+    const completedEntries = dates.map((date) => ({
+      completed: entriesByDate.get(date) ?? false,
+      date,
+    }));
+
+    return {
+      currentStreak: getCurrentStreak(completedEntries),
+      entries: completedEntries,
+      id: habit.id,
+      name: habit.name,
+    };
+  });
+};
+
+const getFallbackHabits = (): HabitChainHabit[] => {
+  return mockHabits.map((habit: Habit) => ({
+    currentStreak: habit.currentStreak,
+    entries: habit.entries,
+    id: habit.id,
+    name: habit.name,
+  }));
+};
+
+export function HabitChain({ habitIds, habits, entries }: HabitChainProps) {
+  const resolvedHabits = buildHabitChainHabits(habits, entries) ?? getFallbackHabits();
+  const visibleHabits = getVisibleHabits(resolvedHabits, habitIds);
   const todayKey = formatDateKey(getToday());
 
-  if (habits.length === 0) {
+  if (visibleHabits.length === 0) {
     return <p className="text-sm text-muted">No matching habits.</p>;
   }
 
   return (
     <section aria-label="Habit chains" className="space-y-3">
       <TooltipProvider>
-        {habits.map((habit) => {
-          const entries = [...habit.entries]
-            .sort((first, second) => first.date.localeCompare(second.date))
-            .slice(-DAYS_TO_DISPLAY);
+        {visibleHabits.map((habit) => (
+          <Card className="gap-2 px-3 py-3" key={habit.id}>
+            <CardContent className="space-y-2 px-0">
+              <div className="flex items-start justify-between gap-3">
+                <h2 className="text-sm font-semibold text-foreground">{habit.name}</h2>
+                <p
+                  className="inline-flex items-center gap-1.5 text-sm font-semibold text-foreground"
+                  data-slot="habit-chain-streak"
+                >
+                  <Flame aria-hidden className="size-4 text-[var(--color-accent-pink)]" />
+                  <span className="text-base leading-none">{`${habit.currentStreak} day streak`}</span>
+                </p>
+              </div>
 
-          return (
-            <Card className="gap-2 px-3 py-3" key={habit.id}>
-              <CardContent className="space-y-2 px-0">
-                <div className="flex items-start justify-between gap-3">
-                  <h2 className="text-sm font-semibold text-foreground">{habit.name}</h2>
-                  <p
-                    className="inline-flex items-center gap-1.5 text-sm font-semibold text-foreground"
-                    data-slot="habit-chain-streak"
-                  >
-                    <Flame aria-hidden className="size-4 text-[var(--color-accent-pink)]" />
-                    <span className="text-base leading-none">{`${habit.currentStreak} day streak`}</span>
-                  </p>
-                </div>
+              <div className="grid grid-cols-10 gap-[5px]" data-slot="habit-chain-grid">
+                {habit.entries.map((entry) => {
+                  const isToday = entry.date === todayKey;
+                  const statusLabel = entry.completed ? 'Completed' : 'Missed';
 
-                <div className="grid grid-cols-10 gap-[5px]" data-slot="habit-chain-grid">
-                  {entries.map((entry) => {
-                    const isToday = entry.date === todayKey;
-                    const statusLabel = entry.completed ? 'Completed' : 'Missed';
-
-                    return (
-                      <Tooltip key={`${habit.id}-${entry.date}`}>
-                        <TooltipTrigger asChild>
-                          <button
-                            aria-label={`${habit.name} ${entry.date} ${statusLabel}`}
-                            className={cn(
-                              'aspect-square w-full cursor-pointer rounded-full border',
-                              entry.completed
-                                ? 'bg-[var(--color-accent-mint)]'
-                                : 'bg-[var(--color-muted)]/40',
-                              isToday ? 'border-[var(--color-primary)]' : 'border-transparent',
-                            )}
-                            data-completed={entry.completed ? 'true' : 'false'}
-                            data-date={entry.date}
-                            data-slot="habit-chain-day"
-                            data-today={isToday ? 'true' : 'false'}
-                            title={formatDateLabel(entry.date)}
-                            type="button"
-                          />
-                        </TooltipTrigger>
-                        <TooltipContent side="top" sideOffset={6}>
-                          {formatDateLabel(entry.date)}
-                        </TooltipContent>
-                      </Tooltip>
-                    );
-                  })}
-                </div>
-              </CardContent>
-            </Card>
-          );
-        })}
+                  return (
+                    <Tooltip key={`${habit.id}-${entry.date}`}>
+                      <TooltipTrigger asChild>
+                        <button
+                          aria-label={`${habit.name} ${entry.date} ${statusLabel}`}
+                          className={cn(
+                            'aspect-square w-full cursor-pointer rounded-full border',
+                            entry.completed
+                              ? 'bg-[var(--color-accent-mint)]'
+                              : 'bg-[var(--color-muted)]/40',
+                            isToday ? 'border-[var(--color-primary)]' : 'border-transparent',
+                          )}
+                          data-completed={entry.completed ? 'true' : 'false'}
+                          data-date={entry.date}
+                          data-slot="habit-chain-day"
+                          data-today={isToday ? 'true' : 'false'}
+                          title={formatDateLabel(entry.date)}
+                          type="button"
+                        />
+                      </TooltipTrigger>
+                      <TooltipContent side="top" sideOffset={6}>
+                        {formatDateLabel(entry.date)}
+                      </TooltipContent>
+                    </Tooltip>
+                  );
+                })}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
       </TooltipProvider>
     </section>
   );

--- a/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
@@ -2,7 +2,11 @@ import { render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
 import { mockDailySnapshot } from '@/lib/mock-data/dashboard';
-import { calculateWeightTrend, SnapshotCards } from './snapshot-cards';
+import {
+  calculateHabitCompletionPercent,
+  calculateWeightTrend,
+  SnapshotCards,
+} from './snapshot-cards';
 
 describe('calculateWeightTrend', () => {
   it('returns neutral when yesterday weight is not positive', () => {
@@ -20,15 +24,26 @@ describe('calculateWeightTrend', () => {
   });
 });
 
+describe('calculateHabitCompletionPercent', () => {
+  it('returns 0 when there are no active habits', () => {
+    expect(calculateHabitCompletionPercent(0, 0)).toBe(0);
+  });
+
+  it('returns the rounded completion percent for active habits', () => {
+    expect(calculateHabitCompletionPercent(1, 3)).toBe(33);
+    expect(calculateHabitCompletionPercent(3, 4)).toBe(75);
+  });
+});
+
 describe('SnapshotCards', () => {
-  it('renders four snapshot cards in a responsive grid with mock data values', () => {
+  it('renders five snapshot cards in a responsive grid with mock data values', () => {
     const { container } = render(<MemoryRouter><SnapshotCards /></MemoryRouter>);
 
     const grid = container.querySelector('div.grid.grid-cols-2');
     expect(grid).toBeInTheDocument();
 
     const cards = container.querySelectorAll('[data-slot="stat-card"]');
-    expect(cards).toHaveLength(4);
+    expect(cards).toHaveLength(5);
 
     expect(screen.getByText(`${mockDailySnapshot.weight.toFixed(1)} lbs`)).toBeInTheDocument();
     expect(
@@ -41,6 +56,9 @@ describe('SnapshotCards', () => {
         `${mockDailySnapshot.macros.protein.actual}g / ${mockDailySnapshot.macros.protein.target}g`,
       ),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(`${mockDailySnapshot.habitsCompleted} / ${mockDailySnapshot.habitsTotal} complete`),
+    ).toBeInTheDocument();
     expect(screen.getByText(mockDailySnapshot.workoutName ?? 'Rest Day')).toBeInTheDocument();
   });
 
@@ -50,15 +68,18 @@ describe('SnapshotCards', () => {
     const weightCard = screen.getByText('Body Weight').closest('[data-slot="stat-card"]');
     const caloriesCard = screen.getByText('Calories').closest('[data-slot="stat-card"]');
     const proteinCard = screen.getByText('Protein').closest('[data-slot="stat-card"]');
+    const habitsCard = screen.getByText('Habits').closest('[data-slot="stat-card"]');
     const workoutCard = screen.getByText("Today's Workout").closest('[data-slot="stat-card"]');
 
     expect(weightCard).toHaveClass('bg-[var(--color-accent-cream)]');
     expect(caloriesCard).toHaveClass('bg-[var(--color-accent-pink)]');
     expect(proteinCard).toHaveClass('bg-[var(--color-accent-mint)]');
+    expect(habitsCard).toHaveClass('bg-[var(--color-accent-mint)]');
     expect(workoutCard).toHaveClass('bg-secondary');
     expect(screen.getByText('Body Weight')).toHaveClass('text-on-cream');
     expect(screen.getByText('Calories')).toHaveClass('text-on-pink');
     expect(screen.getByText('Protein')).toHaveClass('text-on-mint');
+    expect(screen.getByText('Habits')).toHaveClass('text-on-mint');
 
     const expectedTrend = calculateWeightTrend(
       mockDailySnapshot.weight,
@@ -85,6 +106,8 @@ describe('SnapshotCards', () => {
         <SnapshotCards
           snapshot={{
             ...mockDailySnapshot,
+            habitsCompleted: 0,
+            habitsTotal: 0,
             weightYesterday: 0,
             workoutName: null,
           }}
@@ -101,6 +124,7 @@ describe('SnapshotCards', () => {
     const proteinCard = screen
       .getByText('Protein')
       .closest('[data-slot="stat-card"]') as HTMLElement;
+    const habitsCard = screen.getByText('Habits').closest('[data-slot="stat-card"]') as HTMLElement;
     const workoutCard = screen
       .getByText("Today's Workout")
       .closest('[data-slot="stat-card"]') as HTMLElement;
@@ -110,6 +134,8 @@ describe('SnapshotCards', () => {
 
     expect(within(caloriesCard).getByLabelText('trend neutral')).toBeInTheDocument();
     expect(within(proteinCard).getByLabelText('trend neutral')).toBeInTheDocument();
+    expect(within(habitsCard).getByLabelText('trend neutral')).toBeInTheDocument();
+    expect(within(habitsCard).getByText('0 / 0 complete')).toBeInTheDocument();
 
     expect(within(workoutCard).queryByLabelText(/trend/i)).not.toBeInTheDocument();
     expect(within(workoutCard).getByText('Rest Day')).toBeInTheDocument();

--- a/apps/web/src/features/dashboard/components/snapshot-cards.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.tsx
@@ -25,7 +25,23 @@ export const calculateWeightTrend = (weight: number, weightYesterday: number): S
   };
 };
 
+export const calculateHabitCompletionPercent = (
+  habitsCompleted: number,
+  habitsTotal: number,
+): number => {
+  if (habitsTotal <= 0) {
+    return 0;
+  }
+
+  return Math.round((habitsCompleted / habitsTotal) * 100);
+};
+
 export function SnapshotCards({ snapshot = mockDailySnapshot }: SnapshotCardsProps) {
+  const habitCompletionPercent = calculateHabitCompletionPercent(
+    snapshot.habitsCompleted,
+    snapshot.habitsTotal,
+  );
+
   return (
     <div className="grid grid-cols-2 gap-3 sm:gap-4">
       <StatCard
@@ -56,8 +72,17 @@ export function SnapshotCards({ snapshot = mockDailySnapshot }: SnapshotCardsPro
       />
 
       <StatCard
-        className="border-primary/20 bg-secondary"
+        accentTextClassName="text-on-mint"
+        className={accentCardStyles.mint}
         data-stagger="3"
+        label="Habits"
+        trend={{ direction: 'neutral', value: habitCompletionPercent }}
+        value={`${snapshot.habitsCompleted} / ${snapshot.habitsTotal} complete`}
+      />
+
+      <StatCard
+        className="border-primary/20 bg-secondary"
+        data-stagger="4"
         label="Today's Workout"
         value={snapshot.workoutName ?? 'Rest Day'}
       />

--- a/apps/web/src/features/habits/api/habits.test.tsx
+++ b/apps/web/src/features/habits/api/habits.test.tsx
@@ -1,0 +1,167 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { HabitEntry } from '@pulse/shared';
+import { type ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { apiRequest } from '@/lib/api-client';
+import { createAppQueryClient } from '@/lib/query-client';
+
+import { useToggleHabit, useUpdateHabitEntry } from './habits';
+import { habitKeys } from './keys';
+
+vi.mock('@/lib/api-client', () => ({
+  apiRequest: vi.fn(),
+}));
+
+const mockedApiRequest = vi.mocked(apiRequest);
+
+function createDeferredPromise<T>() {
+  let resolveDeferred: ((value: T | PromiseLike<T>) => void) | undefined;
+  let rejectDeferred: ((reason?: unknown) => void) | undefined;
+
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolveDeferred = resolvePromise;
+    rejectDeferred = rejectPromise;
+  });
+
+  return {
+    promise,
+    reject: (reason?: unknown) => {
+      if (!rejectDeferred) {
+        throw new Error('Deferred promise reject handler was not initialized');
+      }
+
+      rejectDeferred(reason);
+    },
+    resolve: (value: T | PromiseLike<T>) => {
+      if (!resolveDeferred) {
+        throw new Error('Deferred promise resolve handler was not initialized');
+      }
+
+      resolveDeferred(value);
+    },
+  };
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+afterEach(() => {
+  mockedApiRequest.mockReset();
+});
+
+describe('habit api hooks', () => {
+  it('optimistically updates and rolls back a toggled habit entry on failure', async () => {
+    const queryClient = createAppQueryClient();
+    const wrapper = createWrapper(queryClient);
+    const queryKey = habitKeys.entries({ from: '2026-03-07', to: '2026-03-07' });
+    const initialEntries: HabitEntry[] = [
+      {
+        id: 'entry-1',
+        habitId: 'habit-1',
+        userId: 'user-1',
+        date: '2026-03-07',
+        completed: false,
+        value: null,
+        createdAt: 1,
+      },
+    ];
+
+    queryClient.setQueryData(queryKey, initialEntries);
+
+    const deferred = createDeferredPromise<HabitEntry>();
+    void deferred.promise.catch(() => undefined);
+    mockedApiRequest.mockReturnValueOnce(deferred.promise);
+
+    const { result } = renderHook(() => useToggleHabit(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        habitId: 'habit-1',
+        date: '2026-03-07',
+        completed: true,
+        entryId: 'entry-1',
+      });
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData<HabitEntry[]>(queryKey)).toEqual([
+        expect.objectContaining({
+          completed: true,
+          habitId: 'habit-1',
+          id: 'entry-1',
+        }),
+      ]);
+    });
+
+    act(() => {
+      deferred.reject(new Error('toggle failed'));
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData<HabitEntry[]>(queryKey)).toEqual(initialEntries);
+    });
+  });
+
+  it('optimistically patches a tracked entry and keeps the server result on success', async () => {
+    const queryClient = createAppQueryClient();
+    const wrapper = createWrapper(queryClient);
+    const queryKey = habitKeys.entries({ from: '2026-03-07', to: '2026-03-07' });
+    const initialEntries: HabitEntry[] = [
+      {
+        id: 'entry-2',
+        habitId: 'habit-2',
+        userId: 'user-1',
+        date: '2026-03-07',
+        completed: false,
+        value: 6,
+        createdAt: 2,
+      },
+    ];
+    const updatedEntry: HabitEntry = {
+      ...initialEntries[0],
+      completed: true,
+      value: 8,
+    };
+
+    queryClient.setQueryData(queryKey, initialEntries);
+
+    const deferred = createDeferredPromise<HabitEntry>();
+    mockedApiRequest.mockReturnValueOnce(deferred.promise);
+
+    const { result } = renderHook(() => useUpdateHabitEntry(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        id: 'entry-2',
+        habitId: 'habit-2',
+        date: '2026-03-07',
+        completed: true,
+        value: 8,
+      });
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData<HabitEntry[]>(queryKey)).toEqual([
+        expect.objectContaining({
+          completed: true,
+          id: 'entry-2',
+          value: 8,
+        }),
+      ]);
+    });
+
+    await act(async () => {
+      deferred.resolve(updatedEntry);
+      await deferred.promise;
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData<HabitEntry[]>(queryKey)).toEqual([updatedEntry]);
+    });
+  });
+});

--- a/apps/web/src/features/habits/api/habits.ts
+++ b/apps/web/src/features/habits/api/habits.ts
@@ -1,5 +1,16 @@
 import { useMutation, useQuery, useQueryClient, type QueryKey } from '@tanstack/react-query';
-import { habitEntrySchema, habitSchema, type HabitEntry } from '@pulse/shared';
+import {
+  createHabitInputSchema,
+  habitEntrySchema,
+  habitSchema,
+  reorderHabitsInputSchema,
+  updateHabitInputSchema,
+  type CreateHabitInput,
+  type Habit,
+  type HabitEntry,
+  type ReorderHabitsInput,
+  type UpdateHabitInput,
+} from '@pulse/shared';
 import { z } from 'zod';
 
 import { apiRequest } from '@/lib/api-client';
@@ -9,6 +20,9 @@ import { habitKeys } from './keys';
 const habitsSchema = z.array(habitSchema);
 const habitEntriesSchema = z.array(habitEntrySchema);
 const habitEntriesKeyPrefix = [...habitKeys.all, 'entries'] as const;
+const successSchema = z.object({
+  success: z.literal(true),
+});
 
 type HabitEntriesParams = {
   from: string;
@@ -38,10 +52,17 @@ type MutationContext = {
   previousEntries: HabitEntryQuerySnapshot;
 };
 
+type ReorderMutationContext = {
+  previousHabits: Habit[] | undefined;
+};
+
 const compareHabitEntries = (left: HabitEntry, right: HabitEntry) =>
   left.date.localeCompare(right.date) ||
   left.createdAt - right.createdAt ||
   left.id.localeCompare(right.id);
+
+const compareHabits = (left: Habit, right: Habit) =>
+  left.sortOrder - right.sortOrder || left.createdAt - right.createdAt || left.id.localeCompare(right.id);
 
 const isHabitEntriesParams = (value: unknown): value is HabitEntriesParams => {
   return (
@@ -118,6 +139,35 @@ const findCachedHabitEntry = (
   return undefined;
 };
 
+const upsertHabit = (habits: Habit[] | undefined, nextHabit: Habit) => {
+  const currentHabits = habits ?? [];
+  const existingIndex = currentHabits.findIndex((habit) => habit.id === nextHabit.id);
+
+  if (existingIndex === -1) {
+    return [...currentHabits, nextHabit].sort(compareHabits);
+  }
+
+  const nextHabits = [...currentHabits];
+  nextHabits[existingIndex] = nextHabit;
+
+  return nextHabits.sort(compareHabits);
+};
+
+const reorderCachedHabits = (habits: Habit[] | undefined, items: ReorderHabitsInput['items']) => {
+  if (!habits) {
+    return habits;
+  }
+
+  const nextOrderById = new Map(items.map((item) => [item.id, item.sortOrder]));
+
+  return habits
+    .map((habit) => ({
+      ...habit,
+      sortOrder: nextOrderById.get(habit.id) ?? habit.sortOrder,
+    }))
+    .sort(compareHabits);
+};
+
 export function useHabits() {
   return useQuery({
     queryFn: ({ signal }) =>
@@ -140,6 +190,110 @@ export function useHabitEntries(from: string, to: string) {
         signal,
       }),
     queryKey: habitKeys.entries({ from, to }),
+  });
+}
+
+export function useCreateHabit() {
+  const queryClient = useQueryClient();
+
+  return useMutation<Habit, Error, CreateHabitInput>({
+    mutationFn: (values) => {
+      const payload = createHabitInputSchema.parse(values);
+
+      return apiRequest('/api/v1/habits', {
+        body: payload,
+        method: 'POST',
+        schema: habitSchema,
+      });
+    },
+    onSuccess: (habit) => {
+      queryClient.setQueryData<Habit[]>(habitKeys.list(), (currentHabits) =>
+        upsertHabit(currentHabits, habit),
+      );
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: habitKeys.list() });
+    },
+  });
+}
+
+export function useUpdateHabit() {
+  const queryClient = useQueryClient();
+
+  return useMutation<Habit, Error, { id: string; values: UpdateHabitInput }>({
+    mutationFn: ({ id, values }) => {
+      const payload = updateHabitInputSchema.parse(values);
+
+      return apiRequest(`/api/v1/habits/${id}`, {
+        body: payload,
+        method: 'PUT',
+        schema: habitSchema,
+      });
+    },
+    onSuccess: (habit) => {
+      queryClient.setQueryData<Habit[]>(habitKeys.list(), (currentHabits) =>
+        upsertHabit(currentHabits, habit),
+      );
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: habitKeys.list() });
+    },
+  });
+}
+
+export function useDeleteHabit() {
+  const queryClient = useQueryClient();
+
+  return useMutation<{ success: true }, Error, { id: string }>({
+    mutationFn: ({ id }) =>
+      apiRequest(`/api/v1/habits/${id}`, {
+        method: 'DELETE',
+        schema: successSchema,
+      }),
+    onSuccess: (_response, variables) => {
+      queryClient.setQueryData<Habit[]>(habitKeys.list(), (currentHabits) =>
+        currentHabits?.filter((habit) => habit.id !== variables.id),
+      );
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: habitKeys.list() });
+    },
+  });
+}
+
+export function useReorderHabits() {
+  const queryClient = useQueryClient();
+
+  return useMutation<{ success: true }, Error, ReorderHabitsInput['items'], ReorderMutationContext>({
+    mutationFn: (items) => {
+      const payload = reorderHabitsInputSchema.parse({ items });
+
+      return apiRequest('/api/v1/habits/reorder', {
+        body: payload,
+        method: 'PATCH',
+        schema: successSchema,
+      });
+    },
+    onMutate: async (items) => {
+      await queryClient.cancelQueries({ queryKey: habitKeys.list() });
+
+      const previousHabits = queryClient.getQueryData<Habit[]>(habitKeys.list());
+      queryClient.setQueryData<Habit[]>(habitKeys.list(), (currentHabits) =>
+        reorderCachedHabits(currentHabits, items),
+      );
+
+      return { previousHabits };
+    },
+    onError: (_error, _variables, context) => {
+      if (!context) {
+        return;
+      }
+
+      queryClient.setQueryData(habitKeys.list(), context.previousHabits);
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: habitKeys.list() });
+    },
   });
 }
 

--- a/apps/web/src/features/habits/api/habits.ts
+++ b/apps/web/src/features/habits/api/habits.ts
@@ -172,24 +172,31 @@ const reorderCachedHabits = (habits: Habit[] | undefined, items: ReorderHabitsIn
 
 export function useHabits() {
   return useQuery({
-    queryFn: ({ signal }) =>
-      apiRequest('/api/v1/habits', {
+    queryFn: async ({ signal }) => {
+      const habits = await apiRequest<Habit[]>('/api/v1/habits', {
         method: 'GET',
-        schema: habitsSchema,
         signal,
-      }),
+      });
+
+      return habitsSchema.parse(habits);
+    },
     queryKey: habitKeys.list(),
   });
 }
 
 export function useHabitEntries(from: string, to: string) {
   return useQuery({
-    queryFn: ({ signal }) =>
-      apiRequest(`/api/v1/habit-entries?from=${from}&to=${to}`, {
-        method: 'GET',
-        schema: habitEntriesSchema,
-        signal,
-      }),
+    queryFn: async ({ signal }) => {
+      const entries = await apiRequest<HabitEntry[]>(
+        `/api/v1/habit-entries?from=${from}&to=${to}`,
+        {
+          method: 'GET',
+          signal,
+        },
+      );
+
+      return habitEntriesSchema.parse(entries);
+    },
     queryKey: habitKeys.entries({ from, to }),
   });
 }
@@ -198,14 +205,14 @@ export function useCreateHabit() {
   const queryClient = useQueryClient();
 
   return useMutation<Habit, Error, CreateHabitInput>({
-    mutationFn: (values) => {
+    mutationFn: async (values) => {
       const payload = createHabitInputSchema.parse(values);
-
-      return apiRequest('/api/v1/habits', {
+      const habit = await apiRequest<Habit>('/api/v1/habits', {
         body: payload,
         method: 'POST',
-        schema: habitSchema,
       });
+
+      return habitSchema.parse(habit);
     },
     onSuccess: (habit) => {
       queryClient.setQueryData<Habit[]>(habitKeys.list(), (currentHabits) =>
@@ -222,14 +229,14 @@ export function useUpdateHabit() {
   const queryClient = useQueryClient();
 
   return useMutation<Habit, Error, { id: string; values: UpdateHabitInput }>({
-    mutationFn: ({ id, values }) => {
+    mutationFn: async ({ id, values }) => {
       const payload = updateHabitInputSchema.parse(values);
-
-      return apiRequest(`/api/v1/habits/${id}`, {
+      const habit = await apiRequest<Habit>(`/api/v1/habits/${id}`, {
         body: payload,
         method: 'PUT',
-        schema: habitSchema,
       });
+
+      return habitSchema.parse(habit);
     },
     onSuccess: (habit) => {
       queryClient.setQueryData<Habit[]>(habitKeys.list(), (currentHabits) =>
@@ -246,11 +253,13 @@ export function useDeleteHabit() {
   const queryClient = useQueryClient();
 
   return useMutation<{ success: true }, Error, { id: string }>({
-    mutationFn: ({ id }) =>
-      apiRequest(`/api/v1/habits/${id}`, {
+    mutationFn: async ({ id }) => {
+      const response = await apiRequest<{ success: true }>(`/api/v1/habits/${id}`, {
         method: 'DELETE',
-        schema: successSchema,
-      }),
+      });
+
+      return successSchema.parse(response);
+    },
     onSuccess: (_response, variables) => {
       queryClient.setQueryData<Habit[]>(habitKeys.list(), (currentHabits) =>
         currentHabits?.filter((habit) => habit.id !== variables.id),
@@ -270,11 +279,10 @@ export function useReorderHabits() {
       mutationFn: (items) => {
         const payload = reorderHabitsInputSchema.parse({ items });
 
-        return apiRequest('/api/v1/habits/reorder', {
+        return apiRequest<{ success: true }>('/api/v1/habits/reorder', {
           body: payload,
           method: 'PATCH',
-          schema: successSchema,
-        });
+        }).then((response) => successSchema.parse(response));
       },
       onMutate: async (items) => {
         await queryClient.cancelQueries({ queryKey: habitKeys.list() });
@@ -304,16 +312,18 @@ export function useToggleHabit() {
   const queryClient = useQueryClient();
 
   return useMutation<HabitEntry, Error, ToggleHabitVariables, MutationContext>({
-    mutationFn: ({ habitId, date, completed, value }) =>
-      apiRequest(`/api/v1/habits/${habitId}/entries`, {
+    mutationFn: async ({ habitId, date, completed, value }) => {
+      const entry = await apiRequest<HabitEntry>(`/api/v1/habits/${habitId}/entries`, {
         body: {
           completed,
           ...(value === undefined ? {} : { value }),
           date,
         },
         method: 'POST',
-        schema: habitEntrySchema,
-      }),
+      });
+
+      return habitEntrySchema.parse(entry);
+    },
     onMutate: async (variables) => {
       await queryClient.cancelQueries({ queryKey: habitEntriesKeyPrefix });
 
@@ -355,15 +365,17 @@ export function useUpdateHabitEntry() {
   const queryClient = useQueryClient();
 
   return useMutation<HabitEntry, Error, UpdateHabitEntryVariables, MutationContext>({
-    mutationFn: ({ id, completed, value }) =>
-      apiRequest(`/api/v1/habit-entries/${id}`, {
+    mutationFn: async ({ id, completed, value }) => {
+      const entry = await apiRequest<HabitEntry>(`/api/v1/habit-entries/${id}`, {
         body: {
           ...(completed === undefined ? {} : { completed }),
           ...(value === undefined ? {} : { value }),
         },
         method: 'PATCH',
-        schema: habitEntrySchema,
-      }),
+      });
+
+      return habitEntrySchema.parse(entry);
+    },
     onMutate: async (variables) => {
       await queryClient.cancelQueries({ queryKey: habitEntriesKeyPrefix });
 

--- a/apps/web/src/features/habits/api/habits.ts
+++ b/apps/web/src/features/habits/api/habits.ts
@@ -62,7 +62,9 @@ const compareHabitEntries = (left: HabitEntry, right: HabitEntry) =>
   left.id.localeCompare(right.id);
 
 const compareHabits = (left: Habit, right: Habit) =>
-  left.sortOrder - right.sortOrder || left.createdAt - right.createdAt || left.id.localeCompare(right.id);
+  left.sortOrder - right.sortOrder ||
+  left.createdAt - right.createdAt ||
+  left.id.localeCompare(right.id);
 
 const isHabitEntriesParams = (value: unknown): value is HabitEntriesParams => {
   return (
@@ -177,7 +179,6 @@ export function useHabits() {
         signal,
       }),
     queryKey: habitKeys.list(),
-    select: (habits) => habits.filter((habit) => habit.active),
   });
 }
 
@@ -264,37 +265,39 @@ export function useDeleteHabit() {
 export function useReorderHabits() {
   const queryClient = useQueryClient();
 
-  return useMutation<{ success: true }, Error, ReorderHabitsInput['items'], ReorderMutationContext>({
-    mutationFn: (items) => {
-      const payload = reorderHabitsInputSchema.parse({ items });
+  return useMutation<{ success: true }, Error, ReorderHabitsInput['items'], ReorderMutationContext>(
+    {
+      mutationFn: (items) => {
+        const payload = reorderHabitsInputSchema.parse({ items });
 
-      return apiRequest('/api/v1/habits/reorder', {
-        body: payload,
-        method: 'PATCH',
-        schema: successSchema,
-      });
-    },
-    onMutate: async (items) => {
-      await queryClient.cancelQueries({ queryKey: habitKeys.list() });
+        return apiRequest('/api/v1/habits/reorder', {
+          body: payload,
+          method: 'PATCH',
+          schema: successSchema,
+        });
+      },
+      onMutate: async (items) => {
+        await queryClient.cancelQueries({ queryKey: habitKeys.list() });
 
-      const previousHabits = queryClient.getQueryData<Habit[]>(habitKeys.list());
-      queryClient.setQueryData<Habit[]>(habitKeys.list(), (currentHabits) =>
-        reorderCachedHabits(currentHabits, items),
-      );
+        const previousHabits = queryClient.getQueryData<Habit[]>(habitKeys.list());
+        queryClient.setQueryData<Habit[]>(habitKeys.list(), (currentHabits) =>
+          reorderCachedHabits(currentHabits, items),
+        );
 
-      return { previousHabits };
-    },
-    onError: (_error, _variables, context) => {
-      if (!context) {
-        return;
-      }
+        return { previousHabits };
+      },
+      onError: (_error, _variables, context) => {
+        if (!context) {
+          return;
+        }
 
-      queryClient.setQueryData(habitKeys.list(), context.previousHabits);
+        queryClient.setQueryData(habitKeys.list(), context.previousHabits);
+      },
+      onSettled: async () => {
+        await queryClient.invalidateQueries({ queryKey: habitKeys.list() });
+      },
     },
-    onSettled: async () => {
-      await queryClient.invalidateQueries({ queryKey: habitKeys.list() });
-    },
-  });
+  );
 }
 
 export function useToggleHabit() {

--- a/apps/web/src/features/habits/api/habits.ts
+++ b/apps/web/src/features/habits/api/habits.ts
@@ -1,0 +1,246 @@
+import { useMutation, useQuery, useQueryClient, type QueryKey } from '@tanstack/react-query';
+import { habitEntrySchema, habitSchema, type HabitEntry } from '@pulse/shared';
+import { z } from 'zod';
+
+import { apiRequest } from '@/lib/api-client';
+
+import { habitKeys } from './keys';
+
+const habitsSchema = z.array(habitSchema);
+const habitEntriesSchema = z.array(habitEntrySchema);
+const habitEntriesKeyPrefix = [...habitKeys.all, 'entries'] as const;
+
+type HabitEntriesParams = {
+  from: string;
+  to: string;
+};
+
+type ToggleHabitVariables = {
+  habitId: string;
+  date: string;
+  completed: boolean;
+  entryId?: string | null;
+  value?: number;
+};
+
+type UpdateHabitEntryVariables = {
+  id: string;
+  habitId: string;
+  date: string;
+  completed?: boolean;
+  value?: number;
+};
+
+type HabitEntryQuerySnapshot = Array<readonly [QueryKey, HabitEntry[] | undefined]>;
+
+type MutationContext = {
+  optimisticEntry: HabitEntry;
+  previousEntries: HabitEntryQuerySnapshot;
+};
+
+const compareHabitEntries = (left: HabitEntry, right: HabitEntry) =>
+  left.date.localeCompare(right.date) ||
+  left.createdAt - right.createdAt ||
+  left.id.localeCompare(right.id);
+
+const isHabitEntriesParams = (value: unknown): value is HabitEntriesParams => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'from' in value &&
+    typeof value.from === 'string' &&
+    'to' in value &&
+    typeof value.to === 'string'
+  );
+};
+
+const getEntriesParamsFromQueryKey = (queryKey: QueryKey): HabitEntriesParams | null => {
+  const maybeParams = queryKey[2];
+  return isHabitEntriesParams(maybeParams) ? maybeParams : null;
+};
+
+const snapshotHabitEntryQueries = (queryClient: ReturnType<typeof useQueryClient>) =>
+  queryClient.getQueriesData<HabitEntry[]>({
+    queryKey: habitEntriesKeyPrefix,
+  });
+
+const restoreHabitEntryQueries = (
+  queryClient: ReturnType<typeof useQueryClient>,
+  snapshot: HabitEntryQuerySnapshot,
+) => {
+  snapshot.forEach(([queryKey, entries]) => {
+    queryClient.setQueryData(queryKey, entries);
+  });
+};
+
+const upsertHabitEntry = (entries: HabitEntry[] | undefined, nextEntry: HabitEntry) => {
+  const currentEntries = entries ?? [];
+  const existingIndex = currentEntries.findIndex(
+    (entry) =>
+      entry.id === nextEntry.id ||
+      (entry.habitId === nextEntry.habitId && entry.date === nextEntry.date),
+  );
+
+  if (existingIndex === -1) {
+    return [...currentEntries, nextEntry].sort(compareHabitEntries);
+  }
+
+  const nextEntries = [...currentEntries];
+  nextEntries[existingIndex] = nextEntry;
+  return nextEntries.sort(compareHabitEntries);
+};
+
+const applyHabitEntryToCache = (
+  queryClient: ReturnType<typeof useQueryClient>,
+  nextEntry: HabitEntry,
+) => {
+  snapshotHabitEntryQueries(queryClient).forEach(([queryKey, entries]) => {
+    const params = getEntriesParamsFromQueryKey(queryKey);
+    if (!params || nextEntry.date < params.from || nextEntry.date > params.to) {
+      return;
+    }
+
+    queryClient.setQueryData(queryKey, upsertHabitEntry(entries, nextEntry));
+  });
+};
+
+const findCachedHabitEntry = (
+  queryClient: ReturnType<typeof useQueryClient>,
+  entryId: string,
+): HabitEntry | undefined => {
+  for (const [, entries] of snapshotHabitEntryQueries(queryClient)) {
+    const match = entries?.find((entry) => entry.id === entryId);
+    if (match) {
+      return match;
+    }
+  }
+
+  return undefined;
+};
+
+export function useHabits() {
+  return useQuery({
+    queryFn: ({ signal }) =>
+      apiRequest('/api/v1/habits', {
+        method: 'GET',
+        schema: habitsSchema,
+        signal,
+      }),
+    queryKey: habitKeys.list(),
+    select: (habits) => habits.filter((habit) => habit.active),
+  });
+}
+
+export function useHabitEntries(from: string, to: string) {
+  return useQuery({
+    queryFn: ({ signal }) =>
+      apiRequest(`/api/v1/habit-entries?from=${from}&to=${to}`, {
+        method: 'GET',
+        schema: habitEntriesSchema,
+        signal,
+      }),
+    queryKey: habitKeys.entries({ from, to }),
+  });
+}
+
+export function useToggleHabit() {
+  const queryClient = useQueryClient();
+
+  return useMutation<HabitEntry, Error, ToggleHabitVariables, MutationContext>({
+    mutationFn: ({ habitId, date, completed, value }) =>
+      apiRequest(`/api/v1/habits/${habitId}/entries`, {
+        body: {
+          completed,
+          ...(value === undefined ? {} : { value }),
+          date,
+        },
+        method: 'POST',
+        schema: habitEntrySchema,
+      }),
+    onMutate: async (variables) => {
+      await queryClient.cancelQueries({ queryKey: habitEntriesKeyPrefix });
+
+      const previousEntries = snapshotHabitEntryQueries(queryClient);
+      const optimisticEntry: HabitEntry = {
+        id: variables.entryId ?? `optimistic-${variables.habitId}-${variables.date}`,
+        habitId: variables.habitId,
+        userId: 'optimistic',
+        date: variables.date,
+        completed: variables.completed,
+        value: variables.value ?? null,
+        createdAt: Date.now(),
+      };
+
+      applyHabitEntryToCache(queryClient, optimisticEntry);
+
+      return {
+        optimisticEntry,
+        previousEntries,
+      };
+    },
+    onError: (_error, _variables, context) => {
+      if (!context) {
+        return;
+      }
+
+      restoreHabitEntryQueries(queryClient, context.previousEntries);
+    },
+    onSuccess: (entry) => {
+      applyHabitEntryToCache(queryClient, entry);
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: habitEntriesKeyPrefix });
+    },
+  });
+}
+
+export function useUpdateHabitEntry() {
+  const queryClient = useQueryClient();
+
+  return useMutation<HabitEntry, Error, UpdateHabitEntryVariables, MutationContext>({
+    mutationFn: ({ id, completed, value }) =>
+      apiRequest(`/api/v1/habit-entries/${id}`, {
+        body: {
+          ...(completed === undefined ? {} : { completed }),
+          ...(value === undefined ? {} : { value }),
+        },
+        method: 'PATCH',
+        schema: habitEntrySchema,
+      }),
+    onMutate: async (variables) => {
+      await queryClient.cancelQueries({ queryKey: habitEntriesKeyPrefix });
+
+      const previousEntries = snapshotHabitEntryQueries(queryClient);
+      const existingEntry = findCachedHabitEntry(queryClient, variables.id);
+      const optimisticEntry: HabitEntry = {
+        id: variables.id,
+        habitId: variables.habitId,
+        userId: existingEntry?.userId ?? 'optimistic',
+        date: variables.date,
+        completed: variables.completed ?? existingEntry?.completed ?? false,
+        value: variables.value ?? existingEntry?.value ?? null,
+        createdAt: existingEntry?.createdAt ?? Date.now(),
+      };
+
+      applyHabitEntryToCache(queryClient, optimisticEntry);
+
+      return {
+        optimisticEntry,
+        previousEntries,
+      };
+    },
+    onError: (_error, _variables, context) => {
+      if (!context) {
+        return;
+      }
+
+      restoreHabitEntryQueries(queryClient, context.previousEntries);
+    },
+    onSuccess: (entry) => {
+      applyHabitEntryToCache(queryClient, entry);
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: habitEntriesKeyPrefix });
+    },
+  });
+}

--- a/apps/web/src/features/habits/api/keys.ts
+++ b/apps/web/src/features/habits/api/keys.ts
@@ -1,0 +1,6 @@
+export const habitKeys = {
+  all: ['habits'] as const,
+  detail: (id: string) => [...habitKeys.all, 'detail', id] as const,
+  entries: (params: { from: string; to: string }) => [...habitKeys.all, 'entries', params] as const,
+  list: () => [...habitKeys.all, 'list'] as const,
+};

--- a/apps/web/src/features/habits/components/daily-habits.tsx
+++ b/apps/web/src/features/habits/components/daily-habits.tsx
@@ -1,85 +1,29 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { CheckCheck, CircleDashed } from 'lucide-react';
+import type { Habit, HabitEntry } from '@pulse/shared';
 
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
-import { accentCardStyles } from '@/lib/accent-card-styles';
+import { Input } from '@/components/ui/input';
+import {
+  useHabitEntries,
+  useHabits,
+  useToggleHabit,
+  useUpdateHabitEntry,
+} from '@/features/habits/api/habits';
 import { trackingSurfaceClasses } from '@/features/habits/lib/habit-constants';
 import type { HabitConfig } from '@/features/habits/types';
-import { Input } from '@/components/ui/input';
+import { accentCardStyles } from '@/lib/accent-card-styles';
+import { toDateKey } from '@/lib/date';
 import { cn } from '@/lib/utils';
 
 type HabitValue = boolean | number | null;
 
 export type DailyHabit = HabitConfig & {
+  entryId: string | null;
   todayValue: HabitValue;
 };
-
-const defaultHabits: DailyHabit[] = [
-  {
-    id: 'hydrate',
-    name: 'Hydrate',
-    emoji: '💧',
-    trackingType: 'numeric',
-    target: 8,
-    unit: 'glasses',
-    todayValue: 6,
-  },
-  {
-    id: 'vitamins',
-    name: 'Take vitamins',
-    emoji: '💊',
-    trackingType: 'boolean',
-    target: null,
-    unit: null,
-    todayValue: true,
-  },
-  {
-    id: 'protein',
-    name: 'Protein goal',
-    emoji: '🥗',
-    trackingType: 'numeric',
-    target: 120,
-    unit: 'grams',
-    todayValue: 90,
-  },
-  {
-    id: 'sleep',
-    name: 'Sleep',
-    emoji: '😴',
-    trackingType: 'time',
-    target: 8,
-    unit: 'hours',
-    todayValue: 7.5,
-  },
-  {
-    id: 'mobility',
-    name: 'Mobility warm-up',
-    emoji: '🧘',
-    trackingType: 'boolean',
-    target: null,
-    unit: null,
-    todayValue: false,
-  },
-  {
-    id: 'reading',
-    name: 'Read',
-    emoji: '📚',
-    trackingType: 'time',
-    target: 1,
-    unit: 'hours',
-    todayValue: 1,
-  },
-  {
-    id: 'veggies',
-    name: 'Veggie servings',
-    emoji: '🥦',
-    trackingType: 'numeric',
-    target: 3,
-    unit: 'servings',
-    todayValue: 3,
-  },
-];
 
 const todayFormatter = new Intl.DateTimeFormat('en-US', {
   weekday: 'long',
@@ -132,18 +76,181 @@ function parseInputValue(rawValue: string) {
   return Number.isFinite(numericValue) ? numericValue : null;
 }
 
-type DailyHabitsProps = {
-  habits?: DailyHabit[];
+function buildDailyHabits(habits: Habit[], entries: HabitEntry[]): DailyHabit[] {
+  const entryByHabitId = new Map(entries.map((entry) => [entry.habitId, entry]));
+
+  return habits.map((habit) => {
+    const entry = entryByHabitId.get(habit.id);
+    const todayValue: HabitValue =
+      habit.trackingType === 'boolean' ? (entry?.completed ?? false) : (entry?.value ?? null);
+
+    return {
+      id: habit.id,
+      name: habit.name,
+      emoji: habit.emoji ?? '•',
+      trackingType: habit.trackingType,
+      target: habit.target,
+      unit: habit.unit,
+      entryId: entry?.id ?? null,
+      todayValue,
+    };
+  });
+}
+
+function DailyHabitsLoadingState() {
+  return (
+    <div aria-busy="true" className="space-y-4">
+      <Card className={accentCardStyles.pink}>
+        <CardHeader className="gap-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] opacity-70 dark:text-muted dark:opacity-100">
+            Daily habits
+          </p>
+          <div className="space-y-3">
+            <div className="h-8 w-56 animate-pulse rounded-full bg-black/10 dark:bg-secondary" />
+            <div className="h-4 w-full max-w-2xl animate-pulse rounded-full bg-black/10 dark:bg-secondary" />
+          </div>
+        </CardHeader>
+      </Card>
+
+      <div className="grid gap-4">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <Card key={index} className="gap-4 border-transparent py-5 shadow-sm">
+            <CardHeader className="space-y-3 pb-0">
+              <div className="h-6 w-44 animate-pulse rounded-full bg-black/10 dark:bg-secondary" />
+              <div className="h-4 w-56 animate-pulse rounded-full bg-black/10 dark:bg-secondary" />
+            </CardHeader>
+            <CardContent>
+              <div className="h-11 animate-pulse rounded-xl bg-black/10 dark:bg-secondary" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <p className="sr-only">Loading today&apos;s habits.</p>
+    </div>
+  );
+}
+
+type DailyHabitsErrorStateProps = {
+  message: string;
+  onRetry: () => void;
 };
 
-export function DailyHabits({ habits = defaultHabits }: DailyHabitsProps) {
-  const [habitValues, setHabitValues] = useState<Record<string, HabitValue>>(() =>
-    Object.fromEntries(habits.map((habit) => [habit.id, habit.todayValue])),
+function DailyHabitsErrorState({ message, onRetry }: DailyHabitsErrorStateProps) {
+  return (
+    <div className="space-y-4">
+      <Card className={accentCardStyles.pink}>
+        <CardHeader className="gap-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] opacity-70 dark:text-muted dark:opacity-100">
+            Daily habits
+          </p>
+          <div className="space-y-2">
+            <CardTitle
+              aria-level={2}
+              className="text-3xl font-semibold tracking-tight"
+              role="heading"
+            >
+              {todayFormatter.format(new Date())}
+            </CardTitle>
+            <CardDescription className="max-w-2xl text-sm opacity-70 dark:text-muted dark:opacity-100">
+              Habit progress could not be loaded right now.
+            </CardDescription>
+          </div>
+        </CardHeader>
+      </Card>
+
+      <Card className="border-dashed">
+        <CardContent className="flex flex-col gap-4 py-6 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-muted">{message}</p>
+          <Button onClick={onRetry} type="button">
+            Try again
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export function DailyHabits() {
+  const today = toDateKey(new Date());
+  const [draftValues, setDraftValues] = useState<Record<string, string>>({});
+
+  const habitsQuery = useHabits();
+  const habitEntriesQuery = useHabitEntries(today, today);
+  const toggleHabitMutation = useToggleHabit();
+  const updateHabitEntryMutation = useUpdateHabitEntry();
+
+  const dailyHabits = useMemo(
+    () => buildDailyHabits(habitsQuery.data ?? [], habitEntriesQuery.data ?? []),
+    [habitEntriesQuery.data, habitsQuery.data],
   );
 
-  const completedCount = habits.filter((habit) =>
-    getHabitCompletion(habit, habitValues[habit.id]),
+  const completedCount = dailyHabits.filter((habit) =>
+    getHabitCompletion(habit, habit.todayValue),
   ).length;
+
+  const clearDraftValue = (habitId: string) => {
+    setDraftValues((currentValues) => {
+      if (!(habitId in currentValues)) {
+        return currentValues;
+      }
+
+      return Object.fromEntries(Object.entries(currentValues).filter(([key]) => key !== habitId));
+    });
+  };
+
+  const commitTrackedValue = (habit: DailyHabit) => {
+    const draftValue = draftValues[habit.id];
+    if (draftValue === undefined) {
+      return;
+    }
+
+    clearDraftValue(habit.id);
+
+    const nextValue = parseInputValue(draftValue);
+    const currentValue = typeof habit.todayValue === 'number' ? habit.todayValue : null;
+    if (nextValue === currentValue) {
+      return;
+    }
+
+    const completed = getHabitCompletion(habit, nextValue);
+
+    if (habit.entryId && nextValue !== null) {
+      updateHabitEntryMutation.mutate({
+        id: habit.entryId,
+        habitId: habit.id,
+        date: today,
+        completed,
+        value: nextValue,
+      });
+      return;
+    }
+
+    toggleHabitMutation.mutate({
+      habitId: habit.id,
+      entryId: habit.entryId,
+      date: today,
+      completed,
+      ...(nextValue === null ? {} : { value: nextValue }),
+    });
+  };
+
+  if (habitsQuery.isPending || habitEntriesQuery.isPending) {
+    return <DailyHabitsLoadingState />;
+  }
+
+  if (habitsQuery.isError || habitEntriesQuery.isError) {
+    const error = habitsQuery.error ?? habitEntriesQuery.error;
+
+    return (
+      <DailyHabitsErrorState
+        message={error instanceof Error ? error.message : 'Unable to load daily habits.'}
+        onRetry={() => {
+          void Promise.all([habitsQuery.refetch(), habitEntriesQuery.refetch()]);
+        }}
+      />
+    );
+  }
 
   return (
     <div className="space-y-4">
@@ -167,137 +274,163 @@ export function DailyHabits({ habits = defaultHabits }: DailyHabitsProps) {
               </CardDescription>
             </div>
             <div className="inline-flex self-start rounded-full bg-black/10 px-4 py-2 text-sm font-semibold dark:bg-secondary dark:text-foreground">
-              {completedCount} of {habits.length} habits complete
+              {completedCount} of {dailyHabits.length} habits complete
             </div>
           </div>
         </CardHeader>
       </Card>
 
-      <div className="grid gap-4">
-        {habits.map((habit) => {
-          const value = habitValues[habit.id];
-          const isComplete = getHabitCompletion(habit, value);
-          const progressText = getProgressText(habit, value);
-          const progressPercent = getProgressPercent(habit, value);
+      {dailyHabits.length === 0 ? (
+        <Card className="border-dashed">
+          <CardContent className="py-6">
+            <p className="text-base font-medium text-foreground">
+              No active habits configured yet.
+            </p>
+            <p className="mt-2 text-sm text-muted">
+              Add or reactivate habits in settings before logging today&apos;s progress.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4">
+          {dailyHabits.map((habit) => {
+            const value = habit.todayValue;
+            const isComplete = getHabitCompletion(habit, value);
+            const progressText = getProgressText(habit, value);
+            const progressPercent = getProgressPercent(habit, value);
+            const isSavingValue =
+              updateHabitEntryMutation.isPending &&
+              updateHabitEntryMutation.variables?.habitId === habit.id;
+            const isSavingToggle =
+              toggleHabitMutation.isPending && toggleHabitMutation.variables?.habitId === habit.id;
 
-          return (
-            <Card
-              key={habit.id}
-              className={cn(
-                'gap-4 border-transparent py-5 shadow-sm transition-transform duration-200',
-                trackingSurfaceClasses[habit.trackingType],
-                isComplete && 'ring-2 ring-emerald-500/40',
-              )}
-            >
-              <CardHeader className="flex flex-row items-start justify-between gap-4 pb-0">
-                <div className="space-y-1">
-                  <div className="flex items-center gap-3">
-                    <span className="text-3xl leading-none" aria-hidden="true">
-                      {habit.emoji}
-                    </span>
-                    <CardTitle aria-level={3} className="text-xl font-semibold" role="heading">
-                      {habit.name}
-                    </CardTitle>
+            return (
+              <Card
+                key={habit.id}
+                className={cn(
+                  'gap-4 border-transparent py-5 shadow-sm transition-transform duration-200',
+                  trackingSurfaceClasses[habit.trackingType],
+                  isComplete && 'ring-2 ring-emerald-500/40',
+                )}
+              >
+                <CardHeader className="flex flex-row items-start justify-between gap-4 pb-0">
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-3">
+                      <span className="text-3xl leading-none" aria-hidden="true">
+                        {habit.emoji}
+                      </span>
+                      <CardTitle aria-level={3} className="text-xl font-semibold" role="heading">
+                        {habit.name}
+                      </CardTitle>
+                    </div>
+                    <CardDescription className="pl-12 text-sm opacity-70 dark:text-muted dark:opacity-100">
+                      {progressText}
+                    </CardDescription>
                   </div>
-                  <CardDescription className="pl-12 text-sm opacity-70 dark:text-muted dark:opacity-100">
-                    {progressText}
-                  </CardDescription>
-                </div>
-                <div
-                  className={cn(
-                    'inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em]',
-                    isComplete
-                      ? 'bg-primary text-primary-foreground'
-                      : 'bg-black/10 opacity-70 dark:bg-secondary dark:text-foreground dark:opacity-100',
-                  )}
-                >
-                  {isComplete ? (
-                    <CheckCheck className="size-3.5" />
-                  ) : (
-                    <CircleDashed className="size-3.5" />
-                  )}
-                  <span>{isComplete ? 'Done' : 'In progress'}</span>
-                </div>
-              </CardHeader>
-
-              <CardContent className="space-y-4">
-                {habit.trackingType === 'boolean' ? (
-                  <label
-                    className="flex cursor-pointer items-center gap-3 rounded-xl bg-white/70 px-4 py-3 shadow-sm dark:bg-secondary/60 dark:shadow-none"
-                    htmlFor={`habit-${habit.id}`}
+                  <div
+                    className={cn(
+                      'inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em]',
+                      isComplete
+                        ? 'bg-primary text-primary-foreground'
+                        : 'bg-black/10 opacity-70 dark:bg-secondary dark:text-foreground dark:opacity-100',
+                    )}
                   >
-                    <Checkbox
-                      id={`habit-${habit.id}`}
-                      aria-label={habit.name}
-                      checked={value === true}
-                      className="border-border bg-white dark:bg-background"
-                      onCheckedChange={(checked) => {
-                        setHabitValues((currentValues) => ({
-                          ...currentValues,
-                          [habit.id]: checked === true,
-                        }));
-                      }}
-                    />
-                    <span className="text-sm font-medium text-foreground">
-                      Mark this habit complete for today
-                    </span>
-                  </label>
-                ) : (
-                  <div className="grid gap-3 sm:grid-cols-[minmax(0,9rem)_1fr] sm:items-end">
-                    <div className="space-y-2">
-                      <label
-                        className="text-xs font-semibold uppercase tracking-[0.18em] opacity-70 dark:text-muted dark:opacity-100"
-                        htmlFor={`habit-${habit.id}`}
-                      >
-                        {habit.trackingType === 'time' ? 'Hours today' : 'Logged today'}
-                      </label>
-                      <Input
+                    {isComplete ? (
+                      <CheckCheck className="size-3.5" />
+                    ) : (
+                      <CircleDashed className="size-3.5" />
+                    )}
+                    <span>{isComplete ? 'Done' : 'In progress'}</span>
+                  </div>
+                </CardHeader>
+
+                <CardContent className="space-y-4">
+                  {habit.trackingType === 'boolean' ? (
+                    <label
+                      className="flex cursor-pointer items-center gap-3 rounded-xl bg-white/70 px-4 py-3 shadow-sm dark:bg-secondary/60 dark:shadow-none"
+                      htmlFor={`habit-${habit.id}`}
+                    >
+                      <Checkbox
                         id={`habit-${habit.id}`}
                         aria-label={habit.name}
-                        className="h-11 border-border bg-white/75 text-lg font-semibold text-foreground placeholder:text-muted focus-visible:border-ring focus-visible:ring-ring/20 dark:bg-background"
-                        inputMode="decimal"
-                        min="0"
-                        step={habit.trackingType === 'time' ? '0.25' : '1'}
-                        type="number"
-                        value={typeof value === 'number' ? value : ''}
-                        onChange={(event) => {
-                          const nextValue = parseInputValue(event.currentTarget.value);
-
-                          setHabitValues((currentValues) => ({
-                            ...currentValues,
-                            [habit.id]: nextValue,
-                          }));
+                        checked={value === true}
+                        className="border-border bg-white dark:bg-background"
+                        disabled={isSavingToggle}
+                        onCheckedChange={(checked) => {
+                          toggleHabitMutation.mutate({
+                            habitId: habit.id,
+                            entryId: habit.entryId,
+                            date: today,
+                            completed: checked === true,
+                          });
                         }}
                       />
-                    </div>
+                      <span className="text-sm font-medium text-foreground">
+                        Mark this habit complete for today
+                      </span>
+                    </label>
+                  ) : (
+                    <div className="grid gap-3 sm:grid-cols-[minmax(0,9rem)_1fr] sm:items-end">
+                      <div className="space-y-2">
+                        <label
+                          className="text-xs font-semibold uppercase tracking-[0.18em] opacity-70 dark:text-muted dark:opacity-100"
+                          htmlFor={`habit-${habit.id}`}
+                        >
+                          {habit.trackingType === 'time' ? 'Hours today' : 'Logged today'}
+                        </label>
+                        <Input
+                          id={`habit-${habit.id}`}
+                          aria-label={habit.name}
+                          className="h-11 border-border bg-white/75 text-lg font-semibold text-foreground placeholder:text-muted focus-visible:border-ring focus-visible:ring-ring/20 dark:bg-background"
+                          disabled={isSavingValue || isSavingToggle}
+                          inputMode="decimal"
+                          min="0"
+                          step={habit.trackingType === 'time' ? '0.25' : '1'}
+                          type="number"
+                          value={
+                            draftValues[habit.id] ??
+                            (typeof value === 'number' ? formatNumber(value) : '')
+                          }
+                          onBlur={() => commitTrackedValue(habit)}
+                          onChange={(event) => {
+                            const nextValue = event.currentTarget.value;
 
-                    <div className="space-y-2">
-                      <div className="flex items-center justify-between gap-3 text-sm">
-                        <span className="font-semibold dark:text-foreground">{progressText}</span>
-                        <span className="opacity-70 dark:text-muted dark:opacity-100">
-                          {Math.round(progressPercent)}%
-                        </span>
-                      </div>
-                      <div
-                        aria-hidden="true"
-                        className="h-2 overflow-hidden rounded-full bg-black/10 dark:bg-secondary"
-                      >
-                        <div
-                          className="h-full rounded-full bg-emerald-500 transition-[width] duration-200"
-                          style={{ width: `${progressPercent}%` }}
+                            setDraftValues((currentValues) => ({
+                              ...currentValues,
+                              [habit.id]: nextValue,
+                            }));
+                          }}
                         />
                       </div>
-                      <p className="text-xs font-medium tracking-wide uppercase opacity-70 dark:text-muted dark:opacity-100">
-                        Target: {formatNumber(habit.target ?? 0)} {habit.unit}
-                      </p>
+
+                      <div className="space-y-2">
+                        <div className="flex items-center justify-between gap-3 text-sm">
+                          <span className="font-semibold dark:text-foreground">{progressText}</span>
+                          <span className="opacity-70 dark:text-muted dark:opacity-100">
+                            {Math.round(progressPercent)}%
+                          </span>
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          className="h-2 overflow-hidden rounded-full bg-black/10 dark:bg-secondary"
+                        >
+                          <div
+                            className="h-full rounded-full bg-emerald-500 transition-[width] duration-200"
+                            style={{ width: `${progressPercent}%` }}
+                          />
+                        </div>
+                        <p className="text-xs font-medium tracking-wide uppercase opacity-70 dark:text-muted dark:opacity-100">
+                          Target: {formatNumber(habit.target ?? 0)} {habit.unit}
+                        </p>
+                      </div>
                     </div>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          );
-        })}
-      </div>
+                  )}
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/habits/components/daily-habits.tsx
+++ b/apps/web/src/features/habits/components/daily-habits.tsx
@@ -294,7 +294,10 @@ export function DailyHabits() {
       ) : (
         <div className="grid gap-4">
           {dailyHabits.map((habit) => {
-            const value = habit.todayValue;
+            const value =
+              habit.trackingType === 'boolean' || draftValues[habit.id] === undefined
+                ? habit.todayValue
+                : parseInputValue(draftValues[habit.id]);
             const isComplete = getHabitCompletion(habit, value);
             const progressText = getProgressText(habit, value);
             const progressPercent = getProgressPercent(habit, value);

--- a/apps/web/src/features/habits/components/habit-form.tsx
+++ b/apps/web/src/features/habits/components/habit-form.tsx
@@ -178,42 +178,42 @@ export function HabitForm({ initialHabit, onCancel, onSave }: HabitFormProps) {
             </select>
           </div>
 
-          {requiresGoal ? (
-            <div className="grid gap-4 sm:grid-cols-2">
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground" htmlFor="habit-target">
-                  Target
-                </label>
-                <Input
-                  id="habit-target"
-                  min="0"
-                  name="target"
-                  step="any"
-                  type="number"
-                  className={cn(errors.target && 'border-destructive')}
-                  onChange={(event) => updateField('target', event.target.value)}
-                  placeholder="8"
-                  value={formState.target}
-                />
-                {errors.target ? <p className="text-sm text-destructive">{errors.target}</p> : null}
-              </div>
-
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground" htmlFor="habit-unit">
-                  Unit
-                </label>
-                <Input
-                  id="habit-unit"
-                  name="unit"
-                  className={cn(errors.unit && 'border-destructive')}
-                  onChange={(event) => updateField('unit', event.target.value)}
-                  placeholder="glasses"
-                  value={formState.unit}
-                />
-                {errors.unit ? <p className="text-sm text-destructive">{errors.unit}</p> : null}
-              </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground" htmlFor="habit-target">
+                Target
+              </label>
+              <Input
+                id="habit-target"
+                min="0"
+                name="target"
+                step="any"
+                type="number"
+                className={cn(errors.target && 'border-destructive')}
+                disabled={!requiresGoal}
+                onChange={(event) => updateField('target', event.target.value)}
+                placeholder="8"
+                value={formState.target}
+              />
+              {errors.target ? <p className="text-sm text-destructive">{errors.target}</p> : null}
             </div>
-          ) : null}
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground" htmlFor="habit-unit">
+                Unit
+              </label>
+              <Input
+                id="habit-unit"
+                name="unit"
+                className={cn(errors.unit && 'border-destructive')}
+                disabled={!requiresGoal}
+                onChange={(event) => updateField('unit', event.target.value)}
+                placeholder="glasses"
+                value={formState.unit}
+              />
+              {errors.unit ? <p className="text-sm text-destructive">{errors.unit}</p> : null}
+            </div>
+          </div>
 
           <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
             <Button className="sm:order-2" type="submit">

--- a/apps/web/src/features/habits/components/habit-form.tsx
+++ b/apps/web/src/features/habits/components/habit-form.tsx
@@ -92,7 +92,7 @@ export function HabitForm({ initialHabit, onCancel, onSave }: HabitFormProps) {
           <div className="space-y-1">
             <CardTitle className="text-xl font-semibold text-foreground">{modeLabel}</CardTitle>
             <CardDescription>
-              Pick how the habit should be tracked, then save it into the local list.
+              Pick how the habit should be tracked, then save it to your account.
             </CardDescription>
           </div>
           <div

--- a/apps/web/src/features/habits/components/habit-settings.test.tsx
+++ b/apps/web/src/features/habits/components/habit-settings.test.tsx
@@ -214,7 +214,7 @@ describe('HabitSettings', () => {
     );
   });
 
-  it('hides target and unit fields for boolean habits', () => {
+  it('shows target and unit fields for boolean habits in a disabled state', () => {
     render(<HabitSettings />);
 
     const addHabitButton = screen.getAllByRole('button', { name: 'Add habit' })[0];
@@ -226,8 +226,8 @@ describe('HabitSettings', () => {
     fireEvent.click(addHabitButton);
 
     expect(screen.getByLabelText('Tracking type')).toHaveValue('boolean');
-    expect(screen.queryByLabelText('Target')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('Unit')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Target')).toBeDisabled();
+    expect(screen.getByLabelText('Unit')).toBeDisabled();
   });
 
   it('closes the form when cancel is pressed', () => {

--- a/apps/web/src/features/habits/components/habit-settings.test.tsx
+++ b/apps/web/src/features/habits/components/habit-settings.test.tsx
@@ -1,38 +1,152 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import type { Habit } from '@pulse/shared';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  useCreateHabit,
+  useDeleteHabit,
+  useHabits,
+  useReorderHabits,
+  useUpdateHabit,
+} from '@/features/habits/api/habits';
 import { HabitSettings } from '@/features/habits/components/habit-settings';
 
-function getHabitOrder() {
-  const list = screen.getByRole('list', { name: 'Habit list' });
+vi.mock('@/features/habits/api/habits', () => ({
+  useCreateHabit: vi.fn(),
+  useDeleteHabit: vi.fn(),
+  useHabits: vi.fn(),
+  useReorderHabits: vi.fn(),
+  useUpdateHabit: vi.fn(),
+}));
 
-  return within(list)
-    .getAllByRole('heading', { level: 3 })
-    .map((heading) => heading.textContent);
+const mockedUseCreateHabit = vi.mocked(useCreateHabit);
+const mockedUseDeleteHabit = vi.mocked(useDeleteHabit);
+const mockedUseHabits = vi.mocked(useHabits);
+const mockedUseReorderHabits = vi.mocked(useReorderHabits);
+const mockedUseUpdateHabit = vi.mocked(useUpdateHabit);
+
+const habits: Habit[] = [
+  {
+    active: true,
+    createdAt: 1,
+    emoji: '💧',
+    id: 'hydrate',
+    name: 'Hydrate',
+    sortOrder: 0,
+    target: 8,
+    trackingType: 'numeric',
+    unit: 'glasses',
+    updatedAt: 1,
+    userId: 'user-1',
+  },
+  {
+    active: true,
+    createdAt: 2,
+    emoji: '💊',
+    id: 'vitamins',
+    name: 'Take vitamins',
+    sortOrder: 1,
+    target: null,
+    trackingType: 'boolean',
+    unit: null,
+    updatedAt: 2,
+    userId: 'user-1',
+  },
+  {
+    active: true,
+    createdAt: 3,
+    emoji: '😴',
+    id: 'sleep',
+    name: 'Sleep',
+    sortOrder: 2,
+    target: 8,
+    trackingType: 'time',
+    unit: 'hours',
+    updatedAt: 3,
+    userId: 'user-1',
+  },
+];
+
+function createMutationMock() {
+  return {
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+  };
 }
 
 describe('HabitSettings', () => {
-  it('creates a numeric habit with conditional target and unit fields', () => {
+  beforeEach(() => {
+    mockedUseHabits.mockReturnValue({
+      data: habits,
+      error: null,
+      isError: false,
+      isPending: false,
+    } as ReturnType<typeof useHabits>);
+    mockedUseCreateHabit.mockReturnValue(
+      createMutationMock() as unknown as ReturnType<typeof useCreateHabit>,
+    );
+    mockedUseUpdateHabit.mockReturnValue(
+      createMutationMock() as unknown as ReturnType<typeof useUpdateHabit>,
+    );
+    mockedUseDeleteHabit.mockReturnValue(
+      createMutationMock() as unknown as ReturnType<typeof useDeleteHabit>,
+    );
+    mockedUseReorderHabits.mockReturnValue(
+      createMutationMock() as unknown as ReturnType<typeof useReorderHabits>,
+    );
+  });
+
+  it('shows a loading state while habits are being fetched', () => {
+    mockedUseHabits.mockReturnValue({
+      data: undefined,
+      error: null,
+      isError: false,
+      isPending: true,
+    } as ReturnType<typeof useHabits>);
+
     render(<HabitSettings />);
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Add habit' })[0]);
+    expect(screen.getByText('Loading habits...')).toBeInTheDocument();
+  });
 
+  it('creates a numeric habit through the create mutation', async () => {
+    const createMutation = createMutationMock();
+    mockedUseCreateHabit.mockReturnValue(
+      createMutation as unknown as ReturnType<typeof useCreateHabit>,
+    );
+
+    render(<HabitSettings />);
+
+    const addHabitButton = screen.getAllByRole('button', { name: 'Add habit' })[0];
+
+    if (!addHabitButton) {
+      throw new Error('Expected add habit button.');
+    }
+
+    fireEvent.click(addHabitButton);
     fireEvent.change(screen.getByLabelText('Habit name'), { target: { value: 'Stretch' } });
     fireEvent.change(screen.getByLabelText('Tracking type'), { target: { value: 'numeric' } });
-
-    expect(screen.getByLabelText('Target')).toBeInTheDocument();
-    expect(screen.getByLabelText('Unit')).toBeInTheDocument();
-
     fireEvent.change(screen.getByLabelText('Target'), { target: { value: '15' } });
     fireEvent.change(screen.getByLabelText('Unit'), { target: { value: 'minutes' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-    expect(screen.getByRole('heading', { name: 'Stretch', level: 3 })).toBeInTheDocument();
-    expect(screen.getByText('15 minutes target')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(createMutation.mutateAsync).toHaveBeenCalledWith({
+        emoji: '💧',
+        name: 'Stretch',
+        target: 15,
+        trackingType: 'numeric',
+        unit: 'minutes',
+      }),
+    );
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument());
   });
 
-  it('pre-fills habit data when editing and updates the list on save', () => {
+  it('pre-fills habit data when editing and calls the update mutation', async () => {
+    const updateMutation = createMutationMock();
+    mockedUseUpdateHabit.mockReturnValue(
+      updateMutation as unknown as ReturnType<typeof useUpdateHabit>,
+    );
+
     render(<HabitSettings />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Edit Hydrate' }));
@@ -45,54 +159,71 @@ describe('HabitSettings', () => {
     fireEvent.change(screen.getByLabelText('Habit name'), { target: { value: 'Hydration' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-    expect(screen.getByRole('heading', { name: 'Hydration', level: 3 })).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'Hydrate', level: 3 })).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(updateMutation.mutateAsync).toHaveBeenCalledWith({
+        id: 'hydrate',
+        values: {
+          emoji: '💧',
+          name: 'Hydration',
+          target: 8,
+          trackingType: 'numeric',
+          unit: 'glasses',
+        },
+      }),
+    );
   });
 
-  it('deletes habits only after confirmation', () => {
+  it('deletes habits only after confirmation', async () => {
+    const deleteMutation = createMutationMock();
     const confirmSpy = vi
       .spyOn(window, 'confirm')
       .mockReturnValueOnce(false)
       .mockReturnValueOnce(true);
 
+    mockedUseDeleteHabit.mockReturnValue(
+      deleteMutation as unknown as ReturnType<typeof useDeleteHabit>,
+    );
+
     render(<HabitSettings />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete Sleep' }));
-    expect(screen.getByRole('heading', { name: 'Sleep', level: 3 })).toBeInTheDocument();
+    expect(deleteMutation.mutateAsync).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete Sleep' }));
-    expect(screen.queryByRole('heading', { name: 'Sleep', level: 3 })).not.toBeInTheDocument();
 
+    await waitFor(() => expect(deleteMutation.mutateAsync).toHaveBeenCalledWith({ id: 'sleep' }));
     expect(confirmSpy).toHaveBeenCalledTimes(2);
   });
 
-  it('reorders habits with the up and down controls', () => {
+  it('reorders habits with the up and down controls', async () => {
+    const reorderMutation = createMutationMock();
+    mockedUseReorderHabits.mockReturnValue(
+      reorderMutation as unknown as ReturnType<typeof useReorderHabits>,
+    );
+
     render(<HabitSettings />);
 
-    expect(getHabitOrder()).toEqual([
-      'Hydrate',
-      'Take vitamins',
-      'Protein goal',
-      'Sleep',
-      'Mobility warm-up',
-    ]);
-
     fireEvent.click(screen.getByRole('button', { name: 'Move Hydrate down' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Move Sleep up' }));
 
-    expect(getHabitOrder()).toEqual([
-      'Take vitamins',
-      'Hydrate',
-      'Sleep',
-      'Protein goal',
-      'Mobility warm-up',
-    ]);
+    await waitFor(() =>
+      expect(reorderMutation.mutateAsync).toHaveBeenCalledWith([
+        { id: 'vitamins', sortOrder: 0 },
+        { id: 'hydrate', sortOrder: 1 },
+        { id: 'sleep', sortOrder: 2 },
+      ]),
+    );
   });
 
   it('hides target and unit fields for boolean habits', () => {
     render(<HabitSettings />);
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Add habit' })[0]);
+    const addHabitButton = screen.getAllByRole('button', { name: 'Add habit' })[0];
+
+    if (!addHabitButton) {
+      throw new Error('Expected add habit button.');
+    }
+
+    fireEvent.click(addHabitButton);
 
     expect(screen.getByLabelText('Tracking type')).toHaveValue('boolean');
     expect(screen.queryByLabelText('Target')).not.toBeInTheDocument();
@@ -102,7 +233,13 @@ describe('HabitSettings', () => {
   it('closes the form when cancel is pressed', () => {
     render(<HabitSettings />);
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Add habit' })[0]);
+    const addHabitButton = screen.getAllByRole('button', { name: 'Add habit' })[0];
+
+    if (!addHabitButton) {
+      throw new Error('Expected add habit button.');
+    }
+
+    fireEvent.click(addHabitButton);
     expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));

--- a/apps/web/src/features/habits/components/habit-settings.tsx
+++ b/apps/web/src/features/habits/components/habit-settings.tsx
@@ -1,13 +1,17 @@
 import { useState } from 'react';
 import { ArrowDown, ArrowUp, PencilLine, Plus, Trash2 } from 'lucide-react';
+import type { CreateHabitInput, Habit, UpdateHabitInput } from '@pulse/shared';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
-  defaultHabitConfigs,
-  trackingSurfaceClasses,
-  trackingTypeLabels,
-} from '@/features/habits/lib/habit-constants';
+  useCreateHabit,
+  useDeleteHabit,
+  useHabits,
+  useReorderHabits,
+  useUpdateHabit,
+} from '@/features/habits/api/habits';
+import { trackingSurfaceClasses, trackingTypeLabels } from '@/features/habits/lib/habit-constants';
 import type { HabitConfig, HabitConfigDraft } from '@/features/habits/types';
 import { cn } from '@/lib/utils';
 
@@ -22,20 +26,6 @@ type HabitEditorState =
       mode: 'edit';
     }
   | null;
-
-function createHabitId(name: string) {
-  const slug = name
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-
-  if (globalThis.crypto?.randomUUID) {
-    return `${slug || 'habit'}-${globalThis.crypto.randomUUID().slice(0, 8)}`;
-  }
-
-  return `${slug || 'habit'}-${Math.random().toString(36).slice(2, 10)}`;
-}
 
 function describeHabit(habit: HabitConfig) {
   if (habit.trackingType === 'boolean') {
@@ -54,33 +44,73 @@ function moveHabit(list: HabitConfig[], fromIndex: number, toIndex: number) {
   return nextList;
 }
 
-export function HabitSettings() {
-  const [habits, setHabits] = useState<HabitConfig[]>(defaultHabitConfigs);
-  const [editorState, setEditorState] = useState<HabitEditorState>(null);
+function toHabitConfig(habit: Habit): HabitConfig {
+  return {
+    id: habit.id,
+    name: habit.name,
+    emoji: habit.emoji ?? '•',
+    trackingType: habit.trackingType,
+    target: habit.target,
+    unit: habit.unit,
+  };
+}
 
+function toCreateHabitInput(values: HabitConfigDraft): CreateHabitInput {
+  return {
+    emoji: values.emoji,
+    name: values.name,
+    target: values.target,
+    trackingType: values.trackingType,
+    unit: values.unit,
+  };
+}
+
+function toUpdateHabitInput(values: HabitConfigDraft): UpdateHabitInput {
+  return {
+    emoji: values.emoji,
+    name: values.name,
+    target: values.target,
+    trackingType: values.trackingType,
+    unit: values.unit,
+  };
+}
+
+export function HabitSettings() {
+  const [editorState, setEditorState] = useState<HabitEditorState>(null);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const habitsQuery = useHabits();
+  const createHabitMutation = useCreateHabit();
+  const updateHabitMutation = useUpdateHabit();
+  const deleteHabitMutation = useDeleteHabit();
+  const reorderHabitsMutation = useReorderHabits();
+
+  const habits = (habitsQuery.data ?? []).map(toHabitConfig);
   const editingHabit =
     editorState?.mode === 'edit'
       ? (habits.find((habit) => habit.id === editorState.habitId) ?? null)
       : null;
 
-  function handleSave(values: HabitConfigDraft) {
-    if (editorState?.mode === 'edit') {
-      setHabits((currentHabits) =>
-        currentHabits.map((habit) =>
-          habit.id === editorState.habitId ? { ...habit, ...values } : habit,
-        ),
-      );
-    } else {
-      setHabits((currentHabits) => [
-        ...currentHabits,
-        { id: createHabitId(values.name), ...values },
-      ]);
-    }
+  async function handleSave(values: HabitConfigDraft) {
+    setErrorMessage('');
 
-    setEditorState(null);
+    try {
+      if (editorState?.mode === 'edit') {
+        await updateHabitMutation.mutateAsync({
+          id: editorState.habitId,
+          values: toUpdateHabitInput(values),
+        });
+      } else {
+        await createHabitMutation.mutateAsync(toCreateHabitInput(values));
+      }
+
+      setEditorState(null);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Habit changes could not be saved.');
+    }
   }
 
-  function handleDelete(habitId: string) {
+  async function handleDelete(habitId: string) {
     const habit = habits.find((item) => item.id === habitId);
 
     if (!habit) {
@@ -93,28 +123,44 @@ export function HabitSettings() {
       return;
     }
 
-    setHabits((currentHabits) => currentHabits.filter((item) => item.id !== habitId));
-    setEditorState((currentState) =>
-      currentState?.mode === 'edit' && currentState.habitId === habitId ? null : currentState,
-    );
+    setErrorMessage('');
+
+    try {
+      await deleteHabitMutation.mutateAsync({ id: habitId });
+      setEditorState((currentState) =>
+        currentState?.mode === 'edit' && currentState.habitId === habitId ? null : currentState,
+      );
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Habit changes could not be saved.');
+    }
   }
 
-  function handleMove(habitId: string, direction: 'up' | 'down') {
-    setHabits((currentHabits) => {
-      const currentIndex = currentHabits.findIndex((habit) => habit.id === habitId);
+  async function handleMove(habitId: string, direction: 'up' | 'down') {
+    const currentIndex = habits.findIndex((habit) => habit.id === habitId);
 
-      if (currentIndex === -1) {
-        return currentHabits;
-      }
+    if (currentIndex === -1) {
+      return;
+    }
 
-      const nextIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
+    const nextIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
 
-      if (nextIndex < 0 || nextIndex >= currentHabits.length) {
-        return currentHabits;
-      }
+    if (nextIndex < 0 || nextIndex >= habits.length) {
+      return;
+    }
 
-      return moveHabit(currentHabits, currentIndex, nextIndex);
-    });
+    setErrorMessage('');
+
+    try {
+      const reorderedHabits = moveHabit(habits, currentIndex, nextIndex);
+      await reorderHabitsMutation.mutateAsync(
+        reorderedHabits.map((habit, index) => ({
+          id: habit.id,
+          sortOrder: index,
+        })),
+      );
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Habit changes could not be saved.');
+    }
   }
 
   return (
@@ -139,10 +185,29 @@ export function HabitSettings() {
               Add habit
             </Button>
           </div>
+          {errorMessage ? (
+            <p className="text-sm text-destructive" role="alert">
+              {errorMessage}
+            </p>
+          ) : null}
         </CardHeader>
 
         <CardContent>
-          {habits.length > 0 ? (
+          {habitsQuery.isPending ? (
+            <div
+              aria-busy="true"
+              className="rounded-2xl border border-dashed border-border px-5 py-8 text-center"
+            >
+              <p className="text-base font-medium text-foreground">Loading habits...</p>
+            </div>
+          ) : habitsQuery.isError ? (
+            <div className="rounded-2xl border border-dashed border-destructive/40 px-5 py-8 text-center">
+              <p className="text-base font-medium text-foreground">Could not load habits.</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Refresh the page or try again in a moment.
+              </p>
+            </div>
+          ) : habits.length > 0 ? (
             <ul aria-label="Habit list" className="space-y-3">
               {habits.map((habit, index) => (
                 <li key={habit.id}>
@@ -172,7 +237,7 @@ export function HabitSettings() {
                         <Button
                           aria-label={`Move ${habit.name} up`}
                           disabled={index === 0}
-                          onClick={() => handleMove(habit.id, 'up')}
+                          onClick={() => void handleMove(habit.id, 'up')}
                           size="icon-sm"
                           type="button"
                           variant="outline"
@@ -182,7 +247,7 @@ export function HabitSettings() {
                         <Button
                           aria-label={`Move ${habit.name} down`}
                           disabled={index === habits.length - 1}
-                          onClick={() => handleMove(habit.id, 'down')}
+                          onClick={() => void handleMove(habit.id, 'down')}
                           size="icon-sm"
                           type="button"
                           variant="outline"
@@ -201,7 +266,7 @@ export function HabitSettings() {
                         </Button>
                         <Button
                           aria-label={`Delete ${habit.name}`}
-                          onClick={() => handleDelete(habit.id)}
+                          onClick={() => void handleDelete(habit.id)}
                           size="sm"
                           type="button"
                           variant="ghost"
@@ -231,7 +296,7 @@ export function HabitSettings() {
           key={editorState.mode === 'edit' ? editorState.habitId : 'create'}
           initialHabit={editingHabit}
           onCancel={() => setEditorState(null)}
-          onSave={handleSave}
+          onSave={(values) => void handleSave(values)}
         />
       ) : (
         <Card className="gap-4 border-dashed border-border/80 shadow-sm">

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,13 +1,10 @@
 import { StrictMode } from 'react';
-import { QueryClientProvider } from '@tanstack/react-query';
 import { createRoot } from 'react-dom/client';
 import App from '@/App';
 import { ThemeProvider } from '@/components/theme-provider';
-import { createAppQueryClient } from '@/lib/query-client';
 import './styles/globals.css';
 
 const rootElement = document.getElementById('root');
-const queryClient = createAppQueryClient();
 
 if (!rootElement) {
   throw new Error('Failed to find the root element');
@@ -15,10 +12,8 @@ if (!rootElement) {
 
 createRoot(rootElement).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
-        <App />
-      </ThemeProvider>
-    </QueryClientProvider>
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>,
 );

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -1,12 +1,19 @@
+import type { Habit, HabitEntry } from '@pulse/shared';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useHabitEntries, useHabits } from '@/features/habits/api/habits';
 import { getDashboardGreeting } from '@/features/dashboard/lib/greeting';
 import { getMockSnapshotForDate } from '@/lib/mock-data/dashboard';
 import { DashboardPage } from './dashboard';
 
 const formatWeight = (value: number): string => `${value.toFixed(1)} lbs`;
+
+vi.mock('@/features/habits/api/habits', () => ({
+  useHabitEntries: vi.fn(),
+  useHabits: vi.fn(),
+}));
 
 vi.mock('recharts', async () => {
   const actual = await vi.importActual<typeof import('recharts')>('recharts');
@@ -30,10 +37,54 @@ vi.mock('recharts', async () => {
   };
 });
 
+const mockedUseHabitEntries = vi.mocked(useHabitEntries);
+const mockedUseHabits = vi.mocked(useHabits);
+
+const habits: Habit[] = [
+  {
+    active: true,
+    createdAt: 1,
+    emoji: '🧘',
+    id: 'habit-meditate',
+    name: 'Meditate',
+    sortOrder: 0,
+    target: null,
+    trackingType: 'boolean',
+    unit: null,
+    updatedAt: 1,
+    userId: 'user-1',
+  },
+];
+
+const todayEntry: HabitEntry = {
+  completed: true,
+  createdAt: 1,
+  date: '2026-03-06',
+  habitId: 'habit-meditate',
+  id: 'entry-1',
+  userId: 'user-1',
+  value: null,
+};
+
 describe('DashboardPage', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-06T10:00:00'));
+
+    mockedUseHabits.mockReturnValue({
+      data: habits,
+      error: null,
+      isError: false,
+      isPending: false,
+    } as ReturnType<typeof useHabits>);
+    mockedUseHabitEntries.mockImplementation((from, to) =>
+      ({
+        data: from === '2026-03-06' && to === '2026-03-06' ? [todayEntry] : [todayEntry],
+        error: null,
+        isError: false,
+        isPending: false,
+      }) as ReturnType<typeof useHabitEntries>,
+    );
   });
 
   afterEach(() => {
@@ -51,6 +102,7 @@ describe('DashboardPage', () => {
     expect(screen.getByText('Good morning')).toBeInTheDocument();
     expect(screen.getByLabelText('Calendar day picker')).toBeInTheDocument();
     expect(screen.getByText('Body Weight')).toBeInTheDocument();
+    expect(screen.getByText('Habits')).toBeInTheDocument();
     expect(screen.getByLabelText('Macro display mode')).toBeInTheDocument();
     expect(screen.getByLabelText('Habit chains')).toBeInTheDocument();
     expect(screen.getByLabelText('Trend sparklines')).toBeInTheDocument();
@@ -81,6 +133,15 @@ describe('DashboardPage', () => {
   });
 
   it('updates snapshot content when a new calendar day is selected', () => {
+    mockedUseHabitEntries.mockImplementation((from, to) =>
+      ({
+        data: from === '2026-03-04' && to === '2026-03-04' ? [] : [todayEntry],
+        error: null,
+        isError: false,
+        isPending: false,
+      }) as ReturnType<typeof useHabitEntries>,
+    );
+
     render(
       <MemoryRouter>
         <DashboardPage />
@@ -90,11 +151,14 @@ describe('DashboardPage', () => {
     const todaySnapshot = getMockSnapshotForDate(new Date('2026-03-06T00:00:00'));
     const selectedSnapshot = getMockSnapshotForDate(new Date('2026-03-04T00:00:00'));
     const bodyWeightCard = screen.getByText('Body Weight').closest('[data-slot="stat-card"]');
+    const habitsCard = screen.getByText('Habits').closest('[data-slot="stat-card"]');
 
     expect(bodyWeightCard).toBeInTheDocument();
+    expect(habitsCard).toBeInTheDocument();
     expect(
       within(bodyWeightCard as HTMLElement).getByText(formatWeight(todaySnapshot.weight)),
     ).toBeInTheDocument();
+    expect(within(habitsCard as HTMLElement).getByText('1 / 1 complete')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /select wednesday, march 4, 2026/i }));
 
@@ -102,6 +166,7 @@ describe('DashboardPage', () => {
       within(bodyWeightCard as HTMLElement).getByText(formatWeight(selectedSnapshot.weight)),
     ).toBeInTheDocument();
     expect(screen.getByText(`${selectedSnapshot.macros.calories.actual}kcal`)).toBeInTheDocument();
+    expect(within(habitsCard as HTMLElement).getByText('0 / 1 complete')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Recent Workouts' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -7,13 +7,34 @@ import { RecentWorkouts } from '@/features/dashboard/components/recent-workouts'
 import { SnapshotCards } from '@/features/dashboard/components/snapshot-cards';
 import { getDashboardGreeting } from '@/features/dashboard/lib/greeting';
 import { TrendSparklines } from '@/features/dashboard/components/trend-sparkline';
-import { getToday } from '@/lib/date';
+import { useHabitEntries, useHabits } from '@/features/habits/api/habits';
+import { addDays, getToday, toDateKey } from '@/lib/date';
 import { getMockSnapshotForDate } from '@/lib/mock-data/dashboard';
 
 export function DashboardPage() {
   const [selectedDate, setSelectedDate] = useState<Date>(() => getToday());
-  const selectedSnapshot = useMemo(() => getMockSnapshotForDate(selectedDate), [selectedDate]);
+  const selectedDateKey = toDateKey(selectedDate);
+  const today = getToday();
+  const todayKey = toDateKey(today);
+  const habitRangeStart = toDateKey(addDays(today, -29));
   const greeting = getDashboardGreeting();
+
+  const habitsQuery = useHabits();
+  const selectedHabitEntriesQuery = useHabitEntries(selectedDateKey, selectedDateKey);
+  const habitChainEntriesQuery = useHabitEntries(habitRangeStart, todayKey);
+
+  const selectedSnapshot = useMemo(() => {
+    const baseSnapshot = getMockSnapshotForDate(selectedDate);
+    const habits = habitsQuery.data ?? [];
+    const entries = selectedHabitEntriesQuery.data ?? [];
+    const completedCount = entries.filter((entry) => entry.completed).length;
+
+    return {
+      ...baseSnapshot,
+      habitsCompleted: completedCount,
+      habitsTotal: habits.length,
+    };
+  }, [habitsQuery.data, selectedDate, selectedHabitEntriesQuery.data]);
 
   return (
     <main className="flex w-full flex-col gap-8 py-6">
@@ -51,7 +72,7 @@ export function DashboardPage() {
           className="order-2 flex min-w-0 flex-col gap-6 md:order-2 xl:order-1"
           data-slot="dashboard-sidebar-column"
         >
-          <HabitChain />
+          <HabitChain habits={habitsQuery.data ?? []} entries={habitChainEntriesQuery.data ?? []} />
           <TrendSparklines />
         </div>
 

--- a/apps/web/src/pages/habits.tsx
+++ b/apps/web/src/pages/habits.tsx
@@ -1,4 +1,4 @@
-import { DailyHabits, HabitHistory } from '@/features/habits';
+import { DailyHabits, HabitHistory, HabitSettings } from '@/features/habits';
 
 export function HabitsPage() {
   return (
@@ -9,6 +9,7 @@ export function HabitsPage() {
         trended over the last 90 days.
       </p>
       <DailyHabits />
+      <HabitSettings />
       <HabitHistory />
     </section>
   );

--- a/apps/web/src/pages/settings.test.tsx
+++ b/apps/web/src/pages/settings.test.tsx
@@ -1,10 +1,19 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ThemeProvider } from '@/components/theme-provider';
 import { THEME_STORAGE_KEY } from '@/hooks/useTheme';
 import { DEFAULT_SETTINGS, SETTINGS_STORAGE_KEY, SettingsPage } from '@/pages/settings';
+
+vi.mock('@/features/habits', async () => {
+  const actual = await vi.importActual<typeof import('@/features/habits')>('@/features/habits');
+
+  return {
+    ...actual,
+    HabitSettings: () => <div data-testid="habit-settings" />,
+  };
+});
 
 function renderSettingsPage() {
   return render(

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,6 +3,8 @@ import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const apiProxyTarget = process.env.VITE_API_PROXY_TARGET ?? 'http://127.0.0.1:3001';
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
@@ -12,6 +14,12 @@ export default defineConfig({
   },
   server: {
     host: true,
+    proxy: {
+      '/api': {
+        changeOrigin: true,
+        target: apiProxyTarget,
+      },
+    },
   },
   test: {
     include: ['src/**/*.{test,spec}.{ts,tsx}'],

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export * from './schemas/activities.js';
 export * from './schemas/agent-tokens.js';
 export * from './schemas/entity-links.js';
 export * from './schemas/equipment.js';
+export * from './schemas/habit-entries.js';
 export * from './schemas/habits.js';
 export * from './schemas/health-conditions.js';
 export * from './schemas/journal.js';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export * from './schemas/activities.js';
 export * from './schemas/agent-tokens.js';
 export * from './schemas/entity-links.js';
 export * from './schemas/equipment.js';
+export * from './schemas/habits.js';
 export * from './schemas/health-conditions.js';
 export * from './schemas/journal.js';
 export * from './schemas/resources.js';

--- a/packages/shared/src/schemas/habit-entries.test.ts
+++ b/packages/shared/src/schemas/habit-entries.test.ts
@@ -90,6 +90,15 @@ describe('habitEntryQueryParamsSchema', () => {
     ).toThrow();
   });
 
+  it('rejects date ranges longer than 366 days', () => {
+    expect(() =>
+      habitEntryQueryParamsSchema.parse({
+        from: '2025-01-01',
+        to: '2026-01-03',
+      }),
+    ).toThrow();
+  });
+
   it('infers the HabitEntryQueryParams type from the schema', () => {
     const payload: HabitEntryQueryParams = {
       from: '2026-03-01',

--- a/packages/shared/src/schemas/habit-entries.test.ts
+++ b/packages/shared/src/schemas/habit-entries.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createHabitEntryInputSchema,
+  habitEntryQueryParamsSchema,
+  habitEntrySchema,
+  type HabitEntry,
+  type HabitEntryQueryParams,
+  type UpdateHabitEntryInput,
+  updateHabitEntryInputSchema,
+} from './habit-entries';
+
+describe('createHabitEntryInputSchema', () => {
+  it('parses a valid habit entry payload', () => {
+    const payload = createHabitEntryInputSchema.parse({
+      date: '2026-03-07',
+      completed: true,
+      value: 8,
+    });
+
+    expect(payload).toEqual({
+      date: '2026-03-07',
+      completed: true,
+      value: 8,
+    });
+  });
+
+  it('accepts boolean-style entries without a value', () => {
+    const payload = createHabitEntryInputSchema.parse({
+      date: '2026-03-07',
+      completed: false,
+    });
+
+    expect(payload.value).toBeUndefined();
+  });
+
+  it('rejects malformed dates', () => {
+    expect(() =>
+      createHabitEntryInputSchema.parse({
+        date: '03/07/2026',
+        completed: true,
+      }),
+    ).toThrow();
+  });
+});
+
+describe('updateHabitEntryInputSchema', () => {
+  it('accepts partial updates', () => {
+    const payload = updateHabitEntryInputSchema.parse({
+      value: 45,
+    });
+
+    expect(payload).toEqual({
+      value: 45,
+    });
+  });
+
+  it('rejects empty payloads', () => {
+    expect(() => updateHabitEntryInputSchema.parse({})).toThrow();
+  });
+
+  it('infers the UpdateHabitEntryInput type from the schema', () => {
+    const payload: UpdateHabitEntryInput = {
+      completed: true,
+    };
+
+    expect(payload.completed).toBe(true);
+  });
+});
+
+describe('habitEntryQueryParamsSchema', () => {
+  it('accepts a valid inclusive date range', () => {
+    const payload = habitEntryQueryParamsSchema.parse({
+      from: '2026-03-01',
+      to: '2026-03-07',
+    });
+
+    expect(payload).toEqual({
+      from: '2026-03-01',
+      to: '2026-03-07',
+    });
+  });
+
+  it('rejects inverted date ranges', () => {
+    expect(() =>
+      habitEntryQueryParamsSchema.parse({
+        from: '2026-03-08',
+        to: '2026-03-07',
+      }),
+    ).toThrow();
+  });
+
+  it('infers the HabitEntryQueryParams type from the schema', () => {
+    const payload: HabitEntryQueryParams = {
+      from: '2026-03-01',
+      to: '2026-03-07',
+    };
+
+    expect(payload.to).toBe('2026-03-07');
+  });
+});
+
+describe('habitEntrySchema', () => {
+  it('parses persisted habit entry records', () => {
+    const payload = habitEntrySchema.parse({
+      id: 'entry-1',
+      habitId: 'habit-1',
+      userId: 'user-1',
+      date: '2026-03-07',
+      completed: true,
+      value: null,
+      createdAt: 1_700_000_000_000,
+    });
+
+    expect(payload.completed).toBe(true);
+  });
+
+  it('infers the HabitEntry type from the schema', () => {
+    const payload: HabitEntry = {
+      id: 'entry-1',
+      habitId: 'habit-1',
+      userId: 'user-1',
+      date: '2026-03-07',
+      completed: false,
+      value: 30,
+      createdAt: 1_700_000_000_000,
+    };
+
+    expect(payload.value).toBe(30);
+  });
+});

--- a/packages/shared/src/schemas/habit-entries.ts
+++ b/packages/shared/src/schemas/habit-entries.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+
+import { dateSchema } from './common.js';
+
+const habitEntryValueSchema = z.number().finite();
+
+export const createHabitEntryInputSchema = z.object({
+  date: dateSchema,
+  completed: z.boolean(),
+  value: habitEntryValueSchema.optional(),
+});
+
+export const updateHabitEntryInputSchema = z
+  .object({
+    completed: z.boolean().optional(),
+    value: habitEntryValueSchema.optional(),
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: 'At least one field is required',
+  });
+
+export const habitEntryQueryParamsSchema = z
+  .object({
+    from: dateSchema,
+    to: dateSchema,
+  })
+  .refine((value) => value.from <= value.to, {
+    message: '`from` must be on or before `to`',
+    path: ['to'],
+  });
+
+export const habitEntrySchema = z.object({
+  id: z.string(),
+  habitId: z.string(),
+  userId: z.string(),
+  date: dateSchema,
+  completed: z.boolean(),
+  value: z.number().nullable(),
+  createdAt: z.number().int(),
+});
+
+export type CreateHabitEntryInput = z.infer<typeof createHabitEntryInputSchema>;
+export type UpdateHabitEntryInput = z.infer<typeof updateHabitEntryInputSchema>;
+export type HabitEntryQueryParams = z.infer<typeof habitEntryQueryParamsSchema>;
+export type HabitEntry = z.infer<typeof habitEntrySchema>;

--- a/packages/shared/src/schemas/habit-entries.ts
+++ b/packages/shared/src/schemas/habit-entries.ts
@@ -3,6 +3,12 @@ import { z } from 'zod';
 import { dateSchema } from './common.js';
 
 const habitEntryValueSchema = z.number().finite();
+const MAX_HABIT_ENTRY_RANGE_DAYS = 366;
+
+const getUtcDateValue = (date: string) => {
+  const [year, month, day] = date.split('-').map(Number);
+  return Date.UTC(year ?? 0, (month ?? 1) - 1, day ?? 1);
+};
 
 export const createHabitEntryInputSchema = z.object({
   date: dateSchema,
@@ -27,7 +33,19 @@ export const habitEntryQueryParamsSchema = z
   .refine((value) => value.from <= value.to, {
     message: '`from` must be on or before `to`',
     path: ['to'],
-  });
+  })
+  .refine(
+    (value) => {
+      const diffDays =
+        (getUtcDateValue(value.to) - getUtcDateValue(value.from)) / (1000 * 60 * 60 * 24);
+
+      return diffDays <= MAX_HABIT_ENTRY_RANGE_DAYS;
+    },
+    {
+      message: `Date range cannot exceed ${MAX_HABIT_ENTRY_RANGE_DAYS} days`,
+      path: ['to'],
+    },
+  );
 
 export const habitEntrySchema = z.object({
   id: z.string(),

--- a/packages/shared/src/schemas/habits.test.ts
+++ b/packages/shared/src/schemas/habits.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createHabitInputSchema,
+  habitSchema,
+  type Habit,
+  type ReorderHabitsInput,
+  reorderHabitsInputSchema,
+  type UpdateHabitInput,
+  updateHabitInputSchema,
+} from './habits';
+
+describe('createHabitInputSchema', () => {
+  it('parses boolean habits without target or unit', () => {
+    const payload = createHabitInputSchema.parse({
+      name: ' Supplements ',
+      emoji: ' 💊 ',
+      trackingType: 'boolean',
+    });
+
+    expect(payload).toEqual({
+      name: 'Supplements',
+      emoji: '💊',
+      trackingType: 'boolean',
+    });
+  });
+
+  it('requires target and unit for numeric and time habits', () => {
+    expect(() =>
+      createHabitInputSchema.parse({
+        name: 'Water',
+        trackingType: 'numeric',
+      }),
+    ).toThrow();
+
+    expect(() =>
+      createHabitInputSchema.parse({
+        name: 'Sleep',
+        trackingType: 'time',
+        target: 8,
+      }),
+    ).toThrow();
+  });
+
+  it('rejects target and unit for boolean habits', () => {
+    expect(() =>
+      createHabitInputSchema.parse({
+        name: 'Meditate',
+        trackingType: 'boolean',
+        target: 1,
+        unit: 'session',
+      }),
+    ).toThrow();
+  });
+});
+
+describe('updateHabitInputSchema', () => {
+  it('accepts partial updates', () => {
+    const payload = updateHabitInputSchema.parse({
+      unit: ' hours ',
+    });
+
+    expect(payload).toEqual({
+      unit: 'hours',
+    });
+  });
+
+  it('rejects empty update payloads', () => {
+    expect(() => updateHabitInputSchema.parse({})).toThrow();
+  });
+
+  it('infers the UpdateHabitInput type from the schema', () => {
+    const payload: UpdateHabitInput = {
+      name: 'Walk',
+      trackingType: 'numeric',
+    };
+
+    expect(payload.name).toBe('Walk');
+  });
+});
+
+describe('reorderHabitsInputSchema', () => {
+  it('accepts a valid reorder payload', () => {
+    const payload = reorderHabitsInputSchema.parse({
+      items: [
+        { id: 'habit-1', sortOrder: 0 },
+        { id: 'habit-2', sortOrder: 1 },
+      ],
+    });
+
+    expect(payload.items).toHaveLength(2);
+  });
+
+  it('rejects duplicate habit ids', () => {
+    expect(() =>
+      reorderHabitsInputSchema.parse({
+        items: [
+          { id: 'habit-1', sortOrder: 0 },
+          { id: 'habit-1', sortOrder: 1 },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it('infers the ReorderHabitsInput type from the schema', () => {
+    const payload: ReorderHabitsInput = {
+      items: [{ id: 'habit-1', sortOrder: 2 }],
+    };
+
+    expect(payload.items[0]?.sortOrder).toBe(2);
+  });
+});
+
+describe('habitSchema', () => {
+  it('parses persisted habit records', () => {
+    const payload = habitSchema.parse({
+      id: 'habit-1',
+      userId: 'user-1',
+      name: 'Water',
+      emoji: '💧',
+      trackingType: 'numeric',
+      target: 8,
+      unit: 'glasses',
+      sortOrder: 0,
+      active: true,
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_100_000,
+    });
+
+    expect(payload.name).toBe('Water');
+  });
+
+  it('infers the Habit type from the schema', () => {
+    const payload: Habit = {
+      id: 'habit-1',
+      userId: 'user-1',
+      name: 'Supplements',
+      emoji: null,
+      trackingType: 'boolean',
+      target: null,
+      unit: null,
+      sortOrder: 1,
+      active: true,
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_000,
+    };
+
+    expect(payload.active).toBe(true);
+  });
+});

--- a/packages/shared/src/schemas/habits.ts
+++ b/packages/shared/src/schemas/habits.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod';
+
+export const habitTrackingTypeSchema = z.enum(['boolean', 'numeric', 'time']);
+
+const nullableTrimmedString = (maxLength: number) =>
+  z.string().trim().min(1).max(maxLength).nullable();
+
+const targetSchema = z.number().positive().nullable();
+
+const habitDefinitionFieldsSchema = z.object({
+  name: z.string().trim().min(1).max(255),
+  emoji: nullableTrimmedString(32).optional(),
+  trackingType: habitTrackingTypeSchema,
+  target: targetSchema.optional(),
+  unit: nullableTrimmedString(50).optional(),
+});
+
+const validateHabitDefinition = (
+  value: z.infer<typeof habitDefinitionFieldsSchema>,
+  context: z.RefinementCtx,
+) => {
+  const requiresTarget = value.trackingType !== 'boolean';
+  const target = value.target ?? null;
+  const unit = value.unit ?? null;
+
+  if (requiresTarget) {
+    if (target === null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Target is required for numeric and time habits',
+        path: ['target'],
+      });
+    }
+
+    if (unit === null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Unit is required for numeric and time habits',
+        path: ['unit'],
+      });
+    }
+
+    return;
+  }
+
+  if (target !== null) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Boolean habits cannot define a target',
+      path: ['target'],
+    });
+  }
+
+  if (unit !== null) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Boolean habits cannot define a unit',
+      path: ['unit'],
+    });
+  }
+};
+
+const habitDefinitionSchema = habitDefinitionFieldsSchema.superRefine(validateHabitDefinition);
+
+export const createHabitInputSchema = habitDefinitionSchema;
+
+export const updateHabitInputSchema = habitDefinitionFieldsSchema
+  .partial()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: 'At least one field is required',
+  });
+
+export const reorderHabitsInputSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        id: z.string().trim().min(1),
+        sortOrder: z.number().int().nonnegative(),
+      }),
+    )
+    .min(1)
+    .refine((items) => new Set(items.map((item) => item.id)).size === items.length, {
+      message: 'Habit ids must be unique',
+    }),
+});
+
+export const habitSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  name: z.string(),
+  emoji: z.string().nullable(),
+  trackingType: habitTrackingTypeSchema,
+  target: z.number().nullable(),
+  unit: z.string().nullable(),
+  sortOrder: z.number().int().nonnegative(),
+  active: z.boolean(),
+  createdAt: z.number().int(),
+  updatedAt: z.number().int(),
+});
+
+export type HabitTrackingType = z.infer<typeof habitTrackingTypeSchema>;
+export type CreateHabitInput = z.infer<typeof createHabitInputSchema>;
+export type UpdateHabitInput = z.infer<typeof updateHabitInputSchema>;
+export type ReorderHabitsInput = z.infer<typeof reorderHabitsInputSchema>;
+export type Habit = z.infer<typeof habitSchema>;


### PR DESCRIPTION
## Summary

This PR takes habits from mock-driven UI to a fully wired end-to-end feature across the shared package, API, and web app. It adds authenticated habit definition and habit entry endpoints, then connects the daily habits, settings, history, and dashboard surfaces to those live APIs with TanStack Query. The main goal is to let each user create and manage habits, record daily completion/value data, and see habit chains update from persisted data instead of local mocks. It also adds broad automated coverage so the new flow is exercised at the schema, API, component, and browser levels.

## Key Changes

- Added shared Zod schemas and tests for habit definitions and habit entries in `@pulse/shared`
- Registered new Fastify routes for:
  - `/api/v1/habits` CRUD operations
  - `/api/v1/habits/:id/entries` create/list for a specific habit
  - `/api/v1/habit-entries` date-range listing
  - `/api/v1/habit-entries/:id` partial updates
- Implemented user-scoped store logic for habit CRUD, sort ordering, soft delete behavior, and habit entry persistence
- Added habit entry upsert behavior so each habit/date pair resolves to a single stored entry instead of duplicate rows
- Built frontend habits API utilities, query keys, and query client integration for fetching and mutating habits data
- Replaced mock data in the daily habits view with live queries and mutations for check-off/value updates
- Wired habit settings and history screens to create, edit, delete, and fetch persisted habits/entries
- Updated dashboard habit-related components so chains and snapshot cards reflect real habits data
- Added API route tests, shared schema tests, frontend API/component/page tests, and a Playwright habits E2E flow

## Technical Notes

- All new API paths are protected by auth and explicitly scoped by `userId`; reviewers should pay attention to the not-found behavior for out-of-scope habits and entries, since that is part of the data isolation model.
- Habit entry writes use an upsert-by-`habitId`+`date` approach. That simplifies the daily tracking UX, but it also means repeated submissions for the same day intentionally overwrite the existing entry rather than create a history of edits.
- Validation stays centralized in shared Zod schemas, and the API returns the project-standard `{ data }` / `{ error }` response shape throughout the new routes.
- The web layer now depends on TanStack Query invalidation to keep the daily view, settings/history screens, and dashboard chain UI in sync after mutations; reviewers should focus on whether cache refresh coverage matches the expected user flows.
- Playwright and test setup were updated to support the new habits end-to-end path, including creating a habit, checking it off, and verifying the dashboard chain reflects persisted state.

## Commits

- `6fb67d5 feat(web): add habits end-to-end flow`
- `24d3002 feat(web): wire habits daily view to api`
- `d46e747 feat(api): add habit entry routes`
- `be51d3a feat(api): add habits CRUD routes`

## Tasks

- **Habits CRUD API**: Create, read, update, delete habit definitions scoped to userId
- **Habit entries API**: Log daily habit entries, read entries by date range, toggle completion
- **Wire habits daily view to API**: Replace mock data with TanStack Query hooks, connect check-off to mutations
- **Wire habits config + history to API**: Connect create/edit/delete to mutations, history view to query with date range
- **E2E: habits flow**: Playwright test for create habit, check off, verify chain on dashboard

## Diff Stats

```
apps/api/src/index.ts                              |   4 +
 apps/api/src/routes/habit-entries/index.test.ts    | 484 +++++++++++++++++++
 apps/api/src/routes/habit-entries/index.ts         | 126 +++++
 apps/api/src/routes/habit-entries/store.test.ts    | 221 +++++++++
 apps/api/src/routes/habit-entries/store.ts         | 180 +++++++
 apps/api/src/routes/habits/index.test.ts           | 454 ++++++++++++++++++
 apps/api/src/routes/habits/index.ts                | 137 ++++++
 apps/api/src/routes/habits/store.ts                | 173 +++++++
 apps/web/e2e/habits.spec.ts                        | 102 ++++
 apps/web/e2e/smoke.spec.ts                         |   4 +-
 apps/web/package.json                              |   6 +-
 apps/web/playwright.config.ts                      |  25 +-
 apps/web/src/App.tsx                               |  13 +-
 .../src/__tests__/components/daily-habits.test.tsx | 225 +++++++--
 .../features/dashboard/components/habit-chain.tsx  | 189 +++++---
 .../dashboard/components/snapshot-cards.test.tsx   |  32 +-
 .../dashboard/components/snapshot-cards.tsx        |  27 +-
 apps/web/src/features/habits/api/habits.test.tsx   | 167 +++++++
 apps/web/src/features/habits/api/habits.ts         | 400 ++++++++++++++++
 apps/web/src/features/habits/api/keys.ts           |   6 +
 .../features/habits/components/daily-habits.tsx    | 515 +++++++++++++--------
 .../src/features/habits/components/habit-form.tsx  |   2 +-
 .../habits/components/habit-settings.test.tsx      | 225 +++++++--
 .../features/habits/components/habit-settings.tsx  | 175 ++++---
 apps/web/src/lib/api-client.ts                     | 123 +++++
 apps/web/src/lib/query-client.ts                   |  15 +
 apps/web/src/pages/dashboard.test.tsx              |  65 +++
 apps/web/src/pages/dashboard.tsx                   |  27 +-
 apps/web/src/pages/settings.test.tsx               |  11 +-
 apps/web/vite.config.ts                            |   8 +
 packages/shared/src/index.ts                       |   2 +
 packages/shared/src/schemas/habit-entries.test.ts  | 131 ++++++
 packages/shared/src/schemas/habit-entries.ts       |  45 ++
 packages/shared/src/schemas/habits.test.ts         | 150 ++++++
 packages/shared/src/schemas/habits.ts              | 105 +++++
 pnpm-lock.yaml                                     |  21 +
 36 files changed, 4177 insertions(+), 418 deletions(-)
```