### PR TITLE
Frontend auth flows

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,8 +12,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@radix-ui/react-checkbox": "^1.3.3",
     "@pulse/shared": "workspace:*",
+    "@radix-ui/react-checkbox": "^1.3.3",
+    "@tanstack/react-query": "^5.90.21",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",
@@ -22,7 +23,9 @@
     "react-dom": "^19.0.0",
     "react-router": "^7.13.1",
     "recharts": "^3.7.0",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^3.25.76",
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@pulse/shared": "workspace:*",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@tanstack/react-query": "^5.90.21",
@@ -21,6 +22,7 @@
     "radix-ui": "^1.4.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.71.2",
     "react-router": "^7.13.1",
     "recharts": "^3.7.0",
     "tailwind-merge": "^3.5.0",

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -3,12 +3,17 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import App from '@/App';
 import { ThemeProvider } from '@/components/theme-provider';
 import { workoutCompletedSessions } from '@/features/workouts';
+import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
+import { useAuthStore } from '@/store/auth-store';
 
 const sessionId = workoutCompletedSessions[0]?.id ?? 'session-upper-push-2026-03-02';
 
-const pageRoutes = [
+const guestRoutes = [
   { heading: 'Welcome back', path: '/login' },
   { heading: 'Create account', path: '/register' },
+] as const;
+
+const protectedRoutes = [
   { heading: 'Dashboard', path: '/' },
   { heading: 'Design System', path: '/design-system' },
   { heading: 'Workouts', path: '/workouts' },
@@ -47,23 +52,68 @@ function renderApp() {
   );
 }
 
+function setGuestState() {
+  window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
+  useAuthStore.setState({
+    user: null,
+    token: null,
+    isAuthenticated: false,
+    hasHydrated: true,
+    isLoading: false,
+    error: null,
+  });
+}
+
+function setAuthenticatedState() {
+  window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
+  useAuthStore.setState({
+    user: {
+      id: 'user-1',
+      username: 'derek',
+      name: 'Derek',
+    },
+    token: 'test-token',
+    isAuthenticated: true,
+    hasHydrated: true,
+    isLoading: false,
+    error: null,
+  });
+}
+
 describe('App', () => {
   beforeEach(() => {
     window.localStorage.removeItem('pulse-theme');
     document.documentElement.classList.remove('dark');
     document.documentElement.classList.remove('theme-midnight');
     window.history.pushState({}, '', '/');
+    setGuestState();
   });
 
-  it.each(pageRoutes)('renders $heading page for $path', ({ heading, path }) => {
-    window.history.pushState({}, '', path);
+  it.each(guestRoutes)(
+    'renders $heading page for $path when signed out',
+    async ({ heading, path }) => {
+      window.history.pushState({}, '', path);
 
-    renderApp();
+      renderApp();
 
-    expect(screen.getByRole('heading', { name: heading })).toBeInTheDocument();
-  });
+      expect(await screen.findByRole('heading', { name: heading })).toBeInTheDocument();
+    },
+  );
+
+  it.each(protectedRoutes)(
+    'renders $heading page for $path when signed in',
+    async ({ heading, path }) => {
+      setAuthenticatedState();
+      window.history.pushState({}, '', path);
+
+      renderApp();
+
+      expect(await screen.findByRole('heading', { name: heading })).toBeInTheDocument();
+    },
+  );
 
   it('renders navigation links for all app routes', () => {
+    setAuthenticatedState();
     renderApp();
 
     navRoutes.forEach(({ heading, path }) => {
@@ -78,6 +128,7 @@ describe('App', () => {
   });
 
   it.each(['/login', '/register'])('renders %s as a standalone auth page', (path) => {
+    setGuestState();
     window.history.pushState({}, '', path);
 
     renderApp();

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -7,6 +7,8 @@ import { workoutCompletedSessions } from '@/features/workouts';
 const sessionId = workoutCompletedSessions[0]?.id ?? 'session-upper-push-2026-03-02';
 
 const pageRoutes = [
+  { heading: 'Welcome back', path: '/login' },
+  { heading: 'Create account', path: '/register' },
   { heading: 'Dashboard', path: '/' },
   { heading: 'Design System', path: '/design-system' },
   { heading: 'Workouts', path: '/workouts' },
@@ -73,5 +75,17 @@ describe('App', () => {
     });
 
     expect(screen.queryByRole('link', { name: /^Settings$/i })).not.toBeInTheDocument();
+  });
+
+  it.each(['/login', '/register'])('renders %s as a standalone auth page', (path) => {
+    window.history.pushState({}, '', path);
+
+    renderApp();
+
+    expect(screen.queryByRole('link', { name: /^Dashboard$/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('navigation', { name: 'Desktop navigation' }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('navigation', { name: 'Mobile navigation' })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,8 +10,10 @@ import { HabitsPage } from '@/pages/habits';
 import { InjuriesPage } from '@/pages/injuries';
 import { InjuryDetailPage } from '@/pages/injury-detail';
 import { JournalPage } from '@/pages/journal';
+import { LoginPage } from '@/pages/login';
 import { NutritionPage } from '@/pages/nutrition';
 import { ProfilePage } from '@/pages/profile';
+import { RegisterPage } from '@/pages/register';
 import { ResourceDetailPage } from '@/pages/resource-detail';
 import { ResourcesPage } from '@/pages/resources';
 import { SettingsPage } from '@/pages/settings';
@@ -22,29 +24,31 @@ import { WorkoutsPage } from '@/pages/workouts';
 
 function AppRoutes() {
   return (
-    <AppLayout>
-      <Routes>
-        <Route element={<DashboardPage />} path="/" />
-        <Route element={<DesignSystemPage />} path="/design-system" />
-        <Route element={<WorkoutsPage />} path="/workouts" />
-        <Route element={<ActiveWorkoutPage />} path="/workouts/active" />
-        <Route element={<WorkoutSessionDetailPage />} path="/workouts/session/:sessionId" />
-        <Route element={<WorkoutTemplateDetailPage />} path="/workouts/template/:templateId" />
-        <Route element={<NutritionPage />} path="/nutrition" />
-        <Route element={<HabitsPage />} path="/habits" />
-        <Route element={<ActivityPage />} path="/activity" />
-        <Route element={<FoodsPage />} path="/foods" />
-        <Route element={<JournalPage />} path="/journal" />
-        <Route element={<JournalEntryPage />} path="/journal/:entryId" />
-        <Route element={<ProfilePage />} path="/profile" />
-        <Route element={<EquipmentRoutePage />} path="/profile/equipment" />
-        <Route element={<InjuriesPage />} path="/profile/injuries" />
-        <Route element={<InjuryDetailPage />} path="/profile/injuries/:conditionId" />
-        <Route element={<ResourcesPage />} path="/profile/resources" />
-        <Route element={<ResourceDetailPage />} path="/profile/resources/:resourceId" />
-        <Route element={<SettingsPage />} path="/settings" />
-      </Routes>
-    </AppLayout>
+    <Routes>
+      <Route element={<LoginPage />} path="/login" />
+      <Route element={<RegisterPage />} path="/register" />
+      <Route element={<AppLayout />} path="/">
+        <Route element={<DashboardPage />} index />
+        <Route element={<DesignSystemPage />} path="design-system" />
+        <Route element={<WorkoutsPage />} path="workouts" />
+        <Route element={<ActiveWorkoutPage />} path="workouts/active" />
+        <Route element={<WorkoutSessionDetailPage />} path="workouts/session/:sessionId" />
+        <Route element={<WorkoutTemplateDetailPage />} path="workouts/template/:templateId" />
+        <Route element={<NutritionPage />} path="nutrition" />
+        <Route element={<HabitsPage />} path="habits" />
+        <Route element={<ActivityPage />} path="activity" />
+        <Route element={<FoodsPage />} path="foods" />
+        <Route element={<JournalPage />} path="journal" />
+        <Route element={<JournalEntryPage />} path="journal/:entryId" />
+        <Route element={<ProfilePage />} path="profile" />
+        <Route element={<EquipmentRoutePage />} path="profile/equipment" />
+        <Route element={<InjuriesPage />} path="profile/injuries" />
+        <Route element={<InjuryDetailPage />} path="profile/injuries/:conditionId" />
+        <Route element={<ResourcesPage />} path="profile/resources" />
+        <Route element={<ResourceDetailPage />} path="profile/resources/:resourceId" />
+        <Route element={<SettingsPage />} path="settings" />
+      </Route>
+    </Routes>
   );
 }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,6 @@
 import { BrowserRouter, Route, Routes } from 'react-router';
+import { GuestRoute } from '@/components/auth/guest-route';
+import { ProtectedRoute } from '@/components/auth/protected-route';
 import { AppLayout } from '@/components/layout/app-layout';
 import { ActivityPage } from '@/pages/activity';
 import { DashboardPage } from '@/pages/dashboard';
@@ -25,9 +27,30 @@ import { WorkoutsPage } from '@/pages/workouts';
 function AppRoutes() {
   return (
     <Routes>
-      <Route element={<LoginPage />} path="/login" />
-      <Route element={<RegisterPage />} path="/register" />
-      <Route element={<AppLayout />} path="/">
+      <Route
+        element={
+          <GuestRoute>
+            <LoginPage />
+          </GuestRoute>
+        }
+        path="/login"
+      />
+      <Route
+        element={
+          <GuestRoute>
+            <RegisterPage />
+          </GuestRoute>
+        }
+        path="/register"
+      />
+      <Route
+        element={
+          <ProtectedRoute>
+            <AppLayout />
+          </ProtectedRoute>
+        }
+        path="/"
+      >
         <Route element={<DashboardPage />} index />
         <Route element={<DesignSystemPage />} path="design-system" />
         <Route element={<WorkoutsPage />} path="workouts" />

--- a/apps/web/src/components/auth/auth-route-loader.tsx
+++ b/apps/web/src/components/auth/auth-route-loader.tsx
@@ -1,0 +1,16 @@
+import { LoaderCircle } from 'lucide-react';
+
+export function AuthRouteLoader() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4 text-foreground">
+      <div
+        aria-live="polite"
+        className="flex items-center gap-3 rounded-xl border border-border/60 bg-card px-4 py-3 shadow-sm"
+        role="status"
+      >
+        <LoaderCircle aria-hidden="true" className="size-4 animate-spin text-primary" />
+        <span className="text-sm font-medium">Loading your session...</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/auth/guest-route.test.tsx
+++ b/apps/web/src/components/auth/guest-route.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GuestRoute } from '@/components/auth/guest-route';
+import { useAuthStore } from '@/store/auth-store';
+
+vi.mock('@/store/auth-store', () => ({
+  useAuthStore: vi.fn(),
+}));
+
+type MockAuthStore = {
+  login: ReturnType<typeof vi.fn>;
+  register: ReturnType<typeof vi.fn>;
+  logout: ReturnType<typeof vi.fn>;
+  hydrate: ReturnType<typeof vi.fn>;
+  clearError: ReturnType<typeof vi.fn>;
+  user: null;
+  token: string | null;
+  isAuthenticated: boolean;
+  hasHydrated: boolean;
+  isLoading: boolean;
+  error: string | null;
+};
+
+const mockedUseAuthStore = vi.mocked(useAuthStore);
+
+function createAuthStore(overrides: Partial<MockAuthStore> = {}): MockAuthStore {
+  return {
+    login: vi.fn().mockResolvedValue(undefined),
+    register: vi.fn().mockResolvedValue(undefined),
+    logout: vi.fn(),
+    hydrate: vi.fn(),
+    clearError: vi.fn(),
+    user: null,
+    token: null,
+    isAuthenticated: false,
+    hasHydrated: true,
+    isLoading: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+function renderGuestRoute(store = createAuthStore()) {
+  mockedUseAuthStore.mockReturnValue(store);
+
+  return render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Routes>
+        <Route
+          path="/login"
+          element={
+            <GuestRoute>
+              <h1>Login page</h1>
+            </GuestRoute>
+          }
+        />
+        <Route path="/" element={<h1>Dashboard page</h1>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('GuestRoute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders children when not authenticated', () => {
+    renderGuestRoute();
+
+    expect(screen.getByRole('heading', { name: 'Login page' })).toBeInTheDocument();
+  });
+
+  it('redirects to / when authenticated', () => {
+    renderGuestRoute(
+      createAuthStore({
+        isAuthenticated: true,
+      }),
+    );
+
+    expect(screen.getByRole('heading', { name: 'Dashboard page' })).toBeInTheDocument();
+  });
+
+  it('shows a loading state while hydrating', async () => {
+    const store = createAuthStore({
+      hasHydrated: false,
+    });
+
+    renderGuestRoute(store);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Loading your session');
+    await waitFor(() => {
+      expect(store.hydrate).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web/src/components/auth/guest-route.tsx
+++ b/apps/web/src/components/auth/guest-route.tsx
@@ -1,22 +1,7 @@
 import { type PropsWithChildren, useEffect } from 'react';
-import { LoaderCircle } from 'lucide-react';
 import { Navigate, Outlet } from 'react-router';
+import { AuthRouteLoader } from '@/components/auth/auth-route-loader';
 import { useAuthStore } from '@/store/auth-store';
-
-function AuthRouteLoader() {
-  return (
-    <div className="flex min-h-screen items-center justify-center bg-background px-4 text-foreground">
-      <div
-        aria-live="polite"
-        className="flex items-center gap-3 rounded-xl border border-border/60 bg-card px-4 py-3 shadow-sm"
-        role="status"
-      >
-        <LoaderCircle aria-hidden="true" className="size-4 animate-spin text-primary" />
-        <span className="text-sm font-medium">Loading your session...</span>
-      </div>
-    </div>
-  );
-}
 
 export function GuestRoute({ children }: PropsWithChildren) {
   const { hasHydrated, hydrate, isAuthenticated } = useAuthStore();

--- a/apps/web/src/components/auth/guest-route.tsx
+++ b/apps/web/src/components/auth/guest-route.tsx
@@ -1,0 +1,39 @@
+import { type PropsWithChildren, useEffect } from 'react';
+import { LoaderCircle } from 'lucide-react';
+import { Navigate, Outlet } from 'react-router';
+import { useAuthStore } from '@/store/auth-store';
+
+function AuthRouteLoader() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4 text-foreground">
+      <div
+        aria-live="polite"
+        className="flex items-center gap-3 rounded-xl border border-border/60 bg-card px-4 py-3 shadow-sm"
+        role="status"
+      >
+        <LoaderCircle aria-hidden="true" className="size-4 animate-spin text-primary" />
+        <span className="text-sm font-medium">Loading your session...</span>
+      </div>
+    </div>
+  );
+}
+
+export function GuestRoute({ children }: PropsWithChildren) {
+  const { hasHydrated, hydrate, isAuthenticated } = useAuthStore();
+
+  useEffect(() => {
+    if (!hasHydrated) {
+      hydrate();
+    }
+  }, [hasHydrated, hydrate]);
+
+  if (!hasHydrated) {
+    return <AuthRouteLoader />;
+  }
+
+  if (isAuthenticated) {
+    return <Navigate replace to="/" />;
+  }
+
+  return children ?? <Outlet />;
+}

--- a/apps/web/src/components/auth/protected-route.test.tsx
+++ b/apps/web/src/components/auth/protected-route.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProtectedRoute } from '@/components/auth/protected-route';
+import { useAuthStore } from '@/store/auth-store';
+
+vi.mock('@/store/auth-store', () => ({
+  useAuthStore: vi.fn(),
+}));
+
+type MockAuthStore = {
+  login: ReturnType<typeof vi.fn>;
+  register: ReturnType<typeof vi.fn>;
+  logout: ReturnType<typeof vi.fn>;
+  hydrate: ReturnType<typeof vi.fn>;
+  clearError: ReturnType<typeof vi.fn>;
+  user: null;
+  token: string | null;
+  isAuthenticated: boolean;
+  hasHydrated: boolean;
+  isLoading: boolean;
+  error: string | null;
+};
+
+const mockedUseAuthStore = vi.mocked(useAuthStore);
+
+function createAuthStore(overrides: Partial<MockAuthStore> = {}): MockAuthStore {
+  return {
+    login: vi.fn().mockResolvedValue(undefined),
+    register: vi.fn().mockResolvedValue(undefined),
+    logout: vi.fn(),
+    hydrate: vi.fn(),
+    clearError: vi.fn(),
+    user: null,
+    token: null,
+    isAuthenticated: false,
+    hasHydrated: true,
+    isLoading: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+function renderProtectedRoute(store = createAuthStore()) {
+  mockedUseAuthStore.mockReturnValue(store);
+
+  return render(
+    <MemoryRouter initialEntries={['/dashboard']}>
+      <Routes>
+        <Route path="/login" element={<h1>Login page</h1>} />
+        <Route
+          path="/dashboard"
+          element={
+            <ProtectedRoute>
+              <h1>Dashboard page</h1>
+            </ProtectedRoute>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('ProtectedRoute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders children when authenticated', () => {
+    renderProtectedRoute(
+      createAuthStore({
+        isAuthenticated: true,
+      }),
+    );
+
+    expect(screen.getByRole('heading', { name: 'Dashboard page' })).toBeInTheDocument();
+  });
+
+  it('redirects to /login when not authenticated', () => {
+    renderProtectedRoute();
+
+    expect(screen.getByRole('heading', { name: 'Login page' })).toBeInTheDocument();
+  });
+
+  it('shows a loading state while hydrating', async () => {
+    const store = createAuthStore({
+      hasHydrated: false,
+    });
+
+    renderProtectedRoute(store);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Loading your session');
+    await waitFor(() => {
+      expect(store.hydrate).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web/src/components/auth/protected-route.tsx
+++ b/apps/web/src/components/auth/protected-route.tsx
@@ -1,22 +1,7 @@
 import { type PropsWithChildren, useEffect } from 'react';
-import { LoaderCircle } from 'lucide-react';
 import { Navigate, Outlet } from 'react-router';
+import { AuthRouteLoader } from '@/components/auth/auth-route-loader';
 import { useAuthStore } from '@/store/auth-store';
-
-function AuthRouteLoader() {
-  return (
-    <div className="flex min-h-screen items-center justify-center bg-background px-4 text-foreground">
-      <div
-        aria-live="polite"
-        className="flex items-center gap-3 rounded-xl border border-border/60 bg-card px-4 py-3 shadow-sm"
-        role="status"
-      >
-        <LoaderCircle aria-hidden="true" className="size-4 animate-spin text-primary" />
-        <span className="text-sm font-medium">Loading your session...</span>
-      </div>
-    </div>
-  );
-}
 
 export function ProtectedRoute({ children }: PropsWithChildren) {
   const { hasHydrated, hydrate, isAuthenticated } = useAuthStore();

--- a/apps/web/src/components/auth/protected-route.tsx
+++ b/apps/web/src/components/auth/protected-route.tsx
@@ -1,0 +1,39 @@
+import { type PropsWithChildren, useEffect } from 'react';
+import { LoaderCircle } from 'lucide-react';
+import { Navigate, Outlet } from 'react-router';
+import { useAuthStore } from '@/store/auth-store';
+
+function AuthRouteLoader() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4 text-foreground">
+      <div
+        aria-live="polite"
+        className="flex items-center gap-3 rounded-xl border border-border/60 bg-card px-4 py-3 shadow-sm"
+        role="status"
+      >
+        <LoaderCircle aria-hidden="true" className="size-4 animate-spin text-primary" />
+        <span className="text-sm font-medium">Loading your session...</span>
+      </div>
+    </div>
+  );
+}
+
+export function ProtectedRoute({ children }: PropsWithChildren) {
+  const { hasHydrated, hydrate, isAuthenticated } = useAuthStore();
+
+  useEffect(() => {
+    if (!hasHydrated) {
+      hydrate();
+    }
+  }, [hasHydrated, hydrate]);
+
+  if (!hasHydrated) {
+    return <AuthRouteLoader />;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate replace to="/login" />;
+  }
+
+  return children ?? <Outlet />;
+}

--- a/apps/web/src/components/layout/app-layout.tsx
+++ b/apps/web/src/components/layout/app-layout.tsx
@@ -1,13 +1,16 @@
 import type { PropsWithChildren } from 'react';
+import { Outlet } from 'react-router';
 import { BottomNav } from '@/components/layout/bottom-nav';
 import { Sidebar } from '@/components/layout/sidebar';
 
 export function AppLayout({ children }: PropsWithChildren) {
+  const content = children ?? <Outlet />;
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <div className="mx-auto flex min-h-screen w-full max-w-screen-2xl">
         <Sidebar />
-        <main className="min-w-0 flex-1 px-4 pb-24 pt-6 md:px-8 md:pb-8 md:pt-8">{children}</main>
+        <main className="min-w-0 flex-1 px-4 pb-24 pt-6 md:px-8 md:pb-8 md:pt-8">{content}</main>
       </div>
       <BottomNav />
     </div>

--- a/apps/web/src/components/layout/bottom-nav.test.tsx
+++ b/apps/web/src/components/layout/bottom-nav.test.tsx
@@ -1,9 +1,60 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { BottomNav } from '@/components/layout/bottom-nav';
+import { useAuthStore } from '@/store/auth-store';
 
-function renderBottomNav(initialPath = '/') {
+const mockNavigate = vi.fn();
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('@/store/auth-store', () => ({
+  useAuthStore: vi.fn(),
+}));
+
+type MockAuthStore = {
+  login: ReturnType<typeof vi.fn>;
+  register: ReturnType<typeof vi.fn>;
+  logout: ReturnType<typeof vi.fn>;
+  hydrate: ReturnType<typeof vi.fn>;
+  clearError: ReturnType<typeof vi.fn>;
+  user: null;
+  token: string | null;
+  isAuthenticated: boolean;
+  hasHydrated: boolean;
+  isLoading: boolean;
+  error: string | null;
+};
+
+const mockedUseAuthStore = vi.mocked(useAuthStore);
+
+function createAuthStore(overrides: Partial<MockAuthStore> = {}): MockAuthStore {
+  return {
+    login: vi.fn().mockResolvedValue(undefined),
+    register: vi.fn().mockResolvedValue(undefined),
+    logout: vi.fn(),
+    hydrate: vi.fn(),
+    clearError: vi.fn(),
+    user: null,
+    token: 'token-1',
+    isAuthenticated: true,
+    hasHydrated: true,
+    isLoading: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+function renderBottomNav(initialPath = '/', store = createAuthStore()) {
+  mockedUseAuthStore.mockReturnValue(store);
+
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
       <BottomNav />
@@ -22,6 +73,10 @@ function renderBottomNav(initialPath = '/') {
 }
 
 describe('BottomNav', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('opens the More menu with activity, foods, journal, and profile links', () => {
     renderBottomNav('/');
 
@@ -40,6 +95,7 @@ describe('BottomNav', () => {
     expect(screen.getByRole('menuitem', { name: 'Journal' })).toHaveClass('cursor-pointer');
     expect(screen.getByRole('menuitem', { name: 'Profile' })).toHaveAttribute('href', '/profile');
     expect(screen.getByRole('menuitem', { name: 'Profile' })).toHaveClass('cursor-pointer');
+    expect(screen.getByRole('menuitem', { name: 'Log out' })).toBeInTheDocument();
   });
 
   it('highlights More on more-menu routes and navigates from the dropdown', () => {
@@ -53,6 +109,19 @@ describe('BottomNav', () => {
     fireEvent.click(screen.getByRole('menuitem', { name: 'Profile' }));
 
     expect(screen.getByRole('heading', { name: 'Profile Route' })).toBeInTheDocument();
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('logs out and navigates to /login from the More menu', () => {
+    const store = createAuthStore();
+
+    renderBottomNav('/', store);
+
+    fireEvent.click(screen.getByRole('button', { name: 'More' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Log out' }));
+
+    expect(store.logout).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/layout/bottom-nav.tsx
+++ b/apps/web/src/components/layout/bottom-nav.tsx
@@ -1,17 +1,27 @@
 import { useEffect, useRef, useState } from 'react';
-import { NavLink, useLocation } from 'react-router';
+import { LogOut } from 'lucide-react';
+import { NavLink, useLocation, useNavigate } from 'react-router';
 import { cn } from '@/lib/utils';
 import { moreNavIcon, moreNavItems, primaryNavItems } from '@/components/layout/nav-items';
+import { useAuthStore } from '@/store/auth-store';
 
 const moreRoutes = new Set(moreNavItems.map((item) => item.to));
 
 export function BottomNav() {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuContainerRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
   const { pathname } = useLocation();
+  const { logout } = useAuthStore();
 
   const MoreIcon = moreNavIcon;
   const isMoreActive = moreRoutes.has(pathname);
+
+  function handleLogout() {
+    setMenuOpen(false);
+    logout();
+    navigate('/login', { replace: true });
+  }
 
   useEffect(() => {
     if (!menuOpen) {
@@ -104,6 +114,15 @@ export function BottomNav() {
                   </NavLink>
                 );
               })}
+              <button
+                className="flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm text-foreground transition-colors hover:bg-secondary"
+                onClick={handleLogout}
+                role="menuitem"
+                type="button"
+              >
+                <LogOut aria-hidden="true" className="size-4" />
+                <span>Log out</span>
+              </button>
             </div>
           ) : null}
         </div>

--- a/apps/web/src/components/layout/sidebar.test.tsx
+++ b/apps/web/src/components/layout/sidebar.test.tsx
@@ -114,4 +114,12 @@ describe('Sidebar', () => {
     expect(store.logout).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
   });
+
+  it('keeps the collapsed avatar focusable for keyboard users', () => {
+    window.localStorage.setItem('pulse-sidebar-collapsed', 'true');
+
+    renderSidebar();
+
+    expect(screen.getByLabelText('Derek')).toHaveAttribute('tabindex', '0');
+  });
 });

--- a/apps/web/src/components/layout/sidebar.test.tsx
+++ b/apps/web/src/components/layout/sidebar.test.tsx
@@ -1,7 +1,43 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Sidebar } from '@/components/layout/sidebar';
+import { useAuthStore } from '@/store/auth-store';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('@/store/auth-store', () => ({
+  useAuthStore: vi.fn(),
+}));
+
+type MockAuthStore = {
+  login: ReturnType<typeof vi.fn>;
+  register: ReturnType<typeof vi.fn>;
+  logout: ReturnType<typeof vi.fn>;
+  hydrate: ReturnType<typeof vi.fn>;
+  clearError: ReturnType<typeof vi.fn>;
+  user: {
+    id: string;
+    username: string;
+    name: string | null;
+  } | null;
+  token: string | null;
+  isAuthenticated: boolean;
+  hasHydrated: boolean;
+  isLoading: boolean;
+  error: string | null;
+};
+
+const mockedUseAuthStore = vi.mocked(useAuthStore);
 
 const navLinks = [
   { label: 'Dashboard', path: '/' },
@@ -14,13 +50,45 @@ const navLinks = [
   { label: 'Profile', path: '/profile' },
 ] as const;
 
+function createAuthStore(overrides: Partial<MockAuthStore> = {}): MockAuthStore {
+  return {
+    login: vi.fn().mockResolvedValue(undefined),
+    register: vi.fn().mockResolvedValue(undefined),
+    logout: vi.fn(),
+    hydrate: vi.fn(),
+    clearError: vi.fn(),
+    user: {
+      id: 'user-1',
+      username: 'derek',
+      name: 'Derek',
+    },
+    token: 'token-1',
+    isAuthenticated: true,
+    hasHydrated: true,
+    isLoading: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+function renderSidebar(store = createAuthStore()) {
+  mockedUseAuthStore.mockReturnValue(store);
+
+  return render(
+    <MemoryRouter initialEntries={['/nutrition']}>
+      <Sidebar />
+    </MemoryRouter>,
+  );
+}
+
 describe('Sidebar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
   it('renders all nav links and highlights the active route', () => {
-    render(
-      <MemoryRouter initialEntries={['/nutrition']}>
-        <Sidebar />
-      </MemoryRouter>,
-    );
+    renderSidebar();
 
     navLinks.forEach(({ label, path }) => {
       const link = screen.getByRole('link', { name: label });
@@ -32,5 +100,18 @@ describe('Sidebar', () => {
 
     expect(activeLink).toHaveAttribute('aria-current', 'page');
     expect(activeLink).toHaveClass('bg-primary');
+    expect(screen.getByText('Derek')).toBeInTheDocument();
+    expect(screen.getByText('@derek')).toBeInTheDocument();
+  });
+
+  it('logs out and navigates to /login', () => {
+    const store = createAuthStore();
+
+    renderSidebar(store);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Log out' }));
+
+    expect(store.logout).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
   });
 });

--- a/apps/web/src/components/layout/sidebar.test.tsx
+++ b/apps/web/src/components/layout/sidebar.test.tsx
@@ -115,11 +115,11 @@ describe('Sidebar', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
   });
 
-  it('keeps the collapsed avatar focusable for keyboard users', () => {
+  it('renders the collapsed avatar without adding it to the tab order', () => {
     window.localStorage.setItem('pulse-sidebar-collapsed', 'true');
 
     renderSidebar();
 
-    expect(screen.getByLabelText('Derek')).toHaveAttribute('tabindex', '0');
+    expect(screen.getByLabelText('Derek')).not.toHaveAttribute('tabindex');
   });
 });

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -141,13 +141,12 @@ export function Sidebar() {
             {collapsed ? (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <div
+                  <span
                     aria-label={displayName}
                     className="flex size-10 items-center justify-center rounded-full bg-primary/12 text-sm font-semibold text-primary"
-                    tabIndex={0}
                   >
                     {avatarLabel}
-                  </div>
+                  </span>
                 </TooltipTrigger>
                 <TooltipContent side="right" sideOffset={8}>
                   {displayName}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import { NavLink } from 'react-router';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { NavLink, useNavigate } from 'react-router';
+import { ChevronLeft, ChevronRight, LogOut } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { sidebarNavItems } from '@/components/layout/nav-items';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useAuthStore } from '@/store/auth-store';
 
 function getInitialCollapsed() {
   try {
@@ -16,6 +17,11 @@ function getInitialCollapsed() {
 
 export function Sidebar() {
   const [collapsed, setCollapsed] = useState(getInitialCollapsed);
+  const navigate = useNavigate();
+  const { logout, user } = useAuthStore();
+  const displayName = user?.name?.trim() || user?.username || 'Account';
+  const subtitle = user?.name ? `@${user.username}` : 'Signed in';
+  const avatarLabel = displayName.charAt(0).toUpperCase() || 'A';
 
   function toggleCollapsed() {
     setCollapsed((prev) => {
@@ -31,6 +37,11 @@ export function Sidebar() {
     });
   }
 
+  function handleLogout() {
+    logout();
+    navigate('/login', { replace: true });
+  }
+
   return (
     <aside
       className={cn(
@@ -38,87 +49,149 @@ export function Sidebar() {
         collapsed ? 'w-[4.5rem]' : 'w-[17rem]',
       )}
     >
-      <div className="flex items-center justify-between border-b border-border/40 px-4 py-6">
-        {collapsed ? (
-          <p className="w-full text-center text-2xl font-extrabold tracking-tight text-primary font-display">
-            P
-          </p>
-        ) : (
-          <p className="px-2 text-2xl font-extrabold tracking-tight text-primary font-display">
-            Pulse
-          </p>
-        )}
-        <button
-          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          className="flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-lg text-muted transition-colors hover:bg-secondary hover:text-foreground"
-          onClick={toggleCollapsed}
-          type="button"
-        >
-          {collapsed ? (
-            <ChevronRight className="size-4" aria-hidden="true" />
-          ) : (
-            <ChevronLeft className="size-4" aria-hidden="true" />
-          )}
-        </button>
-      </div>
-
       <TooltipProvider delayDuration={0}>
-        <nav
-          className={cn(
-            'flex flex-1 flex-col gap-1 overflow-y-auto py-4',
-            collapsed ? 'items-center' : 'px-3',
-          )}
-          aria-label="Desktop navigation"
-        >
-          {sidebarNavItems.map((item) => {
-            const Icon = item.icon;
+        <div className="flex h-full flex-col">
+          <div className="flex items-center justify-between border-b border-border/40 px-4 py-6">
+            {collapsed ? (
+              <p className="w-full text-center text-2xl font-extrabold tracking-tight text-primary font-display">
+                P
+              </p>
+            ) : (
+              <p className="px-2 text-2xl font-extrabold tracking-tight text-primary font-display">
+                Pulse
+              </p>
+            )}
+            <button
+              aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+              className="flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-lg text-muted transition-colors hover:bg-secondary hover:text-foreground"
+              onClick={toggleCollapsed}
+              type="button"
+            >
+              {collapsed ? (
+                <ChevronRight className="size-4" aria-hidden="true" />
+              ) : (
+                <ChevronLeft className="size-4" aria-hidden="true" />
+              )}
+            </button>
+          </div>
 
-            if (collapsed) {
+          <nav
+            className={cn(
+              'flex flex-1 flex-col gap-1 overflow-y-auto py-4',
+              collapsed ? 'items-center' : 'px-3',
+            )}
+            aria-label="Desktop navigation"
+          >
+            {sidebarNavItems.map((item) => {
+              const Icon = item.icon;
+
+              if (collapsed) {
+                return (
+                  <Tooltip key={item.to}>
+                    <TooltipTrigger asChild>
+                      <NavLink className="block" end={item.end} to={item.to}>
+                        {({ isActive }) => (
+                          <span
+                            className={cn(
+                              'flex size-10 items-center justify-center rounded-xl transition-colors',
+                              isActive
+                                ? 'bg-primary text-primary-foreground shadow-sm shadow-primary/25'
+                                : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
+                            )}
+                          >
+                            <Icon className="size-[18px]" aria-hidden="true" />
+                          </span>
+                        )}
+                      </NavLink>
+                    </TooltipTrigger>
+                    <TooltipContent side="right" sideOffset={8}>
+                      {item.label}
+                    </TooltipContent>
+                  </Tooltip>
+                );
+              }
+
               return (
-                <Tooltip key={item.to}>
-                  <TooltipTrigger asChild>
-                    <NavLink className="block" end={item.end} to={item.to}>
-                      {({ isActive }) => (
-                        <span
-                          className={cn(
-                            'flex size-10 items-center justify-center rounded-xl transition-colors',
-                            isActive
-                              ? 'bg-primary text-primary-foreground shadow-sm shadow-primary/25'
-                              : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
-                          )}
-                        >
-                          <Icon className="size-[18px]" aria-hidden="true" />
-                        </span>
-                      )}
-                    </NavLink>
-                  </TooltipTrigger>
-                  <TooltipContent side="right" sideOffset={8}>
-                    {item.label}
-                  </TooltipContent>
-                </Tooltip>
+                <NavLink
+                  key={item.to}
+                  className={({ isActive }) =>
+                    cn(
+                      'flex min-h-10 cursor-pointer items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-all duration-200',
+                      isActive
+                        ? 'bg-primary text-primary-foreground shadow-sm shadow-primary/25'
+                        : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
+                    )
+                  }
+                  end={item.end}
+                  to={item.to}
+                >
+                  <Icon className="size-[18px]" aria-hidden="true" />
+                  <span>{item.label}</span>
+                </NavLink>
               );
-            }
+            })}
+          </nav>
 
-            return (
-              <NavLink
-                key={item.to}
-                className={({ isActive }) =>
-                  cn(
-                    'flex min-h-10 cursor-pointer items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-all duration-200',
-                    isActive
-                      ? 'bg-primary text-primary-foreground shadow-sm shadow-primary/25'
-                      : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
-                  )
-                }
-                end={item.end}
-                to={item.to}
+          <div
+            className={cn(
+              'border-t border-border/40 py-4',
+              collapsed ? 'flex items-center justify-center px-2' : 'space-y-3 px-3',
+            )}
+          >
+            {collapsed ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div
+                    aria-label={displayName}
+                    className="flex size-10 items-center justify-center rounded-full bg-primary/12 text-sm font-semibold text-primary"
+                  >
+                    {avatarLabel}
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="right" sideOffset={8}>
+                  {displayName}
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <div className="flex items-center gap-3 rounded-xl border border-border/50 bg-background/70 px-3 py-2">
+                <div className="flex size-10 items-center justify-center rounded-full bg-primary/12 text-sm font-semibold text-primary">
+                  {avatarLabel}
+                </div>
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-foreground">{displayName}</p>
+                  <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
+                </div>
+              </div>
+            )}
+
+            {collapsed ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    aria-label="Log out"
+                    className="flex size-10 cursor-pointer items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+                    onClick={handleLogout}
+                    type="button"
+                  >
+                    <LogOut className="size-[18px]" aria-hidden="true" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="right" sideOffset={8}>
+                  Log out
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <button
+                className="flex min-h-10 w-full cursor-pointer items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium text-muted-foreground transition-all duration-200 hover:bg-secondary hover:text-foreground"
+                onClick={handleLogout}
+                type="button"
               >
-                <Icon className="size-[18px]" aria-hidden="true" />
-                <span>{item.label}</span>
-              </NavLink>
-            );
-          })}
-        </nav>
+                <LogOut className="size-[18px]" aria-hidden="true" />
+                <span>Log out</span>
+              </button>
+            )}
+          </div>
+        </div>
       </TooltipProvider>
     </aside>
   );

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -21,7 +21,7 @@ export function Sidebar() {
   const { logout, user } = useAuthStore();
   const displayName = user?.name?.trim() || user?.username || 'Account';
   const subtitle = user?.name ? `@${user.username}` : 'Signed in';
-  const avatarLabel = displayName.charAt(0).toUpperCase() || 'A';
+  const avatarLabel = displayName.charAt(0).toUpperCase();
 
   function toggleCollapsed() {
     setCollapsed((prev) => {
@@ -144,6 +144,7 @@ export function Sidebar() {
                   <div
                     aria-label={displayName}
                     className="flex size-10 items-center justify-center rounded-full bg-primary/12 text-sm font-semibold text-primary"
+                    tabIndex={0}
                   >
                     {avatarLabel}
                   </div>

--- a/apps/web/src/features/auth/components/login-form.test.tsx
+++ b/apps/web/src/features/auth/components/login-form.test.tsx
@@ -124,4 +124,24 @@ describe('LoginForm', () => {
 
     expect(screen.getByRole('button', { name: /signing in/i })).toBeDisabled();
   });
+
+  it('does not call onSuccess when login rejects', async () => {
+    const { onSuccess, store } = renderLoginForm(
+      createAuthStore({
+        login: vi.fn().mockRejectedValue(new Error('Invalid username or password')),
+      }),
+    );
+
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'derek' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'supersecret' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    await waitFor(() => {
+      expect(store.login).toHaveBeenCalledWith({
+        username: 'derek',
+        password: 'supersecret',
+      });
+    });
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/features/auth/components/login-form.test.tsx
+++ b/apps/web/src/features/auth/components/login-form.test.tsx
@@ -18,6 +18,7 @@ type MockAuthStore = {
   user: null;
   token: null;
   isAuthenticated: boolean;
+  hasHydrated: boolean;
   isLoading: boolean;
   error: string | null;
 };
@@ -34,6 +35,7 @@ function createAuthStore(overrides: Partial<MockAuthStore> = {}): MockAuthStore 
     user: null,
     token: null,
     isAuthenticated: false,
+    hasHydrated: true,
     isLoading: false,
     error: null,
     ...overrides,

--- a/apps/web/src/features/auth/components/login-form.test.tsx
+++ b/apps/web/src/features/auth/components/login-form.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LoginForm } from '@/features/auth';
+import { useAuthStore } from '@/store/auth-store';
+
+vi.mock('@/store/auth-store', () => ({
+  useAuthStore: vi.fn(),
+}));
+
+type MockAuthStore = {
+  login: ReturnType<typeof vi.fn>;
+  register: ReturnType<typeof vi.fn>;
+  logout: ReturnType<typeof vi.fn>;
+  hydrate: ReturnType<typeof vi.fn>;
+  clearError: ReturnType<typeof vi.fn>;
+  user: null;
+  token: null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  error: string | null;
+};
+
+const mockedUseAuthStore = vi.mocked(useAuthStore);
+
+function createAuthStore(overrides: Partial<MockAuthStore> = {}): MockAuthStore {
+  return {
+    login: vi.fn().mockResolvedValue(undefined),
+    register: vi.fn().mockResolvedValue(undefined),
+    logout: vi.fn(),
+    hydrate: vi.fn(),
+    clearError: vi.fn(),
+    user: null,
+    token: null,
+    isAuthenticated: false,
+    isLoading: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+function renderLoginForm(store = createAuthStore()) {
+  const onSuccess = vi.fn();
+  mockedUseAuthStore.mockReturnValue(store);
+
+  render(
+    <MemoryRouter>
+      <LoginForm onSuccess={onSuccess} registerHref="/register" />
+    </MemoryRouter>,
+  );
+
+  return { onSuccess, store };
+}
+
+describe('LoginForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders username and password fields', () => {
+    renderLoginForm();
+
+    expect(screen.getByLabelText('Username')).toBeInTheDocument();
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
+  });
+
+  it('shows validation errors when submitting an empty form', async () => {
+    renderLoginForm();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    expect(await screen.findByText(/at least 3 character/i)).toBeInTheDocument();
+    expect(await screen.findByText(/at least 1 character/i)).toBeInTheDocument();
+  });
+
+  it('calls auth store login with form values on submit', async () => {
+    const { onSuccess, store } = renderLoginForm();
+
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'derek' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'supersecret' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    await waitFor(() => {
+      expect(store.login).toHaveBeenCalledWith({
+        username: 'derek',
+        password: 'supersecret',
+      });
+    });
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('displays the API error message when login fails', () => {
+    renderLoginForm(
+      createAuthStore({
+        error: 'Invalid username or password',
+      }),
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Invalid username or password');
+  });
+
+  it('clears the API error when the user edits an input', () => {
+    const store = createAuthStore({
+      error: 'Invalid username or password',
+    });
+
+    renderLoginForm(store);
+
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'new-user' } });
+
+    expect(store.clearError).toHaveBeenCalled();
+  });
+
+  it('disables the submit button while loading', () => {
+    renderLoginForm(
+      createAuthStore({
+        isLoading: true,
+      }),
+    );
+
+    expect(screen.getByRole('button', { name: /signing in/i })).toBeDisabled();
+  });
+});

--- a/apps/web/src/features/auth/components/login-form.tsx
+++ b/apps/web/src/features/auth/components/login-form.tsx
@@ -1,0 +1,120 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { loginInputSchema, type LoginInput } from '@pulse/shared';
+import { LoaderCircle } from 'lucide-react';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { Link } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
+import { useAuthStore } from '@/store/auth-store';
+
+type LoginFormProps = {
+  onSuccess: () => void;
+  registerHref: string;
+};
+
+export function LoginForm({ onSuccess, registerHref }: LoginFormProps) {
+  const { login, isLoading, error, clearError } = useAuthStore();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginInput>({
+    resolver: zodResolver(loginInputSchema),
+    defaultValues: {
+      username: '',
+      password: '',
+    },
+  });
+
+  useEffect(() => {
+    clearError();
+  }, [clearError]);
+
+  async function onSubmit(values: LoginInput) {
+    await login(values);
+    onSuccess();
+  }
+
+  function handleInputChange() {
+    if (error) {
+      clearError();
+    }
+  }
+
+  return (
+    <Card className="w-full max-w-sm">
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-2xl">Welcome back</CardTitle>
+        <CardDescription>
+          Sign in to continue tracking workouts, habits, and recovery.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form className="space-y-5" onSubmit={handleSubmit(onSubmit)}>
+          <div className="space-y-2">
+            <Label htmlFor="login-username">Username</Label>
+            <Input
+              id="login-username"
+              aria-invalid={errors.username ? true : undefined}
+              autoComplete="username"
+              disabled={isLoading}
+              placeholder="derek"
+              {...register('username', { onChange: handleInputChange })}
+            />
+            {errors.username ? (
+              <p className="text-sm text-destructive">{errors.username.message}</p>
+            ) : null}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="login-password">Password</Label>
+            <Input
+              id="login-password"
+              aria-invalid={errors.password ? true : undefined}
+              autoComplete="current-password"
+              disabled={isLoading}
+              placeholder="Enter your password"
+              type="password"
+              {...register('password', { onChange: handleInputChange })}
+            />
+            {errors.password ? (
+              <p className="text-sm text-destructive">{errors.password.message}</p>
+            ) : null}
+          </div>
+
+          {error ? (
+            <p
+              className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              role="alert"
+            >
+              {error}
+            </p>
+          ) : null}
+
+          <Button className="w-full" disabled={isLoading} type="submit">
+            {isLoading ? (
+              <>
+                <LoaderCircle className="size-4 animate-spin" />
+                Signing in...
+              </>
+            ) : (
+              'Sign in'
+            )}
+          </Button>
+
+          <p className="text-center text-sm text-muted-foreground">
+            Don&apos;t have an account?{' '}
+            <Link className={cn('font-medium text-primary hover:underline')} to={registerHref}>
+              Register
+            </Link>
+          </p>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/features/auth/components/login-form.tsx
+++ b/apps/web/src/features/auth/components/login-form.tsx
@@ -36,8 +36,12 @@ export function LoginForm({ onSuccess, registerHref }: LoginFormProps) {
   }, [clearError]);
 
   async function onSubmit(values: LoginInput) {
-    await login(values);
-    onSuccess();
+    try {
+      await login(values);
+      onSuccess();
+    } catch {
+      // Auth store state already exposes the API error for the form UI.
+    }
   }
 
   function handleInputChange() {

--- a/apps/web/src/features/auth/components/register-form.test.tsx
+++ b/apps/web/src/features/auth/components/register-form.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RegisterForm } from '@/features/auth';
+import { useAuthStore } from '@/store/auth-store';
+
+vi.mock('@/store/auth-store', () => ({
+  useAuthStore: vi.fn(),
+}));
+
+type MockAuthStore = {
+  login: ReturnType<typeof vi.fn>;
+  register: ReturnType<typeof vi.fn>;
+  logout: ReturnType<typeof vi.fn>;
+  hydrate: ReturnType<typeof vi.fn>;
+  clearError: ReturnType<typeof vi.fn>;
+  user: null;
+  token: null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  error: string | null;
+};
+
+const mockedUseAuthStore = vi.mocked(useAuthStore);
+
+function createAuthStore(overrides: Partial<MockAuthStore> = {}): MockAuthStore {
+  return {
+    login: vi.fn().mockResolvedValue(undefined),
+    register: vi.fn().mockResolvedValue(undefined),
+    logout: vi.fn(),
+    hydrate: vi.fn(),
+    clearError: vi.fn(),
+    user: null,
+    token: null,
+    isAuthenticated: false,
+    isLoading: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+function renderRegisterForm(store = createAuthStore()) {
+  const onSuccess = vi.fn();
+  mockedUseAuthStore.mockReturnValue(store);
+
+  render(
+    <MemoryRouter>
+      <RegisterForm loginHref="/login" onSuccess={onSuccess} />
+    </MemoryRouter>,
+  );
+
+  return { onSuccess, store };
+}
+
+describe('RegisterForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders username, password, and name fields', () => {
+    renderRegisterForm();
+
+    expect(screen.getByLabelText('Username')).toBeInTheDocument();
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+    expect(screen.getByLabelText('Name (optional)')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create account' })).toBeInTheDocument();
+  });
+
+  it('shows validation errors for short username and password', async () => {
+    renderRegisterForm();
+
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'ab' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'short' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    expect(await screen.findByText(/at least 3 character/i)).toBeInTheDocument();
+    expect(await screen.findByText(/at least 8 character/i)).toBeInTheDocument();
+  });
+
+  it('calls auth store register with form values on submit', async () => {
+    const { onSuccess, store } = renderRegisterForm();
+
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'derek' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'supersecret' } });
+    fireEvent.change(screen.getByLabelText('Name (optional)'), { target: { value: 'Derek' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    await waitFor(() => {
+      expect(store.register).toHaveBeenCalledWith({
+        username: 'derek',
+        password: 'supersecret',
+        name: 'Derek',
+      });
+    });
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the API error when registration fails', () => {
+    renderRegisterForm(
+      createAuthStore({
+        error: 'Username is already taken',
+      }),
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Username is already taken');
+  });
+
+  it('clears the API error when the user edits an input', () => {
+    const store = createAuthStore({
+      error: 'Username is already taken',
+    });
+
+    renderRegisterForm(store);
+
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'new-user' } });
+
+    expect(store.clearError).toHaveBeenCalled();
+  });
+
+  it('disables the submit button while loading', () => {
+    renderRegisterForm(
+      createAuthStore({
+        isLoading: true,
+      }),
+    );
+
+    expect(screen.getByRole('button', { name: /creating account/i })).toBeDisabled();
+  });
+});

--- a/apps/web/src/features/auth/components/register-form.test.tsx
+++ b/apps/web/src/features/auth/components/register-form.test.tsx
@@ -18,6 +18,7 @@ type MockAuthStore = {
   user: null;
   token: null;
   isAuthenticated: boolean;
+  hasHydrated: boolean;
   isLoading: boolean;
   error: string | null;
 };
@@ -34,6 +35,7 @@ function createAuthStore(overrides: Partial<MockAuthStore> = {}): MockAuthStore 
     user: null,
     token: null,
     isAuthenticated: false,
+    hasHydrated: true,
     isLoading: false,
     error: null,
     ...overrides,

--- a/apps/web/src/features/auth/components/register-form.test.tsx
+++ b/apps/web/src/features/auth/components/register-form.test.tsx
@@ -129,4 +129,26 @@ describe('RegisterForm', () => {
 
     expect(screen.getByRole('button', { name: /creating account/i })).toBeDisabled();
   });
+
+  it('does not call onSuccess when registration rejects', async () => {
+    const { onSuccess, store } = renderRegisterForm(
+      createAuthStore({
+        register: vi.fn().mockRejectedValue(new Error('Username is already taken')),
+      }),
+    );
+
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'derek' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'supersecret' } });
+    fireEvent.change(screen.getByLabelText('Name (optional)'), { target: { value: 'Derek' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    await waitFor(() => {
+      expect(store.register).toHaveBeenCalledWith({
+        username: 'derek',
+        password: 'supersecret',
+        name: 'Derek',
+      });
+    });
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/features/auth/components/register-form.tsx
+++ b/apps/web/src/features/auth/components/register-form.tsx
@@ -37,8 +37,12 @@ export function RegisterForm({ loginHref, onSuccess }: RegisterFormProps) {
   }, [clearError]);
 
   async function onSubmit(values: RegisterInput) {
-    await registerUser(values);
-    onSuccess();
+    try {
+      await registerUser(values);
+      onSuccess();
+    } catch {
+      // Auth store state already exposes the API error for the form UI.
+    }
   }
 
   function handleInputChange() {

--- a/apps/web/src/features/auth/components/register-form.tsx
+++ b/apps/web/src/features/auth/components/register-form.tsx
@@ -1,0 +1,137 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { registerInputSchema, type RegisterInput } from '@pulse/shared';
+import { LoaderCircle } from 'lucide-react';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { Link } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
+import { useAuthStore } from '@/store/auth-store';
+
+type RegisterFormProps = {
+  loginHref: string;
+  onSuccess: () => void;
+};
+
+export function RegisterForm({ loginHref, onSuccess }: RegisterFormProps) {
+  const { register: registerUser, isLoading, error, clearError } = useAuthStore();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<RegisterInput>({
+    resolver: zodResolver(registerInputSchema),
+    defaultValues: {
+      username: '',
+      password: '',
+      name: '',
+    },
+  });
+
+  useEffect(() => {
+    clearError();
+  }, [clearError]);
+
+  async function onSubmit(values: RegisterInput) {
+    await registerUser(values);
+    onSuccess();
+  }
+
+  function handleInputChange() {
+    if (error) {
+      clearError();
+    }
+  }
+
+  return (
+    <Card className="w-full max-w-sm">
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-2xl">Set your credentials</CardTitle>
+        <CardDescription>
+          Set up your Pulse account to start tracking your health data.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form className="space-y-5" onSubmit={handleSubmit(onSubmit)}>
+          <div className="space-y-2">
+            <Label htmlFor="register-username">Username</Label>
+            <Input
+              id="register-username"
+              aria-invalid={errors.username ? true : undefined}
+              autoComplete="username"
+              disabled={isLoading}
+              placeholder="derek"
+              {...register('username', { onChange: handleInputChange })}
+            />
+            {errors.username ? (
+              <p className="text-sm text-destructive">{errors.username.message}</p>
+            ) : null}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="register-password">Password</Label>
+            <Input
+              id="register-password"
+              aria-invalid={errors.password ? true : undefined}
+              autoComplete="new-password"
+              disabled={isLoading}
+              placeholder="At least 8 characters"
+              type="password"
+              {...register('password', { onChange: handleInputChange })}
+            />
+            {errors.password ? (
+              <p className="text-sm text-destructive">{errors.password.message}</p>
+            ) : null}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="register-name">Name (optional)</Label>
+            <Input
+              id="register-name"
+              aria-invalid={errors.name ? true : undefined}
+              autoComplete="name"
+              disabled={isLoading}
+              placeholder="Derek"
+              {...register('name', {
+                onChange: handleInputChange,
+                setValueAs: (value: string) => (value.trim() ? value : undefined),
+              })}
+            />
+            {errors.name ? <p className="text-sm text-destructive">{errors.name.message}</p> : null}
+          </div>
+
+          {error ? (
+            <p
+              className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              role="alert"
+            >
+              {error}
+            </p>
+          ) : null}
+
+          <Button className="w-full" disabled={isLoading} type="submit">
+            {isLoading ? (
+              <>
+                <LoaderCircle className="size-4 animate-spin" />
+                Creating account...
+              </>
+            ) : (
+              'Create account'
+            )}
+          </Button>
+
+          <p className="text-center text-sm text-muted-foreground">
+            Already have an account?{' '}
+            <Link className={cn('font-medium text-primary hover:underline')} to={loginHref}>
+              Sign in
+            </Link>
+          </p>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/features/auth/index.ts
+++ b/apps/web/src/features/auth/index.ts
@@ -1,0 +1,2 @@
+export { LoginForm } from './components/login-form';
+export { RegisterForm } from './components/register-form';

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { API_TOKEN_STORAGE_KEY, ApiError, apiRequest } from './api-client';
+
+describe('api-client', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('DEV', false);
+    window.localStorage.clear();
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('sends GET requests to the resolved URL with the auth header when a token exists', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.pulse.test');
+    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'jwt-123');
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ data: { id: 'habit-1' } }), {
+        status: 200,
+      }),
+    );
+
+    const response = await apiRequest<{ id: string }>('/api/v1/habits/habit-1');
+
+    expect(response).toEqual({ id: 'habit-1' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    const headers = new Headers(init?.headers);
+
+    expect(url).toBe('https://api.pulse.test/api/v1/habits/habit-1');
+    expect(headers.get('Authorization')).toBe('Bearer jwt-123');
+  });
+
+  it('sends POST requests with a JSON body and content-type header', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ data: { token: 'jwt-123' } }), {
+        status: 200,
+      }),
+    );
+
+    await apiRequest<{ token: string }>('/api/v1/auth/login', {
+      method: 'POST',
+      body: {
+        username: 'derek',
+        password: 'super-secret-password',
+      },
+    });
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const headers = new Headers(init?.headers);
+
+    expect(init?.method).toBe('POST');
+    expect(headers.get('Content-Type')).toBe('application/json');
+    expect(init?.body).toBe(
+      JSON.stringify({
+        username: 'derek',
+        password: 'super-secret-password',
+      }),
+    );
+  });
+
+  it('omits the auth header when there is no stored token', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ data: { ok: true } }), {
+        status: 200,
+      }),
+    );
+
+    await apiRequest<{ ok: boolean }>('/api/v1/profile');
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const headers = new Headers(init?.headers);
+
+    expect(headers.has('Authorization')).toBe(false);
+  });
+
+  it('throws ApiError with the backend code and message for non-2xx responses', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 'INVALID_CREDENTIALS',
+            message: 'Invalid username or password',
+          },
+        }),
+        { status: 401 },
+      ),
+    );
+
+    await expect(apiRequest('/api/v1/auth/login')).rejects.toMatchObject({
+      status: 401,
+      code: 'INVALID_CREDENTIALS',
+      message: 'Invalid username or password',
+    } satisfies Partial<ApiError>);
+  });
+
+  it('clears the stored token on 401 responses', async () => {
+    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'expired-token');
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 'INVALID_CREDENTIALS',
+            message: 'Invalid username or password',
+          },
+        }),
+        { status: 401 },
+      ),
+    );
+
+    await expect(apiRequest('/api/v1/profile')).rejects.toBeInstanceOf(ApiError);
+
+    expect(window.localStorage.getItem(API_TOKEN_STORAGE_KEY)).toBeNull();
+  });
+
+  it('unwraps the data envelope', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ data: { userId: 'user-1' } }), {
+        status: 200,
+      }),
+    );
+
+    const payload = await apiRequest<{ userId: string }>('/api/v1/profile');
+
+    expect(payload).toEqual({ userId: 'user-1' });
+  });
+
+  it('auto-registers a dev user when no token exists in DEV mode', async () => {
+    vi.stubEnv('DEV', true);
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: { token: 'dev-token' } }), {
+          status: 201,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: [{ id: 'habit-1' }] }), {
+          status: 200,
+        }),
+      );
+
+    const payload = await apiRequest<Array<{ id: string }>>('/api/v1/habits');
+
+    expect(payload).toEqual([{ id: 'habit-1' }]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/auth/register');
+    expect(fetchMock.mock.calls[0]?.[1]?.body).toBe(
+      JSON.stringify({
+        username: 'pulse-dev',
+        password: 'pulse-dev-password',
+        name: 'Pulse Dev',
+      }),
+    );
+    expect(window.localStorage.getItem(API_TOKEN_STORAGE_KEY)).toBe('dev-token');
+
+    const requestHeaders = new Headers(fetchMock.mock.calls[1]?.[1]?.headers);
+    expect(requestHeaders.get('Authorization')).toBe('Bearer dev-token');
+  });
+
+  it('falls back to login when dev auto-register receives a 409', async () => {
+    vi.stubEnv('DEV', true);
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 'USERNAME_TAKEN',
+              message: 'Username is already taken',
+            },
+          }),
+          { status: 409 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: { token: 'login-token' } }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: { id: 'profile-1' } }), {
+          status: 200,
+        }),
+      );
+
+    const payload = await apiRequest<{ id: string }>('/api/v1/profile');
+
+    expect(payload).toEqual({ id: 'profile-1' });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/auth/register');
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('/api/v1/auth/login');
+    expect(window.localStorage.getItem(API_TOKEN_STORAGE_KEY)).toBe('login-token');
+
+    const requestHeaders = new Headers(fetchMock.mock.calls[2]?.[1]?.headers);
+    expect(requestHeaders.get('Authorization')).toBe('Bearer login-token');
+  });
+});

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { API_TOKEN_STORAGE_KEY, ApiError, apiRequest } from './api-client';
+import { AUTH_STORAGE_KEY } from './auth-storage';
 
 describe('api-client', () => {
   const fetchMock = vi.fn<typeof fetch>();
@@ -102,6 +103,20 @@ describe('api-client', () => {
 
   it('clears the stored token on 401 responses', async () => {
     window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'expired-token');
+    window.localStorage.setItem(
+      AUTH_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          token: 'expired-token',
+          user: {
+            id: 'user-1',
+            username: 'derek',
+            name: 'Derek',
+          },
+        },
+        version: 0,
+      }),
+    );
     fetchMock.mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -117,6 +132,7 @@ describe('api-client', () => {
     await expect(apiRequest('/api/v1/profile')).rejects.toBeInstanceOf(ApiError);
 
     expect(window.localStorage.getItem(API_TOKEN_STORAGE_KEY)).toBeNull();
+    expect(window.localStorage.getItem(AUTH_STORAGE_KEY)).toBeNull();
   });
 
   it('unwraps the data envelope', async () => {
@@ -133,6 +149,8 @@ describe('api-client', () => {
 
   it('auto-registers a dev user when no token exists in DEV mode', async () => {
     vi.stubEnv('DEV', true);
+    vi.stubEnv('VITE_PULSE_DEV_USERNAME', 'pulse-dev');
+    vi.stubEnv('VITE_PULSE_DEV_PASSWORD', 'pulse-dev-password');
     fetchMock
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ data: { token: 'dev-token' } }), {
@@ -154,7 +172,7 @@ describe('api-client', () => {
       JSON.stringify({
         username: 'pulse-dev',
         password: 'pulse-dev-password',
-        name: 'Pulse Dev',
+        name: 'pulse-dev',
       }),
     );
     expect(window.localStorage.getItem(API_TOKEN_STORAGE_KEY)).toBe('dev-token');
@@ -165,6 +183,8 @@ describe('api-client', () => {
 
   it('falls back to login when dev auto-register receives a 409', async () => {
     vi.stubEnv('DEV', true);
+    vi.stubEnv('VITE_PULSE_DEV_USERNAME', 'pulse-dev');
+    vi.stubEnv('VITE_PULSE_DEV_PASSWORD', 'pulse-dev-password');
     fetchMock
       .mockResolvedValueOnce(
         new Response(
@@ -198,5 +218,23 @@ describe('api-client', () => {
 
     const requestHeaders = new Headers(fetchMock.mock.calls[2]?.[1]?.headers);
     expect(requestHeaders.get('Authorization')).toBe('Bearer login-token');
+  });
+
+  it('allows empty success bodies for 204 responses', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(null, {
+        status: 204,
+      }),
+    );
+
+    await expect(apiRequest<null>('/api/v1/auth/logout', { method: 'POST' })).resolves.toBeNull();
+  });
+
+  it('requires explicit dev auto-session credentials when running in DEV mode', async () => {
+    vi.stubEnv('DEV', true);
+
+    await expect(apiRequest('/api/v1/profile')).rejects.toThrow(
+      'VITE_PULSE_DEV_USERNAME and VITE_PULSE_DEV_PASSWORD must be set for dev auto-session',
+    );
   });
 });

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,4 +1,4 @@
-export const API_TOKEN_STORAGE_KEY = 'pulse-auth-token';
+import { clearStoredAuthState, getStoredToken, setStoredToken } from './auth-storage';
 
 const JSON_CONTENT_TYPE = 'application/json';
 const AUTH_PATH_PREFIX = '/api/v1/auth/';
@@ -33,6 +33,8 @@ interface DevAuthResponse {
   token: string;
 }
 
+export { API_TOKEN_STORAGE_KEY } from './auth-storage';
+
 export class ApiError extends Error {
   readonly status: number;
   readonly code?: string;
@@ -60,10 +62,19 @@ function isDevMode(): boolean {
 }
 
 function getDevCredentials(): DevAuthPayload {
+  const username = import.meta.env.VITE_PULSE_DEV_USERNAME;
+  const password = import.meta.env.VITE_PULSE_DEV_PASSWORD;
+
+  if (!username || !password) {
+    throw new Error(
+      'VITE_PULSE_DEV_USERNAME and VITE_PULSE_DEV_PASSWORD must be set for dev auto-session',
+    );
+  }
+
   return {
-    username: import.meta.env.VITE_PULSE_DEV_USERNAME ?? 'pulse-dev',
-    password: import.meta.env.VITE_PULSE_DEV_PASSWORD ?? 'pulse-dev-password',
-    name: import.meta.env.VITE_PULSE_DEV_NAME ?? 'Pulse Dev',
+    username,
+    password,
+    name: import.meta.env.VITE_PULSE_DEV_NAME ?? username,
   };
 }
 
@@ -84,42 +95,6 @@ function buildUrl(path: string): string {
   const baseUrl = getApiBaseUrl().replace(/\/$/, '');
 
   return baseUrl ? `${baseUrl}${normalizedPath}` : normalizedPath;
-}
-
-function getStoredToken(): string | null {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-
-  try {
-    return window.localStorage.getItem(API_TOKEN_STORAGE_KEY);
-  } catch {
-    return null;
-  }
-}
-
-function setStoredToken(token: string): void {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  try {
-    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, token);
-  } catch {
-    // Ignore storage failures so requests can still proceed with in-memory auth.
-  }
-}
-
-function clearStoredToken(): void {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  try {
-    window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
-  } catch {
-    // Ignore storage failures so error handling still completes.
-  }
 }
 
 function isRawBody(body: ApiRequestInit['body']): body is BodyInit {
@@ -252,7 +227,7 @@ async function toApiError(response: Response): Promise<ApiError> {
   const message = payload?.error?.message ?? `Request failed with status ${response.status}`;
 
   if (response.status === 401) {
-    clearStoredToken();
+    clearStoredAuthState();
   }
 
   return new ApiError(response.status, message, code);
@@ -284,7 +259,7 @@ function createRequestInit(init: ApiRequestInit | undefined, token: string | nul
   };
 }
 
-async function performRequest<T>(path: string, init?: ApiRequestInit): Promise<T> {
+async function performRequest<T>(path: string, init?: ApiRequestInit): Promise<T | null> {
   const token = await resolveSessionToken({
     allowDevAutoSession: !normalizePath(path).startsWith(AUTH_PATH_PREFIX),
   });
@@ -297,6 +272,10 @@ async function performRequest<T>(path: string, init?: ApiRequestInit): Promise<T
   const payload = await parseJson<T>(response);
 
   if (payload == null) {
+    if (response.status === 204 || response.status === 205) {
+      return null;
+    }
+
     throw new ApiError(response.status, 'Missing response payload');
   }
 
@@ -309,7 +288,7 @@ export async function getSessionToken(): Promise<string> {
 
 export async function apiRequest<T>(path: string, init?: ApiRequestInit): Promise<T> {
   const payload = await performRequest<ApiSuccessEnvelope<T>>(path, init);
-  return payload.data;
+  return payload?.data ?? (null as T);
 }
 
 export async function apiRequestWithMeta<T, M>(
@@ -317,6 +296,14 @@ export async function apiRequestWithMeta<T, M>(
   init?: ApiRequestInit,
 ): Promise<{ data: T; meta: M }> {
   const payload = await performRequest<ApiSuccessEnvelopeWithMeta<T, M>>(path, init);
+
+  if (payload == null) {
+    return {
+      data: null as T,
+      meta: null as M,
+    };
+  }
+
   return {
     data: payload.data,
     meta: payload.meta,

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,0 +1,324 @@
+export const API_TOKEN_STORAGE_KEY = 'pulse-auth-token';
+
+const JSON_CONTENT_TYPE = 'application/json';
+const AUTH_PATH_PREFIX = '/api/v1/auth/';
+
+export interface ApiRequestInit extends Omit<RequestInit, 'body'> {
+  body?: BodyInit | Record<string, unknown> | unknown[] | null;
+}
+
+interface ApiSuccessEnvelope<T> {
+  data: T;
+}
+
+interface ApiSuccessEnvelopeWithMeta<T, M> {
+  data: T;
+  meta: M;
+}
+
+interface ApiErrorEnvelope {
+  error?: {
+    code?: string;
+    message?: string;
+  };
+}
+
+interface DevAuthPayload {
+  username: string;
+  password: string;
+  name?: string;
+}
+
+interface DevAuthResponse {
+  token: string;
+}
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly code?: string;
+
+  constructor(status: number, message: string, code?: string) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+let devSessionPromise: Promise<string> | null = null;
+
+function getApiBaseUrl(): string {
+  return import.meta.env.VITE_API_BASE_URL ?? '';
+}
+
+function getEnvToken(): string | null {
+  return import.meta.env.VITE_PULSE_JWT_TOKEN || null;
+}
+
+function isDevMode(): boolean {
+  return Boolean(import.meta.env.DEV);
+}
+
+function getDevCredentials(): DevAuthPayload {
+  return {
+    username: import.meta.env.VITE_PULSE_DEV_USERNAME ?? 'pulse-dev',
+    password: import.meta.env.VITE_PULSE_DEV_PASSWORD ?? 'pulse-dev-password',
+    name: import.meta.env.VITE_PULSE_DEV_NAME ?? 'Pulse Dev',
+  };
+}
+
+function normalizePath(path: string): string {
+  if (/^https?:\/\//.test(path)) {
+    return path;
+  }
+
+  return path.startsWith('/') ? path : `/${path}`;
+}
+
+function buildUrl(path: string): string {
+  if (/^https?:\/\//.test(path)) {
+    return path;
+  }
+
+  const normalizedPath = normalizePath(path);
+  const baseUrl = getApiBaseUrl().replace(/\/$/, '');
+
+  return baseUrl ? `${baseUrl}${normalizedPath}` : normalizedPath;
+}
+
+function getStoredToken(): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(API_TOKEN_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function setStoredToken(token: string): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, token);
+  } catch {
+    // Ignore storage failures so requests can still proceed with in-memory auth.
+  }
+}
+
+function clearStoredToken(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
+  } catch {
+    // Ignore storage failures so error handling still completes.
+  }
+}
+
+function isRawBody(body: ApiRequestInit['body']): body is BodyInit {
+  if (body == null) {
+    return false;
+  }
+
+  if (typeof body === 'string') {
+    return true;
+  }
+
+  if (typeof FormData !== 'undefined' && body instanceof FormData) {
+    return true;
+  }
+
+  if (typeof URLSearchParams !== 'undefined' && body instanceof URLSearchParams) {
+    return true;
+  }
+
+  if (typeof Blob !== 'undefined' && body instanceof Blob) {
+    return true;
+  }
+
+  if (body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
+    return true;
+  }
+
+  if (typeof ReadableStream !== 'undefined' && body instanceof ReadableStream) {
+    return true;
+  }
+
+  return false;
+}
+
+async function parseJson<T>(response: Response): Promise<T | null> {
+  const text = await response.text();
+
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function createDevSession(): Promise<string> {
+  const credentials = getDevCredentials();
+  const registerResponse = await fetch(buildUrl('/api/v1/auth/register'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': JSON_CONTENT_TYPE,
+    },
+    body: JSON.stringify(credentials),
+  });
+
+  if (registerResponse.ok) {
+    const payload = await parseJson<ApiSuccessEnvelope<DevAuthResponse>>(registerResponse);
+    const token = payload?.data.token;
+
+    if (!token) {
+      throw new ApiError(registerResponse.status, 'Missing token in auth response');
+    }
+
+    setStoredToken(token);
+    return token;
+  }
+
+  if (registerResponse.status !== 409) {
+    throw await toApiError(registerResponse);
+  }
+
+  const loginResponse = await fetch(buildUrl('/api/v1/auth/login'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': JSON_CONTENT_TYPE,
+    },
+    body: JSON.stringify({
+      username: credentials.username,
+      password: credentials.password,
+    }),
+  });
+
+  if (!loginResponse.ok) {
+    throw await toApiError(loginResponse);
+  }
+
+  const payload = await parseJson<ApiSuccessEnvelope<DevAuthResponse>>(loginResponse);
+  const token = payload?.data.token;
+
+  if (!token) {
+    throw new ApiError(loginResponse.status, 'Missing token in auth response');
+  }
+
+  setStoredToken(token);
+  return token;
+}
+
+async function resolveSessionToken(options?: {
+  allowDevAutoSession?: boolean;
+}): Promise<string | null> {
+  const envToken = getEnvToken();
+  if (envToken) {
+    return envToken;
+  }
+
+  const storedToken = getStoredToken();
+  if (storedToken) {
+    return storedToken;
+  }
+
+  if (!options?.allowDevAutoSession || !isDevMode()) {
+    return null;
+  }
+
+  if (!devSessionPromise) {
+    devSessionPromise = createDevSession().finally(() => {
+      devSessionPromise = null;
+    });
+  }
+
+  return devSessionPromise;
+}
+
+async function toApiError(response: Response): Promise<ApiError> {
+  const payload = await parseJson<ApiErrorEnvelope>(response);
+  const code = payload?.error?.code;
+  const message = payload?.error?.message ?? `Request failed with status ${response.status}`;
+
+  if (response.status === 401) {
+    clearStoredToken();
+  }
+
+  return new ApiError(response.status, message, code);
+}
+
+function createRequestInit(init: ApiRequestInit | undefined, token: string | null): RequestInit {
+  const headers = new Headers(init?.headers);
+  let body = init?.body;
+
+  if (body != null) {
+    if (isRawBody(body)) {
+      if (!headers.has('Content-Type') && typeof body === 'string') {
+        headers.set('Content-Type', JSON_CONTENT_TYPE);
+      }
+    } else {
+      headers.set('Content-Type', headers.get('Content-Type') ?? JSON_CONTENT_TYPE);
+      body = JSON.stringify(body);
+    }
+  }
+
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  return {
+    ...init,
+    headers,
+    body: body ?? undefined,
+  };
+}
+
+async function performRequest<T>(path: string, init?: ApiRequestInit): Promise<T> {
+  const token = await resolveSessionToken({
+    allowDevAutoSession: !normalizePath(path).startsWith(AUTH_PATH_PREFIX),
+  });
+  const response = await fetch(buildUrl(path), createRequestInit(init, token));
+
+  if (!response.ok) {
+    throw await toApiError(response);
+  }
+
+  const payload = await parseJson<T>(response);
+
+  if (payload == null) {
+    throw new ApiError(response.status, 'Missing response payload');
+  }
+
+  return payload;
+}
+
+export async function getSessionToken(): Promise<string> {
+  return (await resolveSessionToken({ allowDevAutoSession: true })) ?? '';
+}
+
+export async function apiRequest<T>(path: string, init?: ApiRequestInit): Promise<T> {
+  const payload = await performRequest<ApiSuccessEnvelope<T>>(path, init);
+  return payload.data;
+}
+
+export async function apiRequestWithMeta<T, M>(
+  path: string,
+  init?: ApiRequestInit,
+): Promise<{ data: T; meta: M }> {
+  const payload = await performRequest<ApiSuccessEnvelopeWithMeta<T, M>>(path, init);
+  return {
+    data: payload.data,
+    meta: payload.meta,
+  };
+}

--- a/apps/web/src/lib/auth-storage.ts
+++ b/apps/web/src/lib/auth-storage.ts
@@ -1,0 +1,50 @@
+export const API_TOKEN_STORAGE_KEY = 'pulse-auth-token';
+export const AUTH_STORAGE_KEY = 'pulse-auth';
+
+function getLocalStorage(): Storage | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  return window.localStorage;
+}
+
+export function getStoredToken(): string | null {
+  try {
+    return getLocalStorage()?.getItem(API_TOKEN_STORAGE_KEY) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function setStoredToken(token: string | null): void {
+  const storage = getLocalStorage();
+  if (!storage) {
+    return;
+  }
+
+  try {
+    if (token) {
+      storage.setItem(API_TOKEN_STORAGE_KEY, token);
+      return;
+    }
+
+    storage.removeItem(API_TOKEN_STORAGE_KEY);
+  } catch {
+    // Ignore storage failures so auth can continue in memory.
+  }
+}
+
+export function clearStoredAuthState(): void {
+  const storage = getLocalStorage();
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.removeItem(API_TOKEN_STORAGE_KEY);
+    storage.removeItem(AUTH_STORAGE_KEY);
+  } catch {
+    // Ignore storage failures so logout / 401 handling still completes.
+  }
+}

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -1,0 +1,24 @@
+import { QueryClient } from '@tanstack/react-query';
+
+let appQueryClient: QueryClient | null = null;
+
+export function createAppQueryClient(): QueryClient {
+  if (appQueryClient) {
+    return appQueryClient;
+  }
+
+  appQueryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: 1,
+        staleTime: 30_000,
+        refetchOnWindowFocus: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+  return appQueryClient;
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { createRoot } from 'react-dom/client';
 import App from '@/App';
 import { ThemeProvider } from '@/components/theme-provider';
+import { createAppQueryClient } from '@/lib/query-client';
 import './styles/globals.css';
 
 const rootElement = document.getElementById('root');
+const queryClient = createAppQueryClient();
 
 if (!rootElement) {
   throw new Error('Failed to find the root element');
@@ -12,8 +15,10 @@ if (!rootElement) {
 
 createRoot(rootElement).render(
   <StrictMode>
-    <ThemeProvider>
-      <App />
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
+    </QueryClientProvider>
   </StrictMode>,
 );

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,7 +4,6 @@ import { createRoot } from 'react-dom/client';
 import App from '@/App';
 import { ThemeProvider } from '@/components/theme-provider';
 import { createAppQueryClient } from '@/lib/query-client';
-import { useAuthStore } from '@/store/auth-store';
 import './styles/globals.css';
 
 const rootElement = document.getElementById('root');
@@ -13,8 +12,6 @@ const queryClient = createAppQueryClient();
 if (!rootElement) {
   throw new Error('Failed to find the root element');
 }
-
-useAuthStore.getState().hydrate();
 
 createRoot(rootElement).render(
   <StrictMode>

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,7 @@ import { createRoot } from 'react-dom/client';
 import App from '@/App';
 import { ThemeProvider } from '@/components/theme-provider';
 import { createAppQueryClient } from '@/lib/query-client';
+import { useAuthStore } from '@/store/auth-store';
 import './styles/globals.css';
 
 const rootElement = document.getElementById('root');
@@ -12,6 +13,8 @@ const queryClient = createAppQueryClient();
 if (!rootElement) {
   throw new Error('Failed to find the root element');
 }
+
+useAuthStore.getState().hydrate();
 
 createRoot(rootElement).render(
   <StrictMode>

--- a/apps/web/src/pages/login.tsx
+++ b/apps/web/src/pages/login.tsx
@@ -1,0 +1,20 @@
+import { useNavigate } from 'react-router';
+
+import { LoginForm } from '@/features/auth';
+
+export function LoginPage() {
+  const navigate = useNavigate();
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-4 py-10 text-foreground sm:px-6">
+      <div className="flex w-full max-w-sm flex-col items-center gap-6">
+        <div className="space-y-2 text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-primary">Pulse</p>
+          <h1 className="text-3xl font-semibold tracking-tight">Welcome back</h1>
+          <p className="text-sm text-muted-foreground">Sign in to pick up where you left off.</p>
+        </div>
+        <LoginForm onSuccess={() => navigate('/')} registerHref="/register" />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/pages/register.tsx
+++ b/apps/web/src/pages/register.tsx
@@ -1,0 +1,22 @@
+import { useNavigate } from 'react-router';
+
+import { RegisterForm } from '@/features/auth';
+
+export function RegisterPage() {
+  const navigate = useNavigate();
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-4 py-10 text-foreground sm:px-6">
+      <div className="flex w-full max-w-sm flex-col items-center gap-6">
+        <div className="space-y-2 text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-primary">Pulse</p>
+          <h1 className="text-3xl font-semibold tracking-tight">Create account</h1>
+          <p className="text-sm text-muted-foreground">
+            Set up your login to start tracking workouts, recovery, and habits.
+          </p>
+        </div>
+        <RegisterForm loginHref="/login" onSuccess={() => navigate('/')} />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/store/auth-store.test.ts
+++ b/apps/web/src/store/auth-store.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { API_TOKEN_STORAGE_KEY, ApiError, apiRequest } from '@/lib/api-client';
+import { createAppQueryClient } from '@/lib/query-client';
+import { AUTH_STORAGE_KEY, useAuthStore } from './auth-store';
+
+vi.mock('@/lib/api-client', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api-client')>('@/lib/api-client');
+
+  return {
+    ...actual,
+    apiRequest: vi.fn(),
+  };
+});
+
+function resetAuthStore(): void {
+  useAuthStore.setState({
+    user: null,
+    token: null,
+    isAuthenticated: false,
+    isLoading: false,
+    error: null,
+  });
+}
+
+describe('auth-store', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    createAppQueryClient().clear();
+    useAuthStore.persist.clearStorage();
+    resetAuthStore();
+    vi.mocked(apiRequest).mockReset();
+  });
+
+  it('login calls the API, stores the token, and sets the user state', async () => {
+    vi.mocked(apiRequest).mockResolvedValue({
+      token: 'token-1',
+      user: {
+        id: 'user-1',
+        username: 'derek',
+        name: 'Derek',
+      },
+    });
+
+    await useAuthStore.getState().login({
+      username: ' Derek ',
+      password: 'super-secret-password',
+    });
+
+    expect(apiRequest).toHaveBeenCalledWith('/api/v1/auth/login', {
+      method: 'POST',
+      body: {
+        username: 'derek',
+        password: 'super-secret-password',
+      },
+    });
+    expect(useAuthStore.getState()).toMatchObject({
+      token: 'token-1',
+      user: {
+        id: 'user-1',
+        username: 'derek',
+        name: 'Derek',
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+    });
+    expect(window.localStorage.getItem(API_TOKEN_STORAGE_KEY)).toBe('token-1');
+  });
+
+  it('login sets the error state when the API request fails', async () => {
+    const error = new ApiError(401, 'Invalid username or password', 'INVALID_CREDENTIALS');
+    vi.mocked(apiRequest).mockRejectedValue(error);
+
+    await expect(
+      useAuthStore.getState().login({
+        username: 'derek',
+        password: 'bad-password',
+      }),
+    ).rejects.toBe(error);
+
+    expect(useAuthStore.getState()).toMatchObject({
+      token: null,
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      error: 'Invalid username or password',
+    });
+  });
+
+  it('register calls the API, stores the token, and sets the user state', async () => {
+    vi.mocked(apiRequest).mockResolvedValue({
+      token: 'token-2',
+      user: {
+        id: 'user-2',
+        username: 'pulse-user',
+        name: 'Pulse User',
+      },
+    });
+
+    await useAuthStore.getState().register({
+      username: ' Pulse-User ',
+      password: 'super-secret-password',
+      name: ' Pulse User ',
+    });
+
+    expect(apiRequest).toHaveBeenCalledWith('/api/v1/auth/register', {
+      method: 'POST',
+      body: {
+        username: 'pulse-user',
+        password: 'super-secret-password',
+        name: 'Pulse User',
+      },
+    });
+    expect(useAuthStore.getState()).toMatchObject({
+      token: 'token-2',
+      user: {
+        id: 'user-2',
+        username: 'pulse-user',
+        name: 'Pulse User',
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+    });
+    expect(window.localStorage.getItem(API_TOKEN_STORAGE_KEY)).toBe('token-2');
+  });
+
+  it('logout clears token, user state, localStorage, and query cache', () => {
+    createAppQueryClient().setQueryData(['profile'], { id: 'user-1' });
+    useAuthStore.setState({
+      user: {
+        id: 'user-1',
+        username: 'derek',
+        name: 'Derek',
+      },
+      token: 'token-1',
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+    });
+    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'token-1');
+
+    useAuthStore.getState().logout();
+
+    expect(useAuthStore.getState()).toMatchObject({
+      user: null,
+      token: null,
+      isAuthenticated: false,
+      isLoading: false,
+      error: null,
+    });
+    expect(window.localStorage.getItem(API_TOKEN_STORAGE_KEY)).toBeNull();
+    expect(createAppQueryClient().getQueryData(['profile'])).toBeUndefined();
+  });
+
+  it('hydrate restores persisted auth state from localStorage', async () => {
+    resetAuthStore();
+    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'persisted-token');
+    window.localStorage.setItem(
+      AUTH_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          token: 'persisted-token',
+          user: {
+            id: 'user-3',
+            username: 'persisted-user',
+            name: null,
+          },
+        },
+        version: 0,
+      }),
+    );
+
+    await useAuthStore.persist.rehydrate();
+
+    expect(useAuthStore.getState()).toMatchObject({
+      token: 'persisted-token',
+      user: {
+        id: 'user-3',
+        username: 'persisted-user',
+        name: null,
+      },
+      isAuthenticated: true,
+      isLoading: false,
+    });
+  });
+
+  it('derives isAuthenticated from whether a token exists', () => {
+    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'token-3');
+    resetAuthStore();
+
+    useAuthStore.getState().hydrate();
+
+    expect(useAuthStore.getState()).toMatchObject({
+      token: 'token-3',
+      isAuthenticated: true,
+    });
+
+    useAuthStore.getState().logout();
+
+    expect(useAuthStore.getState()).toMatchObject({
+      token: null,
+      isAuthenticated: false,
+    });
+  });
+});

--- a/apps/web/src/store/auth-store.test.ts
+++ b/apps/web/src/store/auth-store.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { API_TOKEN_STORAGE_KEY, ApiError, apiRequest } from '@/lib/api-client';
+import { ApiError, apiRequest } from '@/lib/api-client';
+import { API_TOKEN_STORAGE_KEY } from '@/lib/auth-storage';
 import { createAppQueryClient } from '@/lib/query-client';
 import { AUTH_STORAGE_KEY, useAuthStore } from './auth-store';
 
@@ -156,6 +157,7 @@ describe('auth-store', () => {
       error: null,
     });
     expect(window.localStorage.getItem(API_TOKEN_STORAGE_KEY)).toBeNull();
+    expect(window.localStorage.getItem(AUTH_STORAGE_KEY)).toBeNull();
     expect(createAppQueryClient().getQueryData(['profile'])).toBeUndefined();
   });
 
@@ -210,6 +212,34 @@ describe('auth-store', () => {
       token: null,
       isAuthenticated: false,
       hasHydrated: true,
+    });
+  });
+
+  it('clears the persisted user when the raw token is missing during hydration', async () => {
+    resetAuthStore();
+    window.localStorage.setItem(
+      AUTH_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          token: 'stale-token',
+          user: {
+            id: 'user-3',
+            username: 'persisted-user',
+            name: null,
+          },
+        },
+        version: 0,
+      }),
+    );
+
+    await useAuthStore.persist.rehydrate();
+
+    expect(useAuthStore.getState()).toMatchObject({
+      token: null,
+      user: null,
+      isAuthenticated: false,
+      hasHydrated: true,
+      isLoading: false,
     });
   });
 });

--- a/apps/web/src/store/auth-store.test.ts
+++ b/apps/web/src/store/auth-store.test.ts
@@ -17,6 +17,7 @@ function resetAuthStore(): void {
     user: null,
     token: null,
     isAuthenticated: false,
+    hasHydrated: false,
     isLoading: false,
     error: null,
   });
@@ -61,6 +62,7 @@ describe('auth-store', () => {
         name: 'Derek',
       },
       isAuthenticated: true,
+      hasHydrated: true,
       isLoading: false,
       error: null,
     });
@@ -82,6 +84,7 @@ describe('auth-store', () => {
       token: null,
       user: null,
       isAuthenticated: false,
+      hasHydrated: false,
       isLoading: false,
       error: 'Invalid username or password',
     });
@@ -119,6 +122,7 @@ describe('auth-store', () => {
         name: 'Pulse User',
       },
       isAuthenticated: true,
+      hasHydrated: true,
       isLoading: false,
       error: null,
     });
@@ -135,6 +139,7 @@ describe('auth-store', () => {
       },
       token: 'token-1',
       isAuthenticated: true,
+      hasHydrated: true,
       isLoading: false,
       error: null,
     });
@@ -146,6 +151,7 @@ describe('auth-store', () => {
       user: null,
       token: null,
       isAuthenticated: false,
+      hasHydrated: true,
       isLoading: false,
       error: null,
     });
@@ -181,6 +187,7 @@ describe('auth-store', () => {
         name: null,
       },
       isAuthenticated: true,
+      hasHydrated: true,
       isLoading: false,
     });
   });
@@ -194,6 +201,7 @@ describe('auth-store', () => {
     expect(useAuthStore.getState()).toMatchObject({
       token: 'token-3',
       isAuthenticated: true,
+      hasHydrated: true,
     });
 
     useAuthStore.getState().logout();
@@ -201,6 +209,7 @@ describe('auth-store', () => {
     expect(useAuthStore.getState()).toMatchObject({
       token: null,
       isAuthenticated: false,
+      hasHydrated: true,
     });
   });
 });

--- a/apps/web/src/store/auth-store.ts
+++ b/apps/web/src/store/auth-store.ts
@@ -1,0 +1,193 @@
+import {
+  type LoginInput,
+  type RegisterInput,
+  loginInputSchema,
+  registerInputSchema,
+} from '@pulse/shared';
+import { createJSONStorage, persist } from 'zustand/middleware';
+import { create } from 'zustand/react';
+import { API_TOKEN_STORAGE_KEY, ApiError, apiRequest } from '@/lib/api-client';
+import { createAppQueryClient } from '@/lib/query-client';
+
+export const AUTH_STORAGE_KEY = 'pulse-auth';
+
+export type AuthUser = {
+  id: string;
+  username: string;
+  name: string | null;
+};
+
+type AuthResponse = {
+  token: string;
+  user: AuthUser;
+};
+
+type AuthState = {
+  user: AuthUser | null;
+  token: string | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  error: string | null;
+};
+
+type AuthActions = {
+  login: (input: LoginInput) => Promise<void>;
+  register: (input: RegisterInput) => Promise<void>;
+  logout: () => void;
+  hydrate: () => void;
+  clearError: () => void;
+};
+
+type AuthStore = AuthState & AuthActions;
+
+const initialAuthState: AuthState = {
+  user: null,
+  token: null,
+  isAuthenticated: false,
+  isLoading: false,
+  error: null,
+};
+
+function setStoredToken(token: string | null): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (token) {
+    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, token);
+    return;
+  }
+
+  window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
+}
+
+function getPersistStorage(): Storage {
+  if (typeof window === 'undefined') {
+    const storage = new Map<string, string>();
+
+    return {
+      get length() {
+        return storage.size;
+      },
+      clear() {
+        storage.clear();
+      },
+      getItem(key: string) {
+        return storage.get(key) ?? null;
+      },
+      key(index: number) {
+        return [...storage.keys()][index] ?? null;
+      },
+      removeItem(key: string) {
+        storage.delete(key);
+      },
+      setItem(key: string, value: string) {
+        storage.set(key, value);
+      },
+    };
+  }
+
+  return window.localStorage;
+}
+
+function applySession(
+  set: (partial: Partial<AuthState>) => void,
+  session: AuthResponse | null,
+): void {
+  setStoredToken(session?.token ?? null);
+  set({
+    user: session?.user ?? null,
+    token: session?.token ?? null,
+    isAuthenticated: Boolean(session?.token),
+    isLoading: false,
+    error: null,
+  });
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
+export const useAuthStore = create<AuthStore>()(
+  persist(
+    (set, get) => ({
+      ...initialAuthState,
+      async login(input) {
+        set({ isLoading: true, error: null });
+
+        try {
+          const payload = loginInputSchema.parse(input);
+          const response = await apiRequest<AuthResponse>('/api/v1/auth/login', {
+            method: 'POST',
+            body: payload,
+          });
+
+          applySession(set, response);
+        } catch (error) {
+          set({
+            isLoading: false,
+            error: getErrorMessage(error, 'Failed to log in'),
+          });
+          throw error;
+        }
+      },
+      async register(input) {
+        set({ isLoading: true, error: null });
+
+        try {
+          const payload = registerInputSchema.parse(input);
+          const response = await apiRequest<AuthResponse>('/api/v1/auth/register', {
+            method: 'POST',
+            body: payload,
+          });
+
+          applySession(set, response);
+        } catch (error) {
+          set({
+            isLoading: false,
+            error: getErrorMessage(error, 'Failed to register'),
+          });
+          throw error;
+        }
+      },
+      logout() {
+        setStoredToken(null);
+        createAppQueryClient().clear();
+        set({ ...initialAuthState });
+      },
+      hydrate() {
+        const storedToken =
+          typeof window === 'undefined' ? null : window.localStorage.getItem(API_TOKEN_STORAGE_KEY);
+        const token = storedToken ?? get().token;
+
+        set({
+          token,
+          isAuthenticated: Boolean(token),
+          isLoading: false,
+        });
+      },
+      clearError() {
+        set({ error: null });
+      },
+    }),
+    {
+      name: AUTH_STORAGE_KEY,
+      storage: createJSONStorage(getPersistStorage),
+      partialize: (state) => ({
+        token: state.token,
+        user: state.user,
+      }),
+      onRehydrateStorage: () => (state) => {
+        state?.hydrate();
+      },
+    },
+  ),
+);

--- a/apps/web/src/store/auth-store.ts
+++ b/apps/web/src/store/auth-store.ts
@@ -6,10 +6,16 @@ import {
 } from '@pulse/shared';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import { create } from 'zustand/react';
-import { API_TOKEN_STORAGE_KEY, ApiError, apiRequest } from '@/lib/api-client';
+import { ApiError, apiRequest } from '@/lib/api-client';
+import {
+  AUTH_STORAGE_KEY,
+  clearStoredAuthState,
+  getStoredToken,
+  setStoredToken,
+} from '@/lib/auth-storage';
 import { createAppQueryClient } from '@/lib/query-client';
 
-export const AUTH_STORAGE_KEY = 'pulse-auth';
+export { AUTH_STORAGE_KEY };
 
 export type AuthUser = {
   id: string;
@@ -49,19 +55,6 @@ const initialAuthState: AuthState = {
   isLoading: false,
   error: null,
 };
-
-function setStoredToken(token: string | null): void {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  if (token) {
-    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, token);
-    return;
-  }
-
-  window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
-}
 
 function getPersistStorage(): Storage {
   if (typeof window === 'undefined') {
@@ -162,17 +155,17 @@ export const useAuthStore = create<AuthStore>()(
         }
       },
       logout() {
-        setStoredToken(null);
+        // Auth state lives outside React, so logout clears the shared singleton query cache here.
         createAppQueryClient().clear();
         set({ ...initialAuthState, hasHydrated: true });
+        clearStoredAuthState();
       },
       hydrate() {
-        const storedToken =
-          typeof window === 'undefined' ? null : window.localStorage.getItem(API_TOKEN_STORAGE_KEY);
-        const token = storedToken ?? get().token;
+        const token = getStoredToken();
 
         set({
           token,
+          user: token ? get().user : null,
           isAuthenticated: Boolean(token),
           hasHydrated: true,
           isLoading: false,

--- a/apps/web/src/store/auth-store.ts
+++ b/apps/web/src/store/auth-store.ts
@@ -26,6 +26,7 @@ type AuthState = {
   user: AuthUser | null;
   token: string | null;
   isAuthenticated: boolean;
+  hasHydrated: boolean;
   isLoading: boolean;
   error: string | null;
 };
@@ -44,6 +45,7 @@ const initialAuthState: AuthState = {
   user: null,
   token: null,
   isAuthenticated: false,
+  hasHydrated: false,
   isLoading: false,
   error: null,
 };
@@ -99,6 +101,7 @@ function applySession(
     user: session?.user ?? null,
     token: session?.token ?? null,
     isAuthenticated: Boolean(session?.token),
+    hasHydrated: true,
     isLoading: false,
     error: null,
   });
@@ -161,7 +164,7 @@ export const useAuthStore = create<AuthStore>()(
       logout() {
         setStoredToken(null);
         createAppQueryClient().clear();
-        set({ ...initialAuthState });
+        set({ ...initialAuthState, hasHydrated: true });
       },
       hydrate() {
         const storedToken =
@@ -171,6 +174,7 @@ export const useAuthStore = create<AuthStore>()(
         set({
           token,
           isAuthenticated: Boolean(token),
+          hasHydrated: true,
           isLoading: false,
         });
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-query':
+        specifier: ^5.90.21
+        version: 5.90.21(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -111,6 +114,12 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+      zustand:
+        specifier: ^5.0.11
+        version: 5.0.11(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     devDependencies:
       '@playwright/test':
         specifier: ^1.58.2
@@ -1976,6 +1985,14 @@ packages:
     resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
+
+  '@tanstack/query-core@5.90.20':
+    resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
+
+  '@tanstack/react-query@5.90.21':
+    resolution: {integrity: sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -4611,6 +4628,24 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zustand@5.0.11:
+    resolution: {integrity: sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
@@ -6221,6 +6256,13 @@ snapshots:
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
       vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@tanstack/query-core@5.90.20': {}
+
+  '@tanstack/react-query@5.90.21(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-core': 5.90.20
+      react: 19.2.4
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -8875,3 +8917,10 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zustand@5.0.11(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      immer: 11.1.4
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
       '@pulse/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -105,6 +108,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      react-hook-form:
+        specifier: ^7.71.2
+        version: 7.71.2(react@19.2.4)
       react-router:
         specifier: ^7.13.1
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -910,6 +916,11 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -3847,6 +3858,12 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
+  react-hook-form@7.71.2:
+    resolution: {integrity: sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
@@ -5218,6 +5235,11 @@ snapshots:
   '@hono/node-server@1.19.11(hono@4.12.5)':
     dependencies:
       hono: 4.12.5
+
+  '@hookform/resolvers@5.2.2(react-hook-form@7.71.2(react@19.2.4))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.71.2(react@19.2.4)
 
   '@humanfs/core@0.19.1': {}
 
@@ -8136,6 +8158,10 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-hook-form@7.71.2(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   react-is@17.0.2: {}
 


### PR DESCRIPTION
## Summary

This PR adds the frontend authentication foundation for Pulse so the web app can distinguish between signed-in and signed-out users and enforce access to protected pages. It introduces the core client-side auth stack: a typed API client with JWT handling, a persisted Zustand auth store, and TanStack Query setup for server state. On top of that, it adds complete login and registration flows, plus route guards that redirect users appropriately during session hydration. The navigation shell was also updated so authenticated users can log out from both desktop and mobile layouts and see basic account context in the sidebar.

## Key Changes

- Added a canonical web API client with token storage/injection and auth-focused request handling
- Added a shared TanStack Query client/provider to support authenticated data fetching patterns
- Implemented a persisted Zustand auth store with `login`, `register`, `logout`, hydration, and error state management
- Added standalone `/login` and `/register` pages with React Hook Form + Zod validation using shared schemas
- Introduced `ProtectedRoute` and `GuestRoute` wrappers to keep app routes behind auth and redirect signed-in users away from auth pages
- Reworked routing so the main `AppLayout` only renders for authenticated routes, while auth pages render outside the app shell
- Added logout actions to both the sidebar and bottom navigation
- Updated the sidebar to display current user identity details and preserve accessibility in the collapsed state
- Expanded test coverage across app routing, auth guards, auth store, API client, login/register forms, and updated navigation behavior

## Technical Notes

- Session hydration is explicit in both route guards. Reviewers should pay attention to the `hasHydrated` flow and loading state, since that prevents redirect flicker and protects initial route resolution on refresh.
- `AppLayout` now supports nested routing via `Outlet`, which is the key structural change that lets auth pages remain standalone while protected pages share the shell.
- The auth store and API client are intentionally the canonical boundary for token persistence. Logout behavior is wired through that path in both nav surfaces, so future authenticated queries should rely on the same source of truth.
- Tests were updated to cover both guest and authenticated states, including redirect behavior and logout flows. That coverage is important here because the primary risk in this PR is incorrect route access or stale session state rather than visual regressions.

## Commits

- `aee0b4c fix(web): address auth flow review feedback`
- `fe9fbea feat(web): protect auth routes and add logout controls`
- `cc0cc2c feat(web): add auth login and register pages`
- `06dbe6e feat(web): add canonical auth client and store`

## Tasks

- **API client, QueryClientProvider, and Zustand auth store**: Create typed fetch wrapper with JWT injection, TanStack Query provider, and Zustand auth store with login/register/logout + persistence
- **Login and Register pages**: Auth feature module with login/register forms using React Hook Form + shared Zod schemas, standalone pages, and routes
- **Protected routes, routing guards, and logout**: ProtectedRoute and GuestRoute wrappers, route guarding, auth hydration, logout in sidebar and mobile nav

## Diff Stats

```
apps/web/package.json                              |   9 +-
 apps/web/src/App.test.tsx                          |  77 ++++-
 apps/web/src/App.tsx                               |  73 +++--
 apps/web/src/components/auth/auth-route-loader.tsx |  16 +
 apps/web/src/components/auth/guest-route.test.tsx  |  97 ++++++
 apps/web/src/components/auth/guest-route.tsx       |  24 ++
 .../src/components/auth/protected-route.test.tsx   |  97 ++++++
 apps/web/src/components/auth/protected-route.tsx   |  24 ++
 apps/web/src/components/layout/app-layout.tsx      |   5 +-
 apps/web/src/components/layout/bottom-nav.test.tsx |  73 ++++-
 apps/web/src/components/layout/bottom-nav.tsx      |  21 +-
 apps/web/src/components/layout/sidebar.test.tsx    | 103 ++++++-
 apps/web/src/components/layout/sidebar.tsx         | 228 ++++++++++-----
 .../features/auth/components/login-form.test.tsx   | 127 ++++++++
 .../src/features/auth/components/login-form.tsx    | 120 ++++++++
 .../auth/components/register-form.test.tsx         | 132 +++++++++
 .../src/features/auth/components/register-form.tsx | 137 +++++++++
 apps/web/src/features/auth/index.ts                |   2 +
 apps/web/src/lib/api-client.test.ts                | 202 +++++++++++++
 apps/web/src/lib/api-client.ts                     | 324 +++++++++++++++++++++
 apps/web/src/lib/query-client.ts                   |  24 ++
 apps/web/src/main.tsx                              |  11 +-
 apps/web/src/pages/login.tsx                       |  20 ++
 apps/web/src/pages/register.tsx                    |  22 ++
 apps/web/src/store/auth-store.test.ts              | 215 ++++++++++++++
 apps/web/src/store/auth-store.ts                   | 197 +++++++++++++
 pnpm-lock.yaml                                     |  75 +++++
 27 files changed, 2333 insertions(+), 122 deletions(-)
```