### PR TITLE
Nutrition API + frontend wiring

### DIFF
--- a/apps/api/src/__tests__/foods-nutrition.test.ts
+++ b/apps/api/src/__tests__/foods-nutrition.test.ts
@@ -402,10 +402,6 @@ const parseData = <T>(response: { json: () => unknown }) => {
   return (response.json() as { data: T }).data;
 };
 
-const waitForClockTick = async () => {
-  await new Promise((resolve) => setTimeout(resolve, 5));
-};
-
 const createTestApp = async () => {
   process.env.JWT_SECRET = 'integration-test-jwt-secret';
 
@@ -474,6 +470,8 @@ const createMealViaApi = async (
 
 describe('foods and nutrition integration', () => {
   beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-03-01T00:00:00.000Z'));
     testState.reset();
   });
 
@@ -565,7 +563,7 @@ describe('foods and nutrition integration', () => {
         ],
       });
 
-      await waitForClockTick();
+      vi.advanceTimersByTime(5);
       await createMealViaApi(app, userToken, '2026-03-09', {
         name: 'Snack',
         items: [
@@ -861,7 +859,7 @@ describe('foods and nutrition integration', () => {
       const firstUseFood = parseData<StoredFood[]>(afterFirstUseResponse)[0];
       expect(firstUseFood?.lastUsedAt).not.toBeNull();
 
-      await waitForClockTick();
+      vi.advanceTimersByTime(5);
       await createMealViaApi(app, userToken, '2026-03-14', {
         name: 'Breakfast',
         items: [

--- a/apps/api/src/__tests__/foods-nutrition.test.ts
+++ b/apps/api/src/__tests__/foods-nutrition.test.ts
@@ -1,0 +1,894 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type StoredFood = {
+  id: string;
+  userId: string;
+  name: string;
+  brand: string | null;
+  servingSize: string | null;
+  servingGrams: number | null;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  fiber: number | null;
+  sugar: number | null;
+  verified: boolean;
+  source: string | null;
+  notes: string | null;
+  lastUsedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+type StoredNutritionLog = {
+  id: string;
+  userId: string;
+  date: string;
+  notes: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+type StoredMeal = {
+  id: string;
+  nutritionLogId: string;
+  name: string;
+  time: string | null;
+  notes: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+type StoredMealItem = {
+  id: string;
+  mealId: string;
+  foodId: string | null;
+  name: string;
+  amount: number;
+  unit: string;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  fiber: number | null;
+  sugar: number | null;
+  createdAt: number;
+};
+
+const testState = vi.hoisted(() => {
+  const foods = new Map<string, StoredFood>();
+  const nutritionLogs = new Map<string, StoredNutritionLog>();
+  const meals = new Map<string, StoredMeal>();
+  const mealItems = new Map<string, StoredMealItem>();
+  let idCounter = 1;
+  let timestampCounter = 1_700_000_000_000;
+
+  return {
+    foods,
+    nutritionLogs,
+    meals,
+    mealItems,
+    reset() {
+      foods.clear();
+      nutritionLogs.clear();
+      meals.clear();
+      mealItems.clear();
+      idCounter = 1;
+      timestampCounter = 1_700_000_000_000;
+    },
+    nextId(prefix: string) {
+      const id = `${prefix}-${idCounter}`;
+      idCounter += 1;
+      return id;
+    },
+    nextTimestamp() {
+      const timestamp = timestampCounter;
+      timestampCounter += 1;
+      return timestamp;
+    },
+  };
+});
+
+const getLogKey = (userId: string, date: string) => `${userId}:${date}`;
+
+const sortFoods = (foods: StoredFood[], sort: 'name' | 'protein' | 'recent') => {
+  const byName = (left: StoredFood, right: StoredFood) => {
+    const nameCompare = left.name.localeCompare(right.name, undefined, { sensitivity: 'base' });
+    if (nameCompare !== 0) {
+      return nameCompare;
+    }
+
+    return (left.brand ?? '').localeCompare(right.brand ?? '', undefined, {
+      sensitivity: 'base',
+    });
+  };
+
+  if (sort === 'protein') {
+    return [...foods].sort((left, right) => {
+      if (left.protein !== right.protein) {
+        return right.protein - left.protein;
+      }
+
+      return byName(left, right);
+    });
+  }
+
+  if (sort === 'recent') {
+    return [...foods].sort((left, right) => {
+      const leftNull = left.lastUsedAt === null ? 1 : 0;
+      const rightNull = right.lastUsedAt === null ? 1 : 0;
+
+      if (leftNull !== rightNull) {
+        return leftNull - rightNull;
+      }
+
+      if (left.lastUsedAt !== right.lastUsedAt) {
+        return (right.lastUsedAt ?? 0) - (left.lastUsedAt ?? 0);
+      }
+
+      return byName(left, right);
+    });
+  }
+
+  return [...foods].sort(byName);
+};
+
+vi.mock('../routes/foods/store.js', () => ({
+  createFood: vi.fn(
+    async (
+      input: Omit<StoredFood, 'createdAt' | 'updatedAt' | 'lastUsedAt'> & {
+        createdAt?: number;
+        updatedAt?: number;
+        lastUsedAt?: number | null;
+      },
+    ) => {
+      const now = testState.nextTimestamp();
+      const food: StoredFood = {
+        ...input,
+        brand: input.brand ?? null,
+        servingSize: input.servingSize ?? null,
+        servingGrams: input.servingGrams ?? null,
+        fiber: input.fiber ?? null,
+        sugar: input.sugar ?? null,
+        source: input.source ?? null,
+        notes: input.notes ?? null,
+        lastUsedAt: input.lastUsedAt ?? null,
+        createdAt: input.createdAt ?? now,
+        updatedAt: input.updatedAt ?? now,
+      };
+
+      testState.foods.set(food.id, food);
+      return food;
+    },
+  ),
+  listFoods: vi.fn(
+    async (
+      userId: string,
+      query: {
+        q?: string;
+        sort: 'name' | 'protein' | 'recent';
+        page: number;
+        limit: number;
+      },
+    ) => {
+      const normalizedQuery = query.q?.toLowerCase();
+      const filtered = [...testState.foods.values()].filter((food) => {
+        if (food.userId !== userId) {
+          return false;
+        }
+
+        if (!normalizedQuery) {
+          return true;
+        }
+
+        return (
+          food.name.toLowerCase().includes(normalizedQuery) ||
+          (food.brand ?? '').toLowerCase().includes(normalizedQuery)
+        );
+      });
+
+      const sorted = sortFoods(filtered, query.sort);
+      const offset = (query.page - 1) * query.limit;
+
+      return {
+        foods: sorted.slice(offset, offset + query.limit),
+        total: sorted.length,
+      };
+    },
+  ),
+  updateFood: vi.fn(async (id: string, userId: string, updates: Partial<StoredFood>) => {
+    const existing = testState.foods.get(id);
+    if (!existing || existing.userId !== userId) {
+      return undefined;
+    }
+
+    const updated: StoredFood = {
+      ...existing,
+      ...updates,
+      brand: 'brand' in updates ? (updates.brand ?? null) : existing.brand,
+      servingSize: 'servingSize' in updates ? (updates.servingSize ?? null) : existing.servingSize,
+      servingGrams:
+        'servingGrams' in updates ? (updates.servingGrams ?? null) : existing.servingGrams,
+      fiber: 'fiber' in updates ? (updates.fiber ?? null) : existing.fiber,
+      sugar: 'sugar' in updates ? (updates.sugar ?? null) : existing.sugar,
+      source: 'source' in updates ? (updates.source ?? null) : existing.source,
+      notes: 'notes' in updates ? (updates.notes ?? null) : existing.notes,
+      updatedAt: Date.now(),
+    };
+
+    testState.foods.set(id, updated);
+    return updated;
+  }),
+  deleteFood: vi.fn(async (id: string, userId: string) => {
+    const existing = testState.foods.get(id);
+    if (!existing || existing.userId !== userId) {
+      return false;
+    }
+
+    testState.foods.delete(id);
+    return true;
+  }),
+  updateFoodLastUsedAt: vi.fn(async (foodId: string, userId: string, lastUsedAt = Date.now()) => {
+    const existing = testState.foods.get(foodId);
+    if (!existing || existing.userId !== userId) {
+      throw new Error('Failed to update food last used timestamp');
+    }
+
+    const updated: StoredFood = {
+      ...existing,
+      lastUsedAt,
+    };
+
+    testState.foods.set(foodId, updated);
+  }),
+}));
+
+vi.mock('../routes/nutrition/store.js', () => ({
+  createMealForDate: vi.fn(
+    async (
+      userId: string,
+      date: string,
+      input: {
+        name: string;
+        time?: string;
+        notes?: string;
+        items: Array<{
+          foodId?: string;
+          name: string;
+          amount: number;
+          unit: string;
+          calories: number;
+          protein: number;
+          carbs: number;
+          fat: number;
+        }>;
+      },
+    ) => {
+      const logKey = getLogKey(userId, date);
+      let log = testState.nutritionLogs.get(logKey);
+
+      if (!log) {
+        const now = testState.nextTimestamp();
+        log = {
+          id: testState.nextId('log'),
+          userId,
+          date,
+          notes: null,
+          createdAt: now,
+          updatedAt: now,
+        };
+        testState.nutritionLogs.set(logKey, log);
+      }
+
+      const now = testState.nextTimestamp();
+      const meal: StoredMeal = {
+        id: testState.nextId('meal'),
+        nutritionLogId: log.id,
+        name: input.name,
+        time: input.time ?? null,
+        notes: input.notes ?? null,
+        createdAt: now,
+        updatedAt: now,
+      };
+      testState.meals.set(meal.id, meal);
+
+      const items = input.items.map((item) => {
+        const createdAt = testState.nextTimestamp();
+        const createdItem: StoredMealItem = {
+          id: testState.nextId('meal-item'),
+          mealId: meal.id,
+          foodId: item.foodId ?? null,
+          name: item.name,
+          amount: item.amount,
+          unit: item.unit,
+          calories: item.calories,
+          protein: item.protein,
+          carbs: item.carbs,
+          fat: item.fat,
+          fiber: null,
+          sugar: null,
+          createdAt,
+        };
+        testState.mealItems.set(createdItem.id, createdItem);
+        return createdItem;
+      });
+
+      return { meal, items };
+    },
+  ),
+  getDailyNutritionForDate: vi.fn(async (userId: string, date: string) => {
+    const log = testState.nutritionLogs.get(getLogKey(userId, date));
+    if (!log) {
+      return null;
+    }
+
+    const dayMeals = [...testState.meals.values()]
+      .filter((meal) => meal.nutritionLogId === log.id)
+      .sort((left, right) => left.createdAt - right.createdAt);
+
+    return {
+      log,
+      meals: dayMeals.map((meal) => ({
+        meal,
+        items: [...testState.mealItems.values()]
+          .filter((item) => item.mealId === meal.id)
+          .sort((left, right) => left.createdAt - right.createdAt),
+      })),
+    };
+  }),
+  getDailyNutritionSummaryForDate: vi.fn(async (userId: string, date: string) => {
+    const log = testState.nutritionLogs.get(getLogKey(userId, date));
+
+    if (!log) {
+      return {
+        date,
+        meals: 0,
+        actual: {
+          calories: 0,
+          protein: 0,
+          carbs: 0,
+          fat: 0,
+        },
+        target: null,
+      };
+    }
+
+    const dayMeals = [...testState.meals.values()].filter((meal) => meal.nutritionLogId === log.id);
+    const dayMealIds = new Set(dayMeals.map((meal) => meal.id));
+    const items = [...testState.mealItems.values()].filter((item) => dayMealIds.has(item.mealId));
+
+    return {
+      date,
+      meals: dayMeals.length,
+      actual: {
+        calories: items.reduce((total, item) => total + item.calories, 0),
+        protein: items.reduce((total, item) => total + item.protein, 0),
+        carbs: items.reduce((total, item) => total + item.carbs, 0),
+        fat: items.reduce((total, item) => total + item.fat, 0),
+      },
+      target: null,
+    };
+  }),
+  deleteMealForDate: vi.fn(async (userId: string, date: string, mealId: string) => {
+    const log = testState.nutritionLogs.get(getLogKey(userId, date));
+    if (!log) {
+      return false;
+    }
+
+    const meal = testState.meals.get(mealId);
+    if (!meal || meal.nutritionLogId !== log.id) {
+      return false;
+    }
+
+    testState.meals.delete(mealId);
+
+    for (const item of [...testState.mealItems.values()]) {
+      if (item.mealId === mealId) {
+        testState.mealItems.delete(item.id);
+      }
+    }
+
+    return true;
+  }),
+}));
+
+const createAuthorizationHeader = (token: string) => ({
+  authorization: `Bearer ${token}`,
+});
+
+const parseData = <T>(response: { json: () => unknown }) => {
+  return (response.json() as { data: T }).data;
+};
+
+const waitForClockTick = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 5));
+};
+
+const createTestApp = async () => {
+  process.env.JWT_SECRET = 'integration-test-jwt-secret';
+
+  vi.resetModules();
+
+  const { buildServer } = await import('../index.js');
+  const app = buildServer();
+  await app.ready();
+
+  return { app };
+};
+
+const createFoodViaApi = async (
+  app: FastifyInstance,
+  token: string,
+  payload: {
+    name: string;
+    brand?: string;
+    servingSize: string;
+    calories: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+  },
+) => {
+  const response = await app.inject({
+    method: 'POST',
+    url: '/api/v1/foods',
+    headers: createAuthorizationHeader(token),
+    payload,
+  });
+
+  expect(response.statusCode).toBe(201);
+  return parseData<StoredFood>(response);
+};
+
+const createMealViaApi = async (
+  app: FastifyInstance,
+  token: string,
+  date: string,
+  payload: {
+    name: string;
+    time?: string;
+    items: Array<{
+      foodId?: string;
+      name: string;
+      amount: number;
+      unit: string;
+      calories: number;
+      protein: number;
+      carbs: number;
+      fat: number;
+    }>;
+  },
+) => {
+  const response = await app.inject({
+    method: 'POST',
+    url: `/api/v1/nutrition/${date}/meals`,
+    headers: createAuthorizationHeader(token),
+    payload,
+  });
+
+  expect(response.statusCode).toBe(201);
+  return parseData<{ meal: StoredMeal; items: StoredMealItem[] }>(response);
+};
+
+describe('foods and nutrition integration', () => {
+  beforeEach(() => {
+    testState.reset();
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+    vi.useRealTimers();
+    vi.resetModules();
+  });
+
+  it('covers foods CRUD, search, deletion, and recency sorting', async () => {
+    const { app } = await createTestApp();
+
+    try {
+      const userToken = app.jwt.sign({ userId: 'user-a' });
+      const otherUserToken = app.jwt.sign({ userId: 'user-b' });
+
+      const yogurt = await createFoodViaApi(app, userToken, {
+        name: 'Greek Yogurt',
+        brand: 'Fage',
+        servingSize: '170 g',
+        calories: 90,
+        protein: 18,
+        carbs: 5,
+        fat: 0,
+      });
+
+      const almonds = await createFoodViaApi(app, userToken, {
+        name: 'Almonds',
+        brand: 'Blue Diamond',
+        servingSize: '28 g',
+        calories: 170,
+        protein: 6,
+        carbs: 6,
+        fat: 15,
+      });
+
+      const nameSearchResponse = await app.inject({
+        method: 'GET',
+        url: '/api/v1/foods?q=yogurt',
+        headers: createAuthorizationHeader(userToken),
+      });
+
+      expect(nameSearchResponse.statusCode).toBe(200);
+      const nameSearchFoods = parseData<StoredFood[]>(nameSearchResponse);
+      expect(nameSearchFoods.map((food) => food.id)).toEqual([yogurt.id]);
+
+      const brandSearchResponse = await app.inject({
+        method: 'GET',
+        url: '/api/v1/foods?q=diamond',
+        headers: createAuthorizationHeader(userToken),
+      });
+
+      expect(brandSearchResponse.statusCode).toBe(200);
+      const brandSearchFoods = parseData<StoredFood[]>(brandSearchResponse);
+      expect(brandSearchFoods.map((food) => food.id)).toEqual([almonds.id]);
+
+      const updateResponse = await app.inject({
+        method: 'PUT',
+        url: `/api/v1/foods/${yogurt.id}`,
+        headers: createAuthorizationHeader(userToken),
+        payload: {
+          protein: 20,
+          servingSize: '200 g',
+        },
+      });
+
+      expect(updateResponse.statusCode).toBe(200);
+      expect(parseData<StoredFood>(updateResponse)).toEqual(
+        expect.objectContaining({
+          id: yogurt.id,
+          protein: 20,
+          servingSize: '200 g',
+        }),
+      );
+
+      await createMealViaApi(app, userToken, '2026-03-09', {
+        name: 'Breakfast',
+        items: [
+          {
+            foodId: yogurt.id,
+            name: 'Greek Yogurt',
+            amount: 1,
+            unit: 'cup',
+            calories: 90,
+            protein: 20,
+            carbs: 5,
+            fat: 0,
+          },
+        ],
+      });
+
+      await waitForClockTick();
+      await createMealViaApi(app, userToken, '2026-03-09', {
+        name: 'Snack',
+        items: [
+          {
+            foodId: almonds.id,
+            name: 'Almonds',
+            amount: 1,
+            unit: 'oz',
+            calories: 170,
+            protein: 6,
+            carbs: 6,
+            fat: 15,
+          },
+        ],
+      });
+
+      const recentResponse = await app.inject({
+        method: 'GET',
+        url: '/api/v1/foods?sort=recent',
+        headers: createAuthorizationHeader(userToken),
+      });
+
+      expect(recentResponse.statusCode).toBe(200);
+      const recentFoods = parseData<StoredFood[]>(recentResponse);
+      expect(recentFoods.map((food) => food.id)).toEqual([almonds.id, yogurt.id]);
+      expect((recentFoods[0]?.lastUsedAt ?? 0) - (recentFoods[1]?.lastUsedAt ?? 0)).toBeGreaterThan(
+        0,
+      );
+
+      const deleteResponse = await app.inject({
+        method: 'DELETE',
+        url: `/api/v1/foods/${yogurt.id}`,
+        headers: createAuthorizationHeader(userToken),
+      });
+
+      expect(deleteResponse.statusCode).toBe(200);
+      expect(parseData<{ success: true }>(deleteResponse)).toEqual({ success: true });
+
+      const deletedFoodSearchResponse = await app.inject({
+        method: 'GET',
+        url: '/api/v1/foods?q=yogurt',
+        headers: createAuthorizationHeader(userToken),
+      });
+
+      expect(deletedFoodSearchResponse.statusCode).toBe(200);
+      expect(parseData<StoredFood[]>(deletedFoodSearchResponse)).toEqual([]);
+
+      const otherUserSearchResponse = await app.inject({
+        method: 'GET',
+        url: '/api/v1/foods?q=almonds',
+        headers: createAuthorizationHeader(otherUserToken),
+      });
+
+      expect(otherUserSearchResponse.statusCode).toBe(200);
+      expect(parseData<StoredFood[]>(otherUserSearchResponse)).toEqual([]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('creates daily nutrition with multiple meals and deletes a meal with nested items', async () => {
+    const { app } = await createTestApp();
+
+    try {
+      const userToken = app.jwt.sign({ userId: 'user-a' });
+      const date = '2026-03-10';
+
+      const breakfast = await createMealViaApi(app, userToken, date, {
+        name: 'Breakfast',
+        time: '08:00',
+        items: [
+          {
+            name: 'Oatmeal',
+            amount: 1,
+            unit: 'bowl',
+            calories: 300,
+            protein: 10,
+            carbs: 54,
+            fat: 6,
+          },
+        ],
+      });
+
+      const lunch = await createMealViaApi(app, userToken, date, {
+        name: 'Lunch',
+        time: '12:30',
+        items: [
+          {
+            name: 'Chicken Rice Bowl',
+            amount: 1,
+            unit: 'plate',
+            calories: 640,
+            protein: 42,
+            carbs: 68,
+            fat: 22,
+          },
+        ],
+      });
+
+      const dinner = await createMealViaApi(app, userToken, date, {
+        name: 'Dinner',
+        time: '18:45',
+        items: [
+          {
+            name: 'Salmon',
+            amount: 6,
+            unit: 'oz',
+            calories: 350,
+            protein: 38,
+            carbs: 0,
+            fat: 20,
+          },
+        ],
+      });
+
+      const dailyResponse = await app.inject({
+        method: 'GET',
+        url: `/api/v1/nutrition/${date}`,
+        headers: createAuthorizationHeader(userToken),
+      });
+
+      expect(dailyResponse.statusCode).toBe(200);
+      const dailyData = parseData<{
+        log: StoredNutritionLog;
+        meals: Array<{ meal: StoredMeal; items: StoredMealItem[] }>;
+      }>(dailyResponse);
+      expect(dailyData.log.date).toBe(date);
+      expect(dailyData.meals).toHaveLength(3);
+      expect(dailyData.meals.map((entry) => entry.meal.name)).toEqual([
+        breakfast.meal.name,
+        lunch.meal.name,
+        dinner.meal.name,
+      ]);
+      expect(dailyData.meals.every((entry) => entry.items.length === 1)).toBe(true);
+
+      const deleteMealResponse = await app.inject({
+        method: 'DELETE',
+        url: `/api/v1/nutrition/${date}/meals/${lunch.meal.id}`,
+        headers: createAuthorizationHeader(userToken),
+      });
+
+      expect(deleteMealResponse.statusCode).toBe(200);
+      expect(parseData<{ success: true }>(deleteMealResponse)).toEqual({ success: true });
+
+      const afterDeleteResponse = await app.inject({
+        method: 'GET',
+        url: `/api/v1/nutrition/${date}`,
+        headers: createAuthorizationHeader(userToken),
+      });
+
+      expect(afterDeleteResponse.statusCode).toBe(200);
+      const afterDeleteData = parseData<{
+        log: StoredNutritionLog;
+        meals: Array<{ meal: StoredMeal; items: StoredMealItem[] }>;
+      }>(afterDeleteResponse);
+      expect(afterDeleteData.meals).toHaveLength(2);
+      expect(afterDeleteData.meals.map((entry) => entry.meal.name)).toEqual(['Breakfast', 'Dinner']);
+      expect(afterDeleteData.meals.flatMap((entry) => entry.items).map((item) => item.mealId)).not.toContain(
+        lunch.meal.id,
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns summary totals from meal items and zeros for an empty day', async () => {
+    const { app } = await createTestApp();
+
+    try {
+      const userToken = app.jwt.sign({ userId: 'user-a' });
+      const date = '2026-03-11';
+
+      await createMealViaApi(app, userToken, date, {
+        name: 'Lunch',
+        items: [
+          {
+            name: 'Turkey Sandwich',
+            amount: 1,
+            unit: 'serving',
+            calories: 420,
+            protein: 32,
+            carbs: 38,
+            fat: 14,
+          },
+          {
+            name: 'Apple',
+            amount: 1,
+            unit: 'medium',
+            calories: 95,
+            protein: 0,
+            carbs: 25,
+            fat: 0,
+          },
+        ],
+      });
+
+      await createMealViaApi(app, userToken, date, {
+        name: 'Dinner',
+        items: [
+          {
+            name: 'Steak',
+            amount: 8,
+            unit: 'oz',
+            calories: 560,
+            protein: 52,
+            carbs: 0,
+            fat: 36,
+          },
+        ],
+      });
+
+      const summaryResponse = await app.inject({
+        method: 'GET',
+        url: `/api/v1/nutrition/${date}/summary`,
+        headers: createAuthorizationHeader(userToken),
+      });
+
+      expect(summaryResponse.statusCode).toBe(200);
+      expect(parseData(summaryResponse)).toEqual({
+        date,
+        meals: 2,
+        actual: {
+          calories: 1_075,
+          protein: 84,
+          carbs: 63,
+          fat: 50,
+        },
+        target: null,
+      });
+
+      const emptySummaryResponse = await app.inject({
+        method: 'GET',
+        url: '/api/v1/nutrition/2026-03-12/summary',
+        headers: createAuthorizationHeader(userToken),
+      });
+
+      expect(emptySummaryResponse.statusCode).toBe(200);
+      expect(parseData(emptySummaryResponse)).toEqual({
+        date: '2026-03-12',
+        meals: 0,
+        actual: {
+          calories: 0,
+          protein: 0,
+          carbs: 0,
+          fat: 0,
+        },
+        target: null,
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('advances lastUsedAt when the same food is used in a newer meal', async () => {
+    const { app } = await createTestApp();
+
+    try {
+      const userToken = app.jwt.sign({ userId: 'user-a' });
+
+      const eggs = await createFoodViaApi(app, userToken, {
+        name: 'Eggs',
+        brand: 'Farm Fresh',
+        servingSize: '2 large',
+        calories: 140,
+        protein: 12,
+        carbs: 1,
+        fat: 10,
+      });
+
+      await createMealViaApi(app, userToken, '2026-03-13', {
+        name: 'Breakfast',
+        items: [
+          {
+            foodId: eggs.id,
+            name: 'Eggs',
+            amount: 1,
+            unit: 'serving',
+            calories: 140,
+            protein: 12,
+            carbs: 1,
+            fat: 10,
+          },
+        ],
+      });
+
+      const afterFirstUseResponse = await app.inject({
+        method: 'GET',
+        url: '/api/v1/foods?q=eggs&sort=recent',
+        headers: createAuthorizationHeader(userToken),
+      });
+
+      expect(afterFirstUseResponse.statusCode).toBe(200);
+      const firstUseFood = parseData<StoredFood[]>(afterFirstUseResponse)[0];
+      expect(firstUseFood?.lastUsedAt).not.toBeNull();
+
+      await waitForClockTick();
+      await createMealViaApi(app, userToken, '2026-03-14', {
+        name: 'Breakfast',
+        items: [
+          {
+            foodId: eggs.id,
+            name: 'Eggs',
+            amount: 1,
+            unit: 'serving',
+            calories: 140,
+            protein: 12,
+            carbs: 1,
+            fat: 10,
+          },
+        ],
+      });
+
+      const afterSecondUseResponse = await app.inject({
+        method: 'GET',
+        url: '/api/v1/foods?q=eggs&sort=recent',
+        headers: createAuthorizationHeader(userToken),
+      });
+
+      expect(afterSecondUseResponse.statusCode).toBe(200);
+      const secondUseFood = parseData<StoredFood[]>(afterSecondUseResponse)[0];
+      expect((secondUseFood?.lastUsedAt ?? 0) - (firstUseFood?.lastUsedAt ?? 0)).toBeGreaterThan(0);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import { exerciseRoutes } from './routes/exercises/index.js';
 import { foodsRoutes } from './routes/foods/index.js';
 import { habitEntryCollectionRoutes } from './routes/habit-entries/index.js';
 import { habitRoutes } from './routes/habits/index.js';
+import { nutritionRoutes } from './routes/nutrition/index.js';
 import { nutritionTargetRoutes } from './routes/nutrition-targets/index.js';
 import { scheduledWorkoutRoutes } from './routes/scheduled-workouts/index.js';
 import { weightRoutes } from './routes/weight/index.js';
@@ -42,6 +43,7 @@ export const buildServer = () => {
   app.register(foodsRoutes, { prefix: '/api/v1/foods' });
   app.register(habitRoutes, { prefix: '/api/v1/habits' });
   app.register(habitEntryCollectionRoutes, { prefix: '/api/v1/habit-entries' });
+  app.register(nutritionRoutes, { prefix: '/api/v1/nutrition' });
   app.register(nutritionTargetRoutes, { prefix: '/api/v1/nutrition-targets' });
   app.register(scheduledWorkoutRoutes, { prefix: '/api/v1/scheduled-workouts' });
   app.register(weightRoutes, { prefix: '/api/v1/weight' });

--- a/apps/api/src/routes/nutrition/index.test.ts
+++ b/apps/api/src/routes/nutrition/index.test.ts
@@ -1,0 +1,391 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildServer } from '../../index.js';
+import { updateFoodLastUsedAt } from '../foods/store.js';
+
+import { createMealForDate, deleteMealForDate, getDailyNutritionForDate } from './store.js';
+
+vi.mock('./store.js', () => ({
+  createMealForDate: vi.fn(),
+  deleteMealForDate: vi.fn(),
+  getDailyNutritionForDate: vi.fn(),
+}));
+
+vi.mock('../foods/store.js', () => ({
+  updateFoodLastUsedAt: vi.fn(),
+}));
+
+const createAuthorizationHeader = (token: string) => ({
+  authorization: `Bearer ${token}`,
+});
+
+const meal = {
+  id: 'meal-1',
+  nutritionLogId: 'log-1',
+  name: 'Lunch',
+  time: '12:30',
+  notes: null,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+};
+
+const mealItems = [
+  {
+    id: 'item-1',
+    mealId: 'meal-1',
+    foodId: 'food-1',
+    name: 'Chicken Breast',
+    amount: 8,
+    unit: 'oz',
+    calories: 374,
+    protein: 70,
+    carbs: 0,
+    fat: 8,
+    fiber: null,
+    sugar: null,
+    createdAt: 1_700_000_000_001,
+  },
+  {
+    id: 'item-2',
+    mealId: 'meal-1',
+    foodId: null,
+    name: 'Olive Oil',
+    amount: 1,
+    unit: 'tbsp',
+    calories: 120,
+    protein: 0,
+    carbs: 0,
+    fat: 14,
+    fiber: null,
+    sugar: null,
+    createdAt: 1_700_000_000_002,
+  },
+];
+
+describe('nutrition routes', () => {
+  beforeEach(() => {
+    vi.mocked(createMealForDate).mockReset();
+    vi.mocked(deleteMealForDate).mockReset();
+    vi.mocked(getDailyNutritionForDate).mockReset();
+    vi.mocked(updateFoodLastUsedAt).mockReset();
+    vi.mocked(updateFoodLastUsedAt).mockResolvedValue(undefined);
+    process.env.JWT_SECRET = 'test-nutrition-routes-secret';
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  it('creates a meal for a date and updates referenced food recency', async () => {
+    vi.mocked(createMealForDate).mockResolvedValue({
+      meal,
+      items: mealItems,
+    });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/v1/nutrition/2026-03-09/meals',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          name: ' Lunch ',
+          time: '12:30',
+          items: [
+            {
+              foodId: 'food-1',
+              name: ' Chicken Breast ',
+              amount: 8,
+              unit: ' oz ',
+              calories: 374,
+              protein: 70,
+              carbs: 0,
+              fat: 8,
+            },
+            {
+              name: 'Olive Oil',
+              amount: 1,
+              unit: 'tbsp',
+              calories: 120,
+              protein: 0,
+              carbs: 0,
+              fat: 14,
+            },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(response.json()).toEqual({
+        data: {
+          meal,
+          items: mealItems,
+        },
+      });
+      expect(vi.mocked(createMealForDate)).toHaveBeenCalledWith('user-1', '2026-03-09', {
+        name: 'Lunch',
+        time: '12:30',
+        items: [
+          {
+            foodId: 'food-1',
+            name: 'Chicken Breast',
+            amount: 8,
+            unit: 'oz',
+            calories: 374,
+            protein: 70,
+            carbs: 0,
+            fat: 8,
+          },
+          {
+            name: 'Olive Oil',
+            amount: 1,
+            unit: 'tbsp',
+            calories: 120,
+            protein: 0,
+            carbs: 0,
+            fat: 14,
+          },
+        ],
+      });
+      expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenCalledWith('food-1', 'user-1');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('gets nested daily nutrition data or null for missing logs', async () => {
+    vi.mocked(getDailyNutritionForDate)
+      .mockResolvedValueOnce({
+        log: {
+          id: 'log-1',
+          userId: 'user-1',
+          date: '2026-03-09',
+          notes: null,
+          createdAt: 1_700_000_000_000,
+          updatedAt: 1_700_000_000_000,
+        },
+        meals: [
+          {
+            meal,
+            items: mealItems,
+          },
+        ],
+      })
+      .mockResolvedValueOnce(null);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const [foundResponse, emptyResponse] = await Promise.all([
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/nutrition/2026-03-09',
+          headers: createAuthorizationHeader(authToken),
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/nutrition/2026-03-10',
+          headers: createAuthorizationHeader(authToken),
+        }),
+      ]);
+
+      expect(foundResponse.statusCode).toBe(200);
+      expect(foundResponse.json()).toEqual({
+        data: {
+          log: {
+            id: 'log-1',
+            userId: 'user-1',
+            date: '2026-03-09',
+            notes: null,
+            createdAt: 1_700_000_000_000,
+            updatedAt: 1_700_000_000_000,
+          },
+          meals: [
+            {
+              meal,
+              items: mealItems,
+            },
+          ],
+        },
+      });
+      expect(emptyResponse.statusCode).toBe(200);
+      expect(emptyResponse.json()).toEqual({
+        data: null,
+      });
+      expect(vi.mocked(getDailyNutritionForDate)).toHaveBeenNthCalledWith(
+        1,
+        'user-1',
+        '2026-03-09',
+      );
+      expect(vi.mocked(getDailyNutritionForDate)).toHaveBeenNthCalledWith(
+        2,
+        'user-1',
+        '2026-03-10',
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('deletes an existing meal in user scope and returns not found otherwise', async () => {
+    vi.mocked(deleteMealForDate).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+
+      const deleteResponse = await app.inject({
+        method: 'DELETE',
+        url: '/api/v1/nutrition/2026-03-09/meals/meal-1',
+        headers: createAuthorizationHeader(authToken),
+      });
+      const missingResponse = await app.inject({
+        method: 'DELETE',
+        url: '/api/v1/nutrition/2026-03-09/meals/missing-meal',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(deleteResponse.statusCode).toBe(200);
+      expect(deleteResponse.json()).toEqual({
+        data: {
+          success: true,
+        },
+      });
+      expect(missingResponse.statusCode).toBe(404);
+      expect(missingResponse.json()).toEqual({
+        error: {
+          code: 'MEAL_NOT_FOUND',
+          message: 'Meal not found',
+        },
+      });
+      expect(vi.mocked(deleteMealForDate)).toHaveBeenNthCalledWith(
+        1,
+        'user-1',
+        '2026-03-09',
+        'meal-1',
+      );
+      expect(vi.mocked(deleteMealForDate)).toHaveBeenNthCalledWith(
+        2,
+        'user-1',
+        '2026-03-09',
+        'missing-meal',
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('validates date and meal payloads', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const [invalidDateResponse, invalidPayloadResponse, invalidDeleteParamsResponse] =
+        await Promise.all([
+          app.inject({
+            method: 'GET',
+            url: '/api/v1/nutrition/03-09-2026',
+            headers: createAuthorizationHeader(authToken),
+          }),
+          app.inject({
+            method: 'POST',
+            url: '/api/v1/nutrition/2026-03-09/meals',
+            headers: createAuthorizationHeader(authToken),
+            payload: {
+              name: 'Lunch',
+              time: '7:30',
+              items: [],
+            },
+          }),
+          app.inject({
+            method: 'DELETE',
+            url: '/api/v1/nutrition/2026-03-09/meals/%20%20',
+            headers: createAuthorizationHeader(authToken),
+          }),
+        ]);
+
+      expect(invalidDateResponse.statusCode).toBe(400);
+      expect(invalidDateResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid nutrition date',
+        },
+      });
+
+      expect(invalidPayloadResponse.statusCode).toBe(400);
+      expect(invalidPayloadResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid meal payload',
+        },
+      });
+
+      expect(invalidDeleteParamsResponse.statusCode).toBe(400);
+      expect(invalidDeleteParamsResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid meal parameters',
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('requires auth for nutrition endpoints', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const responses = await Promise.all([
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/nutrition/2026-03-09/meals',
+          payload: {
+            name: 'Lunch',
+            items: [
+              {
+                name: 'Chicken Breast',
+                amount: 8,
+                unit: 'oz',
+                calories: 374,
+                protein: 70,
+                carbs: 0,
+                fat: 8,
+              },
+            ],
+          },
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/nutrition/2026-03-09',
+        }),
+        app.inject({
+          method: 'DELETE',
+          url: '/api/v1/nutrition/2026-03-09/meals/meal-1',
+        }),
+      ]);
+
+      for (const response of responses) {
+        expect(response.statusCode).toBe(401);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'UNAUTHORIZED',
+            message: 'Authentication required',
+          },
+        });
+      }
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apps/api/src/routes/nutrition/index.test.ts
+++ b/apps/api/src/routes/nutrition/index.test.ts
@@ -3,12 +3,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildServer } from '../../index.js';
 import { updateFoodLastUsedAt } from '../foods/store.js';
 
-import { createMealForDate, deleteMealForDate, getDailyNutritionForDate } from './store.js';
+import {
+  createMealForDate,
+  deleteMealForDate,
+  getDailyNutritionForDate,
+  getDailyNutritionSummaryForDate,
+} from './store.js';
 
 vi.mock('./store.js', () => ({
   createMealForDate: vi.fn(),
   deleteMealForDate: vi.fn(),
   getDailyNutritionForDate: vi.fn(),
+  getDailyNutritionSummaryForDate: vi.fn(),
 }));
 
 vi.mock('../foods/store.js', () => ({
@@ -62,11 +68,29 @@ const mealItems = [
   },
 ];
 
+const nutritionSummary = {
+  date: '2026-03-09',
+  meals: 1,
+  actual: {
+    calories: 494,
+    protein: 70,
+    carbs: 0,
+    fat: 22,
+  },
+  target: {
+    calories: 2200,
+    protein: 180,
+    carbs: 250,
+    fat: 70,
+  },
+};
+
 describe('nutrition routes', () => {
   beforeEach(() => {
     vi.mocked(createMealForDate).mockReset();
     vi.mocked(deleteMealForDate).mockReset();
     vi.mocked(getDailyNutritionForDate).mockReset();
+    vi.mocked(getDailyNutritionSummaryForDate).mockReset();
     vi.mocked(updateFoodLastUsedAt).mockReset();
     vi.mocked(updateFoodLastUsedAt).mockResolvedValue(undefined);
     process.env.JWT_SECRET = 'test-nutrition-routes-secret';
@@ -283,17 +307,94 @@ describe('nutrition routes', () => {
     }
   });
 
+  it('gets a daily nutrition summary with actuals, target, and meal count', async () => {
+    vi.mocked(getDailyNutritionSummaryForDate)
+      .mockResolvedValueOnce(nutritionSummary)
+      .mockResolvedValueOnce({
+        date: '2026-03-10',
+        meals: 0,
+        actual: {
+          calories: 0,
+          protein: 0,
+          carbs: 0,
+          fat: 0,
+        },
+        target: null,
+      });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+
+      const [foundResponse, emptyResponse] = await Promise.all([
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/nutrition/2026-03-09/summary',
+          headers: createAuthorizationHeader(authToken),
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/nutrition/2026-03-10/summary',
+          headers: createAuthorizationHeader(authToken),
+        }),
+      ]);
+
+      expect(foundResponse.statusCode).toBe(200);
+      expect(foundResponse.json()).toEqual({
+        data: nutritionSummary,
+      });
+      expect(emptyResponse.statusCode).toBe(200);
+      expect(emptyResponse.json()).toEqual({
+        data: {
+          date: '2026-03-10',
+          meals: 0,
+          actual: {
+            calories: 0,
+            protein: 0,
+            carbs: 0,
+            fat: 0,
+          },
+          target: null,
+        },
+      });
+      expect(vi.mocked(getDailyNutritionSummaryForDate)).toHaveBeenNthCalledWith(
+        1,
+        'user-1',
+        '2026-03-09',
+      );
+      expect(vi.mocked(getDailyNutritionSummaryForDate)).toHaveBeenNthCalledWith(
+        2,
+        'user-1',
+        '2026-03-10',
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
   it('validates date and meal payloads', async () => {
     const app = buildServer();
 
     try {
       await app.ready();
       const authToken = app.jwt.sign({ userId: 'user-1' });
-      const [invalidDateResponse, invalidPayloadResponse, invalidDeleteParamsResponse] =
+      const [
+        invalidDateResponse,
+        invalidSummaryDateResponse,
+        invalidPayloadResponse,
+        invalidDeleteParamsResponse,
+      ] =
         await Promise.all([
           app.inject({
             method: 'GET',
             url: '/api/v1/nutrition/03-09-2026',
+            headers: createAuthorizationHeader(authToken),
+          }),
+          app.inject({
+            method: 'GET',
+            url: '/api/v1/nutrition/03-09-2026/summary',
             headers: createAuthorizationHeader(authToken),
           }),
           app.inject({
@@ -315,6 +416,13 @@ describe('nutrition routes', () => {
 
       expect(invalidDateResponse.statusCode).toBe(400);
       expect(invalidDateResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid nutrition date',
+        },
+      });
+      expect(invalidSummaryDateResponse.statusCode).toBe(400);
+      expect(invalidSummaryDateResponse.json()).toEqual({
         error: {
           code: 'VALIDATION_ERROR',
           message: 'Invalid nutrition date',
@@ -368,6 +476,10 @@ describe('nutrition routes', () => {
         app.inject({
           method: 'GET',
           url: '/api/v1/nutrition/2026-03-09',
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/nutrition/2026-03-09/summary',
         }),
         app.inject({
           method: 'DELETE',

--- a/apps/api/src/routes/nutrition/index.test.ts
+++ b/apps/api/src/routes/nutrition/index.test.ts
@@ -128,6 +128,8 @@ describe('nutrition routes', () => {
               protein: 70,
               carbs: 0,
               fat: 8,
+              fiber: 0,
+              sugar: 0,
             },
             {
               name: 'Olive Oil',
@@ -162,6 +164,8 @@ describe('nutrition routes', () => {
             protein: 70,
             carbs: 0,
             fat: 8,
+            fiber: 0,
+            sugar: 0,
           },
           {
             name: 'Olive Oil',
@@ -175,6 +179,52 @@ describe('nutrition routes', () => {
         ],
       });
       expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenCalledWith('food-1', 'user-1');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('does not fail meal creation when recency updates fail', async () => {
+    vi.mocked(createMealForDate).mockResolvedValue({
+      meal,
+      items: mealItems,
+    });
+    vi.mocked(updateFoodLastUsedAt).mockRejectedValueOnce(new Error('transient update failure'));
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/v1/nutrition/2026-03-09/meals',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          name: 'Lunch',
+          items: [
+            {
+              foodId: 'food-1',
+              name: 'Chicken Breast',
+              amount: 8,
+              unit: 'oz',
+              calories: 374,
+              protein: 70,
+              carbs: 0,
+              fat: 8,
+            },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(response.json()).toEqual({
+        data: {
+          meal,
+          items: mealItems,
+        },
+      });
       expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenCalledWith('food-1', 'user-1');
     } finally {
       await app.close();
@@ -382,6 +432,7 @@ describe('nutrition routes', () => {
       const authToken = app.jwt.sign({ userId: 'user-1' });
       const [
         invalidDateResponse,
+        invalidCalendarDateResponse,
         invalidSummaryDateResponse,
         invalidPayloadResponse,
         invalidDeleteParamsResponse,
@@ -390,6 +441,11 @@ describe('nutrition routes', () => {
           app.inject({
             method: 'GET',
             url: '/api/v1/nutrition/03-09-2026',
+            headers: createAuthorizationHeader(authToken),
+          }),
+          app.inject({
+            method: 'GET',
+            url: '/api/v1/nutrition/2026-02-30',
             headers: createAuthorizationHeader(authToken),
           }),
           app.inject({
@@ -416,6 +472,13 @@ describe('nutrition routes', () => {
 
       expect(invalidDateResponse.statusCode).toBe(400);
       expect(invalidDateResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid nutrition date',
+        },
+      });
+      expect(invalidCalendarDateResponse.statusCode).toBe(400);
+      expect(invalidCalendarDateResponse.json()).toEqual({
         error: {
           code: 'VALIDATION_ERROR',
           message: 'Invalid nutrition date',

--- a/apps/api/src/routes/nutrition/index.ts
+++ b/apps/api/src/routes/nutrition/index.ts
@@ -1,0 +1,76 @@
+import { createMealInputSchema } from '@pulse/shared';
+import type { FastifyPluginAsync } from 'fastify';
+
+import { sendError } from '../../lib/reply.js';
+import { requireAuth } from '../../middleware/auth.js';
+import { updateFoodLastUsedAt } from '../foods/store.js';
+
+import { createMealForDate, deleteMealForDate, getDailyNutritionForDate } from './store.js';
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const isValidDateParam = (date: string) => DATE_PATTERN.test(date);
+const isValidMealIdParam = (mealId: string) => mealId.trim().length > 0;
+const isNonEmptyString = (value: string | null): value is string =>
+  typeof value === 'string' && value.length > 0;
+
+export const nutritionRoutes: FastifyPluginAsync = async (app) => {
+  app.addHook('onRequest', requireAuth);
+
+  app.post<{ Params: { date: string } }>('/:date/meals', async (request, reply) => {
+    if (!isValidDateParam(request.params.date)) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid nutrition date');
+    }
+
+    const parsedBody = createMealInputSchema.safeParse(request.body);
+    if (!parsedBody.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid meal payload');
+    }
+
+    const created = await createMealForDate(request.userId, request.params.date, parsedBody.data);
+
+    const foodIds = [...new Set(created.items.map((item) => item.foodId).filter(isNonEmptyString))];
+    await Promise.all(foodIds.map((foodId) => updateFoodLastUsedAt(foodId, request.userId)));
+
+    return reply.code(201).send({
+      data: created,
+    });
+  });
+
+  app.get<{ Params: { date: string } }>('/:date', async (request, reply) => {
+    if (!isValidDateParam(request.params.date)) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid nutrition date');
+    }
+
+    const nutrition = await getDailyNutritionForDate(request.userId, request.params.date);
+
+    return reply.send({
+      data: nutrition,
+    });
+  });
+
+  app.delete<{ Params: { date: string; mealId: string } }>(
+    '/:date/meals/:mealId',
+    async (request, reply) => {
+      if (!isValidDateParam(request.params.date) || !isValidMealIdParam(request.params.mealId)) {
+        return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid meal parameters');
+      }
+
+      const deleted = await deleteMealForDate(
+        request.userId,
+        request.params.date,
+        request.params.mealId,
+      );
+
+      if (!deleted) {
+        return sendError(reply, 404, 'MEAL_NOT_FOUND', 'Meal not found');
+      }
+
+      return reply.send({
+        data: {
+          success: true,
+        },
+      });
+    },
+  );
+};

--- a/apps/api/src/routes/nutrition/index.ts
+++ b/apps/api/src/routes/nutrition/index.ts
@@ -5,7 +5,12 @@ import { sendError } from '../../lib/reply.js';
 import { requireAuth } from '../../middleware/auth.js';
 import { updateFoodLastUsedAt } from '../foods/store.js';
 
-import { createMealForDate, deleteMealForDate, getDailyNutritionForDate } from './store.js';
+import {
+  createMealForDate,
+  deleteMealForDate,
+  getDailyNutritionForDate,
+  getDailyNutritionSummaryForDate,
+} from './store.js';
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -46,6 +51,18 @@ export const nutritionRoutes: FastifyPluginAsync = async (app) => {
 
     return reply.send({
       data: nutrition,
+    });
+  });
+
+  app.get<{ Params: { date: string } }>('/:date/summary', async (request, reply) => {
+    if (!isValidDateParam(request.params.date)) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid nutrition date');
+    }
+
+    const summary = await getDailyNutritionSummaryForDate(request.userId, request.params.date);
+
+    return reply.send({
+      data: summary,
     });
   });
 

--- a/apps/api/src/routes/nutrition/index.ts
+++ b/apps/api/src/routes/nutrition/index.ts
@@ -14,7 +14,14 @@ import {
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
-const isValidDateParam = (date: string) => DATE_PATTERN.test(date);
+const isValidDateParam = (date: string) => {
+  if (!DATE_PATTERN.test(date)) {
+    return false;
+  }
+
+  const parsed = new Date(`${date}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(date);
+};
 const isValidMealIdParam = (mealId: string) => mealId.trim().length > 0;
 const isNonEmptyString = (value: string | null): value is string =>
   typeof value === 'string' && value.length > 0;
@@ -35,7 +42,7 @@ export const nutritionRoutes: FastifyPluginAsync = async (app) => {
     const created = await createMealForDate(request.userId, request.params.date, parsedBody.data);
 
     const foodIds = [...new Set(created.items.map((item) => item.foodId).filter(isNonEmptyString))];
-    await Promise.all(foodIds.map((foodId) => updateFoodLastUsedAt(foodId, request.userId)));
+    await Promise.allSettled(foodIds.map((foodId) => updateFoodLastUsedAt(foodId, request.userId)));
 
     return reply.code(201).send({
       data: created,

--- a/apps/api/src/routes/nutrition/store.test.ts
+++ b/apps/api/src/routes/nutrition/store.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mealItems, meals, nutritionLogs, nutritionTargets } from '../../db/schema/index.js';
+
+const testState = vi.hoisted(() => {
+  const aggregateGet = vi.fn();
+  const aggregateWhere = vi.fn(() => ({
+    get: aggregateGet,
+  }));
+  const aggregateLeftJoinMealItems = vi.fn(() => ({
+    where: aggregateWhere,
+  }));
+  const aggregateLeftJoinMeals = vi.fn(() => ({
+    leftJoin: aggregateLeftJoinMealItems,
+  }));
+  const aggregateFrom = vi.fn(() => ({
+    leftJoin: aggregateLeftJoinMeals,
+  }));
+
+  const targetGet = vi.fn();
+  const targetLimit = vi.fn(() => ({
+    get: targetGet,
+  }));
+  const targetOrderBy = vi.fn(() => ({
+    limit: targetLimit,
+  }));
+  const targetWhere = vi.fn(() => ({
+    orderBy: targetOrderBy,
+  }));
+  const targetFrom = vi.fn(() => ({
+    where: targetWhere,
+  }));
+
+  const select = vi.fn();
+
+  const queueSummarySelects = () => {
+    select.mockImplementationOnce(() => ({
+      from: aggregateFrom,
+    }));
+    select.mockImplementationOnce(() => ({
+      from: targetFrom,
+    }));
+  };
+
+  return {
+    db: {
+      select,
+    },
+    reset() {
+      select.mockReset();
+      aggregateFrom.mockClear();
+      aggregateLeftJoinMeals.mockClear();
+      aggregateLeftJoinMealItems.mockClear();
+      aggregateWhere.mockClear();
+      aggregateGet.mockClear();
+      targetFrom.mockClear();
+      targetWhere.mockClear();
+      targetOrderBy.mockClear();
+      targetLimit.mockClear();
+      targetGet.mockClear();
+      queueSummarySelects();
+    },
+    select,
+    aggregateFrom,
+    aggregateLeftJoinMeals,
+    aggregateLeftJoinMealItems,
+    aggregateWhere,
+    aggregateGet,
+    targetFrom,
+    targetWhere,
+    targetOrderBy,
+    targetLimit,
+    targetGet,
+  };
+});
+
+vi.mock('../../db/index.js', () => ({
+  db: testState.db,
+}));
+
+describe('nutrition store', () => {
+  beforeEach(() => {
+    testState.reset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns a daily summary using aggregated actuals and effective target macros', async () => {
+    testState.aggregateGet.mockReturnValue({
+      calories: 1_850,
+      protein: 150,
+      carbs: 175,
+      fat: 62,
+      meals: 3,
+    });
+    testState.targetGet.mockReturnValue({
+      calories: 2_200,
+      protein: 180,
+      carbs: 250,
+      fat: 70,
+    });
+
+    const { getDailyNutritionSummaryForDate } = await import('./store.js');
+    const summary = await getDailyNutritionSummaryForDate('user-1', '2026-03-09');
+
+    expect(summary).toEqual({
+      date: '2026-03-09',
+      meals: 3,
+      actual: {
+        calories: 1_850,
+        protein: 150,
+        carbs: 175,
+        fat: 62,
+      },
+      target: {
+        calories: 2_200,
+        protein: 180,
+        carbs: 250,
+        fat: 70,
+      },
+    });
+
+    expect(testState.select).toHaveBeenCalledTimes(2);
+    expect(testState.aggregateFrom).toHaveBeenCalledWith(nutritionLogs);
+    expect(testState.aggregateLeftJoinMeals).toHaveBeenCalledWith(
+      meals,
+      expect.anything(),
+    );
+    expect(testState.aggregateLeftJoinMealItems).toHaveBeenCalledWith(
+      mealItems,
+      expect.anything(),
+    );
+    expect(testState.targetFrom).toHaveBeenCalledWith(nutritionTargets);
+    expect(testState.targetLimit).toHaveBeenCalledWith(1);
+  });
+
+  it('returns zeroed actuals with null target when no log or target exists', async () => {
+    testState.aggregateGet.mockReturnValue(undefined);
+    testState.targetGet.mockReturnValue(undefined);
+
+    const { getDailyNutritionSummaryForDate } = await import('./store.js');
+    const summary = await getDailyNutritionSummaryForDate('user-1', '2026-03-10');
+
+    expect(summary).toEqual({
+      date: '2026-03-10',
+      meals: 0,
+      actual: {
+        calories: 0,
+        protein: 0,
+        carbs: 0,
+        fat: 0,
+      },
+      target: null,
+    });
+    expect(testState.targetOrderBy).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/routes/nutrition/store.ts
+++ b/apps/api/src/routes/nutrition/store.ts
@@ -1,0 +1,241 @@
+import { and, asc, eq, inArray } from 'drizzle-orm';
+
+import type { CreateMealInput } from '@pulse/shared';
+
+import { mealItems, meals, nutritionLogs } from '../../db/schema/index.js';
+
+export type NutritionLogRecord = {
+  id: string;
+  userId: string;
+  date: string;
+  notes: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type MealRecord = {
+  id: string;
+  nutritionLogId: string;
+  name: string;
+  time: string | null;
+  notes: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type MealItemRecord = {
+  id: string;
+  mealId: string;
+  foodId: string | null;
+  name: string;
+  amount: number;
+  unit: string;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  fiber: number | null;
+  sugar: number | null;
+  createdAt: number;
+};
+
+export type DailyNutritionRecord = {
+  log: NutritionLogRecord;
+  meals: Array<{
+    meal: MealRecord;
+    items: MealItemRecord[];
+  }>;
+};
+
+const nutritionLogSelection = {
+  id: nutritionLogs.id,
+  userId: nutritionLogs.userId,
+  date: nutritionLogs.date,
+  notes: nutritionLogs.notes,
+  createdAt: nutritionLogs.createdAt,
+  updatedAt: nutritionLogs.updatedAt,
+};
+
+const mealSelection = {
+  id: meals.id,
+  nutritionLogId: meals.nutritionLogId,
+  name: meals.name,
+  time: meals.time,
+  notes: meals.notes,
+  createdAt: meals.createdAt,
+  updatedAt: meals.updatedAt,
+};
+
+const mealItemSelection = {
+  id: mealItems.id,
+  mealId: mealItems.mealId,
+  foodId: mealItems.foodId,
+  name: mealItems.name,
+  amount: mealItems.amount,
+  unit: mealItems.unit,
+  calories: mealItems.calories,
+  protein: mealItems.protein,
+  carbs: mealItems.carbs,
+  fat: mealItems.fat,
+  fiber: mealItems.fiber,
+  sugar: mealItems.sugar,
+  createdAt: mealItems.createdAt,
+};
+
+const toNullable = <T>(value: T | undefined): T | null => value ?? null;
+
+export const createMealForDate = async (
+  userId: string,
+  date: string,
+  input: CreateMealInput,
+): Promise<{ meal: MealRecord; items: MealItemRecord[] }> => {
+  const { db } = await import('../../db/index.js');
+
+  return db.transaction((tx) => {
+    tx.insert(nutritionLogs)
+      .values({
+        userId,
+        date,
+      })
+      .onConflictDoNothing({
+        target: [nutritionLogs.userId, nutritionLogs.date],
+      })
+      .run();
+
+    const nutritionLog = tx
+      .select(nutritionLogSelection)
+      .from(nutritionLogs)
+      .where(and(eq(nutritionLogs.userId, userId), eq(nutritionLogs.date, date)))
+      .limit(1)
+      .get();
+
+    if (!nutritionLog) {
+      throw new Error('Failed to load nutrition log');
+    }
+
+    const meal = tx
+      .insert(meals)
+      .values({
+        nutritionLogId: nutritionLog.id,
+        name: input.name,
+        time: toNullable(input.time),
+        notes: toNullable(input.notes),
+      })
+      .returning(mealSelection)
+      .get();
+
+    if (!meal) {
+      throw new Error('Failed to persist meal');
+    }
+
+    const items = input.items.map((item) => {
+      const mealItem = tx
+        .insert(mealItems)
+        .values({
+          mealId: meal.id,
+          foodId: toNullable(item.foodId),
+          name: item.name,
+          amount: item.amount,
+          unit: item.unit,
+          calories: item.calories,
+          protein: item.protein,
+          carbs: item.carbs,
+          fat: item.fat,
+        })
+        .returning(mealItemSelection)
+        .get();
+
+      if (!mealItem) {
+        throw new Error('Failed to persist meal item');
+      }
+
+      return mealItem;
+    });
+
+    return { meal, items };
+  });
+};
+
+export const getDailyNutritionForDate = async (
+  userId: string,
+  date: string,
+): Promise<DailyNutritionRecord | null> => {
+  const { db } = await import('../../db/index.js');
+
+  const log = db
+    .select(nutritionLogSelection)
+    .from(nutritionLogs)
+    .where(and(eq(nutritionLogs.userId, userId), eq(nutritionLogs.date, date)))
+    .limit(1)
+    .get();
+
+  if (!log) {
+    return null;
+  }
+
+  const dayMeals = db
+    .select(mealSelection)
+    .from(meals)
+    .where(eq(meals.nutritionLogId, log.id))
+    .orderBy(asc(meals.createdAt))
+    .all();
+
+  if (dayMeals.length === 0) {
+    return {
+      log,
+      meals: [],
+    };
+  }
+
+  const mealIds = dayMeals.map((meal) => meal.id);
+  const items = db
+    .select(mealItemSelection)
+    .from(mealItems)
+    .where(inArray(mealItems.mealId, mealIds))
+    .orderBy(asc(mealItems.createdAt))
+    .all();
+
+  const itemsByMealId = new Map<string, MealItemRecord[]>();
+  for (const item of items) {
+    const existingItems = itemsByMealId.get(item.mealId) ?? [];
+    existingItems.push(item);
+    itemsByMealId.set(item.mealId, existingItems);
+  }
+
+  return {
+    log,
+    meals: dayMeals.map((meal) => ({
+      meal,
+      items: itemsByMealId.get(meal.id) ?? [],
+    })),
+  };
+};
+
+export const deleteMealForDate = async (
+  userId: string,
+  date: string,
+  mealId: string,
+): Promise<boolean> => {
+  const { db } = await import('../../db/index.js');
+
+  return db.transaction((tx) => {
+    const scopedMeal = tx
+      .select({ id: meals.id })
+      .from(meals)
+      .innerJoin(nutritionLogs, eq(nutritionLogs.id, meals.nutritionLogId))
+      .where(
+        and(eq(meals.id, mealId), eq(nutritionLogs.userId, userId), eq(nutritionLogs.date, date)),
+      )
+      .limit(1)
+      .get();
+
+    if (!scopedMeal) {
+      return false;
+    }
+
+    tx.delete(mealItems).where(eq(mealItems.mealId, mealId)).run();
+    const result = tx.delete(meals).where(eq(meals.id, mealId)).run();
+
+    return result.changes === 1;
+  });
+};

--- a/apps/api/src/routes/nutrition/store.ts
+++ b/apps/api/src/routes/nutrition/store.ts
@@ -160,29 +160,25 @@ export const createMealForDate = async (
       throw new Error('Failed to persist meal');
     }
 
-    const items = input.items.map((item) => {
-      const mealItem = tx
-        .insert(mealItems)
-        .values({
-          mealId: meal.id,
-          foodId: toNullable(item.foodId),
-          name: item.name,
-          amount: item.amount,
-          unit: item.unit,
-          calories: item.calories,
-          protein: item.protein,
-          carbs: item.carbs,
-          fat: item.fat,
-        })
-        .returning(mealItemSelection)
-        .get();
+    const itemValues = input.items.map((item) => ({
+      mealId: meal.id,
+      foodId: toNullable(item.foodId),
+      name: item.name,
+      amount: item.amount,
+      unit: item.unit,
+      calories: item.calories,
+      protein: item.protein,
+      carbs: item.carbs,
+      fat: item.fat,
+      fiber: toNullable(item.fiber),
+      sugar: toNullable(item.sugar),
+    }));
 
-      if (!mealItem) {
-        throw new Error('Failed to persist meal item');
-      }
+    const items = tx.insert(mealItems).values(itemValues).returning(mealItemSelection).all();
 
-      return mealItem;
-    });
+    if (items.length !== input.items.length) {
+      throw new Error('Failed to persist meal items');
+    }
 
     return { meal, items };
   });

--- a/apps/api/src/routes/nutrition/store.ts
+++ b/apps/api/src/routes/nutrition/store.ts
@@ -2,7 +2,7 @@ import { and, asc, desc, eq, inArray, lte, sql } from 'drizzle-orm';
 
 import type { CreateMealInput } from '@pulse/shared';
 
-import { mealItems, meals, nutritionLogs, nutritionTargets } from '../../db/schema/index.js';
+import { foods, mealItems, meals, nutritionLogs, nutritionTargets } from '../../db/schema/index.js';
 
 export type NutritionLogRecord = {
   id: string;
@@ -173,6 +173,21 @@ export const createMealForDate = async (
       fiber: toNullable(item.fiber),
       sugar: toNullable(item.sugar),
     }));
+
+    const foodIds = [
+      ...new Set(itemValues.map((item) => item.foodId).filter((foodId): foodId is string => foodId !== null)),
+    ];
+    if (foodIds.length > 0) {
+      const ownedFoods = tx
+        .select({ id: foods.id })
+        .from(foods)
+        .where(and(inArray(foods.id, foodIds), eq(foods.userId, userId)))
+        .all();
+
+      if (ownedFoods.length !== foodIds.length) {
+        throw new Error('One or more foodIds do not belong to this user');
+      }
+    }
 
     const items = tx.insert(mealItems).values(itemValues).returning(mealItemSelection).all();
 

--- a/apps/api/src/routes/nutrition/store.ts
+++ b/apps/api/src/routes/nutrition/store.ts
@@ -1,8 +1,8 @@
-import { and, asc, eq, inArray } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, lte, sql } from 'drizzle-orm';
 
 import type { CreateMealInput } from '@pulse/shared';
 
-import { mealItems, meals, nutritionLogs } from '../../db/schema/index.js';
+import { mealItems, meals, nutritionLogs, nutritionTargets } from '../../db/schema/index.js';
 
 export type NutritionLogRecord = {
   id: string;
@@ -47,6 +47,23 @@ export type DailyNutritionRecord = {
   }>;
 };
 
+export type NutritionSummaryRecord = {
+  date: string;
+  meals: number;
+  actual: {
+    calories: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+  };
+  target: {
+    calories: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+  } | null;
+};
+
 const nutritionLogSelection = {
   id: nutritionLogs.id,
   userId: nutritionLogs.userId,
@@ -80,6 +97,21 @@ const mealItemSelection = {
   fiber: mealItems.fiber,
   sugar: mealItems.sugar,
   createdAt: mealItems.createdAt,
+};
+
+const nutritionSummarySelection = {
+  calories: sql<number>`coalesce(sum(${mealItems.calories}), 0)`,
+  protein: sql<number>`coalesce(sum(${mealItems.protein}), 0)`,
+  carbs: sql<number>`coalesce(sum(${mealItems.carbs}), 0)`,
+  fat: sql<number>`coalesce(sum(${mealItems.fat}), 0)`,
+  meals: sql<number>`count(distinct ${meals.id})`,
+};
+
+const nutritionTargetMacroSelection = {
+  calories: nutritionTargets.calories,
+  protein: nutritionTargets.protein,
+  carbs: nutritionTargets.carbs,
+  fat: nutritionTargets.fat,
 };
 
 const toNullable = <T>(value: T | undefined): T | null => value ?? null;
@@ -208,6 +240,56 @@ export const getDailyNutritionForDate = async (
       meal,
       items: itemsByMealId.get(meal.id) ?? [],
     })),
+  };
+};
+
+export const getDailyNutritionSummaryForDate = async (
+  userId: string,
+  date: string,
+): Promise<NutritionSummaryRecord> => {
+  const { db } = await import('../../db/index.js');
+
+  const actuals =
+    db
+      .select(nutritionSummarySelection)
+      .from(nutritionLogs)
+      .leftJoin(meals, eq(meals.nutritionLogId, nutritionLogs.id))
+      .leftJoin(mealItems, eq(mealItems.mealId, meals.id))
+      .where(and(eq(nutritionLogs.userId, userId), eq(nutritionLogs.date, date)))
+      .get() ?? {
+      calories: 0,
+      protein: 0,
+      carbs: 0,
+      fat: 0,
+      meals: 0,
+    };
+
+  const target =
+    db
+      .select(nutritionTargetMacroSelection)
+      .from(nutritionTargets)
+      .where(and(eq(nutritionTargets.userId, userId), lte(nutritionTargets.effectiveDate, date)))
+      .orderBy(desc(nutritionTargets.effectiveDate))
+      .limit(1)
+      .get() ?? null;
+
+  return {
+    date,
+    meals: Number(actuals.meals ?? 0),
+    actual: {
+      calories: Number(actuals.calories ?? 0),
+      protein: Number(actuals.protein ?? 0),
+      carbs: Number(actuals.carbs ?? 0),
+      fat: Number(actuals.fat ?? 0),
+    },
+    target: target
+      ? {
+          calories: Number(target.calories),
+          protein: Number(target.protein),
+          carbs: Number(target.carbs),
+          fat: Number(target.fat),
+        }
+      : null,
   };
 };
 

--- a/apps/web/src/features/nutrition/api/keys.ts
+++ b/apps/web/src/features/nutrition/api/keys.ts
@@ -1,0 +1,5 @@
+export const nutritionKeys = {
+  all: ['nutrition'] as const,
+  daily: (date: string) => [...nutritionKeys.all, 'daily', date] as const,
+  summary: (date: string) => [...nutritionKeys.all, 'summary', date] as const,
+};

--- a/apps/web/src/features/nutrition/api/nutrition.test.tsx
+++ b/apps/web/src/features/nutrition/api/nutrition.test.tsx
@@ -1,0 +1,143 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { nutritionKeys } from './keys';
+import { useDailyNutrition, useDeleteMeal, useNutritionSummary } from './nutrition';
+
+const mockFetch = vi.fn();
+
+const createJsonResponse = (data: unknown) =>
+  new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status: 200,
+  });
+
+describe('nutrition api hooks', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  it('loads daily nutrition for a given date', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        log: {
+          id: 'log-1',
+          userId: 'user-1',
+          date: '2026-03-09',
+          notes: null,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        meals: [
+          {
+            meal: {
+              id: 'meal-1',
+              nutritionLogId: 'log-1',
+              name: 'Breakfast',
+              time: '07:20',
+              notes: null,
+              createdAt: 1,
+              updatedAt: 1,
+            },
+            items: [
+              {
+                id: 'item-1',
+                mealId: 'meal-1',
+                foodId: 'food-eggs',
+                name: 'Large Eggs',
+                amount: 3,
+                unit: 'eggs',
+                calories: 210,
+                protein: 18,
+                carbs: 1,
+                fat: 15,
+                fiber: null,
+                sugar: null,
+                createdAt: 1,
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useDailyNutrition('2026-03-09'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.log.id).toBe('log-1');
+    expect(result.current.data?.meals[0]?.meal.id).toBe('meal-1');
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/nutrition/2026-03-09', expect.any(Object));
+  });
+
+  it('loads daily nutrition summary for a given date', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        date: '2026-03-09',
+        meals: 3,
+        actual: {
+          calories: 1984,
+          protein: 172,
+          carbs: 211,
+          fat: 62,
+        },
+        target: {
+          calories: 2200,
+          protein: 180,
+          carbs: 250,
+          fat: 73,
+        },
+      }),
+    );
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useNutritionSummary('2026-03-09'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.actual.calories).toBe(1984);
+    expect(result.current.data?.target?.protein).toBe(180);
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/nutrition/2026-03-09/summary',
+      expect.any(Object),
+    );
+  });
+
+  it('deletes a meal and invalidates daily + summary cache for that date', async () => {
+    mockFetch.mockResolvedValueOnce(createJsonResponse({ success: true }));
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useDeleteMeal(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        date: '2026-03-09',
+        mealId: 'meal-1',
+      });
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/nutrition/2026-03-09/meals/meal-1',
+      expect.objectContaining({
+        method: 'DELETE',
+      }),
+    );
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: nutritionKeys.daily('2026-03-09'),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: nutritionKeys.summary('2026-03-09'),
+    });
+  });
+});

--- a/apps/web/src/features/nutrition/api/nutrition.ts
+++ b/apps/web/src/features/nutrition/api/nutrition.ts
@@ -1,68 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { DailyNutrition, DeleteMealResult, NutritionSummary } from '@pulse/shared';
 
 import { apiRequest } from '@/lib/api-client';
 
 import { nutritionKeys } from './keys';
-
-export type NutritionLog = {
-  id: string;
-  userId: string;
-  date: string;
-  notes: string | null;
-  createdAt: number;
-  updatedAt: number;
-};
-
-export type NutritionMealRecord = {
-  id: string;
-  nutritionLogId: string;
-  name: string;
-  time: string | null;
-  notes: string | null;
-  createdAt: number;
-  updatedAt: number;
-};
-
-export type NutritionMealItem = {
-  id: string;
-  mealId: string;
-  foodId: string | null;
-  name: string;
-  amount: number;
-  unit: string;
-  calories: number;
-  protein: number;
-  carbs: number;
-  fat: number;
-  fiber: number | null;
-  sugar: number | null;
-  createdAt: number;
-};
-
-export type DailyNutrition = {
-  log: NutritionLog;
-  meals: Array<{
-    meal: NutritionMealRecord;
-    items: NutritionMealItem[];
-  }>;
-} | null;
-
-export type NutritionSummary = {
-  date: string;
-  meals: number;
-  actual: {
-    calories: number;
-    protein: number;
-    carbs: number;
-    fat: number;
-  };
-  target: {
-    calories: number;
-    protein: number;
-    carbs: number;
-    fat: number;
-  } | null;
-};
 
 export type DeleteMealInput = {
   date: string;
@@ -82,7 +23,7 @@ const fetchNutritionSummary = (date: string, signal?: AbortSignal) =>
   });
 
 const deleteMeal = ({ date, mealId }: DeleteMealInput) =>
-  apiRequest<{ success: true }>(`/api/v1/nutrition/${date}/meals/${mealId}`, {
+  apiRequest<DeleteMealResult>(`/api/v1/nutrition/${date}/meals/${mealId}`, {
     method: 'DELETE',
   });
 

--- a/apps/web/src/features/nutrition/api/nutrition.ts
+++ b/apps/web/src/features/nutrition/api/nutrition.ts
@@ -1,0 +1,117 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { apiRequest } from '@/lib/api-client';
+
+import { nutritionKeys } from './keys';
+
+export type NutritionLog = {
+  id: string;
+  userId: string;
+  date: string;
+  notes: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type NutritionMealRecord = {
+  id: string;
+  nutritionLogId: string;
+  name: string;
+  time: string | null;
+  notes: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type NutritionMealItem = {
+  id: string;
+  mealId: string;
+  foodId: string | null;
+  name: string;
+  amount: number;
+  unit: string;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  fiber: number | null;
+  sugar: number | null;
+  createdAt: number;
+};
+
+export type DailyNutrition = {
+  log: NutritionLog;
+  meals: Array<{
+    meal: NutritionMealRecord;
+    items: NutritionMealItem[];
+  }>;
+} | null;
+
+export type NutritionSummary = {
+  date: string;
+  meals: number;
+  actual: {
+    calories: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+  };
+  target: {
+    calories: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+  } | null;
+};
+
+export type DeleteMealInput = {
+  date: string;
+  mealId: string;
+};
+
+const fetchDailyNutrition = (date: string, signal?: AbortSignal) =>
+  apiRequest<DailyNutrition>(`/api/v1/nutrition/${date}`, {
+    method: 'GET',
+    signal,
+  });
+
+const fetchNutritionSummary = (date: string, signal?: AbortSignal) =>
+  apiRequest<NutritionSummary>(`/api/v1/nutrition/${date}/summary`, {
+    method: 'GET',
+    signal,
+  });
+
+const deleteMeal = ({ date, mealId }: DeleteMealInput) =>
+  apiRequest<{ success: true }>(`/api/v1/nutrition/${date}/meals/${mealId}`, {
+    method: 'DELETE',
+  });
+
+export const useDailyNutrition = (date: string) =>
+  useQuery({
+    queryKey: nutritionKeys.daily(date),
+    queryFn: ({ signal }) => fetchDailyNutrition(date, signal),
+  });
+
+export const useNutritionSummary = (date: string) =>
+  useQuery({
+    queryKey: nutritionKeys.summary(date),
+    queryFn: ({ signal }) => fetchNutritionSummary(date, signal),
+  });
+
+export const useDeleteMeal = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteMeal,
+    onSuccess: async (_result, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: nutritionKeys.daily(variables.date),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: nutritionKeys.summary(variables.date),
+        }),
+      ]);
+    },
+  });
+};

--- a/apps/web/src/features/nutrition/components/meal-card.test.tsx
+++ b/apps/web/src/features/nutrition/components/meal-card.test.tsx
@@ -1,9 +1,45 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
-import { MealCard } from '@/features/nutrition/components/meal-card';
-import { mockDailyMeals } from '@/lib/mock-data/nutrition';
+import { describe, expect, it, vi } from 'vitest';
 
-const breakfastMeal = mockDailyMeals['2026-03-05'][0];
+import { MealCard } from '@/features/nutrition/components/meal-card';
+
+const breakfastMeal = {
+  id: 'meal-breakfast',
+  name: 'Breakfast',
+  time: '07:20',
+  items: [
+    {
+      id: 'item-eggs',
+      name: 'Large Eggs',
+      amount: 3,
+      unit: 'eggs',
+      calories: 210,
+      protein: 18,
+      carbs: 1,
+      fat: 15,
+    },
+    {
+      id: 'item-bread',
+      name: 'Whole Wheat Bread',
+      amount: 2,
+      unit: 'slices',
+      calories: 220,
+      protein: 10,
+      carbs: 44,
+      fat: 2,
+    },
+    {
+      id: 'item-shake',
+      name: 'Whey Protein',
+      amount: 1,
+      unit: 'scoop',
+      calories: 105,
+      protein: 1,
+      carbs: 27,
+      fat: 0,
+    },
+  ],
+};
 
 describe('MealCard', () => {
   it('renders the meal summary collapsed by default', () => {
@@ -43,5 +79,14 @@ describe('MealCard', () => {
 
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
     expect(screen.queryByText('Large Eggs')).not.toBeInTheDocument();
+  });
+
+  it('calls onDelete with the meal id when delete is clicked', () => {
+    const onDelete = vi.fn();
+
+    render(<MealCard meal={breakfastMeal} onDelete={onDelete} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Breakfast' }));
+
+    expect(onDelete).toHaveBeenCalledWith('meal-breakfast');
   });
 });

--- a/apps/web/src/features/nutrition/components/meal-card.tsx
+++ b/apps/web/src/features/nutrition/components/meal-card.tsx
@@ -1,6 +1,7 @@
 import { useId, useState } from 'react';
-import { ChevronDown } from 'lucide-react';
-import type { Meal } from '@/lib/mock-data/nutrition';
+import { ChevronDown, Trash2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 import {
@@ -10,8 +11,26 @@ import {
   formatServing,
 } from '@/features/nutrition/lib/nutrition-utils';
 
+export type MealCardMeal = {
+  id: string;
+  name: string;
+  time: string | null;
+  items: Array<{
+    id: string;
+    name: string;
+    amount: number;
+    unit: string;
+    calories: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+  }>;
+};
+
 type MealCardProps = {
-  meal: Meal;
+  meal: MealCardMeal;
+  onDelete?: (mealId: string) => void;
+  isDeleting?: boolean;
 };
 
 const ITEM_HEADER_LABELS = [
@@ -21,43 +40,61 @@ const ITEM_HEADER_LABELS = [
   { key: 'fat', label: 'Fat' },
 ] as const;
 
-export function MealCard({ meal }: MealCardProps) {
+export function MealCard({ meal, onDelete, isDeleting = false }: MealCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const contentId = useId();
   const totals = calculateMacroTotals(meal.items);
+  const formattedTime = formatMealTime(meal.time);
+  const canDelete = typeof onDelete === 'function';
 
   return (
     <Card className="gap-0 overflow-hidden border-border bg-[var(--color-card)] py-0 shadow-none">
-      <button
-        aria-controls={contentId}
-        aria-expanded={isExpanded}
-        className="flex w-full cursor-pointer flex-col gap-4 px-5 py-4 text-left transition-colors hover:bg-secondary/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
-        type="button"
-        onClick={() => setIsExpanded((current) => !current)}
-      >
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1">
-            <h2 className="text-lg font-semibold text-foreground">{meal.name}</h2>
-            <p className="text-sm text-muted">{meal.time}</p>
+      <div className="flex items-start gap-3 px-5 py-4">
+        <button
+          aria-controls={contentId}
+          aria-expanded={isExpanded}
+          className="flex flex-1 cursor-pointer flex-col gap-4 text-left transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+          type="button"
+          onClick={() => setIsExpanded((current) => !current)}
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold text-foreground">{meal.name}</h2>
+              <p className="text-sm text-muted">{formattedTime}</p>
+            </div>
+            <ChevronDown
+              aria-hidden="true"
+              className={cn(
+                'mt-0.5 size-5 shrink-0 text-muted transition-transform duration-200',
+                isExpanded && 'rotate-180',
+              )}
+            />
           </div>
-          <ChevronDown
-            aria-hidden="true"
-            className={cn(
-              'mt-0.5 size-5 shrink-0 text-muted transition-transform duration-200',
-              isExpanded && 'rotate-180',
-            )}
-          />
-        </div>
 
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
-          <span className="font-semibold tracking-tight text-foreground">
-            {formatCalories(totals.calories)}
-          </span>
-          <span className="text-muted">{formatGrams(totals.protein)} protein</span>
-          <span className="text-muted">{formatGrams(totals.carbs)} carbs</span>
-          <span className="text-muted">{formatGrams(totals.fat)} fat</span>
-        </div>
-      </button>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+            <span className="font-semibold tracking-tight text-foreground">
+              {formatCalories(totals.calories)}
+            </span>
+            <span className="text-muted">{formatGrams(totals.protein)} protein</span>
+            <span className="text-muted">{formatGrams(totals.carbs)} carbs</span>
+            <span className="text-muted">{formatGrams(totals.fat)} fat</span>
+          </div>
+        </button>
+
+        {canDelete ? (
+          <Button
+            aria-label={`Delete ${meal.name}`}
+            className="shrink-0"
+            disabled={isDeleting}
+            onClick={() => onDelete(meal.id)}
+            size="icon-sm"
+            type="button"
+            variant="ghost"
+          >
+            <Trash2 />
+          </Button>
+        ) : null}
+      </div>
 
       {isExpanded ? (
         <div className="border-t border-border/80 px-5 py-4" id={contentId}>
@@ -114,4 +151,23 @@ function MacroCell({ label, value }: MacroCellProps) {
       <p className="font-medium text-foreground">{value}</p>
     </div>
   );
+}
+
+function formatMealTime(time: string | null) {
+  if (!time) {
+    return 'Time not set';
+  }
+
+  const [rawHours, rawMinutes] = time.split(':');
+  const hours = Number(rawHours);
+  const minutes = Number(rawMinutes);
+
+  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) {
+    return time;
+  }
+
+  const meridiem = hours >= 12 ? 'PM' : 'AM';
+  const normalizedHours = hours % 12 || 12;
+
+  return `${normalizedHours}:${String(minutes).padStart(2, '0')} ${meridiem}`;
 }

--- a/apps/web/src/features/nutrition/lib/nutrition-utils.ts
+++ b/apps/web/src/features/nutrition/lib/nutrition-utils.ts
@@ -1,5 +1,3 @@
-export const MEAL_ORDER = ['Breakfast', 'Lunch', 'Dinner', 'Snacks'] as const;
-
 export type MacroTotals = {
   calories: number;
   protein: number;
@@ -13,16 +11,10 @@ type MealSource = {
   items: MacroSource[];
 };
 
-type ServingSource =
-  | {
-      amount: number;
-      unit: string;
-    }
-  | {
-      quantity: number;
-      servingSize: number;
-      servingUnit: string;
-    };
+type ServingSource = {
+  amount: number;
+  unit: string;
+};
 
 const DEFAULT_TOTALS: MacroTotals = {
   calories: 0,
@@ -84,11 +76,7 @@ export function formatGrams(value: number): string {
 }
 
 export function formatServing(item: ServingSource): string {
-  if ('amount' in item) {
-    return `${formatNumber(item.amount)} ${item.unit}`;
-  }
-
-  return `${formatNumber(item.quantity * item.servingSize)} ${item.servingUnit}`;
+  return `${formatNumber(item.amount)} ${item.unit}`;
 }
 
 export function formatDayLabel(date: string): string {

--- a/apps/web/src/features/nutrition/lib/nutrition-utils.ts
+++ b/apps/web/src/features/nutrition/lib/nutrition-utils.ts
@@ -1,9 +1,28 @@
-import type { DailyTargets, FoodItem, Meal } from '@/lib/mock-data/nutrition';
-
 export const MEAL_ORDER = ['Breakfast', 'Lunch', 'Dinner', 'Snacks'] as const;
 
-export type MacroKey = keyof DailyTargets;
-export type MacroTotals = DailyTargets;
+export type MacroTotals = {
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+};
+export type MacroKey = keyof MacroTotals;
+
+type MacroSource = Pick<MacroTotals, MacroKey>;
+type MealSource = {
+  items: MacroSource[];
+};
+
+type ServingSource =
+  | {
+      amount: number;
+      unit: string;
+    }
+  | {
+      quantity: number;
+      servingSize: number;
+      servingUnit: string;
+    };
 
 const DEFAULT_TOTALS: MacroTotals = {
   calories: 0,
@@ -13,7 +32,7 @@ const DEFAULT_TOTALS: MacroTotals = {
 };
 
 export function calculateMacroTotals(
-  sources: Array<Pick<FoodItem, MacroKey>> | Meal[],
+  sources: Array<MacroSource | MealSource>,
 ): MacroTotals {
   return sources.reduce<MacroTotals>((totals, source) => {
     const macrosToAdd = 'items' in source ? calculateMacroTotals(source.items) : source;
@@ -27,8 +46,33 @@ export function calculateMacroTotals(
   }, DEFAULT_TOTALS);
 }
 
-export function sortMeals(meals: Meal[]): Meal[] {
-  return [...meals].sort((left, right) => MEAL_ORDER.indexOf(left.name) - MEAL_ORDER.indexOf(right.name));
+function getMealSortIndex(name: string) {
+  const normalizedName = name.trim().toLowerCase();
+
+  switch (normalizedName) {
+    case 'breakfast':
+      return 0;
+    case 'lunch':
+      return 1;
+    case 'dinner':
+      return 2;
+    case 'snacks':
+      return 3;
+    default:
+      return Number.MAX_SAFE_INTEGER;
+  }
+}
+
+export function sortMeals<T extends { name: string }>(meals: T[]): T[] {
+  return [...meals].sort((left, right) => {
+    const orderDifference = getMealSortIndex(left.name) - getMealSortIndex(right.name);
+
+    if (orderDifference !== 0) {
+      return orderDifference;
+    }
+
+    return left.name.localeCompare(right.name);
+  });
 }
 
 export function formatCalories(value: number): string {
@@ -39,7 +83,11 @@ export function formatGrams(value: number): string {
   return `${Math.round(value)}g`;
 }
 
-export function formatServing(item: FoodItem): string {
+export function formatServing(item: ServingSource): string {
+  if ('amount' in item) {
+    return `${formatNumber(item.amount)} ${item.unit}`;
+  }
+
   return `${formatNumber(item.quantity * item.servingSize)} ${item.servingUnit}`;
 }
 

--- a/apps/web/src/pages/nutrition.test.tsx
+++ b/apps/web/src/pages/nutrition.test.tsx
@@ -1,36 +1,364 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { NutritionPage } from '@/pages/nutrition';
 import { createQueryClientWrapper } from '@/test/query-client';
 
-import { NutritionPage } from '@/pages/nutrition';
+type ApiMealItem = {
+  id: string;
+  mealId: string;
+  foodId: string | null;
+  name: string;
+  amount: number;
+  unit: string;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  fiber: number | null;
+  sugar: number | null;
+  createdAt: number;
+};
+
+type ApiMeal = {
+  meal: {
+    id: string;
+    nutritionLogId: string;
+    name: string;
+    time: string | null;
+    notes: string | null;
+    createdAt: number;
+    updatedAt: number;
+  };
+  items: ApiMealItem[];
+};
+
+type ApiDailyNutrition = {
+  log: {
+    id: string;
+    userId: string;
+    date: string;
+    notes: string | null;
+    createdAt: number;
+    updatedAt: number;
+  };
+  meals: ApiMeal[];
+} | null;
+
+type MacroTotals = {
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+};
+
+type DateState = {
+  daily: ApiDailyNutrition;
+  target: MacroTotals | null;
+};
+
+const TARGETS: MacroTotals = {
+  calories: 2300,
+  protein: 190,
+  carbs: 260,
+  fat: 75,
+};
+
+function createJsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify({ data }), {
+    headers: { 'Content-Type': 'application/json' },
+    status,
+  });
+}
+
+function cloneDaily(daily: ApiDailyNutrition): ApiDailyNutrition {
+  return daily ? (JSON.parse(JSON.stringify(daily)) as ApiDailyNutrition) : null;
+}
+
+function calculateActuals(daily: ApiDailyNutrition): MacroTotals {
+  if (!daily) {
+    return {
+      calories: 0,
+      protein: 0,
+      carbs: 0,
+      fat: 0,
+    };
+  }
+
+  return daily.meals
+    .flatMap((meal) => meal.items)
+    .reduce(
+      (totals, item) => ({
+        calories: totals.calories + item.calories,
+        protein: totals.protein + item.protein,
+        carbs: totals.carbs + item.carbs,
+        fat: totals.fat + item.fat,
+      }),
+      {
+        calories: 0,
+        protein: 0,
+        carbs: 0,
+        fat: 0,
+      },
+    );
+}
+
+function createMeal(args: {
+  id: string;
+  name: string;
+  time: string;
+  items: Array<{
+    id: string;
+    name: string;
+    amount: number;
+    unit: string;
+    calories: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+  }>;
+}): ApiMeal {
+  return {
+    meal: {
+      id: args.id,
+      nutritionLogId: 'log-2026-03-05',
+      name: args.name,
+      time: args.time,
+      notes: null,
+      createdAt: 1,
+      updatedAt: 1,
+    },
+    items: args.items.map((item) => ({
+      id: item.id,
+      mealId: args.id,
+      foodId: null,
+      name: item.name,
+      amount: item.amount,
+      unit: item.unit,
+      calories: item.calories,
+      protein: item.protein,
+      carbs: item.carbs,
+      fat: item.fat,
+      fiber: null,
+      sugar: null,
+      createdAt: 1,
+    })),
+  };
+}
+
+function createNutritionApiMock(initialState: Record<string, DateState>) {
+  const state = new Map<string, DateState>(
+    Object.entries(initialState).map(([date, value]) => [
+      date,
+      {
+        daily: cloneDaily(value.daily),
+        target: value.target,
+      },
+    ]),
+  );
+
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(typeof input === 'string' ? input : input.toString(), 'http://localhost');
+    const method = init?.method ?? 'GET';
+    const pathParts = url.pathname.split('/').filter(Boolean);
+
+    if (pathParts[0] !== 'api' || pathParts[1] !== 'v1' || pathParts[2] !== 'nutrition') {
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    }
+
+    const date = pathParts[3];
+    const dateState = state.get(date) ?? {
+      daily: null,
+      target: null,
+    };
+
+    if (method === 'GET' && pathParts.length === 4) {
+      return createJsonResponse(cloneDaily(dateState.daily));
+    }
+
+    if (method === 'GET' && pathParts.length === 5 && pathParts[4] === 'summary') {
+      const actual = calculateActuals(dateState.daily);
+      const meals = dateState.daily?.meals.length ?? 0;
+
+      return createJsonResponse({
+        date,
+        meals,
+        actual,
+        target: dateState.target,
+      });
+    }
+
+    if (method === 'DELETE' && pathParts.length === 6 && pathParts[4] === 'meals') {
+      const mealId = pathParts[5];
+
+      if (!dateState.daily) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: 'MEAL_NOT_FOUND',
+              message: 'Meal not found',
+            },
+          }),
+          {
+            headers: { 'Content-Type': 'application/json' },
+            status: 404,
+          },
+        );
+      }
+
+      dateState.daily = {
+        ...dateState.daily,
+        meals: dateState.daily.meals.filter((entry) => entry.meal.id !== mealId),
+      };
+      state.set(date, dateState);
+
+      return createJsonResponse({ success: true });
+    }
+
+    throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+  });
+
+  return { fetchMock };
+}
+
+function createDeferredResponse() {
+  let resolve: (value: Response) => void = () => {};
+
+  const promise = new Promise<Response>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
+}
+
+function getMealToggleButton(mealName: string) {
+  const candidateButtons = screen.getAllByRole('button', {
+    name: new RegExp(mealName, 'i'),
+  });
+  const button = candidateButtons.find((candidate) => candidate.hasAttribute('aria-controls'));
+
+  if (!button) {
+    throw new Error(`Expected a meal toggle button for ${mealName}`);
+  }
+
+  return button;
+}
+
+const previousDayMeals = [
+  createMeal({
+    id: 'meal-lunch',
+    name: 'Lunch',
+    time: '12:30',
+    items: [
+      {
+        id: 'item-chicken',
+        name: 'Chicken Breast',
+        amount: 6,
+        unit: 'oz',
+        calories: 281,
+        protein: 52,
+        carbs: 0,
+        fat: 6,
+      },
+      {
+        id: 'item-rice',
+        name: 'White Rice',
+        amount: 1,
+        unit: 'cup',
+        calories: 205,
+        protein: 4,
+        carbs: 45,
+        fat: 0,
+      },
+    ],
+  }),
+  createMeal({
+    id: 'meal-breakfast',
+    name: 'Breakfast',
+    time: '07:20',
+    items: [
+      {
+        id: 'item-eggs',
+        name: 'Large Eggs',
+        amount: 3,
+        unit: 'eggs',
+        calories: 210,
+        protein: 18,
+        carbs: 1,
+        fat: 15,
+      },
+      {
+        id: 'item-bread',
+        name: 'Whole Wheat Bread',
+        amount: 2,
+        unit: 'slices',
+        calories: 220,
+        protein: 10,
+        carbs: 44,
+        fat: 2,
+      },
+    ],
+  }),
+  createMeal({
+    id: 'meal-dinner',
+    name: 'Dinner',
+    time: '18:40',
+    items: [
+      {
+        id: 'item-salmon',
+        name: 'Atlantic Salmon',
+        amount: 5,
+        unit: 'oz',
+        calories: 290,
+        protein: 31,
+        carbs: 0,
+        fat: 17,
+      },
+      {
+        id: 'item-potato',
+        name: 'Sweet Potato',
+        amount: 1,
+        unit: 'medium',
+        calories: 112,
+        protein: 2,
+        carbs: 26,
+        fat: 0,
+      },
+    ],
+  }),
+  createMeal({
+    id: 'meal-snacks',
+    name: 'Snacks',
+    time: '15:45',
+    items: [
+      {
+        id: 'item-yogurt',
+        name: 'Greek Yogurt',
+        amount: 170,
+        unit: 'g',
+        calories: 90,
+        protein: 18,
+        carbs: 5,
+        fat: 0,
+      },
+      {
+        id: 'item-almonds',
+        name: 'Almonds',
+        amount: 1,
+        unit: 'oz',
+        calories: 164,
+        protein: 6,
+        carbs: 6,
+        fat: 14,
+      },
+    ],
+  }),
+];
 
 describe('NutritionPage', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-06T12:00:00'));
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(() =>
-        Promise.resolve(
-          new Response(
-            JSON.stringify({
-              data: {
-                id: 'target-current',
-                calories: 2300,
-                protein: 190,
-                carbs: 260,
-                fat: 75,
-                effectiveDate: '2026-03-06',
-                createdAt: 1,
-                updatedAt: 1,
-              },
-            }),
-            { headers: { 'Content-Type': 'application/json' }, status: 200 },
-          ),
-        ),
-      ),
-    );
   });
 
   afterEach(() => {
@@ -38,93 +366,171 @@ describe('NutritionPage', () => {
     vi.unstubAllGlobals();
   });
 
-  it('defaults to today with empty nutrition data, live targets, and blocked future navigation', async () => {
+  it('loads today from API, shows empty state, and blocks future navigation', async () => {
+    const { fetchMock } = createNutritionApiMock({
+      '2026-03-06': {
+        daily: null,
+        target: TARGETS,
+      },
+      '2026-03-05': {
+        daily: {
+          log: {
+            id: 'log-2026-03-05',
+            userId: 'user-1',
+            date: '2026-03-05',
+            notes: null,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          meals: previousDayMeals,
+        },
+        target: TARGETS,
+      },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
     const { wrapper } = createQueryClientWrapper();
-
     render(<NutritionPage />, { wrapper });
-    const dailyTotals = screen.getByLabelText('Daily macro totals');
-
-    expect(screen.getByRole('heading', { name: 'Nutrition' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Daily totals' })).toBeInTheDocument();
-    expect(screen.getByText('Friday, March 6')).toBeInTheDocument();
-    expect(screen.getByText('Friday, Mar 6')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Go to next day' })).toBeDisabled();
-    expect(screen.queryByRole('button', { name: 'Today' })).not.toBeInTheDocument();
-    expect(screen.getByText('No meals logged for this day')).toBeInTheDocument();
 
     await vi.runAllTimersAsync();
     await Promise.resolve();
 
-    expect(within(dailyTotals).getByText(/2300 cal/)).toBeInTheDocument();
+    const dailyTotals = screen.getByLabelText('Daily macro totals');
 
-    expect(within(dailyTotals).getByText('0 cal')).toHaveClass('text-emerald-950');
-    expect(within(dailyTotals).getAllByText('0g')).toHaveLength(3);
-    expect(within(dailyTotals).getByText(/\/ 190g/)).toBeInTheDocument();
-    expect(within(dailyTotals).getByText(/\/ 260g/)).toBeInTheDocument();
-    expect(within(dailyTotals).getByText(/\/ 75g/)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Nutrition' })).toBeInTheDocument();
+    expect(screen.getByText('Friday, March 6')).toBeInTheDocument();
+    expect(screen.getByText('Friday, Mar 6')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to next day' })).toBeDisabled();
+    expect(screen.getByText('No meals logged for this day')).toBeInTheDocument();
+    expect(within(dailyTotals).getByText(/\/ 2300 cal/)).toBeInTheDocument();
 
-    for (const progressBar of screen.getAllByRole('progressbar')) {
-      expect(progressBar).toHaveAttribute('aria-valuenow', '0');
-    }
+    expect(fetchMock).toHaveBeenCalledWith('/api/v1/nutrition/2026-03-06', expect.any(Object));
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/nutrition/2026-03-06/summary',
+      expect.any(Object),
+    );
   });
 
-  it('shows the previous day data when navigating back and returns to today via the shortcut', () => {
-    const { wrapper } = createQueryClientWrapper();
+  it('renders previous day meals from API in breakfast, lunch, dinner, snacks order', async () => {
+    const { fetchMock } = createNutritionApiMock({
+      '2026-03-06': {
+        daily: null,
+        target: TARGETS,
+      },
+      '2026-03-05': {
+        daily: {
+          log: {
+            id: 'log-2026-03-05',
+            userId: 'user-1',
+            date: '2026-03-05',
+            notes: null,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          meals: previousDayMeals,
+        },
+        target: TARGETS,
+      },
+    });
+    vi.stubGlobal('fetch', fetchMock);
 
+    const { wrapper } = createQueryClientWrapper();
     render(<NutritionPage />, { wrapper });
 
     fireEvent.click(screen.getByRole('button', { name: 'Go to previous day' }));
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
 
-    const dailyTotals = screen.getByLabelText('Daily macro totals');
-    const macroProgress = screen
-      .getByRole('heading', { name: 'Macro progress' })
-      .closest('section');
-    const breakfast = screen.getByRole('button', { name: /breakfast/i });
+    const breakfast = getMealToggleButton('Breakfast');
+    const lunch = getMealToggleButton('Lunch');
+    const dinner = getMealToggleButton('Dinner');
+    const snacks = getMealToggleButton('Snacks');
 
     expect(screen.getByText('Thursday, March 5')).toBeInTheDocument();
-    expect(screen.getByText('Thursday, Mar 5')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Today' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Go to next day' })).not.toBeDisabled();
-
-    expect(within(dailyTotals).getByText('2131 cal')).toHaveClass('text-emerald-950');
-    expect(within(dailyTotals).getByText('192g')).toHaveClass('text-red-900');
-    expect(screen.queryByText('No meals logged for this day')).not.toBeInTheDocument();
-
-    expect(macroProgress).not.toBeNull();
-
-    if (!macroProgress) {
-      throw new Error('Expected macro progress section to exist');
-    }
-
-    expect(within(macroProgress).getAllByRole('progressbar')).toHaveLength(4);
-    expect(
-      macroProgress.compareDocumentPosition(breakfast) & Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(
-      dailyTotals.compareDocumentPosition(macroProgress) & Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Today' }));
-
-    expect(screen.getByText('Friday, March 6')).toBeInTheDocument();
-    expect(screen.getByText('No meals logged for this day')).toBeInTheDocument();
-  });
-
-  it('renders meal cards in breakfast, lunch, dinner, snacks order for a day with data', () => {
-    const { wrapper } = createQueryClientWrapper();
-
-    render(<NutritionPage />, { wrapper });
-    fireEvent.click(screen.getByRole('button', { name: 'Go to previous day' }));
-
-    const breakfast = screen.getByRole('button', { name: /breakfast/i });
-    const lunch = screen.getByRole('button', { name: /lunch/i });
-    const dinner = screen.getByRole('button', { name: /dinner/i });
-    const snacks = screen.getByRole('button', { name: /snacks/i });
-
     expect(
       breakfast.compareDocumentPosition(lunch) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(lunch.compareDocumentPosition(dinner) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(dinner.compareDocumentPosition(snacks) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('expands a meal and deletes it via the API mutation', async () => {
+    const { fetchMock } = createNutritionApiMock({
+      '2026-03-06': {
+        daily: null,
+        target: TARGETS,
+      },
+      '2026-03-05': {
+        daily: {
+          log: {
+            id: 'log-2026-03-05',
+            userId: 'user-1',
+            date: '2026-03-05',
+            notes: null,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          meals: previousDayMeals,
+        },
+        target: TARGETS,
+      },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { wrapper } = createQueryClientWrapper();
+    render(<NutritionPage />, { wrapper });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go to previous day' }));
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    fireEvent.click(getMealToggleButton('Breakfast'));
+    expect(screen.getByText('Large Eggs')).toBeInTheDocument();
+    expect(screen.getByText('3 eggs')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Breakfast' }));
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(
+      screen
+        .queryAllByRole('button', { name: /breakfast/i })
+        .find((candidate) => candidate.hasAttribute('aria-controls')),
+    ).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/nutrition/2026-03-05/meals/meal-breakfast',
+      expect.objectContaining({
+        method: 'DELETE',
+      }),
+    );
+    const dailyTotals = screen.getByLabelText('Daily macro totals');
+    expect(within(dailyTotals).getByText('1142 cal')).toBeInTheDocument();
+  });
+
+  it('shows loading skeletons while daily + summary queries are pending', () => {
+    const deferredDaily = createDeferredResponse();
+    const deferredSummary = createDeferredResponse();
+
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = new URL(typeof input === 'string' ? input : input.toString(), 'http://localhost');
+
+      if (url.pathname === '/api/v1/nutrition/2026-03-06') {
+        return deferredDaily.promise;
+      }
+
+      if (url.pathname === '/api/v1/nutrition/2026-03-06/summary') {
+        return deferredSummary.promise;
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { wrapper } = createQueryClientWrapper();
+    render(<NutritionPage />, { wrapper });
+
+    expect(screen.getByLabelText('Loading nutrition')).toBeInTheDocument();
+    expect(screen.getByLabelText('Loading nutrition rings')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/nutrition.test.tsx
+++ b/apps/web/src/pages/nutrition.test.tsx
@@ -1,63 +1,16 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
+import type { DailyNutrition, DailyNutritionMeal, NutritionMacroTotals } from '@pulse/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { NutritionPage } from '@/pages/nutrition';
 import { createQueryClientWrapper } from '@/test/query-client';
 
-type ApiMealItem = {
-  id: string;
-  mealId: string;
-  foodId: string | null;
-  name: string;
-  amount: number;
-  unit: string;
-  calories: number;
-  protein: number;
-  carbs: number;
-  fat: number;
-  fiber: number | null;
-  sugar: number | null;
-  createdAt: number;
-};
-
-type ApiMeal = {
-  meal: {
-    id: string;
-    nutritionLogId: string;
-    name: string;
-    time: string | null;
-    notes: string | null;
-    createdAt: number;
-    updatedAt: number;
-  };
-  items: ApiMealItem[];
-};
-
-type ApiDailyNutrition = {
-  log: {
-    id: string;
-    userId: string;
-    date: string;
-    notes: string | null;
-    createdAt: number;
-    updatedAt: number;
-  };
-  meals: ApiMeal[];
-} | null;
-
-type MacroTotals = {
-  calories: number;
-  protein: number;
-  carbs: number;
-  fat: number;
-};
-
 type DateState = {
-  daily: ApiDailyNutrition;
-  target: MacroTotals | null;
+  daily: DailyNutrition;
+  target: NutritionMacroTotals | null;
 };
 
-const TARGETS: MacroTotals = {
+const TARGETS: NutritionMacroTotals = {
   calories: 2300,
   protein: 190,
   carbs: 260,
@@ -71,11 +24,11 @@ function createJsonResponse(data: unknown, status = 200) {
   });
 }
 
-function cloneDaily(daily: ApiDailyNutrition): ApiDailyNutrition {
-  return daily ? (JSON.parse(JSON.stringify(daily)) as ApiDailyNutrition) : null;
+function cloneDaily(daily: DailyNutrition): DailyNutrition {
+  return daily ? (JSON.parse(JSON.stringify(daily)) as DailyNutrition) : null;
 }
 
-function calculateActuals(daily: ApiDailyNutrition): MacroTotals {
+function calculateActuals(daily: DailyNutrition): NutritionMacroTotals {
   if (!daily) {
     return {
       calories: 0,
@@ -117,7 +70,7 @@ function createMeal(args: {
     carbs: number;
     fat: number;
   }>;
-}): ApiMeal {
+}): DailyNutritionMeal {
   return {
     meal: {
       id: args.id,
@@ -532,5 +485,27 @@ describe('NutritionPage', () => {
 
     expect(screen.getByLabelText('Loading nutrition')).toBeInTheDocument();
     expect(screen.getByLabelText('Loading nutrition rings')).toBeInTheDocument();
+  });
+
+  it('shows no-target copy and hides macro rings when no daily target is configured', async () => {
+    const { fetchMock } = createNutritionApiMock({
+      '2026-03-06': {
+        daily: null,
+        target: null,
+      },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { wrapper } = createQueryClientWrapper();
+    render(<NutritionPage />, { wrapper });
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    const dailyTotals = screen.getByLabelText('Daily macro totals');
+
+    expect(within(dailyTotals).getAllByText('/ No target set')).toHaveLength(4);
+    expect(screen.getByText(/No daily macro target is set yet/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Eaten' })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/nutrition.tsx
+++ b/apps/web/src/pages/nutrition.tsx
@@ -64,7 +64,7 @@ export function NutritionPage() {
   );
 
   const dailyTotals = dailySummaryQuery.data?.actual ?? EMPTY_TOTALS;
-  const dailyTargets = dailySummaryQuery.data?.target ?? EMPTY_TOTALS;
+  const dailyTargets = dailySummaryQuery.data?.target ?? null;
   const isLoadingDay = dailyNutritionQuery.isPending || dailySummaryQuery.isPending;
   const nutritionError =
     (dailyNutritionQuery.isError && dailyNutritionQuery.error) ||
@@ -130,8 +130,8 @@ export function NutritionPage() {
               <div className="mt-5 grid grid-cols-2 gap-3 md:grid-cols-4">
                 {MACRO_CONFIG.map((macro) => {
                   const actual = dailyTotals[macro.key];
-                  const target = dailyTargets[macro.key];
-                  const isOverTarget = actual > target;
+                  const target = dailyTargets?.[macro.key] ?? null;
+                  const isOverTarget = target !== null && actual > target;
 
                   return (
                     <div
@@ -144,7 +144,9 @@ export function NutritionPage() {
                       <p className="mt-2 text-sm font-semibold">
                         <span
                           className={cn(
-                            isOverTarget
+                            target === null
+                              ? 'text-foreground'
+                              : isOverTarget
                               ? 'text-red-900 dark:text-red-400'
                               : 'text-emerald-950 dark:text-emerald-400',
                             'text-lg tracking-tight',
@@ -152,10 +154,17 @@ export function NutritionPage() {
                         >
                           {macro.formatValue(actual)}
                         </span>
-                        <span className="opacity-70 dark:text-muted dark:opacity-100">
-                          {' '}
-                          / {macro.formatValue(target)}
-                        </span>
+                        {target === null ? (
+                          <span className="opacity-70 dark:text-muted dark:opacity-100">
+                            {' '}
+                            / No target set
+                          </span>
+                        ) : (
+                          <span className="opacity-70 dark:text-muted dark:opacity-100">
+                            {' '}
+                            / {macro.formatValue(target)}
+                          </span>
+                        )}
                       </p>
                     </div>
                   );
@@ -166,8 +175,10 @@ export function NutritionPage() {
 
           {isLoadingDay ? (
             <NutritionRingsSkeleton />
-          ) : (
+          ) : dailyTargets ? (
             <NutritionMacroRings actuals={dailyTotals} targets={dailyTargets} />
+          ) : (
+            <NutritionTargetsPlaceholder />
           )}
 
           {deleteErrorMessage ? (
@@ -198,6 +209,17 @@ export function NutritionPage() {
           </div>
         </>
       )}
+    </section>
+  );
+}
+
+function NutritionTargetsPlaceholder() {
+  return (
+    <section className="rounded-2xl border border-dashed border-border/70 bg-card/70 px-6 py-8 text-center shadow-sm">
+      <h2 className="text-lg font-semibold text-foreground">Macro progress</h2>
+      <p className="mt-2 text-sm text-muted">
+        No daily macro target is set yet. Add one in settings to enable progress rings.
+      </p>
     </section>
   );
 }

--- a/apps/web/src/pages/nutrition.tsx
+++ b/apps/web/src/pages/nutrition.tsx
@@ -1,19 +1,22 @@
 import { useState } from 'react';
 
 import { DateNavBar, MealCard, NutritionMacroRings } from '@/features/nutrition';
-import { useNutritionTargets } from '@/features/nutrition/api/targets';
+import {
+  useDailyNutrition,
+  useDeleteMeal,
+  useNutritionSummary,
+} from '@/features/nutrition/api/nutrition';
 import {
   formatDateKey,
-  calculateMacroTotals,
   formatCalories,
   formatDayLabel,
   formatGrams,
   sortMeals,
   startOfDay,
+  type MacroTotals,
   type MacroKey,
 } from '@/features/nutrition/lib/nutrition-utils';
 import { accentCardStyles } from '@/lib/accent-card-styles';
-import { mockDailyMeals, mockDailyTargets } from '@/lib/mock-data/nutrition';
 import { cn } from '@/lib/utils';
 
 const MACRO_CONFIG: Array<{
@@ -27,7 +30,7 @@ const MACRO_CONFIG: Array<{
   { key: 'fat', label: 'Fat', formatValue: formatGrams },
 ];
 
-const EMPTY_TOTALS = {
+const EMPTY_TOTALS: MacroTotals = {
   calories: 0,
   protein: 0,
   carbs: 0,
@@ -36,18 +39,52 @@ const EMPTY_TOTALS = {
 
 export function NutritionPage() {
   const [selectedDate, setSelectedDate] = useState(() => startOfDay(new Date()));
-  const { data: currentTargets } = useNutritionTargets();
   const dateKey = formatDateKey(selectedDate);
-  const selectedMeals = sortMeals(mockDailyMeals[dateKey] ?? []);
-  const dailyTotals = selectedMeals.length > 0 ? calculateMacroTotals(selectedMeals) : EMPTY_TOTALS;
-  const dailyTargets = currentTargets
-    ? {
-        calories: currentTargets.calories,
-        protein: currentTargets.protein,
-        carbs: currentTargets.carbs,
-        fat: currentTargets.fat,
-      }
-    : mockDailyTargets;
+
+  const dailyNutritionQuery = useDailyNutrition(dateKey);
+  const dailySummaryQuery = useNutritionSummary(dateKey);
+  const deleteMealMutation = useDeleteMeal();
+
+  const selectedMeals = sortMeals(
+    (dailyNutritionQuery.data?.meals ?? []).map(({ meal, items }) => ({
+      id: meal.id,
+      name: meal.name,
+      time: meal.time,
+      items: items.map((item) => ({
+        id: item.id,
+        name: item.name,
+        amount: item.amount,
+        unit: item.unit,
+        calories: item.calories,
+        protein: item.protein,
+        carbs: item.carbs,
+        fat: item.fat,
+      })),
+    })),
+  );
+
+  const dailyTotals = dailySummaryQuery.data?.actual ?? EMPTY_TOTALS;
+  const dailyTargets = dailySummaryQuery.data?.target ?? EMPTY_TOTALS;
+  const isLoadingDay = dailyNutritionQuery.isPending || dailySummaryQuery.isPending;
+  const nutritionError =
+    (dailyNutritionQuery.isError && dailyNutritionQuery.error) ||
+    (dailySummaryQuery.isError && dailySummaryQuery.error) ||
+    null;
+  const deleteErrorMessage =
+    deleteMealMutation.isError && deleteMealMutation.error instanceof Error
+      ? deleteMealMutation.error.message
+      : null;
+
+  async function handleDeleteMeal(mealId: string) {
+    try {
+      await deleteMealMutation.mutateAsync({
+        date: dateKey,
+        mealId,
+      });
+    } catch {
+      return;
+    }
+  }
 
   return (
     <section className="space-y-5">
@@ -60,69 +97,149 @@ export function NutritionPage() {
 
       <DateNavBar selectedDate={selectedDate} onDateChange={setSelectedDate} />
 
-      <section
-        aria-label="Daily macro totals"
-        className={cn('rounded-2xl border border-border/70 px-5 py-5', accentCardStyles.cream)}
-      >
-        <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <h2 className="text-lg font-semibold">Daily totals</h2>
-            <p className="text-sm opacity-70 dark:text-muted dark:opacity-100">
-              Actual intake against your daily macro targets.
-            </p>
-          </div>
-          <p className="text-sm font-medium opacity-75 dark:text-muted dark:opacity-100">
-            {formatDayLabel(dateKey)}
+      {nutritionError ? (
+        <section className="rounded-2xl border border-destructive/30 px-5 py-6">
+          <h2 className="text-lg font-semibold text-foreground">Unable to load nutrition</h2>
+          <p className="mt-2 text-sm text-muted">
+            {nutritionError instanceof Error
+              ? nutritionError.message
+              : 'Could not load nutrition data.'}
           </p>
-        </div>
-
-        <div className="mt-5 grid grid-cols-2 gap-3 md:grid-cols-4">
-          {MACRO_CONFIG.map((macro) => {
-            const actual = dailyTotals[macro.key];
-            const target = dailyTargets[macro.key];
-            const isOverTarget = actual > target;
-
-            return (
-              <div
-                key={macro.key}
-                className="rounded-xl border border-black/8 bg-white/30 px-4 py-4 backdrop-blur-sm dark:border-border dark:bg-secondary/60"
-              >
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] opacity-65 dark:text-muted dark:opacity-100">
-                  {macro.label}
-                </p>
-                <p className="mt-2 text-sm font-semibold">
-                  <span
-                    className={cn(
-                      isOverTarget
-                        ? 'text-red-900 dark:text-red-400'
-                        : 'text-emerald-950 dark:text-emerald-400',
-                      'text-lg tracking-tight',
-                    )}
-                  >
-                    {macro.formatValue(actual)}
-                  </span>
-                  <span className="opacity-70 dark:text-muted dark:opacity-100">
-                    {' '}
-                    / {macro.formatValue(target)}
-                  </span>
+        </section>
+      ) : (
+        <>
+          <section
+            aria-label="Daily macro totals"
+            className={cn('rounded-2xl border border-border/70 px-5 py-5', accentCardStyles.cream)}
+          >
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold">Daily totals</h2>
+                <p className="text-sm opacity-70 dark:text-muted dark:opacity-100">
+                  Actual intake against your daily macro targets.
                 </p>
               </div>
-            );
-          })}
-        </div>
-      </section>
+              <p className="text-sm font-medium opacity-75 dark:text-muted dark:opacity-100">
+                {formatDayLabel(dateKey)}
+              </p>
+            </div>
 
-      <NutritionMacroRings actuals={dailyTotals} targets={dailyTargets} />
+            {isLoadingDay ? (
+              <NutritionTotalsSkeleton />
+            ) : (
+              <div className="mt-5 grid grid-cols-2 gap-3 md:grid-cols-4">
+                {MACRO_CONFIG.map((macro) => {
+                  const actual = dailyTotals[macro.key];
+                  const target = dailyTargets[macro.key];
+                  const isOverTarget = actual > target;
 
-      <div className="space-y-3">
-        {selectedMeals.length > 0 ? (
-          selectedMeals.map((meal) => <MealCard key={meal.id} meal={meal} />)
-        ) : (
-          <div className="flex min-h-40 items-center justify-center rounded-2xl border border-dashed border-border/70 bg-card/70 px-6 py-10 text-center shadow-sm">
-            <p className="text-sm font-medium text-muted">No meals logged for this day</p>
+                  return (
+                    <div
+                      key={macro.key}
+                      className="rounded-xl border border-black/8 bg-white/30 px-4 py-4 backdrop-blur-sm dark:border-border dark:bg-secondary/60"
+                    >
+                      <p className="text-xs font-semibold uppercase tracking-[0.18em] opacity-65 dark:text-muted dark:opacity-100">
+                        {macro.label}
+                      </p>
+                      <p className="mt-2 text-sm font-semibold">
+                        <span
+                          className={cn(
+                            isOverTarget
+                              ? 'text-red-900 dark:text-red-400'
+                              : 'text-emerald-950 dark:text-emerald-400',
+                            'text-lg tracking-tight',
+                          )}
+                        >
+                          {macro.formatValue(actual)}
+                        </span>
+                        <span className="opacity-70 dark:text-muted dark:opacity-100">
+                          {' '}
+                          / {macro.formatValue(target)}
+                        </span>
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+
+          {isLoadingDay ? (
+            <NutritionRingsSkeleton />
+          ) : (
+            <NutritionMacroRings actuals={dailyTotals} targets={dailyTargets} />
+          )}
+
+          {deleteErrorMessage ? (
+            <p className="text-sm text-destructive" role="alert">
+              {deleteErrorMessage}
+            </p>
+          ) : null}
+
+          <div className="space-y-3">
+            {isLoadingDay ? (
+              <NutritionMealSkeleton />
+            ) : selectedMeals.length > 0 ? (
+              selectedMeals.map((meal) => (
+                <MealCard
+                  key={meal.id}
+                  isDeleting={
+                    deleteMealMutation.isPending && deleteMealMutation.variables?.mealId === meal.id
+                  }
+                  meal={meal}
+                  onDelete={(mealId) => void handleDeleteMeal(mealId)}
+                />
+              ))
+            ) : (
+              <div className="flex min-h-40 items-center justify-center rounded-2xl border border-dashed border-border/70 bg-card/70 px-6 py-10 text-center shadow-sm">
+                <p className="text-sm font-medium text-muted">No meals logged for this day</p>
+              </div>
+            )}
           </div>
-        )}
+        </>
+      )}
+    </section>
+  );
+}
+
+function NutritionTotalsSkeleton() {
+  return (
+    <div aria-label="Loading nutrition" className="mt-5 grid grid-cols-2 gap-3 md:grid-cols-4">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div
+          key={index}
+          className="h-20 animate-pulse rounded-xl border border-black/8 bg-white/30 dark:border-border dark:bg-secondary/60"
+        />
+      ))}
+    </div>
+  );
+}
+
+function NutritionRingsSkeleton() {
+  return (
+    <section className="space-y-4" aria-label="Loading nutrition rings">
+      <div className="h-5 w-40 animate-pulse rounded bg-muted/70" />
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div
+            key={index}
+            className="h-44 animate-pulse rounded-2xl border border-border/70 bg-card/90"
+          />
+        ))}
       </div>
     </section>
+  );
+}
+
+function NutritionMealSkeleton() {
+  return (
+    <>
+      {Array.from({ length: 2 }).map((_, index) => (
+        <div
+          key={index}
+          className="h-28 animate-pulse rounded-2xl border border-border/70 bg-card/90"
+        />
+      ))}
+    </>
   );
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,6 +11,7 @@ export * from './schemas/habits.js';
 export * from './schemas/health-conditions.js';
 export * from './schemas/journal.js';
 export * from './schemas/foods.js';
+export * from './schemas/nutrition.js';
 export * from './schemas/nutrition-targets.js';
 export * from './schemas/resources.js';
 export * from './schemas/scheduled-workouts.js';

--- a/packages/shared/src/schemas/nutrition.test.ts
+++ b/packages/shared/src/schemas/nutrition.test.ts
@@ -2,9 +2,15 @@ import { describe, expect, it } from 'vitest';
 
 import {
   type CreateMealInput,
+  type DailyNutrition,
+  type DeleteMealResult,
   type MealItemInput,
+  type NutritionSummary,
   createMealInputSchema,
+  dailyNutritionSchema,
+  deleteMealResultSchema,
   mealItemInputSchema,
+  nutritionSummarySchema,
 } from './nutrition';
 
 describe('mealItemInputSchema', () => {
@@ -125,5 +131,125 @@ describe('createMealInputSchema', () => {
     };
 
     expect(meal.name).toBe('Breakfast');
+  });
+});
+
+describe('dailyNutritionSchema', () => {
+  it('parses a valid daily nutrition payload', () => {
+    const payload = dailyNutritionSchema.parse({
+      log: {
+        id: 'log-1',
+        userId: 'user-1',
+        date: '2026-03-09',
+        notes: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      meals: [
+        {
+          meal: {
+            id: 'meal-1',
+            nutritionLogId: 'log-1',
+            name: 'Breakfast',
+            time: '07:20',
+            notes: null,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          items: [
+            {
+              id: 'item-1',
+              mealId: 'meal-1',
+              foodId: null,
+              name: 'Large Eggs',
+              amount: 3,
+              unit: 'eggs',
+              calories: 210,
+              protein: 18,
+              carbs: 1,
+              fat: 15,
+              fiber: null,
+              sugar: null,
+              createdAt: 1,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(payload?.meals).toHaveLength(1);
+    expect(payload?.meals[0]?.items[0]?.name).toBe('Large Eggs');
+  });
+
+  it('accepts null when no log exists for the date', () => {
+    expect(dailyNutritionSchema.parse(null)).toBeNull();
+  });
+
+  it('infers DailyNutrition from the schema', () => {
+    const daily: DailyNutrition = null;
+    expect(daily).toBeNull();
+  });
+});
+
+describe('nutritionSummarySchema', () => {
+  it('parses summary payloads with and without target', () => {
+    const withTarget = nutritionSummarySchema.parse({
+      date: '2026-03-09',
+      meals: 3,
+      actual: {
+        calories: 2100,
+        protein: 180,
+        carbs: 220,
+        fat: 70,
+      },
+      target: {
+        calories: 2300,
+        protein: 190,
+        carbs: 260,
+        fat: 75,
+      },
+    });
+
+    const withoutTarget = nutritionSummarySchema.parse({
+      date: '2026-03-09',
+      meals: 0,
+      actual: {
+        calories: 0,
+        protein: 0,
+        carbs: 0,
+        fat: 0,
+      },
+      target: null,
+    });
+
+    expect(withTarget.target?.calories).toBe(2300);
+    expect(withoutTarget.target).toBeNull();
+  });
+
+  it('infers NutritionSummary from the schema', () => {
+    const summary: NutritionSummary = {
+      date: '2026-03-09',
+      meals: 1,
+      actual: {
+        calories: 210,
+        protein: 18,
+        carbs: 1,
+        fat: 15,
+      },
+      target: null,
+    };
+
+    expect(summary.actual.protein).toBe(18);
+  });
+});
+
+describe('deleteMealResultSchema', () => {
+  it('parses successful delete payloads', () => {
+    expect(deleteMealResultSchema.parse({ success: true })).toEqual({ success: true });
+  });
+
+  it('infers DeleteMealResult from the schema', () => {
+    const result: DeleteMealResult = { success: true };
+    expect(result.success).toBe(true);
   });
 });

--- a/packages/shared/src/schemas/nutrition.test.ts
+++ b/packages/shared/src/schemas/nutrition.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type CreateMealInput,
+  type MealItemInput,
+  createMealInputSchema,
+  mealItemInputSchema,
+} from './nutrition';
+
+describe('mealItemInputSchema', () => {
+  it('parses a valid meal item payload', () => {
+    const item = mealItemInputSchema.parse({
+      foodId: 'food-1',
+      name: ' Cooked Rice ',
+      amount: 1.5,
+      unit: ' cup ',
+      calories: 300,
+      protein: 6,
+      carbs: 65,
+      fat: 1,
+    });
+
+    expect(item).toEqual({
+      foodId: 'food-1',
+      name: 'Cooked Rice',
+      amount: 1.5,
+      unit: 'cup',
+      calories: 300,
+      protein: 6,
+      carbs: 65,
+      fat: 1,
+    });
+  });
+
+  it('rejects invalid quantities and macros', () => {
+    expect(() =>
+      mealItemInputSchema.parse({
+        name: 'Cooked Rice',
+        amount: 0,
+        unit: 'cup',
+        calories: -1,
+        protein: 6,
+        carbs: 65,
+        fat: 1,
+      }),
+    ).toThrow();
+  });
+
+  it('infers the MealItemInput type from the schema', () => {
+    const item: MealItemInput = {
+      name: 'Egg Whites',
+      amount: 4,
+      unit: 'oz',
+      calories: 68,
+      protein: 14,
+      carbs: 0,
+      fat: 0,
+    };
+
+    expect(item.protein).toBe(14);
+  });
+});
+
+describe('createMealInputSchema', () => {
+  it('parses a valid meal payload with items', () => {
+    const meal = createMealInputSchema.parse({
+      name: ' Lunch ',
+      time: '12:30',
+      notes: ' Post workout ',
+      items: [
+        {
+          name: 'Cooked Rice',
+          amount: 1,
+          unit: 'cup',
+          calories: 200,
+          protein: 4,
+          carbs: 45,
+          fat: 1,
+        },
+      ],
+    });
+
+    expect(meal).toEqual({
+      name: 'Lunch',
+      time: '12:30',
+      notes: 'Post workout',
+      items: [
+        {
+          name: 'Cooked Rice',
+          amount: 1,
+          unit: 'cup',
+          calories: 200,
+          protein: 4,
+          carbs: 45,
+          fat: 1,
+        },
+      ],
+    });
+  });
+
+  it('rejects invalid meal payloads', () => {
+    expect(() =>
+      createMealInputSchema.parse({
+        name: '  ',
+        time: '7:30',
+        items: [],
+      }),
+    ).toThrow();
+  });
+
+  it('infers the CreateMealInput type from the schema', () => {
+    const meal: CreateMealInput = {
+      name: 'Breakfast',
+      items: [
+        {
+          name: 'Oats',
+          amount: 60,
+          unit: 'g',
+          calories: 228,
+          protein: 8,
+          carbs: 39,
+          fat: 4,
+        },
+      ],
+    };
+
+    expect(meal.name).toBe('Breakfast');
+  });
+});

--- a/packages/shared/src/schemas/nutrition.test.ts
+++ b/packages/shared/src/schemas/nutrition.test.ts
@@ -24,6 +24,8 @@ describe('mealItemInputSchema', () => {
       protein: 6,
       carbs: 65,
       fat: 1,
+      fiber: 2.5,
+      sugar: 1,
     });
 
     expect(item).toEqual({
@@ -35,6 +37,8 @@ describe('mealItemInputSchema', () => {
       protein: 6,
       carbs: 65,
       fat: 1,
+      fiber: 2.5,
+      sugar: 1,
     });
   });
 
@@ -48,6 +52,7 @@ describe('mealItemInputSchema', () => {
         protein: 6,
         carbs: 65,
         fat: 1,
+        fiber: -1,
       }),
     ).toThrow();
   });
@@ -61,6 +66,8 @@ describe('mealItemInputSchema', () => {
       protein: 14,
       carbs: 0,
       fat: 0,
+      fiber: 0,
+      sugar: 0,
     };
 
     expect(item.protein).toBe(14);

--- a/packages/shared/src/schemas/nutrition.ts
+++ b/packages/shared/src/schemas/nutrition.ts
@@ -81,6 +81,8 @@ export const mealItemInputSchema = z.object({
   protein: nonnegativeNumber,
   carbs: nonnegativeNumber,
   fat: nonnegativeNumber,
+  fiber: nonnegativeNumber.optional(),
+  sugar: nonnegativeNumber.optional(),
 });
 
 export const createMealInputSchema = z.object({

--- a/packages/shared/src/schemas/nutrition.ts
+++ b/packages/shared/src/schemas/nutrition.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+const requiredText = (maxLength = 255) => z.string().trim().min(1).max(maxLength);
+const nonnegativeNumber = z.number().nonnegative().finite();
+
+const mealTimeSchema = z.string().regex(/^\d{2}:\d{2}$/);
+
+export const mealItemInputSchema = z.object({
+  foodId: z.string().trim().min(1).optional(),
+  name: requiredText(),
+  amount: z.number().positive().finite(),
+  unit: requiredText(50),
+  calories: nonnegativeNumber,
+  protein: nonnegativeNumber,
+  carbs: nonnegativeNumber,
+  fat: nonnegativeNumber,
+});
+
+export const createMealInputSchema = z.object({
+  name: requiredText(120),
+  time: mealTimeSchema.optional(),
+  notes: requiredText(2_000).optional(),
+  items: z.array(mealItemInputSchema).min(1),
+});
+
+export type MealItemInput = z.infer<typeof mealItemInputSchema>;
+export type CreateMealInput = z.infer<typeof createMealInputSchema>;

--- a/packages/shared/src/schemas/nutrition.ts
+++ b/packages/shared/src/schemas/nutrition.ts
@@ -5,7 +5,7 @@ import { dateSchema } from './common.js';
 const requiredText = (maxLength = 255) => z.string().trim().min(1).max(maxLength);
 const nonnegativeNumber = z.number().nonnegative().finite();
 
-const mealTimeSchema = z.string().regex(/^\d{2}:\d{2}$/);
+const mealTimeSchema = z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/);
 
 export const nutritionMacroTotalsSchema = z.object({
   calories: nonnegativeNumber,

--- a/packages/shared/src/schemas/nutrition.ts
+++ b/packages/shared/src/schemas/nutrition.ts
@@ -1,9 +1,76 @@
 import { z } from 'zod';
 
+import { dateSchema } from './common.js';
+
 const requiredText = (maxLength = 255) => z.string().trim().min(1).max(maxLength);
 const nonnegativeNumber = z.number().nonnegative().finite();
 
 const mealTimeSchema = z.string().regex(/^\d{2}:\d{2}$/);
+
+export const nutritionMacroTotalsSchema = z.object({
+  calories: nonnegativeNumber,
+  protein: nonnegativeNumber,
+  carbs: nonnegativeNumber,
+  fat: nonnegativeNumber,
+});
+
+export const nutritionLogSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  date: dateSchema,
+  notes: z.string().nullable(),
+  createdAt: z.number().int(),
+  updatedAt: z.number().int(),
+});
+
+export const nutritionMealSchema = z.object({
+  id: z.string(),
+  nutritionLogId: z.string(),
+  name: requiredText(120),
+  time: mealTimeSchema.nullable(),
+  notes: z.string().nullable(),
+  createdAt: z.number().int(),
+  updatedAt: z.number().int(),
+});
+
+export const nutritionMealItemSchema = z.object({
+  id: z.string(),
+  mealId: z.string(),
+  foodId: z.string().nullable(),
+  name: requiredText(),
+  amount: z.number().positive().finite(),
+  unit: requiredText(50),
+  calories: nonnegativeNumber,
+  protein: nonnegativeNumber,
+  carbs: nonnegativeNumber,
+  fat: nonnegativeNumber,
+  fiber: nonnegativeNumber.nullable(),
+  sugar: nonnegativeNumber.nullable(),
+  createdAt: z.number().int(),
+});
+
+export const dailyNutritionMealSchema = z.object({
+  meal: nutritionMealSchema,
+  items: z.array(nutritionMealItemSchema),
+});
+
+export const dailyNutritionSchema = z
+  .object({
+    log: nutritionLogSchema,
+    meals: z.array(dailyNutritionMealSchema),
+  })
+  .nullable();
+
+export const nutritionSummarySchema = z.object({
+  date: dateSchema,
+  meals: z.number().int().nonnegative(),
+  actual: nutritionMacroTotalsSchema,
+  target: nutritionMacroTotalsSchema.nullable(),
+});
+
+export const deleteMealResultSchema = z.object({
+  success: z.literal(true),
+});
 
 export const mealItemInputSchema = z.object({
   foodId: z.string().trim().min(1).optional(),
@@ -25,3 +92,11 @@ export const createMealInputSchema = z.object({
 
 export type MealItemInput = z.infer<typeof mealItemInputSchema>;
 export type CreateMealInput = z.infer<typeof createMealInputSchema>;
+export type NutritionMacroTotals = z.infer<typeof nutritionMacroTotalsSchema>;
+export type NutritionLog = z.infer<typeof nutritionLogSchema>;
+export type NutritionMeal = z.infer<typeof nutritionMealSchema>;
+export type NutritionMealItem = z.infer<typeof nutritionMealItemSchema>;
+export type DailyNutritionMeal = z.infer<typeof dailyNutritionMealSchema>;
+export type DailyNutrition = z.infer<typeof dailyNutritionSchema>;
+export type NutritionSummary = z.infer<typeof nutritionSummarySchema>;
+export type DeleteMealResult = z.infer<typeof deleteMealResultSchema>;


### PR DESCRIPTION
## Summary
This PR introduces the first full nutrition logging API surface and wires the nutrition page to live backend data instead of mock fixtures. On the API side, it adds date-scoped meal create/read/delete endpoints plus a daily summary endpoint that aggregates actual macros and resolves the effective nutrition target for that date. On the web side, the nutrition page now fetches daily meals and summary data via TanStack Query, supports deleting meals, and handles loading, error, and no-target states. The shared package now exports nutrition schemas/types so API and frontend consume the same contracts, and new tests cover route behavior, data-store summary logic, and end-to-end nutrition/foods flows.

## Key Changes
- Added `/api/v1/nutrition` routes:
- `POST /:date/meals` to create meals with items for a day.
- `GET /:date` to fetch a day’s nutrition log with nested meals/items.
- `GET /:date/summary` to return aggregated macros + meal count + target (or `null`).
- `DELETE /:date/meals/:mealId` to remove a meal in user/date scope.
- Registered nutrition routes in API server bootstrap (`apps/api/src/index.ts`).
- Implemented nutrition store operations with Drizzle transactions and userId/date scoping.
- Updated meal creation flow to dedupe referenced `foodId`s and bump `foods.lastUsedAt`.
- Added shared nutrition schemas/types in `@pulse/shared` and exported them from package index.
- Added web nutrition API hooks + query keys (`useDailyNutrition`, `useNutritionSummary`, `useDeleteMeal`).
- Reworked nutrition page to:
- read meals/totals from API,
- delete meals with cache invalidation,
- show skeletons and error states,
- support missing-target UX (`target: null`) and hide macro rings when no target exists.
- Updated `MealCard` to use API-shaped meal data, format meal time, and expose delete action.
- Expanded tests across API routes/store, foods+nutrition HTTP integration flows, shared schemas, and frontend query/page/component behavior.

## Technical Notes
- Summary target lookup uses “latest target effective on or before date” (`effectiveDate <= date`, descending, `limit 1`), so historical dates resolve the correct target version.
- `POST /nutrition/:date/meals` validates input with shared Zod schema and trims/normalizes fields before persistence; route date validation is regex-based (`YYYY-MM-DD` format check).
- Meal deletion is scoped by joining `meals` to `nutritionLogs` and matching `userId + date + mealId` before deleting meal items and meal rows.
- Frontend intentionally splits daily data and summary into separate queries; delete mutation invalidates both query keys for that date to keep totals/rings and meal cards consistent.

## Commits

- `d843169 test(api): add foods and nutrition integration tests`
- `c4cbf29 fix(nutrition): handle missing targets and share API types`
- `bf47d5e feat(web): wire nutrition page to nutrition api`
- `c17b972 feat(api): add daily nutrition summary endpoint`
- `affc345 feat(api): add nutrition meal logging endpoints`

## Tasks

- **Nutrition logs + meals + items API**: CRUD for daily logs, meals, and meal items with userId scoping
- **Daily nutrition summary endpoint**: Aggregate macros for a date vs targets, return summary object
- **Wire nutrition view to API**: Connect daily nutrition view, meal cards, macro rings to real data
- **API tests: foods, nutrition logs, meals**: Integration tests for foods CRUD + search, nutrition log + meal operations

## Diff Stats

```
apps/api/src/__tests__/foods-nutrition.test.ts     | 894 +++++++++++++++++++++
 apps/api/src/index.ts                              |   2 +
 apps/api/src/routes/nutrition/index.test.ts        | 503 ++++++++++++
 apps/api/src/routes/nutrition/index.ts             |  93 +++
 apps/api/src/routes/nutrition/store.test.ts        | 159 ++++
 apps/api/src/routes/nutrition/store.ts             | 323 ++++++++
 apps/web/src/features/nutrition/api/keys.ts        |   5 +
 .../src/features/nutrition/api/nutrition.test.tsx  | 143 ++++
 apps/web/src/features/nutrition/api/nutrition.ts   |  58 ++
 .../nutrition/components/meal-card.test.tsx        |  51 +-
 .../features/nutrition/components/meal-card.tsx    | 120 ++-
 .../src/features/nutrition/lib/nutrition-utils.ts  |  54 +-
 apps/web/src/pages/nutrition.test.tsx              | 533 ++++++++++--
 apps/web/src/pages/nutrition.tsx                   | 285 +++++--
 packages/shared/src/index.ts                       |   1 +
 packages/shared/src/schemas/nutrition.test.ts      | 255 ++++++
 packages/shared/src/schemas/nutrition.ts           | 102 +++
 17 files changed, 3388 insertions(+), 193 deletions(-)
```