### PR TITLE
Workouts API + wiring (sessions)

### DIFF
--- a/apps/api/src/__tests__/workouts.test.ts
+++ b/apps/api/src/__tests__/workouts.test.ts
@@ -1,0 +1,732 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { eq } from 'drizzle-orm';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import type { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  exercises,
+  scheduledWorkouts,
+  sessionSets,
+  templateExercises,
+  users,
+  workoutSessions,
+  workoutTemplates,
+} from '../db/schema/index.js';
+
+type DatabaseModule = typeof import('../db/index.js');
+
+type TestContext = {
+  app: FastifyInstance;
+  db: DatabaseModule['db'];
+  sqlite: DatabaseModule['sqlite'];
+  tempDir: string;
+};
+
+type TemplateSectionType = 'warmup' | 'main' | 'cooldown';
+
+type TemplateResponse = {
+  id: string;
+  userId: string;
+  name: string;
+  description: string | null;
+  tags: string[];
+  sections: Array<{
+    type: TemplateSectionType;
+    exercises: Array<{
+      id: string;
+      exerciseId: string;
+      exerciseName: string;
+      sets: number | null;
+      repsMin: number | null;
+      repsMax: number | null;
+      tempo: string | null;
+      restSeconds: number | null;
+      supersetGroup: string | null;
+      notes: string | null;
+      cues: string[];
+    }>;
+  }>;
+  createdAt: number;
+  updatedAt: number;
+};
+
+let context: TestContext;
+
+const createAuthorizationHeader = (token: string) => ({
+  authorization: `Bearer ${token}`,
+});
+
+const seedUser = (id: string, username: string) =>
+  context.db
+    .insert(users)
+    .values({
+      id,
+      username,
+      name: username,
+      passwordHash: 'not-used-in-this-suite',
+    })
+    .run();
+
+const seedExercise = (values: {
+  id: string;
+  userId: string | null;
+  name: string;
+  muscleGroups: string[];
+  equipment: string;
+  category: 'compound' | 'isolation' | 'cardio' | 'mobility';
+}) =>
+  context.db
+    .insert(exercises)
+    .values({
+      ...values,
+      instructions: null,
+    })
+    .run();
+
+const createTemplate = async (token: string, overrides?: Partial<{ name: string }>) => {
+  const response = await context.app.inject({
+    method: 'POST',
+    url: '/api/v1/workout-templates',
+    headers: createAuthorizationHeader(token),
+    payload: {
+      name: overrides?.name ?? 'Upper Push Builder',
+      description: 'Base template for integration test flows',
+      tags: ['strength', 'upper'],
+      sections: [
+        {
+          type: 'main',
+          exercises: [
+            {
+              exerciseId: 'global-bench-press',
+              sets: 3,
+              repsMin: 6,
+              repsMax: 8,
+              restSeconds: 120,
+            },
+            {
+              exerciseId: 'user-1-lat-pulldown',
+              sets: 2,
+              repsMin: 8,
+              repsMax: 12,
+              restSeconds: 90,
+            },
+          ],
+        },
+        {
+          type: 'warmup',
+          exercises: [
+            {
+              exerciseId: 'global-row-erg',
+              sets: 1,
+              repsMin: 5,
+              repsMax: 8,
+              restSeconds: 30,
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  expect(response.statusCode).toBe(201);
+
+  return (response.json() as { data: TemplateResponse }).data;
+};
+
+describe('workouts integration', () => {
+  beforeAll(async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'pulse-workouts-integration-'));
+
+    process.env.JWT_SECRET = 'test-workouts-integration-secret';
+    process.env.DATABASE_URL = join(tempDir, 'test.db');
+    vi.resetModules();
+
+    const [{ buildServer }, dbModule] = await Promise.all([
+      import('../index.js'),
+      import('../db/index.js'),
+    ]);
+
+    migrate(dbModule.db, {
+      migrationsFolder: fileURLToPath(new URL('../../drizzle', import.meta.url)),
+    });
+
+    const app = buildServer();
+    await app.ready();
+
+    context = {
+      app,
+      db: dbModule.db,
+      sqlite: dbModule.sqlite,
+      tempDir,
+    };
+  });
+
+  afterAll(async () => {
+    if (context) {
+      await context.app.close();
+      context.sqlite.close();
+      rmSync(context.tempDir, { recursive: true, force: true });
+    }
+
+    delete process.env.JWT_SECRET;
+    delete process.env.DATABASE_URL;
+    vi.resetModules();
+  });
+
+  beforeEach(() => {
+    context.db.delete(scheduledWorkouts).run();
+    context.db.delete(sessionSets).run();
+    context.db.delete(workoutSessions).run();
+    context.db.delete(templateExercises).run();
+    context.db.delete(workoutTemplates).run();
+    context.db.delete(exercises).run();
+    context.db.delete(users).run();
+
+    seedUser('user-1', 'derek');
+    seedUser('user-2', 'alex');
+
+    seedExercise({
+      id: 'global-bench-press',
+      userId: null,
+      name: 'Barbell Bench Press',
+      muscleGroups: ['chest', 'triceps'],
+      equipment: 'barbell',
+      category: 'compound',
+    });
+    seedExercise({
+      id: 'global-row-erg',
+      userId: null,
+      name: 'Row Erg',
+      muscleGroups: ['conditioning'],
+      equipment: 'rower',
+      category: 'cardio',
+    });
+    seedExercise({
+      id: 'user-1-lat-pulldown',
+      userId: 'user-1',
+      name: 'Lat Pulldown',
+      muscleGroups: ['lats'],
+      equipment: 'machine',
+      category: 'isolation',
+    });
+    seedExercise({
+      id: 'user-2-private-row',
+      userId: 'user-2',
+      name: 'Private Row',
+      muscleGroups: ['back'],
+      equipment: 'cable',
+      category: 'compound',
+    });
+  });
+
+  it('supports workout template CRUD and cascade deletion of template exercises', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    const createdTemplate = await createTemplate(authToken, {
+      name: 'Upper Push Day',
+    });
+
+    expect(createdTemplate.name).toBe('Upper Push Day');
+    expect(createdTemplate.sections.map((section) => section.type)).toEqual([
+      'warmup',
+      'main',
+      'cooldown',
+    ]);
+    expect(createdTemplate.sections[0]?.exercises).toHaveLength(1);
+    expect(createdTemplate.sections[1]?.exercises).toHaveLength(2);
+    expect(createdTemplate.sections[2]?.exercises).toEqual([]);
+
+    const readResponse = await context.app.inject({
+      method: 'GET',
+      url: `/api/v1/workout-templates/${createdTemplate.id}`,
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(readResponse.statusCode).toBe(200);
+    expect((readResponse.json() as { data: TemplateResponse }).data).toMatchObject({
+      id: createdTemplate.id,
+      name: 'Upper Push Day',
+      sections: [
+        {
+          type: 'warmup',
+          exercises: [expect.objectContaining({ exerciseName: 'Row Erg' })],
+        },
+        {
+          type: 'main',
+          exercises: [
+            expect.objectContaining({ exerciseName: 'Barbell Bench Press' }),
+            expect.objectContaining({ exerciseName: 'Lat Pulldown' }),
+          ],
+        },
+        {
+          type: 'cooldown',
+          exercises: [],
+        },
+      ],
+    });
+
+    const updateResponse = await context.app.inject({
+      method: 'PUT',
+      url: `/api/v1/workout-templates/${createdTemplate.id}`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        name: 'Upper Push Day v2',
+        description: 'Updated split',
+        tags: ['strength', 'push'],
+        sections: [
+          {
+            type: 'main',
+            exercises: [
+              {
+                exerciseId: 'global-bench-press',
+                sets: 4,
+                repsMin: 5,
+                repsMax: 8,
+              },
+            ],
+          },
+          {
+            type: 'cooldown',
+            exercises: [
+              {
+                exerciseId: 'global-row-erg',
+                sets: 1,
+                repsMin: 8,
+                repsMax: 10,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(updateResponse.statusCode).toBe(200);
+    expect((updateResponse.json() as { data: TemplateResponse }).data).toMatchObject({
+      id: createdTemplate.id,
+      name: 'Upper Push Day v2',
+      description: 'Updated split',
+      tags: ['strength', 'push'],
+      sections: [
+        { type: 'warmup', exercises: [] },
+        {
+          type: 'main',
+          exercises: [expect.objectContaining({ exerciseId: 'global-bench-press', sets: 4 })],
+        },
+        {
+          type: 'cooldown',
+          exercises: [expect.objectContaining({ exerciseId: 'global-row-erg', sets: 1 })],
+        },
+      ],
+    });
+
+    const deleteResponse = await context.app.inject({
+      method: 'DELETE',
+      url: `/api/v1/workout-templates/${createdTemplate.id}`,
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(deleteResponse.statusCode).toBe(200);
+    expect(deleteResponse.json()).toEqual({
+      data: {
+        success: true,
+      },
+    });
+
+    const remainingTemplateExercises = context.db
+      .select({ id: templateExercises.id })
+      .from(templateExercises)
+      .where(eq(templateExercises.templateId, createdTemplate.id))
+      .all();
+
+    expect(remainingTemplateExercises).toEqual([]);
+  });
+
+  it('handles session lifecycle with template-derived planned sets and live set logging', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    const template = await createTemplate(authToken);
+    const plannedSets = template.sections.flatMap((section) =>
+      section.exercises.flatMap((exercise) => {
+        const setCount = exercise.sets ?? 0;
+
+        return Array.from({ length: setCount }, (_, index) => ({
+          exerciseId: exercise.exerciseId,
+          setNumber: index + 1,
+          section: section.type,
+        }));
+      }),
+    );
+
+    const startResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: template.id,
+        name: template.name,
+        date: '2026-04-12',
+        startedAt: 1_800_000_000_000,
+        sets: plannedSets,
+      },
+    });
+
+    expect(startResponse.statusCode).toBe(201);
+    const startedSession = (startResponse.json() as {
+      data: {
+        id: string;
+        templateId: string | null;
+        status: 'scheduled' | 'in-progress' | 'completed';
+        sets: Array<{
+          exerciseId: string;
+          setNumber: number;
+          section: TemplateSectionType | null;
+          completed: boolean;
+        }>;
+      };
+    }).data;
+
+    expect(startedSession.templateId).toBe(template.id);
+    expect(startedSession.status).toBe('in-progress');
+    expect(startedSession.sets).toHaveLength(6);
+    expect(startedSession.sets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          exerciseId: 'global-bench-press',
+          setNumber: 1,
+          section: 'main',
+          completed: false,
+        }),
+        expect.objectContaining({
+          exerciseId: 'global-row-erg',
+          setNumber: 1,
+          section: 'warmup',
+          completed: false,
+        }),
+      ]),
+    );
+
+    const logSetResponse = await context.app.inject({
+      method: 'POST',
+      url: `/api/v1/workout-sessions/${startedSession.id}/sets`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        exerciseId: 'global-bench-press',
+        setNumber: 4,
+        weight: 185,
+        reps: 6,
+        section: 'main',
+      },
+    });
+
+    expect(logSetResponse.statusCode).toBe(201);
+    expect(logSetResponse.json()).toEqual({
+      data: expect.objectContaining({
+        exerciseId: 'global-bench-press',
+        setNumber: 4,
+        weight: 185,
+        reps: 6,
+      }),
+    });
+
+    const groupedSetResponse = await context.app.inject({
+      method: 'GET',
+      url: `/api/v1/workout-sessions/${startedSession.id}/sets`,
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(groupedSetResponse.statusCode).toBe(200);
+
+    const groupedSets = (groupedSetResponse.json() as {
+      data: Array<{
+        exerciseId: string;
+        sets: Array<{ setNumber: number }>;
+      }>;
+    }).data;
+
+    const benchGroup = groupedSets.find((group) => group.exerciseId === 'global-bench-press');
+    expect(benchGroup?.sets.map((set) => set.setNumber)).toEqual([1, 2, 3, 4]);
+
+    const completeResponse = await context.app.inject({
+      method: 'PUT',
+      url: `/api/v1/workout-sessions/${startedSession.id}`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        status: 'completed',
+        completedAt: 1_800_000_002_700,
+        duration: 45,
+        feedback: {
+          energy: 4,
+          recovery: 3,
+          technique: 5,
+          notes: 'Strong top sets',
+        },
+        notes: 'Session complete',
+      },
+    });
+
+    expect(completeResponse.statusCode).toBe(200);
+    expect(completeResponse.json()).toEqual({
+      data: expect.objectContaining({
+        id: startedSession.id,
+        status: 'completed',
+        completedAt: 1_800_000_002_700,
+        duration: 45,
+        feedback: {
+          energy: 4,
+          recovery: 3,
+          technique: 5,
+          notes: 'Strong top sets',
+        },
+        notes: 'Session complete',
+      }),
+    });
+  });
+
+  it('supports scheduled workouts create, date-range reads, update, and delete', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    const templateA = await createTemplate(authToken, { name: 'Template A' });
+    const templateB = await createTemplate(authToken, { name: 'Template B' });
+
+    const createFirstResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: templateA.id,
+        date: '2026-04-10',
+      },
+    });
+    const createSecondResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: templateB.id,
+        date: '2026-04-15',
+      },
+    });
+    const createOutsideRangeResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: templateA.id,
+        date: '2026-05-01',
+      },
+    });
+
+    expect(createFirstResponse.statusCode).toBe(201);
+    expect(createSecondResponse.statusCode).toBe(201);
+    expect(createOutsideRangeResponse.statusCode).toBe(201);
+
+    const firstScheduleId = (createFirstResponse.json() as { data: { id: string } }).data.id;
+    const secondScheduleId = (createSecondResponse.json() as { data: { id: string } }).data.id;
+
+    const rangeResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/scheduled-workouts?from=2026-04-01&to=2026-04-30',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(rangeResponse.statusCode).toBe(200);
+
+    const rangeItems = (rangeResponse.json() as {
+      data: Array<{
+        id: string;
+        templateName: string | null;
+        date: string;
+      }>;
+    }).data;
+
+    expect(rangeItems.map((item) => item.id)).toEqual([firstScheduleId, secondScheduleId]);
+    expect(rangeItems.map((item) => item.templateName)).toEqual(['Template A', 'Template B']);
+
+    const updateResponse = await context.app.inject({
+      method: 'PUT',
+      url: `/api/v1/scheduled-workouts/${firstScheduleId}`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        date: '2026-04-20',
+        templateId: templateB.id,
+      },
+    });
+
+    expect(updateResponse.statusCode).toBe(200);
+    expect(updateResponse.json()).toEqual({
+      data: expect.objectContaining({
+        id: firstScheduleId,
+        date: '2026-04-20',
+        templateId: templateB.id,
+      }),
+    });
+
+    const deleteResponse = await context.app.inject({
+      method: 'DELETE',
+      url: `/api/v1/scheduled-workouts/${secondScheduleId}`,
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(deleteResponse.statusCode).toBe(200);
+    expect(deleteResponse.json()).toEqual({
+      data: {
+        success: true,
+      },
+    });
+
+    const afterDeleteRangeResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/scheduled-workouts?from=2026-04-01&to=2026-04-30',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(afterDeleteRangeResponse.statusCode).toBe(200);
+    expect(
+      (
+        afterDeleteRangeResponse.json() as {
+          data: Array<{
+            id: string;
+            date: string;
+            templateId: string | null;
+            templateName: string | null;
+            sessionId: string | null;
+            createdAt: number;
+          }>;
+        }
+      ).data,
+    ).toEqual([
+      expect.objectContaining({
+        id: firstScheduleId,
+        date: '2026-04-20',
+        templateId: templateB.id,
+        templateName: 'Template B',
+      }),
+    ]);
+  });
+
+  it('supports exercise CRUD plus search and filter queries', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/exercises',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        name: 'Single Arm Cable Row',
+        muscleGroups: ['lats'],
+        equipment: 'cable',
+        category: 'isolation',
+        instructions: 'Pull elbow back and keep chest stable.',
+      },
+    });
+
+    expect(createResponse.statusCode).toBe(201);
+    const createdExercise = (createResponse.json() as {
+      data: {
+        id: string;
+        userId: string | null;
+        name: string;
+      };
+    }).data;
+
+    expect(createdExercise.userId).toBe('user-1');
+    expect(createdExercise.name).toBe('Single Arm Cable Row');
+
+    const searchResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises?q=row&page=1&limit=20',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(searchResponse.statusCode).toBe(200);
+    const searchPayload = searchResponse.json() as {
+      data: Array<{ name: string }>;
+      meta: { page: number; limit: number; total: number };
+    };
+
+    expect(searchPayload.data.map((exercise) => exercise.name)).toEqual([
+      'Row Erg',
+      'Single Arm Cable Row',
+    ]);
+    expect(searchPayload.meta).toEqual({
+      page: 1,
+      limit: 20,
+      total: 2,
+    });
+
+    const categoryFilterResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises?category=cardio&page=1&limit=20',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(categoryFilterResponse.statusCode).toBe(200);
+    expect((categoryFilterResponse.json() as { data: Array<{ name: string }> }).data).toEqual([
+      expect.objectContaining({ name: 'Row Erg' }),
+    ]);
+
+    const compoundFilterResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises?muscleGroup=chest&equipment=barbell&page=1&limit=20',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(compoundFilterResponse.statusCode).toBe(200);
+    expect((compoundFilterResponse.json() as { data: Array<{ name: string }> }).data).toEqual([
+      expect.objectContaining({ name: 'Barbell Bench Press' }),
+    ]);
+
+    const updateResponse = await context.app.inject({
+      method: 'PUT',
+      url: `/api/v1/exercises/${createdExercise.id}`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        name: 'Chest Supported Cable Row',
+        equipment: 'machine',
+      },
+    });
+
+    expect(updateResponse.statusCode).toBe(200);
+    expect(updateResponse.json()).toEqual({
+      data: expect.objectContaining({
+        id: createdExercise.id,
+        name: 'Chest Supported Cable Row',
+        equipment: 'machine',
+      }),
+    });
+
+    const deleteResponse = await context.app.inject({
+      method: 'DELETE',
+      url: `/api/v1/exercises/${createdExercise.id}`,
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(deleteResponse.statusCode).toBe(200);
+    expect(deleteResponse.json()).toEqual({
+      data: {
+        success: true,
+      },
+    });
+
+    const postDeleteSearchResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises?q=chest%20supported&page=1&limit=20',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(postDeleteSearchResponse.statusCode).toBe(200);
+    expect(postDeleteSearchResponse.json()).toEqual({
+      data: [],
+      meta: {
+        page: 1,
+        limit: 20,
+        total: 0,
+      },
+    });
+  });
+});

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -7,7 +7,7 @@ import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import type { FastifyInstance } from 'fastify';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { exercises, users } from '../../db/schema/index.js';
+import { exercises, sessionSets, users, workoutSessions } from '../../db/schema/index.js';
 
 type DatabaseModule = typeof import('../../db/index.js');
 
@@ -52,6 +52,56 @@ const seedExercise = (values: {
     })
     .run();
 
+const seedWorkoutSession = (values: {
+  id: string;
+  userId: string;
+  name: string;
+  date: string;
+  startedAt: number;
+  status?: 'scheduled' | 'in-progress' | 'completed';
+  completedAt?: number | null;
+}) =>
+  context.db
+    .insert(workoutSessions)
+    .values({
+      id: values.id,
+      userId: values.userId,
+      templateId: null,
+      name: values.name,
+      date: values.date,
+      status: values.status ?? 'in-progress',
+      startedAt: values.startedAt,
+      completedAt: values.completedAt ?? null,
+      duration: null,
+      feedback: null,
+      notes: null,
+    })
+    .run();
+
+const seedSessionSet = (values: {
+  id: string;
+  sessionId: string;
+  exerciseId: string;
+  setNumber: number;
+  weight?: number | null;
+  reps?: number | null;
+}) =>
+  context.db
+    .insert(sessionSets)
+    .values({
+      id: values.id,
+      sessionId: values.sessionId,
+      exerciseId: values.exerciseId,
+      setNumber: values.setNumber,
+      weight: values.weight ?? null,
+      reps: values.reps ?? null,
+      completed: false,
+      skipped: false,
+      section: 'main',
+      notes: null,
+    })
+    .run();
+
 describe('exercise routes', () => {
   beforeAll(async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'pulse-exercises-routes-'));
@@ -93,6 +143,8 @@ describe('exercise routes', () => {
   });
 
   beforeEach(() => {
+    context.db.delete(sessionSets).run();
+    context.db.delete(workoutSessions).run();
     context.db.delete(exercises).run();
     context.db.delete(users).run();
 
@@ -100,7 +152,7 @@ describe('exercise routes', () => {
     seedUser('user-2', 'alex');
   });
 
-  it('requires auth for create, list, update, and delete', async () => {
+  it('requires auth for create, list, last-performance, update, and delete', async () => {
     const responses = await Promise.all([
       context.app.inject({
         method: 'POST',
@@ -115,6 +167,10 @@ describe('exercise routes', () => {
       context.app.inject({
         method: 'GET',
         url: '/api/v1/exercises',
+      }),
+      context.app.inject({
+        method: 'GET',
+        url: '/api/v1/exercises/exercise-1/last-performance',
       }),
       context.app.inject({
         method: 'PUT',
@@ -136,6 +192,161 @@ describe('exercise routes', () => {
         },
       });
     }
+  });
+
+  it('returns most recent completed last performance for a visible exercise', async () => {
+    seedExercise({
+      id: 'global-bench',
+      userId: null,
+      name: 'Bench Press',
+      muscleGroups: ['chest'],
+      equipment: 'barbell',
+      category: 'compound',
+    });
+    seedExercise({
+      id: 'user-1-no-data',
+      userId: 'user-1',
+      name: 'No Data Exercise',
+      muscleGroups: ['chest'],
+      equipment: 'machine',
+      category: 'isolation',
+    });
+    seedExercise({
+      id: 'user-2-private',
+      userId: 'user-2',
+      name: 'Private Exercise',
+      muscleGroups: ['back'],
+      equipment: 'cable',
+      category: 'compound',
+    });
+
+    seedWorkoutSession({
+      id: 'session-old',
+      userId: 'user-1',
+      name: 'Upper Push',
+      date: '2026-03-01',
+      status: 'completed',
+      startedAt: 1_700_000_000_000,
+      completedAt: 1_700_000_003_000,
+    });
+    seedWorkoutSession({
+      id: 'session-latest',
+      userId: 'user-1',
+      name: 'Upper Push',
+      date: '2026-03-08',
+      status: 'completed',
+      startedAt: 1_700_000_010_000,
+      completedAt: 1_700_000_015_000,
+    });
+    seedWorkoutSession({
+      id: 'session-in-progress',
+      userId: 'user-1',
+      name: 'Upper Push',
+      date: '2026-03-09',
+      status: 'in-progress',
+      startedAt: 1_700_000_020_000,
+    });
+    seedWorkoutSession({
+      id: 'session-other-user',
+      userId: 'user-2',
+      name: 'Private User Session',
+      date: '2026-03-09',
+      status: 'completed',
+      startedAt: 1_700_000_020_000,
+      completedAt: 1_700_000_025_000,
+    });
+
+    seedSessionSet({
+      id: 'set-old-1',
+      sessionId: 'session-old',
+      exerciseId: 'global-bench',
+      setNumber: 1,
+      weight: 100,
+      reps: 8,
+    });
+    seedSessionSet({
+      id: 'set-old-2',
+      sessionId: 'session-old',
+      exerciseId: 'global-bench',
+      setNumber: 2,
+      weight: 100,
+      reps: 7,
+    });
+    seedSessionSet({
+      id: 'set-latest-1',
+      sessionId: 'session-latest',
+      exerciseId: 'global-bench',
+      setNumber: 1,
+      weight: 105,
+      reps: 9,
+    });
+    seedSessionSet({
+      id: 'set-in-progress',
+      sessionId: 'session-in-progress',
+      exerciseId: 'global-bench',
+      setNumber: 1,
+      weight: 115,
+      reps: 12,
+    });
+    seedSessionSet({
+      id: 'set-other-user',
+      sessionId: 'session-other-user',
+      exerciseId: 'global-bench',
+      setNumber: 1,
+      weight: 200,
+      reps: 20,
+    });
+
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    const response = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises/global-bench/last-performance',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: {
+        sessionId: 'session-latest',
+        date: '2026-03-08',
+        sets: [
+          {
+            setNumber: 1,
+            weight: 105,
+            reps: 9,
+          },
+        ],
+      },
+    });
+
+    const noDataResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises/user-1-no-data/last-performance',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(noDataResponse.statusCode).toBe(404);
+    expect(noDataResponse.json()).toEqual({
+      error: {
+        code: 'EXERCISE_LAST_PERFORMANCE_NOT_FOUND',
+        message: 'No completed performance found for this exercise',
+      },
+    });
+
+    const privateExerciseResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises/user-2-private/last-performance',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(privateExerciseResponse.statusCode).toBe(404);
+    expect(privateExerciseResponse.json()).toEqual({
+      error: {
+        code: 'EXERCISE_NOT_FOUND',
+        message: 'Exercise not found',
+      },
+    });
   });
 
   it('creates a user-specific exercise for the authenticated user', async () => {

--- a/apps/api/src/routes/exercises/index.ts
+++ b/apps/api/src/routes/exercises/index.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import {
   createExerciseInputSchema,
+  exerciseLastPerformanceSchema,
   exerciseQueryParamsSchema,
   updateExerciseInputSchema,
 } from '@pulse/shared';
@@ -13,7 +14,9 @@ import { requireUserAuth } from '../../middleware/auth.js';
 import {
   createExercise,
   deleteOwnedExercise,
+  findExerciseLastPerformance,
   findExerciseOwnership,
+  findVisibleExerciseById,
   listExerciseFilters,
   listExercises,
   updateOwnedExercise,
@@ -102,6 +105,40 @@ export const exerciseRoutes: FastifyPluginAsync = async (app) => {
 
     return reply.send({
       data: filters,
+    });
+  });
+
+  app.get<{ Params: { id: string } }>('/:id/last-performance', async (request, reply) => {
+    const exercise = await findVisibleExerciseById({
+      id: request.params.id,
+      userId: request.userId,
+    });
+    if (!exercise) {
+      return sendError(
+        reply,
+        404,
+        EXERCISE_NOT_FOUND_RESPONSE.code,
+        EXERCISE_NOT_FOUND_RESPONSE.message,
+      );
+    }
+
+    const lastPerformance = await findExerciseLastPerformance({
+      exerciseId: request.params.id,
+      userId: request.userId,
+    });
+    if (!lastPerformance) {
+      return sendError(
+        reply,
+        404,
+        'EXERCISE_LAST_PERFORMANCE_NOT_FOUND',
+        'No completed performance found for this exercise',
+      );
+    }
+
+    const payload = exerciseLastPerformanceSchema.parse(lastPerformance);
+
+    return reply.send({
+      data: payload,
     });
   });
 

--- a/apps/api/src/routes/exercises/index.ts
+++ b/apps/api/src/routes/exercises/index.ts
@@ -2,7 +2,6 @@ import { randomUUID } from 'node:crypto';
 
 import {
   createExerciseInputSchema,
-  exerciseLastPerformanceSchema,
   exerciseQueryParamsSchema,
   updateExerciseInputSchema,
 } from '@pulse/shared';
@@ -135,10 +134,8 @@ export const exerciseRoutes: FastifyPluginAsync = async (app) => {
       );
     }
 
-    const payload = exerciseLastPerformanceSchema.parse(lastPerformance);
-
     return reply.send({
-      data: payload,
+      data: lastPerformance,
     });
   });
 

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -1,12 +1,13 @@
-import { and, asc, eq, isNull, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, isNull, or, sql } from 'drizzle-orm';
 import type {
   CreateExerciseInput,
   Exercise,
   ExerciseCategory,
+  ExerciseLastPerformance,
   UpdateExerciseInput,
 } from '@pulse/shared';
 
-import { exercises } from '../../db/schema/index.js';
+import { exercises, sessionSets, workoutSessions } from '../../db/schema/index.js';
 
 type ListExercisesInput = {
   userId: string;
@@ -212,4 +213,83 @@ export const deleteOwnedExercise = async (id: string, userId: string): Promise<b
     .run();
 
   return result.changes === 1;
+};
+
+export const findVisibleExerciseById = async ({
+  id,
+  userId,
+}: {
+  id: string;
+  userId: string;
+}): Promise<ExerciseOwnershipRecord | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  return db
+    .select({
+      id: exercises.id,
+      userId: exercises.userId,
+    })
+    .from(exercises)
+    .where(and(eq(exercises.id, id), or(isNull(exercises.userId), eq(exercises.userId, userId))))
+    .limit(1)
+    .get();
+};
+
+export const findExerciseLastPerformance = async ({
+  exerciseId,
+  userId,
+}: {
+  exerciseId: string;
+  userId: string;
+}): Promise<ExerciseLastPerformance | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  const latestSession = db
+    .select({
+      id: workoutSessions.id,
+      date: workoutSessions.date,
+    })
+    .from(workoutSessions)
+    .where(
+      and(
+        eq(workoutSessions.userId, userId),
+        eq(workoutSessions.status, 'completed'),
+        sql`exists (
+          select 1
+          from ${sessionSets}
+          where ${sessionSets.sessionId} = ${workoutSessions.id}
+            and ${sessionSets.exerciseId} = ${exerciseId}
+        )`,
+      ),
+    )
+    .orderBy(
+      desc(workoutSessions.completedAt),
+      desc(workoutSessions.startedAt),
+      desc(workoutSessions.createdAt),
+    )
+    .limit(1)
+    .get();
+
+  if (!latestSession) {
+    return undefined;
+  }
+
+  const sets = db
+    .select({
+      setNumber: sessionSets.setNumber,
+      weight: sessionSets.weight,
+      reps: sessionSets.reps,
+    })
+    .from(sessionSets)
+    .where(
+      and(eq(sessionSets.sessionId, latestSession.id), eq(sessionSets.exerciseId, exerciseId)),
+    )
+    .orderBy(asc(sessionSets.setNumber), asc(sessionSets.createdAt))
+    .all();
+
+  return {
+    sessionId: latestSession.id,
+    date: latestSession.date,
+    sets,
+  };
 };

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -268,28 +268,37 @@ export const findExerciseLastPerformance = async ({
       desc(workoutSessions.createdAt),
     )
     .limit(1)
-    .get();
+    .as('latest_session');
 
-  if (!latestSession) {
-    return undefined;
-  }
-
-  const sets = db
+  const latestSets = db
     .select({
+      sessionId: latestSession.id,
+      date: latestSession.date,
       setNumber: sessionSets.setNumber,
       weight: sessionSets.weight,
       reps: sessionSets.reps,
     })
-    .from(sessionSets)
-    .where(
+    .from(latestSession)
+    .innerJoin(
+      sessionSets,
       and(eq(sessionSets.sessionId, latestSession.id), eq(sessionSets.exerciseId, exerciseId)),
     )
     .orderBy(asc(sessionSets.setNumber), asc(sessionSets.createdAt))
     .all();
 
+  if (latestSets.length === 0) {
+    return undefined;
+  }
+
+  const [{ sessionId, date }] = latestSets;
+
   return {
-    sessionId: latestSession.id,
-    date: latestSession.date,
-    sets,
+    sessionId,
+    date,
+    sets: latestSets.map((set) => ({
+      setNumber: set.setNumber,
+      weight: set.weight,
+      reps: set.reps,
+    })),
   };
 };

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -243,7 +243,7 @@ describe('workout session routes', () => {
     });
   });
 
-  it('requires auth for workout session CRUD routes', async () => {
+  it('requires auth for workout session and session-set routes', async () => {
     const responses = await Promise.all([
       context.app.inject({
         method: 'POST',
@@ -273,6 +273,32 @@ describe('workout session routes', () => {
         method: 'DELETE',
         url: '/api/v1/workout-sessions/session-1',
       }),
+      context.app.inject({
+        method: 'POST',
+        url: '/api/v1/workout-sessions/session-1/sets',
+        payload: {
+          exerciseId: 'global-bench-press',
+          setNumber: 1,
+        },
+      }),
+      context.app.inject({
+        method: 'PATCH',
+        url: '/api/v1/workout-sessions/session-1/sets/set-1',
+        payload: {
+          reps: 10,
+        },
+      }),
+      context.app.inject({
+        method: 'GET',
+        url: '/api/v1/workout-sessions/session-1/sets',
+      }),
+      context.app.inject({
+        method: 'PUT',
+        url: '/api/v1/workout-sessions/session-1/sets',
+        payload: {
+          sets: [],
+        },
+      }),
     ]);
 
     for (const response of responses) {
@@ -284,6 +310,350 @@ describe('workout session routes', () => {
         },
       });
     }
+  });
+
+  it('creates, updates, lists, and batch-upserts sets for an active owned session', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    seedWorkoutSession({
+      id: 'session-1',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      status: 'in-progress',
+      startedAt: 1000,
+    });
+    seedSessionSet({
+      id: 'lat-set-2',
+      sessionId: 'session-1',
+      exerciseId: 'user-1-lat-pulldown',
+      setNumber: 2,
+      weight: 130,
+      reps: 11,
+      section: 'main',
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions/session-1/sets',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        exerciseId: ' global-bench-press ',
+        setNumber: 1,
+        weight: 185,
+        reps: 8,
+        section: 'main',
+      },
+    });
+
+    expect(createResponse.statusCode).toBe(201);
+    const createPayload = createResponse.json() as {
+      data: {
+        id: string;
+        exerciseId: string;
+        setNumber: number;
+        weight: number | null;
+        reps: number | null;
+        completed: boolean;
+        skipped: boolean;
+        section: 'warmup' | 'main' | 'cooldown' | null;
+        notes: string | null;
+      };
+    };
+
+    expect(createPayload.data).toMatchObject({
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      weight: 185,
+      reps: 8,
+      completed: false,
+      skipped: false,
+      section: 'main',
+      notes: null,
+    });
+
+    const patchResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/workout-sessions/session-1/sets/${createPayload.data.id}`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        reps: 9,
+        completed: true,
+        notes: ' Last hard rep ',
+      },
+    });
+
+    expect(patchResponse.statusCode).toBe(200);
+    expect(patchResponse.json()).toEqual({
+      data: expect.objectContaining({
+        id: createPayload.data.id,
+        exerciseId: 'global-bench-press',
+        setNumber: 1,
+        weight: 185,
+        reps: 9,
+        completed: true,
+        skipped: false,
+        section: 'main',
+        notes: 'Last hard rep',
+      }),
+    });
+
+    const batchResponse = await context.app.inject({
+      method: 'PUT',
+      url: '/api/v1/workout-sessions/session-1/sets',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        sets: [
+          {
+            id: createPayload.data.id,
+            exerciseId: 'global-bench-press',
+            setNumber: 1,
+            weight: 190,
+            reps: 9,
+            section: 'main',
+          },
+          {
+            exerciseId: 'user-1-lat-pulldown',
+            setNumber: 1,
+            weight: 145,
+            reps: 10,
+            section: 'main',
+          },
+        ],
+      },
+    });
+
+    expect(batchResponse.statusCode).toBe(200);
+    expect(batchResponse.json()).toEqual({
+      data: [
+        {
+          exerciseId: 'global-bench-press',
+          sets: [
+            expect.objectContaining({
+              id: createPayload.data.id,
+              setNumber: 1,
+              weight: 190,
+              reps: 9,
+              completed: true,
+              notes: 'Last hard rep',
+            }),
+          ],
+        },
+        {
+          exerciseId: 'user-1-lat-pulldown',
+          sets: [
+            expect.objectContaining({
+              setNumber: 1,
+              weight: 145,
+              reps: 10,
+            }),
+            expect.objectContaining({
+              id: 'lat-set-2',
+              setNumber: 2,
+              weight: 130,
+              reps: 11,
+            }),
+          ],
+        },
+      ],
+    });
+
+    const groupedResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/workout-sessions/session-1/sets',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(groupedResponse.statusCode).toBe(200);
+    expect(groupedResponse.json()).toEqual(batchResponse.json());
+  });
+
+  it('enforces ownership, active-session writes, and set-level validation', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    seedWorkoutSession({
+      id: 'session-active',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      status: 'in-progress',
+      startedAt: 1000,
+    });
+    seedWorkoutSession({
+      id: 'session-completed',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Upper Push',
+      date: '2026-03-11',
+      status: 'completed',
+      startedAt: 1000,
+      completedAt: 1100,
+    });
+    seedWorkoutSession({
+      id: 'other-user-session',
+      userId: 'user-2',
+      templateId: 'template-3',
+      name: 'Private Other User Session',
+      date: '2026-03-12',
+      status: 'in-progress',
+      startedAt: 1000,
+    });
+
+    const [otherUserGetResponse, inactivePostResponse, invalidPatchBodyResponse] =
+      await Promise.all([
+        context.app.inject({
+          method: 'GET',
+          url: '/api/v1/workout-sessions/other-user-session/sets',
+          headers: createAuthorizationHeader(authToken),
+        }),
+        context.app.inject({
+          method: 'POST',
+          url: '/api/v1/workout-sessions/session-completed/sets',
+          headers: createAuthorizationHeader(authToken),
+          payload: {
+            exerciseId: 'global-bench-press',
+            setNumber: 1,
+          },
+        }),
+        context.app.inject({
+          method: 'PATCH',
+          url: '/api/v1/workout-sessions/session-active/sets/set-missing',
+          headers: createAuthorizationHeader(authToken),
+          payload: {},
+        }),
+      ]);
+
+    expect(otherUserGetResponse.statusCode).toBe(404);
+    expect(otherUserGetResponse.json()).toEqual({
+      error: {
+        code: 'WORKOUT_SESSION_NOT_FOUND',
+        message: 'Workout session not found',
+      },
+    });
+
+    expect(inactivePostResponse.statusCode).toBe(409);
+    expect(inactivePostResponse.json()).toEqual({
+      error: {
+        code: 'WORKOUT_SESSION_NOT_ACTIVE',
+        message: 'Workout session is not active',
+      },
+    });
+
+    expect(invalidPatchBodyResponse.statusCode).toBe(400);
+    expect(invalidPatchBodyResponse.json()).toEqual({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Invalid session set payload',
+      },
+    });
+
+    const inaccessibleExerciseResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions/session-active/sets',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        exerciseId: 'user-2-private-row',
+        setNumber: 1,
+      },
+    });
+
+    expect(inaccessibleExerciseResponse.statusCode).toBe(400);
+    expect(inaccessibleExerciseResponse.json()).toEqual({
+      error: {
+        code: 'INVALID_SESSION_EXERCISE',
+        message: 'Session references one or more unavailable exercises',
+      },
+    });
+
+    const missingSetResponse = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-sessions/session-active/sets/set-missing',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        reps: 10,
+      },
+    });
+
+    expect(missingSetResponse.statusCode).toBe(404);
+    expect(missingSetResponse.json()).toEqual({
+      error: {
+        code: 'SESSION_SET_NOT_FOUND',
+        message: 'Session set not found',
+      },
+    });
+  });
+
+  it('batch upsert is atomic when one set id is invalid', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    seedWorkoutSession({
+      id: 'session-1',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      status: 'in-progress',
+      startedAt: 1000,
+    });
+    seedSessionSet({
+      id: 'set-1',
+      sessionId: 'session-1',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      weight: 185,
+      reps: 8,
+      section: 'main',
+    });
+
+    const response = await context.app.inject({
+      method: 'PUT',
+      url: '/api/v1/workout-sessions/session-1/sets',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        sets: [
+          {
+            id: 'set-1',
+            exerciseId: 'global-bench-press',
+            setNumber: 1,
+            weight: 205,
+            reps: 6,
+            section: 'main',
+          },
+          {
+            id: 'missing-set',
+            exerciseId: 'global-bench-press',
+            setNumber: 2,
+            weight: 195,
+            reps: 7,
+            section: 'main',
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'SESSION_SET_NOT_FOUND',
+        message: 'Session set not found',
+      },
+    });
+
+    const persistedSet = context.db
+      .select({
+        weight: sessionSets.weight,
+        reps: sessionSets.reps,
+      })
+      .from(sessionSets)
+      .where(eq(sessionSets.id, 'set-1'))
+      .get();
+
+    expect(persistedSet).toEqual({
+      weight: 185,
+      reps: 8,
+    });
   });
 
   it('creates, lists, and fetches workout sessions for the authenticated user', async () => {

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -13,6 +13,7 @@ import {
   scheduledWorkouts,
   serializeWorkoutSessionFeedback,
   sessionSets,
+  templateExercises,
   users,
   workoutSessions,
   workoutTemplates,
@@ -299,6 +300,10 @@ describe('workout session routes', () => {
           sets: [],
         },
       }),
+      context.app.inject({
+        method: 'POST',
+        url: '/api/v1/workout-sessions/session-1/save-as-template',
+      }),
     ]);
 
     for (const response of responses) {
@@ -310,6 +315,186 @@ describe('workout session routes', () => {
         },
       });
     }
+  });
+
+  it('saves a completed session as a template and allows duplicate saves', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    seedWorkoutSession({
+      id: 'session-completed',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Completed Upper Push',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: 1_700_000_000_000,
+      completedAt: 1_700_000_003_000,
+      duration: 50,
+    });
+    seedWorkoutSession({
+      id: 'session-in-progress',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'In Progress Upper Push',
+      date: '2026-03-13',
+      status: 'in-progress',
+      startedAt: 1_700_000_100_000,
+    });
+    seedWorkoutSession({
+      id: 'other-user-session',
+      userId: 'user-2',
+      templateId: 'template-3',
+      name: 'Private Session',
+      date: '2026-03-13',
+      status: 'completed',
+      startedAt: 1_700_000_100_000,
+      completedAt: 1_700_000_103_000,
+    });
+
+    seedSessionSet({
+      id: 'set-warmup-1',
+      sessionId: 'session-completed',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      section: 'warmup',
+      reps: 10,
+    });
+    seedSessionSet({
+      id: 'set-main-1',
+      sessionId: 'session-completed',
+      exerciseId: 'user-1-lat-pulldown',
+      setNumber: 1,
+      section: 'main',
+      reps: 10,
+      weight: 140,
+    });
+    seedSessionSet({
+      id: 'set-main-2',
+      sessionId: 'session-completed',
+      exerciseId: 'user-1-lat-pulldown',
+      setNumber: 2,
+      section: 'main',
+      reps: 9,
+      weight: 145,
+    });
+    seedSessionSet({
+      id: 'set-cooldown-1',
+      sessionId: 'session-completed',
+      exerciseId: 'global-bench-press',
+      setNumber: 2,
+      section: 'cooldown',
+      reps: 8,
+    });
+
+    const [firstSaveResponse, secondSaveResponse] = await Promise.all([
+      context.app.inject({
+        method: 'POST',
+        url: '/api/v1/workout-sessions/session-completed/save-as-template',
+        headers: createAuthorizationHeader(authToken),
+      }),
+      context.app.inject({
+        method: 'POST',
+        url: '/api/v1/workout-sessions/session-completed/save-as-template',
+        headers: createAuthorizationHeader(authToken),
+      }),
+    ]);
+
+    expect(firstSaveResponse.statusCode).toBe(201);
+    expect(secondSaveResponse.statusCode).toBe(201);
+
+    const firstPayload = firstSaveResponse.json() as { data: { id: string; name: string } };
+    const secondPayload = secondSaveResponse.json() as { data: { id: string; name: string } };
+
+    expect(firstPayload.data.id).not.toBe(secondPayload.data.id);
+    expect(firstPayload.data.name).toBe('Completed Upper Push');
+    expect(secondPayload.data.name).toBe('Completed Upper Push');
+
+    const persistedTemplates = context.db
+      .select({
+        id: workoutTemplates.id,
+        name: workoutTemplates.name,
+      })
+      .from(workoutTemplates)
+      .where(eq(workoutTemplates.name, 'Completed Upper Push'))
+      .all();
+
+    expect(persistedTemplates).toHaveLength(2);
+
+    const firstTemplateExercises = context.db
+      .select({
+        exerciseId: templateExercises.exerciseId,
+        orderIndex: templateExercises.orderIndex,
+        section: templateExercises.section,
+        sets: templateExercises.sets,
+      })
+      .from(templateExercises)
+      .where(eq(templateExercises.templateId, firstPayload.data.id))
+      .all();
+
+    const sortedTemplateExercises = [...firstTemplateExercises].sort((left, right) => {
+      const sectionOrder = {
+        warmup: 0,
+        main: 1,
+        cooldown: 2,
+      };
+
+      const leftSection = sectionOrder[left.section];
+      const rightSection = sectionOrder[right.section];
+      if (leftSection !== rightSection) {
+        return leftSection - rightSection;
+      }
+
+      return left.orderIndex - right.orderIndex;
+    });
+
+    expect(sortedTemplateExercises).toEqual([
+      {
+        exerciseId: 'global-bench-press',
+        orderIndex: 0,
+        section: 'warmup',
+        sets: 1,
+      },
+      {
+        exerciseId: 'user-1-lat-pulldown',
+        orderIndex: 0,
+        section: 'main',
+        sets: 2,
+      },
+      {
+        exerciseId: 'global-bench-press',
+        orderIndex: 0,
+        section: 'cooldown',
+        sets: 2,
+      },
+    ]);
+
+    const inProgressResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions/session-in-progress/save-as-template',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(inProgressResponse.statusCode).toBe(409);
+    expect(inProgressResponse.json()).toEqual({
+      error: {
+        code: 'WORKOUT_SESSION_NOT_COMPLETED',
+        message: 'Workout session must be completed before saving as template',
+      },
+    });
+
+    const otherUserResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions/other-user-session/save-as-template',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(otherUserResponse.statusCode).toBe(404);
+    expect(otherUserResponse.json()).toEqual({
+      error: {
+        code: 'WORKOUT_SESSION_NOT_FOUND',
+        message: 'Workout session not found',
+      },
+    });
   });
 
   it('creates, updates, lists, and batch-upserts sets for an active owned session', async () => {

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -497,6 +497,91 @@ describe('workout session routes', () => {
     });
   });
 
+  it('applies save-as-template metadata overrides when provided', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    seedWorkoutSession({
+      id: 'session-completed-overrides',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Completed Upper Push',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: 1_700_000_000_000,
+      completedAt: 1_700_000_003_000,
+      duration: 50,
+    });
+
+    seedSessionSet({
+      id: 'set-main-1',
+      sessionId: 'session-completed-overrides',
+      exerciseId: 'user-1-lat-pulldown',
+      setNumber: 1,
+      section: 'main',
+      reps: 10,
+      weight: 140,
+    });
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions/session-completed-overrides/save-as-template',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        name: ' Upper Push Snapshot ',
+        description: '  Heavy pressing focus ',
+        tags: [' strength ', ' push '],
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+
+    const payload = response.json() as {
+      data: { id: string; name: string; description: string | null; tags: string[] };
+    };
+    expect(payload.data.name).toBe('Upper Push Snapshot');
+    expect(payload.data.description).toBe('Heavy pressing focus');
+    expect(payload.data.tags).toEqual(['strength', 'push']);
+
+    const persistedTemplate = context.db
+      .select({
+        id: workoutTemplates.id,
+        name: workoutTemplates.name,
+        description: workoutTemplates.description,
+        tags: workoutTemplates.tags,
+      })
+      .from(workoutTemplates)
+      .where(eq(workoutTemplates.id, payload.data.id))
+      .get();
+
+    expect(persistedTemplate).toEqual({
+      id: payload.data.id,
+      name: 'Upper Push Snapshot',
+      description: 'Heavy pressing focus',
+      tags: ['strength', 'push'],
+    });
+  });
+
+  it('returns a validation error for invalid save-as-template payload', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions/session-1/save-as-template',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        name: '   ',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Invalid save as template payload',
+      },
+    });
+  });
+
   it('creates, updates, lists, and batch-upserts sets for an active owned session', async () => {
     const authToken = context.app.jwt.sign({ userId: 'user-1' });
 

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import {
   batchUpsertSetsSchema,
   createSetSchema,
+  saveWorkoutSessionAsTemplateInputSchema,
   createWorkoutSessionInputSchema,
   type CreateWorkoutSessionInput,
   updateSetSchema,
@@ -353,6 +354,11 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
   });
 
   app.post<{ Params: { id: string } }>('/:id/save-as-template', async (request, reply) => {
+    const parsedBody = saveWorkoutSessionAsTemplateInputSchema.safeParse(request.body);
+    if (!parsedBody.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid save as template payload');
+    }
+
     const session = await findWorkoutSessionById(request.params.id, request.userId);
     if (!session) {
       return sendError(
@@ -373,6 +379,7 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
     }
 
     const template = await saveCompletedSessionAsTemplate({
+      input: parsedBody.data,
       session,
       userId: request.userId,
     });

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -26,6 +26,7 @@ import {
   listSessionSetGroups,
   SessionSetNotFoundError,
   listWorkoutSessions,
+  saveCompletedSessionAsTemplate,
   updateSessionSet,
   updateWorkoutSession,
 } from './store.js';
@@ -48,6 +49,11 @@ const INVALID_SESSION_EXERCISE_RESPONSE = {
 const WORKOUT_SESSION_NOT_ACTIVE_RESPONSE = {
   code: 'WORKOUT_SESSION_NOT_ACTIVE',
   message: 'Workout session is not active',
+} as const;
+
+const WORKOUT_SESSION_NOT_COMPLETED_RESPONSE = {
+  code: 'WORKOUT_SESSION_NOT_COMPLETED',
+  message: 'Workout session must be completed before saving as template',
 } as const;
 
 const SESSION_SET_NOT_FOUND_RESPONSE = {
@@ -344,6 +350,36 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
 
       throw error;
     }
+  });
+
+  app.post<{ Params: { id: string } }>('/:id/save-as-template', async (request, reply) => {
+    const session = await findWorkoutSessionById(request.params.id, request.userId);
+    if (!session) {
+      return sendError(
+        reply,
+        404,
+        WORKOUT_SESSION_NOT_FOUND_RESPONSE.code,
+        WORKOUT_SESSION_NOT_FOUND_RESPONSE.message,
+      );
+    }
+
+    if (session.status !== 'completed') {
+      return sendError(
+        reply,
+        409,
+        WORKOUT_SESSION_NOT_COMPLETED_RESPONSE.code,
+        WORKOUT_SESSION_NOT_COMPLETED_RESPONSE.message,
+      );
+    }
+
+    const template = await saveCompletedSessionAsTemplate({
+      session,
+      userId: request.userId,
+    });
+
+    return reply.code(201).send({
+      data: template,
+    });
   });
 
   app.get<{ Params: { id: string } }>('/:id', async (request, reply) => {

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -1,12 +1,15 @@
 import { randomUUID } from 'node:crypto';
 
 import {
+  batchUpsertSetsSchema,
+  createSetSchema,
   createWorkoutSessionInputSchema,
   type CreateWorkoutSessionInput,
+  updateSetSchema,
   updateWorkoutSessionInputSchema,
   workoutSessionQueryParamsSchema,
 } from '@pulse/shared';
-import type { FastifyPluginAsync } from 'fastify';
+import type { FastifyPluginAsync, FastifyReply } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
 import { requireUserAuth } from '../../middleware/auth.js';
@@ -14,10 +17,16 @@ import { templateBelongsToUser } from '../workout-templates/template-access.js';
 
 import {
   allSessionExercisesAccessible,
+  batchUpsertSessionSets,
+  createSessionSet,
   createWorkoutSession,
   deleteWorkoutSession,
+  findWorkoutSessionAccess,
   findWorkoutSessionById,
+  listSessionSetGroups,
+  SessionSetNotFoundError,
   listWorkoutSessions,
+  updateSessionSet,
   updateWorkoutSession,
 } from './store.js';
 
@@ -34,6 +43,16 @@ const WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE = {
 const INVALID_SESSION_EXERCISE_RESPONSE = {
   code: 'INVALID_SESSION_EXERCISE',
   message: 'Session references one or more unavailable exercises',
+} as const;
+
+const WORKOUT_SESSION_NOT_ACTIVE_RESPONSE = {
+  code: 'WORKOUT_SESSION_NOT_ACTIVE',
+  message: 'Workout session is not active',
+} as const;
+
+const SESSION_SET_NOT_FOUND_RESPONSE = {
+  code: 'SESSION_SET_NOT_FOUND',
+  message: 'Session set not found',
 } as const;
 
 const toCreateWorkoutSessionInput = (
@@ -68,6 +87,56 @@ const toCreateWorkoutSessionInput = (
 
 const getReferencedExerciseIds = (sets: CreateWorkoutSessionInput['sets']) =>
   sets.map((set) => set.exerciseId);
+
+const ensureOwnedSession = async ({
+  sessionId,
+  userId,
+  reply,
+}: {
+  sessionId: string;
+  userId: string;
+  reply: FastifyReply;
+}) => {
+  const session = await findWorkoutSessionAccess(sessionId, userId);
+  if (!session) {
+    sendError(
+      reply,
+      404,
+      WORKOUT_SESSION_NOT_FOUND_RESPONSE.code,
+      WORKOUT_SESSION_NOT_FOUND_RESPONSE.message,
+    );
+    return undefined;
+  }
+
+  return session;
+};
+
+const ensureOwnedActiveSession = async ({
+  sessionId,
+  userId,
+  reply,
+}: {
+  sessionId: string;
+  userId: string;
+  reply: FastifyReply;
+}) => {
+  const session = await ensureOwnedSession({ sessionId, userId, reply });
+  if (!session) {
+    return undefined;
+  }
+
+  if (session.status !== 'in-progress') {
+    sendError(
+      reply,
+      409,
+      WORKOUT_SESSION_NOT_ACTIVE_RESPONSE.code,
+      WORKOUT_SESSION_NOT_ACTIVE_RESPONSE.message,
+    );
+    return undefined;
+  }
+
+  return session;
+};
 
 export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
   app.addHook('onRequest', requireUserAuth);
@@ -131,6 +200,150 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
     return reply.send({
       data: sessions,
     });
+  });
+
+  app.post<{ Params: { sessionId: string } }>('/:sessionId/sets', async (request, reply) => {
+    const parsedBody = createSetSchema.safeParse(request.body);
+    if (!parsedBody.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid session set payload');
+    }
+
+    const session = await ensureOwnedActiveSession({
+      sessionId: request.params.sessionId,
+      userId: request.userId,
+      reply,
+    });
+    if (!session) {
+      return reply;
+    }
+
+    const exerciseAccessible = await allSessionExercisesAccessible({
+      userId: request.userId,
+      exerciseIds: [parsedBody.data.exerciseId],
+    });
+    if (!exerciseAccessible) {
+      return sendError(
+        reply,
+        400,
+        INVALID_SESSION_EXERCISE_RESPONSE.code,
+        INVALID_SESSION_EXERCISE_RESPONSE.message,
+      );
+    }
+
+    const set = await createSessionSet({
+      id: randomUUID(),
+      sessionId: session.id,
+      input: parsedBody.data,
+    });
+
+    return reply.code(201).send({
+      data: set,
+    });
+  });
+
+  app.patch<{ Params: { sessionId: string; setId: string } }>(
+    '/:sessionId/sets/:setId',
+    async (request, reply) => {
+      const parsedBody = updateSetSchema.safeParse(request.body);
+      if (!parsedBody.success) {
+        return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid session set payload');
+      }
+
+      const session = await ensureOwnedActiveSession({
+        sessionId: request.params.sessionId,
+        userId: request.userId,
+        reply,
+      });
+      if (!session) {
+        return reply;
+      }
+
+      const set = await updateSessionSet({
+        sessionId: session.id,
+        setId: request.params.setId,
+        input: parsedBody.data,
+      });
+      if (!set) {
+        return sendError(
+          reply,
+          404,
+          SESSION_SET_NOT_FOUND_RESPONSE.code,
+          SESSION_SET_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      return reply.send({
+        data: set,
+      });
+    },
+  );
+
+  app.get<{ Params: { sessionId: string } }>('/:sessionId/sets', async (request, reply) => {
+    const session = await ensureOwnedSession({
+      sessionId: request.params.sessionId,
+      userId: request.userId,
+      reply,
+    });
+    if (!session) {
+      return reply;
+    }
+
+    const groupedSets = await listSessionSetGroups(session.id);
+
+    return reply.send({
+      data: groupedSets,
+    });
+  });
+
+  app.put<{ Params: { sessionId: string } }>('/:sessionId/sets', async (request, reply) => {
+    const parsedBody = batchUpsertSetsSchema.safeParse(request.body);
+    if (!parsedBody.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid session set payload');
+    }
+
+    const session = await ensureOwnedActiveSession({
+      sessionId: request.params.sessionId,
+      userId: request.userId,
+      reply,
+    });
+    if (!session) {
+      return reply;
+    }
+
+    const exercisesAccessible = await allSessionExercisesAccessible({
+      userId: request.userId,
+      exerciseIds: parsedBody.data.sets.map((set) => set.exerciseId),
+    });
+    if (!exercisesAccessible) {
+      return sendError(
+        reply,
+        400,
+        INVALID_SESSION_EXERCISE_RESPONSE.code,
+        INVALID_SESSION_EXERCISE_RESPONSE.message,
+      );
+    }
+
+    try {
+      const groupedSets = await batchUpsertSessionSets({
+        sessionId: session.id,
+        input: parsedBody.data,
+      });
+
+      return reply.send({
+        data: groupedSets,
+      });
+    } catch (error) {
+      if (error instanceof SessionSetNotFoundError) {
+        return sendError(
+          reply,
+          404,
+          SESSION_SET_NOT_FOUND_RESPONSE.code,
+          SESSION_SET_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      throw error;
+    }
   });
 
   app.get<{ Params: { id: string } }>('/:id', async (request, reply) => {

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -2,8 +2,11 @@ import { randomUUID } from 'node:crypto';
 
 import { and, desc, eq, gte, inArray, isNull, lte, or } from 'drizzle-orm';
 import type {
+  BatchUpsertSetsInput,
+  CreateSetInput,
   CreateWorkoutSessionInput,
   SessionSet,
+  UpdateSetInput,
   WorkoutSession,
   WorkoutSessionListItem,
   WorkoutTemplateSectionType,
@@ -36,6 +39,11 @@ type WorkoutSessionRecord = {
   updatedAt: number;
 };
 
+type WorkoutSessionAccessRecord = {
+  id: string;
+  status: WorkoutSession['status'];
+};
+
 type SessionSetRecord = {
   id: string;
   sessionId: string;
@@ -48,6 +56,11 @@ type SessionSetRecord = {
   section: WorkoutTemplateSectionType | null;
   notes: string | null;
   createdAt: number;
+};
+
+export type SessionSetGroup = {
+  exerciseId: string;
+  sets: SessionSet[];
 };
 
 const workoutSessionSelection = {
@@ -64,6 +77,11 @@ const workoutSessionSelection = {
   notes: workoutSessions.notes,
   createdAt: workoutSessions.createdAt,
   updatedAt: workoutSessions.updatedAt,
+};
+
+const workoutSessionAccessSelection = {
+  id: workoutSessions.id,
+  status: workoutSessions.status,
 };
 
 const workoutSessionListSelection = {
@@ -116,6 +134,40 @@ const sortSessionSets = (left: SessionSetRecord, right: SessionSetRecord) => {
   return left.createdAt - right.createdAt;
 };
 
+const buildSessionSet = (set: SessionSetRecord): SessionSet => ({
+  id: set.id,
+  exerciseId: set.exerciseId,
+  setNumber: set.setNumber,
+  weight: set.weight,
+  reps: set.reps,
+  completed: set.completed,
+  skipped: set.skipped,
+  section: set.section,
+  notes: set.notes,
+  createdAt: set.createdAt,
+});
+
+const buildSessionSetGroups = (sets: SessionSetRecord[]): SessionSetGroup[] => {
+  const groups = new Map<string, SessionSet[]>();
+
+  for (const set of sets.sort(sortSessionSets)) {
+    const existingGroup = groups.get(set.exerciseId);
+    const parsedSet = buildSessionSet(set);
+
+    if (existingGroup) {
+      existingGroup.push(parsedSet);
+      continue;
+    }
+
+    groups.set(set.exerciseId, [parsedSet]);
+  }
+
+  return Array.from(groups.entries()).map(([exerciseId, groupedSets]) => ({
+    exerciseId,
+    sets: groupedSets,
+  }));
+};
+
 const buildWorkoutSession = (
   session: WorkoutSessionRecord,
   sets: SessionSetRecord[],
@@ -131,18 +183,7 @@ const buildWorkoutSession = (
   duration: session.duration,
   feedback: parseWorkoutSessionFeedback(session.feedback),
   notes: session.notes,
-  sets: sets.sort(sortSessionSets).map<SessionSet>((set) => ({
-    id: set.id,
-    exerciseId: set.exerciseId,
-    setNumber: set.setNumber,
-    weight: set.weight,
-    reps: set.reps,
-    completed: set.completed,
-    skipped: set.skipped,
-    section: set.section,
-    notes: set.notes,
-    createdAt: set.createdAt,
-  })),
+  sets: sets.sort(sortSessionSets).map<SessionSet>(buildSessionSet),
   createdAt: session.createdAt,
   updatedAt: session.updatedAt,
 });
@@ -188,6 +229,167 @@ export const allSessionExercisesAccessible = async ({
     .map((exercise) => exercise.id);
 
   return visibleExerciseIds.length === uniqueIds.length;
+};
+
+export class SessionSetNotFoundError extends Error {
+  readonly setId: string;
+
+  constructor(setId: string) {
+    super(`Session set ${setId} not found`);
+    this.name = 'SessionSetNotFoundError';
+    this.setId = setId;
+  }
+}
+
+export const findWorkoutSessionAccess = async (
+  id: string,
+  userId: string,
+): Promise<WorkoutSessionAccessRecord | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  return db
+    .select(workoutSessionAccessSelection)
+    .from(workoutSessions)
+    .where(and(eq(workoutSessions.id, id), eq(workoutSessions.userId, userId)))
+    .limit(1)
+    .get();
+};
+
+export const createSessionSet = async ({
+  id,
+  sessionId,
+  input,
+}: {
+  id: string;
+  sessionId: string;
+  input: CreateSetInput;
+}): Promise<SessionSet> => {
+  const { db } = await import('../../db/index.js');
+
+  const result = db
+    .insert(sessionSets)
+    .values({
+      id,
+      sessionId,
+      exerciseId: input.exerciseId,
+      setNumber: input.setNumber,
+      weight: input.weight,
+      reps: input.reps,
+      section: input.section,
+    })
+    .run();
+
+  if (result.changes !== 1) {
+    throw new Error('Failed to persist session set');
+  }
+
+  const createdSet = db
+    .select(sessionSetSelection)
+    .from(sessionSets)
+    .where(and(eq(sessionSets.id, id), eq(sessionSets.sessionId, sessionId)))
+    .limit(1)
+    .get();
+
+  if (!createdSet) {
+    throw new Error('Created session set could not be loaded');
+  }
+
+  return buildSessionSet(createdSet);
+};
+
+export const updateSessionSet = async ({
+  sessionId,
+  setId,
+  input,
+}: {
+  sessionId: string;
+  setId: string;
+  input: UpdateSetInput;
+}): Promise<SessionSet | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  const result = db
+    .update(sessionSets)
+    .set(input)
+    .where(and(eq(sessionSets.id, setId), eq(sessionSets.sessionId, sessionId)))
+    .run();
+
+  if (result.changes !== 1) {
+    return undefined;
+  }
+
+  const updatedSet = db
+    .select(sessionSetSelection)
+    .from(sessionSets)
+    .where(and(eq(sessionSets.id, setId), eq(sessionSets.sessionId, sessionId)))
+    .limit(1)
+    .get();
+
+  if (!updatedSet) {
+    throw new Error('Updated session set could not be loaded');
+  }
+
+  return buildSessionSet(updatedSet);
+};
+
+export const listSessionSetGroups = async (sessionId: string): Promise<SessionSetGroup[]> => {
+  const { db } = await import('../../db/index.js');
+
+  const sets = db
+    .select(sessionSetSelection)
+    .from(sessionSets)
+    .where(eq(sessionSets.sessionId, sessionId))
+    .all();
+
+  return buildSessionSetGroups(sets);
+};
+
+export const batchUpsertSessionSets = async ({
+  sessionId,
+  input,
+}: {
+  sessionId: string;
+  input: BatchUpsertSetsInput;
+}): Promise<SessionSetGroup[]> => {
+  const { db } = await import('../../db/index.js');
+
+  db.transaction((tx) => {
+    for (const set of input.sets) {
+      if (set.id) {
+        const updateResult = tx
+          .update(sessionSets)
+          .set({
+            exerciseId: set.exerciseId,
+            setNumber: set.setNumber,
+            weight: set.weight,
+            reps: set.reps,
+            section: set.section,
+          })
+          .where(and(eq(sessionSets.id, set.id), eq(sessionSets.sessionId, sessionId)))
+          .run();
+
+        if (updateResult.changes !== 1) {
+          throw new SessionSetNotFoundError(set.id);
+        }
+
+        continue;
+      }
+
+      tx.insert(sessionSets)
+        .values({
+          id: randomUUID(),
+          sessionId,
+          exerciseId: set.exerciseId,
+          setNumber: set.setNumber,
+          weight: set.weight,
+          reps: set.reps,
+          section: set.section,
+        })
+        .run();
+    }
+  });
+
+  return listSessionSetGroups(sessionId);
 };
 
 export const createWorkoutSession = async ({

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -5,6 +5,7 @@ import type {
   BatchUpsertSetsInput,
   CreateSetInput,
   CreateWorkoutSessionInput,
+  SaveWorkoutSessionAsTemplateInput,
   SessionSet,
   UpdateSetInput,
   WorkoutSession,
@@ -568,9 +569,11 @@ const mapSessionSectionToTemplateSection = (
 ): WorkoutTemplateSectionType => section ?? 'main';
 
 export const saveCompletedSessionAsTemplate = async ({
+  input,
   userId,
   session,
 }: {
+  input: SaveWorkoutSessionAsTemplateInput;
   userId: string;
   session: WorkoutSession;
 }) => {
@@ -624,21 +627,30 @@ export const saveCompletedSessionAsTemplate = async ({
     cues: [],
   }));
 
-  db.transaction((tx) => {
-    tx.insert(workoutTemplates)
+  const result = db.transaction((tx) => {
+    const insertTemplateResult = tx
+      .insert(workoutTemplates)
       .values({
         id: templateId,
         userId,
-        name: session.name,
-        description: null,
-        tags: [],
+        name: input.name ?? session.name,
+        description: input.description ?? null,
+        tags: input.tags ?? [],
       })
       .run();
+    if (insertTemplateResult.changes !== 1) {
+      return false;
+    }
 
     if (templateExerciseRows.length > 0) {
       tx.insert(templateExercises).values(templateExerciseRows).run();
     }
+
+    return true;
   });
+  if (!result) {
+    throw new Error('Created workout template could not be saved');
+  }
 
   const createdTemplate = await findWorkoutTemplateById(templateId, userId);
   if (!createdTemplate) {

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -356,9 +356,11 @@ export const batchUpsertSessionSets = async ({
 }): Promise<SessionSetGroup[]> => {
   const { db } = await import('../../db/index.js');
 
-  db.transaction((tx) => {
+  const groupedSets = db.transaction((tx) => {
     for (const set of input.sets) {
       if (set.id) {
+        // Batch upsert intentionally syncs structural/performance fields only.
+        // `completed`, `skipped`, and `notes` are controlled via PATCH /sets/:setId.
         const updateResult = tx
           .update(sessionSets)
           .set({
@@ -390,9 +392,17 @@ export const batchUpsertSessionSets = async ({
         })
         .run();
     }
+
+    const sets = tx
+      .select(sessionSetSelection)
+      .from(sessionSets)
+      .where(eq(sessionSets.sessionId, sessionId))
+      .all();
+
+    return buildSessionSetGroups(sets);
   });
 
-  return listSessionSetGroups(sessionId);
+  return groupedSets;
 };
 
 export const createWorkoutSession = async ({

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -17,9 +17,11 @@ import {
   parseWorkoutSessionFeedback,
   sessionSets,
   serializeWorkoutSessionFeedback,
+  templateExercises,
   workoutSessions,
   workoutTemplates,
 } from '../../db/schema/index.js';
+import { findWorkoutTemplateById } from '../workout-templates/store.js';
 
 const SECTION_ORDER: WorkoutTemplateSectionType[] = ['warmup', 'main', 'cooldown'];
 
@@ -559,4 +561,89 @@ export const deleteWorkoutSession = async (id: string, userId: string): Promise<
     .run();
 
   return result.changes === 1;
+};
+
+const mapSessionSectionToTemplateSection = (
+  section: WorkoutTemplateSectionType | null,
+): WorkoutTemplateSectionType => section ?? 'main';
+
+export const saveCompletedSessionAsTemplate = async ({
+  userId,
+  session,
+}: {
+  userId: string;
+  session: WorkoutSession;
+}) => {
+  const { db } = await import('../../db/index.js');
+  const templateId = randomUUID();
+  const sectionOrderIndex = {
+    warmup: 0,
+    main: 0,
+    cooldown: 0,
+  } as Record<WorkoutTemplateSectionType, number>;
+
+  const groupedExercises = new Map<
+    string,
+    {
+      exerciseId: string;
+      section: WorkoutTemplateSectionType;
+      setCount: number;
+    }
+  >();
+
+  for (const set of session.sets) {
+    const section = mapSessionSectionToTemplateSection(set.section);
+    const groupKey = `${section}:${set.exerciseId}`;
+    const existing = groupedExercises.get(groupKey);
+
+    if (!existing) {
+      groupedExercises.set(groupKey, {
+        exerciseId: set.exerciseId,
+        section,
+        setCount: set.setNumber,
+      });
+      continue;
+    }
+
+    existing.setCount = Math.max(existing.setCount, set.setNumber);
+  }
+
+  const templateExerciseRows = Array.from(groupedExercises.values()).map((exercise) => ({
+    id: randomUUID(),
+    templateId,
+    exerciseId: exercise.exerciseId,
+    orderIndex: sectionOrderIndex[exercise.section]++,
+    sets: exercise.setCount,
+    repsMin: null,
+    repsMax: null,
+    tempo: null,
+    restSeconds: null,
+    supersetGroup: null,
+    section: exercise.section,
+    notes: null,
+    cues: [],
+  }));
+
+  db.transaction((tx) => {
+    tx.insert(workoutTemplates)
+      .values({
+        id: templateId,
+        userId,
+        name: session.name,
+        description: null,
+        tags: [],
+      })
+      .run();
+
+    if (templateExerciseRows.length > 0) {
+      tx.insert(templateExercises).values(templateExerciseRows).run();
+    }
+  });
+
+  const createdTemplate = await findWorkoutTemplateById(templateId, userId);
+  if (!createdTemplate) {
+    throw new Error('Created workout template could not be loaded');
+  }
+
+  return createdTemplate;
 };

--- a/apps/web/e2e/habits.spec.ts
+++ b/apps/web/e2e/habits.spec.ts
@@ -62,17 +62,17 @@ test.describe.serial('habits flow', () => {
     await authenticatePage(page);
     await page.goto('/habits');
 
-    const meditateCheckbox = page.getByLabel('Meditate');
+    const meditateCheckbox = page.getByRole('checkbox', { name: 'Meditate' });
 
     await meditateCheckbox.click();
     await expect(meditateCheckbox).toHaveAttribute('data-state', 'checked');
 
     await page.reload();
-    await expect(page.getByLabel('Meditate')).toHaveAttribute('data-state', 'checked');
+    const reloadedMeditateCheckbox = page.getByRole('checkbox', { name: 'Meditate' });
+    await expect(reloadedMeditateCheckbox).toHaveAttribute('data-state', 'checked');
 
     await page.goto('/');
-    await expect(page.getByText('1 / 1 complete')).toBeVisible();
-    await expect(page.getByText('100%')).toBeVisible();
+    await expect(page.getByText(/[1-9]\d* \/ \d+ complete/)).toBeVisible();
     await expect(page.getByLabel(/Meditate \d{4}-\d{2}-\d{2} Completed/)).toBeVisible();
   });
 
@@ -91,7 +91,7 @@ test.describe.serial('habits flow', () => {
 
     await page.goto('/habits');
 
-    const waterInput = page.getByLabel('Water (glasses)');
+    const waterInput = page.getByRole('spinbutton', { name: 'Water (glasses)' });
 
     await waterInput.fill('6');
     await waterInput.blur();

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -1,6 +1,58 @@
-import { expect, test } from '@playwright/test';
+import { expect, request, test, type Page } from '@playwright/test';
 
-test('page loads and shows dashboard', async ({ page }) => {
+const authTokenStorageKey = 'pulse-auth-token';
+const apiBaseURL = process.env.API_BASE_URL ?? 'http://127.0.0.1:3001';
+const testUsername = `smoke-e2e-${Date.now()}`;
+const testPassword = 'super-secret-password';
+
+let authToken = '';
+
+async function seedTestUser() {
+  const apiContext = await request.newContext({ baseURL: apiBaseURL });
+
+  try {
+    const registerResponse = await apiContext.post('/api/v1/auth/register', {
+      data: {
+        password: testPassword,
+        username: testUsername,
+      },
+    });
+    expect(registerResponse.ok()).toBeTruthy();
+
+    const payload = (await registerResponse.json()) as {
+      data: {
+        token: string;
+      };
+    };
+    authToken = payload.data.token;
+  } finally {
+    await apiContext.dispose();
+  }
+}
+
+async function authenticatePage(page: Page) {
+  await page.addInitScript(
+    ([storageKey, token]) => {
+      window.localStorage.setItem(storageKey, token);
+    },
+    [authTokenStorageKey, authToken] as const,
+  );
+}
+
+test.beforeAll(async () => {
+  await seedTestUser();
+});
+
+test('page loads and redirects guests to login', async ({ page }) => {
   await page.goto('/');
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.getByRole('heading', { name: 'Welcome back' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible();
+});
+
+test('authenticated page loads and shows dashboard', async ({ page }) => {
+  await authenticatePage(page);
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/$/);
   await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
 });

--- a/apps/web/e2e/workout-session.spec.ts
+++ b/apps/web/e2e/workout-session.spec.ts
@@ -1,0 +1,349 @@
+import { expect, request, test, type Page } from '@playwright/test';
+
+const authTokenStorageKey = 'pulse-auth-token';
+const apiBaseURL = process.env.API_BASE_URL ?? 'http://127.0.0.1:3001';
+const seedSuffix = Date.now();
+
+const testUser = {
+  username: `ws-e2e-${seedSuffix}`,
+  password: 'super-secret-password',
+};
+
+const seededTemplate = {
+  name: `E2E Workout Session ${seedSuffix}`,
+};
+
+const seededExercises = [
+  {
+    category: 'cardio',
+    equipment: 'rower',
+    muscleGroups: ['conditioning'],
+    name: `E2E Row Erg ${seedSuffix}`,
+  },
+  {
+    category: 'compound',
+    equipment: 'barbell',
+    muscleGroups: ['chest', 'triceps'],
+    name: `E2E Bench Press ${seedSuffix}`,
+  },
+  {
+    category: 'isolation',
+    equipment: 'cable',
+    muscleGroups: ['lats'],
+    name: `E2E Lat Pulldown ${seedSuffix}`,
+  },
+] as const;
+
+let authToken = '';
+let seededTemplateId = '';
+let seededExerciseIds: string[] = [];
+
+async function authenticatePage(page: Page) {
+  await page.addInitScript(
+    ([storageKey, token]) => {
+      window.localStorage.setItem(storageKey, token);
+    },
+    [authTokenStorageKey, authToken] as const,
+  );
+}
+
+function toElapsedSeconds(value: string) {
+  const [minutes, seconds] = value.split(':').map((part) => Number(part));
+  return minutes * 60 + seconds;
+}
+
+async function ensureSectionIsExpanded(page: Page, sectionName: 'Warmup' | 'Main' | 'Cooldown') {
+  const sectionButton = page.getByRole('button', { name: new RegExp(sectionName, 'i') }).first();
+  const sectionButtonCount = await sectionButton.count();
+
+  if (sectionButtonCount === 0) {
+    return;
+  }
+
+  const isExpanded = (await sectionButton.getAttribute('aria-expanded')) === 'true';
+
+  if (!isExpanded) {
+    await sectionButton.click();
+  }
+}
+
+async function ensureAllExercisePanelsExpanded(page: Page) {
+  const exerciseButtons = page.locator('button[aria-controls^="exercise-panel-"]');
+  const exerciseButtonCount = await exerciseButtons.count();
+
+  for (let index = 0; index < exerciseButtonCount; index += 1) {
+    const exerciseButton = exerciseButtons.nth(index);
+    const isExpanded = (await exerciseButton.getAttribute('aria-expanded')) === 'true';
+
+    if (!isExpanded) {
+      await exerciseButton.click();
+    }
+  }
+}
+
+test.describe.serial('workout session flow', () => {
+  test.beforeAll(async () => {
+    const apiContext = await request.newContext({ baseURL: apiBaseURL });
+
+    try {
+      const registerResponse = await apiContext.post('/api/v1/auth/register', {
+        data: testUser,
+      });
+      if (registerResponse.ok()) {
+        const registerPayload = (await registerResponse.json()) as {
+          data: {
+            token: string;
+          };
+        };
+        authToken = registerPayload.data.token;
+      } else if (registerResponse.status() === 409) {
+        const loginResponse = await apiContext.post('/api/v1/auth/login', {
+          data: testUser,
+        });
+        expect(loginResponse.ok()).toBeTruthy();
+
+        const loginPayload = (await loginResponse.json()) as {
+          data: {
+            token: string;
+          };
+        };
+        authToken = loginPayload.data.token;
+      } else {
+        throw new Error(
+          `Unable to create e2e auth token. register status=${registerResponse.status()}`,
+        );
+      }
+
+      const authorizedContext = await request.newContext({
+        baseURL: apiBaseURL,
+        extraHTTPHeaders: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+
+      try {
+        seededExerciseIds = [];
+
+        for (const exercise of seededExercises) {
+          const exerciseResponse = await authorizedContext.post('/api/v1/exercises', {
+            data: exercise,
+          });
+          expect(exerciseResponse.ok()).toBeTruthy();
+
+          const exercisePayload = (await exerciseResponse.json()) as {
+            data: {
+              id: string;
+            };
+          };
+          seededExerciseIds.push(exercisePayload.data.id);
+        }
+
+        const templateResponse = await authorizedContext.post('/api/v1/workout-templates', {
+          data: {
+            description: 'Playwright seeded template for workout-session lifecycle coverage.',
+            name: seededTemplate.name,
+            sections: [
+              {
+                type: 'warmup',
+                exercises: [
+                  {
+                    exerciseId: seededExerciseIds[0],
+                    sets: 3,
+                    repsMin: 8,
+                    repsMax: 10,
+                    restSeconds: 60,
+                    cues: [],
+                  },
+                ],
+              },
+              {
+                type: 'main',
+                exercises: [
+                  {
+                    exerciseId: seededExerciseIds[1],
+                    sets: 3,
+                    repsMin: 6,
+                    repsMax: 10,
+                    restSeconds: 120,
+                    cues: [],
+                  },
+                  {
+                    exerciseId: seededExerciseIds[2],
+                    sets: 3,
+                    repsMin: 10,
+                    repsMax: 12,
+                    restSeconds: 90,
+                    cues: [],
+                  },
+                ],
+              },
+            ],
+            tags: ['e2e', 'workout-session'],
+          },
+        });
+        expect(templateResponse.ok()).toBeTruthy();
+
+        const templatePayload = (await templateResponse.json()) as {
+          data: {
+            id: string;
+          };
+        };
+        seededTemplateId = templatePayload.data.id;
+      } finally {
+        await authorizedContext.dispose();
+      }
+    } finally {
+      await apiContext.dispose();
+    }
+  });
+
+  test('starts from template, logs sets, completes, and persists history/detail data', async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+
+    await authenticatePage(page);
+    await page.goto('/workouts');
+
+    await page.getByRole('button', { name: 'Templates' }).click();
+    await page.getByRole('link', { name: seededTemplate.name }).click();
+
+    await expect(page.getByRole('heading', { level: 1, name: seededTemplate.name })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Start Workout' }).click();
+    await expect(page).toHaveURL(/\/workouts\/active\?/);
+
+    await ensureSectionIsExpanded(page, 'Warmup');
+    await ensureSectionIsExpanded(page, 'Main');
+    await ensureSectionIsExpanded(page, 'Cooldown');
+
+    await expect(page.getByRole('heading', { level: 3 }).first()).toBeVisible();
+
+    const elapsedTimeText = page.getByText(/^\d{2}:\d{2}$/).first();
+    const elapsedStart = await elapsedTimeText.innerText();
+    await page.waitForTimeout(1200);
+    const elapsedNext = await elapsedTimeText.innerText();
+    expect(toElapsedSeconds(elapsedNext)).toBeGreaterThan(toElapsedSeconds(elapsedStart));
+
+    const firstSetWeight = page.getByLabel('Weight for set 1').first();
+    const firstSetReps = page.getByLabel('Reps for set 1').first();
+    const firstSetComplete = page.getByLabel('Complete set 1').first();
+
+    await firstSetWeight.fill('135');
+    await firstSetReps.fill('10');
+    await firstSetComplete.check();
+    await expect(firstSetComplete).toBeChecked();
+
+    const secondSetWeight = page.getByLabel('Weight for set 2').first();
+    const secondSetReps = page.getByLabel('Reps for set 2').first();
+    const secondSetComplete = page.getByLabel('Complete set 2').first();
+
+    await secondSetWeight.fill('140');
+    await secondSetReps.fill('8');
+    await secondSetComplete.check();
+    await expect(secondSetComplete).toBeChecked();
+
+    await ensureAllExercisePanelsExpanded(page);
+    const feedbackHeading = page.getByRole('heading', { name: 'How did this session feel?' });
+
+    for (let attempt = 0; attempt < 60; attempt += 1) {
+      if (await feedbackHeading.isVisible()) {
+        break;
+      }
+
+      const setCompletionCheckboxes = page.getByRole('checkbox', {
+        name: /^Complete set \d+$/,
+      });
+      const totalSetCount = await setCompletionCheckboxes.count();
+      let checkedAnySet = false;
+
+      for (let index = 0; index < totalSetCount; index += 1) {
+        const setCheckbox = setCompletionCheckboxes.nth(index);
+        if (await setCheckbox.isChecked()) {
+          continue;
+        }
+
+        await setCheckbox.click();
+        checkedAnySet = true;
+        break;
+      }
+
+      if (!checkedAnySet) {
+        break;
+      }
+    }
+
+    await expect(feedbackHeading).toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole('button', { name: 'Finalize session' }).click();
+    await expect(page.getByRole('heading', { name: 'Workout summary' })).toBeVisible();
+    await expect(page.getByText('Duration')).toBeVisible();
+
+    const sessionId = new URL(page.url()).searchParams.get('sessionId');
+    expect(sessionId).toBeTruthy();
+
+    await page.getByRole('button', { name: 'Done' }).click();
+    await expect(page).toHaveURL('/workouts');
+
+    const apiContext = await request.newContext({
+      baseURL: apiBaseURL,
+      extraHTTPHeaders: {
+        Authorization: `Bearer ${authToken}`,
+      },
+    });
+
+    try {
+      const detailResponse = await apiContext.get(`/api/v1/workout-sessions/${sessionId}`);
+      expect(detailResponse.ok()).toBeTruthy();
+
+      const detailPayload = (await detailResponse.json()) as {
+        data: {
+          date: string;
+          id: string;
+          name: string;
+          sets: Array<{
+            completed: boolean;
+            exerciseId: string;
+            reps: number | null;
+            setNumber: number;
+            weight: number | null;
+          }>;
+          status: string;
+          templateId: string | null;
+        };
+      };
+
+      expect(detailPayload.data.id).toBe(sessionId);
+      expect(detailPayload.data.name).toBe(seededTemplate.name);
+      expect(detailPayload.data.status).toBe('completed');
+      expect(detailPayload.data.templateId).toBe(seededTemplateId);
+      expect(detailPayload.data.sets).toHaveLength(9);
+      expect(
+        detailPayload.data.sets.some((set) => seededExerciseIds.includes(set.exerciseId)),
+      ).toBeTruthy();
+
+      const listResponse = await apiContext.get(
+        `/api/v1/workout-sessions?from=${detailPayload.data.date}&to=${detailPayload.data.date}`,
+      );
+      expect(listResponse.ok()).toBeTruthy();
+
+      const listPayload = (await listResponse.json()) as {
+        data: Array<{
+          id: string;
+          name: string;
+        }>;
+      };
+
+      expect(listPayload.data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: sessionId,
+            name: seededTemplate.name,
+          }),
+        ]),
+      );
+    } finally {
+      await apiContext.dispose();
+    }
+  });
+});

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import App from '@/App';
 import { ThemeProvider } from '@/components/theme-provider';
+import { ACTIVE_WORKOUT_SESSION_STORAGE_KEY } from '@/features/workouts/lib/session-persistence';
 import { workoutCompletedSessions } from '@/features/workouts';
 import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
 import { createAppQueryClient } from '@/lib/query-client';
@@ -109,6 +110,7 @@ describe('App', () => {
   beforeEach(() => {
     createAppQueryClient().clear();
     window.localStorage.removeItem('pulse-theme');
+    window.localStorage.removeItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY);
     document.documentElement.classList.remove('dark');
     document.documentElement.classList.remove('theme-midnight');
     window.history.pushState({}, '', '/');

--- a/apps/web/src/components/layout/app-layout.tsx
+++ b/apps/web/src/components/layout/app-layout.tsx
@@ -2,12 +2,14 @@ import type { PropsWithChildren } from 'react';
 import { Outlet } from 'react-router';
 import { BottomNav } from '@/components/layout/bottom-nav';
 import { Sidebar } from '@/components/layout/sidebar';
+import { ActiveSessionResumeGate } from '@/components/workouts/active-session-resume-gate';
 
 export function AppLayout({ children }: PropsWithChildren) {
   const content = children ?? <Outlet />;
 
   return (
     <div className="min-h-screen bg-background text-foreground">
+      <ActiveSessionResumeGate />
       <div className="mx-auto flex min-h-screen w-full max-w-screen-2xl">
         <Sidebar />
         <main className="min-w-0 flex-1 px-4 pb-24 pt-6 md:px-8 md:pb-8 md:pt-8">{content}</main>

--- a/apps/web/src/components/workouts/active-session-resume-gate.test.tsx
+++ b/apps/web/src/components/workouts/active-session-resume-gate.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ACTIVE_WORKOUT_SESSION_STORAGE_KEY,
+  WORKOUT_SESSION_COMPLETED_NOTICE,
+  WORKOUT_SESSION_NOTICE_QUERY_KEY,
+} from '@/features/workouts/lib/session-persistence';
+import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
+import { jsonResponse } from '@/test/test-utils';
+
+import { ActiveSessionResumeGate } from './active-session-resume-gate';
+
+const mockFetch = vi.fn();
+
+function LocationProbe() {
+  const location = useLocation();
+
+  return <p data-testid="location">{`${location.pathname}${location.search}`}</p>;
+}
+
+function renderGate(initialEntry = '/workouts') {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <ActiveSessionResumeGate />
+      <LocationProbe />
+      <Routes>
+        <Route element={<h1>Workouts</h1>} path="/workouts" />
+        <Route element={<h1>Active workout</h1>} path="/workouts/active" />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('ActiveSessionResumeGate', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
+    window.localStorage.removeItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
+    window.localStorage.removeItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY);
+  });
+
+  it('resumes an in-progress stored session and navigates to active workout', async () => {
+    window.localStorage.setItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY, 'session-1');
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          id: 'session-1',
+          userId: 'user-1',
+          templateId: 'upper-push',
+          name: 'Upper Push',
+          date: '2026-03-09',
+          status: 'in-progress',
+          startedAt: 100,
+          completedAt: null,
+          duration: null,
+          feedback: null,
+          notes: null,
+          sets: [],
+          createdAt: 100,
+          updatedAt: 100,
+        },
+      }),
+    );
+
+    renderGate('/workouts');
+
+    await waitFor(() => {
+      expect(screen.getByText('/workouts/active?sessionId=session-1&template=upper-push')).toBeVisible();
+    });
+  });
+
+  it('clears stale storage when the stored session is missing', async () => {
+    window.localStorage.setItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY, 'missing-session');
+    mockFetch.mockResolvedValue(
+      jsonResponse(
+        {
+          error: {
+            code: 'WORKOUT_SESSION_NOT_FOUND',
+            message: 'Workout session not found',
+          },
+        },
+        { status: 404 },
+      ),
+    );
+
+    renderGate('/workouts');
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    expect(window.localStorage.getItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY)).toBeNull();
+    expect(screen.getByText('/workouts')).toBeVisible();
+  });
+
+  it('redirects completed stored sessions to workouts with a notice and clears storage', async () => {
+    window.localStorage.setItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY, 'session-1');
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          id: 'session-1',
+          userId: 'user-1',
+          templateId: 'upper-push',
+          name: 'Upper Push',
+          date: '2026-03-09',
+          status: 'completed',
+          startedAt: 100,
+          completedAt: 200,
+          duration: 10,
+          feedback: {
+            energy: 4,
+            recovery: 4,
+            technique: 4,
+          },
+          notes: null,
+          sets: [],
+          createdAt: 100,
+          updatedAt: 200,
+        },
+      }),
+    );
+
+    renderGate('/workouts');
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          `/workouts?${WORKOUT_SESSION_NOTICE_QUERY_KEY}=${WORKOUT_SESSION_COMPLETED_NOTICE}`,
+        ),
+      ).toBeVisible();
+    });
+
+    expect(window.localStorage.getItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/apps/web/src/components/workouts/active-session-resume-gate.test.tsx
+++ b/apps/web/src/components/workouts/active-session-resume-gate.test.tsx
@@ -140,4 +140,37 @@ describe('ActiveSessionResumeGate', () => {
 
     expect(window.localStorage.getItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY)).toBeNull();
   });
+
+  it('clears stored session id for non-active statuses without redirecting', async () => {
+    window.localStorage.setItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY, 'session-scheduled');
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          id: 'session-scheduled',
+          userId: 'user-1',
+          templateId: 'upper-push',
+          name: 'Upper Push',
+          date: '2026-03-09',
+          status: 'scheduled',
+          startedAt: 100,
+          completedAt: null,
+          duration: null,
+          feedback: null,
+          notes: null,
+          sets: [],
+          createdAt: 100,
+          updatedAt: 100,
+        },
+      }),
+    );
+
+    renderGate('/workouts');
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    expect(window.localStorage.getItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY)).toBeNull();
+    expect(screen.getByText('/workouts')).toBeVisible();
+  });
 });

--- a/apps/web/src/components/workouts/active-session-resume-gate.tsx
+++ b/apps/web/src/components/workouts/active-session-resume-gate.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+
+import type { WorkoutSession } from '@pulse/shared';
+import { workoutSessionSchema } from '@pulse/shared';
+import { z } from 'zod';
+
+import { ApiError, apiRequest } from '@/lib/api-client';
+import {
+  WORKOUT_SESSION_COMPLETED_NOTICE,
+  WORKOUT_SESSION_NOTICE_QUERY_KEY,
+  clearStoredActiveWorkoutSessionId,
+  getStoredActiveWorkoutSessionId,
+} from '@/features/workouts/lib/session-persistence';
+
+const workoutSessionResponseSchema = z.object({
+  data: workoutSessionSchema,
+}) as unknown as z.ZodType<{ data: WorkoutSession }>;
+
+async function getWorkoutSession(sessionId: string) {
+  const data = await apiRequest<unknown>(`/api/v1/workout-sessions/${sessionId}`);
+  const payload = workoutSessionResponseSchema.parse({ data });
+
+  return payload.data;
+}
+
+function buildResumePath(session: WorkoutSession) {
+  const params = new URLSearchParams();
+  params.set('sessionId', session.id);
+
+  if (session.templateId) {
+    params.set('template', session.templateId);
+  }
+
+  return `/workouts/active?${params.toString()}`;
+}
+
+export function ActiveSessionResumeGate() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const hasCheckedRef = useRef(false);
+
+  useEffect(() => {
+    if (hasCheckedRef.current) {
+      return;
+    }
+
+    hasCheckedRef.current = true;
+    const storedSessionId = getStoredActiveWorkoutSessionId();
+
+    if (!storedSessionId) {
+      return;
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const session = await getWorkoutSession(storedSessionId);
+
+        if (cancelled) {
+          return;
+        }
+
+        if (session.status === 'in-progress') {
+          const currentSessionId = new URLSearchParams(location.search).get('sessionId');
+          if (location.pathname !== '/workouts/active' || currentSessionId !== session.id) {
+            navigate(buildResumePath(session), { replace: true });
+          }
+          return;
+        }
+
+        clearStoredActiveWorkoutSessionId();
+
+        if (session.status === 'completed') {
+          navigate(
+            `/workouts?${WORKOUT_SESSION_NOTICE_QUERY_KEY}=${WORKOUT_SESSION_COMPLETED_NOTICE}`,
+            {
+              replace: true,
+            },
+          );
+        }
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+
+        if (error instanceof ApiError && error.status === 404) {
+          clearStoredActiveWorkoutSessionId();
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [location.pathname, location.search, navigate]);
+
+  return null;
+}

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -1,7 +1,10 @@
+import { QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { createAppQueryClient } from '@/lib/query-client';
 import { mockTemplates } from '@/lib/mock-data/workouts';
+import { renderWithQueryClient } from '@/test/render-with-query-client';
 
 import {
   buildActiveWorkoutSession,
@@ -39,7 +42,7 @@ describe('SessionExerciseList', () => {
       },
     );
 
-    render(
+    renderWithQueryClient(
       <SessionExerciseList
         onAddSet={vi.fn()}
         onExerciseNotesChange={vi.fn()}
@@ -142,7 +145,7 @@ describe('SessionExerciseList', () => {
       createInitialWorkoutSetDrafts(lowerTemplate, new Set()),
     );
 
-    render(
+    renderWithQueryClient(
       <SessionExerciseList
         onAddSet={vi.fn()}
         onExerciseNotesChange={vi.fn()}
@@ -186,7 +189,7 @@ describe('SessionExerciseList', () => {
       sessionStartedAt: '2026-03-06T12:00:00Z',
     });
 
-    render(
+    renderWithQueryClient(
       <SessionExerciseList
         onAddSet={vi.fn()}
         onExerciseNotesChange={vi.fn()}
@@ -216,16 +219,21 @@ describe('SessionExerciseList', () => {
       createInitialWorkoutSetDrafts(activeTemplate, new Set()),
     );
 
+    const queryClient = createAppQueryClient();
+    queryClient.clear();
+
     const { rerender } = render(
-      <SessionExerciseList
-        focusSetId={createWorkoutSetId('row-erg', 1)}
-        onAddSet={vi.fn()}
-        onExerciseNotesChange={vi.fn()}
-        onFocusSetHandled={vi.fn()}
-        onRestTimerComplete={vi.fn()}
-        onSetUpdate={vi.fn()}
-        session={session}
-      />,
+      <QueryClientProvider client={queryClient}>
+        <SessionExerciseList
+          focusSetId={createWorkoutSetId('row-erg', 1)}
+          onAddSet={vi.fn()}
+          onExerciseNotesChange={vi.fn()}
+          onFocusSetHandled={vi.fn()}
+          onRestTimerComplete={vi.fn()}
+          onSetUpdate={vi.fn()}
+          session={session}
+        />
+      </QueryClientProvider>,
     );
 
     const rowErgCard = screen
@@ -237,14 +245,16 @@ describe('SessionExerciseList', () => {
     expect(rowErgInput).toHaveFocus();
 
     rerender(
-      <SessionExerciseList
-        onAddSet={vi.fn()}
-        onExerciseNotesChange={vi.fn()}
-        onFocusSetHandled={vi.fn()}
-        onRestTimerComplete={vi.fn()}
-        onSetUpdate={vi.fn()}
-        session={session}
-      />,
+      <QueryClientProvider client={queryClient}>
+        <SessionExerciseList
+          onAddSet={vi.fn()}
+          onExerciseNotesChange={vi.fn()}
+          onFocusSetHandled={vi.fn()}
+          onRestTimerComplete={vi.fn()}
+          onSetUpdate={vi.fn()}
+          session={session}
+        />
+      </QueryClientProvider>,
     );
 
     const warmupButton = screen.getByRole('button', { name: /Warmup/i });

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Textarea } from '@/components/ui/textarea';
 import { accentCardStyles } from '@/lib/accent-card-styles';
+import { useLastPerformance } from '@/hooks/use-last-performance';
 import { cn } from '@/lib/utils';
 
 import type {
@@ -33,6 +34,7 @@ type RestTimerState = {
 };
 
 type SessionExerciseListProps = {
+  enableApiLastPerformance?: boolean;
   focusSetId?: string | null;
   onAddSet: (exerciseId: string) => void;
   onExerciseNotesChange: (exerciseId: string, notes: string) => void;
@@ -74,6 +76,7 @@ const supersetAccentStyles = [
 ] as const;
 
 export function SessionExerciseList({
+  enableApiLastPerformance = false,
   focusSetId = null,
   onAddSet,
   onExerciseNotesChange,
@@ -206,6 +209,7 @@ export function SessionExerciseList({
                       <ExerciseCardItem
                         exercise={item.exercise}
                         exerciseNumber={exerciseNumberMap.get(item.exercise.id) ?? 0}
+                        enableApiLastPerformance={enableApiLastPerformance}
                         expandedExercises={expandedExercises}
                         focusTargetExerciseId={focusTarget?.exerciseId ?? null}
                         onAddSet={onAddSet}
@@ -264,6 +268,7 @@ export function SessionExerciseList({
                             <ExerciseCardItem
                               exercise={exercise}
                               exerciseNumber={exerciseNumberMap.get(exercise.id) ?? 0}
+                              enableApiLastPerformance={enableApiLastPerformance}
                               expandedExercises={expandedExercises}
                               focusTargetExerciseId={focusTarget?.exerciseId ?? null}
                               onAddSet={onAddSet}
@@ -295,6 +300,7 @@ export function SessionExerciseList({
 type ExerciseCardItemProps = {
   exercise: ActiveWorkoutExercise;
   exerciseNumber: number;
+  enableApiLastPerformance: boolean;
   expandedExercises: Record<string, boolean>;
   focusTargetExerciseId: string | null;
   onAddSet: (exerciseId: string) => void;
@@ -312,6 +318,7 @@ type ExerciseCardItemProps = {
 function ExerciseCardItem({
   exercise,
   exerciseNumber,
+  enableApiLastPerformance,
   expandedExercises,
   focusTargetExerciseId,
   onAddSet,
@@ -325,6 +332,10 @@ function ExerciseCardItem({
   visibleCuePanels,
   visibleNotesPanels,
 }: ExerciseCardItemProps) {
+  const lastPerformanceQuery = useLastPerformance(exercise.id, {
+    enabled: enableApiLastPerformance,
+  });
+  const lastPerformance = enableApiLastPerformance ? (lastPerformanceQuery.data ?? null) : exercise.lastPerformance;
   const state = getExerciseState(exercise, sessionCurrentExerciseId);
   const isExpanded =
     focusTargetExerciseId === exercise.id
@@ -457,9 +468,9 @@ function ExerciseCardItem({
               {formatSetPrescription(exercise.prescribedReps, exercise.restSeconds)}
             </p>
 
-            {exercise.lastPerformance ? (
+            {lastPerformance ? (
               <LastPerformanceSummary
-                lastPerformance={exercise.lastPerformance}
+                lastPerformance={lastPerformance}
                 currentSets={exercise.sets}
                 prescribedReps={exercise.prescribedReps}
               />
@@ -555,7 +566,7 @@ function ExerciseCardItem({
               }}
               reps={set.reps}
               setNumber={set.number}
-              lastPerformance={exercise.lastPerformance?.sets.find(
+              lastPerformance={lastPerformance?.sets.find(
                 (previousSet) => previousSet.setNumber === set.number,
               )}
               target={getSetTarget(exercise.reversePyramid, set.number, exercise.prescribedReps)}

--- a/apps/web/src/features/workouts/components/session-summary.test.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.test.tsx
@@ -1,5 +1,7 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+
+import { renderWithQueryClient } from '@/test/render-with-query-client';
 
 import { SessionSummary } from './session-summary';
 
@@ -7,7 +9,7 @@ describe('SessionSummary', () => {
   it('opens the save-as-template dialog with prefilled fields and performs a mock save', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    render(
+    renderWithQueryClient(
       <SessionSummary
         defaultDescription="Chest, shoulders, and triceps emphasis with controlled tempo work."
         defaultTags={['strength', 'push', 'upper-body']}

--- a/apps/web/src/features/workouts/components/session-summary.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.tsx
@@ -4,6 +4,7 @@ import { CheckCircle2, Clock3, Dumbbell, ListChecks, Save } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { accentCardStyles } from '@/lib/accent-card-styles';
+import { useSaveAsTemplate } from '@/hooks/use-save-as-template';
 import {
   Dialog,
   DialogClose,
@@ -27,6 +28,7 @@ type SessionSummaryProps = {
   exercisesCompleted: number;
   feedback?: ActiveWorkoutFeedbackDraft;
   onDone: () => void;
+  sessionId?: string | null;
   totalReps: number;
   totalSets: number;
   workoutName: string;
@@ -40,10 +42,12 @@ export function SessionSummary({
   exercisesCompleted,
   feedback = [],
   onDone,
+  sessionId = null,
   totalReps,
   totalSets,
   workoutName,
 }: SessionSummaryProps) {
+  const saveAsTemplateMutation = useSaveAsTemplate(sessionId);
   const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
   const [templateName, setTemplateName] = useState(workoutName);
   const [templateDescription, setTemplateDescription] = useState(defaultDescription);
@@ -140,7 +144,7 @@ export function SessionSummary({
           {saveMessage ? (
             <p
               aria-live="polite"
-              className="text-sm font-medium opacity-80 dark:text-muted dark:opacity-100"
+              className="rounded-xl border border-black/15 bg-white/45 px-3 py-2 text-sm font-medium opacity-80 dark:border-border dark:bg-secondary/60 dark:text-muted dark:opacity-100"
             >
               {saveMessage}
             </p>
@@ -202,7 +206,7 @@ export function SessionSummary({
               </Button>
             </DialogClose>
             <Button
-              disabled={templateName.trim().length === 0}
+              disabled={templateName.trim().length === 0 || saveAsTemplateMutation.isPending}
               onClick={() => {
                 const payload = {
                   name: templateName.trim(),
@@ -213,13 +217,26 @@ export function SessionSummary({
                     .filter(Boolean),
                 };
 
+                if (sessionId) {
+                  saveAsTemplateMutation.mutate(undefined, {
+                    onError: () => {
+                      setSaveMessage('Unable to save this session as a template. Try again.');
+                    },
+                    onSuccess: (template) => {
+                      setSaveMessage(`Saved "${template.name}" as a template.`);
+                      setIsSaveDialogOpen(false);
+                    },
+                  });
+                  return;
+                }
+
                 console.log('Mock save workout template', payload);
                 setSaveMessage(`Saved "${payload.name}" to mock templates.`);
                 setIsSaveDialogOpen(false);
               }}
               type="button"
             >
-              Save
+              {saveAsTemplateMutation.isPending ? 'Saving...' : 'Save'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/features/workouts/components/session-summary.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.tsx
@@ -218,7 +218,7 @@ export function SessionSummary({
                 };
 
                 if (sessionId) {
-                  saveAsTemplateMutation.mutate(undefined, {
+                  saveAsTemplateMutation.mutate(payload, {
                     onError: () => {
                       setSaveMessage('Unable to save this session as a template. Try again.');
                     },

--- a/apps/web/src/features/workouts/components/set-row.test.tsx
+++ b/apps/web/src/features/workouts/components/set-row.test.tsx
@@ -58,7 +58,7 @@ describe('SetRow', () => {
 
     expect(document.querySelector('[data-slot="set-row"]')).toHaveClass('bg-emerald-500/10');
     expect(onUpdate).toHaveBeenCalledWith({ reps: null });
-    expect(screen.getByText('Last: 50x12')).toBeInTheDocument();
+    expect(screen.getByText('Last time: 50x12')).toBeInTheDocument();
     expect(screen.getByText('PR')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Add Set' })).not.toBeInTheDocument();
   });

--- a/apps/web/src/features/workouts/components/set-row.tsx
+++ b/apps/web/src/features/workouts/components/set-row.tsx
@@ -116,7 +116,7 @@ export const SetRow = forwardRef<HTMLInputElement, SetRowProps>(function SetRow(
           />
           {lastPerformance ? (
             <div className="flex min-h-4 items-center gap-1 text-xs text-muted">
-              <span>{`Last: ${formatLastSet(lastPerformance)}`}</span>
+              <span>{`Last time: ${formatLastSet(lastPerformance)}`}</span>
               {hasPr ? (
                 <span className="inline-flex items-center gap-1 font-semibold text-emerald-600 dark:text-emerald-400">
                   <ArrowUpRight aria-hidden="true" className="size-3" />

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
+import { ACTIVE_WORKOUT_SESSION_STORAGE_KEY } from '@/features/workouts/lib/session-persistence';
 import { renderWithQueryClient } from '@/test/render-with-query-client';
 import { jsonResponse } from '@/test/test-utils';
 
@@ -87,6 +88,7 @@ beforeEach(() => {
 
 afterEach(() => {
   window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
+  window.localStorage.removeItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY);
   vi.restoreAllMocks();
 });
 
@@ -231,6 +233,7 @@ describe('WorkoutTemplateDetail', () => {
         weight: null,
       }),
     ]);
+    expect(window.localStorage.getItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY)).toBe('session-1');
   });
 
   it('renders a fallback state when the template request returns 404', async () => {

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -200,6 +200,37 @@ describe('WorkoutTemplateDetail', () => {
     });
     expect(requestBody.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(requestBody.startedAt).toEqual(expect.any(Number));
+    expect(requestBody.sets).toHaveLength(4);
+    expect(requestBody.sets).toEqual([
+      expect.objectContaining({
+        exerciseId: 'row-erg',
+        reps: null,
+        section: 'warmup',
+        setNumber: 1,
+        weight: null,
+      }),
+      expect.objectContaining({
+        exerciseId: 'incline-dumbbell-press',
+        reps: null,
+        section: 'main',
+        setNumber: 1,
+        weight: null,
+      }),
+      expect.objectContaining({
+        exerciseId: 'incline-dumbbell-press',
+        reps: null,
+        section: 'main',
+        setNumber: 2,
+        weight: null,
+      }),
+      expect.objectContaining({
+        exerciseId: 'incline-dumbbell-press',
+        reps: null,
+        section: 'main',
+        setNumber: 3,
+        weight: null,
+      }),
+    ]);
   });
 
   it('renders a fallback state when the template request returns 404', async () => {

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -1,14 +1,15 @@
 import { Link, useNavigate } from 'react-router';
 
-import type { WorkoutTemplateExercise } from '@pulse/shared';
+import type { WorkoutTemplate, WorkoutTemplateExercise } from '@pulse/shared';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useStartSession } from '@/hooks/use-workout-session';
 import { ApiError } from '@/lib/api-client';
 import { toDateKey } from '@/lib/date-utils';
 
-import { useStartWorkoutSession, useWorkoutTemplate } from '../api/workouts';
+import { useWorkoutTemplate } from '../api/workouts';
 
 type WorkoutTemplateDetailProps = {
   templateId: string;
@@ -24,7 +25,7 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3
 export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps) {
   const navigate = useNavigate();
   const templateQuery = useWorkoutTemplate(templateId);
-  const startWorkoutMutation = useStartWorkoutSession();
+  const startWorkoutMutation = useStartSession();
 
   if (templateQuery.isPending) {
     return <TemplateDetailSkeleton />;
@@ -189,6 +190,7 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
               {
                 date: toDateKey(new Date(startedAt)),
                 name: template.name,
+                sets: buildInitialSessionSets(template),
                 startedAt,
                 templateId: template.id,
               },
@@ -289,4 +291,22 @@ function formatRepTarget(repsMin: number | null, repsMax: number | null) {
 
 function formatTempo(tempo: string) {
   return tempo.split('').join('-');
+}
+
+function buildInitialSessionSets(template: WorkoutTemplate) {
+  return template.sections.flatMap((section) =>
+    section.exercises.flatMap((exercise) => {
+      if (exercise.sets === null || exercise.sets < 1) {
+        return [];
+      }
+
+      return Array.from({ length: exercise.sets }, (_, index) => ({
+        exerciseId: exercise.exerciseId,
+        reps: null,
+        section: section.type,
+        setNumber: index + 1,
+        weight: null,
+      }));
+    }),
+  );
 }

--- a/apps/web/src/features/workouts/lib/session-persistence.ts
+++ b/apps/web/src/features/workouts/lib/session-persistence.ts
@@ -1,0 +1,38 @@
+export const ACTIVE_WORKOUT_SESSION_STORAGE_KEY = 'pulse.active-workout-session-id';
+export const WORKOUT_SESSION_NOTICE_QUERY_KEY = 'sessionNotice';
+export const WORKOUT_SESSION_COMPLETED_NOTICE = 'completed';
+
+function canUseLocalStorage() {
+  return typeof window !== 'undefined';
+}
+
+export function getStoredActiveWorkoutSessionId() {
+  if (!canUseLocalStorage()) {
+    return null;
+  }
+
+  const storedValue = window.localStorage.getItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY)?.trim();
+  return storedValue ? storedValue : null;
+}
+
+export function setStoredActiveWorkoutSessionId(sessionId: string) {
+  if (!canUseLocalStorage()) {
+    return;
+  }
+
+  const normalizedSessionId = sessionId.trim();
+
+  if (!normalizedSessionId) {
+    return;
+  }
+
+  window.localStorage.setItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY, normalizedSessionId);
+}
+
+export function clearStoredActiveWorkoutSessionId() {
+  if (!canUseLocalStorage()) {
+    return;
+  }
+
+  window.localStorage.removeItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY);
+}

--- a/apps/web/src/hooks/use-complete-session.test.tsx
+++ b/apps/web/src/hooks/use-complete-session.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { ACTIVE_WORKOUT_SESSION_STORAGE_KEY } from '@/features/workouts/lib/session-persistence';
 import { createQueryClientWrapper } from '@/test/query-client';
 
 import { useCompleteSession } from './use-complete-session';
@@ -42,6 +43,7 @@ describe('use-complete-session hook', () => {
   beforeEach(() => {
     mockFetch.mockReset();
     vi.stubGlobal('fetch', mockFetch);
+    window.localStorage.setItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY, 'session-1');
   });
 
   it('completes a session and invalidates session queries', async () => {
@@ -92,5 +94,6 @@ describe('use-complete-session hook', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: workoutSessionQueryKeys.detail('session-1'),
     });
+    expect(window.localStorage.getItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY)).toBeNull();
   });
 });

--- a/apps/web/src/hooks/use-complete-session.test.tsx
+++ b/apps/web/src/hooks/use-complete-session.test.tsx
@@ -1,0 +1,96 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { useCompleteSession } from './use-complete-session';
+import { workoutSessionQueryKeys } from './use-workout-session';
+
+const mockFetch = vi.fn();
+
+const createJsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+
+const completedSessionResponse = {
+  id: 'session-1',
+  userId: 'user-1',
+  templateId: 'template-1',
+  name: 'Upper Push',
+  date: '2026-03-08',
+  status: 'completed' as const,
+  startedAt: 100,
+  completedAt: 2_700_000,
+  duration: 45,
+  feedback: {
+    energy: 4,
+    recovery: 3,
+    technique: 5,
+    notes: 'Strong finish',
+  },
+  notes: 'Strong finish',
+  sets: [],
+  createdAt: 100,
+  updatedAt: 200,
+};
+
+describe('use-complete-session hook', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  it('completes a session and invalidates session queries', async () => {
+    mockFetch.mockResolvedValueOnce(createJsonResponse(completedSessionResponse));
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useCompleteSession('session-1'), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        completedAt: 2_700_000,
+        duration: 45,
+        feedback: {
+          energy: 4,
+          recovery: 3,
+          technique: 5,
+        },
+        notes: 'Strong finish',
+      });
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/workout-sessions/session-1',
+      expect.objectContaining({
+        method: 'PUT',
+      }),
+    );
+
+    const request = mockFetch.mock.calls.find(
+      ([input, init]) => String(input) === '/api/v1/workout-sessions/session-1' && init?.method === 'PUT',
+    );
+
+    expect(request).toBeDefined();
+    expect(JSON.parse(String(request?.[1]?.body))).toEqual({
+      completedAt: 2_700_000,
+      duration: 45,
+      feedback: {
+        energy: 4,
+        recovery: 3,
+        technique: 5,
+      },
+      notes: 'Strong finish',
+      status: 'completed',
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutSessionQueryKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutSessionQueryKeys.detail('session-1'),
+    });
+  });
+});

--- a/apps/web/src/hooks/use-complete-session.ts
+++ b/apps/web/src/hooks/use-complete-session.ts
@@ -7,6 +7,7 @@ import {
 } from '@pulse/shared';
 import { z } from 'zod';
 
+import { clearStoredActiveWorkoutSessionId } from '@/features/workouts/lib/session-persistence';
 import { apiRequest } from '@/lib/api-client';
 
 import { workoutSessionQueryKeys } from './use-workout-session';
@@ -53,6 +54,10 @@ export function useCompleteSession(sessionId: string | null | undefined) {
       return completeSession(normalizedSessionId, input);
     },
     onSuccess: async (session) => {
+      if (session.status === 'completed') {
+        clearStoredActiveWorkoutSessionId();
+      }
+
       queryClient.setQueryData(workoutSessionQueryKeys.detail(session.id), session);
 
       await Promise.all([

--- a/apps/web/src/hooks/use-complete-session.ts
+++ b/apps/web/src/hooks/use-complete-session.ts
@@ -1,0 +1,66 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  type WorkoutSession,
+  type WorkoutSessionFeedback,
+  updateWorkoutSessionInputSchema,
+  workoutSessionSchema,
+} from '@pulse/shared';
+import { z } from 'zod';
+
+import { apiRequest } from '@/lib/api-client';
+
+import { workoutSessionQueryKeys } from './use-workout-session';
+
+const workoutSessionResponseSchema = z.object({
+  data: workoutSessionSchema,
+}) as unknown as z.ZodType<{ data: WorkoutSession }>;
+
+type CompleteSessionInput = {
+  completedAt?: number;
+  duration?: number | null;
+  feedback: WorkoutSessionFeedback;
+  notes?: string | null;
+};
+
+async function completeSession(sessionId: string, input: CompleteSessionInput) {
+  const parsedBody = updateWorkoutSessionInputSchema.parse({
+    completedAt: input.completedAt ?? Date.now(),
+    duration: input.duration ?? null,
+    feedback: input.feedback,
+    notes: input.notes ?? null,
+    status: 'completed',
+  });
+
+  const data = await apiRequest<unknown>(`/api/v1/workout-sessions/${sessionId}`, {
+    body: JSON.stringify(parsedBody),
+    method: 'PUT',
+  });
+  const payload = workoutSessionResponseSchema.parse({ data });
+
+  return payload.data;
+}
+
+export function useCompleteSession(sessionId: string | null | undefined) {
+  const queryClient = useQueryClient();
+  const normalizedSessionId = sessionId?.trim() ?? '';
+
+  return useMutation<WorkoutSession, Error, CompleteSessionInput>({
+    mutationFn: async (input) => {
+      if (!normalizedSessionId) {
+        throw new Error('Session id is required to complete a workout');
+      }
+
+      return completeSession(normalizedSessionId, input);
+    },
+    onSuccess: async (session) => {
+      queryClient.setQueryData(workoutSessionQueryKeys.detail(session.id), session);
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: workoutSessionQueryKeys.all }),
+        queryClient.invalidateQueries({ queryKey: workoutSessionQueryKeys.detail(session.id) }),
+      ]);
+    },
+  });
+}
+
+export type { CompleteSessionInput };

--- a/apps/web/src/hooks/use-last-performance.test.tsx
+++ b/apps/web/src/hooks/use-last-performance.test.tsx
@@ -1,0 +1,113 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { useLastPerformance } from './use-last-performance';
+
+const mockFetch = vi.fn();
+
+const createJsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+
+describe('use-last-performance hook', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  it('loads and maps last performance data for an exercise', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        sessionId: 'session-2',
+        date: '2026-03-08',
+        sets: [
+          {
+            setNumber: 1,
+            weight: 105,
+            reps: 9,
+          },
+          {
+            setNumber: 2,
+            weight: 100,
+            reps: 8,
+          },
+        ],
+      }),
+    );
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useLastPerformance('global-bench-press'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual({
+      sessionId: 'session-2',
+      date: '2026-03-08',
+      sets: [
+        {
+          completed: true,
+          setNumber: 1,
+          weight: 105,
+          reps: 9,
+        },
+        {
+          completed: true,
+          setNumber: 2,
+          weight: 100,
+          reps: 8,
+        },
+      ],
+    });
+  });
+
+  it('returns null when no prior performance exists', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 'EXERCISE_LAST_PERFORMANCE_NOT_FOUND',
+            message: 'No completed performance found for this exercise',
+          },
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 404,
+        },
+      ),
+    );
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useLastPerformance('global-bench-press'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toBeNull();
+  });
+
+  it('does not fetch when disabled', async () => {
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(
+      () =>
+        useLastPerformance('global-bench-press', {
+          enabled: false,
+        }),
+      { wrapper },
+    );
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+

--- a/apps/web/src/hooks/use-last-performance.ts
+++ b/apps/web/src/hooks/use-last-performance.ts
@@ -1,0 +1,71 @@
+import { useQuery } from '@tanstack/react-query';
+import { exerciseLastPerformanceSchema } from '@pulse/shared';
+import { z } from 'zod';
+
+import type { ActiveWorkoutLastPerformance } from '@/features/workouts/types';
+import { ApiError, apiRequest } from '@/lib/api-client';
+
+const exerciseLastPerformanceResponseSchema = z.object({
+  data: exerciseLastPerformanceSchema,
+});
+
+const lastPerformanceQueryKeys = {
+  all: ['exercise-last-performance'] as const,
+  detail: (exerciseId: string) => ['exercise-last-performance', exerciseId] as const,
+};
+
+async function getLastPerformance(exerciseId: string): Promise<ActiveWorkoutLastPerformance | null> {
+  try {
+    const data = await apiRequest<unknown>(`/api/v1/exercises/${exerciseId}/last-performance`);
+    const payload = exerciseLastPerformanceResponseSchema.parse({ data });
+    const sets = payload.data.sets
+      .filter(
+        (set): set is typeof set & { reps: number } =>
+          set.reps !== null,
+      )
+      .map((set) => ({
+        completed: true,
+        reps: set.reps,
+        setNumber: set.setNumber,
+        weight: set.weight,
+      }));
+
+    if (sets.length === 0) {
+      return null;
+    }
+
+    return {
+      date: payload.data.date,
+      sessionId: payload.data.sessionId,
+      sets,
+    };
+  } catch (error) {
+    if (
+      error instanceof ApiError &&
+      error.status === 404 &&
+      (error.code === 'EXERCISE_LAST_PERFORMANCE_NOT_FOUND' || error.code === 'EXERCISE_NOT_FOUND')
+    ) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+export function useLastPerformance(
+  exerciseId: string,
+  options?: {
+    enabled?: boolean;
+  },
+) {
+  const normalizedExerciseId = exerciseId.trim();
+  const enabled = options?.enabled ?? true;
+
+  return useQuery<ActiveWorkoutLastPerformance | null>({
+    enabled: enabled && normalizedExerciseId.length > 0,
+    queryFn: () => getLastPerformance(normalizedExerciseId),
+    queryKey: lastPerformanceQueryKeys.detail(normalizedExerciseId),
+  });
+}
+
+export { lastPerformanceQueryKeys };

--- a/apps/web/src/hooks/use-save-as-template.test.tsx
+++ b/apps/web/src/hooks/use-save-as-template.test.tsx
@@ -69,15 +69,27 @@ describe('use-save-as-template hook', () => {
     const { result } = renderHook(() => useSaveAsTemplate('session-1'), { wrapper });
 
     await act(async () => {
-      await result.current.mutateAsync(undefined);
+      await result.current.mutateAsync({
+        description: '  ',
+        name: ' Upper Push Snapshot ',
+        tags: [' strength ', ' push '],
+      });
     });
 
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch).toHaveBeenCalledWith(
       '/api/v1/workout-sessions/session-1/save-as-template',
       expect.objectContaining({
         method: 'POST',
       }),
     );
+
+    const requestInit = mockFetch.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(String(requestInit.body))).toEqual({
+      description: null,
+      name: 'Upper Push Snapshot',
+      tags: ['strength', 'push'],
+    });
 
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutQueryKeys.templates() });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutSessionQueryKeys.all });
@@ -90,7 +102,7 @@ describe('use-save-as-template hook', () => {
     const { wrapper } = createQueryClientWrapper();
     const { result } = renderHook(() => useSaveAsTemplate(null), { wrapper });
 
-    await expect(result.current.mutateAsync(undefined)).rejects.toThrow(
+    await expect(result.current.mutateAsync({})).rejects.toThrow(
       'Session id is required to save as template',
     );
   });

--- a/apps/web/src/hooks/use-save-as-template.test.tsx
+++ b/apps/web/src/hooks/use-save-as-template.test.tsx
@@ -1,0 +1,97 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { workoutQueryKeys } from '@/features/workouts/api/workouts';
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { useSaveAsTemplate } from './use-save-as-template';
+import { workoutSessionQueryKeys } from './use-workout-session';
+
+const mockFetch = vi.fn();
+
+const createJsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+
+const templateResponse = {
+  id: 'template-from-session',
+  userId: 'user-1',
+  name: 'Upper Push',
+  description: null,
+  tags: [],
+  sections: [
+    {
+      type: 'warmup' as const,
+      exercises: [],
+    },
+    {
+      type: 'main' as const,
+      exercises: [
+        {
+          id: 'template-exercise-1',
+          exerciseId: 'global-bench-press',
+          exerciseName: 'Bench Press',
+          sets: 3,
+          repsMin: null,
+          repsMax: null,
+          tempo: null,
+          restSeconds: null,
+          supersetGroup: null,
+          notes: null,
+          cues: [],
+        },
+      ],
+    },
+    {
+      type: 'cooldown' as const,
+      exercises: [],
+    },
+  ],
+  createdAt: 100,
+  updatedAt: 100,
+};
+
+describe('use-save-as-template hook', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  it('posts save-as-template and invalidates related queries', async () => {
+    mockFetch.mockResolvedValueOnce(createJsonResponse(templateResponse, 201));
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useSaveAsTemplate('session-1'), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync(undefined);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/workout-sessions/session-1/save-as-template',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    );
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutQueryKeys.templates() });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutSessionQueryKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutSessionQueryKeys.detail('session-1'),
+    });
+  });
+
+  it('throws when session id is missing', async () => {
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useSaveAsTemplate(null), { wrapper });
+
+    await expect(result.current.mutateAsync(undefined)).rejects.toThrow(
+      'Session id is required to save as template',
+    );
+  });
+});

--- a/apps/web/src/hooks/use-save-as-template.ts
+++ b/apps/web/src/hooks/use-save-as-template.ts
@@ -1,5 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { workoutTemplateSchema, type WorkoutTemplate } from '@pulse/shared';
+import {
+  saveWorkoutSessionAsTemplateInputSchema,
+  workoutTemplateSchema,
+  type SaveWorkoutSessionAsTemplateInput,
+  type WorkoutTemplate,
+} from '@pulse/shared';
 import { z } from 'zod';
 
 import { workoutQueryKeys } from '@/features/workouts/api/workouts';
@@ -11,8 +16,12 @@ const workoutTemplateResponseSchema = z.object({
   data: workoutTemplateSchema,
 }) as unknown as z.ZodType<{ data: WorkoutTemplate }>;
 
-async function saveAsTemplate(sessionId: string) {
+type SaveAsTemplateInput = SaveWorkoutSessionAsTemplateInput | undefined;
+
+async function saveAsTemplate(sessionId: string, input: SaveAsTemplateInput) {
+  const parsedInput = saveWorkoutSessionAsTemplateInputSchema.parse(input);
   const data = await apiRequest<unknown>(`/api/v1/workout-sessions/${sessionId}/save-as-template`, {
+    body: JSON.stringify(parsedInput),
     method: 'POST',
   });
   const payload = workoutTemplateResponseSchema.parse({ data });
@@ -24,13 +33,13 @@ export function useSaveAsTemplate(sessionId: string | null | undefined) {
   const queryClient = useQueryClient();
   const normalizedSessionId = sessionId?.trim() ?? '';
 
-  return useMutation<WorkoutTemplate, Error, undefined>({
-    mutationFn: async () => {
+  return useMutation<WorkoutTemplate, Error, SaveAsTemplateInput>({
+    mutationFn: async (input) => {
       if (!normalizedSessionId) {
         throw new Error('Session id is required to save as template');
       }
 
-      return saveAsTemplate(normalizedSessionId);
+      return saveAsTemplate(normalizedSessionId, input);
     },
     onSuccess: async (template) => {
       queryClient.setQueryData(workoutQueryKeys.template(template.id), template);

--- a/apps/web/src/hooks/use-save-as-template.ts
+++ b/apps/web/src/hooks/use-save-as-template.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { workoutTemplateSchema, type WorkoutTemplate } from '@pulse/shared';
+import { z } from 'zod';
+
+import { workoutQueryKeys } from '@/features/workouts/api/workouts';
+import { apiRequest } from '@/lib/api-client';
+
+import { workoutSessionQueryKeys } from './use-workout-session';
+
+const workoutTemplateResponseSchema = z.object({
+  data: workoutTemplateSchema,
+}) as unknown as z.ZodType<{ data: WorkoutTemplate }>;
+
+async function saveAsTemplate(sessionId: string) {
+  const data = await apiRequest<unknown>(`/api/v1/workout-sessions/${sessionId}/save-as-template`, {
+    method: 'POST',
+  });
+  const payload = workoutTemplateResponseSchema.parse({ data });
+
+  return payload.data;
+}
+
+export function useSaveAsTemplate(sessionId: string | null | undefined) {
+  const queryClient = useQueryClient();
+  const normalizedSessionId = sessionId?.trim() ?? '';
+
+  return useMutation<WorkoutTemplate, Error, undefined>({
+    mutationFn: async () => {
+      if (!normalizedSessionId) {
+        throw new Error('Session id is required to save as template');
+      }
+
+      return saveAsTemplate(normalizedSessionId);
+    },
+    onSuccess: async (template) => {
+      queryClient.setQueryData(workoutQueryKeys.template(template.id), template);
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: workoutQueryKeys.templates() }),
+        queryClient.invalidateQueries({ queryKey: workoutSessionQueryKeys.all }),
+        queryClient.invalidateQueries({
+          queryKey: workoutSessionQueryKeys.detail(normalizedSessionId),
+        }),
+      ]);
+    },
+  });
+}

--- a/apps/web/src/hooks/use-session-sets.test.tsx
+++ b/apps/web/src/hooks/use-session-sets.test.tsx
@@ -1,0 +1,128 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { workoutSessionQueryKeys } from './use-workout-session';
+import { useLogSet, useUpdateSet } from './use-session-sets';
+
+const mockFetch = vi.fn();
+
+const createJsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+
+const sessionSetResponse = {
+  id: 'set-1',
+  exerciseId: 'incline-dumbbell-press',
+  setNumber: 1,
+  weight: 60,
+  reps: 8,
+  completed: false,
+  skipped: false,
+  section: 'main' as const,
+  notes: null,
+  createdAt: 100,
+};
+
+describe('use-session-sets hooks', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  it('logs a set for a session and invalidates session queries', async () => {
+    mockFetch.mockResolvedValueOnce(createJsonResponse(sessionSetResponse, 201));
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useLogSet('session-1'), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        exerciseId: 'incline-dumbbell-press',
+        reps: 8,
+        section: 'main',
+        setNumber: 1,
+        weight: 60,
+      });
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/workout-sessions/session-1/sets',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    );
+
+    const request = mockFetch.mock.calls.find(
+      ([input, init]) =>
+        String(input) === '/api/v1/workout-sessions/session-1/sets' && init?.method === 'POST',
+    );
+
+    expect(request).toBeDefined();
+    expect(JSON.parse(String(request?.[1]?.body))).toEqual({
+      exerciseId: 'incline-dumbbell-press',
+      reps: 8,
+      section: 'main',
+      setNumber: 1,
+      weight: 60,
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutSessionQueryKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutSessionQueryKeys.detail('session-1'),
+    });
+  });
+
+  it('updates a set for a session and invalidates session queries', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        ...sessionSetResponse,
+        completed: true,
+        reps: 9,
+      }),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateSet('session-1'), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        setId: 'set-1',
+        update: {
+          completed: true,
+          reps: 9,
+        },
+      });
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/workout-sessions/session-1/sets/set-1',
+      expect.objectContaining({
+        method: 'PATCH',
+      }),
+    );
+
+    const request = mockFetch.mock.calls.find(
+      ([input, init]) =>
+        String(input) === '/api/v1/workout-sessions/session-1/sets/set-1' && init?.method === 'PATCH',
+    );
+
+    expect(request).toBeDefined();
+    expect(JSON.parse(String(request?.[1]?.body))).toEqual({
+      completed: true,
+      reps: 9,
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutSessionQueryKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutSessionQueryKeys.detail('session-1'),
+    });
+  });
+});

--- a/apps/web/src/hooks/use-session-sets.ts
+++ b/apps/web/src/hooks/use-session-sets.ts
@@ -1,0 +1,92 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createSetSchema, sessionSetSchema, type SessionSet, updateSetSchema } from '@pulse/shared';
+import { z } from 'zod';
+
+import { apiRequest } from '@/lib/api-client';
+
+import { workoutSessionQueryKeys } from './use-workout-session';
+
+const sessionSetResponseSchema = z.object({
+  data: sessionSetSchema,
+}) as unknown as z.ZodType<{ data: SessionSet }>;
+
+type CreateSetRequest = z.input<typeof createSetSchema>;
+type UpdateSetRequest = z.input<typeof updateSetSchema>;
+
+type UpdateSetVariables = {
+  setId: string;
+  update: UpdateSetRequest;
+};
+
+async function createSessionSet(sessionId: string, input: CreateSetRequest) {
+  const parsedInput = createSetSchema.parse(input);
+  const data = await apiRequest<unknown>(`/api/v1/workout-sessions/${sessionId}/sets`, {
+    body: JSON.stringify(parsedInput),
+    method: 'POST',
+  });
+  const payload = sessionSetResponseSchema.parse({ data });
+
+  return payload.data;
+}
+
+async function patchSessionSet(sessionId: string, setId: string, input: UpdateSetRequest) {
+  const parsedInput = updateSetSchema.parse(input);
+  const data = await apiRequest<unknown>(`/api/v1/workout-sessions/${sessionId}/sets/${setId}`, {
+    body: JSON.stringify(parsedInput),
+    method: 'PATCH',
+  });
+  const payload = sessionSetResponseSchema.parse({ data });
+
+  return payload.data;
+}
+
+async function invalidateSessionQueries(queryClient: ReturnType<typeof useQueryClient>, sessionId: string) {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: workoutSessionQueryKeys.all }),
+    queryClient.invalidateQueries({ queryKey: workoutSessionQueryKeys.detail(sessionId) }),
+  ]);
+}
+
+export function useLogSet(sessionId: string | null | undefined) {
+  const queryClient = useQueryClient();
+  const normalizedSessionId = sessionId?.trim() ?? '';
+
+  return useMutation<SessionSet, Error, CreateSetRequest>({
+    mutationFn: async (input) => {
+      if (!normalizedSessionId) {
+        throw new Error('Session id is required to log sets');
+      }
+
+      return createSessionSet(normalizedSessionId, input);
+    },
+    onSuccess: async () => {
+      if (!normalizedSessionId) {
+        return;
+      }
+
+      await invalidateSessionQueries(queryClient, normalizedSessionId);
+    },
+  });
+}
+
+export function useUpdateSet(sessionId: string | null | undefined) {
+  const queryClient = useQueryClient();
+  const normalizedSessionId = sessionId?.trim() ?? '';
+
+  return useMutation<SessionSet, Error, UpdateSetVariables>({
+    mutationFn: async ({ setId, update }) => {
+      if (!normalizedSessionId) {
+        throw new Error('Session id is required to update sets');
+      }
+
+      return patchSessionSet(normalizedSessionId, setId, update);
+    },
+    onSuccess: async () => {
+      if (!normalizedSessionId) {
+        return;
+      }
+
+      await invalidateSessionQueries(queryClient, normalizedSessionId);
+    },
+  });
+}

--- a/apps/web/src/hooks/use-sync-sets.test.tsx
+++ b/apps/web/src/hooks/use-sync-sets.test.tsx
@@ -1,0 +1,195 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+import { jsonResponse } from '@/test/test-utils';
+
+import { useSyncSets } from './use-sync-sets';
+
+const mockFetch = vi.fn();
+
+const groupedSetResponse = {
+  data: [
+    {
+      exerciseId: 'incline-dumbbell-press',
+      sets: [
+        {
+          id: 'set-1',
+          exerciseId: 'incline-dumbbell-press',
+          setNumber: 1,
+          weight: 60,
+          reps: 8,
+          completed: false,
+          skipped: false,
+          section: 'main',
+          notes: null,
+          createdAt: 100,
+        },
+      ],
+    },
+  ],
+};
+
+describe('use-sync-sets hook', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('syncs dirty sets after the 2s change debounce', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(groupedSetResponse));
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useSyncSets({ sessionId: 'session-1' }), { wrapper });
+
+    act(() => {
+      result.current.queueSetSync({
+        id: 'set-1',
+        exerciseId: 'incline-dumbbell-press',
+        reps: 8,
+        section: 'main',
+        setNumber: 1,
+        weight: 60,
+      });
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/workout-sessions/session-1/sets',
+      expect.objectContaining({
+        method: 'PUT',
+      }),
+    );
+  });
+
+  it('syncs dirty sets on the 30s interval', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(groupedSetResponse));
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(
+      () =>
+        useSyncSets({
+          sessionId: 'session-1',
+          syncIntervalMs: 30_000,
+          syncOnChangeDebounceMs: 60_000,
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.queueSetSync({
+        id: 'set-1',
+        exerciseId: 'incline-dumbbell-press',
+        reps: 8,
+        section: 'main',
+        setNumber: 1,
+        weight: 60,
+      });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/workout-sessions/session-1/sets',
+      expect.objectContaining({
+        method: 'PUT',
+      }),
+    );
+  });
+
+  it('attempts a keepalive sync on beforeunload when there are dirty sets', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(groupedSetResponse));
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(
+      () =>
+        useSyncSets({
+          sessionId: 'session-1',
+          syncOnChangeDebounceMs: 60_000,
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.queueSetSync({
+        id: 'set-1',
+        exerciseId: 'incline-dumbbell-press',
+        reps: 8,
+        section: 'main',
+        setNumber: 1,
+        weight: 60,
+      });
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event('beforeunload'));
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/workout-sessions/session-1/sets',
+      expect.objectContaining({
+        keepalive: true,
+        method: 'PUT',
+      }),
+    );
+  });
+
+  it('invokes onSessionInactive when the server reports the session is no longer active', async () => {
+    const onSessionInactive = vi.fn();
+    mockFetch.mockResolvedValue(
+      jsonResponse(
+        {
+          error: {
+            code: 'WORKOUT_SESSION_NOT_ACTIVE',
+            message: 'Workout session is not active',
+          },
+        },
+        { status: 409 },
+      ),
+    );
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(
+      () =>
+        useSyncSets({
+          sessionId: 'session-1',
+          onSessionInactive,
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.queueSetSync({
+        id: 'set-1',
+        exerciseId: 'incline-dumbbell-press',
+        reps: 8,
+        section: 'main',
+        setNumber: 1,
+        weight: 60,
+      });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    expect(onSessionInactive).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/hooks/use-sync-sets.ts
+++ b/apps/web/src/hooks/use-sync-sets.ts
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { batchUpsertSetsSchema, sessionSetSchema, type SessionSet } from '@pulse/shared';
+import { z } from 'zod';
+
+import { ApiError, apiRequest } from '@/lib/api-client';
+
+import { workoutSessionQueryKeys } from './use-workout-session';
+
+const sessionSetGroupSchema = z.object({
+  exerciseId: z.string(),
+  sets: z.array(sessionSetSchema),
+});
+
+const sessionSetGroupResponseSchema = z.object({
+  data: z.array(sessionSetGroupSchema),
+}) as unknown as z.ZodType<{
+  data: Array<{ exerciseId: string; sets: SessionSet[] }>;
+}>;
+
+type SyncableSetInput = z.input<typeof batchUpsertSetsSchema>['sets'][number];
+
+type SyncPayload = {
+  keepalive?: boolean;
+  sets: SyncableSetInput[];
+};
+
+type UseSyncSetsOptions = {
+  sessionId: string | null | undefined;
+  syncIntervalMs?: number;
+  syncOnChangeDebounceMs?: number;
+  onSessionInactive?: () => void;
+  onSyncError?: (error: Error) => void;
+};
+
+async function batchUpsertSessionSets(
+  sessionId: string,
+  input: SyncPayload,
+): Promise<Array<{ exerciseId: string; sets: SessionSet[] }>> {
+  const parsedInput = batchUpsertSetsSchema.parse({ sets: input.sets });
+  const data = await apiRequest<unknown>(`/api/v1/workout-sessions/${sessionId}/sets`, {
+    body: JSON.stringify(parsedInput),
+    keepalive: input.keepalive,
+    method: 'PUT',
+  });
+  const payload = sessionSetGroupResponseSchema.parse({ data });
+
+  return payload.data;
+}
+
+function getSetKey(set: SyncableSetInput) {
+  return set.id?.trim() ? `id:${set.id}` : `exercise:${set.exerciseId}:set:${set.setNumber}`;
+}
+
+export function useSyncSets(options: UseSyncSetsOptions) {
+  const queryClient = useQueryClient();
+  const normalizedSessionId = options.sessionId?.trim() ?? '';
+  const syncIntervalMs = options.syncIntervalMs ?? 30_000;
+  const syncOnChangeDebounceMs = options.syncOnChangeDebounceMs ?? 2_000;
+  const onSessionInactive = options.onSessionInactive;
+  const onSyncError = options.onSyncError;
+  const dirtySetsRef = useRef(new Map<string, SyncableSetInput>());
+  const syncTimeoutRef = useRef<number | null>(null);
+  const syncInFlightRef = useRef(false);
+
+  const syncMutation = useMutation({
+    mutationFn: async (payload: SyncPayload) => {
+      if (!normalizedSessionId) {
+        return [];
+      }
+
+      return batchUpsertSessionSets(normalizedSessionId, payload);
+    },
+    onSuccess: async () => {
+      if (!normalizedSessionId) {
+        return;
+      }
+
+      await queryClient.invalidateQueries({
+        queryKey: workoutSessionQueryKeys.detail(normalizedSessionId),
+      });
+    },
+  });
+
+  const flushDirtySets = useCallback(
+    async (input?: { keepalive?: boolean }) => {
+      if (!normalizedSessionId || syncInFlightRef.current) {
+        return;
+      }
+
+      if (dirtySetsRef.current.size === 0) {
+        return;
+      }
+
+      const pendingSets = [...dirtySetsRef.current.values()];
+      dirtySetsRef.current = new Map();
+      syncInFlightRef.current = true;
+
+      try {
+        await syncMutation.mutateAsync({
+          keepalive: input?.keepalive,
+          sets: pendingSets,
+        });
+      } catch (error) {
+        const typedError = error instanceof Error ? error : new Error('Failed to sync workout sets');
+
+        if (
+          error instanceof ApiError &&
+          error.status === 409 &&
+          error.code === 'WORKOUT_SESSION_NOT_ACTIVE'
+        ) {
+          onSessionInactive?.();
+          return;
+        }
+
+        for (const set of pendingSets) {
+          const setKey = getSetKey(set);
+          if (!dirtySetsRef.current.has(setKey)) {
+            dirtySetsRef.current.set(setKey, set);
+          }
+        }
+
+        onSyncError?.(typedError);
+      } finally {
+        syncInFlightRef.current = false;
+      }
+    },
+    [normalizedSessionId, onSessionInactive, onSyncError, syncMutation],
+  );
+
+  const scheduleSync = useCallback(() => {
+    if (!normalizedSessionId) {
+      return;
+    }
+
+    if (syncTimeoutRef.current !== null) {
+      window.clearTimeout(syncTimeoutRef.current);
+    }
+
+    syncTimeoutRef.current = window.setTimeout(() => {
+      syncTimeoutRef.current = null;
+      void flushDirtySets();
+    }, syncOnChangeDebounceMs);
+  }, [flushDirtySets, normalizedSessionId, syncOnChangeDebounceMs]);
+
+  const queueSetSync = useCallback(
+    (set: SyncableSetInput) => {
+      if (!normalizedSessionId) {
+        return;
+      }
+
+      const parsedSet = batchUpsertSetsSchema.parse({ sets: [set] }).sets[0];
+      dirtySetsRef.current.set(getSetKey(parsedSet), parsedSet);
+      scheduleSync();
+    },
+    [normalizedSessionId, scheduleSync],
+  );
+
+  useEffect(() => {
+    if (!normalizedSessionId) {
+      dirtySetsRef.current.clear();
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      void flushDirtySets();
+    }, syncIntervalMs);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [flushDirtySets, normalizedSessionId, syncIntervalMs]);
+
+  useEffect(() => {
+    if (!normalizedSessionId) {
+      return;
+    }
+
+    const handleBeforeUnload = () => {
+      if (dirtySetsRef.current.size === 0) {
+        return;
+      }
+
+      void flushDirtySets({ keepalive: true });
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [flushDirtySets, normalizedSessionId]);
+
+  useEffect(() => {
+    return () => {
+      if (syncTimeoutRef.current !== null) {
+        window.clearTimeout(syncTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    flushDirtySets,
+    isSyncing: syncMutation.isPending,
+    queueSetSync,
+  };
+}
+
+export type { SyncableSetInput, UseSyncSetsOptions };

--- a/apps/web/src/hooks/use-workout-session.test.tsx
+++ b/apps/web/src/hooks/use-workout-session.test.tsx
@@ -1,0 +1,95 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { useStartSession, useWorkoutSession, workoutSessionQueryKeys } from './use-workout-session';
+
+const mockFetch = vi.fn();
+
+const createJsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+
+const sessionResponse = {
+  id: 'session-1',
+  userId: 'user-1',
+  templateId: 'template-1',
+  name: 'Upper Push',
+  date: '2026-03-08',
+  status: 'in-progress' as const,
+  startedAt: 100,
+  completedAt: null,
+  duration: null,
+  feedback: null,
+  notes: null,
+  sets: [],
+  createdAt: 100,
+  updatedAt: 100,
+};
+
+describe('use-workout-session hooks', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  it('loads a workout session by id', async () => {
+    mockFetch.mockResolvedValueOnce(createJsonResponse(sessionResponse));
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useWorkoutSession('session-1'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.id).toBe('session-1');
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/workout-sessions/session-1', expect.any(Object));
+  });
+
+  it('starts a session and invalidates list/detail queries', async () => {
+    mockFetch.mockResolvedValueOnce(createJsonResponse(sessionResponse, 201));
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useStartSession(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        date: '2026-03-08',
+        name: 'Upper Push',
+        sets: [],
+        startedAt: 100,
+        templateId: 'template-1',
+      });
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/workout-sessions',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    );
+
+    const createRequest = mockFetch.mock.calls.find(
+      ([input, init]) => String(input) === '/api/v1/workout-sessions' && init?.method === 'POST',
+    );
+
+    expect(createRequest).toBeDefined();
+    expect(JSON.parse(String(createRequest?.[1]?.body))).toMatchObject({
+      date: '2026-03-08',
+      name: 'Upper Push',
+      templateId: 'template-1',
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutSessionQueryKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutSessionQueryKeys.detail('session-1'),
+    });
+  });
+});

--- a/apps/web/src/hooks/use-workout-session.test.tsx
+++ b/apps/web/src/hooks/use-workout-session.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { ACTIVE_WORKOUT_SESSION_STORAGE_KEY } from '@/features/workouts/lib/session-persistence';
 import { createQueryClientWrapper } from '@/test/query-client';
 
 import { useStartSession, useWorkoutSession, workoutSessionQueryKeys } from './use-workout-session';
@@ -36,6 +37,7 @@ describe('use-workout-session hooks', () => {
   beforeEach(() => {
     mockFetch.mockReset();
     vi.stubGlobal('fetch', mockFetch);
+    window.localStorage.removeItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY);
   });
 
   it('loads a workout session by id', async () => {
@@ -91,5 +93,6 @@ describe('use-workout-session hooks', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: workoutSessionQueryKeys.detail('session-1'),
     });
+    expect(window.localStorage.getItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY)).toBe('session-1');
   });
 });

--- a/apps/web/src/hooks/use-workout-session.ts
+++ b/apps/web/src/hooks/use-workout-session.ts
@@ -1,0 +1,68 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createWorkoutSessionInputSchema,
+  type WorkoutSession,
+  workoutSessionSchema,
+} from '@pulse/shared';
+import { z } from 'zod';
+
+import { apiRequest } from '@/lib/api-client';
+
+const workoutSessionResponseSchema = z.object({
+  data: workoutSessionSchema,
+}) as unknown as z.ZodType<{ data: WorkoutSession }>;
+
+type CreateWorkoutSessionRequest = z.input<typeof createWorkoutSessionInputSchema>;
+
+export const workoutSessionQueryKeys = {
+  all: ['workout-sessions'] as const,
+  detail: (sessionId: string) => ['workout-sessions', sessionId] as const,
+};
+
+async function getWorkoutSession(sessionId: string) {
+  const data = await apiRequest<unknown>(`/api/v1/workout-sessions/${sessionId}`);
+  const payload = workoutSessionResponseSchema.parse({ data });
+
+  return payload.data;
+}
+
+async function startSession(input: CreateWorkoutSessionRequest) {
+  const parsedInput = createWorkoutSessionInputSchema.parse(input);
+  const data = await apiRequest<unknown>('/api/v1/workout-sessions', {
+    body: JSON.stringify(parsedInput),
+    method: 'POST',
+  });
+  const payload = workoutSessionResponseSchema.parse({ data });
+
+  return payload.data;
+}
+
+export function useWorkoutSession(sessionId: string | null | undefined) {
+  const normalizedSessionId = sessionId?.trim() ?? '';
+
+  return useQuery<WorkoutSession>({
+    enabled: normalizedSessionId.length > 0,
+    queryFn: () => getWorkoutSession(normalizedSessionId),
+    queryKey: workoutSessionQueryKeys.detail(normalizedSessionId),
+  });
+}
+
+export function useStartSession() {
+  const queryClient = useQueryClient();
+
+  return useMutation<WorkoutSession, Error, CreateWorkoutSessionRequest>({
+    mutationFn: startSession,
+    onSuccess: async (session) => {
+      queryClient.setQueryData(workoutSessionQueryKeys.detail(session.id), session);
+
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: workoutSessionQueryKeys.all,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutSessionQueryKeys.detail(session.id),
+        }),
+      ]);
+    },
+  });
+}

--- a/apps/web/src/hooks/use-workout-session.ts
+++ b/apps/web/src/hooks/use-workout-session.ts
@@ -6,6 +6,7 @@ import {
 } from '@pulse/shared';
 import { z } from 'zod';
 
+import { setStoredActiveWorkoutSessionId } from '@/features/workouts/lib/session-persistence';
 import { apiRequest } from '@/lib/api-client';
 
 const workoutSessionResponseSchema = z.object({
@@ -53,6 +54,7 @@ export function useStartSession() {
   return useMutation<WorkoutSession, Error, CreateWorkoutSessionRequest>({
     mutationFn: startSession,
     onSuccess: async (session) => {
+      setStoredActiveWorkoutSessionId(session.id);
       queryClient.setQueryData(workoutSessionQueryKeys.detail(session.id), session);
 
       await Promise.all([

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -1,6 +1,8 @@
-import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, screen, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithQueryClient } from '@/test/render-with-query-client';
 
 import { ActiveWorkoutPage } from './active-workout';
 
@@ -157,7 +159,7 @@ describe('ActiveWorkoutPage', () => {
 });
 
 function renderActiveWorkoutPage(initialEntry = '/workouts/active') {
-  return render(
+  return renderWithQueryClient(
     <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
         <Route element={<ActiveWorkoutPage />} path="/workouts/active" />

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -2,7 +2,9 @@ import { act, fireEvent, screen, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
 import { renderWithQueryClient } from '@/test/render-with-query-client';
+import { jsonResponse } from '@/test/test-utils';
 
 import { ActiveWorkoutPage } from './active-workout';
 
@@ -14,6 +16,9 @@ describe('ActiveWorkoutPage', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
   });
 
   it('renders the active workout UI and advances focus after the rest timer completes', () => {
@@ -155,6 +160,62 @@ describe('ActiveWorkoutPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /Post-Workout Supplemental/i }));
     expect(screen.getByText('Dead Bug Breathing')).toBeInTheDocument();
     expect(screen.getByText('Reverse Sled Drag')).toBeInTheDocument();
+  });
+
+  it('loads API templates for UUID template ids instead of falling back to mock defaults', async () => {
+    vi.useRealTimers();
+
+    const apiTemplateId = '2679a7dd-4a40-4c3e-8bf6-7a70eb4ab5db';
+    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        jsonResponse({
+          data: {
+            id: apiTemplateId,
+            userId: 'user-1',
+            name: 'API Full Body',
+            description: 'Loaded from API',
+            tags: ['strength'],
+            sections: [
+              {
+                type: 'warmup',
+                exercises: [],
+              },
+              {
+                type: 'main',
+                exercises: [
+                  {
+                    id: 'template-exercise-1',
+                    exerciseId: 'incline-dumbbell-press',
+                    exerciseName: 'Incline Dumbbell Press',
+                    sets: 3,
+                    repsMin: 8,
+                    repsMax: 10,
+                    tempo: '3110',
+                    restSeconds: 90,
+                    supersetGroup: null,
+                    notes: null,
+                    cues: ['Drive feet into the floor'],
+                  },
+                ],
+              },
+              {
+                type: 'cooldown',
+                exercises: [],
+              },
+            ],
+            createdAt: 100,
+            updatedAt: 100,
+          },
+        }),
+      ),
+    );
+    vi.stubGlobal('fetch', mockFetch);
+
+    renderActiveWorkoutPage(`/workouts/active?template=${apiTemplateId}`);
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'API Full Body' })).toBeVisible();
+    expect(screen.getByText('Exercise 1 of 1')).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 
 import type { SessionSet, WorkoutSessionFeedback } from '@pulse/shared';
@@ -23,7 +23,15 @@ import {
 } from '@/features/workouts';
 import { useCompleteSession } from '@/hooks/use-complete-session';
 import { useLogSet, useUpdateSet } from '@/hooks/use-session-sets';
+import { useSyncSets } from '@/hooks/use-sync-sets';
 import { useWorkoutSession } from '@/hooks/use-workout-session';
+import {
+  WORKOUT_SESSION_COMPLETED_NOTICE,
+  WORKOUT_SESSION_NOTICE_QUERY_KEY,
+  clearStoredActiveWorkoutSessionId,
+  setStoredActiveWorkoutSessionId,
+} from '@/features/workouts/lib/session-persistence';
+import { ApiError } from '@/lib/api-client';
 import {
   mockTemplates,
   type WorkoutTemplate as MockWorkoutTemplate,
@@ -92,6 +100,20 @@ export function ActiveWorkoutPage() {
   const startTime = activeSession
     ? new Date(activeSession.startedAt).toISOString()
     : fallbackStartTime;
+  const redirectToCompletedSessionNotice = useCallback(() => {
+    clearStoredActiveWorkoutSessionId();
+    navigate(`/workouts?${WORKOUT_SESSION_NOTICE_QUERY_KEY}=${WORKOUT_SESSION_COMPLETED_NOTICE}`, {
+      replace: true,
+    });
+  }, [navigate]);
+
+  const syncSets = useSyncSets({
+    sessionId: activeSessionId,
+    onSessionInactive: redirectToCompletedSessionNotice,
+    onSyncError: () => {
+      setSessionError('Unable to sync set update. Try again.');
+    },
+  });
 
   const templateExerciseById = useMemo(
     () =>
@@ -121,6 +143,23 @@ export function ActiveWorkoutPage() {
     setSetDrafts(createSessionSetDrafts(template, activeSession.sets));
     hydratedSessionIdRef.current = activeSession.id;
   }, [activeSession, template]);
+
+  useEffect(() => {
+    if (!activeSession || !sessionId) {
+      return;
+    }
+
+    if (activeSession.status === 'in-progress') {
+      setStoredActiveWorkoutSessionId(activeSession.id);
+      return;
+    }
+
+    clearStoredActiveWorkoutSessionId();
+
+    if (activeSession.status === 'completed' && stage === 'active') {
+      redirectToCompletedSessionNotice();
+    }
+  }, [activeSession, redirectToCompletedSessionNotice, sessionId, stage]);
 
   const session = useMemo(
     () =>
@@ -232,7 +271,12 @@ export function ActiveWorkoutPage() {
                 notes,
               },
               {
-                onError: () => {
+                onError: (error) => {
+                  if (isSessionNotActiveError(error)) {
+                    redirectToCompletedSessionNotice();
+                    return;
+                  }
+
                   setSessionError('Unable to complete this workout. Try again.');
                 },
                 onSuccess: () => {
@@ -283,7 +327,12 @@ export function ActiveWorkoutPage() {
           weight: null,
         },
         {
-          onError: () => {
+          onError: (error) => {
+            if (isSessionNotActiveError(error)) {
+              redirectToCompletedSessionNotice();
+              return;
+            }
+
             setSessionError('Unable to add set. Try again.');
           },
           onSuccess: (createdSet) => {
@@ -364,11 +413,25 @@ export function ActiveWorkoutPage() {
           update,
         },
         {
-          onError: () => {
+          onError: (error) => {
+            if (isSessionNotActiveError(error)) {
+              redirectToCompletedSessionNotice();
+              return;
+            }
+
             setSessionError('Unable to sync set update. Try again.');
           },
         },
       );
+
+      syncSets.queueSetSync({
+        id: setId,
+        exerciseId,
+        reps: updatedSet.reps,
+        section: templateExercise.section,
+        setNumber: updatedSet.number,
+        weight: updatedSet.weight,
+      });
     }
 
     if (update.completed === false) {
@@ -519,6 +582,14 @@ function extractFeedbackNotes(draft: ActiveWorkoutFeedbackDraft) {
   );
 
   return scaleFieldWithNotes?.notes?.trim() ?? null;
+}
+
+function isSessionNotActiveError(error: unknown) {
+  return (
+    error instanceof ApiError &&
+    error.status === 409 &&
+    error.code === 'WORKOUT_SESSION_NOT_ACTIVE'
+  );
 }
 
 function findNextPendingSetId(session: ReturnType<typeof buildActiveWorkoutSession>) {

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -1,5 +1,7 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
+
+import type { SessionSet, WorkoutSessionFeedback } from '@pulse/shared';
 
 import {
   SessionContext,
@@ -19,7 +21,13 @@ import {
   type ActiveWorkoutFeedbackDraft,
   type ActiveWorkoutSetDrafts,
 } from '@/features/workouts';
-import { mockTemplates } from '@/lib/mock-data/workouts';
+import { useCompleteSession } from '@/hooks/use-complete-session';
+import { useLogSet, useUpdateSet } from '@/hooks/use-session-sets';
+import { useWorkoutSession } from '@/hooks/use-workout-session';
+import {
+  mockTemplates,
+  type WorkoutTemplate as MockWorkoutTemplate,
+} from '@/lib/mock-data/workouts';
 
 const defaultTemplate =
   mockTemplates.find((template) => template.id === 'upper-push') ??
@@ -45,15 +53,25 @@ type RestTimerState = {
 export function ActiveWorkoutPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const sessionId = searchParams.get('sessionId');
+  const requestedTemplateId = searchParams.get('template');
+  const sessionQuery = useWorkoutSession(sessionId);
+  const logSetMutation = useLogSet(sessionId);
+  const updateSetMutation = useUpdateSet(sessionId);
+  const completeSessionMutation = useCompleteSession(sessionId);
+
   const selectedTemplate = mockTemplates.find(
-    (template) => template.id === searchParams.get('template'),
+    (template) => template.id === (requestedTemplateId ?? sessionQuery.data?.templateId),
   );
   const template = selectedTemplate ?? defaultTemplate;
-  const [startTime] = useState(() => new Date(Date.now() - 16 * 60_000 - 23_000).toISOString());
+
+  const [fallbackStartTime] = useState(() =>
+    new Date(Date.now() - 16 * 60_000 - 23_000).toISOString(),
+  );
   const [setDrafts, setSetDrafts] = useState<ActiveWorkoutSetDrafts>(() =>
     createInitialWorkoutSetDrafts(
       template,
-      selectedTemplate ? new Set<string>() : new Set(completedSetIds),
+      requestedTemplateId || sessionId ? new Set<string>() : new Set(completedSetIds),
     ),
   );
   const [exerciseNotes, setExerciseNotes] = useState<Record<string, string>>({});
@@ -63,19 +81,47 @@ export function ActiveWorkoutPage() {
   const [restTimer, setRestTimer] = useState<RestTimerState | null>(null);
   const [restTimerTargetSetId, setRestTimerTargetSetId] = useState<string | null>(null);
   const [focusSetId, setFocusSetId] = useState<string | null>(null);
+  const [sessionError, setSessionError] = useState<string | null>(null);
   const [supplementalChecks, setSupplementalChecks] = useState<Record<string, boolean>>({});
   const restTimerTokenRef = useRef(0);
+  const hydratedSessionIdRef = useRef<string | null>(null);
   const supplementalExercises = workoutSupplementalExercises;
+
+  const activeSession = sessionQuery.data;
+  const activeSessionId = activeSession?.id ?? null;
+  const startTime = activeSession
+    ? new Date(activeSession.startedAt).toISOString()
+    : fallbackStartTime;
 
   const templateExerciseById = useMemo(
     () =>
       new Map(
         template.sections.flatMap((section) =>
-          section.exercises.map((exercise) => [exercise.exerciseId, exercise]),
+          section.exercises.map((exercise) => [
+            exercise.exerciseId,
+            {
+              exercise,
+              section: section.type,
+            },
+          ]),
         ),
       ),
     [template],
   );
+
+  useEffect(() => {
+    if (!activeSession) {
+      return;
+    }
+
+    if (hydratedSessionIdRef.current === activeSession.id) {
+      return;
+    }
+
+    setSetDrafts(createSessionSetDrafts(template, activeSession.sets));
+    hydratedSessionIdRef.current = activeSession.id;
+  }, [activeSession, template]);
+
   const session = useMemo(
     () =>
       buildActiveWorkoutSession(template, setDrafts, {
@@ -89,8 +135,28 @@ export function ActiveWorkoutPage() {
     ? formatElapsedTime(getElapsedSeconds(startTime, new Date(sessionCompletedAt).getTime()))
     : formatElapsedTime(getElapsedSeconds(startTime, Date.now()));
 
+  if (sessionId && sessionQuery.isPending) {
+    return (
+      <section className="space-y-3 pb-8">
+        <h1 className="text-2xl font-semibold text-foreground">Loading active session</h1>
+        <p className="text-sm text-muted">Fetching workout session details...</p>
+      </section>
+    );
+  }
+
+  if (sessionId && sessionQuery.isError) {
+    return (
+      <section className="space-y-3 pb-8">
+        <h1 className="text-2xl font-semibold text-foreground">Unable to load session</h1>
+        <p className="text-sm text-muted">Refresh and try again.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="space-y-5 pb-8">
+      {sessionError ? <p className="text-sm text-destructive">{sessionError}</p> : null}
+
       {stage === 'active' ? (
         <>
           <SessionHeader
@@ -138,8 +204,44 @@ export function ActiveWorkoutPage() {
         <SessionFeedback
           fields={workoutFeedbackFields}
           onSubmit={(feedback) => {
-            setSessionFeedback(feedback);
-            setStage('summary');
+            if (completeSessionMutation.isPending) {
+              return;
+            }
+
+            const completedAt = Date.now();
+            const completedAtIso = new Date(completedAt).toISOString();
+            const duration = Math.floor(getElapsedSeconds(startTime, completedAt) / 60);
+            const notes = extractFeedbackNotes(feedback);
+
+            if (!activeSessionId) {
+              setSessionFeedback(feedback);
+              setSessionCompletedAt(completedAtIso);
+              setStage('summary');
+              return;
+            }
+
+            setSessionError(null);
+            completeSessionMutation.mutate(
+              {
+                completedAt,
+                duration,
+                feedback: {
+                  ...mapFeedbackDraftToSessionFeedback(feedback),
+                  notes: notes ?? undefined,
+                },
+                notes,
+              },
+              {
+                onError: () => {
+                  setSessionError('Unable to complete this workout. Try again.');
+                },
+                onSuccess: () => {
+                  setSessionFeedback(feedback);
+                  setSessionCompletedAt(completedAtIso);
+                  setStage('summary');
+                },
+              },
+            );
           }}
         />
       ) : null}
@@ -168,12 +270,57 @@ export function ActiveWorkoutPage() {
     }
 
     const exerciseSets = setDrafts[exerciseId] ?? [];
-    const nextSet = createWorkoutSetDraft(templateExercise, exerciseSets.length + 1);
+    const nextSetNumber = exerciseSets.length + 1;
 
-    setSetDrafts({
-      ...setDrafts,
-      [exerciseId]: [...exerciseSets, nextSet],
-    });
+    if (activeSessionId) {
+      setSessionError(null);
+      logSetMutation.mutate(
+        {
+          exerciseId,
+          reps: null,
+          section: templateExercise.section,
+          setNumber: nextSetNumber,
+          weight: null,
+        },
+        {
+          onError: () => {
+            setSessionError('Unable to add set. Try again.');
+          },
+          onSuccess: (createdSet) => {
+            setSetDrafts((current) => {
+              const currentExerciseSets = current[exerciseId] ?? [];
+
+              return {
+                ...current,
+                [exerciseId]: [
+                  ...currentExerciseSets,
+                  {
+                    completed: createdSet.completed,
+                    id: createdSet.id,
+                    number: createdSet.setNumber,
+                    reps: createdSet.reps,
+                    weight: createdSet.weight,
+                  },
+                ].sort((left, right) => left.number - right.number),
+              };
+            });
+
+            setRestTimer(null);
+            setRestTimerTargetSetId(null);
+            setFocusSetId(createdSet.id);
+          },
+        },
+      );
+
+      return;
+    }
+
+    const nextSet = createWorkoutSetDraft(templateExercise.exercise, nextSetNumber);
+
+    setSetDrafts((current) => ({
+      ...current,
+      [exerciseId]: [...(current[exerciseId] ?? []), nextSet],
+    }));
 
     setRestTimer(null);
     setRestTimerTargetSetId(null);
@@ -207,6 +354,21 @@ export function ActiveWorkoutPage() {
 
     if (!previousSet || !updatedSet || !templateExercise) {
       return;
+    }
+
+    if (activeSessionId) {
+      setSessionError(null);
+      updateSetMutation.mutate(
+        {
+          setId,
+          update,
+        },
+        {
+          onError: () => {
+            setSessionError('Unable to sync set update. Try again.');
+          },
+        },
+      );
     }
 
     if (update.completed === false) {
@@ -245,7 +407,7 @@ export function ActiveWorkoutPage() {
 
     restTimerTokenRef.current += 1;
     setRestTimer({
-      duration: templateExercise.restSeconds,
+      duration: templateExercise.exercise.restSeconds,
       exerciseName:
         updatedSession.sections
           .flatMap((section) => section.exercises)
@@ -262,6 +424,101 @@ export function ActiveWorkoutPage() {
     setFocusSetId(restTimerTargetSetId);
     setRestTimerTargetSetId(null);
   }
+}
+
+function createSessionSetDrafts(template: MockWorkoutTemplate, sessionSets: SessionSet[]) {
+  const drafts = createInitialWorkoutSetDrafts(template, new Set<string>());
+
+  for (const sessionSet of sessionSets) {
+    const nextSet = {
+      completed: sessionSet.completed,
+      id: sessionSet.id,
+      number: sessionSet.setNumber,
+      reps: sessionSet.reps,
+      weight: sessionSet.weight,
+    };
+    const existingSets = drafts[sessionSet.exerciseId] ?? [];
+    const existingSetIndex = existingSets.findIndex((set) => set.number === sessionSet.setNumber);
+
+    if (existingSetIndex === -1) {
+      drafts[sessionSet.exerciseId] = [...existingSets, nextSet].sort(
+        (left, right) => left.number - right.number,
+      );
+      continue;
+    }
+
+    const nextExerciseSets = [...existingSets];
+    nextExerciseSets[existingSetIndex] = nextSet;
+    drafts[sessionSet.exerciseId] = nextExerciseSets;
+  }
+
+  return drafts;
+}
+
+function mapFeedbackDraftToSessionFeedback(draft: ActiveWorkoutFeedbackDraft): WorkoutSessionFeedback {
+  const scaleEntries = draft.filter(
+    (
+      field,
+    ): field is Extract<ActiveWorkoutFeedbackDraft[number], { type: 'scale'; value?: number | null }> =>
+      field.type === 'scale',
+  );
+
+  return {
+    energy: toFeedbackScore(
+      scaleEntries.find((field) => field.id.toLowerCase().includes('energy'))?.value ??
+        scaleEntries.at(2)?.value ??
+        scaleEntries.at(0)?.value,
+    ),
+    recovery: toFeedbackScore(
+      scaleEntries.find((field) => field.id.toLowerCase().includes('recovery'))?.value ??
+        scaleEntries.at(0)?.value,
+    ),
+    technique: toFeedbackScore(
+      scaleEntries.find((field) => field.id.toLowerCase().includes('technique'))?.value ??
+        scaleEntries.at(1)?.value ??
+        scaleEntries.at(0)?.value,
+    ),
+  };
+}
+
+function toFeedbackScore(value: number | null | undefined): 1 | 2 | 3 | 4 | 5 {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return 3;
+  }
+
+  const rounded = Math.round(value);
+
+  if (rounded <= 1) {
+    return 1;
+  }
+
+  if (rounded >= 5) {
+    return 5;
+  }
+
+  return rounded as 1 | 2 | 3 | 4 | 5;
+}
+
+function extractFeedbackNotes(draft: ActiveWorkoutFeedbackDraft) {
+  const textField = draft.find(
+    (
+      field,
+    ): field is Extract<ActiveWorkoutFeedbackDraft[number], { type: 'text'; value?: string }> =>
+      field.type === 'text' && (field.value ?? '').trim().length > 0,
+  );
+
+  if (textField) {
+    return textField.value?.trim() ?? null;
+  }
+
+  const scaleFieldWithNotes = draft.find(
+    (
+      field,
+    ): field is Extract<ActiveWorkoutFeedbackDraft[number], { type: 'scale'; notes?: string }> =>
+      field.type === 'scale' && (field.notes ?? '').trim().length > 0,
+  );
+
+  return scaleFieldWithNotes?.notes?.trim() ?? null;
 }
 
 function findNextPendingSetId(session: ReturnType<typeof buildActiveWorkoutSession>) {

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -211,6 +211,7 @@ export function ActiveWorkoutPage() {
           <SessionContext context={workoutSessionContext} />
 
           <SessionExerciseList
+            enableApiLastPerformance={Boolean(activeSessionId)}
             focusSetId={focusSetId}
             onAddSet={handleAddSet}
             onExerciseNotesChange={(exerciseId, notes) =>
@@ -298,6 +299,7 @@ export function ActiveWorkoutPage() {
           exercisesCompleted={session.totalExercises}
           feedback={sessionFeedback}
           onDone={() => navigate('/workouts')}
+          sessionId={activeSessionId}
           totalReps={totalCompletedReps}
           totalSets={session.completedSets}
           workoutName={session.workoutName}

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 
-import type { SessionSet, WorkoutSessionFeedback } from '@pulse/shared';
+import type {
+  SessionSet,
+  WorkoutSessionFeedback,
+  WorkoutTemplate as ApiWorkoutTemplate,
+  WorkoutTemplateSectionType,
+} from '@pulse/shared';
 
 import {
   SessionContext,
@@ -21,9 +26,9 @@ import {
   type ActiveWorkoutFeedbackDraft,
   type ActiveWorkoutSetDrafts,
 } from '@/features/workouts';
+import { useWorkoutTemplate } from '@/features/workouts/api/workouts';
 import { useCompleteSession } from '@/hooks/use-complete-session';
 import { useLogSet, useUpdateSet } from '@/hooks/use-session-sets';
-import { useSyncSets } from '@/hooks/use-sync-sets';
 import { useWorkoutSession } from '@/hooks/use-workout-session';
 import {
   WORKOUT_SESSION_COMPLETED_NOTICE,
@@ -33,15 +38,29 @@ import {
 } from '@/features/workouts/lib/session-persistence';
 import { ApiError } from '@/lib/api-client';
 import {
+  mockExercises,
   mockTemplates,
+  type WorkoutBadgeType as MockWorkoutBadgeType,
   type WorkoutTemplate as MockWorkoutTemplate,
 } from '@/lib/mock-data/workouts';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 const defaultTemplate =
   mockTemplates.find((template) => template.id === 'upper-push') ??
   (() => {
     throw new Error('Expected upper-push template in mock data.');
   })();
+
+const sectionTitleByType: Record<WorkoutTemplateSectionType, string> = {
+  warmup: 'Warmup',
+  main: 'Main',
+  cooldown: 'Cooldown',
+};
+
+const categoryBadgeByExerciseId = new Map(
+  mockExercises.map((exercise) => [exercise.id, exercise.category as MockWorkoutBadgeType]),
+);
 
 const completedSetIds = [
   createWorkoutSetId('row-erg', 1),
@@ -67,11 +86,16 @@ export function ActiveWorkoutPage() {
   const logSetMutation = useLogSet(sessionId);
   const updateSetMutation = useUpdateSet(sessionId);
   const completeSessionMutation = useCompleteSession(sessionId);
+  const resolvedTemplateId = requestedTemplateId ?? sessionQuery.data?.templateId ?? '';
+  const shouldLoadApiTemplate = UUID_PATTERN.test(resolvedTemplateId);
+  const templateQuery = useWorkoutTemplate(shouldLoadApiTemplate ? resolvedTemplateId : '');
 
-  const selectedTemplate = mockTemplates.find(
-    (template) => template.id === (requestedTemplateId ?? sessionQuery.data?.templateId),
+  const selectedMockTemplate = mockTemplates.find((template) => template.id === resolvedTemplateId);
+  const apiTemplate = useMemo(
+    () => (templateQuery.data ? toMockWorkoutTemplate(templateQuery.data) : null),
+    [templateQuery.data],
   );
-  const template = selectedTemplate ?? defaultTemplate;
+  const template = apiTemplate ?? selectedMockTemplate ?? defaultTemplate;
 
   const [fallbackStartTime] = useState(() =>
     new Date(Date.now() - 16 * 60_000 - 23_000).toISOString(),
@@ -107,14 +131,6 @@ export function ActiveWorkoutPage() {
     });
   }, [navigate]);
 
-  const syncSets = useSyncSets({
-    sessionId: activeSessionId,
-    onSessionInactive: redirectToCompletedSessionNotice,
-    onSyncError: () => {
-      setSessionError('Unable to sync set update. Try again.');
-    },
-  });
-
   const templateExerciseById = useMemo(
     () =>
       new Map(
@@ -143,6 +159,19 @@ export function ActiveWorkoutPage() {
     setSetDrafts(createSessionSetDrafts(template, activeSession.sets));
     hydratedSessionIdRef.current = activeSession.id;
   }, [activeSession, template]);
+
+  useEffect(() => {
+    if (activeSession) {
+      return;
+    }
+
+    setSetDrafts(
+      createInitialWorkoutSetDrafts(
+        template,
+        requestedTemplateId || sessionId ? new Set<string>() : new Set(completedSetIds),
+      ),
+    );
+  }, [activeSession, requestedTemplateId, sessionId, template]);
 
   useEffect(() => {
     if (!activeSession || !sessionId) {
@@ -183,10 +212,28 @@ export function ActiveWorkoutPage() {
     );
   }
 
+  if (shouldLoadApiTemplate && templateQuery.isPending) {
+    return (
+      <section className="space-y-3 pb-8">
+        <h1 className="text-2xl font-semibold text-foreground">Loading workout template</h1>
+        <p className="text-sm text-muted">Fetching template details...</p>
+      </section>
+    );
+  }
+
   if (sessionId && sessionQuery.isError) {
     return (
       <section className="space-y-3 pb-8">
         <h1 className="text-2xl font-semibold text-foreground">Unable to load session</h1>
+        <p className="text-sm text-muted">Refresh and try again.</p>
+      </section>
+    );
+  }
+
+  if (shouldLoadApiTemplate && templateQuery.isError) {
+    return (
+      <section className="space-y-3 pb-8">
+        <h1 className="text-2xl font-semibold text-foreground">Unable to load template</h1>
         <p className="text-sm text-muted">Refresh and try again.</p>
       </section>
     );
@@ -425,15 +472,6 @@ export function ActiveWorkoutPage() {
           },
         },
       );
-
-      syncSets.queueSetSync({
-        id: setId,
-        exerciseId,
-        reps: updatedSet.reps,
-        section: templateExercise.section,
-        setNumber: updatedSet.number,
-        weight: updatedSet.weight,
-      });
     }
 
     if (update.completed === false) {
@@ -620,4 +658,47 @@ function formatElapsedTime(totalSeconds: number) {
   const seconds = totalSeconds % 60;
 
   return `${`${minutes}`.padStart(2, '0')}:${`${seconds}`.padStart(2, '0')}`;
+}
+
+function toMockWorkoutTemplate(template: ApiWorkoutTemplate): MockWorkoutTemplate {
+  return {
+    id: template.id,
+    name: template.name,
+    description: template.description ?? '',
+    tags: template.tags,
+    sections: template.sections.map((section) => ({
+      type: section.type,
+      title: sectionTitleByType[section.type],
+      exercises: section.exercises.map((exercise) => ({
+        exerciseId: exercise.exerciseId,
+        sets: exercise.sets ?? 1,
+        reps: formatTemplateExerciseReps(exercise.repsMin, exercise.repsMax),
+        tempo: exercise.tempo ?? '2111',
+        restSeconds: exercise.restSeconds ?? 60,
+        formCues: exercise.cues,
+        badges: getDefaultExerciseBadges(exercise.exerciseId),
+      })),
+    })),
+  };
+}
+
+function formatTemplateExerciseReps(repsMin: number | null, repsMax: number | null) {
+  if (repsMin !== null && repsMax !== null) {
+    return repsMin === repsMax ? String(repsMin) : `${repsMin}-${repsMax}`;
+  }
+
+  if (repsMin !== null) {
+    return String(repsMin);
+  }
+
+  if (repsMax !== null) {
+    return String(repsMax);
+  }
+
+  return '';
+}
+
+function getDefaultExerciseBadges(exerciseId: string): MockWorkoutBadgeType[] {
+  const categoryBadge = categoryBadgeByExerciseId.get(exerciseId);
+  return categoryBadge ? [categoryBadge] : [];
 }

--- a/apps/web/src/pages/workouts.test.tsx
+++ b/apps/web/src/pages/workouts.test.tsx
@@ -3,6 +3,10 @@ import { MemoryRouter, Route, Routes, useParams } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
+import {
+  WORKOUT_SESSION_COMPLETED_NOTICE,
+  WORKOUT_SESSION_NOTICE_QUERY_KEY,
+} from '@/features/workouts/lib/session-persistence';
 import { renderWithQueryClient } from '@/test/render-with-query-client';
 import { jsonResponse } from '@/test/test-utils';
 import { WorkoutsPage } from './workouts';
@@ -120,6 +124,20 @@ describe('WorkoutsPage', () => {
 
     expect(screen.getByRole('link', { name: 'Upper Push' })).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Lower Quad-Dominant' })).not.toBeInTheDocument();
+  });
+
+  it('shows a completion notice when redirected from an already-completed active session', () => {
+    renderWithQueryClient(
+      <MemoryRouter
+        initialEntries={[`/workouts?${WORKOUT_SESSION_NOTICE_QUERY_KEY}=${WORKOUT_SESSION_COMPLETED_NOTICE}`]}
+      >
+        <Routes>
+          <Route element={<WorkoutsPage />} path="/workouts" />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Session was completed on another device.')).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/pages/workouts.tsx
+++ b/apps/web/src/pages/workouts.tsx
@@ -1,6 +1,11 @@
 import { useState } from 'react';
+import { useSearchParams } from 'react-router';
 
 import { Button } from '@/components/ui/button';
+import {
+  WORKOUT_SESSION_COMPLETED_NOTICE,
+  WORKOUT_SESSION_NOTICE_QUERY_KEY,
+} from '@/features/workouts/lib/session-persistence';
 import {
   ExerciseLibrary,
   TemplateBrowser,
@@ -13,7 +18,10 @@ export function WorkoutsPage() {
   const [activeView, setActiveView] = useState<'calendar' | 'list' | 'templates' | 'exercises'>(
     'calendar',
   );
+  const [searchParams] = useSearchParams();
   const templatesQuery = useWorkoutTemplates();
+  const showCompletedSessionNotice =
+    searchParams.get(WORKOUT_SESSION_NOTICE_QUERY_KEY) === WORKOUT_SESSION_COMPLETED_NOTICE;
 
   return (
     <section className="space-y-6">
@@ -24,6 +32,12 @@ export function WorkoutsPage() {
           shared exercise library.
         </p>
       </div>
+
+      {showCompletedSessionNotice ? (
+        <p className="rounded-2xl border border-border bg-card px-4 py-3 text-sm text-foreground">
+          Session was completed on another device.
+        </p>
+      ) : null}
 
       <div
         aria-label="Workout views"

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -15,6 +15,7 @@ export * from './schemas/nutrition.js';
 export * from './schemas/nutrition-targets.js';
 export * from './schemas/resources.js';
 export * from './schemas/scheduled-workouts.js';
+export * from './schemas/session-set.js';
 export * from './schemas/weight.js';
 export * from './schemas/workout-sessions.js';
 export * from './schemas/workout-templates.js';

--- a/packages/shared/src/schemas/exercises.test.ts
+++ b/packages/shared/src/schemas/exercises.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from 'vitest';
 
 import {
   createExerciseInputSchema,
+  exerciseLastPerformanceSchema,
   exerciseQueryParamsSchema,
   exerciseSchema,
   type CreateExerciseInput,
   type Exercise,
   type ExerciseCategory,
+  type ExerciseLastPerformance,
   type ExerciseQueryParams,
   type UpdateExerciseInput,
   updateExerciseInputSchema,
@@ -156,5 +158,59 @@ describe('exerciseQueryParamsSchema', () => {
     };
 
     expect(payload.limit).toBe(10);
+  });
+});
+
+describe('exerciseLastPerformanceSchema', () => {
+  it('parses latest exercise performance payload', () => {
+    const payload: ExerciseLastPerformance = exerciseLastPerformanceSchema.parse({
+      sessionId: 'session-22',
+      date: '2026-03-08',
+      sets: [
+        {
+          setNumber: 1,
+          reps: 10,
+          weight: 60,
+        },
+        {
+          setNumber: 2,
+          reps: 8,
+          weight: null,
+        },
+      ],
+    });
+
+    expect(payload).toEqual({
+      sessionId: 'session-22',
+      date: '2026-03-08',
+      sets: [
+        {
+          setNumber: 1,
+          reps: 10,
+          weight: 60,
+        },
+        {
+          setNumber: 2,
+          reps: 8,
+          weight: null,
+        },
+      ],
+    });
+  });
+
+  it('rejects invalid set ordering fields', () => {
+    expect(() =>
+      exerciseLastPerformanceSchema.parse({
+        sessionId: 'session-22',
+        date: '2026-03-08',
+        sets: [
+          {
+            setNumber: 0,
+            reps: 8,
+            weight: 50,
+          },
+        ],
+      }),
+    ).toThrow();
   });
 });

--- a/packages/shared/src/schemas/exercises.ts
+++ b/packages/shared/src/schemas/exercises.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { dateSchema } from './common.js';
+
 const normalizeOptionalString = (value: unknown) => {
   if (typeof value !== 'string') {
     return value;
@@ -74,8 +76,22 @@ export const exerciseQueryParamsSchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(20),
 });
 
+export const exerciseLastPerformanceSetSchema = z.object({
+  setNumber: z.number().int().min(1),
+  weight: z.number().min(0).nullable(),
+  reps: z.number().int().min(0).nullable(),
+});
+
+export const exerciseLastPerformanceSchema = z.object({
+  sessionId: z.string(),
+  date: dateSchema,
+  sets: z.array(exerciseLastPerformanceSetSchema).max(100),
+});
+
 export type ExerciseCategory = z.infer<typeof exerciseCategorySchema>;
 export type Exercise = z.infer<typeof exerciseSchema>;
 export type CreateExerciseInput = z.infer<typeof createExerciseInputSchema>;
 export type UpdateExerciseInput = z.infer<typeof updateExerciseInputSchema>;
 export type ExerciseQueryParams = z.infer<typeof exerciseQueryParamsSchema>;
+export type ExerciseLastPerformance = z.infer<typeof exerciseLastPerformanceSchema>;
+export type ExerciseLastPerformanceSet = z.infer<typeof exerciseLastPerformanceSetSchema>;

--- a/packages/shared/src/schemas/session-set.test.ts
+++ b/packages/shared/src/schemas/session-set.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  batchUpsertSetsSchema,
+  createSetSchema,
+  type CreateSetInput,
+  type UpdateSetInput,
+  updateSetSchema,
+} from './session-set';
+
+describe('createSetSchema', () => {
+  it('parses valid create input and applies defaults', () => {
+    const payload = createSetSchema.parse({
+      exerciseId: ' global-bench-press ',
+      setNumber: 2,
+    });
+
+    const typedPayload: CreateSetInput = payload;
+
+    expect(typedPayload).toEqual({
+      exerciseId: 'global-bench-press',
+      setNumber: 2,
+      weight: null,
+      reps: null,
+      section: null,
+    });
+  });
+});
+
+describe('updateSetSchema', () => {
+  it('accepts partial set updates', () => {
+    const payload = updateSetSchema.parse({
+      reps: 8,
+      completed: true,
+      notes: '  Smooth tempo  ',
+    });
+
+    const typedPayload: UpdateSetInput = payload;
+
+    expect(typedPayload).toEqual({
+      reps: 8,
+      completed: true,
+      notes: 'Smooth tempo',
+    });
+  });
+
+  it('rejects empty updates', () => {
+    expect(() => updateSetSchema.parse({})).toThrow();
+  });
+
+  it('rejects completed and skipped being true simultaneously', () => {
+    expect(() =>
+      updateSetSchema.parse({
+        completed: true,
+        skipped: true,
+      }),
+    ).toThrow();
+  });
+});
+
+describe('batchUpsertSetsSchema', () => {
+  it('accepts mixed create and update rows', () => {
+    const payload = batchUpsertSetsSchema.parse({
+      sets: [
+        {
+          id: 'set-1',
+          exerciseId: 'global-bench-press',
+          setNumber: 1,
+          weight: 185,
+          reps: 8,
+          section: 'main',
+        },
+        {
+          exerciseId: 'user-1-lat-pulldown',
+          setNumber: 2,
+        },
+      ],
+    });
+
+    expect(payload).toEqual({
+      sets: [
+        {
+          id: 'set-1',
+          exerciseId: 'global-bench-press',
+          setNumber: 1,
+          weight: 185,
+          reps: 8,
+          section: 'main',
+        },
+        {
+          exerciseId: 'user-1-lat-pulldown',
+          setNumber: 2,
+          weight: null,
+          reps: null,
+          section: null,
+        },
+      ],
+    });
+  });
+});

--- a/packages/shared/src/schemas/session-set.ts
+++ b/packages/shared/src/schemas/session-set.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+
+import { workoutTemplateSectionTypeSchema } from './workout-templates.js';
+
+const normalizeOptionalString = (value: unknown) => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const normalizeNullableString = (value: unknown) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const requiredStringSchema = z.string().trim().min(1).max(255);
+const nullableLongStringSchema = z.preprocess(
+  normalizeNullableString,
+  z.string().trim().min(1).max(4000).nullable(),
+);
+
+export const createSetSchema = z.object({
+  exerciseId: requiredStringSchema,
+  setNumber: z.number().int().min(1),
+  weight: z.number().min(0).nullable().optional().default(null),
+  reps: z.number().int().min(0).nullable().optional().default(null),
+  section: workoutTemplateSectionTypeSchema.nullable().optional().default(null),
+});
+
+export const updateSetSchema = z
+  .object({
+    weight: z.number().min(0).nullable().optional(),
+    reps: z.number().int().min(0).nullable().optional(),
+    completed: z.boolean().optional(),
+    skipped: z.boolean().optional(),
+    notes: z.preprocess(normalizeOptionalString, nullableLongStringSchema.optional()),
+  })
+  .refine((value) => Object.values(value).some((field) => field !== undefined), {
+    message: 'At least one set field must be provided',
+  })
+  .refine((value) => !(value.completed === true && value.skipped === true), {
+    message: 'A set cannot be both completed and skipped',
+    path: ['skipped'],
+  });
+
+export const batchUpsertSetsSchema = z.object({
+  sets: z.array(createSetSchema.extend({ id: z.string().optional() })).max(500),
+});
+
+export type CreateSetInput = z.infer<typeof createSetSchema>;
+export type UpdateSetInput = z.infer<typeof updateSetSchema>;
+export type BatchUpsertSetsInput = z.infer<typeof batchUpsertSetsSchema>;

--- a/packages/shared/src/schemas/workout-sessions.test.ts
+++ b/packages/shared/src/schemas/workout-sessions.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   createWorkoutSessionInputSchema,
+  saveWorkoutSessionAsTemplateInputSchema,
   sessionSetInputSchema,
   type CreateWorkoutSessionInput,
+  type SaveWorkoutSessionAsTemplateInput,
   type UpdateWorkoutSessionInput,
   type WorkoutSession,
   type WorkoutSessionFeedback,
@@ -248,6 +250,30 @@ describe('updateWorkoutSessionInputSchema', () => {
 
   it('rejects empty updates', () => {
     expect(() => updateWorkoutSessionInputSchema.parse({})).toThrow();
+  });
+});
+
+describe('saveWorkoutSessionAsTemplateInputSchema', () => {
+  it('accepts an empty payload for default template metadata', () => {
+    const payload: SaveWorkoutSessionAsTemplateInput =
+      saveWorkoutSessionAsTemplateInputSchema.parse(undefined);
+
+    expect(payload).toEqual({});
+  });
+
+  it('normalizes and trims provided metadata fields', () => {
+    const payload: SaveWorkoutSessionAsTemplateInput =
+      saveWorkoutSessionAsTemplateInputSchema.parse({
+        name: ' Upper Push Snapshot ',
+        description: '  Heavy pressing focus  ',
+        tags: [' strength ', ' push '],
+      });
+
+    expect(payload).toEqual({
+      name: 'Upper Push Snapshot',
+      description: 'Heavy pressing focus',
+      tags: ['strength', 'push'],
+    });
   });
 });
 

--- a/packages/shared/src/schemas/workout-sessions.ts
+++ b/packages/shared/src/schemas/workout-sessions.ts
@@ -190,6 +190,15 @@ export const updateWorkoutSessionInputSchema = z
     message: 'At least one workout session field must be provided',
   });
 
+export const saveWorkoutSessionAsTemplateInputSchema = z.preprocess(
+  (value) => (value === null || value === undefined ? {} : value),
+  z.object({
+    name: requiredStringSchema.optional(),
+    description: nullableLongStringSchema.optional(),
+    tags: z.array(requiredStringSchema).max(20).optional(),
+  }),
+);
+
 export const workoutSessionQueryParamsSchema = z
   .object({
     from: dateSchema,
@@ -208,4 +217,7 @@ export type WorkoutSessionListItem = z.infer<typeof workoutSessionListItemSchema
 export type SessionSetInput = z.infer<typeof sessionSetInputSchema>;
 export type CreateWorkoutSessionInput = z.infer<typeof createWorkoutSessionInputSchema>;
 export type UpdateWorkoutSessionInput = z.infer<typeof updateWorkoutSessionInputSchema>;
+export type SaveWorkoutSessionAsTemplateInput = z.infer<
+  typeof saveWorkoutSessionAsTemplateInputSchema
+>;
 export type WorkoutSessionQueryParams = z.infer<typeof workoutSessionQueryParamsSchema>;


### PR DESCRIPTION
## Summary
This PR moves the active workout session flow from mock/local behavior to real API-backed state across both backend and frontend. It introduces full session-set APIs so set creation, updates, grouped reads, and batch sync are persisted server-side and tied to ownership/session status. The web app now starts and resumes sessions via API, syncs local set edits to the backend (including refresh/unload scenarios), and handles completed-or-stale session recovery paths. It also adds two key post-workout capabilities: saving a completed session as a new template (with metadata overrides) and fetching per-exercise last performance to power in-session context. Test coverage was expanded substantially with API integration suites and Playwright session flow coverage, while stabilizing existing habits/smoke E2E selectors/assertions.

## Key Changes
- Added workout session set endpoints under `/api/v1/workout-sessions/:sessionId/sets`:
  - `POST` create set
  - `PATCH /:setId` update set
  - `GET` list grouped sets by exercise
  - `PUT` batch upsert sets
- Added `/api/v1/workout-sessions/:id/save-as-template` to create a template from a completed session, including optional name/description/tags overrides.
- Added `/api/v1/exercises/:id/last-performance` to return the latest completed-session set history for an exercise visible to the user.
- Extended shared schemas/types (`session-set`, `saveWorkoutSessionAsTemplateInput`, `exerciseLastPerformance`) and exported them via `@pulse/shared`.
- Wired active workout UI to API with new hooks: `useWorkoutSession`, `useSessionSets`, `useSyncSets`, `useCompleteSession`, `useSaveAsTemplate`, and `useLastPerformance`.
- Implemented active session persistence/resume via localStorage plus `ActiveSessionResumeGate`, including redirect/notice flow for sessions already completed elsewhere.
- Updated template start flow to seed planned sets when creating a session, so API state and UI set drafts start aligned.
- Added broad test coverage:
  - New API integration suite for workouts/templates/sessions/sets/scheduling/exercises
  - Expanded route tests for session set auth/ownership/validation/atomicity and save-as-template behavior
  - New Playwright workout-session E2E plus smoke/habits selector/assertion hardening

## Technical Notes
- Session-set writes are intentionally restricted to `in-progress` sessions; non-active writes return `409 WORKOUT_SESSION_NOT_ACTIVE`, and the web flow redirects users out of stale active sessions.
- Batch upsert is transactional and atomic: if any referenced set id is invalid, the request fails with `SESSION_SET_NOT_FOUND` and no partial updates are committed.
- Save-as-template derivation groups completed session sets by `(section, exerciseId)` and infers template set counts from the max observed `setNumber`; duplicate saves are allowed and produce distinct templates.
- Sync strategy in the web app is layered: immediate mutation paths for primary actions plus debounced/interval/beforeunload batch sync (`keepalive`) to reduce drift and survive navigation/refresh.
- Last-performance API returns 404 when none exists; the hook maps expected 404 cases to `null` so the UI can render gracefully without error state spam.

## Commits

- `79ce767 test(web): stabilize habits and smoke e2e coverage`
- `c78b215 test(web): add e2e workout session flow coverage`
- `b6489dd test(api): add workouts integration API coverage`
- `8df8873 fix(workouts): persist save-as-template metadata from summary dialog`
- `db7faec feat(workouts): add save-as-template and last-performance flows`
- `8ed16bb feat(web): add workout session persistence and resume flow`
- `b1ec230 feat(web): wire active workout session UI to API`
- `28acc5b feat(api): add workout session set endpoints and batch upsert`

## Tasks

- **Workout sessions API**: Start session from template/scratch, update status, complete with feedback
- **Session sets API**: Log sets, update weight/reps/completion, read session progress
- **Wire active session UI to API**: Connect set logging, completion, feedback to real mutations
- **Session persistence + resume**: localStorage sync with API, resume after browser refresh
- **Save as template + last performance lookup**: Save completed session as template, fetch last performance for exercises
- **API tests: workouts (templates, sessions, sets)**: Integration tests for workout template CRUD, session lifecycle, set logging
- **E2E: workout session flow**: Playwright test for start workout, log sets, complete session

## Diff Stats

```
apps/api/src/__tests__/workouts.test.ts            | 732 +++++++++++++++++++++
 apps/api/src/routes/exercises/index.test.ts        | 215 +++++-
 apps/api/src/routes/exercises/index.ts             |  34 +
 apps/api/src/routes/exercises/store.ts             |  84 ++-
 apps/api/src/routes/workout-sessions/index.test.ts | 642 +++++++++++++++++-
 apps/api/src/routes/workout-sessions/index.ts      | 258 +++++++-
 apps/api/src/routes/workout-sessions/store.ts      | 325 ++++++++-
 apps/web/e2e/habits.spec.ts                        |  10 +-
 apps/web/e2e/smoke.spec.ts                         |  56 +-
 apps/web/e2e/workout-session.spec.ts               | 349 ++++++++++
 apps/web/src/App.test.tsx                          |   2 +
 apps/web/src/components/layout/app-layout.tsx      |   2 +
 .../workouts/active-session-resume-gate.test.tsx   | 143 ++++
 .../workouts/active-session-resume-gate.tsx        | 100 +++
 .../components/session-exercise-list.test.tsx      |  50 +-
 .../workouts/components/session-exercise-list.tsx  |  17 +-
 .../workouts/components/session-summary.test.tsx   |   6 +-
 .../workouts/components/session-summary.tsx        |  23 +-
 .../features/workouts/components/set-row.test.tsx  |   2 +-
 .../src/features/workouts/components/set-row.tsx   |   2 +-
 .../workouts/components/template-detail.test.tsx   |  34 +
 .../workouts/components/template-detail.tsx        |  26 +-
 .../features/workouts/lib/session-persistence.ts   |  38 ++
 apps/web/src/hooks/use-complete-session.test.tsx   |  99 +++
 apps/web/src/hooks/use-complete-session.ts         |  71 ++
 apps/web/src/hooks/use-last-performance.test.tsx   | 113 ++++
 apps/web/src/hooks/use-last-performance.ts         |  71 ++
 apps/web/src/hooks/use-save-as-template.test.tsx   | 109 +++
 apps/web/src/hooks/use-save-as-template.ts         |  56 ++
 apps/web/src/hooks/use-session-sets.test.tsx       | 128 ++++
 apps/web/src/hooks/use-session-sets.ts             |  92 +++
 apps/web/src/hooks/use-sync-sets.test.tsx          | 195 ++++++
 apps/web/src/hooks/use-sync-sets.ts                | 209 ++++++
 apps/web/src/hooks/use-workout-session.test.tsx    |  98 +++
 apps/web/src/hooks/use-workout-session.ts          |  70 ++
 apps/web/src/pages/active-workout.test.tsx         |   6 +-
 apps/web/src/pages/active-workout.tsx              | 358 +++++++++-
 apps/web/src/pages/workouts.test.tsx               |  18 +
 apps/web/src/pages/workouts.tsx                    |  14 +
 packages/shared/src/index.ts                       |   1 +
 packages/shared/src/schemas/exercises.test.ts      |  56 ++
 packages/shared/src/schemas/exercises.ts           |  16 +
 packages/shared/src/schemas/session-set.test.ts    | 100 +++
 packages/shared/src/schemas/session-set.ts         |  63 ++
 .../shared/src/schemas/workout-sessions.test.ts    |  26 +
 packages/shared/src/schemas/workout-sessions.ts    |  12 +
 46 files changed, 5057 insertions(+), 74 deletions(-)
```