### PR TITLE
Dashboard API + frontend wiring

### DIFF
--- a/apps/api/drizzle/0010_equal_stingray.sql
+++ b/apps/api/drizzle/0010_equal_stingray.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `dashboard_config` ADD `widget_order` text;

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1772921155210,
       "tag": "0009_groovy_spacker_dave",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1773098400000,
+      "tag": "0010_equal_stingray",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.test.ts
+++ b/apps/api/src/db/schema.test.ts
@@ -673,6 +673,7 @@ describe('dashboardConfig schema', () => {
       'userId',
       'habitChainIds',
       'trendMetrics',
+      'widgetOrder',
       'createdAt',
       'updatedAt',
     ]);
@@ -680,6 +681,7 @@ describe('dashboardConfig schema', () => {
     expect(columns.id.defaultFn).toBeTypeOf('function');
     expect(columns.habitChainIds.default).toEqual([]);
     expect(columns.trendMetrics.default).toEqual([]);
+    expect(columns.widgetOrder.notNull).toBe(false);
     expect(columns.createdAt.default).toBeDefined();
     expect(columns.createdAt.defaultFn).toBeTypeOf('function');
     expect(columns.updatedAt.default).toBeDefined();

--- a/apps/api/src/db/schema/dashboard-config.ts
+++ b/apps/api/src/db/schema/dashboard-config.ts
@@ -19,6 +19,7 @@ export const dashboardConfig = sqliteTable(
       .notNull()
       .default([]),
     trendMetrics: text('trend_metrics', { mode: 'json' }).$type<string[]>().notNull().default([]),
+    widgetOrder: text('widget_order', { mode: 'json' }).$type<string[] | null>(),
     createdAt: integer('created_at', { mode: 'number' })
       .notNull()
       .default(sql`(unixepoch() * 1000)`)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -11,6 +11,7 @@ import { habitRoutes } from './routes/habits/index.js';
 import { nutritionRoutes } from './routes/nutrition/index.js';
 import { nutritionTargetRoutes } from './routes/nutrition-targets/index.js';
 import { scheduledWorkoutRoutes } from './routes/scheduled-workouts/index.js';
+import { v1Routes } from './routes/v1/index.js';
 import { weightRoutes } from './routes/weight/index.js';
 import { workoutSessionRoutes } from './routes/workout-sessions/index.js';
 import { workoutTemplateRoutes } from './routes/workout-templates/index.js';
@@ -46,6 +47,7 @@ export const buildServer = () => {
   app.register(nutritionRoutes, { prefix: '/api/v1/nutrition' });
   app.register(nutritionTargetRoutes, { prefix: '/api/v1/nutrition-targets' });
   app.register(scheduledWorkoutRoutes, { prefix: '/api/v1/scheduled-workouts' });
+  app.register(v1Routes, { prefix: '/api/v1' });
   app.register(weightRoutes, { prefix: '/api/v1/weight' });
   app.register(workoutSessionRoutes, { prefix: '/api/v1/workout-sessions' });
   app.register(workoutTemplateRoutes, { prefix: '/api/v1/workout-templates' });

--- a/apps/api/src/routes/v1/dashboard-store.test.ts
+++ b/apps/api/src/routes/v1/dashboard-store.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testState = vi.hoisted(() => {
+  const selectResults: unknown[] = [];
+
+  const select = vi.fn(() => {
+    const get = vi.fn(() => selectResults.shift());
+    const limit = vi.fn(() => ({ get }));
+    const orderBy = vi.fn(() => ({ limit, get }));
+    const where = vi.fn(() => ({ orderBy, limit, get }));
+    const leftJoin = vi.fn(() => ({ leftJoin, where, orderBy, limit, get }));
+    const from = vi.fn(() => ({ leftJoin, where, orderBy, limit, get }));
+
+    return {
+      from,
+    };
+  });
+
+  const tx = {
+    select,
+  };
+
+  const transaction = vi.fn((callback: (value: typeof tx) => unknown) => callback(tx));
+  const db = {
+    transaction,
+  };
+
+  return {
+    db,
+    select,
+    selectResults,
+    transaction,
+    reset() {
+      selectResults.length = 0;
+      select.mockClear();
+      transaction.mockClear();
+    },
+  };
+});
+
+vi.mock('../../db/index.js', () => ({
+  db: testState.db,
+}));
+
+describe('dashboard store', () => {
+  beforeEach(() => {
+    testState.reset();
+  });
+
+  it('aggregates all dashboard snapshot sections from scoped query results', async () => {
+    testState.selectResults.push(
+      { value: 178.4, date: '2026-03-08' },
+      {
+        calories: 1850,
+        protein: 150,
+        carbs: 190,
+        fat: 65,
+      },
+      {
+        calories: 2200,
+        protein: 180,
+        carbs: 250,
+        fat: 70,
+      },
+      {
+        name: 'Upper Push A',
+        status: 'completed',
+        duration: 64,
+      },
+      {
+        total: 6,
+        completed: 4,
+      },
+    );
+
+    const { getDashboardSnapshot } = await import('./dashboard-store.js');
+    const snapshot = await getDashboardSnapshot('user-1', '2026-03-09');
+
+    expect(snapshot).toEqual({
+      date: '2026-03-09',
+      weight: {
+        value: 178.4,
+        date: '2026-03-08',
+        unit: 'lb',
+      },
+      macros: {
+        actual: {
+          calories: 1850,
+          protein: 150,
+          carbs: 190,
+          fat: 65,
+        },
+        target: {
+          calories: 2200,
+          protein: 180,
+          carbs: 250,
+          fat: 70,
+        },
+      },
+      workout: {
+        name: 'Upper Push A',
+        status: 'completed',
+        duration: 64,
+      },
+      habits: {
+        total: 6,
+        completed: 4,
+        percentage: 66.7,
+      },
+    });
+    expect(testState.transaction).toHaveBeenCalledOnce();
+    expect(testState.select).toHaveBeenCalledTimes(5);
+  });
+
+  it('returns null sections and zeroed values when no data exists for the date', async () => {
+    const { getDashboardSnapshot } = await import('./dashboard-store.js');
+    const snapshot = await getDashboardSnapshot('user-1', '2026-03-10');
+
+    expect(snapshot).toEqual({
+      date: '2026-03-10',
+      weight: null,
+      macros: {
+        actual: {
+          calories: 0,
+          protein: 0,
+          carbs: 0,
+          fat: 0,
+        },
+        target: {
+          calories: 0,
+          protein: 0,
+          carbs: 0,
+          fat: 0,
+        },
+      },
+      workout: null,
+      habits: {
+        total: 0,
+        completed: 0,
+        percentage: 0,
+      },
+    });
+    expect(testState.select).toHaveBeenCalledTimes(5);
+  });
+
+  it('rounds habit completion percentage to one decimal place', async () => {
+    testState.selectResults.push(undefined, undefined, undefined, undefined, {
+      total: 3,
+      completed: 2,
+    });
+
+    const { getDashboardSnapshot } = await import('./dashboard-store.js');
+    const snapshot = await getDashboardSnapshot('user-1', '2026-03-11');
+
+    expect(snapshot.habits).toEqual({
+      total: 3,
+      completed: 2,
+      percentage: 66.7,
+    });
+  });
+});

--- a/apps/api/src/routes/v1/dashboard-store.test.ts
+++ b/apps/api/src/routes/v1/dashboard-store.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const testState = vi.hoisted(() => {
   const selectGetResults: unknown[] = [];
   const selectAllResults: unknown[] = [];
+  const insertRunResults: unknown[] = [];
 
   const select = vi.fn(() => {
     const chain = {
@@ -22,6 +23,15 @@ const testState = vi.hoisted(() => {
   });
 
   const db = {
+    insert: vi.fn(() => {
+      const chain = {
+        values: vi.fn(() => chain),
+        onConflictDoUpdate: vi.fn(() => chain),
+        run: vi.fn(() => insertRunResults.shift()),
+      };
+
+      return chain;
+    }),
     select,
   };
 
@@ -30,10 +40,13 @@ const testState = vi.hoisted(() => {
     select,
     selectGetResults,
     selectAllResults,
+    insertRunResults,
     reset() {
       selectGetResults.length = 0;
       selectAllResults.length = 0;
+      insertRunResults.length = 0;
       select.mockClear();
+      db.insert.mockClear();
     },
   };
 });
@@ -233,5 +246,53 @@ describe('dashboard store', () => {
       { date: '2026-03-09', completed: false },
     ]);
     expect(testState.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the stored dashboard config when one exists', async () => {
+    testState.selectGetResults.push({
+      habitChainIds: ['habit-1', 'habit-2'],
+      trendMetrics: ['weight', 'protein'],
+      widgetOrder: ['snapshot', 'trends', 'habits'],
+    });
+
+    const { getDashboardConfig } = await import('./dashboard-store.js');
+    const config = await getDashboardConfig('user-1');
+
+    expect(config).toEqual({
+      habitChainIds: ['habit-1', 'habit-2'],
+      trendMetrics: ['weight', 'protein'],
+      widgetOrder: ['snapshot', 'trends', 'habits'],
+    });
+    expect(testState.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns default dashboard config with active habits when none is stored', async () => {
+    testState.selectGetResults.push(undefined);
+    testState.selectAllResults.push([{ id: 'habit-1' }, { id: 'habit-3' }]);
+
+    const { getDashboardConfig } = await import('./dashboard-store.js');
+    const config = await getDashboardConfig('user-1');
+
+    expect(config).toEqual({
+      habitChainIds: ['habit-1', 'habit-3'],
+      trendMetrics: ['weight', 'calories', 'protein'],
+    });
+    expect(testState.select).toHaveBeenCalledTimes(2);
+  });
+
+  it('upserts dashboard config by userId', async () => {
+    const { upsertDashboardConfig } = await import('./dashboard-store.js');
+    const config = await upsertDashboardConfig('user-1', {
+      habitChainIds: ['habit-1'],
+      trendMetrics: ['calories'],
+      widgetOrder: ['trends', 'snapshot'],
+    });
+
+    expect(config).toEqual({
+      habitChainIds: ['habit-1'],
+      trendMetrics: ['calories'],
+      widgetOrder: ['trends', 'snapshot'],
+    });
+    expect(testState.db.insert).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/routes/v1/dashboard-store.test.ts
+++ b/apps/api/src/routes/v1/dashboard-store.test.ts
@@ -1,18 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const testState = vi.hoisted(() => {
-  const selectResults: unknown[] = [];
+  const selectGetResults: unknown[] = [];
+  const selectAllResults: unknown[] = [];
 
   const select = vi.fn(() => {
-    const get = vi.fn(() => selectResults.shift());
-    const limit = vi.fn(() => ({ get }));
-    const orderBy = vi.fn(() => ({ limit, get }));
-    const where = vi.fn(() => ({ orderBy, limit, get }));
-    const leftJoin = vi.fn(() => ({ leftJoin, where, orderBy, limit, get }));
-    const from = vi.fn(() => ({ leftJoin, where, orderBy, limit, get }));
+    const chain = {
+      from: vi.fn(() => chain),
+      leftJoin: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      groupBy: vi.fn(() => chain),
+      orderBy: vi.fn(() => chain),
+      limit: vi.fn(() => chain),
+      get: vi.fn(() => selectGetResults.shift()),
+      all: vi.fn(() => (selectAllResults.shift() as unknown[] | undefined) ?? []),
+    };
 
     return {
-      from,
+      from: chain.from,
     };
   });
 
@@ -23,9 +28,11 @@ const testState = vi.hoisted(() => {
   return {
     db,
     select,
-    selectResults,
+    selectGetResults,
+    selectAllResults,
     reset() {
-      selectResults.length = 0;
+      selectGetResults.length = 0;
+      selectAllResults.length = 0;
       select.mockClear();
     },
   };
@@ -41,7 +48,7 @@ describe('dashboard store', () => {
   });
 
   it('aggregates all dashboard snapshot sections from scoped query results', async () => {
-    testState.selectResults.push(
+    testState.selectGetResults.push(
       { value: 178.4, date: '2026-03-08' },
       {
         calories: 1850,
@@ -136,7 +143,7 @@ describe('dashboard store', () => {
   });
 
   it('rounds habit completion percentage to one decimal place', async () => {
-    testState.selectResults.push(undefined, undefined, undefined, undefined, {
+    testState.selectGetResults.push(undefined, undefined, undefined, undefined, {
       total: 3,
       completed: 2,
     });
@@ -149,5 +156,82 @@ describe('dashboard store', () => {
       completed: 2,
       percentage: 66.7,
     });
+  });
+
+  it('returns weight trend points in ascending date order', async () => {
+    testState.selectAllResults.push([
+      { date: '2026-03-07', value: 181.6 },
+      { date: '2026-03-09', value: 181.1 },
+    ]);
+
+    const { getDashboardWeightTrend } = await import('./dashboard-store.js');
+    const trend = await getDashboardWeightTrend('user-1', '2026-03-07', '2026-03-09');
+
+    expect(trend).toEqual([
+      { date: '2026-03-07', value: 181.6 },
+      { date: '2026-03-09', value: 181.1 },
+    ]);
+    expect(testState.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('fills missing macro trend days with zero totals', async () => {
+    testState.selectAllResults.push([
+      {
+        date: '2026-03-07',
+        calories: 2100,
+        protein: 170,
+        carbs: 230,
+        fat: 68,
+      },
+      {
+        date: '2026-03-09',
+        calories: 2200,
+        protein: 180,
+        carbs: 240,
+        fat: 70,
+      },
+    ]);
+
+    const { getDashboardMacrosTrend } = await import('./dashboard-store.js');
+    const trend = await getDashboardMacrosTrend('user-1', '2026-03-07', '2026-03-09');
+
+    expect(trend).toEqual([
+      {
+        date: '2026-03-07',
+        calories: 2100,
+        protein: 170,
+        carbs: 230,
+        fat: 68,
+      },
+      {
+        date: '2026-03-08',
+        calories: 0,
+        protein: 0,
+        carbs: 0,
+        fat: 0,
+      },
+      {
+        date: '2026-03-09',
+        calories: 2200,
+        protein: 180,
+        carbs: 240,
+        fat: 70,
+      },
+    ]);
+    expect(testState.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns consistency completion booleans for every day in range', async () => {
+    testState.selectAllResults.push([{ date: '2026-03-08' }]);
+
+    const { getDashboardConsistencyTrend } = await import('./dashboard-store.js');
+    const trend = await getDashboardConsistencyTrend('user-1', '2026-03-07', '2026-03-09');
+
+    expect(trend).toEqual([
+      { date: '2026-03-07', completed: false },
+      { date: '2026-03-08', completed: true },
+      { date: '2026-03-09', completed: false },
+    ]);
+    expect(testState.select).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/routes/v1/dashboard-store.test.ts
+++ b/apps/api/src/routes/v1/dashboard-store.test.ts
@@ -283,6 +283,23 @@ describe('dashboard store', () => {
     expect(testState.select).toHaveBeenCalledTimes(1);
   });
 
+  it('treats all-invalid stored trend metrics as an empty selection', async () => {
+    testState.selectGetResults.push({
+      habitChainIds: ['habit-1'],
+      trendMetrics: ['unknown-metric'],
+      widgetOrder: null,
+    });
+
+    const { getDashboardConfig } = await import('./dashboard-store.js');
+    const config = await getDashboardConfig('user-1');
+
+    expect(config).toEqual({
+      habitChainIds: ['habit-1'],
+      trendMetrics: [],
+    });
+    expect(testState.select).toHaveBeenCalledTimes(1);
+  });
+
   it('returns default dashboard config with active habits when none is stored', async () => {
     testState.selectGetResults.push(undefined);
     testState.selectAllResults.push([{ id: 'habit-1' }, { id: 'habit-3' }]);
@@ -298,6 +315,12 @@ describe('dashboard store', () => {
   });
 
   it('upserts dashboard config by userId', async () => {
+    testState.selectGetResults.push({
+      habitChainIds: ['habit-1'],
+      trendMetrics: ['calories'],
+      widgetOrder: ['trends', 'snapshot'],
+    });
+
     const { upsertDashboardConfig } = await import('./dashboard-store.js');
     const config = await upsertDashboardConfig('user-1', {
       habitChainIds: ['habit-1'],
@@ -311,5 +334,6 @@ describe('dashboard store', () => {
       widgetOrder: ['trends', 'snapshot'],
     });
     expect(testState.db.insert).toHaveBeenCalledTimes(1);
+    expect(testState.select).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/routes/v1/dashboard-store.test.ts
+++ b/apps/api/src/routes/v1/dashboard-store.test.ts
@@ -16,24 +16,17 @@ const testState = vi.hoisted(() => {
     };
   });
 
-  const tx = {
-    select,
-  };
-
-  const transaction = vi.fn((callback: (value: typeof tx) => unknown) => callback(tx));
   const db = {
-    transaction,
+    select,
   };
 
   return {
     db,
     select,
     selectResults,
-    transaction,
     reset() {
       selectResults.length = 0;
       select.mockClear();
-      transaction.mockClear();
     },
   };
 });
@@ -108,7 +101,6 @@ describe('dashboard store', () => {
         percentage: 66.7,
       },
     });
-    expect(testState.transaction).toHaveBeenCalledOnce();
     expect(testState.select).toHaveBeenCalledTimes(5);
   });
 

--- a/apps/api/src/routes/v1/dashboard-store.test.ts
+++ b/apps/api/src/routes/v1/dashboard-store.test.ts
@@ -266,6 +266,23 @@ describe('dashboard store', () => {
     expect(testState.select).toHaveBeenCalledTimes(1);
   });
 
+  it('preserves an explicitly empty stored trend-metric selection', async () => {
+    testState.selectGetResults.push({
+      habitChainIds: ['habit-1'],
+      trendMetrics: [],
+      widgetOrder: null,
+    });
+
+    const { getDashboardConfig } = await import('./dashboard-store.js');
+    const config = await getDashboardConfig('user-1');
+
+    expect(config).toEqual({
+      habitChainIds: ['habit-1'],
+      trendMetrics: [],
+    });
+    expect(testState.select).toHaveBeenCalledTimes(1);
+  });
+
   it('returns default dashboard config with active habits when none is stored', async () => {
     testState.selectGetResults.push(undefined);
     testState.selectAllResults.push([{ id: 'habit-1' }, { id: 'habit-3' }]);

--- a/apps/api/src/routes/v1/dashboard-store.ts
+++ b/apps/api/src/routes/v1/dashboard-store.ts
@@ -1,10 +1,13 @@
-import { and, desc, eq, gte, lt, lte, sql } from 'drizzle-orm';
+import { and, asc, between, desc, eq, gte, lt, lte, sql } from 'drizzle-orm';
 
 import type {
+  DashboardConsistencyTrendPoint,
   DashboardHabitsSnapshot,
+  DashboardMacrosTrendPoint,
   DashboardMacroTotals,
   DashboardSnapshot,
   DashboardWeightSnapshot,
+  DashboardWeightTrendPoint,
   DashboardWorkoutSnapshot,
 } from '@pulse/shared';
 
@@ -50,6 +53,23 @@ const habitSummarySelection = {
   completed: sql<number>`coalesce(sum(case when ${habitEntries.completed} then 1 else 0 end), 0)`,
 };
 
+const weightTrendSelection = {
+  date: bodyWeight.date,
+  value: bodyWeight.weight,
+};
+
+const macrosTrendSelection = {
+  date: nutritionLogs.date,
+  calories: sql<number>`coalesce(sum(${mealItems.calories}), 0)`,
+  protein: sql<number>`coalesce(sum(${mealItems.protein}), 0)`,
+  carbs: sql<number>`coalesce(sum(${mealItems.carbs}), 0)`,
+  fat: sql<number>`coalesce(sum(${mealItems.fat}), 0)`,
+};
+
+const consistencyTrendSelection = {
+  date: workoutSessions.date,
+};
+
 const getDateRangeForUtcDay = (date: string) => {
   const start = new Date(`${date}T00:00:00.000Z`);
   const end = new Date(start);
@@ -59,6 +79,24 @@ const getDateRangeForUtcDay = (date: string) => {
     start: start.getTime(),
     end: end.getTime(),
   };
+};
+
+const addUtcDays = (date: string, days: number) => {
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + days);
+  return parsed.toISOString().slice(0, 10);
+};
+
+const getDatesInRange = (from: string, to: string) => {
+  const dates: string[] = [];
+
+  let current = from;
+  while (current <= to) {
+    dates.push(current);
+    current = addUtcDays(current, 1);
+  }
+
+  return dates;
 };
 
 // TODO: Source this from user preferences once kg/lb switching is introduced.
@@ -136,6 +174,21 @@ const toHabitSnapshot = (
   };
 };
 
+const toMacroTrendPoint = (
+  date: string,
+  value:
+    | {
+        calories: number | null;
+        protein: number | null;
+        carbs: number | null;
+        fat: number | null;
+      }
+    | undefined,
+): DashboardMacrosTrendPoint => ({
+  date,
+  ...toMacroTotals(value),
+});
+
 export const getDashboardSnapshot = async (
   userId: string,
   date: string,
@@ -208,4 +261,79 @@ export const getDashboardSnapshot = async (
     workout: toWorkoutSnapshot(workout),
     habits: toHabitSnapshot(habitsSummary),
   };
+};
+
+export const getDashboardWeightTrend = async (
+  userId: string,
+  from: string,
+  to: string,
+): Promise<DashboardWeightTrendPoint[]> => {
+  const entries = db
+    .select(weightTrendSelection)
+    .from(bodyWeight)
+    .where(and(eq(bodyWeight.userId, userId), between(bodyWeight.date, from, to)))
+    .orderBy(asc(bodyWeight.date))
+    .all();
+
+  return entries.map((entry) => ({
+    date: entry.date,
+    value: Number(entry.value),
+  }));
+};
+
+export const getDashboardMacrosTrend = async (
+  userId: string,
+  from: string,
+  to: string,
+): Promise<DashboardMacrosTrendPoint[]> => {
+  const rows = db
+    .select(macrosTrendSelection)
+    .from(nutritionLogs)
+    .leftJoin(meals, eq(meals.nutritionLogId, nutritionLogs.id))
+    .leftJoin(mealItems, eq(mealItems.mealId, meals.id))
+    .where(and(eq(nutritionLogs.userId, userId), between(nutritionLogs.date, from, to)))
+    .groupBy(nutritionLogs.date)
+    .orderBy(asc(nutritionLogs.date))
+    .all();
+
+  const rowsByDate = new Map(
+    rows.map((row) => [
+      row.date,
+      {
+        calories: row.calories,
+        protein: row.protein,
+        carbs: row.carbs,
+        fat: row.fat,
+      },
+    ]),
+  );
+
+  return getDatesInRange(from, to).map((date) => toMacroTrendPoint(date, rowsByDate.get(date)));
+};
+
+export const getDashboardConsistencyTrend = async (
+  userId: string,
+  from: string,
+  to: string,
+): Promise<DashboardConsistencyTrendPoint[]> => {
+  const completedRows = db
+    .select(consistencyTrendSelection)
+    .from(workoutSessions)
+    .where(
+      and(
+        eq(workoutSessions.userId, userId),
+        eq(workoutSessions.status, 'completed'),
+        between(workoutSessions.date, from, to),
+      ),
+    )
+    .groupBy(workoutSessions.date)
+    .orderBy(asc(workoutSessions.date))
+    .all();
+
+  const completedDates = new Set(completedRows.map((row) => row.date));
+
+  return getDatesInRange(from, to).map((date) => ({
+    date,
+    completed: completedDates.has(date),
+  }));
 };

--- a/apps/api/src/routes/v1/dashboard-store.ts
+++ b/apps/api/src/routes/v1/dashboard-store.ts
@@ -193,8 +193,12 @@ const isDashboardTrendMetric = (value: string): value is DashboardTrendMetric =>
   trendMetricSet.has(value as DashboardTrendMetric);
 
 const toDashboardTrendMetrics = (metrics: string[] | null | undefined): DashboardTrendMetric[] => {
-  if (!metrics || metrics.length === 0) {
+  if (!metrics) {
     return DEFAULT_DASHBOARD_TREND_METRICS;
+  }
+
+  if (metrics.length === 0) {
+    return [];
   }
 
   const validMetrics = metrics.filter(isDashboardTrendMetric);
@@ -397,25 +401,23 @@ export const upsertDashboardConfig = async (
   userId: string,
   input: DashboardConfig,
 ): Promise<DashboardConfig> => {
-  const config = dashboardConfigSchema.parse(input);
-
   db.insert(dashboardConfigTable)
     .values({
       userId,
-      habitChainIds: config.habitChainIds,
-      trendMetrics: config.trendMetrics,
-      widgetOrder: config.widgetOrder ?? null,
+      habitChainIds: input.habitChainIds,
+      trendMetrics: input.trendMetrics,
+      widgetOrder: input.widgetOrder ?? null,
     })
     .onConflictDoUpdate({
       target: dashboardConfigTable.userId,
       set: {
-        habitChainIds: config.habitChainIds,
-        trendMetrics: config.trendMetrics,
-        widgetOrder: config.widgetOrder ?? null,
+        habitChainIds: input.habitChainIds,
+        trendMetrics: input.trendMetrics,
+        widgetOrder: input.widgetOrder ?? null,
         updatedAt: Date.now(),
       },
     })
     .run();
 
-  return config;
+  return input;
 };

--- a/apps/api/src/routes/v1/dashboard-store.ts
+++ b/apps/api/src/routes/v1/dashboard-store.ts
@@ -202,7 +202,9 @@ const toDashboardTrendMetrics = (metrics: string[] | null | undefined): Dashboar
   }
 
   const validMetrics = metrics.filter(isDashboardTrendMetric);
-  return validMetrics.length > 0 ? validMetrics : DEFAULT_DASHBOARD_TREND_METRICS;
+  // Preserve explicit but stale/unknown values as "no selected metrics" instead of
+  // surprising callers with defaults they did not choose.
+  return validMetrics.length > 0 ? validMetrics : [];
 };
 
 const toDashboardConfig = (
@@ -419,5 +421,17 @@ export const upsertDashboardConfig = async (
     })
     .run();
 
-  return input;
+  const persisted =
+    db
+      .select(dashboardConfigSelection)
+      .from(dashboardConfigTable)
+      .where(eq(dashboardConfigTable.userId, userId))
+      .limit(1)
+      .get() ?? null;
+
+  if (!persisted) {
+    throw new Error('Upserted dashboard config could not be loaded');
+  }
+
+  return toDashboardConfig(persisted);
 };

--- a/apps/api/src/routes/v1/dashboard-store.ts
+++ b/apps/api/src/routes/v1/dashboard-store.ts
@@ -8,6 +8,7 @@ import type {
   DashboardWorkoutSnapshot,
 } from '@pulse/shared';
 
+import { db } from '../../db/index.js';
 import {
   bodyWeight,
   habitEntries,
@@ -60,6 +61,9 @@ const getDateRangeForUtcDay = (date: string) => {
   };
 };
 
+// TODO: Source this from user preferences once kg/lb switching is introduced.
+const DEFAULT_WEIGHT_UNIT: DashboardWeightSnapshot['unit'] = 'lb';
+
 const toMacroTotals = (
   value:
     | {
@@ -89,7 +93,7 @@ const toWeightSnapshot = (
   return {
     value: Number(value.value),
     date: value.date,
-    unit: 'lb',
+    unit: DEFAULT_WEIGHT_UNIT,
   };
 };
 
@@ -97,7 +101,7 @@ const toWorkoutSnapshot = (
   value:
     | {
         name: string;
-        status: 'scheduled' | 'in-progress' | 'completed';
+        status: DashboardWorkoutSnapshot['status'];
         duration: number | null;
       }
     | undefined,
@@ -136,75 +140,72 @@ export const getDashboardSnapshot = async (
   userId: string,
   date: string,
 ): Promise<DashboardSnapshot> => {
-  const { db } = await import('../../db/index.js');
   const dayRange = getDateRangeForUtcDay(date);
 
-  return db.transaction((tx) => {
-    const weight =
-      tx
-        .select(weightSelection)
-        .from(bodyWeight)
-        .where(and(eq(bodyWeight.userId, userId), lte(bodyWeight.date, date)))
-        .orderBy(desc(bodyWeight.date))
-        .limit(1)
-        .get() ?? null;
+  const weight =
+    db
+      .select(weightSelection)
+      .from(bodyWeight)
+      .where(and(eq(bodyWeight.userId, userId), lte(bodyWeight.date, date)))
+      .orderBy(desc(bodyWeight.date))
+      .limit(1)
+      .get() ?? null;
 
-    const macrosActual =
-      tx
-        .select(macroActualSelection)
-        .from(nutritionLogs)
-        .leftJoin(meals, eq(meals.nutritionLogId, nutritionLogs.id))
-        .leftJoin(mealItems, eq(mealItems.mealId, meals.id))
-        .where(and(eq(nutritionLogs.userId, userId), eq(nutritionLogs.date, date)))
-        .get() ?? undefined;
+  const macrosActual =
+    db
+      .select(macroActualSelection)
+      .from(nutritionLogs)
+      .leftJoin(meals, eq(meals.nutritionLogId, nutritionLogs.id))
+      .leftJoin(mealItems, eq(mealItems.mealId, meals.id))
+      .where(and(eq(nutritionLogs.userId, userId), eq(nutritionLogs.date, date)))
+      .get() ?? undefined;
 
-    const macrosTarget =
-      tx
-        .select(macroTargetSelection)
-        .from(nutritionTargets)
-        .where(and(eq(nutritionTargets.userId, userId), lte(nutritionTargets.effectiveDate, date)))
-        .orderBy(desc(nutritionTargets.effectiveDate))
-        .limit(1)
-        .get() ?? undefined;
+  const macrosTarget =
+    db
+      .select(macroTargetSelection)
+      .from(nutritionTargets)
+      .where(and(eq(nutritionTargets.userId, userId), lte(nutritionTargets.effectiveDate, date)))
+      .orderBy(desc(nutritionTargets.effectiveDate))
+      .limit(1)
+      .get() ?? undefined;
 
-    const workout = tx
-      .select(workoutSelection)
-      .from(workoutSessions)
-      .where(
+  const workout = db
+    .select(workoutSelection)
+    .from(workoutSessions)
+    .where(
+      and(
+        eq(workoutSessions.userId, userId),
+        gte(workoutSessions.startedAt, dayRange.start),
+        lt(workoutSessions.startedAt, dayRange.end),
+      ),
+    )
+    .orderBy(desc(workoutSessions.startedAt))
+    .limit(1)
+    .get();
+
+  const habitsSummary =
+    db
+      .select(habitSummarySelection)
+      .from(habits)
+      .leftJoin(
+        habitEntries,
         and(
-          eq(workoutSessions.userId, userId),
-          gte(workoutSessions.startedAt, dayRange.start),
-          lt(workoutSessions.startedAt, dayRange.end),
+          eq(habitEntries.habitId, habits.id),
+          eq(habitEntries.userId, userId),
+          eq(habitEntries.date, date),
         ),
       )
-      .orderBy(desc(workoutSessions.startedAt))
-      .limit(1)
-      .get();
+      .where(and(eq(habits.userId, userId), eq(habits.active, true)))
+      .get() ?? undefined;
 
-    const habitsSummary =
-      tx
-        .select(habitSummarySelection)
-        .from(habits)
-        .leftJoin(
-          habitEntries,
-          and(
-            eq(habitEntries.habitId, habits.id),
-            eq(habitEntries.userId, userId),
-            eq(habitEntries.date, date),
-          ),
-        )
-        .where(and(eq(habits.userId, userId), eq(habits.active, true)))
-        .get() ?? undefined;
-
-    return {
-      date,
-      weight: toWeightSnapshot(weight),
-      macros: {
-        actual: toMacroTotals(macrosActual),
-        target: toMacroTotals(macrosTarget),
-      },
-      workout: toWorkoutSnapshot(workout),
-      habits: toHabitSnapshot(habitsSummary),
-    };
-  });
+  return {
+    date,
+    weight: toWeightSnapshot(weight),
+    macros: {
+      actual: toMacroTotals(macrosActual),
+      target: toMacroTotals(macrosTarget),
+    },
+    workout: toWorkoutSnapshot(workout),
+    habits: toHabitSnapshot(habitsSummary),
+  };
 };

--- a/apps/api/src/routes/v1/dashboard-store.ts
+++ b/apps/api/src/routes/v1/dashboard-store.ts
@@ -22,6 +22,7 @@ import {
   nutritionTargets,
   workoutSessions,
 } from '../../db/schema/index.js';
+import { getDatesInRange } from './dashboard-utils.js';
 
 const weightSelection = {
   value: bodyWeight.weight,
@@ -79,24 +80,6 @@ const getDateRangeForUtcDay = (date: string) => {
     start: start.getTime(),
     end: end.getTime(),
   };
-};
-
-const addUtcDays = (date: string, days: number) => {
-  const parsed = new Date(`${date}T00:00:00.000Z`);
-  parsed.setUTCDate(parsed.getUTCDate() + days);
-  return parsed.toISOString().slice(0, 10);
-};
-
-const getDatesInRange = (from: string, to: string) => {
-  const dates: string[] = [];
-
-  let current = from;
-  while (current <= to) {
-    dates.push(current);
-    current = addUtcDays(current, 1);
-  }
-
-  return dates;
 };
 
 // TODO: Source this from user preferences once kg/lb switching is introduced.

--- a/apps/api/src/routes/v1/dashboard-store.ts
+++ b/apps/api/src/routes/v1/dashboard-store.ts
@@ -1,19 +1,23 @@
 import { and, asc, between, desc, eq, gte, lt, lte, sql } from 'drizzle-orm';
 
 import type {
+  DashboardConfig,
   DashboardConsistencyTrendPoint,
   DashboardHabitsSnapshot,
   DashboardMacrosTrendPoint,
   DashboardMacroTotals,
   DashboardSnapshot,
+  DashboardTrendMetric,
   DashboardWeightSnapshot,
   DashboardWeightTrendPoint,
   DashboardWorkoutSnapshot,
 } from '@pulse/shared';
+import { dashboardConfigSchema } from '@pulse/shared';
 
 import { db } from '../../db/index.js';
 import {
   bodyWeight,
+  dashboardConfig as dashboardConfigTable,
   habitEntries,
   habits,
   mealItems,
@@ -71,6 +75,16 @@ const consistencyTrendSelection = {
   date: workoutSessions.date,
 };
 
+const dashboardConfigSelection = {
+  habitChainIds: dashboardConfigTable.habitChainIds,
+  trendMetrics: dashboardConfigTable.trendMetrics,
+  widgetOrder: dashboardConfigTable.widgetOrder,
+};
+
+const activeHabitIdsSelection = {
+  id: habits.id,
+};
+
 const getDateRangeForUtcDay = (date: string) => {
   const start = new Date(`${date}T00:00:00.000Z`);
   const end = new Date(start);
@@ -84,6 +98,7 @@ const getDateRangeForUtcDay = (date: string) => {
 
 // TODO: Source this from user preferences once kg/lb switching is introduced.
 const DEFAULT_WEIGHT_UNIT: DashboardWeightSnapshot['unit'] = 'lb';
+const DEFAULT_DASHBOARD_TREND_METRICS: DashboardTrendMetric[] = ['weight', 'calories', 'protein'];
 
 const toMacroTotals = (
   value:
@@ -171,6 +186,36 @@ const toMacroTrendPoint = (
   date,
   ...toMacroTotals(value),
 });
+
+const trendMetricSet = new Set<DashboardTrendMetric>(DEFAULT_DASHBOARD_TREND_METRICS);
+
+const isDashboardTrendMetric = (value: string): value is DashboardTrendMetric =>
+  trendMetricSet.has(value as DashboardTrendMetric);
+
+const toDashboardTrendMetrics = (metrics: string[] | null | undefined): DashboardTrendMetric[] => {
+  if (!metrics || metrics.length === 0) {
+    return DEFAULT_DASHBOARD_TREND_METRICS;
+  }
+
+  const validMetrics = metrics.filter(isDashboardTrendMetric);
+  return validMetrics.length > 0 ? validMetrics : DEFAULT_DASHBOARD_TREND_METRICS;
+};
+
+const toDashboardConfig = (
+  value: {
+    habitChainIds: string[] | null;
+    trendMetrics: string[] | null;
+    widgetOrder: string[] | null;
+  },
+): DashboardConfig => {
+  const parsed = dashboardConfigSchema.parse({
+    habitChainIds: value.habitChainIds ?? [],
+    trendMetrics: toDashboardTrendMetrics(value.trendMetrics),
+    widgetOrder: value.widgetOrder ?? undefined,
+  });
+
+  return parsed;
+};
 
 export const getDashboardSnapshot = async (
   userId: string,
@@ -319,4 +364,58 @@ export const getDashboardConsistencyTrend = async (
     date,
     completed: completedDates.has(date),
   }));
+};
+
+export const getDashboardConfig = async (userId: string): Promise<DashboardConfig> => {
+  const configRow =
+    db
+      .select(dashboardConfigSelection)
+      .from(dashboardConfigTable)
+      .where(eq(dashboardConfigTable.userId, userId))
+      .limit(1)
+      .get() ?? null;
+
+  if (configRow) {
+    return toDashboardConfig(configRow);
+  }
+
+  const activeHabitIds = db
+    .select(activeHabitIdsSelection)
+    .from(habits)
+    .where(and(eq(habits.userId, userId), eq(habits.active, true)))
+    .orderBy(asc(habits.sortOrder), asc(habits.createdAt))
+    .all()
+    .map((habit) => habit.id);
+
+  return dashboardConfigSchema.parse({
+    habitChainIds: activeHabitIds,
+    trendMetrics: DEFAULT_DASHBOARD_TREND_METRICS,
+  });
+};
+
+export const upsertDashboardConfig = async (
+  userId: string,
+  input: DashboardConfig,
+): Promise<DashboardConfig> => {
+  const config = dashboardConfigSchema.parse(input);
+
+  db.insert(dashboardConfigTable)
+    .values({
+      userId,
+      habitChainIds: config.habitChainIds,
+      trendMetrics: config.trendMetrics,
+      widgetOrder: config.widgetOrder ?? null,
+    })
+    .onConflictDoUpdate({
+      target: dashboardConfigTable.userId,
+      set: {
+        habitChainIds: config.habitChainIds,
+        trendMetrics: config.trendMetrics,
+        widgetOrder: config.widgetOrder ?? null,
+        updatedAt: Date.now(),
+      },
+    })
+    .run();
+
+  return config;
 };

--- a/apps/api/src/routes/v1/dashboard-store.ts
+++ b/apps/api/src/routes/v1/dashboard-store.ts
@@ -1,0 +1,210 @@
+import { and, desc, eq, gte, lt, lte, sql } from 'drizzle-orm';
+
+import type {
+  DashboardHabitsSnapshot,
+  DashboardMacroTotals,
+  DashboardSnapshot,
+  DashboardWeightSnapshot,
+  DashboardWorkoutSnapshot,
+} from '@pulse/shared';
+
+import {
+  bodyWeight,
+  habitEntries,
+  habits,
+  mealItems,
+  meals,
+  nutritionLogs,
+  nutritionTargets,
+  workoutSessions,
+} from '../../db/schema/index.js';
+
+const weightSelection = {
+  value: bodyWeight.weight,
+  date: bodyWeight.date,
+};
+
+const macroActualSelection = {
+  calories: sql<number>`coalesce(sum(${mealItems.calories}), 0)`,
+  protein: sql<number>`coalesce(sum(${mealItems.protein}), 0)`,
+  carbs: sql<number>`coalesce(sum(${mealItems.carbs}), 0)`,
+  fat: sql<number>`coalesce(sum(${mealItems.fat}), 0)`,
+};
+
+const macroTargetSelection = {
+  calories: nutritionTargets.calories,
+  protein: nutritionTargets.protein,
+  carbs: nutritionTargets.carbs,
+  fat: nutritionTargets.fat,
+};
+
+const workoutSelection = {
+  name: workoutSessions.name,
+  status: workoutSessions.status,
+  duration: workoutSessions.duration,
+};
+
+const habitSummarySelection = {
+  total: sql<number>`count(${habits.id})`,
+  completed: sql<number>`coalesce(sum(case when ${habitEntries.completed} then 1 else 0 end), 0)`,
+};
+
+const getDateRangeForUtcDay = (date: string) => {
+  const start = new Date(`${date}T00:00:00.000Z`);
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 1);
+
+  return {
+    start: start.getTime(),
+    end: end.getTime(),
+  };
+};
+
+const toMacroTotals = (
+  value:
+    | {
+        calories: number | null;
+        protein: number | null;
+        carbs: number | null;
+        fat: number | null;
+      }
+    | undefined,
+): DashboardMacroTotals => ({
+  calories: Number(value?.calories ?? 0),
+  protein: Number(value?.protein ?? 0),
+  carbs: Number(value?.carbs ?? 0),
+  fat: Number(value?.fat ?? 0),
+});
+
+const toWeightSnapshot = (
+  value: {
+    value: number;
+    date: string;
+  } | null,
+): DashboardWeightSnapshot | null => {
+  if (!value) {
+    return null;
+  }
+
+  return {
+    value: Number(value.value),
+    date: value.date,
+    unit: 'lb',
+  };
+};
+
+const toWorkoutSnapshot = (
+  value:
+    | {
+        name: string;
+        status: 'scheduled' | 'in-progress' | 'completed';
+        duration: number | null;
+      }
+    | undefined,
+): DashboardWorkoutSnapshot | null => {
+  if (!value) {
+    return null;
+  }
+
+  return {
+    name: value.name,
+    status: value.status,
+    duration: value.duration === null ? null : Number(value.duration),
+  };
+};
+
+const toHabitSnapshot = (
+  value:
+    | {
+        total: number;
+        completed: number;
+      }
+    | undefined,
+): DashboardHabitsSnapshot => {
+  const total = Number(value?.total ?? 0);
+  const completed = Number(value?.completed ?? 0);
+  const percentage = total > 0 ? Number(((completed / total) * 100).toFixed(1)) : 0;
+
+  return {
+    total,
+    completed,
+    percentage,
+  };
+};
+
+export const getDashboardSnapshot = async (
+  userId: string,
+  date: string,
+): Promise<DashboardSnapshot> => {
+  const { db } = await import('../../db/index.js');
+  const dayRange = getDateRangeForUtcDay(date);
+
+  return db.transaction((tx) => {
+    const weight =
+      tx
+        .select(weightSelection)
+        .from(bodyWeight)
+        .where(and(eq(bodyWeight.userId, userId), lte(bodyWeight.date, date)))
+        .orderBy(desc(bodyWeight.date))
+        .limit(1)
+        .get() ?? null;
+
+    const macrosActual =
+      tx
+        .select(macroActualSelection)
+        .from(nutritionLogs)
+        .leftJoin(meals, eq(meals.nutritionLogId, nutritionLogs.id))
+        .leftJoin(mealItems, eq(mealItems.mealId, meals.id))
+        .where(and(eq(nutritionLogs.userId, userId), eq(nutritionLogs.date, date)))
+        .get() ?? undefined;
+
+    const macrosTarget =
+      tx
+        .select(macroTargetSelection)
+        .from(nutritionTargets)
+        .where(and(eq(nutritionTargets.userId, userId), lte(nutritionTargets.effectiveDate, date)))
+        .orderBy(desc(nutritionTargets.effectiveDate))
+        .limit(1)
+        .get() ?? undefined;
+
+    const workout = tx
+      .select(workoutSelection)
+      .from(workoutSessions)
+      .where(
+        and(
+          eq(workoutSessions.userId, userId),
+          gte(workoutSessions.startedAt, dayRange.start),
+          lt(workoutSessions.startedAt, dayRange.end),
+        ),
+      )
+      .orderBy(desc(workoutSessions.startedAt))
+      .limit(1)
+      .get();
+
+    const habitsSummary =
+      tx
+        .select(habitSummarySelection)
+        .from(habits)
+        .leftJoin(
+          habitEntries,
+          and(
+            eq(habitEntries.habitId, habits.id),
+            eq(habitEntries.userId, userId),
+            eq(habitEntries.date, date),
+          ),
+        )
+        .where(and(eq(habits.userId, userId), eq(habits.active, true)))
+        .get() ?? undefined;
+
+    return {
+      date,
+      weight: toWeightSnapshot(weight),
+      macros: {
+        actual: toMacroTotals(macrosActual),
+        target: toMacroTotals(macrosTarget),
+      },
+      workout: toWorkoutSnapshot(workout),
+      habits: toHabitSnapshot(habitsSummary),
+    };
+  });
+};

--- a/apps/api/src/routes/v1/dashboard-utils.ts
+++ b/apps/api/src/routes/v1/dashboard-utils.ts
@@ -1,12 +1,11 @@
+import { getUtcDateValue } from '@pulse/shared';
+
+export { getUtcDateValue };
+
 export const addUtcDays = (date: string, days: number) => {
   const parsed = new Date(`${date}T00:00:00.000Z`);
   parsed.setUTCDate(parsed.getUTCDate() + days);
   return parsed.toISOString().slice(0, 10);
-};
-
-export const getUtcDateValue = (date: string) => {
-  const [year, month, day] = date.split('-').map(Number);
-  return Date.UTC(year ?? 0, (month ?? 1) - 1, day ?? 1);
 };
 
 export const getDatesInRange = (from: string, to: string) => {

--- a/apps/api/src/routes/v1/dashboard-utils.ts
+++ b/apps/api/src/routes/v1/dashboard-utils.ts
@@ -1,0 +1,22 @@
+export const addUtcDays = (date: string, days: number) => {
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + days);
+  return parsed.toISOString().slice(0, 10);
+};
+
+export const getUtcDateValue = (date: string) => {
+  const [year, month, day] = date.split('-').map(Number);
+  return Date.UTC(year ?? 0, (month ?? 1) - 1, day ?? 1);
+};
+
+export const getDatesInRange = (from: string, to: string) => {
+  const dates: string[] = [];
+
+  let current = from;
+  while (current <= to) {
+    dates.push(current);
+    current = addUtcDays(current, 1);
+  }
+
+  return dates;
+};

--- a/apps/api/src/routes/v1/dashboard.test.ts
+++ b/apps/api/src/routes/v1/dashboard.test.ts
@@ -480,6 +480,8 @@ describe('dashboard routes', () => {
         missingSnapshotAuthResponse,
         missingTrendAuthResponse,
         missingConfigAuthResponse,
+        missingConfigPutAuthResponse,
+        missingConfigPostAuthResponse,
         invalidSnapshotAuthResponse,
       ] =
         await Promise.all([
@@ -496,6 +498,22 @@ describe('dashboard routes', () => {
             url: '/api/v1/dashboard/config',
           }),
           app.inject({
+            method: 'PUT',
+            url: '/api/v1/dashboard/config',
+            payload: {
+              habitChainIds: ['habit-1'],
+              trendMetrics: ['weight'],
+            },
+          }),
+          app.inject({
+            method: 'POST',
+            url: '/api/v1/dashboard/config',
+            payload: {
+              habitChainIds: ['habit-1'],
+              trendMetrics: ['weight'],
+            },
+          }),
+          app.inject({
             method: 'GET',
             url: '/api/v1/dashboard/snapshot',
             headers: createAuthorizationHeader('not-a-valid-token'),
@@ -506,6 +524,8 @@ describe('dashboard routes', () => {
         missingSnapshotAuthResponse,
         missingTrendAuthResponse,
         missingConfigAuthResponse,
+        missingConfigPutAuthResponse,
+        missingConfigPostAuthResponse,
         invalidSnapshotAuthResponse,
       ]) {
         expect(response.statusCode).toBe(401);

--- a/apps/api/src/routes/v1/dashboard.test.ts
+++ b/apps/api/src/routes/v1/dashboard.test.ts
@@ -195,4 +195,36 @@ describe('dashboard routes', () => {
       await app.close();
     }
   });
+
+  it('rejects unauthenticated requests', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const [missingAuthResponse, invalidAuthResponse] = await Promise.all([
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/dashboard/snapshot',
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/dashboard/snapshot',
+          headers: createAuthorizationHeader('not-a-valid-token'),
+        }),
+      ]);
+
+      for (const response of [missingAuthResponse, invalidAuthResponse]) {
+        expect(response.statusCode).toBe(401);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'UNAUTHORIZED',
+            message: 'Authentication required',
+          },
+        });
+      }
+      expect(vi.mocked(getDashboardSnapshot)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
 });

--- a/apps/api/src/routes/v1/dashboard.test.ts
+++ b/apps/api/src/routes/v1/dashboard.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildServer } from '../../index.js';
+
+import { getDashboardSnapshot } from './dashboard-store.js';
+
+vi.mock('./dashboard-store.js', () => ({
+  getDashboardSnapshot: vi.fn(),
+}));
+
+const createAuthorizationHeader = (token: string) => ({
+  authorization: `Bearer ${token}`,
+});
+
+describe('dashboard routes', () => {
+  beforeEach(() => {
+    vi.mocked(getDashboardSnapshot).mockReset();
+    process.env.JWT_SECRET = 'test-dashboard-routes-secret';
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+    vi.useRealTimers();
+  });
+
+  it('returns the dashboard snapshot for an explicit date', async () => {
+    vi.mocked(getDashboardSnapshot).mockResolvedValue({
+      date: '2026-03-09',
+      weight: {
+        value: 178.4,
+        date: '2026-03-08',
+        unit: 'lb',
+      },
+      macros: {
+        actual: {
+          calories: 1850,
+          protein: 150,
+          carbs: 190,
+          fat: 65,
+        },
+        target: {
+          calories: 2200,
+          protein: 180,
+          carbs: 250,
+          fat: 70,
+        },
+      },
+      workout: {
+        name: 'Upper Push A',
+        status: 'completed',
+        duration: 64,
+      },
+      habits: {
+        total: 6,
+        completed: 4,
+        percentage: 66.7,
+      },
+    });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/dashboard/snapshot?date=2026-03-09',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: {
+          date: '2026-03-09',
+          weight: {
+            value: 178.4,
+            date: '2026-03-08',
+            unit: 'lb',
+          },
+          macros: {
+            actual: {
+              calories: 1850,
+              protein: 150,
+              carbs: 190,
+              fat: 65,
+            },
+            target: {
+              calories: 2200,
+              protein: 180,
+              carbs: 250,
+              fat: 70,
+            },
+          },
+          workout: {
+            name: 'Upper Push A',
+            status: 'completed',
+            duration: 64,
+          },
+          habits: {
+            total: 6,
+            completed: 4,
+            percentage: 66.7,
+          },
+        },
+      });
+      expect(vi.mocked(getDashboardSnapshot)).toHaveBeenCalledWith('user-1', '2026-03-09');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('defaults the snapshot date to today when date is omitted', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-10T17:04:11.000Z'));
+    vi.mocked(getDashboardSnapshot).mockResolvedValue({
+      date: '2026-03-10',
+      weight: null,
+      macros: {
+        actual: {
+          calories: 0,
+          protein: 0,
+          carbs: 0,
+          fat: 0,
+        },
+        target: {
+          calories: 2200,
+          protein: 180,
+          carbs: 250,
+          fat: 70,
+        },
+      },
+      workout: null,
+      habits: {
+        total: 0,
+        completed: 0,
+        percentage: 0,
+      },
+    });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-2' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/dashboard/snapshot',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().data.date).toBe('2026-03-10');
+      expect(vi.mocked(getDashboardSnapshot)).toHaveBeenCalledWith('user-2', '2026-03-10');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects invalid query params', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-3' });
+      const [invalidShapeResponse, invalidDateResponse] = await Promise.all([
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/dashboard/snapshot?date=03-09-2026',
+          headers: createAuthorizationHeader(authToken),
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/dashboard/snapshot?date=2026-02-30',
+          headers: createAuthorizationHeader(authToken),
+        }),
+      ]);
+
+      expect(invalidShapeResponse.statusCode).toBe(400);
+      expect(invalidShapeResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid dashboard snapshot query',
+        },
+      });
+
+      expect(invalidDateResponse.statusCode).toBe(400);
+      expect(invalidDateResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid dashboard snapshot date',
+        },
+      });
+      expect(vi.mocked(getDashboardSnapshot)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apps/api/src/routes/v1/dashboard.test.ts
+++ b/apps/api/src/routes/v1/dashboard.test.ts
@@ -3,17 +3,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildServer } from '../../index.js';
 
 import {
+  getDashboardConfig,
   getDashboardConsistencyTrend,
   getDashboardMacrosTrend,
   getDashboardSnapshot,
   getDashboardWeightTrend,
+  upsertDashboardConfig,
 } from './dashboard-store.js';
 
 vi.mock('./dashboard-store.js', () => ({
+  getDashboardConfig: vi.fn(),
   getDashboardSnapshot: vi.fn(),
   getDashboardWeightTrend: vi.fn(),
   getDashboardMacrosTrend: vi.fn(),
   getDashboardConsistencyTrend: vi.fn(),
+  upsertDashboardConfig: vi.fn(),
 }));
 
 const createAuthorizationHeader = (token: string) => ({
@@ -22,10 +26,12 @@ const createAuthorizationHeader = (token: string) => ({
 
 describe('dashboard routes', () => {
   beforeEach(() => {
+    vi.mocked(getDashboardConfig).mockReset();
     vi.mocked(getDashboardSnapshot).mockReset();
     vi.mocked(getDashboardWeightTrend).mockReset();
     vi.mocked(getDashboardMacrosTrend).mockReset();
     vi.mocked(getDashboardConsistencyTrend).mockReset();
+    vi.mocked(upsertDashboardConfig).mockReset();
     process.env.JWT_SECRET = 'test-dashboard-routes-secret';
   });
 
@@ -115,6 +121,111 @@ describe('dashboard routes', () => {
         },
       });
       expect(vi.mocked(getDashboardSnapshot)).toHaveBeenCalledWith('user-1', '2026-03-09');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns the dashboard config payload for the authenticated user', async () => {
+    vi.mocked(getDashboardConfig).mockResolvedValue({
+      habitChainIds: ['habit-1', 'habit-2'],
+      trendMetrics: ['weight', 'protein'],
+      widgetOrder: ['snapshot', 'trends'],
+    });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/dashboard/config',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: {
+          habitChainIds: ['habit-1', 'habit-2'],
+          trendMetrics: ['weight', 'protein'],
+          widgetOrder: ['snapshot', 'trends'],
+        },
+      });
+      expect(vi.mocked(getDashboardConfig)).toHaveBeenCalledWith('user-1');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('upserts dashboard config via PUT and POST', async () => {
+    vi.mocked(upsertDashboardConfig).mockResolvedValue({
+      habitChainIds: ['habit-1'],
+      trendMetrics: ['calories'],
+      widgetOrder: ['trends', 'snapshot'],
+    });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-2' });
+      const payload = {
+        habitChainIds: ['habit-1'],
+        trendMetrics: ['calories'],
+        widgetOrder: ['trends', 'snapshot'],
+      };
+
+      const [putResponse, postResponse] = await Promise.all([
+        app.inject({
+          method: 'PUT',
+          url: '/api/v1/dashboard/config',
+          payload,
+          headers: createAuthorizationHeader(authToken),
+        }),
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/dashboard/config',
+          payload,
+          headers: createAuthorizationHeader(authToken),
+        }),
+      ]);
+
+      expect(putResponse.statusCode).toBe(200);
+      expect(putResponse.json()).toEqual({ data: payload });
+      expect(postResponse.statusCode).toBe(200);
+      expect(postResponse.json()).toEqual({ data: payload });
+      expect(vi.mocked(upsertDashboardConfig)).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(upsertDashboardConfig)).toHaveBeenCalledWith('user-2', payload);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects invalid dashboard config payloads', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-2' });
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/v1/dashboard/config',
+        payload: {
+          habitChainIds: ['habit-1'],
+          trendMetrics: ['steps'],
+        },
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid dashboard config payload',
+        },
+      });
+      expect(vi.mocked(upsertDashboardConfig)).not.toHaveBeenCalled();
     } finally {
       await app.close();
     }
@@ -365,26 +476,36 @@ describe('dashboard routes', () => {
 
     try {
       await app.ready();
-      const [missingSnapshotAuthResponse, missingTrendAuthResponse, invalidSnapshotAuthResponse] =
+      const [
+        missingSnapshotAuthResponse,
+        missingTrendAuthResponse,
+        missingConfigAuthResponse,
+        invalidSnapshotAuthResponse,
+      ] =
         await Promise.all([
-        app.inject({
-          method: 'GET',
-          url: '/api/v1/dashboard/snapshot',
-        }),
-        app.inject({
-          method: 'GET',
-          url: '/api/v1/dashboard/trends/weight',
-        }),
-        app.inject({
-          method: 'GET',
-          url: '/api/v1/dashboard/snapshot',
-          headers: createAuthorizationHeader('not-a-valid-token'),
-        }),
-      ]);
+          app.inject({
+            method: 'GET',
+            url: '/api/v1/dashboard/snapshot',
+          }),
+          app.inject({
+            method: 'GET',
+            url: '/api/v1/dashboard/trends/weight',
+          }),
+          app.inject({
+            method: 'GET',
+            url: '/api/v1/dashboard/config',
+          }),
+          app.inject({
+            method: 'GET',
+            url: '/api/v1/dashboard/snapshot',
+            headers: createAuthorizationHeader('not-a-valid-token'),
+          }),
+        ]);
 
       for (const response of [
         missingSnapshotAuthResponse,
         missingTrendAuthResponse,
+        missingConfigAuthResponse,
         invalidSnapshotAuthResponse,
       ]) {
         expect(response.statusCode).toBe(401);
@@ -396,9 +517,11 @@ describe('dashboard routes', () => {
         });
       }
       expect(vi.mocked(getDashboardSnapshot)).not.toHaveBeenCalled();
+      expect(vi.mocked(getDashboardConfig)).not.toHaveBeenCalled();
       expect(vi.mocked(getDashboardWeightTrend)).not.toHaveBeenCalled();
       expect(vi.mocked(getDashboardMacrosTrend)).not.toHaveBeenCalled();
       expect(vi.mocked(getDashboardConsistencyTrend)).not.toHaveBeenCalled();
+      expect(vi.mocked(upsertDashboardConfig)).not.toHaveBeenCalled();
     } finally {
       await app.close();
     }

--- a/apps/api/src/routes/v1/dashboard.test.ts
+++ b/apps/api/src/routes/v1/dashboard.test.ts
@@ -2,10 +2,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildServer } from '../../index.js';
 
-import { getDashboardSnapshot } from './dashboard-store.js';
+import {
+  getDashboardConsistencyTrend,
+  getDashboardMacrosTrend,
+  getDashboardSnapshot,
+  getDashboardWeightTrend,
+} from './dashboard-store.js';
 
 vi.mock('./dashboard-store.js', () => ({
   getDashboardSnapshot: vi.fn(),
+  getDashboardWeightTrend: vi.fn(),
+  getDashboardMacrosTrend: vi.fn(),
+  getDashboardConsistencyTrend: vi.fn(),
 }));
 
 const createAuthorizationHeader = (token: string) => ({
@@ -15,6 +23,9 @@ const createAuthorizationHeader = (token: string) => ({
 describe('dashboard routes', () => {
   beforeEach(() => {
     vi.mocked(getDashboardSnapshot).mockReset();
+    vi.mocked(getDashboardWeightTrend).mockReset();
+    vi.mocked(getDashboardMacrosTrend).mockReset();
+    vi.mocked(getDashboardConsistencyTrend).mockReset();
     process.env.JWT_SECRET = 'test-dashboard-routes-secret';
   });
 
@@ -156,6 +167,102 @@ describe('dashboard routes', () => {
     }
   });
 
+  it('returns weight trend points for an explicit date range', async () => {
+    vi.mocked(getDashboardWeightTrend).mockResolvedValue([
+      { date: '2026-03-07', value: 181.4 },
+      { date: '2026-03-08', value: 181.1 },
+      { date: '2026-03-09', value: 180.9 },
+    ]);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/dashboard/trends/weight?from=2026-03-07&to=2026-03-09',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: [
+          { date: '2026-03-07', value: 181.4 },
+          { date: '2026-03-08', value: 181.1 },
+          { date: '2026-03-09', value: 180.9 },
+        ],
+      });
+      expect(vi.mocked(getDashboardWeightTrend)).toHaveBeenCalledWith(
+        'user-1',
+        '2026-03-07',
+        '2026-03-09',
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('defaults trend ranges when omitted', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-10T17:04:11.000Z'));
+    vi.mocked(getDashboardMacrosTrend).mockResolvedValue([
+      {
+        date: '2026-02-08',
+        calories: 0,
+        protein: 0,
+        carbs: 0,
+        fat: 0,
+      },
+      {
+        date: '2026-03-10',
+        calories: 2200,
+        protein: 180,
+        carbs: 240,
+        fat: 70,
+      },
+    ]);
+    vi.mocked(getDashboardConsistencyTrend).mockResolvedValue([
+      { date: '2026-03-09', completed: true },
+      { date: '2026-03-10', completed: false },
+    ]);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-2' });
+      const [macrosResponse, consistencyResponse] = await Promise.all([
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/dashboard/trends/macros',
+          headers: createAuthorizationHeader(authToken),
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/dashboard/trends/consistency?from=2026-03-09',
+          headers: createAuthorizationHeader(authToken),
+        }),
+      ]);
+
+      expect(macrosResponse.statusCode).toBe(200);
+      expect(vi.mocked(getDashboardMacrosTrend)).toHaveBeenCalledWith(
+        'user-2',
+        '2026-02-08',
+        '2026-03-10',
+      );
+
+      expect(consistencyResponse.statusCode).toBe(200);
+      expect(vi.mocked(getDashboardConsistencyTrend)).toHaveBeenCalledWith(
+        'user-2',
+        '2026-03-09',
+        '2026-03-10',
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
   it('rejects invalid query params', async () => {
     const app = buildServer();
 
@@ -196,6 +303,63 @@ describe('dashboard routes', () => {
     }
   });
 
+  it('rejects invalid trend query params', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-3' });
+      const [invalidShapeResponse, invalidCalendarDateResponse, oversizedRangeResponse] =
+        await Promise.all([
+          app.inject({
+            method: 'GET',
+            url: '/api/v1/dashboard/trends/weight?from=03-09-2026',
+            headers: createAuthorizationHeader(authToken),
+          }),
+          app.inject({
+            method: 'GET',
+            url: '/api/v1/dashboard/trends/macros?from=2026-02-30&to=2026-03-01',
+            headers: createAuthorizationHeader(authToken),
+          }),
+          app.inject({
+            method: 'GET',
+            url: '/api/v1/dashboard/trends/consistency?from=2025-01-01&to=2026-03-09',
+            headers: createAuthorizationHeader(authToken),
+          }),
+        ]);
+
+      expect(invalidShapeResponse.statusCode).toBe(400);
+      expect(invalidShapeResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid dashboard trend query',
+        },
+      });
+
+      expect(invalidCalendarDateResponse.statusCode).toBe(400);
+      expect(invalidCalendarDateResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid dashboard trend date range',
+        },
+      });
+
+      expect(oversizedRangeResponse.statusCode).toBe(400);
+      expect(oversizedRangeResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid dashboard trend query',
+        },
+      });
+
+      expect(vi.mocked(getDashboardWeightTrend)).not.toHaveBeenCalled();
+      expect(vi.mocked(getDashboardMacrosTrend)).not.toHaveBeenCalled();
+      expect(vi.mocked(getDashboardConsistencyTrend)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
   it('rejects unauthenticated requests', async () => {
     const app = buildServer();
 
@@ -205,6 +369,10 @@ describe('dashboard routes', () => {
         app.inject({
           method: 'GET',
           url: '/api/v1/dashboard/snapshot',
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/dashboard/trends/weight',
         }),
         app.inject({
           method: 'GET',
@@ -223,6 +391,9 @@ describe('dashboard routes', () => {
         });
       }
       expect(vi.mocked(getDashboardSnapshot)).not.toHaveBeenCalled();
+      expect(vi.mocked(getDashboardWeightTrend)).not.toHaveBeenCalled();
+      expect(vi.mocked(getDashboardMacrosTrend)).not.toHaveBeenCalled();
+      expect(vi.mocked(getDashboardConsistencyTrend)).not.toHaveBeenCalled();
     } finally {
       await app.close();
     }

--- a/apps/api/src/routes/v1/dashboard.test.ts
+++ b/apps/api/src/routes/v1/dashboard.test.ts
@@ -365,7 +365,8 @@ describe('dashboard routes', () => {
 
     try {
       await app.ready();
-      const [missingAuthResponse, invalidAuthResponse] = await Promise.all([
+      const [missingSnapshotAuthResponse, missingTrendAuthResponse, invalidSnapshotAuthResponse] =
+        await Promise.all([
         app.inject({
           method: 'GET',
           url: '/api/v1/dashboard/snapshot',
@@ -381,7 +382,11 @@ describe('dashboard routes', () => {
         }),
       ]);
 
-      for (const response of [missingAuthResponse, invalidAuthResponse]) {
+      for (const response of [
+        missingSnapshotAuthResponse,
+        missingTrendAuthResponse,
+        invalidSnapshotAuthResponse,
+      ]) {
         expect(response.statusCode).toBe(401);
         expect(response.json()).toEqual({
           error: {

--- a/apps/api/src/routes/v1/dashboard.ts
+++ b/apps/api/src/routes/v1/dashboard.ts
@@ -1,5 +1,6 @@
 import {
   MAX_DASHBOARD_TREND_RANGE_DAYS,
+  dashboardConfigSchema,
   dashboardSnapshotQuerySchema,
   dashboardTrendQuerySchema,
 } from '@pulse/shared';
@@ -9,10 +10,12 @@ import { sendError } from '../../lib/reply.js';
 import { requireUserAuth } from '../../middleware/auth.js';
 
 import {
+  getDashboardConfig,
   getDashboardConsistencyTrend,
   getDashboardMacrosTrend,
   getDashboardSnapshot,
   getDashboardWeightTrend,
+  upsertDashboardConfig,
 } from './dashboard-store.js';
 import { addUtcDays, getUtcDateValue } from './dashboard-utils.js';
 
@@ -90,4 +93,28 @@ export const dashboardRoutes: FastifyPluginAsync = async (app) => {
   app.get('/trends/weight', handleTrendRoute(getDashboardWeightTrend));
   app.get('/trends/macros', handleTrendRoute(getDashboardMacrosTrend));
   app.get('/trends/consistency', handleTrendRoute(getDashboardConsistencyTrend));
+
+  app.get('/config', async (request, reply) => {
+    const config = await getDashboardConfig(request.userId);
+
+    return reply.send({
+      data: config,
+    });
+  });
+
+  const handleConfigUpsert = async (request: FastifyRequest, reply: FastifyReply) => {
+    const parsedBody = dashboardConfigSchema.safeParse(request.body);
+    if (!parsedBody.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid dashboard config payload');
+    }
+
+    const config = await upsertDashboardConfig(request.userId, parsedBody.data);
+
+    return reply.send({
+      data: config,
+    });
+  };
+
+  app.post('/config', handleConfigUpsert);
+  app.put('/config', handleConfigUpsert);
 };

--- a/apps/api/src/routes/v1/dashboard.ts
+++ b/apps/api/src/routes/v1/dashboard.ts
@@ -1,0 +1,42 @@
+import { dashboardSnapshotQuerySchema } from '@pulse/shared';
+import type { FastifyPluginAsync } from 'fastify';
+
+import { sendError } from '../../lib/reply.js';
+import { requireUserAuth } from '../../middleware/auth.js';
+
+import { getDashboardSnapshot } from './dashboard-store.js';
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const getTodayDate = () => new Date().toISOString().slice(0, 10);
+
+const isValidDateParam = (date: string) => {
+  if (!DATE_PATTERN.test(date)) {
+    return false;
+  }
+
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(date);
+};
+
+export const dashboardRoutes: FastifyPluginAsync = async (app) => {
+  app.addHook('onRequest', requireUserAuth);
+
+  app.get('/snapshot', async (request, reply) => {
+    const parsedQuery = dashboardSnapshotQuerySchema.safeParse(request.query);
+    if (!parsedQuery.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid dashboard snapshot query');
+    }
+
+    const requestedDate = parsedQuery.data.date ?? getTodayDate();
+    if (!isValidDateParam(requestedDate)) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid dashboard snapshot date');
+    }
+
+    const snapshot = await getDashboardSnapshot(request.userId, requestedDate);
+
+    return reply.send({
+      data: snapshot,
+    });
+  });
+};

--- a/apps/api/src/routes/v1/dashboard.ts
+++ b/apps/api/src/routes/v1/dashboard.ts
@@ -1,5 +1,9 @@
-import { dashboardSnapshotQuerySchema, dashboardTrendQuerySchema } from '@pulse/shared';
-import type { FastifyPluginAsync } from 'fastify';
+import {
+  MAX_DASHBOARD_TREND_RANGE_DAYS,
+  dashboardSnapshotQuerySchema,
+  dashboardTrendQuerySchema,
+} from '@pulse/shared';
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
 import { requireUserAuth } from '../../middleware/auth.js';
@@ -10,10 +14,10 @@ import {
   getDashboardSnapshot,
   getDashboardWeightTrend,
 } from './dashboard-store.js';
+import { addUtcDays, getUtcDateValue } from './dashboard-utils.js';
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const DEFAULT_TREND_LOOKBACK_DAYS = 30;
-const MAX_TREND_RANGE_DAYS = 365;
 
 // TODO: Accept a user timezone (or offset) so omitted date defaults to the user's local day.
 const getTodayDate = () => new Date().toISOString().slice(0, 10);
@@ -25,17 +29,6 @@ const isValidDateParam = (date: string) => {
 
   const parsed = new Date(`${date}T00:00:00.000Z`);
   return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(date);
-};
-
-const addUtcDays = (date: string, days: number) => {
-  const parsed = new Date(`${date}T00:00:00.000Z`);
-  parsed.setUTCDate(parsed.getUTCDate() + days);
-  return parsed.toISOString().slice(0, 10);
-};
-
-const getUtcDateValue = (date: string) => {
-  const [year, month, day] = date.split('-').map(Number);
-  return Date.UTC(year ?? 0, (month ?? 1) - 1, day ?? 1);
 };
 
 const resolveTrendRange = (query: { from?: string; to?: string }) => {
@@ -51,8 +44,27 @@ const isValidTrendRange = (from: string, to: string) => {
   }
 
   const daysInclusive = (getUtcDateValue(to) - getUtcDateValue(from)) / (1000 * 60 * 60 * 24) + 1;
-  return daysInclusive <= MAX_TREND_RANGE_DAYS;
+  return daysInclusive <= MAX_DASHBOARD_TREND_RANGE_DAYS;
 };
+
+const handleTrendRoute =
+  <T>(getTrend: (userId: string, from: string, to: string) => Promise<T>) =>
+  async (request: FastifyRequest, reply: FastifyReply) => {
+    const parsedQuery = dashboardTrendQuerySchema.safeParse(request.query);
+    if (!parsedQuery.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid dashboard trend query');
+    }
+
+    const range = resolveTrendRange(parsedQuery.data);
+    if (!isValidTrendRange(range.from, range.to)) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid dashboard trend date range');
+    }
+
+    const trend = await getTrend(request.userId, range.from, range.to);
+    return reply.send({
+      data: trend,
+    });
+  };
 
 export const dashboardRoutes: FastifyPluginAsync = async (app) => {
   app.addHook('onRequest', requireUserAuth);
@@ -75,54 +87,7 @@ export const dashboardRoutes: FastifyPluginAsync = async (app) => {
     });
   });
 
-  app.get('/trends/weight', async (request, reply) => {
-    const parsedQuery = dashboardTrendQuerySchema.safeParse(request.query);
-    if (!parsedQuery.success) {
-      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid dashboard trend query');
-    }
-
-    const range = resolveTrendRange(parsedQuery.data);
-    if (!isValidTrendRange(range.from, range.to)) {
-      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid dashboard trend date range');
-    }
-
-    const trend = await getDashboardWeightTrend(request.userId, range.from, range.to);
-    return reply.send({
-      data: trend,
-    });
-  });
-
-  app.get('/trends/macros', async (request, reply) => {
-    const parsedQuery = dashboardTrendQuerySchema.safeParse(request.query);
-    if (!parsedQuery.success) {
-      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid dashboard trend query');
-    }
-
-    const range = resolveTrendRange(parsedQuery.data);
-    if (!isValidTrendRange(range.from, range.to)) {
-      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid dashboard trend date range');
-    }
-
-    const trend = await getDashboardMacrosTrend(request.userId, range.from, range.to);
-    return reply.send({
-      data: trend,
-    });
-  });
-
-  app.get('/trends/consistency', async (request, reply) => {
-    const parsedQuery = dashboardTrendQuerySchema.safeParse(request.query);
-    if (!parsedQuery.success) {
-      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid dashboard trend query');
-    }
-
-    const range = resolveTrendRange(parsedQuery.data);
-    if (!isValidTrendRange(range.from, range.to)) {
-      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid dashboard trend date range');
-    }
-
-    const trend = await getDashboardConsistencyTrend(request.userId, range.from, range.to);
-    return reply.send({
-      data: trend,
-    });
-  });
+  app.get('/trends/weight', handleTrendRoute(getDashboardWeightTrend));
+  app.get('/trends/macros', handleTrendRoute(getDashboardMacrosTrend));
+  app.get('/trends/consistency', handleTrendRoute(getDashboardConsistencyTrend));
 };

--- a/apps/api/src/routes/v1/dashboard.ts
+++ b/apps/api/src/routes/v1/dashboard.ts
@@ -8,6 +8,7 @@ import { getDashboardSnapshot } from './dashboard-store.js';
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
+// TODO: Accept a user timezone (or offset) so omitted date defaults to the user's local day.
 const getTodayDate = () => new Date().toISOString().slice(0, 10);
 
 const isValidDateParam = (date: string) => {

--- a/apps/api/src/routes/v1/dashboard.ts
+++ b/apps/api/src/routes/v1/dashboard.ts
@@ -1,12 +1,19 @@
-import { dashboardSnapshotQuerySchema } from '@pulse/shared';
+import { dashboardSnapshotQuerySchema, dashboardTrendQuerySchema } from '@pulse/shared';
 import type { FastifyPluginAsync } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
 import { requireUserAuth } from '../../middleware/auth.js';
 
-import { getDashboardSnapshot } from './dashboard-store.js';
+import {
+  getDashboardConsistencyTrend,
+  getDashboardMacrosTrend,
+  getDashboardSnapshot,
+  getDashboardWeightTrend,
+} from './dashboard-store.js';
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const DEFAULT_TREND_LOOKBACK_DAYS = 30;
+const MAX_TREND_RANGE_DAYS = 365;
 
 // TODO: Accept a user timezone (or offset) so omitted date defaults to the user's local day.
 const getTodayDate = () => new Date().toISOString().slice(0, 10);
@@ -18,6 +25,33 @@ const isValidDateParam = (date: string) => {
 
   const parsed = new Date(`${date}T00:00:00.000Z`);
   return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(date);
+};
+
+const addUtcDays = (date: string, days: number) => {
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + days);
+  return parsed.toISOString().slice(0, 10);
+};
+
+const getUtcDateValue = (date: string) => {
+  const [year, month, day] = date.split('-').map(Number);
+  return Date.UTC(year ?? 0, (month ?? 1) - 1, day ?? 1);
+};
+
+const resolveTrendRange = (query: { from?: string; to?: string }) => {
+  const to = query.to ?? getTodayDate();
+  const from = query.from ?? addUtcDays(to, -DEFAULT_TREND_LOOKBACK_DAYS);
+
+  return { from, to };
+};
+
+const isValidTrendRange = (from: string, to: string) => {
+  if (!isValidDateParam(from) || !isValidDateParam(to) || from > to) {
+    return false;
+  }
+
+  const daysInclusive = (getUtcDateValue(to) - getUtcDateValue(from)) / (1000 * 60 * 60 * 24) + 1;
+  return daysInclusive <= MAX_TREND_RANGE_DAYS;
 };
 
 export const dashboardRoutes: FastifyPluginAsync = async (app) => {
@@ -38,6 +72,57 @@ export const dashboardRoutes: FastifyPluginAsync = async (app) => {
 
     return reply.send({
       data: snapshot,
+    });
+  });
+
+  app.get('/trends/weight', async (request, reply) => {
+    const parsedQuery = dashboardTrendQuerySchema.safeParse(request.query);
+    if (!parsedQuery.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid dashboard trend query');
+    }
+
+    const range = resolveTrendRange(parsedQuery.data);
+    if (!isValidTrendRange(range.from, range.to)) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid dashboard trend date range');
+    }
+
+    const trend = await getDashboardWeightTrend(request.userId, range.from, range.to);
+    return reply.send({
+      data: trend,
+    });
+  });
+
+  app.get('/trends/macros', async (request, reply) => {
+    const parsedQuery = dashboardTrendQuerySchema.safeParse(request.query);
+    if (!parsedQuery.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid dashboard trend query');
+    }
+
+    const range = resolveTrendRange(parsedQuery.data);
+    if (!isValidTrendRange(range.from, range.to)) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid dashboard trend date range');
+    }
+
+    const trend = await getDashboardMacrosTrend(request.userId, range.from, range.to);
+    return reply.send({
+      data: trend,
+    });
+  });
+
+  app.get('/trends/consistency', async (request, reply) => {
+    const parsedQuery = dashboardTrendQuerySchema.safeParse(request.query);
+    if (!parsedQuery.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid dashboard trend query');
+    }
+
+    const range = resolveTrendRange(parsedQuery.data);
+    if (!isValidTrendRange(range.from, range.to)) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid dashboard trend date range');
+    }
+
+    const trend = await getDashboardConsistencyTrend(request.userId, range.from, range.to);
+    return reply.send({
+      data: trend,
     });
   });
 };

--- a/apps/api/src/routes/v1/index.ts
+++ b/apps/api/src/routes/v1/index.ts
@@ -1,0 +1,7 @@
+import type { FastifyPluginAsync } from 'fastify';
+
+import { dashboardRoutes } from './dashboard.js';
+
+export const v1Routes: FastifyPluginAsync = async (app) => {
+  app.register(dashboardRoutes, { prefix: '/dashboard' });
+};

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -1096,6 +1096,7 @@ describe('workout session routes', () => {
           startedAt: 1_700_000_100_000,
           completedAt: 1_700_000_103_000,
           duration: 50,
+          exerciseCount: 2,
           createdAt: createdPayload.data.createdAt,
         },
         {
@@ -1108,6 +1109,7 @@ describe('workout session routes', () => {
           startedAt: 1_700_000_000_000,
           completedAt: 1_700_000_002_700,
           duration: 45,
+          exerciseCount: 0,
           createdAt: expect.any(Number),
         },
       ],

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -1125,6 +1125,73 @@ describe('workout session routes', () => {
     });
   });
 
+  it('filters workout session listings by status and limit', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    seedWorkoutSession({
+      id: 'session-completed-1',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Upper Push',
+      date: '2026-03-15',
+      status: 'completed',
+      startedAt: 1_700_100_000_000,
+      completedAt: 1_700_100_003_000,
+      duration: 50,
+    });
+    seedWorkoutSession({
+      id: 'session-in-progress',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Upper Push Volume',
+      date: '2026-03-14',
+      status: 'in-progress',
+      startedAt: 1_700_090_000_000,
+    });
+    seedWorkoutSession({
+      id: 'session-completed-2',
+      userId: 'user-1',
+      templateId: 'template-2',
+      name: 'Lower Body',
+      date: '2026-03-13',
+      status: 'completed',
+      startedAt: 1_700_080_000_000,
+      completedAt: 1_700_080_003_000,
+      duration: 48,
+    });
+    seedWorkoutSession({
+      id: 'session-completed-3',
+      userId: 'user-1',
+      templateId: 'template-2',
+      name: 'Lower Body Volume',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: 1_700_070_000_000,
+      completedAt: 1_700_070_003_000,
+      duration: 45,
+    });
+
+    const response = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/workout-sessions?status=completed&limit=2',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: [
+        expect.objectContaining({
+          id: 'session-completed-1',
+          status: 'completed',
+        }),
+        expect.objectContaining({
+          id: 'session-completed-2',
+          status: 'completed',
+        }),
+      ],
+    });
+  });
+
   it('updates owned workout sessions by replacing nested set rows', async () => {
     const authToken = context.app.jwt.sign({ userId: 'user-1' });
 
@@ -1428,14 +1495,41 @@ describe('workout session routes', () => {
   it('rejects invalid list queries and malformed payloads', async () => {
     const authToken = context.app.jwt.sign({ userId: 'user-1' });
 
-    const invalidQueryResponse = await context.app.inject({
-      method: 'GET',
-      url: '/api/v1/workout-sessions?from=2026-03-12&to=2026-03-10',
-      headers: createAuthorizationHeader(authToken),
-    });
+    const [invalidRangeQueryResponse, invalidStatusQueryResponse, invalidLimitQueryResponse] =
+      await Promise.all([
+        context.app.inject({
+          method: 'GET',
+          url: '/api/v1/workout-sessions?from=2026-03-12&to=2026-03-10',
+          headers: createAuthorizationHeader(authToken),
+        }),
+        context.app.inject({
+          method: 'GET',
+          url: '/api/v1/workout-sessions?status=finished',
+          headers: createAuthorizationHeader(authToken),
+        }),
+        context.app.inject({
+          method: 'GET',
+          url: '/api/v1/workout-sessions?limit=0',
+          headers: createAuthorizationHeader(authToken),
+        }),
+      ]);
 
-    expect(invalidQueryResponse.statusCode).toBe(400);
-    expect(invalidQueryResponse.json()).toEqual({
+    expect(invalidRangeQueryResponse.statusCode).toBe(400);
+    expect(invalidRangeQueryResponse.json()).toEqual({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Invalid workout session query',
+      },
+    });
+    expect(invalidStatusQueryResponse.statusCode).toBe(400);
+    expect(invalidStatusQueryResponse.json()).toEqual({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Invalid workout session query',
+      },
+    });
+    expect(invalidLimitQueryResponse.statusCode).toBe(400);
+    expect(invalidLimitQueryResponse.json()).toEqual({
       error: {
         code: 'VALIDATION_ERROR',
         message: 'Invalid workout session query',

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import { and, desc, eq, gte, inArray, isNull, lte, or } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, isNull, lte, or, sql } from 'drizzle-orm';
 import type {
   BatchUpsertSetsInput,
   CreateSetInput,
@@ -97,6 +97,11 @@ const workoutSessionListSelection = {
   startedAt: workoutSessions.startedAt,
   completedAt: workoutSessions.completedAt,
   duration: workoutSessions.duration,
+  exerciseCount: sql<number>`coalesce((
+    select count(distinct ${sessionSets.exerciseId})
+    from ${sessionSets}
+    where ${sessionSets.sessionId} = ${workoutSessions.id}
+  ), 0)`,
   createdAt: workoutSessions.createdAt,
 };
 

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -462,30 +462,46 @@ export const listWorkoutSessions = async ({
   userId,
   from,
   to,
+  status,
+  limit,
 }: {
   userId: string;
-  from: string;
-  to: string;
+  from?: string;
+  to?: string;
+  status?: WorkoutSession['status'];
+  limit?: number;
 }): Promise<WorkoutSessionListItem[]> => {
   const { db } = await import('../../db/index.js');
+  const whereClauses = [eq(workoutSessions.userId, userId)];
 
-  return db
+  if (from) {
+    whereClauses.push(gte(workoutSessions.date, from));
+  }
+
+  if (to) {
+    whereClauses.push(lte(workoutSessions.date, to));
+  }
+
+  if (status) {
+    whereClauses.push(eq(workoutSessions.status, status));
+  }
+
+  const query = db
     .select(workoutSessionListSelection)
     .from(workoutSessions)
     .leftJoin(workoutTemplates, eq(workoutTemplates.id, workoutSessions.templateId))
-    .where(
-      and(
-        eq(workoutSessions.userId, userId),
-        gte(workoutSessions.date, from),
-        lte(workoutSessions.date, to),
-      ),
-    )
+    .where(and(...whereClauses))
     .orderBy(
       desc(workoutSessions.date),
       desc(workoutSessions.startedAt),
       desc(workoutSessions.createdAt),
-    )
-    .all();
+    );
+
+  if (typeof limit === 'number') {
+    return query.limit(limit).all();
+  }
+
+  return query.all();
 };
 
 export const findWorkoutSessionById = async (

--- a/apps/web/src/features/dashboard/components/habit-chain.test.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.test.tsx
@@ -186,4 +186,10 @@ describe('HabitChain', () => {
 
     expect(screen.getByText('No matching habits.')).toBeInTheDocument();
   });
+
+  it('renders an empty state when an explicit empty filter is provided', () => {
+    render(<HabitChain entries={habitEntryRecords} habitIds={[]} habits={habitRecords} />);
+
+    expect(screen.getByText('No matching habits.')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/dashboard/components/habit-chain.test.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.test.tsx
@@ -96,6 +96,34 @@ describe('HabitChain', () => {
     expect(todaySquares[0]).toHaveClass('border-[var(--color-primary)]');
   });
 
+  it('renders a 30-day window ending at the provided end date', () => {
+    const habit = getHabitByIndex(0);
+    const endDate = habit.entries[20]?.date;
+
+    if (!endDate) {
+      throw new Error('Expected a valid end date in mock habit entries.');
+    }
+
+    const { container } = render(
+      <HabitChain
+        endDate={endDate}
+        entries={habitEntryRecords}
+        habitIds={[habit.id]}
+        habits={habitRecords}
+      />,
+    );
+
+    const squares = container.querySelectorAll('[data-slot="habit-chain-day"]');
+    expect(squares).toHaveLength(30);
+    expect(squares[29]).toHaveAttribute('data-date', endDate);
+
+    const highlightedSquares = container.querySelectorAll(
+      '[data-slot="habit-chain-day"][data-today="true"]',
+    );
+    expect(highlightedSquares).toHaveLength(1);
+    expect(highlightedSquares[0]).toHaveAttribute('data-date', endDate);
+  });
+
   it('uses mint squares for completed days and gray squares for missed days', () => {
     const habit = getHabitByIndex(0);
     const { container } = render(

--- a/apps/web/src/features/dashboard/components/habit-chain.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.tsx
@@ -52,7 +52,7 @@ const getCurrentStreak = (entries: HabitChainEntry[]) => {
 };
 
 const getVisibleHabits = (habits: HabitChainHabit[], habitIds?: string[]) => {
-  if (!habitIds || habitIds.length === 0) {
+  if (!habitIds) {
     return habits;
   }
 

--- a/apps/web/src/features/dashboard/components/habit-chain.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.tsx
@@ -10,6 +10,7 @@ type HabitChainProps = {
   habitIds?: string[];
   habits?: HabitRecord[];
   entries?: HabitEntryRecord[];
+  endDate?: string;
 };
 
 type HabitChainEntry = {
@@ -62,6 +63,7 @@ const getVisibleHabits = (habits: HabitChainHabit[], habitIds?: string[]) => {
 const buildHabitChainHabits = (
   habits: HabitRecord[],
   entries: HabitEntryRecord[],
+  endDate: string,
 ): HabitChainHabit[] => {
   const entriesByHabit = new Map<string, Map<string, boolean>>();
 
@@ -71,8 +73,9 @@ const buildHabitChainHabits = (
     entriesByHabit.set(entry.habitId, entriesByDate);
   });
 
+  const rangeEndDate = new Date(`${endDate}T00:00:00`);
   const dates = Array.from({ length: DAYS_TO_DISPLAY }, (_, index) =>
-    toDateKey(addDays(getToday(), index - (DAYS_TO_DISPLAY - 1))),
+    toDateKey(addDays(rangeEndDate, index - (DAYS_TO_DISPLAY - 1))),
   );
 
   return habits.map((habit) => {
@@ -91,10 +94,10 @@ const buildHabitChainHabits = (
   });
 };
 
-export function HabitChain({ habitIds, habits = [], entries = [] }: HabitChainProps) {
-  const resolvedHabits = buildHabitChainHabits(habits, entries);
+export function HabitChain({ habitIds, habits = [], entries = [], endDate }: HabitChainProps) {
+  const selectedDateKey = endDate ?? formatDateKey(getToday());
+  const resolvedHabits = buildHabitChainHabits(habits, entries, selectedDateKey);
   const visibleHabits = getVisibleHabits(resolvedHabits, habitIds);
-  const todayKey = formatDateKey(getToday());
 
   if (visibleHabits.length === 0) {
     return <p className="text-sm text-muted">No matching habits.</p>;
@@ -119,7 +122,7 @@ export function HabitChain({ habitIds, habits = [], entries = [] }: HabitChainPr
 
               <div className="grid grid-cols-10 gap-[5px]" data-slot="habit-chain-grid">
                 {habit.entries.map((entry) => {
-                  const isToday = entry.date === todayKey;
+                  const isSelectedDay = entry.date === selectedDateKey;
                   const statusLabel = entry.completed ? 'Completed' : 'Missed';
 
                   return (
@@ -132,12 +135,14 @@ export function HabitChain({ habitIds, habits = [], entries = [] }: HabitChainPr
                             entry.completed
                               ? 'bg-[var(--color-accent-mint)]'
                               : 'bg-[var(--color-muted)]/40',
-                            isToday ? 'border-[var(--color-primary)]' : 'border-transparent',
+                            isSelectedDay
+                              ? 'border-[var(--color-primary)]'
+                              : 'border-transparent',
                           )}
                           data-completed={entry.completed ? 'true' : 'false'}
                           data-date={entry.date}
                           data-slot="habit-chain-day"
-                          data-today={isToday ? 'true' : 'false'}
+                          data-today={isSelectedDay ? 'true' : 'false'}
                           title={formatDateLabel(entry.date)}
                           type="button"
                         />

--- a/apps/web/src/features/dashboard/components/macro-rings.test.tsx
+++ b/apps/web/src/features/dashboard/components/macro-rings.test.tsx
@@ -1,7 +1,33 @@
+import type { DashboardSnapshot } from '@pulse/shared';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { mockDailySnapshot } from '@/lib/mock-data/dashboard';
+
 import { getMacroRingState, MacroRings } from './macro-rings';
+
+const snapshotFixture: DashboardSnapshot = {
+  date: '2026-03-06',
+  weight: null,
+  macros: {
+    actual: {
+      calories: 1850,
+      protein: 145,
+      carbs: 200,
+      fat: 65,
+    },
+    target: {
+      calories: 2200,
+      protein: 180,
+      carbs: 250,
+      fat: 73,
+    },
+  },
+  workout: null,
+  habits: {
+    total: 3,
+    completed: 2,
+    percentage: 66.7,
+  },
+};
 
 const getMacroItem = (label: string): HTMLElement => {
   const macroLabel = screen.getByText(label);
@@ -34,7 +60,7 @@ describe('getMacroRingState', () => {
 
 describe('MacroRings', () => {
   it('renders four macro rings with distinct colors and eaten values', () => {
-    const { container } = render(<MacroRings />);
+    const { container } = render(<MacroRings snapshot={snapshotFixture} />);
 
     const grid = container.querySelector('div.grid.grid-cols-2.gap-4.lg\\:grid-cols-4');
     expect(grid).toBeInTheDocument();
@@ -45,10 +71,10 @@ describe('MacroRings', () => {
     expect(screen.getByText('Carbs')).toBeInTheDocument();
     expect(screen.getByText('Fat')).toBeInTheDocument();
 
-    expect(screen.getByText(`${mockDailySnapshot.macros.calories.actual}kcal`)).toBeInTheDocument();
-    expect(screen.getByText(`${mockDailySnapshot.macros.protein.actual}g`)).toBeInTheDocument();
-    expect(screen.getByText(`${mockDailySnapshot.macros.carbs.actual}g`)).toBeInTheDocument();
-    expect(screen.getByText(`${mockDailySnapshot.macros.fat.actual}g`)).toBeInTheDocument();
+    expect(screen.getByText('1850kcal')).toBeInTheDocument();
+    expect(screen.getByText('145g')).toBeInTheDocument();
+    expect(screen.getByText('200g')).toBeInTheDocument();
+    expect(screen.getByText('65g')).toBeInTheDocument();
 
     const caloriesRingIndicator = getMacroItem('Calories').querySelector(
       '[data-slot="progress-ring-indicator"]',
@@ -65,8 +91,15 @@ describe('MacroRings', () => {
     expect(fatRingIndicator).toHaveAttribute('stroke', '#A855F7');
   });
 
-  it('toggles to remaining mode and shows inverse progress labels', () => {
+  it('shows zeroed values when snapshot data is unavailable', () => {
     render(<MacroRings />);
+
+    expect(screen.getByText('0kcal')).toBeInTheDocument();
+    expect(screen.getAllByText('0g')).toHaveLength(3);
+  });
+
+  it('toggles to remaining mode and shows inverse progress labels', () => {
+    render(<MacroRings snapshot={snapshotFixture} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Remaining' }));
 
@@ -86,10 +119,13 @@ describe('MacroRings', () => {
     render(
       <MacroRings
         snapshot={{
-          ...mockDailySnapshot,
+          ...snapshotFixture,
           macros: {
-            ...mockDailySnapshot.macros,
-            protein: { actual: 200, target: 180 },
+            ...snapshotFixture.macros,
+            actual: {
+              ...snapshotFixture.macros.actual,
+              protein: 200,
+            },
           },
         }}
       />,

--- a/apps/web/src/features/dashboard/components/macro-rings.tsx
+++ b/apps/web/src/features/dashboard/components/macro-rings.tsx
@@ -1,20 +1,28 @@
 /* eslint-disable react-refresh/only-export-components */
+import type { DashboardSnapshot } from '@pulse/shared';
 import { useState } from 'react';
+
 import { Button } from '@/components/ui/button';
 import { ProgressRing } from '@/components/ui/progress-ring';
-import { mockDailySnapshot, type DailySnapshot, type MacroStat } from '@/lib/mock-data/dashboard';
 
 type MacroRingsProps = {
-  snapshot?: DailySnapshot;
+  snapshot?: DashboardSnapshot;
 };
 
 type MacroMode = 'eaten' | 'remaining';
 
+type MacroKey = keyof DashboardSnapshot['macros']['actual'];
+
 type MacroConfig = {
-  key: keyof DailySnapshot['macros'];
+  key: MacroKey;
   label: string;
   color: string;
   unit: 'kcal' | 'g';
+};
+
+type MacroStat = {
+  actual: number;
+  target: number;
 };
 
 type MacroRingState = {
@@ -65,7 +73,18 @@ export const getMacroRingState = (
   };
 };
 
-export function MacroRings({ snapshot = mockDailySnapshot }: MacroRingsProps) {
+const getMacroStat = (snapshot: DashboardSnapshot | undefined, key: MacroKey): MacroStat => {
+  if (!snapshot) {
+    return { actual: 0, target: 0 };
+  }
+
+  return {
+    actual: snapshot.macros.actual[key],
+    target: snapshot.macros.target[key],
+  };
+};
+
+export function MacroRings({ snapshot }: MacroRingsProps) {
   const [mode, setMode] = useState<MacroMode>('eaten');
 
   return (
@@ -101,12 +120,7 @@ export function MacroRings({ snapshot = mockDailySnapshot }: MacroRingsProps) {
 
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
         {MACRO_CONFIGS.map((macro) => {
-          const state = getMacroRingState(
-            snapshot.macros[macro.key],
-            mode,
-            macro.color,
-            macro.unit,
-          );
+          const state = getMacroRingState(getMacroStat(snapshot, macro.key), mode, macro.color, macro.unit);
 
           return (
             <div

--- a/apps/web/src/features/dashboard/components/recent-workouts.test.tsx
+++ b/apps/web/src/features/dashboard/components/recent-workouts.test.tsx
@@ -1,22 +1,63 @@
 import { render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { afterAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Hoist fake timers before imports so the mock-data module (which computes
-// dates at load time via getToday()) sees the same fake date the tests use.
+import { formatRelativeWorkoutDate } from '@/features/dashboard/lib/recent-workouts';
+import { useRecentWorkouts } from '@/hooks/use-recent-workouts';
+
+import { RecentWorkouts } from './recent-workouts';
+
+vi.mock('@/hooks/use-recent-workouts', () => ({
+  useRecentWorkouts: vi.fn(),
+}));
+
+// Hoist fake timers before imports so relative-date formatting is deterministic.
 vi.hoisted(() => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date('2026-03-06T10:00:00'));
 });
 
-import { formatRelativeWorkoutDate } from '@/features/dashboard/lib/recent-workouts';
-import { mockRecentWorkouts } from '@/lib/mock-data/dashboard';
-
-import { RecentWorkouts } from './recent-workouts';
-
 afterAll(() => {
   vi.useRealTimers();
 });
+
+const recentWorkoutsFixture = [
+  {
+    id: 'session-1',
+    name: 'Upper Push A',
+    date: '2026-03-05',
+    duration: 62,
+    exerciseCount: 6,
+  },
+  {
+    id: 'session-2',
+    name: 'Lower Strength',
+    date: '2026-03-03',
+    duration: 70,
+    exerciseCount: 5,
+  },
+  {
+    id: 'session-3',
+    name: 'Upper Pull A',
+    date: '2026-02-28',
+    duration: 58,
+    exerciseCount: 7,
+  },
+  {
+    id: 'session-4',
+    name: 'Conditioning Circuit',
+    date: '2026-02-25',
+    duration: 45,
+    exerciseCount: 4,
+  },
+  {
+    id: 'session-5',
+    name: 'Upper Push B',
+    date: '2026-02-20',
+    duration: null,
+    exerciseCount: 6,
+  },
+];
 
 describe('formatRelativeWorkoutDate', () => {
   it('formats today, yesterday, day, and week ranges', () => {
@@ -30,7 +71,16 @@ describe('formatRelativeWorkoutDate', () => {
 });
 
 describe('RecentWorkouts', () => {
+  beforeEach(() => {
+    vi.mocked(useRecentWorkouts).mockReset();
+  });
+
   it('renders five recent workout cards with workout links and metadata', () => {
+    vi.mocked(useRecentWorkouts).mockReturnValue({
+      data: recentWorkoutsFixture,
+      isLoading: false,
+    } as ReturnType<typeof useRecentWorkouts>);
+
     render(
       <MemoryRouter>
         <RecentWorkouts />
@@ -43,18 +93,24 @@ describe('RecentWorkouts', () => {
     const workoutLinks = screen.getAllByRole('link', { name: /^Open / });
     expect(workoutLinks).toHaveLength(5);
 
-    mockRecentWorkouts.forEach((workout) => {
+    recentWorkoutsFixture.forEach((workout) => {
       const link = screen.getByRole('link', { name: `Open ${workout.name}` });
 
-      expect(link).toHaveAttribute('href', `/workouts/${workout.id}`);
+      expect(link).toHaveAttribute('href', `/workouts/session/${workout.id}`);
       expect(within(link).getByText(workout.name)).toBeInTheDocument();
-      expect(within(link).getByText(`${workout.totalSets} sets`)).toBeInTheDocument();
-      expect(within(link).getByText(`${workout.totalReps} reps`)).toBeInTheDocument();
-      expect(within(link).getByText(`${workout.duration} min`)).toBeInTheDocument();
+      expect(within(link).getByText(`${workout.exerciseCount} exercises`)).toBeInTheDocument();
+      expect(
+        within(link).getByText(workout.duration === null ? 'Duration n/a' : `${workout.duration} min`),
+      ).toBeInTheDocument();
     });
   });
 
   it('shows relative date labels for recent sessions', () => {
+    vi.mocked(useRecentWorkouts).mockReturnValue({
+      data: recentWorkoutsFixture,
+      isLoading: false,
+    } as ReturnType<typeof useRecentWorkouts>);
+
     render(
       <MemoryRouter>
         <RecentWorkouts />
@@ -66,5 +122,35 @@ describe('RecentWorkouts', () => {
     expect(screen.getByText('6 days ago')).toBeInTheDocument();
     expect(screen.getByText('1 week ago')).toBeInTheDocument();
     expect(screen.getByText('2 weeks ago')).toBeInTheDocument();
+  });
+
+  it('renders skeleton rows while loading', () => {
+    vi.mocked(useRecentWorkouts).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as ReturnType<typeof useRecentWorkouts>);
+
+    const { container } = render(
+      <MemoryRouter>
+        <RecentWorkouts />
+      </MemoryRouter>,
+    );
+
+    expect(container.querySelectorAll('[data-slot="recent-workout-card-skeleton"]')).toHaveLength(4);
+  });
+
+  it('renders an empty state when there are no completed sessions', () => {
+    vi.mocked(useRecentWorkouts).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useRecentWorkouts>);
+
+    render(
+      <MemoryRouter>
+        <RecentWorkouts />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('No completed workouts yet.')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/dashboard/components/recent-workouts.tsx
+++ b/apps/web/src/features/dashboard/components/recent-workouts.tsx
@@ -2,11 +2,12 @@ import { Link } from 'react-router';
 
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
-import { parseDateInput } from '@/lib/date';
 import { formatRelativeWorkoutDate } from '@/features/dashboard/lib/recent-workouts';
-import { mockRecentWorkouts } from '@/lib/mock-data/dashboard';
+import { useRecentWorkouts } from '@/hooks/use-recent-workouts';
+import { parseDateInput } from '@/lib/date';
 
 const WORKOUTS_TO_SHOW = 5;
+const WORKOUT_SKELETON_ROWS = 4;
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'short',
@@ -18,8 +19,34 @@ const formatWorkoutDate = (value: string): string => {
   return dateFormatter.format(parseDateInput(value));
 };
 
+function RecentWorkoutRowsSkeleton() {
+  return (
+    <ul className="grid gap-3" data-slot="recent-workout-skeleton-list">
+      {Array.from({ length: WORKOUT_SKELETON_ROWS }).map((_, index) => (
+        <li key={`workout-skeleton-${index}`}>
+          <Card className="h-full gap-4 px-4 py-4" data-slot="recent-workout-card-skeleton">
+            <div className="space-y-3">
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0 space-y-2">
+                  <div className="h-5 w-40 animate-pulse rounded bg-muted/50" />
+                  <div className="h-4 w-28 animate-pulse rounded bg-muted/50" />
+                </div>
+                <div className="h-6 w-20 animate-pulse rounded-full bg-muted/50" />
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <div className="h-8 w-24 animate-pulse rounded-full bg-muted/50" />
+                <div className="h-8 w-20 animate-pulse rounded-full bg-muted/50" />
+              </div>
+            </div>
+          </Card>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 export function RecentWorkouts() {
-  const workouts = mockRecentWorkouts.slice(0, WORKOUTS_TO_SHOW);
+  const recentWorkoutsQuery = useRecentWorkouts(WORKOUTS_TO_SHOW);
 
   return (
     <section aria-labelledby="recent-workouts-heading" className="space-y-4">
@@ -39,45 +66,54 @@ export function RecentWorkouts() {
         </Button>
       </div>
 
-      <ul className="grid gap-3">
-        {workouts.map((workout) => (
-          <li key={workout.id}>
-            <Link
-              aria-label={`Open ${workout.name}`}
-              className="block cursor-pointer rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-              to={`/workouts/${workout.id}`}
-            >
-              <Card
-                className="h-full gap-4 px-4 py-4 transition-transform duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
-                data-slot="recent-workout-card"
+      {recentWorkoutsQuery.isLoading ? (
+        <RecentWorkoutRowsSkeleton />
+      ) : recentWorkoutsQuery.data && recentWorkoutsQuery.data.length > 0 ? (
+        <ul className="grid gap-3">
+          {recentWorkoutsQuery.data.map((workout) => (
+            <li key={workout.id}>
+              <Link
+                aria-label={`Open ${workout.name}`}
+                className="block cursor-pointer rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                to={`/workouts/session/${workout.id}`}
               >
-                <div className="space-y-3">
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0 space-y-1">
-                      <p className="truncate text-base font-semibold text-foreground">
-                        {workout.name}
-                      </p>
-                      <time className="text-sm text-muted" dateTime={workout.date}>
-                        {formatWorkoutDate(workout.date)}
-                      </time>
+                <Card
+                  className="h-full gap-4 px-4 py-4 transition-transform duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
+                  data-slot="recent-workout-card"
+                >
+                  <div className="space-y-3">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0 space-y-1">
+                        <p className="truncate text-base font-semibold text-foreground">{workout.name}</p>
+                        <time className="text-sm text-muted" dateTime={workout.date}>
+                          {formatWorkoutDate(workout.date)}
+                        </time>
+                      </div>
+
+                      <span className="shrink-0 rounded-full bg-[var(--color-accent-cream)] px-2.5 py-1 text-xs font-semibold text-on-cream dark:bg-amber-500/20 dark:text-amber-400">
+                        {formatRelativeWorkoutDate(workout.date)}
+                      </span>
                     </div>
 
-                    <span className="shrink-0 rounded-full bg-[var(--color-accent-cream)] px-2.5 py-1 text-xs font-semibold text-on-cream dark:bg-amber-500/20 dark:text-amber-400">
-                      {formatRelativeWorkoutDate(workout.date)}
-                    </span>
+                    <div className="flex flex-wrap gap-2 text-sm text-foreground">
+                      <span className="rounded-full bg-secondary px-3 py-1">
+                        {`${workout.exerciseCount} exercises`}
+                      </span>
+                      <span className="rounded-full bg-secondary px-3 py-1">
+                        {workout.duration === null ? 'Duration n/a' : `${workout.duration} min`}
+                      </span>
+                    </div>
                   </div>
-
-                  <div className="flex flex-wrap gap-2 text-sm text-foreground">
-                    <span className="rounded-full bg-secondary px-3 py-1">{`${workout.totalSets} sets`}</span>
-                    <span className="rounded-full bg-secondary px-3 py-1">{`${workout.totalReps} reps`}</span>
-                    <span className="rounded-full bg-secondary px-3 py-1">{`${workout.duration} min`}</span>
-                  </div>
-                </div>
-              </Card>
-            </Link>
-          </li>
-        ))}
-      </ul>
+                </Card>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <Card className="px-4 py-6" data-slot="recent-workout-empty-state">
+          <p className="text-sm text-muted">No completed workouts yet.</p>
+        </Card>
+      )}
     </section>
   );
 }

--- a/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
@@ -1,12 +1,46 @@
+import type { DashboardSnapshot } from '@pulse/shared';
 import { render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
-import { mockDailySnapshot } from '@/lib/mock-data/dashboard';
+
 import {
   calculateHabitCompletionPercent,
   calculateWeightTrend,
   SnapshotCards,
 } from './snapshot-cards';
+
+const snapshotFixture: DashboardSnapshot = {
+  date: '2026-03-06',
+  weight: {
+    date: '2026-03-06',
+    unit: 'lb',
+    value: 181.4,
+  },
+  macros: {
+    actual: {
+      calories: 1900,
+      protein: 170,
+      carbs: 210,
+      fat: 70,
+    },
+    target: {
+      calories: 2300,
+      protein: 190,
+      carbs: 260,
+      fat: 75,
+    },
+  },
+  workout: {
+    name: 'Upper Push A',
+    status: 'completed',
+    duration: 62,
+  },
+  habits: {
+    total: 4,
+    completed: 3,
+    percentage: 75,
+  },
+};
 
 describe('calculateWeightTrend', () => {
   it('returns neutral when yesterday weight is not positive', () => {
@@ -36,10 +70,10 @@ describe('calculateHabitCompletionPercent', () => {
 });
 
 describe('SnapshotCards', () => {
-  it('renders five snapshot cards in a responsive grid with mock data values', () => {
+  it('renders five snapshot cards with dashboard snapshot API values', () => {
     const { container } = render(
       <MemoryRouter>
-        <SnapshotCards />
+        <SnapshotCards snapshot={snapshotFixture} />
       </MemoryRouter>,
     );
 
@@ -49,29 +83,17 @@ describe('SnapshotCards', () => {
     const cards = container.querySelectorAll('[data-slot="stat-card"]');
     expect(cards).toHaveLength(5);
 
-    expect(screen.getByText(`${mockDailySnapshot.weight.toFixed(1)} lbs`)).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        `${mockDailySnapshot.macros.calories.actual} / ${mockDailySnapshot.macros.calories.target}`,
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        `${mockDailySnapshot.macros.protein.actual}g / ${mockDailySnapshot.macros.protein.target}g`,
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        `${mockDailySnapshot.habitsCompleted} / ${mockDailySnapshot.habitsTotal} complete`,
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText(mockDailySnapshot.workoutName ?? 'Rest Day')).toBeInTheDocument();
+    expect(screen.getByText('181.4 lbs')).toBeInTheDocument();
+    expect(screen.getByText('1900 / 2300')).toBeInTheDocument();
+    expect(screen.getByText('170g / 190g')).toBeInTheDocument();
+    expect(screen.getByText('3 / 4 complete')).toBeInTheDocument();
+    expect(screen.getByText('Upper Push A (Completed)')).toBeInTheDocument();
   });
 
-  it('calculates weight trend from yesterday and applies accent card backgrounds', () => {
+  it('applies accent card backgrounds and neutral trends', () => {
     render(
       <MemoryRouter>
-        <SnapshotCards />
+        <SnapshotCards snapshot={snapshotFixture} />
       </MemoryRouter>,
     );
 
@@ -91,37 +113,31 @@ describe('SnapshotCards', () => {
     expect(screen.getByText('Protein')).toHaveClass('text-on-mint');
     expect(screen.getByText('Habits')).toHaveClass('text-on-mint');
 
-    const expectedTrend = calculateWeightTrend(
-      mockDailySnapshot.weight,
-      mockDailySnapshot.weightYesterday,
-    );
-
-    const weightTrend = within(weightCard as HTMLElement).getByLabelText(
-      `trend ${expectedTrend.direction}`,
-    );
-    expect(weightTrend).toBeInTheDocument();
-    expect(weightTrend).toHaveClass('text-on-cream');
-
-    const expectedTrendText =
-      expectedTrend.direction === 'up'
-        ? `+${expectedTrend.value}%`
-        : expectedTrend.direction === 'down'
-          ? `-${expectedTrend.value}%`
-          : `${expectedTrend.value}%`;
-
-    expect(within(weightCard as HTMLElement).getByText(expectedTrendText)).toBeInTheDocument();
+    expect(within(weightCard as HTMLElement).getByLabelText('trend neutral')).toBeInTheDocument();
+    expect(within(weightCard as HTMLElement).getByText('0%')).toBeInTheDocument();
   });
 
-  it('renders neutral calories/protein trends and handles rest day fallback', () => {
-    render(
+  it('renders placeholders for loading and null weight/workout states', () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <SnapshotCards />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getAllByText('--')).not.toHaveLength(0);
+
+    rerender(
       <MemoryRouter>
         <SnapshotCards
           snapshot={{
-            ...mockDailySnapshot,
-            habitsCompleted: 0,
-            habitsTotal: 0,
-            weightYesterday: 0,
-            workoutName: null,
+            ...snapshotFixture,
+            weight: null,
+            workout: null,
+            habits: {
+              total: 0,
+              completed: 0,
+              percentage: 0,
+            },
           }}
         />
       </MemoryRouter>,
@@ -130,26 +146,13 @@ describe('SnapshotCards', () => {
     const weightCard = screen
       .getByText('Body Weight')
       .closest('[data-slot="stat-card"]') as HTMLElement;
-    const caloriesCard = screen
-      .getByText('Calories')
-      .closest('[data-slot="stat-card"]') as HTMLElement;
-    const proteinCard = screen
-      .getByText('Protein')
-      .closest('[data-slot="stat-card"]') as HTMLElement;
     const habitsCard = screen.getByText('Habits').closest('[data-slot="stat-card"]') as HTMLElement;
     const workoutCard = screen
       .getByText("Today's Workout")
       .closest('[data-slot="stat-card"]') as HTMLElement;
 
-    expect(within(weightCard).getByLabelText('trend neutral')).toBeInTheDocument();
-    expect(within(weightCard).getByText('0%')).toBeInTheDocument();
-
-    expect(within(caloriesCard).getByLabelText('trend neutral')).toBeInTheDocument();
-    expect(within(proteinCard).getByLabelText('trend neutral')).toBeInTheDocument();
-    expect(within(habitsCard).getByLabelText('trend neutral')).toBeInTheDocument();
+    expect(within(weightCard).getByText('--')).toBeInTheDocument();
     expect(within(habitsCard).getByText('0 / 0 complete')).toBeInTheDocument();
-
-    expect(within(workoutCard).queryByLabelText(/trend/i)).not.toBeInTheDocument();
     expect(within(workoutCard).getByText('Rest Day')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/dashboard/components/snapshot-cards.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable react-refresh/only-export-components */
+import type { DashboardSnapshot, DashboardWorkoutSnapshot } from '@pulse/shared';
+
 import { StatCard, type StatTrend } from '@/components/ui/stat-card';
 import { accentCardStyles } from '@/lib/accent-card-styles';
-import { mockDailySnapshot, type DailySnapshot } from '@/lib/mock-data/dashboard';
 
 type SnapshotCardsProps = {
-  snapshot?: DailySnapshot;
+  snapshot?: DashboardSnapshot;
 };
 
 export const calculateWeightTrend = (weight: number, weightYesterday: number): StatTrend => {
@@ -37,11 +38,40 @@ export const calculateHabitCompletionPercent = (
   return Math.round((habitsCompleted / habitsTotal) * 100);
 };
 
-export function SnapshotCards({ snapshot = mockDailySnapshot }: SnapshotCardsProps) {
-  const habitCompletionPercent = calculateHabitCompletionPercent(
-    snapshot.habitsCompleted,
-    snapshot.habitsTotal,
-  );
+const formatWeightValue = (snapshot: DashboardSnapshot | undefined) => {
+  if (!snapshot?.weight) {
+    return '--';
+  }
+
+  return `${snapshot.weight.value.toFixed(1)} lbs`;
+};
+
+const formatWorkoutStatus = (status: DashboardWorkoutSnapshot['status']) => {
+  return status
+    .split('_')
+    .map((part) => `${part[0]?.toUpperCase() ?? ''}${part.slice(1)}`)
+    .join(' ');
+};
+
+export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
+  const habitCompletionPercent = snapshot
+    ? calculateHabitCompletionPercent(snapshot.habits.completed, snapshot.habits.total)
+    : 0;
+  const weightValue = formatWeightValue(snapshot);
+  const caloriesValue = snapshot
+    ? `${snapshot.macros.actual.calories} / ${snapshot.macros.target.calories}`
+    : '--';
+  const proteinValue = snapshot
+    ? `${snapshot.macros.actual.protein}g / ${snapshot.macros.target.protein}g`
+    : '--';
+  const habitsValue = snapshot
+    ? `${snapshot.habits.completed} / ${snapshot.habits.total} complete`
+    : '--';
+  const workoutValue = snapshot?.workout
+    ? `${snapshot.workout.name} (${formatWorkoutStatus(snapshot.workout.status)})`
+    : snapshot
+      ? 'Rest Day'
+      : '--';
 
   return (
     <div className="grid grid-cols-2 gap-3 sm:gap-4">
@@ -50,8 +80,8 @@ export function SnapshotCards({ snapshot = mockDailySnapshot }: SnapshotCardsPro
         className={accentCardStyles.cream}
         data-stagger="0"
         label="Body Weight"
-        trend={calculateWeightTrend(snapshot.weight, snapshot.weightYesterday)}
-        value={`${snapshot.weight.toFixed(1)} lbs`}
+        trend={{ direction: 'neutral', value: 0 }}
+        value={weightValue}
       />
 
       <StatCard
@@ -60,7 +90,7 @@ export function SnapshotCards({ snapshot = mockDailySnapshot }: SnapshotCardsPro
         data-stagger="1"
         label="Calories"
         trend={{ direction: 'neutral', value: 0 }}
-        value={`${snapshot.macros.calories.actual} / ${snapshot.macros.calories.target}`}
+        value={caloriesValue}
       />
 
       <StatCard
@@ -69,7 +99,7 @@ export function SnapshotCards({ snapshot = mockDailySnapshot }: SnapshotCardsPro
         data-stagger="2"
         label="Protein"
         trend={{ direction: 'neutral', value: 0 }}
-        value={`${snapshot.macros.protein.actual}g / ${snapshot.macros.protein.target}g`}
+        value={proteinValue}
       />
 
       <StatCard
@@ -78,14 +108,14 @@ export function SnapshotCards({ snapshot = mockDailySnapshot }: SnapshotCardsPro
         data-stagger="3"
         label="Habits"
         trend={{ direction: 'neutral', value: habitCompletionPercent }}
-        value={`${snapshot.habitsCompleted} / ${snapshot.habitsTotal} complete`}
+        value={habitsValue}
       />
 
       <StatCard
         className="border-primary/20 bg-secondary"
         data-stagger="4"
         label="Today's Workout"
-        value={snapshot.workoutName ?? 'Rest Day'}
+        value={workoutValue}
       />
     </div>
   );

--- a/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
@@ -162,6 +162,16 @@ describe('TrendSparklines', () => {
     expect(
       within(weightCard as HTMLElement).getByRole('img', { name: 'Weight Trend sparkline' }),
     ).toBeInTheDocument();
+    expect(vi.mocked(useWeightTrend)).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      { enabled: true },
+    );
+    expect(vi.mocked(useMacroTrend)).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      { enabled: true },
+    );
   });
 
   it('shows skeleton cards while trend queries are loading', () => {
@@ -197,6 +207,16 @@ describe('TrendSparklines', () => {
     expect(screen.getByText('Protein Trend')).toBeInTheDocument();
     expect(screen.queryByText('Weight Trend')).not.toBeInTheDocument();
     expect(screen.queryByText('Calorie Trend')).not.toBeInTheDocument();
+    expect(vi.mocked(useWeightTrend)).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      { enabled: false },
+    );
+    expect(vi.mocked(useMacroTrend)).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      { enabled: true },
+    );
   });
 
   it('renders an empty state when no metrics are selected', () => {
@@ -212,6 +232,34 @@ describe('TrendSparklines', () => {
     render(<TrendSparklines metrics={[]} />);
 
     expect(screen.getByText('No trend metrics selected.')).toBeInTheDocument();
+    expect(screen.queryByText('Weight Trend')).not.toBeInTheDocument();
+    expect(vi.mocked(useWeightTrend)).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      { enabled: false },
+    );
+    expect(vi.mocked(useMacroTrend)).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      { enabled: false },
+    );
+  });
+
+  it('renders an error state when a required trend query fails', () => {
+    vi.mocked(useWeightTrend).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as ReturnType<typeof useWeightTrend>);
+    vi.mocked(useMacroTrend).mockReturnValue({
+      data: sampleMacroTrend,
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useMacroTrend>);
+
+    render(<TrendSparklines metrics={['weight']} />);
+
+    expect(screen.getByText('Unable to load trend data.')).toBeInTheDocument();
     expect(screen.queryByText('Weight Trend')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
@@ -179,4 +179,39 @@ describe('TrendSparklines', () => {
     expect(container.querySelectorAll('[data-slot="trend-sparkline-card-skeleton"]')).toHaveLength(3);
     expect(screen.queryByText('Weight Trend')).not.toBeInTheDocument();
   });
+
+  it('renders only selected trend metrics', () => {
+    vi.mocked(useWeightTrend).mockReturnValue({
+      data: sampleWeightTrend,
+      isLoading: false,
+    } as ReturnType<typeof useWeightTrend>);
+    vi.mocked(useMacroTrend).mockReturnValue({
+      data: sampleMacroTrend,
+      isLoading: false,
+    } as ReturnType<typeof useMacroTrend>);
+
+    const { container } = render(<TrendSparklines endDate="2026-03-07" metrics={['protein']} />);
+
+    const cards = container.querySelectorAll('[data-slot="trend-sparkline-card"]');
+    expect(cards).toHaveLength(1);
+    expect(screen.getByText('Protein Trend')).toBeInTheDocument();
+    expect(screen.queryByText('Weight Trend')).not.toBeInTheDocument();
+    expect(screen.queryByText('Calorie Trend')).not.toBeInTheDocument();
+  });
+
+  it('renders an empty state when no metrics are selected', () => {
+    vi.mocked(useWeightTrend).mockReturnValue({
+      data: sampleWeightTrend,
+      isLoading: false,
+    } as ReturnType<typeof useWeightTrend>);
+    vi.mocked(useMacroTrend).mockReturnValue({
+      data: sampleMacroTrend,
+      isLoading: false,
+    } as ReturnType<typeof useMacroTrend>);
+
+    render(<TrendSparklines metrics={[]} />);
+
+    expect(screen.getByText('No trend metrics selected.')).toBeInTheDocument();
+    expect(screen.queryByText('Weight Trend')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
@@ -1,10 +1,19 @@
 import { render, screen, within } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { mockMacroTrend, mockWeightTrend } from '@/lib/mock-data/dashboard';
 import { calculateTrendChangePercent } from '@/features/dashboard/lib/trend-sparklines';
+import { useMacroTrend } from '@/hooks/use-macro-trend';
+import { useWeightTrend } from '@/hooks/use-weight-trend';
 
 import { TrendSparkline, TrendSparklines } from './trend-sparkline';
+
+vi.mock('@/hooks/use-weight-trend', () => ({
+  useWeightTrend: vi.fn(),
+}));
+
+vi.mock('@/hooks/use-macro-trend', () => ({
+  useMacroTrend: vi.fn(),
+}));
 
 vi.mock('recharts', async () => {
   const actual = await vi.importActual<typeof import('recharts')>('recharts');
@@ -28,6 +37,28 @@ vi.mock('recharts', async () => {
   };
 });
 
+const sampleWeightTrend = [
+  { date: '2026-03-06', value: 175.6 },
+  { date: '2026-03-07', value: 175.2 },
+];
+
+const sampleMacroTrend = [
+  {
+    date: '2026-03-06',
+    calories: 1900,
+    protein: 160,
+    carbs: 210,
+    fat: 70,
+  },
+  {
+    date: '2026-03-07',
+    calories: 2050,
+    protein: 170,
+    carbs: 220,
+    fat: 72,
+  },
+];
+
 describe('calculateTrendChangePercent', () => {
   it('returns zero when the previous value is not positive', () => {
     expect(calculateTrendChangePercent(175, 0)).toBe(0);
@@ -48,7 +79,7 @@ describe('TrendSparkline', () => {
           changePercent={-0.4}
           color="#3B82F6"
           currentValue="175.2 lbs"
-          data={mockWeightTrend.slice(-7)}
+          data={sampleWeightTrend}
           label="Weight Trend"
         />
       </div>,
@@ -63,25 +94,50 @@ describe('TrendSparkline', () => {
     expect(container.querySelector('.recharts-cartesian-axis')).not.toBeInTheDocument();
     expect(container.querySelector('.recharts-legend-wrapper')).not.toBeInTheDocument();
   });
+
+  it('renders empty state text when no trend data exists', () => {
+    render(
+      <TrendSparkline
+        changePercent={0}
+        color="#3B82F6"
+        currentValue="--"
+        data={[]}
+        label="Weight Trend"
+      />,
+    );
+
+    expect(screen.getByText('No trend data yet.')).toBeInTheDocument();
+    expect(screen.queryByRole('img', { name: 'Weight Trend sparkline' })).not.toBeInTheDocument();
+  });
 });
 
 describe('TrendSparklines', () => {
-  it('renders weight, calorie, and protein trend cards from dashboard mock data', () => {
-    const { container } = render(<TrendSparklines />);
+  beforeEach(() => {
+    vi.mocked(useWeightTrend).mockReset();
+    vi.mocked(useMacroTrend).mockReset();
+  });
+
+  it('renders weight, calorie, and protein trend cards from API trend hooks', () => {
+    vi.mocked(useWeightTrend).mockReturnValue({
+      data: sampleWeightTrend,
+      isLoading: false,
+    } as ReturnType<typeof useWeightTrend>);
+    vi.mocked(useMacroTrend).mockReturnValue({
+      data: sampleMacroTrend,
+      isLoading: false,
+    } as ReturnType<typeof useMacroTrend>);
+
+    const { container } = render(<TrendSparklines endDate="2026-03-07" />);
 
     const cards = container.querySelectorAll('[data-slot="trend-sparkline-card"]');
     expect(cards).toHaveLength(3);
 
-    const latestWeight = mockWeightTrend.at(-1)?.value ?? 0;
-    const latestCalories = mockMacroTrend.at(-1)?.calories ?? 0;
-    const latestProtein = mockMacroTrend.at(-1)?.protein ?? 0;
-
     expect(screen.getByText('Weight Trend')).toBeInTheDocument();
     expect(screen.getByText('Calorie Trend')).toBeInTheDocument();
     expect(screen.getByText('Protein Trend')).toBeInTheDocument();
-    expect(screen.getByText(`${latestWeight.toFixed(1)} lbs`)).toBeInTheDocument();
-    expect(screen.getByText(`${latestCalories} kcal`)).toBeInTheDocument();
-    expect(screen.getByText(`${latestProtein} g`)).toBeInTheDocument();
+    expect(screen.getByText('175.2 lbs')).toBeInTheDocument();
+    expect(screen.getByText('2050 kcal')).toBeInTheDocument();
+    expect(screen.getByText('170 g')).toBeInTheDocument();
 
     const weightCard = screen
       .getByText('Weight Trend')
@@ -106,5 +162,21 @@ describe('TrendSparklines', () => {
     expect(
       within(weightCard as HTMLElement).getByRole('img', { name: 'Weight Trend sparkline' }),
     ).toBeInTheDocument();
+  });
+
+  it('shows skeleton cards while trend queries are loading', () => {
+    vi.mocked(useWeightTrend).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as ReturnType<typeof useWeightTrend>);
+    vi.mocked(useMacroTrend).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as ReturnType<typeof useMacroTrend>);
+
+    const { container } = render(<TrendSparklines />);
+
+    expect(container.querySelectorAll('[data-slot="trend-sparkline-card-skeleton"]')).toHaveLength(3);
+    expect(screen.queryByText('Weight Trend')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/dashboard/components/trend-sparkline.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.tsx
@@ -1,5 +1,6 @@
 import { ArrowDownRight, ArrowUpRight, Minus } from 'lucide-react';
 import { Line, LineChart, ResponsiveContainer } from 'recharts';
+import type { DashboardTrendMetric } from '@pulse/shared';
 
 import { Card, CardContent } from '@/components/ui/card';
 import { useMacroTrend } from '@/hooks/use-macro-trend';
@@ -41,7 +42,10 @@ export type TrendSparklineProps = {
 
 export type TrendSparklinesProps = {
   endDate?: string;
+  metrics?: DashboardTrendMetric[];
 };
+
+const DEFAULT_TREND_METRICS: DashboardTrendMetric[] = ['weight', 'calories', 'protein'];
 
 const CHANGE_ICONS = {
   up: ArrowUpRight,
@@ -225,7 +229,7 @@ function TrendMetricCardSkeleton() {
   );
 }
 
-export function TrendSparklines({ endDate }: TrendSparklinesProps) {
+export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
   const range = resolveTrendRange(endDate);
   const weightTrendQuery = useWeightTrend(range.from, range.to);
   const macroTrendQuery = useMacroTrend(range.from, range.to);
@@ -250,8 +254,8 @@ export function TrendSparklines({ endDate }: TrendSparklinesProps) {
   const latestCalories = getLatestValue(calorieSeries, 0);
   const latestProtein = getLatestValue(proteinSeries, 0);
 
-  const configs = [
-    {
+  const allConfigs = {
+    weight: {
       label: 'Weight Trend',
       currentValue: weightSeries.length > 0 ? `${latestWeight.toFixed(1)} lbs` : '--',
       changePercent:
@@ -266,7 +270,7 @@ export function TrendSparklines({ endDate }: TrendSparklinesProps) {
       className: accentCardStyles.cream,
       textClassName: 'text-on-cream',
     },
-    {
+    calories: {
       label: 'Calorie Trend',
       currentValue: calorieSeries.length > 0 ? `${latestCalories} kcal` : '--',
       changePercent:
@@ -281,7 +285,7 @@ export function TrendSparklines({ endDate }: TrendSparklinesProps) {
       className: accentCardStyles.pink,
       textClassName: 'text-on-pink',
     },
-    {
+    protein: {
       label: 'Protein Trend',
       currentValue: proteinSeries.length > 0 ? `${latestProtein} g` : '--',
       changePercent:
@@ -296,7 +300,22 @@ export function TrendSparklines({ endDate }: TrendSparklinesProps) {
       className: accentCardStyles.mint,
       textClassName: 'text-on-mint',
     },
-  ] satisfies TrendMetricCardProps[];
+  } satisfies Record<DashboardTrendMetric, TrendMetricCardProps>;
+
+  const resolvedMetrics = metrics ?? DEFAULT_TREND_METRICS;
+  const configs = resolvedMetrics.map((metric) => allConfigs[metric]);
+
+  if (configs.length === 0) {
+    return (
+      <section aria-label="Trend sparklines">
+        <Card className="gap-0 border-border/70 py-4 shadow-sm">
+          <CardContent className="px-5">
+            <p className="text-sm text-muted-foreground">No trend metrics selected.</p>
+          </CardContent>
+        </Card>
+      </section>
+    );
+  }
 
   return (
     <section aria-label="Trend sparklines">

--- a/apps/web/src/features/dashboard/components/trend-sparkline.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.tsx
@@ -230,11 +230,15 @@ function TrendMetricCardSkeleton() {
 }
 
 export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
+  const resolvedMetrics = metrics ?? DEFAULT_TREND_METRICS;
+  const needsWeight = resolvedMetrics.includes('weight');
+  const needsMacros =
+    resolvedMetrics.includes('calories') || resolvedMetrics.includes('protein');
   const range = resolveTrendRange(endDate);
-  const weightTrendQuery = useWeightTrend(range.from, range.to);
-  const macroTrendQuery = useMacroTrend(range.from, range.to);
+  const weightTrendQuery = useWeightTrend(range.from, range.to, { enabled: needsWeight });
+  const macroTrendQuery = useMacroTrend(range.from, range.to, { enabled: needsMacros });
 
-  if (weightTrendQuery.isLoading || macroTrendQuery.isLoading) {
+  if ((needsWeight && weightTrendQuery.isLoading) || (needsMacros && macroTrendQuery.isLoading)) {
     return (
       <section aria-label="Trend sparklines">
         <div className="grid gap-4">
@@ -246,9 +250,27 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
     );
   }
 
-  const weightSeries = toMetricSeries(weightTrendQuery.data ?? [], (entry) => entry.value);
-  const calorieSeries = toMetricSeries(macroTrendQuery.data ?? [], (entry) => entry.calories);
-  const proteinSeries = toMetricSeries(macroTrendQuery.data ?? [], (entry) => entry.protein);
+  if ((needsWeight && weightTrendQuery.isError) || (needsMacros && macroTrendQuery.isError)) {
+    return (
+      <section aria-label="Trend sparklines">
+        <Card className="gap-0 border-border/70 py-4 shadow-sm">
+          <CardContent className="px-5">
+            <p className="text-sm text-muted-foreground">Unable to load trend data.</p>
+          </CardContent>
+        </Card>
+      </section>
+    );
+  }
+
+  const weightSeries = needsWeight
+    ? toMetricSeries(weightTrendQuery.data ?? [], (entry) => entry.value)
+    : [];
+  const calorieSeries = needsMacros
+    ? toMetricSeries(macroTrendQuery.data ?? [], (entry) => entry.calories)
+    : [];
+  const proteinSeries = needsMacros
+    ? toMetricSeries(macroTrendQuery.data ?? [], (entry) => entry.protein)
+    : [];
 
   const latestWeight = getLatestValue(weightSeries, 0);
   const latestCalories = getLatestValue(calorieSeries, 0);
@@ -302,7 +324,6 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
     },
   } satisfies Record<DashboardTrendMetric, TrendMetricCardProps>;
 
-  const resolvedMetrics = metrics ?? DEFAULT_TREND_METRICS;
   const configs = resolvedMetrics.map((metric) => allConfigs[metric]);
 
   if (configs.length === 0) {

--- a/apps/web/src/features/dashboard/components/trend-sparkline.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.tsx
@@ -2,15 +2,26 @@ import { ArrowDownRight, ArrowUpRight, Minus } from 'lucide-react';
 import { Line, LineChart, ResponsiveContainer } from 'recharts';
 
 import { Card, CardContent } from '@/components/ui/card';
+import { useMacroTrend } from '@/hooks/use-macro-trend';
+import { useWeightTrend } from '@/hooks/use-weight-trend';
 import { accentCardStyles } from '@/lib/accent-card-styles';
+import { addDays, parseDateInput, toDateKey } from '@/lib/date';
 import { calculateTrendChangePercent } from '@/features/dashboard/lib/trend-sparklines';
-import {
-  mockMacroTrend,
-  mockWeightTrend,
-  type MacroTrendEntry,
-  type WeightTrendEntry,
-} from '@/lib/mock-data/dashboard';
 import { cn } from '@/lib/utils';
+
+const TREND_DAYS = 30;
+
+type ChangeDirection = 'up' | 'down' | 'neutral';
+
+type TrendMetricCardProps = {
+  label: string;
+  currentValue: string;
+  changePercent: number;
+  color: string;
+  data: TrendSparklineDatum[];
+  className?: string;
+  textClassName?: string;
+};
 
 export type TrendSparklineDatum = {
   date: string;
@@ -25,18 +36,11 @@ export type TrendSparklineProps = {
   changePercent: number;
   className?: string;
   textClassName?: string;
+  emptyMessage?: string;
 };
 
-type ChangeDirection = 'up' | 'down' | 'neutral';
-
-type TrendMetricCardProps = {
-  label: string;
-  currentValue: string;
-  changePercent: number;
-  color: string;
-  data: TrendSparklineDatum[];
-  className?: string;
-  textClassName?: string;
+export type TrendSparklinesProps = {
+  endDate?: string;
 };
 
 const CHANGE_ICONS = {
@@ -83,48 +87,15 @@ const getChangeDirection = (changePercent: number): ChangeDirection => {
   return 'neutral';
 };
 
-const weightSeries = toMetricSeries(mockWeightTrend, (entry: WeightTrendEntry) => entry.value);
-const calorieSeries = toMetricSeries(mockMacroTrend, (entry: MacroTrendEntry) => entry.calories);
-const proteinSeries = toMetricSeries(mockMacroTrend, (entry: MacroTrendEntry) => entry.protein);
+const resolveTrendRange = (endDate?: string) => {
+  const resolvedEndDate = endDate ?? toDateKey(new Date());
+  const startDate = toDateKey(addDays(parseDateInput(resolvedEndDate), -(TREND_DAYS - 1)));
 
-const TREND_CARD_CONFIGS = [
-  {
-    label: 'Weight Trend',
-    currentValue: `${getLatestValue(weightSeries, 0).toFixed(1)} lbs`,
-    changePercent: calculateTrendChangePercent(
-      getLatestValue(weightSeries, 0),
-      getPreviousValue(weightSeries, getLatestValue(weightSeries, 0)),
-    ),
-    color: 'var(--color-on-cream)',
-    data: weightSeries,
-    className: accentCardStyles.cream,
-    textClassName: 'text-on-cream',
-  },
-  {
-    label: 'Calorie Trend',
-    currentValue: `${getLatestValue(calorieSeries, 0)} kcal`,
-    changePercent: calculateTrendChangePercent(
-      getLatestValue(calorieSeries, 0),
-      getPreviousValue(calorieSeries, getLatestValue(calorieSeries, 0)),
-    ),
-    color: 'var(--color-on-pink)',
-    data: calorieSeries,
-    className: accentCardStyles.pink,
-    textClassName: 'text-on-pink',
-  },
-  {
-    label: 'Protein Trend',
-    currentValue: `${getLatestValue(proteinSeries, 0)} g`,
-    changePercent: calculateTrendChangePercent(
-      getLatestValue(proteinSeries, 0),
-      getPreviousValue(proteinSeries, getLatestValue(proteinSeries, 0)),
-    ),
-    color: 'var(--color-on-mint)',
-    data: proteinSeries,
-    className: accentCardStyles.mint,
-    textClassName: 'text-on-mint',
-  },
-] satisfies TrendMetricCardProps[];
+  return {
+    from: startDate,
+    to: resolvedEndDate,
+  };
+};
 
 export function TrendSparkline({
   data,
@@ -134,6 +105,7 @@ export function TrendSparkline({
   changePercent,
   className,
   textClassName,
+  emptyMessage = 'No trend data yet.',
 }: TrendSparklineProps) {
   const direction = getChangeDirection(changePercent);
   const ChangeIcon = CHANGE_ICONS[direction];
@@ -171,27 +143,33 @@ export function TrendSparkline({
         </div>
       </div>
 
-      <div
-        aria-label={`${label} sparkline`}
-        className="h-[60px] w-full"
-        data-slot="trend-sparkline-chart"
-        role="img"
-      >
-        <ResponsiveContainer height="100%" width="100%">
-          <LineChart data={data} margin={{ top: 6, right: 0, bottom: 2, left: 0 }}>
-            <Line
-              dataKey="value"
-              dot={false}
-              isAnimationActive={false}
-              stroke={color}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={3}
-              type="monotone"
-            />
-          </LineChart>
-        </ResponsiveContainer>
-      </div>
+      {data.length === 0 ? (
+        <div className="flex h-[60px] items-center justify-center rounded-md bg-muted/35" data-slot="trend-sparkline-empty">
+          <p className="text-sm text-muted">{emptyMessage}</p>
+        </div>
+      ) : (
+        <div
+          aria-label={`${label} sparkline`}
+          className="h-[60px] w-full"
+          data-slot="trend-sparkline-chart"
+          role="img"
+        >
+          <ResponsiveContainer height="100%" width="100%">
+            <LineChart data={data} margin={{ top: 6, right: 0, bottom: 2, left: 0 }}>
+              <Line
+                dataKey="value"
+                dot={false}
+                isAnimationActive={false}
+                stroke={color}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={3}
+                type="monotone"
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      )}
     </div>
   );
 }
@@ -228,11 +206,102 @@ function TrendMetricCard({
   );
 }
 
-export function TrendSparklines() {
+function TrendMetricCardSkeleton() {
+  return (
+    <Card className="gap-0 border-transparent py-5 shadow-sm" data-slot="trend-sparkline-card-skeleton">
+      <CardContent className="h-full px-5">
+        <div className="flex h-full flex-col gap-4" data-slot="trend-sparkline-skeleton">
+          <div className="flex items-start justify-between gap-4">
+            <div className="h-4 w-28 animate-pulse rounded bg-muted/50" />
+            <div className="space-y-2">
+              <div className="ml-auto h-8 w-20 animate-pulse rounded bg-muted/50" />
+              <div className="ml-auto h-4 w-14 animate-pulse rounded bg-muted/50" />
+            </div>
+          </div>
+          <div className="h-[60px] w-full animate-pulse rounded bg-muted/50" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function TrendSparklines({ endDate }: TrendSparklinesProps) {
+  const range = resolveTrendRange(endDate);
+  const weightTrendQuery = useWeightTrend(range.from, range.to);
+  const macroTrendQuery = useMacroTrend(range.from, range.to);
+
+  if (weightTrendQuery.isLoading || macroTrendQuery.isLoading) {
+    return (
+      <section aria-label="Trend sparklines">
+        <div className="grid gap-4">
+          <TrendMetricCardSkeleton />
+          <TrendMetricCardSkeleton />
+          <TrendMetricCardSkeleton />
+        </div>
+      </section>
+    );
+  }
+
+  const weightSeries = toMetricSeries(weightTrendQuery.data ?? [], (entry) => entry.value);
+  const calorieSeries = toMetricSeries(macroTrendQuery.data ?? [], (entry) => entry.calories);
+  const proteinSeries = toMetricSeries(macroTrendQuery.data ?? [], (entry) => entry.protein);
+
+  const latestWeight = getLatestValue(weightSeries, 0);
+  const latestCalories = getLatestValue(calorieSeries, 0);
+  const latestProtein = getLatestValue(proteinSeries, 0);
+
+  const configs = [
+    {
+      label: 'Weight Trend',
+      currentValue: weightSeries.length > 0 ? `${latestWeight.toFixed(1)} lbs` : '--',
+      changePercent:
+        weightSeries.length > 1
+          ? calculateTrendChangePercent(
+              latestWeight,
+              getPreviousValue(weightSeries, latestWeight),
+            )
+          : 0,
+      color: 'var(--color-on-cream)',
+      data: weightSeries,
+      className: accentCardStyles.cream,
+      textClassName: 'text-on-cream',
+    },
+    {
+      label: 'Calorie Trend',
+      currentValue: calorieSeries.length > 0 ? `${latestCalories} kcal` : '--',
+      changePercent:
+        calorieSeries.length > 1
+          ? calculateTrendChangePercent(
+              latestCalories,
+              getPreviousValue(calorieSeries, latestCalories),
+            )
+          : 0,
+      color: 'var(--color-on-pink)',
+      data: calorieSeries,
+      className: accentCardStyles.pink,
+      textClassName: 'text-on-pink',
+    },
+    {
+      label: 'Protein Trend',
+      currentValue: proteinSeries.length > 0 ? `${latestProtein} g` : '--',
+      changePercent:
+        proteinSeries.length > 1
+          ? calculateTrendChangePercent(
+              latestProtein,
+              getPreviousValue(proteinSeries, latestProtein),
+            )
+          : 0,
+      color: 'var(--color-on-mint)',
+      data: proteinSeries,
+      className: accentCardStyles.mint,
+      textClassName: 'text-on-mint',
+    },
+  ] satisfies TrendMetricCardProps[];
+
   return (
     <section aria-label="Trend sparklines">
       <div className="grid gap-4">
-        {TREND_CARD_CONFIGS.map((config) => (
+        {configs.map((config) => (
           <TrendMetricCard key={config.label} {...config} />
         ))}
       </div>

--- a/apps/web/src/hooks/use-dashboard-config.test.tsx
+++ b/apps/web/src/hooks/use-dashboard-config.test.tsx
@@ -1,0 +1,86 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { useDashboardConfig, useSaveDashboardConfig } from './use-dashboard-config';
+
+const mockFetch = vi.fn();
+
+const createJsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+
+describe('dashboard config hooks', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  it('loads persisted dashboard config', async () => {
+    mockFetch.mockResolvedValue(
+      createJsonResponse({
+        habitChainIds: ['habit-1', 'habit-2'],
+        trendMetrics: ['weight', 'calories'],
+        widgetOrder: ['snapshot', 'habits'],
+      }),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setDefaultOptions({
+      queries: { retry: false },
+      mutations: { retry: false },
+    });
+
+    const { result } = renderHook(() => useDashboardConfig(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/dashboard/config',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(result.current.data).toEqual({
+      habitChainIds: ['habit-1', 'habit-2'],
+      trendMetrics: ['weight', 'calories'],
+      widgetOrder: ['snapshot', 'habits'],
+    });
+  });
+
+  it('saves dashboard config with PUT', async () => {
+    mockFetch.mockResolvedValue(
+      createJsonResponse({
+        habitChainIds: ['habit-1'],
+        trendMetrics: ['protein'],
+      }),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setDefaultOptions({
+      queries: { retry: false },
+      mutations: { retry: false },
+    });
+
+    const { result } = renderHook(() => useSaveDashboardConfig(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isIdle).toBe(true);
+    });
+
+    await result.current.mutateAsync({
+      habitChainIds: ['habit-1'],
+      trendMetrics: ['protein'],
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/dashboard/config',
+      expect.objectContaining({ method: 'PUT' }),
+    );
+  });
+});

--- a/apps/web/src/hooks/use-dashboard-config.ts
+++ b/apps/web/src/hooks/use-dashboard-config.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { dashboardConfigSchema, type DashboardConfig } from '@pulse/shared';
+
+import { apiRequest } from '@/lib/api-client';
+
+export const dashboardConfigKeys = {
+  all: ['dashboard', 'config'] as const,
+  detail: () => [...dashboardConfigKeys.all, 'current'] as const,
+};
+
+const fetchDashboardConfig = async (signal?: AbortSignal): Promise<DashboardConfig> => {
+  const config = await apiRequest<DashboardConfig>('/api/v1/dashboard/config', {
+    method: 'GET',
+    signal,
+  });
+
+  return dashboardConfigSchema.parse(config);
+};
+
+const putDashboardConfig = async (config: DashboardConfig): Promise<DashboardConfig> => {
+  const payload = dashboardConfigSchema.parse(config);
+  const saved = await apiRequest<DashboardConfig>('/api/v1/dashboard/config', {
+    body: payload,
+    method: 'PUT',
+  });
+
+  return dashboardConfigSchema.parse(saved);
+};
+
+export const useDashboardConfig = () =>
+  useQuery({
+    queryFn: ({ signal }) => fetchDashboardConfig(signal),
+    queryKey: dashboardConfigKeys.detail(),
+  });
+
+export const useSaveDashboardConfig = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: putDashboardConfig,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: dashboardConfigKeys.all });
+    },
+  });
+};

--- a/apps/web/src/hooks/use-dashboard-snapshot.test.tsx
+++ b/apps/web/src/hooks/use-dashboard-snapshot.test.tsx
@@ -1,0 +1,112 @@
+import type { DashboardSnapshot } from '@pulse/shared';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { useDashboardSnapshot } from './use-dashboard-snapshot';
+
+const mockFetch = vi.fn();
+
+const createJsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+
+const snapshotFixture: DashboardSnapshot = {
+  date: '2026-03-06',
+  weight: {
+    date: '2026-03-06',
+    unit: 'lb',
+    value: 181.4,
+  },
+  macros: {
+    actual: {
+      calories: 1900,
+      protein: 170,
+      carbs: 210,
+      fat: 70,
+    },
+    target: {
+      calories: 2300,
+      protein: 190,
+      carbs: 260,
+      fat: 75,
+    },
+  },
+  workout: {
+    name: 'Upper Push A',
+    status: 'completed',
+    duration: 62,
+  },
+  habits: {
+    total: 4,
+    completed: 3,
+    percentage: 75,
+  },
+};
+
+describe('useDashboardSnapshot', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  it('loads snapshot data for the provided date', async () => {
+    mockFetch.mockResolvedValue(createJsonResponse(snapshotFixture));
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setDefaultOptions({
+      queries: { retry: false },
+      mutations: { retry: false },
+    });
+    const { result } = renderHook(() => useDashboardSnapshot('2026-03-06'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/dashboard/snapshot?date=2026-03-06',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(result.current.data).toEqual(snapshotFixture);
+  });
+
+  it('surfaces an error when the response payload is invalid', async () => {
+    mockFetch.mockResolvedValue(
+      createJsonResponse({
+        date: '2026-03-06',
+        weight: null,
+        macros: {
+          actual: {
+            calories: 1900,
+            protein: 170,
+            carbs: 210,
+            fat: 70,
+          },
+        },
+        workout: null,
+        habits: {
+          total: 0,
+          completed: 0,
+          percentage: 0,
+        },
+      }),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setDefaultOptions({
+      queries: { retry: false },
+      mutations: { retry: false },
+    });
+    const { result } = renderHook(() => useDashboardSnapshot('2026-03-06'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/hooks/use-dashboard-snapshot.ts
+++ b/apps/web/src/hooks/use-dashboard-snapshot.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import { dashboardSnapshotSchema, type DashboardSnapshot } from '@pulse/shared';
+
+import { apiRequest } from '@/lib/api-client';
+
+export const dashboardSnapshotKeys = {
+  all: ['dashboard', 'snapshot'] as const,
+  detail: (date: string) => [...dashboardSnapshotKeys.all, date] as const,
+};
+
+const fetchDashboardSnapshot = async (
+  date: string,
+  signal?: AbortSignal,
+): Promise<DashboardSnapshot> => {
+  const snapshot = await apiRequest<DashboardSnapshot>(
+    `/api/v1/dashboard/snapshot?date=${encodeURIComponent(date)}`,
+    {
+      method: 'GET',
+      signal,
+    },
+  );
+
+  return dashboardSnapshotSchema.parse(snapshot);
+};
+
+export const useDashboardSnapshot = (date: string) =>
+  useQuery({
+    enabled: date.length > 0,
+    queryFn: ({ signal }) => fetchDashboardSnapshot(date, signal),
+    queryKey: dashboardSnapshotKeys.detail(date),
+  });

--- a/apps/web/src/hooks/use-habit-chains.test.tsx
+++ b/apps/web/src/hooks/use-habit-chains.test.tsx
@@ -1,0 +1,81 @@
+import type { HabitEntry } from '@pulse/shared';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { useHabitChains } from './use-habit-chains';
+
+const mockFetch = vi.fn();
+
+const createJsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+
+const entriesFixture: HabitEntry[] = [
+  {
+    id: 'entry-1',
+    habitId: 'habit-1',
+    userId: 'user-1',
+    date: '2026-03-05',
+    completed: true,
+    value: null,
+    createdAt: 1,
+  },
+  {
+    id: 'entry-2',
+    habitId: 'habit-1',
+    userId: 'user-1',
+    date: '2026-03-06',
+    completed: false,
+    value: null,
+    createdAt: 2,
+  },
+];
+
+describe('useHabitChains', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  it('loads habit entries for the provided date range', async () => {
+    mockFetch.mockResolvedValue(createJsonResponse(entriesFixture));
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setDefaultOptions({
+      queries: { retry: false },
+      mutations: { retry: false },
+    });
+    const { result } = renderHook(() => useHabitChains('2026-03-01', '2026-03-06'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/habit-entries?from=2026-03-01&to=2026-03-06',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(result.current.data).toEqual(entriesFixture);
+  });
+
+  it('surfaces an error when the payload shape is invalid', async () => {
+    mockFetch.mockResolvedValue(createJsonResponse([{ id: 'entry-1' }]));
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setDefaultOptions({
+      queries: { retry: false },
+      mutations: { retry: false },
+    });
+    const { result } = renderHook(() => useHabitChains('2026-03-01', '2026-03-06'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/hooks/use-habit-chains.ts
+++ b/apps/web/src/hooks/use-habit-chains.ts
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query';
+import { habitEntrySchema, type HabitEntry } from '@pulse/shared';
+import { z } from 'zod';
+
+import { apiRequest } from '@/lib/api-client';
+
+const habitEntriesSchema = z.array(habitEntrySchema);
+
+export const habitChainKeys = {
+  all: ['habits', 'chains'] as const,
+  range: (from: string, to: string) => [...habitChainKeys.all, from, to] as const,
+};
+
+const fetchHabitChains = async (
+  from: string,
+  to: string,
+  signal?: AbortSignal,
+): Promise<HabitEntry[]> => {
+  const entries = await apiRequest<HabitEntry[]>(
+    `/api/v1/habit-entries?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`,
+    {
+      method: 'GET',
+      signal,
+    },
+  );
+
+  return habitEntriesSchema.parse(entries);
+};
+
+export const useHabitChains = (from: string, to: string) =>
+  useQuery({
+    enabled: from.length > 0 && to.length > 0,
+    queryFn: ({ signal }) => fetchHabitChains(from, to, signal),
+    queryKey: habitChainKeys.range(from, to),
+  });

--- a/apps/web/src/hooks/use-macro-trend.test.tsx
+++ b/apps/web/src/hooks/use-macro-trend.test.tsx
@@ -1,0 +1,108 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { useMacroTrend } from './use-macro-trend';
+
+const mockFetch = vi.fn();
+
+const createJsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+
+describe('useMacroTrend', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('loads macro trend for an explicit date range', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse([
+        {
+          date: '2026-03-04',
+          calories: 2100,
+          protein: 170,
+          carbs: 220,
+          fat: 70,
+        },
+      ]),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setDefaultOptions({
+      queries: { retry: false },
+      mutations: { retry: false },
+    });
+
+    const { result } = renderHook(() => useMacroTrend('2026-03-04', '2026-03-05'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/dashboard/trends/macros?from=2026-03-04&to=2026-03-05',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(result.current.data).toEqual([
+      {
+        date: '2026-03-04',
+        calories: 2100,
+        protein: 170,
+        carbs: 220,
+        fat: 70,
+      },
+    ]);
+  });
+
+  it('defaults to a 30-day range ending today when range is omitted', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-03-10T10:00:00.000Z'));
+
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse([
+        {
+          date: '2026-02-09',
+          calories: 0,
+          protein: 0,
+          carbs: 0,
+          fat: 0,
+        },
+        {
+          date: '2026-03-10',
+          calories: 2200,
+          protein: 180,
+          carbs: 250,
+          fat: 70,
+        },
+      ]),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setDefaultOptions({
+      queries: { retry: false },
+      mutations: { retry: false },
+    });
+
+    const { result } = renderHook(() => useMacroTrend(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/dashboard/trends/macros?from=2026-02-09&to=2026-03-10',
+      expect.any(Object),
+    );
+  });
+});

--- a/apps/web/src/hooks/use-macro-trend.test.tsx
+++ b/apps/web/src/hooks/use-macro-trend.test.tsx
@@ -105,4 +105,22 @@ describe('useMacroTrend', () => {
       expect.any(Object),
     );
   });
+
+  it('does not fetch when query is disabled', async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setDefaultOptions({
+      queries: { retry: false },
+      mutations: { retry: false },
+    });
+
+    const { result } = renderHook(() => useMacroTrend('2026-03-04', '2026-03-05', { enabled: false }), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/hooks/use-macro-trend.ts
+++ b/apps/web/src/hooks/use-macro-trend.ts
@@ -5,6 +5,7 @@ import { apiRequest } from '@/lib/api-client';
 import { addDays, getToday, parseDateInput, toDateKey } from '@/lib/date';
 
 const DEFAULT_TREND_DAYS = 30;
+const DEFAULT_QUERY_ENABLED = true;
 
 export const macroTrendKeys = {
   all: ['dashboard', 'macro-trend'] as const,
@@ -38,10 +39,16 @@ const fetchMacroTrend = async (
   return dashboardMacrosTrendSchema.parse(trend);
 };
 
-export const useMacroTrend = (from?: string, to?: string) => {
+export const useMacroTrend = (
+  from?: string,
+  to?: string,
+  options: { enabled?: boolean } = {},
+) => {
   const range = resolveDateRange(from, to);
+  const enabled = options.enabled ?? DEFAULT_QUERY_ENABLED;
 
   return useQuery({
+    enabled,
     queryFn: ({ signal }) => fetchMacroTrend(range.from, range.to, signal),
     queryKey: macroTrendKeys.range(range.from, range.to),
   });

--- a/apps/web/src/hooks/use-macro-trend.ts
+++ b/apps/web/src/hooks/use-macro-trend.ts
@@ -1,0 +1,48 @@
+import { useQuery } from '@tanstack/react-query';
+import { dashboardMacrosTrendSchema, type DashboardMacrosTrendPoint } from '@pulse/shared';
+
+import { apiRequest } from '@/lib/api-client';
+import { addDays, getToday, parseDateInput, toDateKey } from '@/lib/date';
+
+const DEFAULT_TREND_DAYS = 30;
+
+export const macroTrendKeys = {
+  all: ['dashboard', 'macro-trend'] as const,
+  range: (from: string, to: string) => [...macroTrendKeys.all, from, to] as const,
+};
+
+const resolveDateRange = (from?: string, to?: string) => {
+  const resolvedTo = to ?? toDateKey(getToday());
+  const resolvedFrom = from ?? toDateKey(addDays(parseDateInput(resolvedTo), -(DEFAULT_TREND_DAYS - 1)));
+
+  return {
+    from: resolvedFrom,
+    to: resolvedTo,
+  };
+};
+
+const fetchMacroTrend = async (
+  from?: string,
+  to?: string,
+  signal?: AbortSignal,
+): Promise<DashboardMacrosTrendPoint[]> => {
+  const range = resolveDateRange(from, to);
+  const trend = await apiRequest<DashboardMacrosTrendPoint[]>(
+    `/api/v1/dashboard/trends/macros?from=${encodeURIComponent(range.from)}&to=${encodeURIComponent(range.to)}`,
+    {
+      method: 'GET',
+      signal,
+    },
+  );
+
+  return dashboardMacrosTrendSchema.parse(trend);
+};
+
+export const useMacroTrend = (from?: string, to?: string) => {
+  const range = resolveDateRange(from, to);
+
+  return useQuery({
+    queryFn: ({ signal }) => fetchMacroTrend(range.from, range.to, signal),
+    queryKey: macroTrendKeys.range(range.from, range.to),
+  });
+};

--- a/apps/web/src/hooks/use-recent-workouts.test.tsx
+++ b/apps/web/src/hooks/use-recent-workouts.test.tsx
@@ -1,0 +1,214 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { useRecentWorkouts } from './use-recent-workouts';
+
+const mockFetch = vi.fn();
+
+const createJsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+
+describe('useRecentWorkouts', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('loads recent completed workouts and computes exercise counts from session details', async () => {
+    mockFetch.mockImplementation((input: string | URL | Request) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+      if (url === '/api/v1/workout-sessions?status=completed&limit=2') {
+        return Promise.resolve(
+          createJsonResponse([
+            {
+              id: 'session-1',
+              name: 'Upper Push A',
+              date: '2026-03-08',
+              status: 'completed',
+              templateId: 'template-1',
+              templateName: 'Upper Push',
+              startedAt: 1,
+              completedAt: 2,
+              duration: 61,
+              createdAt: 3,
+            },
+            {
+              id: 'session-2',
+              name: 'Lower Strength',
+              date: '2026-03-05',
+              status: 'completed',
+              templateId: 'template-2',
+              templateName: 'Lower Strength',
+              startedAt: 4,
+              completedAt: 5,
+              duration: 70,
+              createdAt: 6,
+            },
+          ]),
+        );
+      }
+
+      if (url === '/api/v1/workout-sessions/session-1') {
+        return Promise.resolve(
+          createJsonResponse({
+            id: 'session-1',
+            userId: 'user-1',
+            templateId: 'template-1',
+            name: 'Upper Push A',
+            date: '2026-03-08',
+            status: 'completed',
+            startedAt: 1,
+            completedAt: 2,
+            duration: 61,
+            feedback: null,
+            notes: null,
+            sets: [
+              {
+                id: 'set-1',
+                exerciseId: 'bench-press',
+                setNumber: 1,
+                weight: 185,
+                reps: 8,
+                completed: true,
+                skipped: false,
+                section: 'main',
+                notes: null,
+                createdAt: 1,
+              },
+              {
+                id: 'set-2',
+                exerciseId: 'bench-press',
+                setNumber: 2,
+                weight: 185,
+                reps: 7,
+                completed: true,
+                skipped: false,
+                section: 'main',
+                notes: null,
+                createdAt: 2,
+              },
+              {
+                id: 'set-3',
+                exerciseId: 'incline-dumbbell-press',
+                setNumber: 1,
+                weight: 75,
+                reps: 10,
+                completed: true,
+                skipped: false,
+                section: 'main',
+                notes: null,
+                createdAt: 3,
+              },
+            ],
+            createdAt: 7,
+            updatedAt: 8,
+          }),
+        );
+      }
+
+      if (url === '/api/v1/workout-sessions/session-2') {
+        return Promise.resolve(
+          createJsonResponse({
+            id: 'session-2',
+            userId: 'user-1',
+            templateId: 'template-2',
+            name: 'Lower Strength',
+            date: '2026-03-05',
+            status: 'completed',
+            startedAt: 4,
+            completedAt: 5,
+            duration: 70,
+            feedback: null,
+            notes: null,
+            sets: [
+              {
+                id: 'set-4',
+                exerciseId: 'squat',
+                setNumber: 1,
+                weight: 275,
+                reps: 5,
+                completed: true,
+                skipped: false,
+                section: 'main',
+                notes: null,
+                createdAt: 4,
+              },
+            ],
+            createdAt: 9,
+            updatedAt: 10,
+          }),
+        );
+      }
+
+      return Promise.resolve(createJsonResponse({ error: { code: 'NOT_FOUND' } }, 404));
+    });
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setDefaultOptions({
+      queries: { retry: false },
+      mutations: { retry: false },
+    });
+
+    const { result } = renderHook(() => useRecentWorkouts(2), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/workout-sessions?status=completed&limit=2',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(result.current.data).toEqual([
+      {
+        id: 'session-1',
+        name: 'Upper Push A',
+        date: '2026-03-08',
+        duration: 61,
+        exerciseCount: 2,
+      },
+      {
+        id: 'session-2',
+        name: 'Lower Strength',
+        date: '2026-03-05',
+        duration: 70,
+        exerciseCount: 1,
+      },
+    ]);
+  });
+
+  it('surfaces an error when list payload is invalid', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse([
+        {
+          name: 'Missing id',
+        },
+      ]),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setDefaultOptions({
+      queries: { retry: false },
+      mutations: { retry: false },
+    });
+
+    const { result } = renderHook(() => useRecentWorkouts(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/hooks/use-recent-workouts.test.tsx
+++ b/apps/web/src/hooks/use-recent-workouts.test.tsx
@@ -25,7 +25,7 @@ describe('useRecentWorkouts', () => {
     vi.unstubAllGlobals();
   });
 
-  it('loads recent completed workouts and computes exercise counts from session details', async () => {
+  it('loads recent completed workouts from the list endpoint without detail fetches', async () => {
     mockFetch.mockImplementation((input: string | URL | Request) => {
       const url =
         typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
@@ -43,6 +43,7 @@ describe('useRecentWorkouts', () => {
               startedAt: 1,
               completedAt: 2,
               duration: 61,
+              exerciseCount: 2,
               createdAt: 3,
             },
             {
@@ -55,101 +56,10 @@ describe('useRecentWorkouts', () => {
               startedAt: 4,
               completedAt: 5,
               duration: 70,
+              exerciseCount: 1,
               createdAt: 6,
             },
           ]),
-        );
-      }
-
-      if (url === '/api/v1/workout-sessions/session-1') {
-        return Promise.resolve(
-          createJsonResponse({
-            id: 'session-1',
-            userId: 'user-1',
-            templateId: 'template-1',
-            name: 'Upper Push A',
-            date: '2026-03-08',
-            status: 'completed',
-            startedAt: 1,
-            completedAt: 2,
-            duration: 61,
-            feedback: null,
-            notes: null,
-            sets: [
-              {
-                id: 'set-1',
-                exerciseId: 'bench-press',
-                setNumber: 1,
-                weight: 185,
-                reps: 8,
-                completed: true,
-                skipped: false,
-                section: 'main',
-                notes: null,
-                createdAt: 1,
-              },
-              {
-                id: 'set-2',
-                exerciseId: 'bench-press',
-                setNumber: 2,
-                weight: 185,
-                reps: 7,
-                completed: true,
-                skipped: false,
-                section: 'main',
-                notes: null,
-                createdAt: 2,
-              },
-              {
-                id: 'set-3',
-                exerciseId: 'incline-dumbbell-press',
-                setNumber: 1,
-                weight: 75,
-                reps: 10,
-                completed: true,
-                skipped: false,
-                section: 'main',
-                notes: null,
-                createdAt: 3,
-              },
-            ],
-            createdAt: 7,
-            updatedAt: 8,
-          }),
-        );
-      }
-
-      if (url === '/api/v1/workout-sessions/session-2') {
-        return Promise.resolve(
-          createJsonResponse({
-            id: 'session-2',
-            userId: 'user-1',
-            templateId: 'template-2',
-            name: 'Lower Strength',
-            date: '2026-03-05',
-            status: 'completed',
-            startedAt: 4,
-            completedAt: 5,
-            duration: 70,
-            feedback: null,
-            notes: null,
-            sets: [
-              {
-                id: 'set-4',
-                exerciseId: 'squat',
-                setNumber: 1,
-                weight: 275,
-                reps: 5,
-                completed: true,
-                skipped: false,
-                section: 'main',
-                notes: null,
-                createdAt: 4,
-              },
-            ],
-            createdAt: 9,
-            updatedAt: 10,
-          }),
         );
       }
 
@@ -172,6 +82,7 @@ describe('useRecentWorkouts', () => {
       '/api/v1/workout-sessions?status=completed&limit=2',
       expect.objectContaining({ method: 'GET' }),
     );
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.current.data).toEqual([
       {
         id: 'session-1',

--- a/apps/web/src/hooks/use-recent-workouts.ts
+++ b/apps/web/src/hooks/use-recent-workouts.ts
@@ -1,9 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import {
-  type WorkoutSession,
   type WorkoutSessionListItem,
   workoutSessionListItemSchema,
-  workoutSessionSchema,
 } from '@pulse/shared';
 import { z } from 'zod';
 
@@ -22,18 +20,6 @@ export const recentWorkoutsKeys = {
   list: (limit: number) => [...recentWorkoutsKeys.all, limit] as const,
 };
 
-const fetchRecentWorkoutDetails = async (sessionId: string, signal?: AbortSignal) => {
-  const workoutSession = await apiRequest<WorkoutSession>(
-    `/api/v1/workout-sessions/${encodeURIComponent(sessionId)}`,
-    {
-      method: 'GET',
-      signal,
-    },
-  );
-
-  return workoutSessionSchema.parse(workoutSession);
-};
-
 const fetchRecentWorkouts = async (limit = DEFAULT_WORKOUT_LIMIT, signal?: AbortSignal) => {
   const normalizedLimit = Math.max(1, Math.floor(limit));
   const sessions = await apiRequest<WorkoutSessionListItem[]>(
@@ -46,26 +32,13 @@ const fetchRecentWorkouts = async (limit = DEFAULT_WORKOUT_LIMIT, signal?: Abort
 
   const parsedSessions = workoutSessionListSchema.parse(sessions).slice(0, normalizedLimit);
 
-  const details = await Promise.all(
-    parsedSessions.map((session) => fetchRecentWorkoutDetails(session.id, signal)),
-  );
-
-  const detailsById = new Map(details.map((detail) => [detail.id, detail]));
-
-  return parsedSessions.map<RecentWorkout>((session) => {
-    const detail = detailsById.get(session.id);
-    const exerciseCount = detail
-      ? new Set(detail.sets.map((set) => set.exerciseId)).size
-      : 0;
-
-    return {
-      id: session.id,
-      name: session.name,
-      date: session.date,
-      duration: session.duration,
-      exerciseCount,
-    };
-  });
+  return parsedSessions.map<RecentWorkout>((session) => ({
+    id: session.id,
+    name: session.name,
+    date: session.date,
+    duration: session.duration,
+    exerciseCount: session.exerciseCount,
+  }));
 };
 
 export const useRecentWorkouts = (limit = DEFAULT_WORKOUT_LIMIT) => {

--- a/apps/web/src/hooks/use-recent-workouts.ts
+++ b/apps/web/src/hooks/use-recent-workouts.ts
@@ -1,0 +1,78 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  type WorkoutSession,
+  type WorkoutSessionListItem,
+  workoutSessionListItemSchema,
+  workoutSessionSchema,
+} from '@pulse/shared';
+import { z } from 'zod';
+
+import { apiRequest } from '@/lib/api-client';
+
+const DEFAULT_WORKOUT_LIMIT = 5;
+
+const workoutSessionListSchema = z.array(workoutSessionListItemSchema);
+
+export type RecentWorkout = Pick<WorkoutSessionListItem, 'id' | 'name' | 'date' | 'duration'> & {
+  exerciseCount: number;
+};
+
+export const recentWorkoutsKeys = {
+  all: ['dashboard', 'recent-workouts'] as const,
+  list: (limit: number) => [...recentWorkoutsKeys.all, limit] as const,
+};
+
+const fetchRecentWorkoutDetails = async (sessionId: string, signal?: AbortSignal) => {
+  const workoutSession = await apiRequest<WorkoutSession>(
+    `/api/v1/workout-sessions/${encodeURIComponent(sessionId)}`,
+    {
+      method: 'GET',
+      signal,
+    },
+  );
+
+  return workoutSessionSchema.parse(workoutSession);
+};
+
+const fetchRecentWorkouts = async (limit = DEFAULT_WORKOUT_LIMIT, signal?: AbortSignal) => {
+  const normalizedLimit = Math.max(1, Math.floor(limit));
+  const sessions = await apiRequest<WorkoutSessionListItem[]>(
+    `/api/v1/workout-sessions?status=completed&limit=${encodeURIComponent(String(normalizedLimit))}`,
+    {
+      method: 'GET',
+      signal,
+    },
+  );
+
+  const parsedSessions = workoutSessionListSchema.parse(sessions).slice(0, normalizedLimit);
+
+  const details = await Promise.all(
+    parsedSessions.map((session) => fetchRecentWorkoutDetails(session.id, signal)),
+  );
+
+  const detailsById = new Map(details.map((detail) => [detail.id, detail]));
+
+  return parsedSessions.map<RecentWorkout>((session) => {
+    const detail = detailsById.get(session.id);
+    const exerciseCount = detail
+      ? new Set(detail.sets.map((set) => set.exerciseId)).size
+      : 0;
+
+    return {
+      id: session.id,
+      name: session.name,
+      date: session.date,
+      duration: session.duration,
+      exerciseCount,
+    };
+  });
+};
+
+export const useRecentWorkouts = (limit = DEFAULT_WORKOUT_LIMIT) => {
+  const normalizedLimit = Math.max(1, Math.floor(limit));
+
+  return useQuery({
+    queryFn: ({ signal }) => fetchRecentWorkouts(normalizedLimit, signal),
+    queryKey: recentWorkoutsKeys.list(normalizedLimit),
+  });
+};

--- a/apps/web/src/hooks/use-weight-trend.test.tsx
+++ b/apps/web/src/hooks/use-weight-trend.test.tsx
@@ -83,4 +83,22 @@ describe('useWeightTrend', () => {
       expect.any(Object),
     );
   });
+
+  it('does not fetch when query is disabled', async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setDefaultOptions({
+      queries: { retry: false },
+      mutations: { retry: false },
+    });
+
+    const { result } = renderHook(() => useWeightTrend('2026-03-04', '2026-03-05', { enabled: false }), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/hooks/use-weight-trend.test.tsx
+++ b/apps/web/src/hooks/use-weight-trend.test.tsx
@@ -1,0 +1,86 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { useWeightTrend } from './use-weight-trend';
+
+const mockFetch = vi.fn();
+
+const createJsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+
+describe('useWeightTrend', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('loads weight trend for an explicit date range', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse([
+        { date: '2026-03-04', value: 181.6 },
+        { date: '2026-03-05', value: 181.2 },
+      ]),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setDefaultOptions({
+      queries: { retry: false },
+      mutations: { retry: false },
+    });
+
+    const { result } = renderHook(() => useWeightTrend('2026-03-04', '2026-03-05'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/dashboard/trends/weight?from=2026-03-04&to=2026-03-05',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(result.current.data).toEqual([
+      { date: '2026-03-04', value: 181.6 },
+      { date: '2026-03-05', value: 181.2 },
+    ]);
+  });
+
+  it('defaults to a 30-day range ending today when range is omitted', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-03-10T10:00:00.000Z'));
+
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse([
+        { date: '2026-02-09', value: 182.1 },
+        { date: '2026-03-10', value: 181.0 },
+      ]),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setDefaultOptions({
+      queries: { retry: false },
+      mutations: { retry: false },
+    });
+
+    const { result } = renderHook(() => useWeightTrend(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/dashboard/trends/weight?from=2026-02-09&to=2026-03-10',
+      expect.any(Object),
+    );
+  });
+});

--- a/apps/web/src/hooks/use-weight-trend.ts
+++ b/apps/web/src/hooks/use-weight-trend.ts
@@ -1,0 +1,48 @@
+import { useQuery } from '@tanstack/react-query';
+import { dashboardWeightTrendSchema, type DashboardWeightTrendPoint } from '@pulse/shared';
+
+import { apiRequest } from '@/lib/api-client';
+import { addDays, getToday, parseDateInput, toDateKey } from '@/lib/date';
+
+const DEFAULT_TREND_DAYS = 30;
+
+export const weightTrendKeys = {
+  all: ['dashboard', 'weight-trend'] as const,
+  range: (from: string, to: string) => [...weightTrendKeys.all, from, to] as const,
+};
+
+const resolveDateRange = (from?: string, to?: string) => {
+  const resolvedTo = to ?? toDateKey(getToday());
+  const resolvedFrom = from ?? toDateKey(addDays(parseDateInput(resolvedTo), -(DEFAULT_TREND_DAYS - 1)));
+
+  return {
+    from: resolvedFrom,
+    to: resolvedTo,
+  };
+};
+
+const fetchWeightTrend = async (
+  from?: string,
+  to?: string,
+  signal?: AbortSignal,
+): Promise<DashboardWeightTrendPoint[]> => {
+  const range = resolveDateRange(from, to);
+  const trend = await apiRequest<DashboardWeightTrendPoint[]>(
+    `/api/v1/dashboard/trends/weight?from=${encodeURIComponent(range.from)}&to=${encodeURIComponent(range.to)}`,
+    {
+      method: 'GET',
+      signal,
+    },
+  );
+
+  return dashboardWeightTrendSchema.parse(trend);
+};
+
+export const useWeightTrend = (from?: string, to?: string) => {
+  const range = resolveDateRange(from, to);
+
+  return useQuery({
+    queryFn: ({ signal }) => fetchWeightTrend(range.from, range.to, signal),
+    queryKey: weightTrendKeys.range(range.from, range.to),
+  });
+};

--- a/apps/web/src/hooks/use-weight-trend.ts
+++ b/apps/web/src/hooks/use-weight-trend.ts
@@ -5,6 +5,7 @@ import { apiRequest } from '@/lib/api-client';
 import { addDays, getToday, parseDateInput, toDateKey } from '@/lib/date';
 
 const DEFAULT_TREND_DAYS = 30;
+const DEFAULT_QUERY_ENABLED = true;
 
 export const weightTrendKeys = {
   all: ['dashboard', 'weight-trend'] as const,
@@ -38,10 +39,16 @@ const fetchWeightTrend = async (
   return dashboardWeightTrendSchema.parse(trend);
 };
 
-export const useWeightTrend = (from?: string, to?: string) => {
+export const useWeightTrend = (
+  from?: string,
+  to?: string,
+  options: { enabled?: boolean } = {},
+) => {
   const range = resolveDateRange(from, to);
+  const enabled = options.enabled ?? DEFAULT_QUERY_ENABLED;
 
   return useQuery({
+    enabled,
     queryFn: ({ signal }) => fetchWeightTrend(range.from, range.to, signal),
     queryKey: weightTrendKeys.range(range.from, range.to),
   });

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -1,20 +1,14 @@
-import type { Habit, HabitEntry } from '@pulse/shared';
+import type { DashboardSnapshot, Habit, HabitEntry } from '@pulse/shared';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useHabitEntries, useHabits } from '@/features/habits/api/habits';
 import { getDashboardGreeting } from '@/features/dashboard/lib/greeting';
 import { createQueryClientWrapper } from '@/test/query-client';
-import { getMockSnapshotForDate } from '@/lib/mock-data/dashboard';
+
 import { DashboardPage } from './dashboard';
 
 const formatWeight = (value: number): string => `${value.toFixed(1)} lbs`;
-
-vi.mock('@/features/habits/api/habits', () => ({
-  useHabitEntries: vi.fn(),
-  useHabits: vi.fn(),
-}));
 
 vi.mock('recharts', async () => {
   const actual = await vi.importActual<typeof import('recharts')>('recharts');
@@ -38,9 +32,6 @@ vi.mock('recharts', async () => {
   };
 });
 
-const mockedUseHabitEntries = vi.mocked(useHabitEntries);
-const mockedUseHabits = vi.mocked(useHabits);
-
 const habits: Habit[] = [
   {
     active: true,
@@ -57,121 +48,195 @@ const habits: Habit[] = [
   },
 ];
 
-const todayEntry: HabitEntry = {
-  completed: true,
-  createdAt: 1,
+const habitEntries: HabitEntry[] = [
+  {
+    completed: false,
+    createdAt: 1,
+    date: '2026-03-04',
+    habitId: 'habit-meditate',
+    id: 'entry-2026-03-04',
+    userId: 'user-1',
+    value: null,
+  },
+  {
+    completed: true,
+    createdAt: 2,
+    date: '2026-03-05',
+    habitId: 'habit-meditate',
+    id: 'entry-2026-03-05',
+    userId: 'user-1',
+    value: null,
+  },
+  {
+    completed: true,
+    createdAt: 3,
+    date: '2026-03-06',
+    habitId: 'habit-meditate',
+    id: 'entry-2026-03-06',
+    userId: 'user-1',
+    value: null,
+  },
+];
+
+const snapshotForToday: DashboardSnapshot = {
   date: '2026-03-06',
-  habitId: 'habit-meditate',
-  id: 'entry-1',
-  userId: 'user-1',
-  value: null,
+  weight: {
+    date: '2026-03-06',
+    unit: 'lb',
+    value: 181.4,
+  },
+  macros: {
+    actual: {
+      calories: 1900,
+      protein: 170,
+      carbs: 210,
+      fat: 70,
+    },
+    target: {
+      calories: 2300,
+      protein: 190,
+      carbs: 260,
+      fat: 75,
+    },
+  },
+  workout: {
+    name: 'Upper Push A',
+    status: 'completed',
+    duration: 62,
+  },
+  habits: {
+    total: 1,
+    completed: 1,
+    percentage: 100,
+  },
+};
+
+const snapshotForMarch4: DashboardSnapshot = {
+  date: '2026-03-04',
+  weight: null,
+  macros: {
+    actual: {
+      calories: 1725,
+      protein: 150,
+      carbs: 180,
+      fat: 60,
+    },
+    target: {
+      calories: 2300,
+      protein: 190,
+      carbs: 260,
+      fat: 75,
+    },
+  },
+  workout: null,
+  habits: {
+    total: 1,
+    completed: 0,
+    percentage: 0,
+  },
 };
 
 describe('DashboardPage', () => {
-  let latestWeightEntry = {
-    id: 'weight-latest',
-    date: '2026-03-06',
-    weight: 181.4,
-    notes: null,
-    createdAt: 1,
-    updatedAt: 1,
-  };
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let snapshotsByDate: Record<string, DashboardSnapshot>;
 
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-06T10:00:00'));
-    latestWeightEntry = {
-      id: 'weight-latest',
-      date: '2026-03-06',
-      weight: 181.4,
-      notes: null,
-      createdAt: 1,
-      updatedAt: 1,
+    snapshotsByDate = {
+      [snapshotForToday.date]: snapshotForToday,
+      [snapshotForMarch4.date]: snapshotForMarch4,
     };
-    vi.stubGlobal(
-      'fetch',
-      vi.fn((input: string | URL | Request, init?: RequestInit) => {
-        const url =
-          typeof input === 'string' ? input : input instanceof URL ? input.pathname : input.url;
 
-        if (url.includes('/api/v1/weight') && init?.method === 'POST') {
-          const body =
-            typeof init.body === 'string'
-              ? (JSON.parse(init.body) as { date: string; weight: number })
-              : null;
+    mockFetch = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      const rawUrl =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url = new URL(rawUrl, 'http://localhost');
 
-          latestWeightEntry = {
-            id: 'weight-latest',
-            date: body?.date ?? latestWeightEntry.date,
-            weight: body?.weight ?? latestWeightEntry.weight,
-            notes: null,
-            createdAt: latestWeightEntry.createdAt,
-            updatedAt: latestWeightEntry.updatedAt + 1,
-          };
-
-          return Promise.resolve(
-            new Response(JSON.stringify({ data: latestWeightEntry }), {
-              headers: { 'Content-Type': 'application/json' },
-              status: 201,
-            }),
-          );
-        }
-
-        if (url.includes('/api/v1/weight/latest')) {
-          return Promise.resolve(
-            new Response(
-              JSON.stringify({
-                data: latestWeightEntry,
-              }),
-              { headers: { 'Content-Type': 'application/json' }, status: 200 },
-            ),
-          );
-        }
-
-        if (url.includes('/api/v1/nutrition-targets/current')) {
-          return Promise.resolve(
-            new Response(
-              JSON.stringify({
-                data: {
-                  id: 'target-current',
-                  calories: 2300,
-                  protein: 190,
-                  carbs: 260,
-                  fat: 75,
-                  effectiveDate: '2026-03-06',
-                  createdAt: 1,
-                  updatedAt: 1,
-                },
-              }),
-              { headers: { 'Content-Type': 'application/json' }, status: 200 },
-            ),
-          );
-        }
+      if (url.pathname === '/api/v1/dashboard/snapshot' && init?.method === 'GET') {
+        const requestedDate = url.searchParams.get('date') ?? snapshotForToday.date;
+        const snapshot = snapshotsByDate[requestedDate] ?? snapshotForToday;
 
         return Promise.resolve(
-          new Response(JSON.stringify({ data: null }), {
+          new Response(JSON.stringify({ data: snapshot }), {
             headers: { 'Content-Type': 'application/json' },
             status: 200,
           }),
         );
-      }),
-    );
+      }
 
-    mockedUseHabits.mockReturnValue({
-      data: habits,
-      error: null,
-      isError: false,
-      isPending: false,
-    } as ReturnType<typeof useHabits>);
-    mockedUseHabitEntries.mockImplementation(
-      (from, to) =>
-        ({
-          data: from === '2026-03-06' && to === '2026-03-06' ? [todayEntry] : [todayEntry],
-          error: null,
-          isError: false,
-          isPending: false,
-        }) as ReturnType<typeof useHabitEntries>,
-    );
+      if (url.pathname === '/api/v1/habits' && init?.method === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: habits }), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/habit-entries' && init?.method === 'GET') {
+        const from = url.searchParams.get('from') ?? '';
+        const to = url.searchParams.get('to') ?? '';
+        const entriesInRange = habitEntries.filter((entry) => entry.date >= from && entry.date <= to);
+
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: entriesInRange }), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/weight' && init?.method === 'POST') {
+        const body = typeof init.body === 'string' ? (JSON.parse(init.body) as { date: string; weight: number }) : null;
+        const nextDate = body?.date ?? snapshotForToday.date;
+        const nextWeight = body?.weight ?? snapshotForToday.weight?.value ?? 0;
+        const previousSnapshot = snapshotsByDate[nextDate] ?? snapshotForToday;
+
+        snapshotsByDate[nextDate] = {
+          ...previousSnapshot,
+          date: nextDate,
+          weight: {
+            date: nextDate,
+            unit: 'lb',
+            value: nextWeight,
+          },
+        };
+
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              data: {
+                id: `weight-${nextDate}`,
+                date: nextDate,
+                weight: nextWeight,
+                notes: null,
+                createdAt: 1,
+                updatedAt: 2,
+              },
+            }),
+            {
+              headers: { 'Content-Type': 'application/json' },
+              status: 201,
+            },
+          ),
+        );
+      }
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 'NOT_FOUND',
+              message: 'Not found',
+            },
+          }),
+          { headers: { 'Content-Type': 'application/json' }, status: 404 },
+        ),
+      );
+    });
+
+    vi.stubGlobal('fetch', mockFetch);
   });
 
   afterEach(() => {
@@ -179,7 +244,7 @@ describe('DashboardPage', () => {
     vi.unstubAllGlobals();
   });
 
-  it('renders the dashboard title, greeting, and responsive column layout', () => {
+  it('renders the dashboard title, greeting, and responsive column layout with API snapshot data', async () => {
     const { wrapper } = createQueryClientWrapper();
     const { container } = render(
       <MemoryRouter>
@@ -188,15 +253,25 @@ describe('DashboardPage', () => {
       { wrapper },
     );
 
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    const bodyWeightCard = screen.getByText('Body Weight').closest('[data-slot="stat-card"]');
+    expect(bodyWeightCard).toBeInTheDocument();
+    expect(within(bodyWeightCard as HTMLElement).getByText(formatWeight(181.4))).toBeInTheDocument();
+
     expect(screen.getByRole('heading', { name: 'Dashboard' })).toBeInTheDocument();
     expect(screen.getByText('Good morning')).toBeInTheDocument();
     expect(screen.getByLabelText('Calendar day picker')).toBeInTheDocument();
-    expect(screen.getByText('Body Weight')).toBeInTheDocument();
     expect(screen.getByText('Habits')).toBeInTheDocument();
     expect(screen.getByLabelText('Macro display mode')).toBeInTheDocument();
     expect(screen.getByLabelText('Habit chains')).toBeInTheDocument();
     expect(screen.getByLabelText('Trend sparklines')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Recent Workouts' })).toBeInTheDocument();
+    expect(screen.getByText('Upper Push A (Completed)')).toBeInTheDocument();
+    expect(screen.getByText('1900 / 2300')).toBeInTheDocument();
+    expect(screen.getByText('170g / 190g')).toBeInTheDocument();
+    expect(screen.getByText('1 / 1 complete')).toBeInTheDocument();
     expect(screen.getByLabelText('Weight (lbs)')).toHaveAttribute('id', 'dashboard-weight-input');
     expect(screen.getByLabelText('Weight (lbs)')).toHaveAttribute('name', 'weight');
     expect(screen.getByLabelText('Weight (lbs)')).toHaveAttribute(
@@ -251,47 +326,54 @@ describe('DashboardPage', () => {
     expect(macroPanel).toHaveClass('order-3', 'md:order-2');
   });
 
-  it('updates snapshot content when a new calendar day is selected', async () => {
-    mockedUseHabitEntries.mockImplementation(
-      (from, to) =>
-        ({
-          data: from === '2026-03-04' && to === '2026-03-04' ? [] : [todayEntry],
-          error: null,
-          isError: false,
-          isPending: false,
-        }) as ReturnType<typeof useHabitEntries>,
-    );
-
+  it('updates snapshot and habit chain windows when a new calendar day is selected', async () => {
     const { wrapper } = createQueryClientWrapper();
-    render(
+    const { container } = render(
       <MemoryRouter>
         <DashboardPage />
       </MemoryRouter>,
       { wrapper },
     );
 
-    const selectedSnapshot = getMockSnapshotForDate(new Date('2026-03-04T00:00:00'));
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
     const bodyWeightCard = screen.getByText('Body Weight').closest('[data-slot="stat-card"]');
     const habitsCard = screen.getByText('Habits').closest('[data-slot="stat-card"]');
 
     expect(bodyWeightCard).toBeInTheDocument();
-    await vi.runAllTimersAsync();
-    await Promise.resolve();
-
     expect(habitsCard).toBeInTheDocument();
-    expect(
-      within(bodyWeightCard as HTMLElement).getByText(formatWeight(181.4)),
-    ).toBeInTheDocument();
+    expect(within(bodyWeightCard as HTMLElement).getByText(formatWeight(181.4))).toBeInTheDocument();
     expect(within(habitsCard as HTMLElement).getByText('1 / 1 complete')).toBeInTheDocument();
+
+    const initialSquares = container.querySelectorAll('[data-slot="habit-chain-day"]');
+    expect(initialSquares[29]).toHaveAttribute('data-date', '2026-03-06');
 
     fireEvent.click(screen.getByRole('button', { name: /select wednesday, march 4, 2026/i }));
 
-    expect(
-      within(bodyWeightCard as HTMLElement).getByText(formatWeight(181.4)),
-    ).toBeInTheDocument();
-    expect(screen.getByText(`${selectedSnapshot.macros.calories.actual}kcal`)).toBeInTheDocument();
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(within(bodyWeightCard as HTMLElement).getByText('--')).toBeInTheDocument();
     expect(within(habitsCard as HTMLElement).getByText('0 / 1 complete')).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Recent Workouts' })).toBeInTheDocument();
+    expect(screen.getByText('Rest Day')).toBeInTheDocument();
+
+    const updatedSquares = container.querySelectorAll('[data-slot="habit-chain-day"]');
+    expect(updatedSquares[29]).toHaveAttribute('data-date', '2026-03-04');
+    expect(updatedSquares[29]).toHaveAttribute('data-today', 'true');
+    expect(
+      mockFetch.mock.calls.some((call) => {
+        const rawInput = call[0];
+        const rawUrl =
+          typeof rawInput === 'string'
+            ? rawInput
+            : rawInput instanceof URL
+              ? rawInput.toString()
+              : rawInput.url;
+
+        return rawUrl.includes('/api/v1/dashboard/snapshot?date=2026-03-04');
+      }),
+    ).toBe(true);
   });
 
   it('logs a new weight entry and refreshes the body weight card', async () => {
@@ -308,9 +390,7 @@ describe('DashboardPage', () => {
     const bodyWeightCard = screen.getByText('Body Weight').closest('[data-slot="stat-card"]');
     expect(bodyWeightCard).toBeInTheDocument();
     await waitFor(() => {
-      expect(
-        within(bodyWeightCard as HTMLElement).getByText(formatWeight(181.4)),
-      ).toBeInTheDocument();
+      expect(within(bodyWeightCard as HTMLElement).getByText(formatWeight(181.4))).toBeInTheDocument();
     });
 
     fireEvent.change(screen.getByLabelText('Weight (lbs)'), { target: { value: '175.5' } });

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -169,53 +169,10 @@ const recentWorkoutsListData = [
     startedAt: 1,
     completedAt: 2,
     duration: 62,
+    exerciseCount: 2,
     createdAt: 3,
   },
 ];
-
-const recentWorkoutDetailsData = {
-  'recent-workout-1': {
-    id: 'recent-workout-1',
-    userId: 'user-1',
-    templateId: 'template-1',
-    name: 'Upper Push A',
-    date: '2026-03-05',
-    status: 'completed',
-    startedAt: 1,
-    completedAt: 2,
-    duration: 62,
-    feedback: null,
-    notes: null,
-    sets: [
-      {
-        id: 'set-1',
-        exerciseId: 'bench-press',
-        setNumber: 1,
-        weight: 185,
-        reps: 8,
-        completed: true,
-        skipped: false,
-        section: 'main',
-        notes: null,
-        createdAt: 1,
-      },
-      {
-        id: 'set-2',
-        exerciseId: 'incline-dumbbell-press',
-        setNumber: 1,
-        weight: 75,
-        reps: 10,
-        completed: true,
-        skipped: false,
-        section: 'main',
-        notes: null,
-        createdAt: 2,
-      },
-    ],
-    createdAt: 4,
-    updatedAt: 5,
-  },
-} as const;
 
 describe('DashboardPage', () => {
   let mockFetch: ReturnType<typeof vi.fn>;
@@ -307,20 +264,6 @@ describe('DashboardPage', () => {
             status: 200,
           }),
         );
-      }
-
-      if (url.pathname.startsWith('/api/v1/workout-sessions/') && init?.method === 'GET') {
-        const sessionId = url.pathname.replace('/api/v1/workout-sessions/', '');
-        const detail = recentWorkoutDetailsData[sessionId as keyof typeof recentWorkoutDetailsData];
-
-        if (detail) {
-          return Promise.resolve(
-            new Response(JSON.stringify({ data: detail }), {
-              headers: { 'Content-Type': 'application/json' },
-              status: 200,
-            }),
-          );
-        }
       }
 
       if (url.pathname === '/api/v1/weight' && init?.method === 'POST') {

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -136,6 +136,87 @@ const snapshotForMarch4: DashboardSnapshot = {
   },
 };
 
+const weightTrendData = [
+  { date: '2026-02-09', value: 182.2 },
+  { date: '2026-03-06', value: 181.4 },
+];
+
+const macroTrendData = [
+  {
+    date: '2026-02-09',
+    calories: 0,
+    protein: 0,
+    carbs: 0,
+    fat: 0,
+  },
+  {
+    date: '2026-03-06',
+    calories: 1900,
+    protein: 170,
+    carbs: 210,
+    fat: 70,
+  },
+];
+
+const recentWorkoutsListData = [
+  {
+    id: 'recent-workout-1',
+    name: 'Upper Push A',
+    date: '2026-03-05',
+    status: 'completed',
+    templateId: 'template-1',
+    templateName: 'Upper Push',
+    startedAt: 1,
+    completedAt: 2,
+    duration: 62,
+    createdAt: 3,
+  },
+];
+
+const recentWorkoutDetailsData = {
+  'recent-workout-1': {
+    id: 'recent-workout-1',
+    userId: 'user-1',
+    templateId: 'template-1',
+    name: 'Upper Push A',
+    date: '2026-03-05',
+    status: 'completed',
+    startedAt: 1,
+    completedAt: 2,
+    duration: 62,
+    feedback: null,
+    notes: null,
+    sets: [
+      {
+        id: 'set-1',
+        exerciseId: 'bench-press',
+        setNumber: 1,
+        weight: 185,
+        reps: 8,
+        completed: true,
+        skipped: false,
+        section: 'main',
+        notes: null,
+        createdAt: 1,
+      },
+      {
+        id: 'set-2',
+        exerciseId: 'incline-dumbbell-press',
+        setNumber: 1,
+        weight: 75,
+        reps: 10,
+        completed: true,
+        skipped: false,
+        section: 'main',
+        notes: null,
+        createdAt: 2,
+      },
+    ],
+    createdAt: 4,
+    updatedAt: 5,
+  },
+} as const;
+
 describe('DashboardPage', () => {
   let mockFetch: ReturnType<typeof vi.fn>;
   let snapshotsByDate: Record<string, DashboardSnapshot>;
@@ -185,6 +266,47 @@ describe('DashboardPage', () => {
             status: 200,
           }),
         );
+      }
+
+      if (url.pathname === '/api/v1/dashboard/trends/weight' && init?.method === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: weightTrendData }), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/dashboard/trends/macros' && init?.method === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: macroTrendData }), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions' && init?.method === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: recentWorkoutsListData }), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          }),
+        );
+      }
+
+      if (url.pathname.startsWith('/api/v1/workout-sessions/') && init?.method === 'GET') {
+        const sessionId = url.pathname.replace('/api/v1/workout-sessions/', '');
+        const detail = recentWorkoutDetailsData[sessionId as keyof typeof recentWorkoutDetailsData];
+
+        if (detail) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ data: detail }), {
+              headers: { 'Content-Type': 'application/json' },
+              status: 200,
+            }),
+          );
+        }
       }
 
       if (url.pathname === '/api/v1/weight' && init?.method === 'POST') {

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -1,4 +1,4 @@
-import type { DashboardSnapshot, Habit, HabitEntry } from '@pulse/shared';
+import type { DashboardConfig, DashboardSnapshot, Habit, HabitEntry } from '@pulse/shared';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -219,6 +219,7 @@ const recentWorkoutDetailsData = {
 
 describe('DashboardPage', () => {
   let mockFetch: ReturnType<typeof vi.fn>;
+  let dashboardConfig: DashboardConfig;
   let snapshotsByDate: Record<string, DashboardSnapshot>;
 
   beforeEach(() => {
@@ -227,6 +228,10 @@ describe('DashboardPage', () => {
     snapshotsByDate = {
       [snapshotForToday.date]: snapshotForToday,
       [snapshotForMarch4.date]: snapshotForMarch4,
+    };
+    dashboardConfig = {
+      habitChainIds: ['habit-meditate'],
+      trendMetrics: ['weight', 'calories', 'protein'],
     };
 
     mockFetch = vi.fn((input: string | URL | Request, init?: RequestInit) => {
@@ -240,6 +245,15 @@ describe('DashboardPage', () => {
 
         return Promise.resolve(
           new Response(JSON.stringify({ data: snapshot }), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/dashboard/config' && init?.method === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: dashboardConfig }), {
             headers: { 'Content-Type': 'application/json' },
             status: 200,
           }),
@@ -524,6 +538,29 @@ describe('DashboardPage', () => {
     await waitFor(() => {
       expect(within(bodyWeightCard as HTMLElement).getByText('175.5 lbs')).toBeInTheDocument();
     });
+  });
+
+  it('renders only configured habit chains and trend metrics', async () => {
+    dashboardConfig = {
+      habitChainIds: [],
+      trendMetrics: ['protein'],
+    };
+
+    const { wrapper } = createQueryClientWrapper();
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+      { wrapper },
+    );
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(screen.getByText('Protein Trend')).toBeInTheDocument();
+    expect(screen.queryByText('Weight Trend')).not.toBeInTheDocument();
+    expect(screen.queryByText('Calorie Trend')).not.toBeInTheDocument();
+    expect(screen.getByText('No matching habits.')).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -15,6 +15,7 @@ import { TrendSparklines } from '@/features/dashboard/components/trend-sparkline
 import { useHabits } from '@/features/habits/api/habits';
 import { useLogWeight } from '@/features/weight/api/weight';
 import { useDashboardSnapshot, dashboardSnapshotKeys } from '@/hooks/use-dashboard-snapshot';
+import { useDashboardConfig } from '@/hooks/use-dashboard-config';
 import { useHabitChains } from '@/hooks/use-habit-chains';
 import { addDays, getToday, toDateKey } from '@/lib/date';
 
@@ -29,6 +30,7 @@ export function DashboardPage() {
   const greeting = getDashboardGreeting();
 
   const snapshotQuery = useDashboardSnapshot(selectedDateKey);
+  const dashboardConfigQuery = useDashboardConfig();
   const habitsQuery = useHabits();
   const habitChainEntriesQuery = useHabitChains(habitRangeStart, selectedDateKey);
 
@@ -147,10 +149,14 @@ export function DashboardPage() {
         >
           <HabitChain
             endDate={selectedDateKey}
+            habitIds={dashboardConfigQuery.data?.habitChainIds}
             habits={habitsQuery.data ?? []}
             entries={habitChainEntriesQuery.data ?? []}
           />
-          <TrendSparklines endDate={selectedDateKey} />
+          <TrendSparklines
+            endDate={selectedDateKey}
+            metrics={dashboardConfigQuery.data?.trendMetrics}
+          />
         </div>
 
         <div

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -150,7 +150,7 @@ export function DashboardPage() {
             habits={habitsQuery.data ?? []}
             entries={habitChainEntriesQuery.data ?? []}
           />
-          <TrendSparklines />
+          <TrendSparklines endDate={selectedDateKey} />
         </div>
 
         <div

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -1,4 +1,5 @@
-import { type FormEvent, useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { type FormEvent, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -10,69 +11,26 @@ import { MacroRings } from '@/features/dashboard/components/macro-rings';
 import { RecentWorkouts } from '@/features/dashboard/components/recent-workouts';
 import { SnapshotCards } from '@/features/dashboard/components/snapshot-cards';
 import { getDashboardGreeting } from '@/features/dashboard/lib/greeting';
-import { useNutritionTargets } from '@/features/nutrition/api/targets';
-import { useLatestWeight, useLogWeight } from '@/features/weight/api/weight';
 import { TrendSparklines } from '@/features/dashboard/components/trend-sparkline';
-import { useHabitEntries, useHabits } from '@/features/habits/api/habits';
-import { addDays, formatDateKey, getToday, toDateKey } from '@/lib/date';
-import { getMockSnapshotForDate } from '@/lib/mock-data/dashboard';
+import { useHabits } from '@/features/habits/api/habits';
+import { useLogWeight } from '@/features/weight/api/weight';
+import { useDashboardSnapshot, dashboardSnapshotKeys } from '@/hooks/use-dashboard-snapshot';
+import { useHabitChains } from '@/hooks/use-habit-chains';
+import { addDays, getToday, toDateKey } from '@/lib/date';
 
 export function DashboardPage() {
+  const queryClient = useQueryClient();
   const [selectedDate, setSelectedDate] = useState<Date>(() => getToday());
   const [weightInput, setWeightInput] = useState('');
   const [weightMessage, setWeightMessage] = useState('');
-  const { data: currentTargets } = useNutritionTargets();
-  const { data: latestWeightEntry } = useLatestWeight();
   const logWeightMutation = useLogWeight();
   const selectedDateKey = toDateKey(selectedDate);
-  const today = getToday();
-  const todayKey = toDateKey(today);
-  const habitRangeStart = toDateKey(addDays(today, -29));
+  const habitRangeStart = toDateKey(addDays(selectedDate, -29));
   const greeting = getDashboardGreeting();
 
+  const snapshotQuery = useDashboardSnapshot(selectedDateKey);
   const habitsQuery = useHabits();
-  const selectedHabitEntriesQuery = useHabitEntries(selectedDateKey, selectedDateKey);
-  const habitChainEntriesQuery = useHabitEntries(habitRangeStart, todayKey);
-
-  const selectedSnapshot = useMemo(() => {
-    const baseSnapshot = getMockSnapshotForDate(selectedDate);
-    const habits = habitsQuery.data ?? [];
-    const entries = selectedHabitEntriesQuery.data ?? [];
-    const completedCount = entries.filter((entry) => entry.completed).length;
-
-    return {
-      ...baseSnapshot,
-      habitsCompleted: completedCount,
-      habitsTotal: habits.length,
-    };
-  }, [habitsQuery.data, selectedDate, selectedHabitEntriesQuery.data]);
-
-  const dashboardSnapshot = useMemo(
-    () => ({
-      ...selectedSnapshot,
-      weight: latestWeightEntry?.weight ?? selectedSnapshot.weight,
-      weightYesterday: selectedSnapshot.weightYesterday,
-      macros: {
-        calories: {
-          ...selectedSnapshot.macros.calories,
-          target: currentTargets?.calories ?? selectedSnapshot.macros.calories.target,
-        },
-        protein: {
-          ...selectedSnapshot.macros.protein,
-          target: currentTargets?.protein ?? selectedSnapshot.macros.protein.target,
-        },
-        carbs: {
-          ...selectedSnapshot.macros.carbs,
-          target: currentTargets?.carbs ?? selectedSnapshot.macros.carbs.target,
-        },
-        fat: {
-          ...selectedSnapshot.macros.fat,
-          target: currentTargets?.fat ?? selectedSnapshot.macros.fat.target,
-        },
-      },
-    }),
-    [currentTargets, latestWeightEntry, selectedSnapshot],
-  );
+  const habitChainEntriesQuery = useHabitChains(habitRangeStart, selectedDateKey);
 
   async function handleWeightSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -85,9 +43,10 @@ export function DashboardPage() {
 
     try {
       await logWeightMutation.mutateAsync({
-        date: formatDateKey(selectedDate),
+        date: selectedDateKey,
         weight: parsedWeight,
       });
+      await queryClient.invalidateQueries({ queryKey: dashboardSnapshotKeys.all });
       setWeightInput('');
       setWeightMessage('Weight entry saved.');
     } catch {
@@ -120,7 +79,7 @@ export function DashboardPage() {
 
           <div className="order-2 md:order-1" data-slot="dashboard-snapshot-panel">
             <div className="flex flex-col gap-6">
-              <SnapshotCards snapshot={dashboardSnapshot} />
+              <SnapshotCards snapshot={snapshotQuery.data} />
               <Card data-qa="dashboard-log-weight-card" data-testid="dashboard-log-weight-card">
                 <CardHeader className="space-y-1">
                   <CardTitle>Log Weight</CardTitle>
@@ -178,7 +137,7 @@ export function DashboardPage() {
           </div>
 
           <div className="order-3 md:order-2" data-slot="dashboard-macro-panel">
-            <MacroRings snapshot={dashboardSnapshot} />
+            <MacroRings snapshot={snapshotQuery.data} />
           </div>
         </div>
 
@@ -186,7 +145,11 @@ export function DashboardPage() {
           className="order-2 flex min-w-0 flex-col gap-6 md:order-2 xl:order-1"
           data-slot="dashboard-sidebar-column"
         >
-          <HabitChain habits={habitsQuery.data ?? []} entries={habitChainEntriesQuery.data ?? []} />
+          <HabitChain
+            endDate={selectedDateKey}
+            habits={habitsQuery.data ?? []}
+            entries={habitChainEntriesQuery.data ?? []}
+          />
           <TrendSparklines />
         </div>
 

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -30,6 +30,7 @@ export function DashboardPage() {
   const greeting = getDashboardGreeting();
 
   const snapshotQuery = useDashboardSnapshot(selectedDateKey);
+  // TODO: apply widgetOrder to section layout once ordering UI is added.
   const dashboardConfigQuery = useDashboardConfig();
   const habitsQuery = useHabits();
   const habitChainEntriesQuery = useHabitChains(habitRangeStart, selectedDateKey);

--- a/apps/web/src/pages/settings.test.tsx
+++ b/apps/web/src/pages/settings.test.tsx
@@ -4,8 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ThemeProvider } from '@/components/theme-provider';
 import { THEME_STORAGE_KEY } from '@/hooks/useTheme';
-import { createQueryClientWrapper } from '@/test/query-client';
 import { DEFAULT_SETTINGS, SETTINGS_STORAGE_KEY, SettingsPage } from '@/pages/settings';
+import { createQueryClientWrapper } from '@/test/query-client';
 
 vi.mock('@/features/habits', async () => {
   const actual = await vi.importActual<typeof import('@/features/habits')>('@/features/habits');
@@ -15,6 +15,41 @@ vi.mock('@/features/habits', async () => {
     HabitSettings: () => <div data-testid="habit-settings" />,
   };
 });
+
+type TestState = {
+  dashboardConfig: {
+    habitChainIds: string[];
+    trendMetrics: Array<'weight' | 'calories' | 'protein'>;
+    widgetOrder?: string[];
+  };
+  habits: Array<{
+    id: string;
+    userId: string;
+    name: string;
+    emoji: string | null;
+    trackingType: 'boolean' | 'numeric' | 'time';
+    target: number | null;
+    unit: string | null;
+    sortOrder: number;
+    active: boolean;
+    createdAt: number;
+    updatedAt: number;
+  }>;
+  nutritionCurrent:
+    | {
+        id: string;
+        calories: number;
+        protein: number;
+        carbs: number;
+        fat: number;
+        effectiveDate: string;
+        createdAt: number;
+        updatedAt: number;
+      }
+    | null;
+  shouldFailDashboardSave: boolean;
+  shouldFailNutritionSave: boolean;
+};
 
 function renderSettingsPage() {
   const { wrapper } = createQueryClientWrapper();
@@ -29,53 +64,142 @@ function renderSettingsPage() {
   );
 }
 
-function getLatestNutritionTargetsPostPayload() {
-  const postCall = vi
+function getLatestPostBody(pathFragment: string) {
+  const call = vi
     .mocked(fetch)
-    .mock.calls.filter(([, init]) => {
+    .mock.calls.filter(([url, init]) => {
+      const raw = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
       const method = init?.method?.toUpperCase();
-      return method === 'POST';
+      return raw.includes(pathFragment) && method !== undefined && method !== 'GET';
     })
     .at(-1);
 
-  if (!postCall) {
-    throw new Error('No nutrition target POST request was captured.');
+  if (!call) {
+    throw new Error(`No request call captured for ${pathFragment}`);
   }
 
-  const [, init] = postCall;
-  return JSON.parse(String(init?.body)) as {
-    calories: number;
-    carbs: number;
-    effectiveDate: string;
-    fat: number;
-    protein: number;
-  };
+  const [, init] = call;
+  return init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : null;
 }
 
 describe('SettingsPage', () => {
+  let state: TestState;
+
   beforeEach(() => {
+    state = {
+      dashboardConfig: {
+        habitChainIds: ['habit-hydrate'],
+        trendMetrics: ['weight', 'calories', 'protein'],
+      },
+      habits: [
+        {
+          id: 'habit-hydrate',
+          userId: 'user-1',
+          name: 'Hydrate',
+          emoji: '💧',
+          trackingType: 'numeric',
+          target: 8,
+          unit: 'glasses',
+          sortOrder: 0,
+          active: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        {
+          id: 'habit-sleep',
+          userId: 'user-1',
+          name: 'Sleep',
+          emoji: '😴',
+          trackingType: 'time',
+          target: 8,
+          unit: 'hours',
+          sortOrder: 1,
+          active: true,
+          createdAt: 2,
+          updatedAt: 2,
+        },
+      ],
+      nutritionCurrent: null,
+      shouldFailDashboardSave: false,
+      shouldFailNutritionSave: false,
+    };
+
     window.localStorage.removeItem(THEME_STORAGE_KEY);
     window.localStorage.removeItem(SETTINGS_STORAGE_KEY);
     document.documentElement.classList.remove('dark');
     document.documentElement.classList.remove('theme-midnight');
+
     vi.stubGlobal(
       'fetch',
       vi.fn((input: string | URL | Request, init?: RequestInit) => {
-        const url =
-          typeof input === 'string' ? input : input instanceof URL ? input.pathname : input.url;
+        const rawUrl =
+          typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+        const url = new URL(rawUrl, 'http://localhost');
 
-        if (url.includes('/api/v1/nutrition-targets/current')) {
+        if (url.pathname === '/api/v1/nutrition-targets/current') {
           return Promise.resolve(
-            new Response(JSON.stringify({ data: null }), {
+            new Response(JSON.stringify({ data: state.nutritionCurrent }), {
               headers: { 'Content-Type': 'application/json' },
               status: 200,
             }),
           );
         }
 
-        if (url.includes('/api/v1/nutrition-targets') && init?.method === 'POST') {
+        if (url.pathname === '/api/v1/nutrition-targets' && init?.method === 'POST') {
+          if (state.shouldFailNutritionSave) {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({ error: { code: 'SERVER_ERROR', message: 'Unavailable' } }),
+                {
+                  headers: { 'Content-Type': 'application/json' },
+                  status: 503,
+                },
+              ),
+            );
+          }
+
           return Promise.resolve(
             new Response(JSON.stringify({ data: JSON.parse(String(init.body)) }), {
+              headers: { 'Content-Type': 'application/json' },
+              status: 200,
+            }),
+          );
+        }
+
+        if (url.pathname === '/api/v1/dashboard/config' && init?.method === 'GET') {
+          return Promise.resolve(
+            new Response(JSON.stringify({ data: state.dashboardConfig }), {
+              headers: { 'Content-Type': 'application/json' },
+              status: 200,
+            }),
+          );
+        }
+
+        if (url.pathname === '/api/v1/dashboard/config' && init?.method === 'PUT') {
+          if (state.shouldFailDashboardSave) {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({ error: { code: 'SERVER_ERROR', message: 'Unavailable' } }),
+                {
+                  headers: { 'Content-Type': 'application/json' },
+                  status: 503,
+                },
+              ),
+            );
+          }
+
+          state.dashboardConfig = JSON.parse(String(init.body)) as TestState['dashboardConfig'];
+          return Promise.resolve(
+            new Response(JSON.stringify({ data: state.dashboardConfig }), {
+              headers: { 'Content-Type': 'application/json' },
+              status: 200,
+            }),
+          );
+        }
+
+        if (url.pathname === '/api/v1/habits' && init?.method === 'GET') {
+          return Promise.resolve(
+            new Response(JSON.stringify({ data: state.habits }), {
               headers: { 'Content-Type': 'application/json' },
               status: 200,
             }),
@@ -96,37 +220,23 @@ describe('SettingsPage', () => {
     vi.unstubAllGlobals();
   });
 
-  it('renders the read-only profile field, theme options, and default prototype settings', () => {
+  it('renders defaults and loads dashboard config from API', async () => {
     renderSettingsPage();
 
     expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Back to Profile/i })).toHaveAttribute(
-      'href',
-      '/profile',
-    );
-    expect(screen.getByRole('heading', { name: 'Profile' })).toBeInTheDocument();
-    expect(screen.getByLabelText('Display name')).toHaveAttribute('readonly');
-    expect(screen.getByPlaceholderText('User')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Theme' })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: /Light/i })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: /Dark/i })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: /Midnight/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Nutrition Targets' })).toBeInTheDocument();
     expect(screen.getByLabelText('Daily calories')).toHaveValue(
       DEFAULT_SETTINGS.nutritionTargets.calories,
     );
-    expect(screen.getByLabelText('Protein (g)')).toHaveValue(
-      DEFAULT_SETTINGS.nutritionTargets.protein,
-    );
-    expect(screen.getByLabelText('Carbs (g)')).toHaveValue(DEFAULT_SETTINGS.nutritionTargets.carbs);
-    expect(screen.getByLabelText('Fat (g)')).toHaveValue(DEFAULT_SETTINGS.nutritionTargets.fat);
-    expect(screen.getByRole('heading', { name: 'Dashboard Configuration' })).toBeInTheDocument();
-    expect(screen.getByRole('checkbox', { name: /Hydrate/i })).toBeChecked();
-    expect(screen.getByRole('checkbox', { name: /Take vitamins/i })).toBeChecked();
-    expect(screen.getByRole('checkbox', { name: /Protein goal/i })).toBeChecked();
+
+    await waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: /Hydrate/i })).toBeChecked();
+    });
+
+    expect(screen.getByRole('checkbox', { name: /Sleep/i })).not.toBeChecked();
     expect(screen.getByRole('checkbox', { name: /Weight/i })).toBeChecked();
-    expect(screen.getByRole('checkbox', { name: /Steps/i })).not.toBeChecked();
-    expect(screen.getByRole('button', { name: 'Save settings' })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /Calories/i })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Protein/i })).toBeChecked();
   });
 
   it('reflects the persisted theme on first render', () => {
@@ -139,60 +249,16 @@ describe('SettingsPage', () => {
     expect(document.documentElement.classList.contains('dark')).toBe(false);
   });
 
-  it('restores saved nutrition targets and dashboard selections on first render', () => {
-    window.localStorage.setItem(
-      SETTINGS_STORAGE_KEY,
-      JSON.stringify({
-        dashboardConfig: {
-          habitChains: ['sleep'],
-          trendSparklines: ['Steps'],
-        },
-        nutritionTargets: {
-          calories: 2350,
-          carbs: 275,
-          fat: 70,
-          protein: 180,
-        },
-      }),
-    );
-
+  it('saves nutrition targets and dashboard config via API', async () => {
     renderSettingsPage();
 
-    expect(screen.getByLabelText('Daily calories')).toHaveValue(2350);
-    expect(screen.getByLabelText('Protein (g)')).toHaveValue(180);
-    expect(screen.getByLabelText('Carbs (g)')).toHaveValue(275);
-    expect(screen.getByLabelText('Fat (g)')).toHaveValue(70);
-    expect(screen.getByRole('checkbox', { name: /Sleep/i })).toBeChecked();
-    expect(screen.getByRole('checkbox', { name: /Hydrate/i })).not.toBeChecked();
-    expect(screen.getByRole('checkbox', { name: /Steps/i })).toBeChecked();
-    expect(screen.getByRole('checkbox', { name: /Weight/i })).not.toBeChecked();
-  });
-
-  it('applies and persists theme changes immediately', () => {
-    renderSettingsPage();
-
-    fireEvent.click(screen.getByRole('radio', { name: /Midnight/i }));
-
-    expect(screen.getByRole('radio', { name: /Midnight/i })).toBeChecked();
-    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('midnight');
-    expect(document.documentElement.classList.contains('theme-midnight')).toBe(true);
-    expect(document.documentElement.classList.contains('dark')).toBe(false);
-
-    fireEvent.click(screen.getByRole('radio', { name: /Light/i }));
-
-    expect(screen.getByRole('radio', { name: /Light/i })).toBeChecked();
-    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
-    expect(document.documentElement.classList.contains('theme-midnight')).toBe(false);
-    expect(document.documentElement.classList.contains('dark')).toBe(false);
-  });
-
-  it('saves nutrition targets and dashboard selections to localStorage', async () => {
-    renderSettingsPage();
+    await waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: /Hydrate/i })).toBeChecked();
+    });
 
     fireEvent.change(screen.getByLabelText('Daily calories'), { target: { value: '2250' } });
-    fireEvent.change(screen.getByLabelText('Protein (g)'), { target: { value: '175' } });
-    fireEvent.click(screen.getByRole('checkbox', { name: /Hydrate/i }));
-    fireEvent.click(screen.getByRole('checkbox', { name: /Steps/i }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /Sleep/i }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /Weight/i }));
     fireEvent.click(screen.getByRole('button', { name: 'Save settings' }));
 
     await waitFor(() => {
@@ -201,243 +267,57 @@ describe('SettingsPage', () => {
       ).toBeInTheDocument();
     });
 
-    await waitFor(() => {
-      expect(JSON.parse(window.localStorage.getItem(SETTINGS_STORAGE_KEY) ?? '')).toEqual({
-        dashboardConfig: {
-          habitChains: ['vitamins', 'protein'],
-          trendSparklines: ['Weight', 'Calories', 'Protein', 'Steps'],
-        },
-        nutritionTargets: {
-          calories: 2250,
-          carbs: 250,
-          fat: 65,
-          protein: 175,
-        },
-      });
-    });
-  });
-
-  it('posts all nutrition targets with a UTC effective date when saving', async () => {
-    renderSettingsPage();
-
-    fireEvent.change(screen.getByLabelText('Daily calories'), { target: { value: '2200' } });
-    fireEvent.change(screen.getByLabelText('Protein (g)'), { target: { value: '180' } });
-    fireEvent.change(screen.getByLabelText('Carbs (g)'), { target: { value: '220' } });
-    fireEvent.change(screen.getByLabelText('Fat (g)'), { target: { value: '70' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Save settings' }));
-
-    await waitFor(() => {
-      expect(
-        screen.getByText('Nutrition targets and dashboard preferences saved.'),
-      ).toBeInTheDocument();
-    });
-
-    expect(getLatestNutritionTargetsPostPayload()).toEqual({
-      calories: 2200,
-      carbs: 220,
+    expect(getLatestPostBody('/api/v1/nutrition-targets')).toEqual({
+      calories: 2250,
+      carbs: 250,
       effectiveDate: new Date().toISOString().slice(0, 10),
-      fat: 70,
-      protein: 180,
+      fat: 65,
+      protein: 150,
+    });
+
+    expect(getLatestPostBody('/api/v1/dashboard/config')).toEqual({
+      habitChainIds: ['habit-hydrate', 'habit-sleep'],
+      trendMetrics: ['calories', 'protein'],
     });
   });
 
-  it('clears nutrition draft state after save so refreshed API targets drive the form', async () => {
-    let currentTargetsRequestCount = 0;
-    vi.stubGlobal(
-      'fetch',
-      vi.fn((input: string | URL | Request, init?: RequestInit) => {
-        const url =
-          typeof input === 'string' ? input : input instanceof URL ? input.pathname : input.url;
-
-        if (url.includes('/api/v1/nutrition-targets/current')) {
-          currentTargetsRequestCount += 1;
-
-          if (currentTargetsRequestCount === 1) {
-            return Promise.resolve(
-              new Response(JSON.stringify({ data: null }), {
-                headers: { 'Content-Type': 'application/json' },
-                status: 200,
-              }),
-            );
-          }
-
-          return Promise.resolve(
-            new Response(
-              JSON.stringify({
-                data: {
-                  id: 'target-current',
-                  calories: 2300,
-                  protein: 190,
-                  carbs: 260,
-                  fat: 75,
-                  effectiveDate: '2026-03-07',
-                  createdAt: 1,
-                  updatedAt: 2,
-                },
-              }),
-              { headers: { 'Content-Type': 'application/json' }, status: 200 },
-            ),
-          );
-        }
-
-        if (url.includes('/api/v1/nutrition-targets') && init?.method === 'POST') {
-          return Promise.resolve(
-            new Response(JSON.stringify({ data: JSON.parse(String(init.body)) }), {
-              headers: { 'Content-Type': 'application/json' },
-              status: 200,
-            }),
-          );
-        }
-
-        return Promise.resolve(
-          new Response(JSON.stringify({ data: null }), {
-            headers: { 'Content-Type': 'application/json' },
-            status: 200,
-          }),
-        );
-      }),
-    );
+  it('shows a partial failure message when dashboard config save fails', async () => {
+    state.shouldFailDashboardSave = true;
 
     renderSettingsPage();
 
-    fireEvent.change(screen.getByLabelText('Daily calories'), { target: { value: '2200' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Save settings' }));
-
     await waitFor(() => {
-      expect(
-        screen.getByText('Nutrition targets and dashboard preferences saved.'),
-      ).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: /Hydrate/i })).toBeChecked();
     });
 
-    await waitFor(() => {
-      expect(screen.getByLabelText('Daily calories')).toHaveValue(2300);
-    });
-
-    expect(screen.getByLabelText('Protein (g)')).toHaveValue(190);
-    expect(screen.getByLabelText('Carbs (g)')).toHaveValue(260);
-    expect(screen.getByLabelText('Fat (g)')).toHaveValue(75);
-  });
-
-  it('preserves dashboard preference saves locally when the targets API call fails', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn((input: string | URL | Request, init?: RequestInit) => {
-        const url =
-          typeof input === 'string' ? input : input instanceof URL ? input.pathname : input.url;
-
-        if (url.includes('/api/v1/nutrition-targets/current')) {
-          return Promise.resolve(
-            new Response(JSON.stringify({ data: null }), {
-              headers: { 'Content-Type': 'application/json' },
-              status: 200,
-            }),
-          );
-        }
-
-        if (url.includes('/api/v1/nutrition-targets') && init?.method === 'POST') {
-          return Promise.resolve(
-            new Response(
-              JSON.stringify({
-                error: {
-                  code: 'SERVER_ERROR',
-                  message: 'Unavailable',
-                },
-              }),
-              { headers: { 'Content-Type': 'application/json' }, status: 503 },
-            ),
-          );
-        }
-
-        return Promise.resolve(
-          new Response(JSON.stringify({ data: null }), {
-            headers: { 'Content-Type': 'application/json' },
-            status: 200,
-          }),
-        );
-      }),
-    );
-
-    renderSettingsPage();
-
-    fireEvent.click(screen.getByRole('checkbox', { name: /Hydrate/i }));
-    fireEvent.click(screen.getByRole('checkbox', { name: /Steps/i }));
     fireEvent.click(screen.getByRole('button', { name: 'Save settings' }));
 
     await waitFor(() => {
       expect(
         screen.getByText(
-          'Nutrition targets could not be saved right now. Dashboard preferences were saved locally.',
+          'Dashboard preferences could not be saved right now. Nutrition targets were saved.',
         ),
       ).toBeInTheDocument();
     });
-
-    expect(JSON.parse(window.localStorage.getItem(SETTINGS_STORAGE_KEY) ?? '')).toEqual({
-      dashboardConfig: {
-        habitChains: ['vitamins', 'protein'],
-        trendSparklines: ['Weight', 'Calories', 'Protein', 'Steps'],
-      },
-      nutritionTargets: {
-        calories: 2000,
-        carbs: 250,
-        fat: 65,
-        protein: 150,
-      },
-    });
   });
 
-  it('loads current nutrition targets from the API when they exist', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn((input: string | URL | Request, init?: RequestInit) => {
-        const url =
-          typeof input === 'string' ? input : input instanceof URL ? input.pathname : input.url;
-
-        if (url.includes('/api/v1/nutrition-targets/current')) {
-          return Promise.resolve(
-            new Response(
-              JSON.stringify({
-                data: {
-                  id: 'target-current',
-                  calories: 2400,
-                  protein: 195,
-                  carbs: 280,
-                  fat: 80,
-                  effectiveDate: '2026-03-07',
-                  createdAt: 1,
-                  updatedAt: 1,
-                },
-              }),
-              { headers: { 'Content-Type': 'application/json' }, status: 200 },
-            ),
-          );
-        }
-
-        if (url.includes('/api/v1/nutrition-targets') && init?.method === 'POST') {
-          return Promise.resolve(
-            new Response(JSON.stringify({ data: JSON.parse(String(init.body)) }), {
-              headers: { 'Content-Type': 'application/json' },
-              status: 200,
-            }),
-          );
-        }
-
-        return Promise.resolve(
-          new Response(JSON.stringify({ data: null }), {
-            headers: { 'Content-Type': 'application/json' },
-            status: 200,
-          }),
-        );
-      }),
-    );
+  it('shows a partial failure message when nutrition target save fails', async () => {
+    state.shouldFailNutritionSave = true;
 
     renderSettingsPage();
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Daily calories')).toHaveValue(2400);
+      expect(screen.getByRole('checkbox', { name: /Hydrate/i })).toBeChecked();
     });
 
-    expect(screen.getByLabelText('Protein (g)')).toHaveValue(195);
-    expect(screen.getByLabelText('Carbs (g)')).toHaveValue(280);
-    expect(screen.getByLabelText('Fat (g)')).toHaveValue(80);
+    fireEvent.click(screen.getByRole('button', { name: 'Save settings' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Nutrition targets could not be saved right now. Dashboard preferences were saved.',
+        ),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/pages/settings.tsx
+++ b/apps/web/src/pages/settings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import type { CreateNutritionTargetInput } from '@pulse/shared';
+import type { CreateNutritionTargetInput, DashboardTrendMetric } from '@pulse/shared';
 import { BackLink } from '@/components/layout/back-link';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -8,8 +8,10 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { defaultHabitConfigs, HabitSettings } from '@/features/habits';
+import { HabitSettings } from '@/features/habits';
+import { useHabits } from '@/features/habits/api/habits';
 import { useNutritionTargets, useUpdateTargets } from '@/features/nutrition/api/targets';
+import { useDashboardConfig, useSaveDashboardConfig } from '@/hooks/use-dashboard-config';
 import type { Theme } from '@/hooks/useTheme';
 import { useThemeContext } from '@/hooks/useThemeContext';
 import { formatUtcDateKey } from '@/lib/date';
@@ -70,16 +72,33 @@ const THEME_OPTIONS: ThemeOption[] = [
 ];
 
 const SETTINGS_STORAGE_KEY = 'pulse-prototype-settings';
-const TREND_SPARKLINE_OPTIONS = ['Weight', 'Calories', 'Protein', 'Steps'] as const;
-const HABIT_CHAIN_OPTIONS = defaultHabitConfigs.map((habit) => ({
-  id: habit.id,
-  label: habit.name,
-}));
+const TREND_SPARKLINE_OPTIONS: Array<{
+  description: string;
+  id: DashboardTrendMetric;
+  label: string;
+}> = [
+  {
+    description: 'Track your recent body weight direction.',
+    id: 'weight',
+    label: 'Weight',
+  },
+  {
+    description: 'Track your daily calorie intake trend.',
+    id: 'calories',
+    label: 'Calories',
+  },
+  {
+    description: 'Track your daily protein intake trend.',
+    id: 'protein',
+    label: 'Protein',
+  },
+];
 
 type SettingsFormState = {
   dashboardConfig: {
-    habitChains: string[];
-    trendSparklines: string[];
+    habitChainIds: string[];
+    trendMetrics: DashboardTrendMetric[];
+    widgetOrder?: string[];
   };
   nutritionTargets: {
     calories: number;
@@ -91,8 +110,8 @@ type SettingsFormState = {
 
 const DEFAULT_SETTINGS: SettingsFormState = {
   dashboardConfig: {
-    habitChains: HABIT_CHAIN_OPTIONS.slice(0, 3).map((habit) => habit.id),
-    trendSparklines: ['Weight', 'Calories', 'Protein'],
+    habitChainIds: [],
+    trendMetrics: ['weight', 'calories', 'protein'],
   },
   nutritionTargets: {
     calories: 2000,
@@ -104,10 +123,6 @@ const DEFAULT_SETTINGS: SettingsFormState = {
 
 function isTheme(value: string): value is Theme {
   return THEME_OPTIONS.some((option) => option.value === value);
-}
-
-function isTrendSparkline(value: string): value is (typeof TREND_SPARKLINE_OPTIONS)[number] {
-  return TREND_SPARKLINE_OPTIONS.includes(value as (typeof TREND_SPARKLINE_OPTIONS)[number]);
 }
 
 function clampNumber(value: unknown, fallback: number) {
@@ -131,20 +146,10 @@ function loadSettings(): SettingsFormState {
     }
 
     const parsedSettings = JSON.parse(rawSettings) as Partial<SettingsFormState>;
-
     const savedNutritionTargets = parsedSettings.nutritionTargets;
-    const savedDashboardConfig = parsedSettings.dashboardConfig;
 
     return {
-      dashboardConfig: {
-        habitChains:
-          savedDashboardConfig?.habitChains?.filter((habitId) =>
-            HABIT_CHAIN_OPTIONS.some((habit) => habit.id === habitId),
-          ) ?? DEFAULT_SETTINGS.dashboardConfig.habitChains,
-        trendSparklines:
-          savedDashboardConfig?.trendSparklines?.filter(isTrendSparkline) ??
-          DEFAULT_SETTINGS.dashboardConfig.trendSparklines,
-      },
+      dashboardConfig: DEFAULT_SETTINGS.dashboardConfig,
       nutritionTargets: {
         calories: clampNumber(
           savedNutritionTargets?.calories,
@@ -252,13 +257,20 @@ function ThemeOptionCard({
 export function SettingsPage() {
   const { setTheme, theme } = useThemeContext();
   const [storedSettings] = useState<SettingsFormState>(() => loadSettings());
-  const [dashboardConfig, setDashboardConfig] = useState(storedSettings.dashboardConfig);
+  const [dashboardConfigDraft, setDashboardConfigDraft] = useState<
+    SettingsFormState['dashboardConfig'] | null
+  >(null);
   const [draftNutritionTargets, setDraftNutritionTargets] = useState<
     SettingsFormState['nutritionTargets'] | null
   >(null);
   const [saveMessage, setSaveMessage] = useState('');
+  const { data: habits = [] } = useHabits();
+  const { data: persistedDashboardConfig } = useDashboardConfig();
+  const saveDashboardConfigMutation = useSaveDashboardConfig();
   const { data: currentTargets } = useNutritionTargets();
   const updateTargetsMutation = useUpdateTargets();
+  const dashboardConfig =
+    dashboardConfigDraft ?? persistedDashboardConfig ?? DEFAULT_SETTINGS.dashboardConfig;
   const nutritionTargets =
     draftNutritionTargets ??
     (currentTargets
@@ -311,25 +323,32 @@ export function SettingsPage() {
 
   function toggleHabitChain(habitId: string, checked: boolean) {
     setSaveMessage('');
-    setDashboardConfig((currentDashboardConfig) => ({
-      ...currentDashboardConfig,
-      habitChains: checked
-        ? [...currentDashboardConfig.habitChains, habitId]
-        : currentDashboardConfig.habitChains.filter((value) => value !== habitId),
-    }));
+    setDashboardConfigDraft((currentDashboardConfig) => {
+      const sourceConfig =
+        currentDashboardConfig ?? persistedDashboardConfig ?? DEFAULT_SETTINGS.dashboardConfig;
+
+      return {
+        ...sourceConfig,
+      habitChainIds: checked
+        ? Array.from(new Set([...sourceConfig.habitChainIds, habitId]))
+        : sourceConfig.habitChainIds.filter((value) => value !== habitId),
+      };
+    });
   }
 
-  function toggleTrendSparkline(
-    metric: (typeof TREND_SPARKLINE_OPTIONS)[number],
-    checked: boolean,
-  ) {
+  function toggleTrendSparkline(metric: DashboardTrendMetric, checked: boolean) {
     setSaveMessage('');
-    setDashboardConfig((currentDashboardConfig) => ({
-      ...currentDashboardConfig,
-      trendSparklines: checked
-        ? [...currentDashboardConfig.trendSparklines, metric]
-        : currentDashboardConfig.trendSparklines.filter((value) => value !== metric),
-    }));
+    setDashboardConfigDraft((currentDashboardConfig) => {
+      const sourceConfig =
+        currentDashboardConfig ?? persistedDashboardConfig ?? DEFAULT_SETTINGS.dashboardConfig;
+
+      return {
+        ...sourceConfig,
+      trendMetrics: checked
+        ? Array.from(new Set([...sourceConfig.trendMetrics, metric]))
+        : sourceConfig.trendMetrics.filter((value) => value !== metric),
+      };
+    });
   }
 
   async function handleSave() {
@@ -338,23 +357,40 @@ export function SettingsPage() {
       effectiveDate: formatUtcDateKey(new Date()),
     };
 
-    try {
-      window.localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings));
-    } catch {
-      // Local persistence is best-effort.
+    const [nutritionResult, dashboardConfigResult] = await Promise.allSettled([
+      updateTargetsMutation.mutateAsync(nextTargets),
+      saveDashboardConfigMutation.mutateAsync(settings.dashboardConfig),
+    ]);
+
+    if (nutritionResult.status === 'fulfilled') {
+      setDraftNutritionTargets(null);
+    }
+    if (dashboardConfigResult.status === 'fulfilled') {
+      setDashboardConfigDraft(null);
     }
 
-    try {
-      await updateTargetsMutation.mutateAsync(nextTargets);
-    } catch {
+    if (nutritionResult.status === 'fulfilled' && dashboardConfigResult.status === 'fulfilled') {
+      setSaveMessage('Nutrition targets and dashboard preferences saved.');
+      return;
+    }
+
+    if (nutritionResult.status === 'rejected' && dashboardConfigResult.status === 'rejected') {
       setSaveMessage(
-        'Nutrition targets could not be saved right now. Dashboard preferences were saved locally.',
+        'Nutrition targets and dashboard preferences could not be saved right now. Please try again.',
       );
       return;
     }
 
-    setDraftNutritionTargets(null);
-    setSaveMessage('Nutrition targets and dashboard preferences saved.');
+    if (nutritionResult.status === 'rejected') {
+      setSaveMessage(
+        'Nutrition targets could not be saved right now. Dashboard preferences were saved.',
+      );
+      return;
+    }
+
+    setSaveMessage(
+      'Dashboard preferences could not be saved right now. Nutrition targets were saved.',
+    );
   }
 
   return (
@@ -504,31 +540,37 @@ export function SettingsPage() {
                 Select the habit streaks to spotlight in the daily dashboard snapshot.
               </p>
             </div>
-            <div className="grid gap-3 md:grid-cols-2">
-              {HABIT_CHAIN_OPTIONS.map((habit) => {
-                const checkboxId = `habit-chain-${habit.id}`;
+            {habits.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No active habits yet. Create habits to customize chain visibility.
+              </p>
+            ) : (
+              <div className="grid gap-3 md:grid-cols-2">
+                {habits.map((habit) => {
+                  const checkboxId = `habit-chain-${habit.id}`;
 
-                return (
-                  <Label
-                    key={habit.id}
-                    className="flex cursor-pointer items-start gap-3 rounded-xl border border-border/80 p-3"
-                    htmlFor={checkboxId}
-                  >
-                    <Checkbox
-                      checked={settings.dashboardConfig.habitChains.includes(habit.id)}
-                      id={checkboxId}
-                      onCheckedChange={(checked) => toggleHabitChain(habit.id, checked === true)}
-                    />
-                    <div className="space-y-1">
-                      <span className="text-sm font-medium text-foreground">{habit.label}</span>
-                      <p className="text-sm text-muted-foreground">
-                        Show this streak chain in the dashboard summary row.
-                      </p>
-                    </div>
-                  </Label>
-                );
-              })}
-            </div>
+                  return (
+                    <Label
+                      key={habit.id}
+                      className="flex cursor-pointer items-start gap-3 rounded-xl border border-border/80 p-3"
+                      htmlFor={checkboxId}
+                    >
+                      <Checkbox
+                        checked={settings.dashboardConfig.habitChainIds.includes(habit.id)}
+                        id={checkboxId}
+                        onCheckedChange={(checked) => toggleHabitChain(habit.id, checked === true)}
+                      />
+                      <div className="space-y-1">
+                        <span className="text-sm font-medium text-foreground">{habit.name}</span>
+                        <p className="text-sm text-muted-foreground">
+                          Show this streak chain in the dashboard summary row.
+                        </p>
+                      </div>
+                    </Label>
+                  );
+                })}
+              </div>
+            )}
           </div>
 
           <div className="space-y-3">
@@ -540,24 +582,24 @@ export function SettingsPage() {
             </div>
             <div className="grid gap-3 md:grid-cols-2">
               {TREND_SPARKLINE_OPTIONS.map((metric) => {
-                const checkboxId = `trend-sparkline-${metric.toLowerCase()}`;
+                const checkboxId = `trend-sparkline-${metric.id}`;
 
                 return (
                   <Label
-                    key={metric}
+                    key={metric.id}
                     className="flex cursor-pointer items-start gap-3 rounded-xl border border-border/80 p-3"
                     htmlFor={checkboxId}
                   >
                     <Checkbox
-                      checked={settings.dashboardConfig.trendSparklines.includes(metric)}
+                      checked={settings.dashboardConfig.trendMetrics.includes(metric.id)}
                       id={checkboxId}
-                      onCheckedChange={(checked) => toggleTrendSparkline(metric, checked === true)}
+                      onCheckedChange={(checked) =>
+                        toggleTrendSparkline(metric.id, checked === true)
+                      }
                     />
                     <div className="space-y-1">
-                      <span className="text-sm font-medium text-foreground">{metric}</span>
-                      <p className="text-sm text-muted-foreground">
-                        Keep the {metric.toLowerCase()} sparkline visible on the dashboard.
-                      </p>
+                      <span className="text-sm font-medium text-foreground">{metric.label}</span>
+                      <p className="text-sm text-muted-foreground">{metric.description}</p>
                     </div>
                   </Label>
                 );
@@ -567,10 +609,16 @@ export function SettingsPage() {
 
           <div className="flex flex-col gap-3 border-t border-border/80 pt-4 sm:flex-row sm:items-center sm:justify-between">
             <p aria-live="polite" className="text-sm text-muted-foreground">
-              {saveMessage || 'Save changes to keep these preferences on this device.'}
+              {saveMessage || 'Save changes to sync these preferences to your account.'}
             </p>
-            <Button disabled={updateTargetsMutation.isPending} onClick={handleSave} type="button">
-              {updateTargetsMutation.isPending ? 'Saving...' : 'Save settings'}
+            <Button
+              disabled={updateTargetsMutation.isPending || saveDashboardConfigMutation.isPending}
+              onClick={handleSave}
+              type="button"
+            >
+              {updateTargetsMutation.isPending || saveDashboardConfigMutation.isPending
+                ? 'Saving...'
+                : 'Save settings'}
             </Button>
           </div>
         </CardContent>

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export * from './schemas/auth.js';
 export * from './schemas/activities.js';
 export * from './schemas/agent-tokens.js';
+export * from './schemas/dashboard.js';
 export * from './schemas/entity-links.js';
 export * from './schemas/equipment.js';
 export * from './schemas/exercises.js';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export * from './schemas/auth.js';
 export * from './schemas/activities.js';
 export * from './schemas/agent-tokens.js';
+export * from './schemas/dashboard-config.js';
 export * from './schemas/dashboard.js';
 export * from './schemas/entity-links.js';
 export * from './schemas/equipment.js';

--- a/packages/shared/src/schemas/dashboard-config.test.ts
+++ b/packages/shared/src/schemas/dashboard-config.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { type DashboardConfig, dashboardConfigSchema } from './dashboard-config';
+
+describe('dashboardConfigSchema', () => {
+  it('parses a complete dashboard config payload', () => {
+    const config = dashboardConfigSchema.parse({
+      habitChainIds: ['habit-1', 'habit-2'],
+      trendMetrics: ['weight', 'calories', 'protein'],
+      widgetOrder: ['snapshot', 'habits', 'trends'],
+    });
+
+    expect(config).toEqual({
+      habitChainIds: ['habit-1', 'habit-2'],
+      trendMetrics: ['weight', 'calories', 'protein'],
+      widgetOrder: ['snapshot', 'habits', 'trends'],
+    });
+  });
+
+  it('accepts config without widget order', () => {
+    expect(
+      dashboardConfigSchema.parse({
+        habitChainIds: ['habit-1'],
+        trendMetrics: ['weight'],
+      }),
+    ).toEqual({
+      habitChainIds: ['habit-1'],
+      trendMetrics: ['weight'],
+    });
+  });
+
+  it('rejects unsupported trend metrics', () => {
+    expect(() =>
+      dashboardConfigSchema.parse({
+        habitChainIds: ['habit-1'],
+        trendMetrics: ['steps'],
+      }),
+    ).toThrow();
+  });
+
+  it('infers DashboardConfig from the schema', () => {
+    const config: DashboardConfig = {
+      habitChainIds: ['habit-1'],
+      trendMetrics: ['protein'],
+    };
+
+    expect(config.trendMetrics).toEqual(['protein']);
+  });
+});

--- a/packages/shared/src/schemas/dashboard-config.ts
+++ b/packages/shared/src/schemas/dashboard-config.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+const trendMetricSchema = z.enum(['weight', 'calories', 'protein']);
+
+const nonEmptyStringArraySchema = z.array(z.string().min(1));
+
+export const dashboardConfigSchema = z.object({
+  habitChainIds: nonEmptyStringArraySchema,
+  trendMetrics: z.array(trendMetricSchema),
+  widgetOrder: nonEmptyStringArraySchema.optional(),
+});
+
+export type DashboardConfig = z.infer<typeof dashboardConfigSchema>;
+export type DashboardTrendMetric = z.infer<typeof trendMetricSchema>;

--- a/packages/shared/src/schemas/dashboard.test.ts
+++ b/packages/shared/src/schemas/dashboard.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type DashboardSnapshot,
+  type DashboardSnapshotQuery,
+  dashboardSnapshotQuerySchema,
+  dashboardSnapshotSchema,
+} from './dashboard';
+
+describe('dashboardSnapshotQuerySchema', () => {
+  it('accepts an empty query for default date handling', () => {
+    expect(dashboardSnapshotQuerySchema.parse({})).toEqual({});
+  });
+
+  it('accepts an optional date query', () => {
+    expect(dashboardSnapshotQuerySchema.parse({ date: '2026-03-09' })).toEqual({
+      date: '2026-03-09',
+    });
+  });
+
+  it('infers DashboardSnapshotQuery from the schema', () => {
+    const query: DashboardSnapshotQuery = {
+      date: '2026-03-09',
+    };
+
+    expect(query.date).toBe('2026-03-09');
+  });
+});
+
+describe('dashboardSnapshotSchema', () => {
+  it('parses a complete dashboard snapshot payload', () => {
+    const snapshot = dashboardSnapshotSchema.parse({
+      date: '2026-03-09',
+      weight: {
+        value: 178.4,
+        date: '2026-03-08',
+        unit: 'lb',
+      },
+      macros: {
+        actual: {
+          calories: 1850,
+          protein: 150,
+          carbs: 190,
+          fat: 65,
+        },
+        target: {
+          calories: 2200,
+          protein: 180,
+          carbs: 250,
+          fat: 70,
+        },
+      },
+      workout: {
+        name: 'Upper Push A',
+        status: 'completed',
+        duration: 64,
+      },
+      habits: {
+        total: 6,
+        completed: 4,
+        percentage: 66.7,
+      },
+    });
+
+    expect(snapshot.habits.percentage).toBe(66.7);
+    expect(snapshot.weight?.unit).toBe('lb');
+  });
+
+  it('accepts null weight and workout values', () => {
+    expect(
+      dashboardSnapshotSchema.parse({
+        date: '2026-03-09',
+        weight: null,
+        macros: {
+          actual: {
+            calories: 0,
+            protein: 0,
+            carbs: 0,
+            fat: 0,
+          },
+          target: {
+            calories: 0,
+            protein: 0,
+            carbs: 0,
+            fat: 0,
+          },
+        },
+        workout: null,
+        habits: {
+          total: 0,
+          completed: 0,
+          percentage: 0,
+        },
+      }),
+    ).toBeTruthy();
+  });
+
+  it('infers DashboardSnapshot from the schema', () => {
+    const snapshot: DashboardSnapshot = {
+      date: '2026-03-09',
+      weight: null,
+      macros: {
+        actual: {
+          calories: 0,
+          protein: 0,
+          carbs: 0,
+          fat: 0,
+        },
+        target: {
+          calories: 2200,
+          protein: 180,
+          carbs: 250,
+          fat: 70,
+        },
+      },
+      workout: null,
+      habits: {
+        total: 2,
+        completed: 1,
+        percentage: 50,
+      },
+    };
+
+    expect(snapshot.habits.completed).toBe(1);
+  });
+});

--- a/packages/shared/src/schemas/dashboard.test.ts
+++ b/packages/shared/src/schemas/dashboard.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  type DashboardConsistencyTrendPoint,
+  type DashboardMacrosTrendPoint,
   type DashboardSnapshot,
   type DashboardSnapshotQuery,
+  type DashboardTrendQuery,
+  type DashboardWeightTrendPoint,
+  dashboardConsistencyTrendSchema,
+  dashboardMacrosTrendSchema,
   dashboardSnapshotQuerySchema,
   dashboardSnapshotSchema,
+  dashboardTrendQuerySchema,
+  dashboardWeightTrendSchema,
 } from './dashboard';
 
 describe('dashboardSnapshotQuerySchema', () => {
@@ -24,6 +32,40 @@ describe('dashboardSnapshotQuerySchema', () => {
     };
 
     expect(query.date).toBe('2026-03-09');
+  });
+});
+
+describe('dashboardTrendQuerySchema', () => {
+  it('accepts empty query params for default trend range handling', () => {
+    expect(dashboardTrendQuerySchema.parse({})).toEqual({});
+  });
+
+  it('accepts a valid bounded range and infers DashboardTrendQuery', () => {
+    const parsed = dashboardTrendQuerySchema.parse({
+      from: '2026-02-01',
+      to: '2026-03-01',
+    });
+
+    const query: DashboardTrendQuery = parsed;
+    expect(query).toEqual({
+      from: '2026-02-01',
+      to: '2026-03-01',
+    });
+  });
+
+  it('rejects inverted and overly-long ranges', () => {
+    expect(() =>
+      dashboardTrendQuerySchema.parse({
+        from: '2026-03-09',
+        to: '2026-03-08',
+      }),
+    ).toThrow();
+    expect(() =>
+      dashboardTrendQuerySchema.parse({
+        from: '2025-01-01',
+        to: '2026-01-01',
+      }),
+    ).toThrow();
   });
 });
 
@@ -122,5 +164,46 @@ describe('dashboardSnapshotSchema', () => {
     };
 
     expect(snapshot.habits.completed).toBe(1);
+  });
+});
+
+describe('dashboard trend schemas', () => {
+  it('parses weight trend points', () => {
+    const points = dashboardWeightTrendSchema.parse([
+      {
+        date: '2026-03-07',
+        value: 181.2,
+      },
+    ]);
+
+    const point: DashboardWeightTrendPoint = points[0] as DashboardWeightTrendPoint;
+    expect(point.value).toBe(181.2);
+  });
+
+  it('parses macro trend points', () => {
+    const points = dashboardMacrosTrendSchema.parse([
+      {
+        date: '2026-03-07',
+        calories: 2100,
+        protein: 180,
+        carbs: 220,
+        fat: 70,
+      },
+    ]);
+
+    const point: DashboardMacrosTrendPoint = points[0] as DashboardMacrosTrendPoint;
+    expect(point.calories).toBe(2100);
+  });
+
+  it('parses consistency trend points', () => {
+    const points = dashboardConsistencyTrendSchema.parse([
+      {
+        date: '2026-03-07',
+        completed: true,
+      },
+    ]);
+
+    const point: DashboardConsistencyTrendPoint = points[0] as DashboardConsistencyTrendPoint;
+    expect(point.completed).toBe(true);
   });
 });

--- a/packages/shared/src/schemas/dashboard.ts
+++ b/packages/shared/src/schemas/dashboard.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+import { dateSchema } from './common.js';
+import { workoutSessionStatusSchema } from './workout-sessions.js';
+
+const macroValueSchema = z.number().nonnegative().finite();
+const percentageSchema = z.number().min(0).max(100).finite();
+
+export const dashboardSnapshotQuerySchema = z.object({
+  date: dateSchema.optional(),
+});
+
+export const dashboardWeightSnapshotSchema = z.object({
+  value: z.number().positive().finite(),
+  date: dateSchema,
+  unit: z.literal('lb'),
+});
+
+export const dashboardMacroTotalsSchema = z.object({
+  calories: macroValueSchema,
+  protein: macroValueSchema,
+  carbs: macroValueSchema,
+  fat: macroValueSchema,
+});
+
+export const dashboardMacroSnapshotSchema = z.object({
+  actual: dashboardMacroTotalsSchema,
+  target: dashboardMacroTotalsSchema,
+});
+
+export const dashboardWorkoutSnapshotSchema = z.object({
+  name: z.string(),
+  status: workoutSessionStatusSchema,
+  duration: z.number().int().nonnegative().nullable(),
+});
+
+export const dashboardHabitsSnapshotSchema = z.object({
+  total: z.number().int().nonnegative(),
+  completed: z.number().int().nonnegative(),
+  percentage: percentageSchema,
+});
+
+export const dashboardSnapshotSchema = z.object({
+  date: dateSchema,
+  weight: dashboardWeightSnapshotSchema.nullable(),
+  macros: dashboardMacroSnapshotSchema,
+  workout: dashboardWorkoutSnapshotSchema.nullable(),
+  habits: dashboardHabitsSnapshotSchema,
+});
+
+export type DashboardSnapshotQuery = z.infer<typeof dashboardSnapshotQuerySchema>;
+export type DashboardWeightSnapshot = z.infer<typeof dashboardWeightSnapshotSchema>;
+export type DashboardMacroTotals = z.infer<typeof dashboardMacroTotalsSchema>;
+export type DashboardMacroSnapshot = z.infer<typeof dashboardMacroSnapshotSchema>;
+export type DashboardWorkoutSnapshot = z.infer<typeof dashboardWorkoutSnapshotSchema>;
+export type DashboardHabitsSnapshot = z.infer<typeof dashboardHabitsSnapshotSchema>;
+export type DashboardSnapshot = z.infer<typeof dashboardSnapshotSchema>;

--- a/packages/shared/src/schemas/dashboard.ts
+++ b/packages/shared/src/schemas/dashboard.ts
@@ -5,10 +5,41 @@ import { workoutSessionStatusSchema } from './workout-sessions.js';
 
 const macroValueSchema = z.number().nonnegative().finite();
 const percentageSchema = z.number().min(0).max(100).finite();
+const MAX_TREND_RANGE_DAYS = 365;
+
+const getUtcDateValue = (date: string) => {
+  const [year, month, day] = date.split('-').map(Number);
+  return Date.UTC(year ?? 0, (month ?? 1) - 1, day ?? 1);
+};
 
 export const dashboardSnapshotQuerySchema = z.object({
   date: dateSchema.optional(),
 });
+
+export const dashboardTrendQuerySchema = z
+  .object({
+    from: dateSchema.optional(),
+    to: dateSchema.optional(),
+  })
+  .refine((value) => !value.from || !value.to || value.from <= value.to, {
+    message: '`from` must be on or before `to`',
+    path: ['to'],
+  })
+  .refine(
+    (value) => {
+      if (!value.from || !value.to) {
+        return true;
+      }
+
+      const diffDays =
+        (getUtcDateValue(value.to) - getUtcDateValue(value.from)) / (1000 * 60 * 60 * 24) + 1;
+      return diffDays <= MAX_TREND_RANGE_DAYS;
+    },
+    {
+      message: `Date range cannot exceed ${MAX_TREND_RANGE_DAYS} days`,
+      path: ['to'],
+    },
+  );
 
 export const dashboardWeightSnapshotSchema = z.object({
   value: z.number().positive().finite(),
@@ -48,10 +79,36 @@ export const dashboardSnapshotSchema = z.object({
   habits: dashboardHabitsSnapshotSchema,
 });
 
+export const dashboardWeightTrendPointSchema = z.object({
+  date: dateSchema,
+  value: z.number().positive().finite(),
+});
+
+export const dashboardMacrosTrendPointSchema = z.object({
+  date: dateSchema,
+  calories: macroValueSchema,
+  protein: macroValueSchema,
+  carbs: macroValueSchema,
+  fat: macroValueSchema,
+});
+
+export const dashboardConsistencyTrendPointSchema = z.object({
+  date: dateSchema,
+  completed: z.boolean(),
+});
+
+export const dashboardWeightTrendSchema = z.array(dashboardWeightTrendPointSchema);
+export const dashboardMacrosTrendSchema = z.array(dashboardMacrosTrendPointSchema);
+export const dashboardConsistencyTrendSchema = z.array(dashboardConsistencyTrendPointSchema);
+
 export type DashboardSnapshotQuery = z.infer<typeof dashboardSnapshotQuerySchema>;
+export type DashboardTrendQuery = z.infer<typeof dashboardTrendQuerySchema>;
 export type DashboardWeightSnapshot = z.infer<typeof dashboardWeightSnapshotSchema>;
 export type DashboardMacroTotals = z.infer<typeof dashboardMacroTotalsSchema>;
 export type DashboardMacroSnapshot = z.infer<typeof dashboardMacroSnapshotSchema>;
 export type DashboardWorkoutSnapshot = z.infer<typeof dashboardWorkoutSnapshotSchema>;
 export type DashboardHabitsSnapshot = z.infer<typeof dashboardHabitsSnapshotSchema>;
 export type DashboardSnapshot = z.infer<typeof dashboardSnapshotSchema>;
+export type DashboardWeightTrendPoint = z.infer<typeof dashboardWeightTrendPointSchema>;
+export type DashboardMacrosTrendPoint = z.infer<typeof dashboardMacrosTrendPointSchema>;
+export type DashboardConsistencyTrendPoint = z.infer<typeof dashboardConsistencyTrendPointSchema>;

--- a/packages/shared/src/schemas/dashboard.ts
+++ b/packages/shared/src/schemas/dashboard.ts
@@ -5,7 +5,7 @@ import { workoutSessionStatusSchema } from './workout-sessions.js';
 
 const macroValueSchema = z.number().nonnegative().finite();
 const percentageSchema = z.number().min(0).max(100).finite();
-const MAX_TREND_RANGE_DAYS = 365;
+export const MAX_DASHBOARD_TREND_RANGE_DAYS = 365;
 
 const getUtcDateValue = (date: string) => {
   const [year, month, day] = date.split('-').map(Number);
@@ -33,10 +33,10 @@ export const dashboardTrendQuerySchema = z
 
       const diffDays =
         (getUtcDateValue(value.to) - getUtcDateValue(value.from)) / (1000 * 60 * 60 * 24) + 1;
-      return diffDays <= MAX_TREND_RANGE_DAYS;
+      return diffDays <= MAX_DASHBOARD_TREND_RANGE_DAYS;
     },
     {
-      message: `Date range cannot exceed ${MAX_TREND_RANGE_DAYS} days`,
+      message: `Date range cannot exceed ${MAX_DASHBOARD_TREND_RANGE_DAYS} days`,
       path: ['to'],
     },
   );

--- a/packages/shared/src/schemas/dashboard.ts
+++ b/packages/shared/src/schemas/dashboard.ts
@@ -7,7 +7,7 @@ const macroValueSchema = z.number().nonnegative().finite();
 const percentageSchema = z.number().min(0).max(100).finite();
 export const MAX_DASHBOARD_TREND_RANGE_DAYS = 365;
 
-const getUtcDateValue = (date: string) => {
+export const getUtcDateValue = (date: string) => {
   const [year, month, day] = date.split('-').map(Number);
   return Date.UTC(year ?? 0, (month ?? 1) - 1, day ?? 1);
 };

--- a/packages/shared/src/schemas/workout-sessions.test.ts
+++ b/packages/shared/src/schemas/workout-sessions.test.ts
@@ -299,16 +299,31 @@ describe('workoutSessionListItemSchema', () => {
 });
 
 describe('workoutSessionQueryParamsSchema', () => {
-  it('requires from to be before or equal to to', () => {
-    expect(workoutSessionQueryParamsSchema.parse({ from: '2026-03-10', to: '2026-03-12' })).toEqual(
-      {
+  it('parses optional range and filter params', () => {
+    expect(
+      workoutSessionQueryParamsSchema.parse({
         from: '2026-03-10',
         to: '2026-03-12',
-      },
-    );
+        status: 'completed',
+        limit: '5',
+      }),
+    ).toEqual({
+      from: '2026-03-10',
+      to: '2026-03-12',
+      status: 'completed',
+      limit: 5,
+    });
+    expect(workoutSessionQueryParamsSchema.parse({ status: 'in-progress', limit: 10 })).toEqual({
+      status: 'in-progress',
+      limit: 10,
+    });
+  });
 
+  it('rejects invalid ranges and limits', () => {
     expect(() =>
       workoutSessionQueryParamsSchema.parse({ from: '2026-03-12', to: '2026-03-10' }),
     ).toThrow();
+    expect(() => workoutSessionQueryParamsSchema.parse({ limit: 0 })).toThrow();
+    expect(() => workoutSessionQueryParamsSchema.parse({ limit: 99 })).toThrow();
   });
 });

--- a/packages/shared/src/schemas/workout-sessions.test.ts
+++ b/packages/shared/src/schemas/workout-sessions.test.ts
@@ -289,6 +289,7 @@ describe('workoutSessionListItemSchema', () => {
       startedAt: 1_700_000_000_000,
       completedAt: null,
       duration: null,
+      exerciseCount: 0,
       createdAt: 1_700_000_000_000,
     });
 

--- a/packages/shared/src/schemas/workout-sessions.ts
+++ b/packages/shared/src/schemas/workout-sessions.ts
@@ -138,6 +138,7 @@ export const workoutSessionListItemSchema = z
     startedAt: z.number().int(),
     completedAt: z.number().int().nullable(),
     duration: nullableIntegerSchema,
+    exerciseCount: z.number().int().nonnegative(),
     createdAt: z.number().int(),
   })
   .superRefine(validateWorkoutSessionTiming);

--- a/packages/shared/src/schemas/workout-sessions.ts
+++ b/packages/shared/src/schemas/workout-sessions.ts
@@ -201,10 +201,12 @@ export const saveWorkoutSessionAsTemplateInputSchema = z.preprocess(
 
 export const workoutSessionQueryParamsSchema = z
   .object({
-    from: dateSchema,
-    to: dateSchema,
+    from: dateSchema.optional(),
+    to: dateSchema.optional(),
+    status: workoutSessionStatusSchema.optional(),
+    limit: z.coerce.number().int().min(1).max(50).optional(),
   })
-  .refine((value) => value.from <= value.to, {
+  .refine((value) => !value.from || !value.to || value.from <= value.to, {
     message: 'from must be less than or equal to to',
     path: ['to'],
   });


### PR DESCRIPTION
## Commits

- `0fda98a fix(dashboard): preserve explicit empty trend metric config`
- `dd206ff feat(dashboard): persist dashboard widget config`
- `5b3ab6c feat(dashboard): wire trends and recent workouts to api`
- `dbbfe9f feat(web): wire dashboard snapshot and habit chains to API`
- `59d401f fix(api): resolve dashboard trend review feedback`
- `c736462 feat(api): add dashboard trend endpoints`
- `092c88e fix(api): address dashboard snapshot review feedback`
- `8716411 feat(api): add dashboard snapshot endpoint`

## Tasks

- **Dashboard snapshot endpoint**: Today's weight, macro summary, workout status, habit completion % for a user
- **Trend data endpoints**: Weight, macros, workout consistency over configurable date ranges
- **Wire dashboard snapshot + habit chains to API**: Connect snapshot cards, macro rings, habit chain widgets to real data
- **Wire trend sparklines + recent workouts to API**: Connect Recharts sparklines and recent workouts list to real trend data
- **Dashboard config persistence**: Save/load widget selection (habit chains, trend metrics) per user
- **E2E: login + dashboard + navigation**: Playwright tests for login flow, dashboard loads with data, navigate between pages

## Diff Stats

```
apps/api/drizzle/0010_equal_stingray.sql           |   1 +
 apps/api/drizzle/meta/_journal.json                |   7 +
 apps/api/src/db/schema.test.ts                     |   2 +
 apps/api/src/db/schema/dashboard-config.ts         |   1 +
 apps/api/src/index.ts                              |   2 +
 apps/api/src/routes/v1/dashboard-store.test.ts     | 315 ++++++++++++
 apps/api/src/routes/v1/dashboard-store.ts          | 423 ++++++++++++++++
 apps/api/src/routes/v1/dashboard-utils.ts          |  22 +
 apps/api/src/routes/v1/dashboard.test.ts           | 549 +++++++++++++++++++++
 apps/api/src/routes/v1/dashboard.ts                | 120 +++++
 apps/api/src/routes/v1/index.ts                    |   7 +
 apps/api/src/routes/workout-sessions/index.test.ts | 108 +++-
 apps/api/src/routes/workout-sessions/store.ts      |  40 +-
 .../dashboard/components/habit-chain.test.tsx      |  34 ++
 .../features/dashboard/components/habit-chain.tsx  |  21 +-
 .../dashboard/components/macro-rings.test.tsx      |  56 ++-
 .../features/dashboard/components/macro-rings.tsx  |  34 +-
 .../dashboard/components/recent-workouts.test.tsx  | 112 ++++-
 .../dashboard/components/recent-workouts.tsx       | 112 +++--
 .../dashboard/components/snapshot-cards.test.tsx   | 123 ++---
 .../dashboard/components/snapshot-cards.tsx        |  56 ++-
 .../dashboard/components/trend-sparkline.test.tsx  | 131 ++++-
 .../dashboard/components/trend-sparkline.tsx       | 250 +++++++---
 apps/web/src/hooks/use-dashboard-config.test.tsx   |  86 ++++
 apps/web/src/hooks/use-dashboard-config.ts         |  45 ++
 apps/web/src/hooks/use-dashboard-snapshot.test.tsx | 112 +++++
 apps/web/src/hooks/use-dashboard-snapshot.ts       |  31 ++
 apps/web/src/hooks/use-habit-chains.test.tsx       |  81 +++
 apps/web/src/hooks/use-habit-chains.ts             |  35 ++
 apps/web/src/hooks/use-macro-trend.test.tsx        | 108 ++++
 apps/web/src/hooks/use-macro-trend.ts              |  48 ++
 apps/web/src/hooks/use-recent-workouts.test.tsx    | 214 ++++++++
 apps/web/src/hooks/use-recent-workouts.ts          |  78 +++
 apps/web/src/hooks/use-weight-trend.test.tsx       |  86 ++++
 apps/web/src/hooks/use-weight-trend.ts             |  48 ++
 apps/web/src/pages/dashboard.test.tsx              | 509 ++++++++++++++-----
 apps/web/src/pages/dashboard.tsx                   |  86 ++--
 apps/web/src/pages/settings.test.tsx               | 488 +++++++-----------
 apps/web/src/pages/settings.tsx                    | 226 +++++----
 packages/shared/src/index.ts                       |   2 +
 .../shared/src/schemas/dashboard-config.test.ts    |  49 ++
 packages/shared/src/schemas/dashboard-config.ts    |  14 +
 packages/shared/src/schemas/dashboard.test.ts      | 209 ++++++++
 packages/shared/src/schemas/dashboard.ts           | 114 +++++
 .../shared/src/schemas/workout-sessions.test.ts    |  25 +-
 packages/shared/src/schemas/workout-sessions.ts    |   8 +-
 46 files changed, 4370 insertions(+), 858 deletions(-)
```