### PR TITLE
Data migration from static app

### DIFF
--- a/apps/api/src/scripts/migrate-static.test.ts
+++ b/apps/api/src/scripts/migrate-static.test.ts
@@ -800,6 +800,13 @@ describe('migrate-static script', () => {
     // Then migrate daily logs (which inserts meal_items referencing "Large Eggs")
     await scriptModule.migrateDailyLogsAndBodyWeight({ userId: 'user-1', dataRoot });
 
+    // Seed a stale timestamp to verify backfill moves it forward when newer usage exists.
+    dbModule.db
+      .update(foods)
+      .set({ lastUsedAt: new Date('2026-03-01T00:00:00.000Z').getTime() })
+      .where(and(eq(foods.userId, 'user-1'), eq(foods.name, 'Large Eggs')))
+      .run();
+
     // Re-run foods migration to trigger lastUsedAt backfill
     const captured = buildLogger();
     const summary2 = await scriptModule.migrateFoodsDatabase({
@@ -811,8 +818,9 @@ describe('migrate-static script', () => {
     // All foods skipped on second run (already exist)
     expect(summary2.inserted).toBe(0);
     expect(summary2.skipped).toBe(3);
+    expect(summary2.lastUsedAtUpdated).toBeGreaterThanOrEqual(2);
 
-    // lastUsedAt should be set on Large Eggs (used in daily logs)
+    // lastUsedAt should be moved to latest usage date for Large Eggs (used in daily logs)
     const eggs = dbModule.db
       .select({ lastUsedAt: foods.lastUsedAt })
       .from(foods)
@@ -820,7 +828,7 @@ describe('migrate-static script', () => {
       .limit(1)
       .get();
 
-    expect(eggs?.lastUsedAt).not.toBeNull();
+    expect(eggs?.lastUsedAt).toBe(new Date('2026-03-06T00:00:00.000Z').getTime());
   });
 
   it('is idempotent for foods migration when re-run', async () => {
@@ -831,23 +839,5 @@ describe('migrate-static script', () => {
     const secondCount = dbModule.db.select().from(foods).where(eq(foods.userId, 'user-1')).all().length;
 
     expect(secondCount).toBe(firstCount);
-  });
-
-  it('parses CLI arguments and enforces required userId', () => {
-    expect(scriptModule.parseCliArgs(['--user', 'user-1'])).toEqual({
-      userId: 'user-1',
-      dataRoot: scriptModule.DEFAULT_STATIC_DATA_ROOT,
-    });
-
-    expect(scriptModule.parseCliArgs(['--user', 'user-1', '--source', '/tmp/static'])).toEqual({
-      userId: 'user-1',
-      dataRoot: '/tmp/static',
-    });
-
-    expect(() => scriptModule.parseCliArgs([])).toThrow('Missing required --user <userId> argument.');
-    expect(() => scriptModule.parseCliArgs(['--user'])).toThrow(
-      'Missing value for --user. Usage: npx tsx src/scripts/migrate-static.ts --user <userId>',
-    );
-    expect(() => scriptModule.parseCliArgs(['--oops'])).toThrow('Unknown argument: --oops');
   });
 });

--- a/apps/api/src/scripts/migrate-static.test.ts
+++ b/apps/api/src/scripts/migrate-static.test.ts
@@ -3,19 +3,24 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   bodyWeight,
+  exercises,
   foods,
   habitEntries,
   habits,
   mealItems,
   meals,
   nutritionLogs,
+  sessionSets,
+  templateExercises,
   users,
+  workoutSessions,
+  workoutTemplates,
 } from '../db/schema/index.js';
 
 type DbModule = typeof import('../db/index.js');
@@ -140,10 +145,25 @@ const seedBaseData = () => {
       },
     ])
     .run();
+
+  dbModule.db
+    .insert(exercises)
+    .values({
+      id: 'exercise-bench-global',
+      userId: null,
+      name: 'Barbell Bench Press',
+      muscleGroups: ['chest', 'triceps'],
+      equipment: 'barbell',
+      category: 'compound',
+      instructions: null,
+    })
+    .run();
 };
 
 const writeFixtureData = () => {
   mkdirSync(join(dataRoot, 'daily', '2026', '03'), { recursive: true });
+  mkdirSync(join(dataRoot, 'workouts', 'templates'), { recursive: true });
+  mkdirSync(join(dataRoot, 'workouts', '2026', 'Q1'), { recursive: true });
 
   writeFileSync(
     join(dataRoot, 'daily', '2026', '03', '2026-03-05.json'),
@@ -243,6 +263,141 @@ const writeFixtureData = () => {
         weight: 181.1,
       },
     ]),
+    'utf8',
+  );
+
+  writeFileSync(
+    join(dataRoot, 'workouts', 'templates', 'upper-push.json'),
+    JSON.stringify({
+      name: 'Upper Push',
+      description: 'Chest and shoulder focused day',
+      tags: ['push', 'strength'],
+      sections: [
+        {
+          type: 'warmup',
+          exercises: [
+            {
+              name: 'Band Pull Apart',
+              sets: 2,
+              reps: '15',
+              category: 'mobility',
+              muscleGroups: ['rear delts'],
+              equipment: 'band',
+            },
+          ],
+        },
+        {
+          type: 'main',
+          exercises: [
+            {
+              name: 'Barbell Bench Press',
+              sets: 3,
+              reps: '5-8',
+              category: 'compound',
+              muscleGroups: ['chest', 'triceps'],
+              equipment: 'barbell',
+            },
+            {
+              name: 'Incline Dumbbell Fly',
+              sets: 3,
+              repsMin: 10,
+              repsMax: 12,
+              category: 'isolation',
+              muscles: ['chest'],
+              equipment: 'dumbbells',
+            },
+          ],
+        },
+      ],
+    }),
+    'utf8',
+  );
+
+  writeFileSync(
+    join(dataRoot, 'workouts', 'templates', 'lower-body.json'),
+    JSON.stringify({
+      templateName: 'Lower Body',
+      warmup: [
+        {
+          name: 'Bodyweight Squat',
+          sets: 2,
+          reps: '10',
+          category: 'mobility',
+          muscleGroups: ['quads'],
+          equipment: 'bodyweight',
+        },
+      ],
+      main: [
+        {
+          name: 'Romanian Deadlift',
+          sets: 4,
+          reps: '6-8',
+          category: 'compound',
+          targetMuscles: ['hamstrings', 'glutes'],
+          equipment: 'barbell',
+        },
+      ],
+    }),
+    'utf8',
+  );
+
+  writeFileSync(
+    join(dataRoot, 'workouts', '2026', 'Q1', 'upper-push-session.json'),
+    JSON.stringify({
+      name: 'Upper Push',
+      startedAt: '2026-01-12T14:00:00.000Z',
+      completedAt: '2026-01-12T14:48:00.000Z',
+      exercises: [
+        {
+          exerciseName: 'Barbell Bench Press',
+          sets: [
+            { setNumber: 1, weight: 185, reps: 8 },
+            { setNumber: 2, weight: 195, reps: 6 },
+          ],
+        },
+        {
+          exerciseName: 'Incline Dumbbell Fly',
+          sets: [
+            { setNumber: 1, weight: 40, reps: 12 },
+            { setNumber: 2, weight: 40, reps: 10 },
+          ],
+        },
+      ],
+    }),
+    'utf8',
+  );
+
+  writeFileSync(
+    join(dataRoot, 'workouts', '2026', 'Q1', 'lower-body-session.json'),
+    JSON.stringify({
+      templateName: 'Lower Body',
+      name: 'Lower Body',
+      startedAt: '2026-01-14T15:00:00.000Z',
+      durationMinutes: 52,
+      sections: [
+        {
+          type: 'warmup',
+          exercises: [
+            {
+              name: 'Bodyweight Squat',
+              sets: [{ reps: 10 }, { reps: 10 }],
+            },
+          ],
+        },
+        {
+          type: 'main',
+          exercises: [
+            {
+              name: 'Romanian Deadlift',
+              sets: [
+                { weight: 225, reps: 8 },
+                { weight: 235, reps: 6 },
+              ],
+            },
+          ],
+        },
+      ],
+    }),
     'utf8',
   );
 };
@@ -412,6 +567,140 @@ describe('migrate-static script', () => {
       .get();
 
     expect(overriddenWeight?.weight).toBe(181.9);
+  });
+
+  it('migrates workout templates and sessions with template linking and set preservation', async () => {
+    const captured = buildLogger();
+
+    const summary = await scriptModule.migrateWorkoutTemplatesAndSessions({
+      userId: 'user-1',
+      dataRoot,
+      logger: captured.logger,
+    });
+
+    expect(summary).toEqual({
+      processedTemplates: 2,
+      failedTemplates: 0,
+      processedSessions: 2,
+      failedSessions: 0,
+      totalTemplateExercises: 5,
+      totalSessionSets: 8,
+      createdExercises: 4,
+    });
+
+    expect(captured.errorMessages).toEqual([]);
+
+    const templateCount = dbModule.db.select().from(workoutTemplates).all().length;
+    const templateExerciseCount = dbModule.db.select().from(templateExercises).all().length;
+    const sessionCount = dbModule.db.select().from(workoutSessions).all().length;
+    const setCount = dbModule.db.select().from(sessionSets).all().length;
+
+    expect(templateCount).toBe(2);
+    expect(templateExerciseCount).toBe(5);
+    expect(sessionCount).toBe(2);
+    expect(setCount).toBe(8);
+
+    const benchExercises = dbModule.db
+      .select({
+        id: exercises.id,
+      })
+      .from(exercises)
+      .where(eq(exercises.name, 'Barbell Bench Press'))
+      .all();
+
+    expect(benchExercises).toHaveLength(1);
+
+    const createdFly = dbModule.db
+      .select({
+        userId: exercises.userId,
+        category: exercises.category,
+      })
+      .from(exercises)
+      .where(eq(exercises.name, 'Incline Dumbbell Fly'))
+      .limit(1)
+      .get();
+
+    expect(createdFly).toEqual({
+      userId: 'user-1',
+      category: 'isolation',
+    });
+
+    const upperTemplate = dbModule.db
+      .select({
+        id: workoutTemplates.id,
+      })
+      .from(workoutTemplates)
+      .where(eq(workoutTemplates.name, 'Upper Push'))
+      .limit(1)
+      .get();
+
+    expect(upperTemplate?.id).toBeTruthy();
+
+    const upperSession = dbModule.db
+      .select({
+        id: workoutSessions.id,
+        templateId: workoutSessions.templateId,
+        status: workoutSessions.status,
+      })
+      .from(workoutSessions)
+      .where(eq(workoutSessions.name, 'Upper Push'))
+      .limit(1)
+      .get();
+
+    expect(upperSession?.status).toBe('completed');
+    expect(upperSession?.templateId).toBe(upperTemplate?.id);
+
+    const benchSet = dbModule.db
+      .select({
+        weight: sessionSets.weight,
+        reps: sessionSets.reps,
+      })
+      .from(sessionSets)
+      .innerJoin(exercises, eq(exercises.id, sessionSets.exerciseId))
+      .where(
+        and(eq(sessionSets.sessionId, upperSession?.id ?? ''), eq(exercises.name, 'Barbell Bench Press')),
+      )
+      .limit(1)
+      .get();
+
+    expect(benchSet).toEqual({
+      weight: 185,
+      reps: 8,
+    });
+  });
+
+  it('is idempotent for workout templates and sessions when re-run', async () => {
+    const captured = buildLogger();
+
+    await scriptModule.migrateWorkoutTemplatesAndSessions({
+      userId: 'user-1',
+      dataRoot,
+      logger: captured.logger,
+    });
+
+    const firstPassCounts = {
+      exercises: dbModule.db.select().from(exercises).all().length,
+      templates: dbModule.db.select().from(workoutTemplates).all().length,
+      templateExercises: dbModule.db.select().from(templateExercises).all().length,
+      sessions: dbModule.db.select().from(workoutSessions).all().length,
+      sets: dbModule.db.select().from(sessionSets).all().length,
+    };
+
+    await scriptModule.migrateWorkoutTemplatesAndSessions({
+      userId: 'user-1',
+      dataRoot,
+      logger: captured.logger,
+    });
+
+    const secondPassCounts = {
+      exercises: dbModule.db.select().from(exercises).all().length,
+      templates: dbModule.db.select().from(workoutTemplates).all().length,
+      templateExercises: dbModule.db.select().from(templateExercises).all().length,
+      sessions: dbModule.db.select().from(workoutSessions).all().length,
+      sets: dbModule.db.select().from(sessionSets).all().length,
+    };
+
+    expect(secondPassCounts).toEqual(firstPassCounts);
   });
 
   it('parses CLI arguments and enforces required userId', () => {

--- a/apps/api/src/scripts/migrate-static.test.ts
+++ b/apps/api/src/scripts/migrate-static.test.ts
@@ -1,0 +1,434 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { eq } from 'drizzle-orm';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  bodyWeight,
+  foods,
+  habitEntries,
+  habits,
+  mealItems,
+  meals,
+  nutritionLogs,
+  users,
+} from '../db/schema/index.js';
+
+type DbModule = typeof import('../db/index.js');
+type ScriptModule = typeof import('./migrate-static.js');
+
+type CapturedLogger = {
+  infoMessages: string[];
+  warnMessages: string[];
+  errorMessages: string[];
+  logger: {
+    info: (...args: unknown[]) => void;
+    warn: (...args: unknown[]) => void;
+    error: (...args: unknown[]) => void;
+  };
+};
+
+let tempDir: string;
+let dataRoot: string;
+let dbModule: DbModule;
+let scriptModule: ScriptModule;
+
+const buildLogger = (): CapturedLogger => {
+  const infoMessages: string[] = [];
+  const warnMessages: string[] = [];
+  const errorMessages: string[] = [];
+
+  return {
+    infoMessages,
+    warnMessages,
+    errorMessages,
+    logger: {
+      info: (...args: unknown[]) => {
+        infoMessages.push(args.map((value) => String(value)).join(' '));
+      },
+      warn: (...args: unknown[]) => {
+        warnMessages.push(args.map((value) => String(value)).join(' '));
+      },
+      error: (...args: unknown[]) => {
+        errorMessages.push(args.map((value) => String(value)).join(' '));
+      },
+    },
+  };
+};
+
+const seedBaseData = () => {
+  dbModule.db
+    .insert(users)
+    .values({
+      id: 'user-1',
+      username: 'migrate-user',
+      name: 'Migrate User',
+      passwordHash: 'not-used',
+    })
+    .run();
+
+  dbModule.db
+    .insert(foods)
+    .values([
+      {
+        id: 'food-eggs',
+        userId: 'user-1',
+        name: 'Large Eggs',
+        brand: null,
+        servingSize: '2 eggs',
+        servingGrams: null,
+        calories: 140,
+        protein: 12,
+        carbs: 1,
+        fat: 10,
+        fiber: null,
+        sugar: null,
+        verified: true,
+        source: 'manual',
+        notes: null,
+        lastUsedAt: null,
+      },
+      {
+        id: 'food-chicken',
+        userId: 'user-1',
+        name: 'Chicken Breast',
+        brand: null,
+        servingSize: '4 oz',
+        servingGrams: null,
+        calories: 180,
+        protein: 35,
+        carbs: 0,
+        fat: 4,
+        fiber: null,
+        sugar: null,
+        verified: true,
+        source: 'manual',
+        notes: null,
+        lastUsedAt: null,
+      },
+    ])
+    .run();
+
+  dbModule.db
+    .insert(habits)
+    .values([
+      {
+        id: 'habit-hydration',
+        userId: 'user-1',
+        name: 'Hydration',
+        emoji: '💧',
+        trackingType: 'boolean',
+        target: null,
+        unit: null,
+        sortOrder: 0,
+        active: true,
+      },
+      {
+        id: 'habit-steps',
+        userId: 'user-1',
+        name: 'Steps',
+        emoji: '👟',
+        trackingType: 'numeric',
+        target: 10000,
+        unit: 'steps',
+        sortOrder: 1,
+        active: true,
+      },
+    ])
+    .run();
+};
+
+const writeFixtureData = () => {
+  mkdirSync(join(dataRoot, 'daily', '2026', '03'), { recursive: true });
+
+  writeFileSync(
+    join(dataRoot, 'daily', '2026', '03', '2026-03-05.json'),
+    JSON.stringify({
+      bodyWeight: 182.4,
+      meals: {
+        breakfast: {
+          time: '7:15 AM',
+          items: [
+            {
+              name: 'Large Eggs',
+              quantity: 2,
+              servingUnit: 'eggs',
+              calories: 140,
+              protein: 12,
+              carbs: 1,
+              fat: 10,
+            },
+            {
+              name: 'Mystery Food',
+              quantity: 1,
+              servingUnit: 'serving',
+              calories: 250,
+              protein: 8,
+              carbs: 20,
+              fat: 12,
+            },
+          ],
+        },
+        lunch: {
+          time: '12:30 PM',
+          items: [
+            {
+              name: 'Chicken Breast',
+              amount: 8,
+              unit: 'oz',
+              calories: 360,
+              protein: 70,
+              carbs: 0,
+              fat: 8,
+            },
+          ],
+        },
+      },
+      checklist: {
+        Hydration: true,
+        Steps: {
+          value: 10250,
+          completed: true,
+        },
+        'Unknown Habit': true,
+      },
+    }),
+    'utf8',
+  );
+
+  writeFileSync(
+    join(dataRoot, 'daily', '2026', '03', '2026-03-06.json'),
+    JSON.stringify({
+      weight: 180.8,
+      meals: [
+        {
+          name: 'Dinner',
+          time: '6:45 PM',
+          items: [
+            {
+              name: 'Large Eggs',
+              amount: 3,
+              unit: 'eggs',
+              calories: 210,
+              protein: 18,
+              carbs: 2,
+              fat: 15,
+            },
+          ],
+        },
+      ],
+      habitEntries: [
+        {
+          name: 'Hydration',
+          completed: false,
+        },
+      ],
+    }),
+    'utf8',
+  );
+
+  writeFileSync(
+    join(dataRoot, 'body-weight.json'),
+    JSON.stringify([
+      {
+        date: '2026-03-05',
+        weight: 181.9,
+      },
+      {
+        date: '2026-03-07',
+        weight: 181.1,
+      },
+    ]),
+    'utf8',
+  );
+};
+
+describe('migrate-static script', () => {
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'pulse-migrate-static-'));
+    dataRoot = join(tempDir, 'static-data');
+
+    process.env.DATABASE_URL = join(tempDir, 'test.db');
+    vi.resetModules();
+
+    dbModule = await import('../db/index.js');
+    migrate(dbModule.db, {
+      migrationsFolder: fileURLToPath(new URL('../../drizzle', import.meta.url)),
+    });
+
+    scriptModule = await import('./migrate-static.js');
+
+    seedBaseData();
+    writeFixtureData();
+  });
+
+  afterEach(() => {
+    dbModule.sqlite.close();
+    rmSync(tempDir, { recursive: true, force: true });
+    delete process.env.DATABASE_URL;
+    vi.resetModules();
+  });
+
+  it('migrates daily logs with nutrition, habits, and merged body weight history', async () => {
+    const captured = buildLogger();
+
+    const summary = await scriptModule.migrateDailyLogsAndBodyWeight({
+      userId: 'user-1',
+      dataRoot,
+      logger: captured.logger,
+    });
+
+    expect(summary).toEqual({
+      processedDays: 3,
+      failedDays: 0,
+      dailyLogDays: 2,
+      bodyWeightFileEntries: 2,
+      totalMeals: 3,
+      totalHabitEntries: 3,
+      totalWeightEntries: 3,
+    });
+
+    expect(captured.errorMessages).toEqual([]);
+    expect(captured.warnMessages.some((line) => line.includes('Missing food reference for "Mystery Food"'))).toBe(
+      true,
+    );
+    expect(captured.warnMessages.some((line) => line.includes('Missing habit reference for "Unknown Habit"'))).toBe(
+      true,
+    );
+
+    expect(dbModule.db.select().from(nutritionLogs).all()).toHaveLength(2);
+    expect(dbModule.db.select().from(meals).all()).toHaveLength(3);
+    expect(dbModule.db.select().from(mealItems).all()).toHaveLength(4);
+
+    const eggsItem = dbModule.db
+      .select({
+        foodId: mealItems.foodId,
+      })
+      .from(mealItems)
+      .where(eq(mealItems.name, 'Large Eggs'))
+      .limit(1)
+      .get();
+
+    expect(eggsItem?.foodId).toBe('food-eggs');
+
+    const unknownItem = dbModule.db
+      .select({
+        foodId: mealItems.foodId,
+      })
+      .from(mealItems)
+      .where(eq(mealItems.name, 'Mystery Food'))
+      .limit(1)
+      .get();
+
+    expect(unknownItem?.foodId).toBeNull();
+
+    const allHabitEntries = dbModule.db.select().from(habitEntries).all();
+    expect(allHabitEntries).toHaveLength(3);
+
+    const stepEntry = dbModule.db
+      .select({
+        value: habitEntries.value,
+        completed: habitEntries.completed,
+      })
+      .from(habitEntries)
+      .where(eq(habitEntries.habitId, 'habit-steps'))
+      .limit(1)
+      .get();
+
+    expect(stepEntry).toEqual({
+      value: 10250,
+      completed: true,
+    });
+
+    const weightEntries = dbModule.db
+      .select({
+        date: bodyWeight.date,
+        weight: bodyWeight.weight,
+      })
+      .from(bodyWeight)
+      .orderBy(bodyWeight.date)
+      .all();
+
+    expect(weightEntries).toEqual([
+      {
+        date: '2026-03-05',
+        weight: 181.9,
+      },
+      {
+        date: '2026-03-06',
+        weight: 180.8,
+      },
+      {
+        date: '2026-03-07',
+        weight: 181.1,
+      },
+    ]);
+  });
+
+  it('is idempotent when re-run for the same user and source data', async () => {
+    const captured = buildLogger();
+
+    await scriptModule.migrateDailyLogsAndBodyWeight({
+      userId: 'user-1',
+      dataRoot,
+      logger: captured.logger,
+    });
+
+    const firstPassCounts = {
+      nutritionLogs: dbModule.db.select().from(nutritionLogs).all().length,
+      meals: dbModule.db.select().from(meals).all().length,
+      mealItems: dbModule.db.select().from(mealItems).all().length,
+      habitEntries: dbModule.db.select().from(habitEntries).all().length,
+      bodyWeight: dbModule.db.select().from(bodyWeight).all().length,
+    };
+
+    await scriptModule.migrateDailyLogsAndBodyWeight({
+      userId: 'user-1',
+      dataRoot,
+      logger: captured.logger,
+    });
+
+    const secondPassCounts = {
+      nutritionLogs: dbModule.db.select().from(nutritionLogs).all().length,
+      meals: dbModule.db.select().from(meals).all().length,
+      mealItems: dbModule.db.select().from(mealItems).all().length,
+      habitEntries: dbModule.db.select().from(habitEntries).all().length,
+      bodyWeight: dbModule.db.select().from(bodyWeight).all().length,
+    };
+
+    expect(secondPassCounts).toEqual(firstPassCounts);
+
+    const overriddenWeight = dbModule.db
+      .select({
+        weight: bodyWeight.weight,
+      })
+      .from(bodyWeight)
+      .where(eq(bodyWeight.date, '2026-03-05'))
+      .limit(1)
+      .get();
+
+    expect(overriddenWeight?.weight).toBe(181.9);
+  });
+
+  it('parses CLI arguments and enforces required userId', () => {
+    expect(scriptModule.parseCliArgs(['--user', 'user-1'])).toEqual({
+      userId: 'user-1',
+      dataRoot: scriptModule.DEFAULT_STATIC_DATA_ROOT,
+    });
+
+    expect(scriptModule.parseCliArgs(['--user', 'user-1', '--source', '/tmp/static'])).toEqual({
+      userId: 'user-1',
+      dataRoot: '/tmp/static',
+    });
+
+    expect(() => scriptModule.parseCliArgs([])).toThrow('Missing required --user <userId> argument.');
+    expect(() => scriptModule.parseCliArgs(['--user'])).toThrow(
+      'Missing value for --user. Usage: npx tsx src/scripts/migrate-static.ts --user <userId>',
+    );
+    expect(() => scriptModule.parseCliArgs(['--oops'])).toThrow('Unknown argument: --oops');
+  });
+});

--- a/apps/api/src/scripts/migrate-static.test.ts
+++ b/apps/api/src/scripts/migrate-static.test.ts
@@ -400,6 +400,47 @@ const writeFixtureData = () => {
     }),
     'utf8',
   );
+
+  writeFileSync(
+    join(dataRoot, 'foods.json'),
+    JSON.stringify([
+      {
+        name: 'Greek Yogurt',
+        brand: 'Fage',
+        servingSize: '3/4 cup',
+        servingGrams: 170,
+        calories: 130,
+        protein: 18,
+        carbs: 7,
+        fat: 0,
+        fiber: 0,
+        sugar: 5,
+        verified: true,
+        source: 'manual',
+        notes: 'Plain 0%',
+      },
+      {
+        name: 'Oat Bran',
+        brand: null,
+        servingSize: '1/4 cup dry',
+        calories: 150,
+        protein: 7,
+        carbohydrates: 27,
+        fat: 3,
+        verified: false,
+        source: 'USDA',
+      },
+      {
+        name: 'Large Eggs',
+        brand: null,
+        calories: 140,
+        protein: 12,
+        carbs: 1,
+        fat: 10,
+      },
+    ]),
+    'utf8',
+  );
 };
 
 describe('migrate-static script', () => {
@@ -701,6 +742,95 @@ describe('migrate-static script', () => {
     };
 
     expect(secondPassCounts).toEqual(firstPassCounts);
+  });
+
+  it('migrates foods from foods.json, skipping duplicates and backfilling lastUsedAt', async () => {
+    const captured = buildLogger();
+
+    const summary = await scriptModule.migrateFoodsDatabase({
+      userId: 'user-1',
+      dataRoot,
+      logger: captured.logger,
+    });
+
+    // Greek Yogurt and Oat Bran are new; Large Eggs already seeded → skipped
+    expect(summary.inserted).toBe(2);
+    expect(summary.skipped).toBe(1);
+    expect(captured.warnMessages).toEqual([]);
+
+    const allFoods = dbModule.db.select().from(foods).where(eq(foods.userId, 'user-1')).all();
+    expect(allFoods).toHaveLength(4); // 2 seeded + 2 inserted
+
+    const yogurt = dbModule.db
+      .select({ brand: foods.brand, protein: foods.protein, verified: foods.verified, source: foods.source })
+      .from(foods)
+      .where(and(eq(foods.userId, 'user-1'), eq(foods.name, 'Greek Yogurt')))
+      .limit(1)
+      .get();
+
+    expect(yogurt).toEqual({ brand: 'Fage', protein: 18, verified: true, source: 'manual' });
+
+    const oatBran = dbModule.db
+      .select({ carbs: foods.carbs, verified: foods.verified, source: foods.source })
+      .from(foods)
+      .where(and(eq(foods.userId, 'user-1'), eq(foods.name, 'Oat Bran')))
+      .limit(1)
+      .get();
+
+    expect(oatBran).toEqual({ carbs: 27, verified: false, source: 'USDA' });
+  });
+
+  it('skips foods.json gracefully when file is missing', async () => {
+    const captured = buildLogger();
+
+    const summary = await scriptModule.migrateFoodsDatabase({
+      userId: 'user-1',
+      dataRoot: '/nonexistent/path',
+      logger: captured.logger,
+    });
+
+    expect(summary).toEqual({ inserted: 0, skipped: 0, lastUsedAtUpdated: 0 });
+    expect(captured.warnMessages.some((m) => m.includes('not found or unreadable'))).toBe(true);
+  });
+
+  it('backfills lastUsedAt from meal_items after daily logs are migrated', async () => {
+    // First migrate foods (new: Greek Yogurt, Oat Bran; seeded: Large Eggs, Chicken Breast)
+    await scriptModule.migrateFoodsDatabase({ userId: 'user-1', dataRoot });
+
+    // Then migrate daily logs (which inserts meal_items referencing "Large Eggs")
+    await scriptModule.migrateDailyLogsAndBodyWeight({ userId: 'user-1', dataRoot });
+
+    // Re-run foods migration to trigger lastUsedAt backfill
+    const captured = buildLogger();
+    const summary2 = await scriptModule.migrateFoodsDatabase({
+      userId: 'user-1',
+      dataRoot,
+      logger: captured.logger,
+    });
+
+    // All foods skipped on second run (already exist)
+    expect(summary2.inserted).toBe(0);
+    expect(summary2.skipped).toBe(3);
+
+    // lastUsedAt should be set on Large Eggs (used in daily logs)
+    const eggs = dbModule.db
+      .select({ lastUsedAt: foods.lastUsedAt })
+      .from(foods)
+      .where(and(eq(foods.userId, 'user-1'), eq(foods.name, 'Large Eggs')))
+      .limit(1)
+      .get();
+
+    expect(eggs?.lastUsedAt).not.toBeNull();
+  });
+
+  it('is idempotent for foods migration when re-run', async () => {
+    await scriptModule.migrateFoodsDatabase({ userId: 'user-1', dataRoot });
+    const firstCount = dbModule.db.select().from(foods).where(eq(foods.userId, 'user-1')).all().length;
+
+    await scriptModule.migrateFoodsDatabase({ userId: 'user-1', dataRoot });
+    const secondCount = dbModule.db.select().from(foods).where(eq(foods.userId, 'user-1')).all().length;
+
+    expect(secondCount).toBe(firstCount);
   });
 
   it('parses CLI arguments and enforces required userId', () => {

--- a/apps/api/src/scripts/migrate-static.ts
+++ b/apps/api/src/scripts/migrate-static.ts
@@ -3,7 +3,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import { basename, join, relative, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { and, eq, isNull, or } from 'drizzle-orm';
+import { and, eq, isNull, max, or } from 'drizzle-orm';
 
 import {
   bodyWeight,
@@ -68,6 +68,12 @@ export type WorkoutMigrationSummary = {
   totalTemplateExercises: number;
   totalSessionSets: number;
   createdExercises: number;
+};
+
+export type FoodsMigrationSummary = {
+  inserted: number;
+  skipped: number;
+  lastUsedAtUpdated: number;
 };
 
 export type CliOptions = {
@@ -2086,6 +2092,188 @@ export const migrateWorkoutTemplatesAndSessions = async ({
   return summary;
 };
 
+export const migrateFoodsDatabase = async ({
+  userId,
+  dataRoot = DEFAULT_STATIC_DATA_ROOT,
+  logger = console,
+}: MigrationOptions): Promise<FoodsMigrationSummary> => {
+  const resolvedDataRoot = resolve(dataRoot);
+  const foodsFilePath = join(resolvedDataRoot, 'foods.json');
+
+  let rawContent: string;
+  try {
+    rawContent = await readFile(foodsFilePath, 'utf8');
+  } catch (error) {
+    logger.warn(`Foods file not found or unreadable at ${foodsFilePath}: ${String(error)}`);
+    return { inserted: 0, skipped: 0, lastUsedAtUpdated: 0 };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawContent);
+  } catch (error) {
+    logger.warn(`Failed to parse foods.json: ${String(error)}`);
+    return { inserted: 0, skipped: 0, lastUsedAtUpdated: 0 };
+  }
+
+  const foodEntries: Record<string, unknown>[] = [];
+
+  if (Array.isArray(parsed)) {
+    for (const item of parsed) {
+      if (isRecord(item)) {
+        foodEntries.push(item);
+      }
+    }
+  } else if (isRecord(parsed)) {
+    const items =
+      getNestedField(parsed, 'foods') ??
+      getNestedField(parsed, 'items') ??
+      getNestedField(parsed, 'data');
+
+    if (Array.isArray(items)) {
+      for (const item of items) {
+        if (isRecord(item)) {
+          foodEntries.push(item);
+        }
+      }
+    } else {
+      for (const value of Object.values(parsed)) {
+        if (isRecord(value)) {
+          foodEntries.push(value);
+        }
+      }
+    }
+  }
+
+  const { db } = await import('../db/index.js');
+
+  const existingRows = db
+    .select({ name: foods.name, brand: foods.brand })
+    .from(foods)
+    .where(eq(foods.userId, userId))
+    .all();
+
+  const existingSet = new Set(
+    existingRows.map((row) => normalizeLookupKey(`${row.name}|${row.brand ?? ''}`)),
+  );
+
+  const summary: FoodsMigrationSummary = { inserted: 0, skipped: 0, lastUsedAtUpdated: 0 };
+
+  for (const entry of foodEntries) {
+    const name = normalizeText(getNestedField(entry, 'name'));
+    if (!name) {
+      logger.warn(`Skipping food entry with missing name: ${JSON.stringify(entry)}`);
+      continue;
+    }
+
+    const brand = normalizeText(getNestedField(entry, 'brand'));
+    const dedupeKey = normalizeLookupKey(`${name}|${brand ?? ''}`);
+
+    if (existingSet.has(dedupeKey)) {
+      logger.info(`Skipping duplicate food "${name}"${brand ? ` (${brand})` : ''} for user ${userId}.`);
+      summary.skipped += 1;
+      continue;
+    }
+
+    const servingSizeRaw =
+      normalizeText(getNestedField(entry, 'servingSize')) ??
+      normalizeText(getNestedField(entry, 'serving_size')) ??
+      normalizeText(getNestedField(entry, 'serving'));
+
+    const servingGrams =
+      toPositiveNumber(getNestedField(entry, 'servingGrams')) ??
+      toPositiveNumber(getNestedField(entry, 'serving_grams')) ??
+      toPositiveNumber(getNestedField(entry, 'grams'));
+
+    const calories = toNonnegativeNumber(
+      getNestedField(entry, 'calories') ?? getNestedField(entry, 'kcal'),
+    );
+    const protein = toNonnegativeNumber(getNestedField(entry, 'protein'));
+    const carbs = toNonnegativeNumber(
+      getNestedField(entry, 'carbs') ?? getNestedField(entry, 'carbohydrates'),
+    );
+    const fat = toNonnegativeNumber(getNestedField(entry, 'fat'));
+    const fiber = toNumber(getNestedField(entry, 'fiber'));
+    const sugar = toNumber(getNestedField(entry, 'sugar'));
+
+    const verifiedRaw = toBoolean(getNestedField(entry, 'verified'));
+    const verified = verifiedRaw ?? false;
+
+    const source = normalizeText(getNestedField(entry, 'source'));
+    const notes = normalizeText(getNestedField(entry, 'notes'));
+
+    db.insert(foods)
+      .values({
+        userId,
+        name,
+        brand,
+        servingSize: servingSizeRaw,
+        servingGrams,
+        calories,
+        protein,
+        carbs,
+        fat,
+        fiber: fiber !== null && fiber >= 0 ? fiber : null,
+        sugar: sugar !== null && sugar >= 0 ? sugar : null,
+        verified,
+        source,
+        notes,
+        lastUsedAt: null,
+      })
+      .run();
+
+    existingSet.add(dedupeKey);
+    summary.inserted += 1;
+  }
+
+  // Backfill lastUsedAt from existing meal_items usage (name match)
+  const usageRows = db
+    .select({
+      name: mealItems.name,
+      latestDate: max(nutritionLogs.date),
+    })
+    .from(mealItems)
+    .innerJoin(meals, eq(meals.id, mealItems.mealId))
+    .innerJoin(nutritionLogs, eq(nutritionLogs.id, meals.nutritionLogId))
+    .where(eq(nutritionLogs.userId, userId))
+    .groupBy(mealItems.name)
+    .all();
+
+  for (const usage of usageRows) {
+    if (!usage.latestDate) {
+      continue;
+    }
+
+    const usageTimestamp = new Date(`${usage.latestDate}T00:00:00.000Z`).getTime();
+    const normalizedName = normalizeLookupKey(usage.name);
+
+    const updated = db
+      .update(foods)
+      .set({ lastUsedAt: usageTimestamp })
+      .where(
+        and(
+          eq(foods.userId, userId),
+          or(
+            isNull(foods.lastUsedAt),
+          ),
+          eq(foods.name, usage.name),
+        ),
+      )
+      .run();
+
+    if (updated.changes > 0) {
+      summary.lastUsedAtUpdated += updated.changes;
+      void normalizedName;
+    }
+  }
+
+  logger.info(
+    `Foods migration summary: inserted ${summary.inserted}, skipped ${summary.skipped}, lastUsedAt updated ${summary.lastUsedAtUpdated}.`,
+  );
+
+  return summary;
+};
+
 export const migrateDailyLogsAndBodyWeight = async ({
   userId,
   dataRoot = DEFAULT_STATIC_DATA_ROOT,
@@ -2362,6 +2550,11 @@ export const parseCliArgs = (args: string[]): CliOptions => {
 
 const runCli = async () => {
   const options = parseCliArgs(process.argv.slice(2));
+  await migrateFoodsDatabase({
+    userId: options.userId,
+    dataRoot: options.dataRoot,
+    logger: console,
+  });
   await migrateDailyLogsAndBodyWeight({
     userId: options.userId,
     dataRoot: options.dataRoot,

--- a/apps/api/src/scripts/migrate-static.ts
+++ b/apps/api/src/scripts/migrate-static.ts
@@ -1,0 +1,1165 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { basename, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { and, eq } from 'drizzle-orm';
+
+import {
+  bodyWeight,
+  foods,
+  habitEntries,
+  habits,
+  mealItems,
+  meals,
+  nutritionLogs,
+} from '../db/schema/index.js';
+
+export const DEFAULT_STATIC_DATA_ROOT = '/Volumes/meridian/Projects/health-fitness-static/data';
+
+const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
+const DAILY_FILENAME_PATTERN = /^(\d{4}-\d{2}-\d{2})\.json$/u;
+const TWENTY_FOUR_HOUR_TIME_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/u;
+const TWELVE_HOUR_TIME_PATTERN = /^(\d{1,2}):([0-5]\d)\s*([AaPp][Mm])$/u;
+const WHITESPACE_PATTERN = /\s+/gu;
+
+type Logger = Pick<Console, 'info' | 'warn' | 'error'>;
+
+type DateWeightMap = Map<string, number>;
+
+type FoodLookup = Map<string, string>;
+
+type HabitLookupEntry = {
+  id: string;
+  name: string;
+  trackingType: 'boolean' | 'numeric' | 'time';
+};
+
+type HabitLookup = Map<string, HabitLookupEntry>;
+
+type MigrationOptions = {
+  userId: string;
+  dataRoot?: string;
+  logger?: Logger;
+};
+
+export type MigrationSummary = {
+  processedDays: number;
+  failedDays: number;
+  dailyLogDays: number;
+  bodyWeightFileEntries: number;
+  totalMeals: number;
+  totalHabitEntries: number;
+  totalWeightEntries: number;
+};
+
+export type CliOptions = {
+  userId: string;
+  dataRoot: string;
+};
+
+export type ParsedMealItem = {
+  name: string;
+  amount: number;
+  unit: string;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  fiber: number | null;
+  sugar: number | null;
+};
+
+export type ParsedMeal = {
+  name: string;
+  time: string | null;
+  notes: string | null;
+  items: ParsedMealItem[];
+};
+
+export type ParsedHabitEntry = {
+  name: string;
+  completed: boolean;
+  value: number | null;
+};
+
+export type ParsedDailyLog = {
+  date: string;
+  meals: ParsedMeal[];
+  habits: ParsedHabitEntry[];
+  bodyWeight: number | null;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const normalizeLookupKey = (value: string) => value.trim().toLowerCase().replace(WHITESPACE_PATTERN, ' ');
+
+const normalizeText = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const toDateKey = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+
+    if (DATE_KEY_PATTERN.test(trimmed)) {
+      return trimmed;
+    }
+
+    const fromIso = trimmed.slice(0, 10);
+    if (DATE_KEY_PATTERN.test(fromIso)) {
+      return fromIso;
+    }
+
+    return null;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const asDate = new Date(value);
+    const iso = asDate.toISOString().slice(0, 10);
+    return DATE_KEY_PATTERN.test(iso) ? iso : null;
+  }
+
+  return null;
+};
+
+const toNumber = (value: unknown): number | null => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'string') {
+    const cleaned = value.trim().replace(/,/gu, '');
+    if (cleaned.length === 0) {
+      return null;
+    }
+
+    const parsed = Number.parseFloat(cleaned);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+};
+
+const toPositiveNumber = (value: unknown): number | null => {
+  const numeric = toNumber(value);
+  if (numeric === null || numeric <= 0) {
+    return null;
+  }
+
+  return numeric;
+};
+
+const toNonnegativeNumber = (value: unknown, fallback = 0): number => {
+  const numeric = toNumber(value);
+  if (numeric === null || numeric < 0) {
+    return fallback;
+  }
+
+  return numeric;
+};
+
+const toBoolean = (value: unknown): boolean | null => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value > 0;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+
+    if (['true', 'yes', 'y', 'done', 'completed', '1'].includes(normalized)) {
+      return true;
+    }
+
+    if (['false', 'no', 'n', '0', 'missed', 'skipped'].includes(normalized)) {
+      return false;
+    }
+  }
+
+  return null;
+};
+
+const toTwentyFourHourTime = (value: unknown): string | null => {
+  const raw = normalizeText(value);
+  if (!raw) {
+    return null;
+  }
+
+  const trimmed = raw.toUpperCase();
+
+  const twentyFourHourMatch = TWENTY_FOUR_HOUR_TIME_PATTERN.exec(trimmed);
+  if (twentyFourHourMatch) {
+    return `${twentyFourHourMatch[1]}:${twentyFourHourMatch[2]}`;
+  }
+
+  const twelveHourMatch = TWELVE_HOUR_TIME_PATTERN.exec(trimmed);
+  if (!twelveHourMatch) {
+    return null;
+  }
+
+  const hours = Number.parseInt(twelveHourMatch[1], 10);
+  const minutes = twelveHourMatch[2];
+  const meridiem = twelveHourMatch[3];
+
+  if (hours < 1 || hours > 12) {
+    return null;
+  }
+
+  const normalizedHours = meridiem === 'AM' ? (hours === 12 ? 0 : hours) : hours === 12 ? 12 : hours + 12;
+
+  return `${String(normalizedHours).padStart(2, '0')}:${minutes}`;
+};
+
+const toTitleCase = (value: string) =>
+  value
+    .trim()
+    .split(WHITESPACE_PATTERN)
+    .filter((segment) => segment.length > 0)
+    .map((segment) => `${segment[0]?.toUpperCase() ?? ''}${segment.slice(1).toLowerCase()}`)
+    .join(' ');
+
+const normalizeMealName = (value: string): string => {
+  const normalized = normalizeLookupKey(value);
+
+  if (normalized === 'breakfast') {
+    return 'Breakfast';
+  }
+
+  if (normalized === 'lunch') {
+    return 'Lunch';
+  }
+
+  if (normalized === 'dinner') {
+    return 'Dinner';
+  }
+
+  if (normalized === 'snack' || normalized === 'snacks') {
+    return 'Snacks';
+  }
+
+  return toTitleCase(value);
+};
+
+const getNestedField = (record: Record<string, unknown>, field: string): unknown => {
+  if (field in record) {
+    return record[field];
+  }
+
+  const lowerField = field.toLowerCase();
+  const match = Object.entries(record).find(([key]) => key.toLowerCase() === lowerField);
+
+  return match?.[1];
+};
+
+const extractFoodItemName = (record: Record<string, unknown>): string | null => {
+  const directName = normalizeText(getNestedField(record, 'name'));
+  if (directName) {
+    return directName;
+  }
+
+  const foodName = normalizeText(getNestedField(record, 'foodName'));
+  if (foodName) {
+    return foodName;
+  }
+
+  const label = normalizeText(getNestedField(record, 'label'));
+  if (label) {
+    return label;
+  }
+
+  return null;
+};
+
+const extractFoodItemAmount = (record: Record<string, unknown>): number | null => {
+  const directAmount = toPositiveNumber(getNestedField(record, 'amount'));
+  if (directAmount !== null) {
+    return directAmount;
+  }
+
+  const quantity = toPositiveNumber(getNestedField(record, 'quantity'));
+  const servingSize = toPositiveNumber(getNestedField(record, 'servingSize'));
+
+  if (quantity !== null && servingSize !== null) {
+    return quantity * servingSize;
+  }
+
+  if (quantity !== null) {
+    return quantity;
+  }
+
+  if (servingSize !== null) {
+    return servingSize;
+  }
+
+  return 1;
+};
+
+const extractFoodItemUnit = (record: Record<string, unknown>): string => {
+  const unit = normalizeText(getNestedField(record, 'unit'));
+  if (unit) {
+    return unit;
+  }
+
+  const servingUnit = normalizeText(getNestedField(record, 'servingUnit'));
+  if (servingUnit) {
+    return servingUnit;
+  }
+
+  return 'serving';
+};
+
+const extractMacroValue = (record: Record<string, unknown>, key: string) => {
+  const directValue = toNonnegativeNumber(getNestedField(record, key));
+  if (directValue > 0) {
+    return directValue;
+  }
+
+  const macrosField = getNestedField(record, 'macros');
+  if (isRecord(macrosField)) {
+    return toNonnegativeNumber(getNestedField(macrosField, key));
+  }
+
+  return directValue;
+};
+
+const parseMealItem = (value: unknown): ParsedMealItem | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const name = extractFoodItemName(value);
+  if (!name) {
+    return null;
+  }
+
+  const amount = extractFoodItemAmount(value);
+  if (amount === null || amount <= 0) {
+    return null;
+  }
+
+  return {
+    name,
+    amount,
+    unit: extractFoodItemUnit(value),
+    calories: extractMacroValue(value, 'calories'),
+    protein: extractMacroValue(value, 'protein'),
+    carbs: extractMacroValue(value, 'carbs'),
+    fat: extractMacroValue(value, 'fat'),
+    fiber: toNumber(getNestedField(value, 'fiber')),
+    sugar: toNumber(getNestedField(value, 'sugar')),
+  };
+};
+
+const parseMeal = (value: unknown, fallbackName: string | null): ParsedMeal | null => {
+  if (Array.isArray(value)) {
+    const items = value.map((item) => parseMealItem(item)).filter((item): item is ParsedMealItem => item !== null);
+
+    if (items.length === 0) {
+      return null;
+    }
+
+    return {
+      name: normalizeMealName(fallbackName ?? 'Meal'),
+      time: null,
+      notes: null,
+      items,
+    };
+  }
+
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const itemListRaw = getNestedField(value, 'items') ?? getNestedField(value, 'foods') ?? value;
+  const rawItems = Array.isArray(itemListRaw) ? itemListRaw : [];
+  const items = rawItems
+    .map((item) => parseMealItem(item))
+    .filter((item): item is ParsedMealItem => item !== null);
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  const mealName =
+    normalizeText(getNestedField(value, 'name')) ??
+    normalizeText(getNestedField(value, 'meal')) ??
+    fallbackName ??
+    'Meal';
+
+  return {
+    name: normalizeMealName(mealName),
+    time: toTwentyFourHourTime(getNestedField(value, 'time')),
+    notes: normalizeText(getNestedField(value, 'notes')),
+    items,
+  };
+};
+
+const parseMealContainer = (value: unknown): ParsedMeal[] => {
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => parseMeal(entry, null))
+      .filter((entry): entry is ParsedMeal => entry !== null);
+  }
+
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  return Object.entries(value)
+    .map(([mealName, mealData]) => parseMeal(mealData, mealName))
+    .filter((entry): entry is ParsedMeal => entry !== null);
+};
+
+const mealSortOrder = new Map([
+  ['Breakfast', 0],
+  ['Lunch', 1],
+  ['Dinner', 2],
+  ['Snacks', 3],
+]);
+
+export const extractMealsFromDailyLog = (raw: unknown): ParsedMeal[] => {
+  if (!isRecord(raw)) {
+    return [];
+  }
+
+  const candidateSources: unknown[] = [];
+
+  const rootMeals = getNestedField(raw, 'meals');
+  if (rootMeals !== undefined) {
+    candidateSources.push(rootMeals);
+  }
+
+  const nutritionField = getNestedField(raw, 'nutrition');
+  if (isRecord(nutritionField)) {
+    const nutritionMeals = getNestedField(nutritionField, 'meals');
+    if (nutritionMeals !== undefined) {
+      candidateSources.push(nutritionMeals);
+    }
+  }
+
+  const directMealBuckets: Record<string, unknown> = {};
+  for (const mealName of ['breakfast', 'lunch', 'dinner', 'snacks']) {
+    const bucket = getNestedField(raw, mealName);
+    if (bucket !== undefined) {
+      directMealBuckets[mealName] = bucket;
+    }
+  }
+
+  if (Object.keys(directMealBuckets).length > 0) {
+    candidateSources.push(directMealBuckets);
+  }
+
+  for (const candidate of candidateSources) {
+    const parsed = parseMealContainer(candidate);
+    if (parsed.length > 0) {
+      return parsed.sort((left, right) => {
+        const leftOrder = mealSortOrder.get(left.name) ?? Number.MAX_SAFE_INTEGER;
+        const rightOrder = mealSortOrder.get(right.name) ?? Number.MAX_SAFE_INTEGER;
+
+        if (leftOrder !== rightOrder) {
+          return leftOrder - rightOrder;
+        }
+
+        return left.name.localeCompare(right.name);
+      });
+    }
+  }
+
+  return [];
+};
+
+const toHabitEntryName = (value: unknown): string | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  return (
+    normalizeText(getNestedField(value, 'name')) ??
+    normalizeText(getNestedField(value, 'habit')) ??
+    normalizeText(getNestedField(value, 'habitName')) ??
+    normalizeText(getNestedField(value, 'label'))
+  );
+};
+
+const toHabitEntryValue = (value: unknown): number | null => {
+  if (!isRecord(value)) {
+    return toNumber(value);
+  }
+
+  return (
+    toNumber(getNestedField(value, 'value')) ??
+    toNumber(getNestedField(value, 'amount')) ??
+    toNumber(getNestedField(value, 'count')) ??
+    toNumber(getNestedField(value, 'minutes'))
+  );
+};
+
+const toHabitEntryCompleted = (value: unknown, numericValue: number | null): boolean => {
+  if (!isRecord(value)) {
+    const directBoolean = toBoolean(value);
+    if (directBoolean !== null) {
+      return directBoolean;
+    }
+
+    return numericValue !== null ? numericValue > 0 : false;
+  }
+
+  const completedField = toBoolean(getNestedField(value, 'completed'));
+  if (completedField !== null) {
+    return completedField;
+  }
+
+  const doneField = toBoolean(getNestedField(value, 'done'));
+  if (doneField !== null) {
+    return doneField;
+  }
+
+  const checkedField = toBoolean(getNestedField(value, 'checked'));
+  if (checkedField !== null) {
+    return checkedField;
+  }
+
+  return numericValue !== null ? numericValue > 0 : false;
+};
+
+const dedupeHabits = (entries: ParsedHabitEntry[]): ParsedHabitEntry[] => {
+  const byName = new Map<string, ParsedHabitEntry>();
+
+  for (const entry of entries) {
+    byName.set(normalizeLookupKey(entry.name), entry);
+  }
+
+  return [...byName.values()];
+};
+
+const parseHabitContainer = (value: unknown): ParsedHabitEntry[] => {
+  if (Array.isArray(value)) {
+    const entries = value
+      .map((entry) => {
+        if (typeof entry === 'string') {
+          const name = normalizeText(entry);
+          if (!name) {
+            return null;
+          }
+
+          return {
+            name,
+            completed: true,
+            value: null,
+          } satisfies ParsedHabitEntry;
+        }
+
+        if (!isRecord(entry)) {
+          return null;
+        }
+
+        const name = toHabitEntryName(entry);
+        if (!name) {
+          return null;
+        }
+
+        const numericValue = toHabitEntryValue(entry);
+
+        return {
+          name,
+          completed: toHabitEntryCompleted(entry, numericValue),
+          value: numericValue,
+        } satisfies ParsedHabitEntry;
+      })
+      .filter((entry): entry is ParsedHabitEntry => entry !== null);
+
+    return dedupeHabits(entries);
+  }
+
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  const entries = Object.entries(value)
+    .map(([name, entryValue]) => {
+      const normalizedName = normalizeText(name);
+      if (!normalizedName) {
+        return null;
+      }
+
+      const numericValue = toHabitEntryValue(entryValue);
+
+      return {
+        name: normalizedName,
+        completed: toHabitEntryCompleted(entryValue, numericValue),
+        value: numericValue,
+      } satisfies ParsedHabitEntry;
+    })
+    .filter((entry): entry is ParsedHabitEntry => entry !== null);
+
+  return dedupeHabits(entries);
+};
+
+export const extractHabitEntriesFromDailyLog = (raw: unknown): ParsedHabitEntry[] => {
+  if (!isRecord(raw)) {
+    return [];
+  }
+
+  const candidateSources: unknown[] = [];
+
+  for (const key of ['checklist', 'habitChecklist', 'habitEntries', 'dailyChecklist', 'habits']) {
+    const source = getNestedField(raw, key);
+    if (source !== undefined) {
+      candidateSources.push(source);
+    }
+  }
+
+  for (const candidate of candidateSources) {
+    const parsed = parseHabitContainer(candidate);
+    if (parsed.length > 0) {
+      return parsed;
+    }
+  }
+
+  return [];
+};
+
+const toWeightValue = (value: unknown): number | null => {
+  if (isRecord(value)) {
+    return (
+      toPositiveNumber(getNestedField(value, 'weight')) ??
+      toPositiveNumber(getNestedField(value, 'bodyWeight')) ??
+      toPositiveNumber(getNestedField(value, 'value')) ??
+      toPositiveNumber(getNestedField(value, 'pounds')) ??
+      toPositiveNumber(getNestedField(value, 'lbs'))
+    );
+  }
+
+  return toPositiveNumber(value);
+};
+
+export const extractBodyWeightFromDailyLog = (raw: unknown): number | null => {
+  if (!isRecord(raw)) {
+    return null;
+  }
+
+  const candidateSources: unknown[] = [getNestedField(raw, 'bodyWeight'), getNestedField(raw, 'weight')];
+
+  const metrics = getNestedField(raw, 'metrics');
+  if (isRecord(metrics)) {
+    candidateSources.push(getNestedField(metrics, 'bodyWeight'));
+    candidateSources.push(getNestedField(metrics, 'weight'));
+  }
+
+  for (const candidate of candidateSources) {
+    const parsedWeight = toWeightValue(candidate);
+    if (parsedWeight !== null) {
+      return parsedWeight;
+    }
+  }
+
+  return null;
+};
+
+const parseDailyLog = (date: string, raw: unknown): ParsedDailyLog => ({
+  date,
+  meals: extractMealsFromDailyLog(raw),
+  habits: extractHabitEntriesFromDailyLog(raw),
+  bodyWeight: extractBodyWeightFromDailyLog(raw),
+});
+
+const readJson = async (filePath: string): Promise<unknown> => {
+  const contents = await readFile(filePath, 'utf8');
+  return JSON.parse(contents) as unknown;
+};
+
+const listJsonFiles = async (directoryPath: string): Promise<string[]> => {
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = join(directoryPath, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await listJsonFiles(fullPath)));
+      continue;
+    }
+
+    if (!entry.isFile() || !entry.name.endsWith('.json')) {
+      continue;
+    }
+
+    files.push(fullPath);
+  }
+
+  return files;
+};
+
+export const loadDailyLogRecords = async (dataRoot: string, logger: Logger): Promise<Map<string, ParsedDailyLog>> => {
+  const dailyRoot = join(dataRoot, 'daily');
+
+  let dailyFiles: string[];
+  try {
+    dailyFiles = await listJsonFiles(dailyRoot);
+  } catch (error) {
+    logger.warn(`Daily log directory not found or unreadable at ${dailyRoot}: ${String(error)}`);
+    return new Map<string, ParsedDailyLog>();
+  }
+
+  const records = new Map<string, ParsedDailyLog>();
+
+  for (const filePath of dailyFiles) {
+    let payload: unknown;
+    try {
+      payload = await readJson(filePath);
+    } catch (error) {
+      logger.warn(`Skipping unreadable daily log file ${filePath}: ${String(error)}`);
+      continue;
+    }
+
+    const filenameMatch = DAILY_FILENAME_PATTERN.exec(basename(filePath));
+    const fileDate = filenameMatch?.[1] ?? null;
+    const payloadDate = isRecord(payload) ? toDateKey(getNestedField(payload, 'date')) : null;
+    const date = fileDate ?? payloadDate;
+
+    if (!date) {
+      logger.warn(`Skipping daily log file with no valid date in filename/content: ${filePath}`);
+      continue;
+    }
+
+    if (records.has(date)) {
+      logger.warn(`Duplicate daily log for ${date} found at ${filePath}; later file wins.`);
+    }
+
+    records.set(date, parseDailyLog(date, payload));
+  }
+
+  return records;
+};
+
+const addWeightEntry = (entries: DateWeightMap, date: string | null, weight: number | null) => {
+  if (!date || weight === null) {
+    return;
+  }
+
+  entries.set(date, weight);
+};
+
+const parseWeightRecord = (raw: Record<string, unknown>, fallbackDate: string | null): [string | null, number | null] => {
+  const date =
+    fallbackDate ??
+    toDateKey(getNestedField(raw, 'date')) ??
+    toDateKey(getNestedField(raw, 'day')) ??
+    toDateKey(getNestedField(raw, 'timestamp'));
+
+  const weight = toWeightValue(raw);
+
+  return [date, weight];
+};
+
+export const parseBodyWeightHistory = (raw: unknown): DateWeightMap => {
+  const entries = new Map<string, number>();
+
+  const visit = (value: unknown, fallbackDate: string | null) => {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        visit(item, null);
+      }
+      return;
+    }
+
+    if (isRecord(value)) {
+      const [date, weight] = parseWeightRecord(value, fallbackDate);
+      addWeightEntry(entries, date, weight);
+
+      for (const nestedCollectionName of ['entries', 'history', 'weights', 'data']) {
+        const nested = getNestedField(value, nestedCollectionName);
+        if (Array.isArray(nested)) {
+          visit(nested, null);
+        }
+      }
+
+      for (const [key, candidateValue] of Object.entries(value)) {
+        const keyAsDate = toDateKey(key);
+        if (!keyAsDate) {
+          continue;
+        }
+
+        if (isRecord(candidateValue)) {
+          const [, candidateWeight] = parseWeightRecord(candidateValue, keyAsDate);
+          addWeightEntry(entries, keyAsDate, candidateWeight);
+          continue;
+        }
+
+        addWeightEntry(entries, keyAsDate, toWeightValue(candidateValue));
+      }
+
+      return;
+    }
+
+    if (fallbackDate) {
+      addWeightEntry(entries, fallbackDate, toWeightValue(value));
+    }
+  };
+
+  visit(raw, null);
+
+  return entries;
+};
+
+const loadBodyWeightHistory = async (dataRoot: string, logger: Logger): Promise<DateWeightMap> => {
+  const filePath = join(dataRoot, 'body-weight.json');
+
+  let payload: unknown;
+  try {
+    payload = await readJson(filePath);
+  } catch {
+    logger.warn(`body-weight.json not found or unreadable at ${filePath}; continuing without it.`);
+    return new Map<string, number>();
+  }
+
+  return parseBodyWeightHistory(payload);
+};
+
+export const mergeWeightEntries = (dailyWeights: DateWeightMap, bodyWeightHistory: DateWeightMap): DateWeightMap => {
+  const merged = new Map<string, number>(dailyWeights);
+
+  for (const [date, weight] of bodyWeightHistory) {
+    merged.set(date, weight);
+  }
+
+  return merged;
+};
+
+const buildFoodLookup = (rows: Array<{ id: string; name: string }>): FoodLookup => {
+  const lookup = new Map<string, string>();
+
+  for (const row of rows) {
+    const key = normalizeLookupKey(row.name);
+
+    if (!lookup.has(key)) {
+      lookup.set(key, row.id);
+    }
+  }
+
+  return lookup;
+};
+
+const buildHabitLookup = (
+  rows: Array<{ id: string; name: string; trackingType: 'boolean' | 'numeric' | 'time' }>,
+): HabitLookup => {
+  const lookup = new Map<string, HabitLookupEntry>();
+
+  for (const row of rows) {
+    const key = normalizeLookupKey(row.name);
+
+    if (!lookup.has(key)) {
+      lookup.set(key, row);
+    }
+  }
+
+  return lookup;
+};
+
+export const migrateDailyLogsAndBodyWeight = async ({
+  userId,
+  dataRoot = DEFAULT_STATIC_DATA_ROOT,
+  logger = console,
+}: MigrationOptions): Promise<MigrationSummary> => {
+  const resolvedDataRoot = resolve(dataRoot);
+
+  const dailyRecords = await loadDailyLogRecords(resolvedDataRoot, logger);
+  const bodyWeightHistory = await loadBodyWeightHistory(resolvedDataRoot, logger);
+
+  const dailyWeights = new Map<string, number>();
+  for (const [date, record] of dailyRecords) {
+    if (record.bodyWeight !== null) {
+      dailyWeights.set(date, record.bodyWeight);
+    }
+  }
+
+  const mergedWeights = mergeWeightEntries(dailyWeights, bodyWeightHistory);
+
+  const { db } = await import('../db/index.js');
+
+  const [foodRows, habitRows] = await Promise.all([
+    db
+      .select({
+        id: foods.id,
+        name: foods.name,
+      })
+      .from(foods)
+      .where(eq(foods.userId, userId))
+      .all(),
+    db
+      .select({
+        id: habits.id,
+        name: habits.name,
+        trackingType: habits.trackingType,
+      })
+      .from(habits)
+      .where(eq(habits.userId, userId))
+      .all(),
+  ]);
+
+  const foodLookup = buildFoodLookup(foodRows);
+  const habitLookup = buildHabitLookup(habitRows);
+
+  const dates = new Set<string>([...dailyRecords.keys(), ...mergedWeights.keys()]);
+  const sortedDates = [...dates].sort((left, right) => left.localeCompare(right));
+
+  const summary: MigrationSummary = {
+    processedDays: 0,
+    failedDays: 0,
+    dailyLogDays: dailyRecords.size,
+    bodyWeightFileEntries: bodyWeightHistory.size,
+    totalMeals: 0,
+    totalHabitEntries: 0,
+    totalWeightEntries: 0,
+  };
+
+  for (const date of sortedDates) {
+    const dayRecord = dailyRecords.get(date) ?? null;
+    const weightForDay = mergedWeights.get(date) ?? null;
+
+    try {
+      const dayResult = db.transaction((tx) => {
+        let insertedMeals = 0;
+        let insertedHabitEntries = 0;
+        let insertedWeightEntries = 0;
+
+        if (dayRecord && dayRecord.meals.length > 0) {
+          tx.insert(nutritionLogs)
+            .values({
+              userId,
+              date,
+              notes: null,
+            })
+            .onConflictDoNothing({
+              target: [nutritionLogs.userId, nutritionLogs.date],
+            })
+            .run();
+
+          const nutritionLog = tx
+            .select({
+              id: nutritionLogs.id,
+            })
+            .from(nutritionLogs)
+            .where(and(eq(nutritionLogs.userId, userId), eq(nutritionLogs.date, date)))
+            .limit(1)
+            .get();
+
+          if (!nutritionLog) {
+            throw new Error(`Failed to load nutrition log for ${date}`);
+          }
+
+          tx.delete(meals).where(eq(meals.nutritionLogId, nutritionLog.id)).run();
+
+          for (const meal of dayRecord.meals) {
+            const insertedMeal = tx
+              .insert(meals)
+              .values({
+                nutritionLogId: nutritionLog.id,
+                name: meal.name,
+                time: meal.time,
+                notes: meal.notes,
+              })
+              .returning({ id: meals.id })
+              .get();
+
+            if (!insertedMeal) {
+              throw new Error(`Failed to insert meal "${meal.name}" on ${date}`);
+            }
+
+            insertedMeals += 1;
+
+            for (const item of meal.items) {
+              const foodId = foodLookup.get(normalizeLookupKey(item.name)) ?? null;
+
+              if (!foodId) {
+                logger.warn(
+                  `Missing food reference for "${item.name}" on ${date}; item imported without linked foodId.`,
+                );
+              }
+
+              tx.insert(mealItems)
+                .values({
+                  mealId: insertedMeal.id,
+                  foodId,
+                  name: item.name,
+                  amount: item.amount,
+                  unit: item.unit,
+                  calories: item.calories,
+                  protein: item.protein,
+                  carbs: item.carbs,
+                  fat: item.fat,
+                  fiber: item.fiber,
+                  sugar: item.sugar,
+                })
+                .run();
+            }
+          }
+        }
+
+        if (dayRecord && dayRecord.habits.length > 0) {
+          for (const habitEntry of dayRecord.habits) {
+            const matchedHabit = habitLookup.get(normalizeLookupKey(habitEntry.name));
+
+            if (!matchedHabit) {
+              logger.warn(
+                `Missing habit reference for "${habitEntry.name}" on ${date}; entry skipped for this day.`,
+              );
+              continue;
+            }
+
+            const valueToPersist =
+              matchedHabit.trackingType === 'boolean' ? null : (habitEntry.value ?? null);
+            const completedToPersist =
+              matchedHabit.trackingType === 'boolean'
+                ? habitEntry.completed
+                : habitEntry.completed || (valueToPersist !== null && valueToPersist > 0);
+
+            tx.insert(habitEntries)
+              .values({
+                habitId: matchedHabit.id,
+                userId,
+                date,
+                completed: completedToPersist,
+                value: valueToPersist,
+              })
+              .onConflictDoUpdate({
+                target: [habitEntries.habitId, habitEntries.date],
+                set: {
+                  completed: completedToPersist,
+                  value: valueToPersist,
+                },
+              })
+              .run();
+
+            insertedHabitEntries += 1;
+          }
+        }
+
+        if (weightForDay !== null) {
+          tx.insert(bodyWeight)
+            .values({
+              userId,
+              date,
+              weight: weightForDay,
+              notes: null,
+            })
+            .onConflictDoUpdate({
+              target: [bodyWeight.userId, bodyWeight.date],
+              set: {
+                weight: weightForDay,
+                notes: null,
+                updatedAt: Date.now(),
+              },
+            })
+            .run();
+
+          insertedWeightEntries = 1;
+        }
+
+        return {
+          meals: insertedMeals,
+          habitEntries: insertedHabitEntries,
+          weightEntries: insertedWeightEntries,
+        };
+      });
+
+      summary.processedDays += 1;
+      summary.totalMeals += dayResult.meals;
+      summary.totalHabitEntries += dayResult.habitEntries;
+      summary.totalWeightEntries += dayResult.weightEntries;
+
+      logger.info(
+        `Processed ${date}: ${dayResult.meals} meals, ${dayResult.habitEntries} habit entries, weight: ${
+          weightForDay ?? 'none'
+        }`,
+      );
+    } catch (error) {
+      summary.failedDays += 1;
+      logger.error(`Failed processing ${date}: ${String(error)}`);
+    }
+  }
+
+  logger.info(
+    `Migration summary: processed ${summary.processedDays} day(s), failed ${summary.failedDays}, meals ${summary.totalMeals}, habit entries ${summary.totalHabitEntries}, weight entries ${summary.totalWeightEntries}.`,
+  );
+
+  return summary;
+};
+
+export const parseCliArgs = (args: string[]): CliOptions => {
+  let userId: string | undefined;
+  let dataRoot = DEFAULT_STATIC_DATA_ROOT;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const current = args[index];
+
+    if (current === '--user') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('--')) {
+        throw new Error('Missing value for --user. Usage: npx tsx src/scripts/migrate-static.ts --user <userId>');
+      }
+
+      userId = next;
+      index += 1;
+      continue;
+    }
+
+    if (current === '--source') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('--')) {
+        throw new Error(
+          'Missing value for --source. Usage: npx tsx src/scripts/migrate-static.ts --user <userId> --source <path>',
+        );
+      }
+
+      dataRoot = next;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${current}`);
+  }
+
+  if (!userId) {
+    throw new Error('Missing required --user <userId> argument.');
+  }
+
+  return {
+    userId,
+    dataRoot,
+  };
+};
+
+const runCli = async () => {
+  const options = parseCliArgs(process.argv.slice(2));
+  await migrateDailyLogsAndBodyWeight({
+    userId: options.userId,
+    dataRoot: options.dataRoot,
+    logger: console,
+  });
+};
+
+const isMainModule = () => {
+  if (!process.argv[1]) {
+    return false;
+  }
+
+  return import.meta.url === pathToFileURL(process.argv[1]).href;
+};
+
+if (isMainModule()) {
+  runCli().catch((error) => {
+    console.error(`Static migration failed: ${String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/apps/api/src/scripts/migrate-static.ts
+++ b/apps/api/src/scripts/migrate-static.ts
@@ -1,9 +1,8 @@
 import { createHash } from 'node:crypto';
 import { readFile, readdir } from 'node:fs/promises';
 import { basename, join, relative, resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
 
-import { and, eq, isNull, max, or } from 'drizzle-orm';
+import { and, eq, isNull, lt, max, or } from 'drizzle-orm';
 
 import {
   bodyWeight,
@@ -22,7 +21,7 @@ import {
 
 export const DEFAULT_STATIC_DATA_ROOT = '/Volumes/meridian/Projects/health-fitness-static/data';
 export const DEFAULT_WORKOUT_TEMPLATE_SUBPATH = join('workouts', 'templates');
-export const DEFAULT_WORKOUT_SESSION_SUBPATH = join('workouts', '2026', 'Q1');
+export const DEFAULT_WORKOUT_SESSION_SUBPATH = 'workouts';
 
 const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
 const DAILY_FILENAME_PATTERN = /^(\d{4}-\d{2}-\d{2})\.json$/u;
@@ -74,11 +73,6 @@ export type FoodsMigrationSummary = {
   inserted: number;
   skipped: number;
   lastUsedAtUpdated: number;
-};
-
-export type CliOptions = {
-  userId: string;
-  dataRoot: string;
 };
 
 export type ParsedMealItem = {
@@ -172,9 +166,9 @@ type ExerciseLookupEntry = {
 };
 
 type ExerciseCreateDefaults = {
-  category: ExerciseCategory;
+  category: ExerciseCategory | null;
   muscleGroups: string[];
-  equipment: string;
+  equipment: string | null;
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -928,6 +922,7 @@ const buildFoodLookup = (rows: Array<{ id: string; name: string }>): FoodLookup 
   const lookup = new Map<string, string>();
 
   for (const row of rows) {
+    // meal_items only stores free-text name, so brand-aware matching is not possible here.
     const key = normalizeLookupKey(row.name);
 
     if (!lookup.has(key)) {
@@ -1006,21 +1001,33 @@ const toTimestampMs = (value: unknown): number | null => {
   return parsed;
 };
 
-const toDurationMs = (value: unknown): number | null => {
+type DurationUnit = 'milliseconds' | 'seconds' | 'minutes' | 'auto';
+
+const toDurationMs = (value: unknown, unit: DurationUnit = 'auto'): number | null => {
   const numeric = toNonnegativeInteger(value);
   if (numeric === null) {
     return null;
   }
 
-  if (numeric >= 100_000) {
+  if (unit === 'milliseconds') {
     return numeric;
   }
 
-  if (numeric <= 600) {
+  if (unit === 'seconds') {
+    return numeric * 1_000;
+  }
+
+  if (unit === 'minutes') {
     return numeric * 60_000;
   }
 
-  return numeric * 1_000;
+  // Ambiguous generic duration fields are interpreted as either milliseconds
+  // (already >= 1 minute) or minutes.
+  if (numeric >= 60_000) {
+    return numeric;
+  }
+
+  return numeric * 60_000;
 };
 
 const toStableMigrationId = (prefix: string, ...parts: string[]) => {
@@ -1647,10 +1654,10 @@ const parseWorkoutSessionRecord = (
     toTimestampMs(getNestedField(objectPayload, 'finishedAt'));
 
   const durationCandidate =
-    toDurationMs(getNestedField(objectPayload, 'duration')) ??
-    toDurationMs(getNestedField(objectPayload, 'durationMs')) ??
-    toDurationMs(getNestedField(objectPayload, 'durationSeconds')) ??
-    toDurationMs(getNestedField(objectPayload, 'durationMinutes'));
+    toDurationMs(getNestedField(objectPayload, 'durationMs'), 'milliseconds') ??
+    toDurationMs(getNestedField(objectPayload, 'durationSeconds'), 'seconds') ??
+    toDurationMs(getNestedField(objectPayload, 'durationMinutes'), 'minutes') ??
+    toDurationMs(getNestedField(objectPayload, 'duration'));
 
   const explicitDate =
     toDateKey(getNestedField(objectPayload, 'date')) ??
@@ -1716,7 +1723,9 @@ const loadWorkoutSessionRecords = async (
     return [];
   }
 
-  const sortedFiles = [...files].sort((left, right) => left.localeCompare(right));
+  const sortedFiles = files
+    .filter((filePath) => !relative(sessionsRoot, filePath).replace(/\\/gu, '/').startsWith('templates/'))
+    .sort((left, right) => left.localeCompare(right));
   const records: ParsedWorkoutSessionRecord[] = [];
 
   for (const filePath of sortedFiles) {
@@ -1771,18 +1780,18 @@ const toExerciseDefaults = (set: {
   muscleGroups: string[];
   equipment: string | null;
 }): ExerciseCreateDefaults => ({
-  category: set.category ?? 'compound',
+  category: set.category,
   muscleGroups: set.muscleGroups.length > 0 ? set.muscleGroups : ['full body'],
-  equipment: set.equipment ?? 'bodyweight',
+  equipment: set.equipment,
 });
 
 const mergeExerciseDefaults = (
   current: ExerciseCreateDefaults,
   incoming: ExerciseCreateDefaults,
 ): ExerciseCreateDefaults => ({
-  category: current.category === 'compound' ? incoming.category : current.category,
+  category: current.category ?? incoming.category,
   muscleGroups: Array.from(new Set([...current.muscleGroups, ...incoming.muscleGroups])),
-  equipment: current.equipment === 'bodyweight' ? incoming.equipment : current.equipment,
+  equipment: current.equipment ?? incoming.equipment,
 });
 
 const collectExerciseDefaults = (
@@ -1880,9 +1889,9 @@ export const migrateWorkoutTemplatesAndSessions = async ({
         id: exerciseId,
         userId,
         name: requirement.displayName,
-        category: requirement.defaults.category,
+        category: requirement.defaults.category ?? 'compound',
         muscleGroups: requirement.defaults.muscleGroups,
-        equipment: requirement.defaults.equipment,
+        equipment: requirement.defaults.equipment ?? 'bodyweight',
         instructions: null,
       })
       .onConflictDoNothing({
@@ -2245,25 +2254,20 @@ export const migrateFoodsDatabase = async ({
     }
 
     const usageTimestamp = new Date(`${usage.latestDate}T00:00:00.000Z`).getTime();
-    const normalizedName = normalizeLookupKey(usage.name);
-
     const updated = db
       .update(foods)
       .set({ lastUsedAt: usageTimestamp })
       .where(
         and(
           eq(foods.userId, userId),
-          or(
-            isNull(foods.lastUsedAt),
-          ),
           eq(foods.name, usage.name),
+          or(isNull(foods.lastUsedAt), lt(foods.lastUsedAt, usageTimestamp)),
         ),
       )
       .run();
 
     if (updated.changes > 0) {
       summary.lastUsedAtUpdated += updated.changes;
-      void normalizedName;
     }
   }
 
@@ -2503,81 +2507,3 @@ export const migrateDailyLogsAndBodyWeight = async ({
 
   return summary;
 };
-
-export const parseCliArgs = (args: string[]): CliOptions => {
-  let userId: string | undefined;
-  let dataRoot = DEFAULT_STATIC_DATA_ROOT;
-
-  for (let index = 0; index < args.length; index += 1) {
-    const current = args[index];
-
-    if (current === '--user') {
-      const next = args[index + 1];
-      if (!next || next.startsWith('--')) {
-        throw new Error('Missing value for --user. Usage: npx tsx src/scripts/migrate-static.ts --user <userId>');
-      }
-
-      userId = next;
-      index += 1;
-      continue;
-    }
-
-    if (current === '--source') {
-      const next = args[index + 1];
-      if (!next || next.startsWith('--')) {
-        throw new Error(
-          'Missing value for --source. Usage: npx tsx src/scripts/migrate-static.ts --user <userId> --source <path>',
-        );
-      }
-
-      dataRoot = next;
-      index += 1;
-      continue;
-    }
-
-    throw new Error(`Unknown argument: ${current}`);
-  }
-
-  if (!userId) {
-    throw new Error('Missing required --user <userId> argument.');
-  }
-
-  return {
-    userId,
-    dataRoot,
-  };
-};
-
-const runCli = async () => {
-  const options = parseCliArgs(process.argv.slice(2));
-  await migrateFoodsDatabase({
-    userId: options.userId,
-    dataRoot: options.dataRoot,
-    logger: console,
-  });
-  await migrateDailyLogsAndBodyWeight({
-    userId: options.userId,
-    dataRoot: options.dataRoot,
-    logger: console,
-  });
-  await migrateWorkoutTemplatesAndSessions({
-    userId: options.userId,
-    dataRoot: options.dataRoot,
-    logger: console,
-  });
-};
-
-const isMainModule = () => {
-  if (!process.argv[1]) {
-    return false;
-  }
-
-  return import.meta.url === pathToFileURL(process.argv[1]).href;
-};
-
-if (isMainModule()) {
-  runCli().catch((error) => {
-    console.error(`Static migration failed: ${String(error)}`);
-    process.exitCode = 1;
-  });
-}

--- a/apps/api/src/scripts/migrate-static.ts
+++ b/apps/api/src/scripts/migrate-static.ts
@@ -1,20 +1,28 @@
+import { createHash } from 'node:crypto';
 import { readFile, readdir } from 'node:fs/promises';
-import { basename, join, resolve } from 'node:path';
+import { basename, join, relative, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull, or } from 'drizzle-orm';
 
 import {
   bodyWeight,
+  exercises,
   foods,
   habitEntries,
   habits,
   mealItems,
   meals,
   nutritionLogs,
+  sessionSets,
+  templateExercises,
+  workoutSessions,
+  workoutTemplates,
 } from '../db/schema/index.js';
 
 export const DEFAULT_STATIC_DATA_ROOT = '/Volumes/meridian/Projects/health-fitness-static/data';
+export const DEFAULT_WORKOUT_TEMPLATE_SUBPATH = join('workouts', 'templates');
+export const DEFAULT_WORKOUT_SESSION_SUBPATH = join('workouts', '2026', 'Q1');
 
 const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
 const DAILY_FILENAME_PATTERN = /^(\d{4}-\d{2}-\d{2})\.json$/u;
@@ -52,6 +60,16 @@ export type MigrationSummary = {
   totalWeightEntries: number;
 };
 
+export type WorkoutMigrationSummary = {
+  processedTemplates: number;
+  failedTemplates: number;
+  processedSessions: number;
+  failedSessions: number;
+  totalTemplateExercises: number;
+  totalSessionSets: number;
+  createdExercises: number;
+};
+
 export type CliOptions = {
   userId: string;
   dataRoot: string;
@@ -87,6 +105,70 @@ export type ParsedDailyLog = {
   meals: ParsedMeal[];
   habits: ParsedHabitEntry[];
   bodyWeight: number | null;
+};
+
+type WorkoutTemplateSectionType = 'warmup' | 'main' | 'cooldown';
+type ExerciseCategory = 'compound' | 'isolation' | 'cardio' | 'mobility';
+
+type ParsedTemplateExercise = {
+  name: string;
+  section: WorkoutTemplateSectionType;
+  orderIndex: number;
+  sets: number | null;
+  repsMin: number | null;
+  repsMax: number | null;
+  tempo: string | null;
+  restSeconds: number | null;
+  supersetGroup: string | null;
+  notes: string | null;
+  cues: string[];
+  category: ExerciseCategory | null;
+  muscleGroups: string[];
+  equipment: string | null;
+};
+
+type ParsedWorkoutTemplateRecord = {
+  sourceKey: string;
+  name: string;
+  description: string | null;
+  tags: string[];
+  exercises: ParsedTemplateExercise[];
+};
+
+type ParsedSessionSet = {
+  exerciseName: string;
+  setNumber: number;
+  weight: number | null;
+  reps: number | null;
+  completed: boolean;
+  skipped: boolean;
+  section: WorkoutTemplateSectionType | null;
+  notes: string | null;
+  category: ExerciseCategory | null;
+  muscleGroups: string[];
+  equipment: string | null;
+};
+
+type ParsedWorkoutSessionRecord = {
+  sourceKey: string;
+  name: string;
+  templateMatchName: string;
+  date: string;
+  startedAt: number;
+  completedAt: number;
+  duration: number;
+  sets: ParsedSessionSet[];
+};
+
+type ExerciseLookupEntry = {
+  id: string;
+  userId: string | null;
+};
+
+type ExerciseCreateDefaults = {
+  category: ExerciseCategory;
+  muscleGroups: string[];
+  equipment: string;
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -866,6 +948,1144 @@ const buildHabitLookup = (
   return lookup;
 };
 
+const WORKOUT_SECTION_ORDER: WorkoutTemplateSectionType[] = ['warmup', 'main', 'cooldown'];
+const SESSION_TIMELESS_FALLBACK_SUFFIX = 'T00:00:00.000Z';
+const MIGRATION_ID_HASH_LENGTH = 24;
+
+const toPositiveInteger = (value: unknown): number | null => {
+  const numeric = toNumber(value);
+  if (numeric === null || numeric <= 0) {
+    return null;
+  }
+
+  return Math.trunc(numeric);
+};
+
+const toNonnegativeInteger = (value: unknown): number | null => {
+  const numeric = toNumber(value);
+  if (numeric === null || numeric < 0) {
+    return null;
+  }
+
+  return Math.trunc(numeric);
+};
+
+const toTimestampMs = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    if (value > 1_000_000_000_000) {
+      return Math.trunc(value);
+    }
+
+    if (value > 1_000_000_000) {
+      return Math.trunc(value * 1_000);
+    }
+
+    return null;
+  }
+
+  const text = normalizeText(value);
+  if (!text) {
+    return null;
+  }
+
+  if (/^-?\d+(\.\d+)?$/u.test(text)) {
+    return toTimestampMs(Number.parseFloat(text));
+  }
+
+  const parsed = Date.parse(text);
+  if (Number.isNaN(parsed)) {
+    return null;
+  }
+
+  return parsed;
+};
+
+const toDurationMs = (value: unknown): number | null => {
+  const numeric = toNonnegativeInteger(value);
+  if (numeric === null) {
+    return null;
+  }
+
+  if (numeric >= 100_000) {
+    return numeric;
+  }
+
+  if (numeric <= 600) {
+    return numeric * 60_000;
+  }
+
+  return numeric * 1_000;
+};
+
+const toStableMigrationId = (prefix: string, ...parts: string[]) => {
+  const source = parts.join('|');
+  const digest = createHash('sha1').update(source).digest('hex').slice(0, MIGRATION_ID_HASH_LENGTH);
+  return `${prefix}-${digest}`;
+};
+
+const toSectionType = (value: unknown): WorkoutTemplateSectionType => {
+  const normalized = normalizeLookupKey(typeof value === 'string' ? value : String(value ?? ''));
+
+  if (normalized.includes('warm')) {
+    return 'warmup';
+  }
+
+  if (normalized.includes('cool') || normalized.includes('recover')) {
+    return 'cooldown';
+  }
+
+  return 'main';
+};
+
+const toExerciseCategory = (value: unknown): ExerciseCategory | null => {
+  const text = normalizeText(value);
+  if (!text) {
+    return null;
+  }
+
+  const normalized = normalizeLookupKey(text);
+
+  if (normalized.includes('isolation')) {
+    return 'isolation';
+  }
+
+  if (normalized.includes('cardio') || normalized.includes('conditioning')) {
+    return 'cardio';
+  }
+
+  if (normalized.includes('mobility') || normalized.includes('stretch') || normalized.includes('warmup')) {
+    return 'mobility';
+  }
+
+  if (normalized.includes('compound')) {
+    return 'compound';
+  }
+
+  return null;
+};
+
+const toStringArray = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    const seen = new Set<string>();
+    const values: string[] = [];
+
+    for (const item of value) {
+      const text = normalizeText(item);
+      if (!text) {
+        continue;
+      }
+
+      const key = normalizeLookupKey(text);
+      if (seen.has(key)) {
+        continue;
+      }
+
+      seen.add(key);
+      values.push(text);
+    }
+
+    return values;
+  }
+
+  const text = normalizeText(value);
+  if (!text) {
+    return [];
+  }
+
+  return toStringArray(text.split(/[|,/]/u).map((segment) => segment.trim()));
+};
+
+const parseRepsRange = (value: unknown): { repsMin: number | null; repsMax: number | null } => {
+  const directNumber = toPositiveInteger(value);
+  if (directNumber !== null) {
+    return {
+      repsMin: directNumber,
+      repsMax: directNumber,
+    };
+  }
+
+  const text = normalizeText(value);
+  if (!text) {
+    return {
+      repsMin: null,
+      repsMax: null,
+    };
+  }
+
+  const rangeMatch = /(\d+)\s*[-to]+\s*(\d+)/iu.exec(text);
+  if (rangeMatch) {
+    const minimum = Number.parseInt(rangeMatch[1], 10);
+    const maximum = Number.parseInt(rangeMatch[2], 10);
+
+    if (Number.isFinite(minimum) && Number.isFinite(maximum)) {
+      return {
+        repsMin: Math.min(minimum, maximum),
+        repsMax: Math.max(minimum, maximum),
+      };
+    }
+  }
+
+  const singleMatch = /(\d+)/u.exec(text);
+  if (singleMatch) {
+    const single = Number.parseInt(singleMatch[1], 10);
+    if (Number.isFinite(single) && single > 0) {
+      return {
+        repsMin: single,
+        repsMax: single,
+      };
+    }
+  }
+
+  return {
+    repsMin: null,
+    repsMax: null,
+  };
+};
+
+const toFallbackWorkoutName = (filePath: string) => {
+  const withoutExtension = basename(filePath, '.json').replace(/[-_]/gu, ' ');
+  return toTitleCase(withoutExtension || 'Workout');
+};
+
+const toTags = (value: unknown) => toStringArray(value).slice(0, 20);
+
+const toExerciseCollection = (value: unknown): unknown[] => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  const nested =
+    getNestedField(value, 'exercises') ??
+    getNestedField(value, 'items') ??
+    getNestedField(value, 'movements') ??
+    getNestedField(value, 'entries');
+
+  if (Array.isArray(nested)) {
+    return nested;
+  }
+
+  return [value];
+};
+
+const extractTemplateSectionSources = (
+  value: unknown,
+): Array<{ section: WorkoutTemplateSectionType; exercises: unknown[] }> => {
+  if (Array.isArray(value)) {
+    return [
+      {
+        section: 'main',
+        exercises: value,
+      },
+    ];
+  }
+
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  const sources: Array<{ section: WorkoutTemplateSectionType; exercises: unknown[] }> = [];
+
+  const explicitSections = getNestedField(value, 'sections');
+  if (Array.isArray(explicitSections)) {
+    for (const sectionEntry of explicitSections) {
+      if (!isRecord(sectionEntry)) {
+        continue;
+      }
+
+      const section = toSectionType(
+        getNestedField(sectionEntry, 'type') ??
+          getNestedField(sectionEntry, 'section') ??
+          getNestedField(sectionEntry, 'name') ??
+          getNestedField(sectionEntry, 'title'),
+      );
+
+      const exercises = toExerciseCollection(sectionEntry);
+      if (exercises.length > 0) {
+        sources.push({ section, exercises });
+      }
+    }
+
+    if (sources.length > 0) {
+      return sources;
+    }
+  }
+
+  for (const section of WORKOUT_SECTION_ORDER) {
+    const sectionValue = getNestedField(value, section);
+    if (sectionValue === undefined) {
+      continue;
+    }
+
+    const exercises = toExerciseCollection(sectionValue);
+    if (exercises.length > 0) {
+      sources.push({ section, exercises });
+    }
+  }
+
+  if (sources.length > 0) {
+    return sources;
+  }
+
+  const fallbackExercises =
+    getNestedField(value, 'exercises') ??
+    getNestedField(value, 'items') ??
+    getNestedField(value, 'movements');
+  const exercises = toExerciseCollection(fallbackExercises);
+  if (exercises.length > 0) {
+    return [
+      {
+        section: 'main',
+        exercises,
+      },
+    ];
+  }
+
+  return [];
+};
+
+const parseTemplateExercise = (
+  value: unknown,
+  section: WorkoutTemplateSectionType,
+  orderIndex: number,
+): ParsedTemplateExercise | null => {
+  if (typeof value === 'string') {
+    const name = normalizeText(value);
+    if (!name) {
+      return null;
+    }
+
+    return {
+      name,
+      section,
+      orderIndex,
+      sets: null,
+      repsMin: null,
+      repsMax: null,
+      tempo: null,
+      restSeconds: null,
+      supersetGroup: null,
+      notes: null,
+      cues: [],
+      category: null,
+      muscleGroups: [],
+      equipment: null,
+    };
+  }
+
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const name =
+    normalizeText(getNestedField(value, 'name')) ??
+    normalizeText(getNestedField(value, 'exerciseName')) ??
+    normalizeText(getNestedField(value, 'exercise')) ??
+    normalizeText(getNestedField(value, 'movement')) ??
+    normalizeText(getNestedField(value, 'title'));
+
+  if (!name) {
+    return null;
+  }
+
+  const repsRange = parseRepsRange(
+    getNestedField(value, 'repsMin') ??
+      getNestedField(value, 'reps') ??
+      getNestedField(value, 'repRange') ??
+      getNestedField(value, 'targetReps'),
+  );
+
+  const muscleGroupsCandidates = [
+    toStringArray(getNestedField(value, 'muscleGroups')),
+    toStringArray(getNestedField(value, 'muscles')),
+    toStringArray(getNestedField(value, 'targetMuscles')),
+  ];
+  const muscleGroups = muscleGroupsCandidates.find((candidate) => candidate.length > 0) ?? [];
+
+  return {
+    name,
+    section,
+    orderIndex,
+    sets:
+      toPositiveInteger(getNestedField(value, 'sets')) ??
+      toPositiveInteger(getNestedField(value, 'setCount')) ??
+      toPositiveInteger(getNestedField(value, 'targetSets')),
+    repsMin:
+      toPositiveInteger(getNestedField(value, 'repsMin')) ??
+      toPositiveInteger(getNestedField(value, 'minReps')) ??
+      repsRange.repsMin,
+    repsMax:
+      toPositiveInteger(getNestedField(value, 'repsMax')) ??
+      toPositiveInteger(getNestedField(value, 'maxReps')) ??
+      repsRange.repsMax,
+    tempo: normalizeText(getNestedField(value, 'tempo')),
+    restSeconds:
+      toNonnegativeInteger(getNestedField(value, 'restSeconds')) ??
+      toNonnegativeInteger(getNestedField(value, 'rest')),
+    supersetGroup:
+      normalizeText(getNestedField(value, 'supersetGroup')) ??
+      normalizeText(getNestedField(value, 'superset')),
+    notes:
+      normalizeText(getNestedField(value, 'notes')) ??
+      normalizeText(getNestedField(value, 'instructions')),
+    cues: toStringArray(getNestedField(value, 'cues') ?? getNestedField(value, 'cue')).slice(0, 20),
+    category: toExerciseCategory(getNestedField(value, 'category')),
+    muscleGroups,
+    equipment:
+      normalizeText(getNestedField(value, 'equipment')) ??
+      normalizeText(getNestedField(value, 'implement')),
+  };
+};
+
+const parseWorkoutTemplateRecord = (
+  templatesRoot: string,
+  filePath: string,
+  payload: unknown,
+): ParsedWorkoutTemplateRecord => {
+  const fallbackName = toFallbackWorkoutName(filePath);
+  const sourceKey = relative(templatesRoot, filePath).replace(/\\/gu, '/');
+
+  const objectPayload = isRecord(payload) ? payload : { exercises: payload };
+
+  const name =
+    normalizeText(getNestedField(objectPayload, 'name')) ??
+    normalizeText(getNestedField(objectPayload, 'templateName')) ??
+    normalizeText(getNestedField(objectPayload, 'workoutName')) ??
+    fallbackName;
+
+  const sectionSources = extractTemplateSectionSources(objectPayload);
+  const exercises = sectionSources.flatMap((sectionSource) =>
+    sectionSource.exercises
+      .map((exercise, index) => parseTemplateExercise(exercise, sectionSource.section, index))
+      .filter((exercise): exercise is ParsedTemplateExercise => exercise !== null),
+  );
+
+  return {
+    sourceKey,
+    name,
+    description: normalizeText(getNestedField(objectPayload, 'description')),
+    tags: toTags(getNestedField(objectPayload, 'tags')),
+    exercises,
+  };
+};
+
+const loadWorkoutTemplateRecords = async (
+  dataRoot: string,
+  logger: Logger,
+): Promise<ParsedWorkoutTemplateRecord[]> => {
+  const templatesRoot = join(dataRoot, DEFAULT_WORKOUT_TEMPLATE_SUBPATH);
+
+  let files: string[];
+  try {
+    files = await listJsonFiles(templatesRoot);
+  } catch (error) {
+    logger.warn(`Workout template directory not found or unreadable at ${templatesRoot}: ${String(error)}`);
+    return [];
+  }
+
+  const sortedFiles = [...files].sort((left, right) => left.localeCompare(right));
+  const records: ParsedWorkoutTemplateRecord[] = [];
+
+  for (const filePath of sortedFiles) {
+    try {
+      const payload = await readJson(filePath);
+      records.push(parseWorkoutTemplateRecord(templatesRoot, filePath, payload));
+    } catch (error) {
+      logger.warn(`Skipping unreadable workout template file ${filePath}: ${String(error)}`);
+    }
+  }
+
+  return records;
+};
+
+const extractSessionSectionSources = (
+  value: unknown,
+): Array<{ section: WorkoutTemplateSectionType | null; exercises: unknown[] }> => {
+  if (Array.isArray(value)) {
+    return [
+      {
+        section: 'main',
+        exercises: value,
+      },
+    ];
+  }
+
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  const sources: Array<{ section: WorkoutTemplateSectionType | null; exercises: unknown[] }> = [];
+
+  const explicitSections = getNestedField(value, 'sections');
+  if (Array.isArray(explicitSections)) {
+    for (const sectionEntry of explicitSections) {
+      if (!isRecord(sectionEntry)) {
+        continue;
+      }
+
+      const section = toSectionType(
+        getNestedField(sectionEntry, 'type') ??
+          getNestedField(sectionEntry, 'section') ??
+          getNestedField(sectionEntry, 'name') ??
+          getNestedField(sectionEntry, 'title'),
+      );
+      const exercises = toExerciseCollection(sectionEntry);
+
+      if (exercises.length > 0) {
+        sources.push({ section, exercises });
+      }
+    }
+
+    if (sources.length > 0) {
+      return sources;
+    }
+  }
+
+  for (const section of WORKOUT_SECTION_ORDER) {
+    const sectionValue = getNestedField(value, section);
+    if (sectionValue === undefined) {
+      continue;
+    }
+
+    const exercises = toExerciseCollection(sectionValue);
+    if (exercises.length > 0) {
+      sources.push({ section, exercises });
+    }
+  }
+
+  if (sources.length > 0) {
+    return sources;
+  }
+
+  const fallbackExercises =
+    getNestedField(value, 'exercises') ??
+    getNestedField(value, 'loggedExercises') ??
+    getNestedField(value, 'movements');
+  const exercises = toExerciseCollection(fallbackExercises);
+  if (exercises.length > 0) {
+    return [
+      {
+        section: null,
+        exercises,
+      },
+    ];
+  }
+
+  return [];
+};
+
+const parseSessionSet = (
+  value: unknown,
+  fallbackSetNumber: number,
+  section: WorkoutTemplateSectionType | null,
+): Omit<ParsedSessionSet, 'exerciseName' | 'category' | 'muscleGroups' | 'equipment'> => {
+  if (!isRecord(value)) {
+    return {
+      setNumber: fallbackSetNumber,
+      weight: null,
+      reps: null,
+      completed: true,
+      skipped: false,
+      section,
+      notes: null,
+    };
+  }
+
+  const explicitSetNumber =
+    toPositiveInteger(getNestedField(value, 'setNumber')) ??
+    toPositiveInteger(getNestedField(value, 'set')) ??
+    toPositiveInteger(getNestedField(value, 'number'));
+  const indexSetNumber = toNonnegativeInteger(getNestedField(value, 'index'));
+
+  const setNumber = explicitSetNumber ?? (indexSetNumber !== null ? indexSetNumber + 1 : fallbackSetNumber);
+
+  const skipped = toBoolean(getNestedField(value, 'skipped')) ?? false;
+  const completed = skipped ? false : (toBoolean(getNestedField(value, 'completed')) ?? true);
+
+  const explicitSection = getNestedField(value, 'section') ?? getNestedField(value, 'sectionType');
+
+  return {
+    setNumber,
+    weight:
+      toNumber(getNestedField(value, 'weight')) ??
+      toNumber(getNestedField(value, 'load')) ??
+      toNumber(getNestedField(value, 'lbs')) ??
+      toNumber(getNestedField(value, 'pounds')) ??
+      toNumber(getNestedField(value, 'kg')),
+    reps:
+      toNonnegativeInteger(getNestedField(value, 'reps')) ??
+      toNonnegativeInteger(getNestedField(value, 'repCount')) ??
+      toNonnegativeInteger(getNestedField(value, 'count')),
+    completed,
+    skipped,
+    section: explicitSection !== undefined ? toSectionType(explicitSection) : section,
+    notes: normalizeText(getNestedField(value, 'notes')),
+  };
+};
+
+const parseSessionExerciseSets = (
+  value: unknown,
+  fallbackSection: WorkoutTemplateSectionType | null,
+): ParsedSessionSet[] => {
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  const exerciseName =
+    normalizeText(getNestedField(value, 'name')) ??
+    normalizeText(getNestedField(value, 'exerciseName')) ??
+    normalizeText(getNestedField(value, 'exercise')) ??
+    normalizeText(getNestedField(value, 'movement'));
+
+  if (!exerciseName) {
+    return [];
+  }
+
+  const category = toExerciseCategory(getNestedField(value, 'category'));
+  const muscleGroups = toStringArray(
+    getNestedField(value, 'muscleGroups') ??
+      getNestedField(value, 'muscles') ??
+      getNestedField(value, 'targetMuscles'),
+  );
+  const equipment =
+    normalizeText(getNestedField(value, 'equipment')) ??
+    normalizeText(getNestedField(value, 'implement'));
+
+  const rawSets =
+    getNestedField(value, 'sets') ??
+    getNestedField(value, 'performedSets') ??
+    getNestedField(value, 'entries') ??
+    getNestedField(value, 'logs');
+
+  let setValues: unknown[] = [];
+  if (Array.isArray(rawSets)) {
+    setValues = rawSets;
+  } else if (isRecord(rawSets)) {
+    setValues = [rawSets];
+  }
+
+  if (setValues.length === 0) {
+    const directWeight =
+      toNumber(getNestedField(value, 'weight')) ??
+      toNumber(getNestedField(value, 'load')) ??
+      toNumber(getNestedField(value, 'lbs'));
+    const directReps = toNonnegativeInteger(getNestedField(value, 'reps'));
+
+    if (directWeight !== null || directReps !== null) {
+      setValues = [value];
+    } else {
+      const inferredSetCount =
+        toPositiveInteger(getNestedField(value, 'setCount')) ??
+        toPositiveInteger(getNestedField(value, 'sets'));
+
+      if (inferredSetCount !== null) {
+        setValues = Array.from({ length: inferredSetCount }, () => value);
+      }
+    }
+  }
+
+  return setValues.map((setEntry, index) => {
+    const parsedSet = parseSessionSet(setEntry, index + 1, fallbackSection);
+
+    return {
+      exerciseName,
+      setNumber: parsedSet.setNumber,
+      weight: parsedSet.weight,
+      reps: parsedSet.reps,
+      completed: parsedSet.completed,
+      skipped: parsedSet.skipped,
+      section: parsedSet.section,
+      notes: parsedSet.notes,
+      category,
+      muscleGroups,
+      equipment,
+    };
+  });
+};
+
+const parseWorkoutSessionRecord = (
+  sessionsRoot: string,
+  filePath: string,
+  payload: unknown,
+): ParsedWorkoutSessionRecord | null => {
+  const sourceKey = relative(sessionsRoot, filePath).replace(/\\/gu, '/');
+  const fallbackName = toFallbackWorkoutName(filePath);
+  const objectPayload = isRecord(payload) ? payload : { exercises: payload };
+
+  const name =
+    normalizeText(getNestedField(objectPayload, 'name')) ??
+    normalizeText(getNestedField(objectPayload, 'workoutName')) ??
+    normalizeText(getNestedField(objectPayload, 'title')) ??
+    fallbackName;
+
+  const templateMatchName =
+    normalizeText(getNestedField(objectPayload, 'templateName')) ??
+    normalizeText(getNestedField(objectPayload, 'template')) ??
+    name;
+
+  const startedAtCandidate =
+    toTimestampMs(getNestedField(objectPayload, 'startedAt')) ??
+    toTimestampMs(getNestedField(objectPayload, 'started_at')) ??
+    toTimestampMs(getNestedField(objectPayload, 'startTime')) ??
+    toTimestampMs(getNestedField(objectPayload, 'started')) ??
+    toTimestampMs(getNestedField(objectPayload, 'start'));
+
+  const completedAtCandidate =
+    toTimestampMs(getNestedField(objectPayload, 'completedAt')) ??
+    toTimestampMs(getNestedField(objectPayload, 'completed_at')) ??
+    toTimestampMs(getNestedField(objectPayload, 'endTime')) ??
+    toTimestampMs(getNestedField(objectPayload, 'endedAt')) ??
+    toTimestampMs(getNestedField(objectPayload, 'finishedAt'));
+
+  const durationCandidate =
+    toDurationMs(getNestedField(objectPayload, 'duration')) ??
+    toDurationMs(getNestedField(objectPayload, 'durationMs')) ??
+    toDurationMs(getNestedField(objectPayload, 'durationSeconds')) ??
+    toDurationMs(getNestedField(objectPayload, 'durationMinutes'));
+
+  const explicitDate =
+    toDateKey(getNestedField(objectPayload, 'date')) ??
+    toDateKey(getNestedField(objectPayload, 'day')) ??
+    toDateKey(getNestedField(objectPayload, 'sessionDate')) ??
+    DAILY_FILENAME_PATTERN.exec(basename(filePath))?.[1] ??
+    null;
+
+  let startedAt =
+    startedAtCandidate ??
+    (explicitDate ? toTimestampMs(`${explicitDate}${SESSION_TIMELESS_FALLBACK_SUFFIX}`) : null);
+  let completedAt = completedAtCandidate;
+
+  if (startedAt === null && completedAt !== null && durationCandidate !== null) {
+    startedAt = completedAt - durationCandidate;
+  }
+
+  if (startedAt === null) {
+    return null;
+  }
+
+  if (completedAt === null) {
+    completedAt = durationCandidate !== null ? startedAt + durationCandidate : startedAt;
+  }
+
+  if (completedAt < startedAt) {
+    completedAt = startedAt;
+  }
+
+  const duration = durationCandidate ?? Math.max(completedAt - startedAt, 0);
+  const date = explicitDate ?? new Date(startedAt).toISOString().slice(0, 10);
+
+  const sectionSources = extractSessionSectionSources(objectPayload);
+  const sets = sectionSources.flatMap((sectionSource) =>
+    sectionSource.exercises.flatMap((exercise) =>
+      parseSessionExerciseSets(exercise, sectionSource.section),
+    ),
+  );
+
+  return {
+    sourceKey,
+    name,
+    templateMatchName,
+    date,
+    startedAt,
+    completedAt,
+    duration,
+    sets,
+  };
+};
+
+const loadWorkoutSessionRecords = async (
+  dataRoot: string,
+  logger: Logger,
+): Promise<ParsedWorkoutSessionRecord[]> => {
+  const sessionsRoot = join(dataRoot, DEFAULT_WORKOUT_SESSION_SUBPATH);
+
+  let files: string[];
+  try {
+    files = await listJsonFiles(sessionsRoot);
+  } catch (error) {
+    logger.warn(`Workout session directory not found or unreadable at ${sessionsRoot}: ${String(error)}`);
+    return [];
+  }
+
+  const sortedFiles = [...files].sort((left, right) => left.localeCompare(right));
+  const records: ParsedWorkoutSessionRecord[] = [];
+
+  for (const filePath of sortedFiles) {
+    try {
+      const payload = await readJson(filePath);
+      const record = parseWorkoutSessionRecord(sessionsRoot, filePath, payload);
+      if (!record) {
+        logger.warn(`Skipping workout session with incomplete timing data: ${filePath}`);
+        continue;
+      }
+
+      records.push(record);
+    } catch (error) {
+      logger.warn(`Skipping unreadable workout session file ${filePath}: ${String(error)}`);
+    }
+  }
+
+  return records;
+};
+
+const buildExerciseLookup = (
+  rows: Array<{ id: string; name: string; userId: string | null }>,
+  userId: string,
+): Map<string, ExerciseLookupEntry> => {
+  const lookup = new Map<string, ExerciseLookupEntry>();
+
+  for (const row of rows) {
+    const key = normalizeLookupKey(row.name);
+    const existing = lookup.get(key);
+
+    if (!existing) {
+      lookup.set(key, {
+        id: row.id,
+        userId: row.userId,
+      });
+      continue;
+    }
+
+    if (existing.userId === null && row.userId === userId) {
+      lookup.set(key, {
+        id: row.id,
+        userId: row.userId,
+      });
+    }
+  }
+
+  return lookup;
+};
+
+const toExerciseDefaults = (set: {
+  category: ExerciseCategory | null;
+  muscleGroups: string[];
+  equipment: string | null;
+}): ExerciseCreateDefaults => ({
+  category: set.category ?? 'compound',
+  muscleGroups: set.muscleGroups.length > 0 ? set.muscleGroups : ['full body'],
+  equipment: set.equipment ?? 'bodyweight',
+});
+
+const mergeExerciseDefaults = (
+  current: ExerciseCreateDefaults,
+  incoming: ExerciseCreateDefaults,
+): ExerciseCreateDefaults => ({
+  category: current.category === 'compound' ? incoming.category : current.category,
+  muscleGroups: Array.from(new Set([...current.muscleGroups, ...incoming.muscleGroups])),
+  equipment: current.equipment === 'bodyweight' ? incoming.equipment : current.equipment,
+});
+
+const collectExerciseDefaults = (
+  templates: ParsedWorkoutTemplateRecord[],
+  sessions: ParsedWorkoutSessionRecord[],
+): Map<string, { displayName: string; defaults: ExerciseCreateDefaults }> => {
+  const requirements = new Map<string, { displayName: string; defaults: ExerciseCreateDefaults }>();
+
+  const register = (
+    exerciseName: string,
+    metadata: {
+      category: ExerciseCategory | null;
+      muscleGroups: string[];
+      equipment: string | null;
+    },
+  ) => {
+    const key = normalizeLookupKey(exerciseName);
+    const incomingDefaults = toExerciseDefaults(metadata);
+    const existing = requirements.get(key);
+
+    if (!existing) {
+      requirements.set(key, {
+        displayName: exerciseName,
+        defaults: incomingDefaults,
+      });
+      return;
+    }
+
+    requirements.set(key, {
+      displayName: existing.displayName,
+      defaults: mergeExerciseDefaults(existing.defaults, incomingDefaults),
+    });
+  };
+
+  for (const template of templates) {
+    for (const exercise of template.exercises) {
+      register(exercise.name, {
+        category: exercise.category,
+        muscleGroups: exercise.muscleGroups,
+        equipment: exercise.equipment,
+      });
+    }
+  }
+
+  for (const session of sessions) {
+    for (const set of session.sets) {
+      register(set.exerciseName, {
+        category: set.category,
+        muscleGroups: set.muscleGroups,
+        equipment: set.equipment,
+      });
+    }
+  }
+
+  return requirements;
+};
+
+export const migrateWorkoutTemplatesAndSessions = async ({
+  userId,
+  dataRoot = DEFAULT_STATIC_DATA_ROOT,
+  logger = console,
+}: MigrationOptions): Promise<WorkoutMigrationSummary> => {
+  const resolvedDataRoot = resolve(dataRoot);
+  const [templateRecords, sessionRecords] = await Promise.all([
+    loadWorkoutTemplateRecords(resolvedDataRoot, logger),
+    loadWorkoutSessionRecords(resolvedDataRoot, logger),
+  ]);
+
+  const { db } = await import('../db/index.js');
+
+  const existingExerciseRows = db
+    .select({
+      id: exercises.id,
+      name: exercises.name,
+      userId: exercises.userId,
+    })
+    .from(exercises)
+    .where(or(eq(exercises.userId, userId), isNull(exercises.userId)))
+    .all();
+
+  const exerciseLookup = buildExerciseLookup(existingExerciseRows, userId);
+  const requiredExerciseDefaults = collectExerciseDefaults(templateRecords, sessionRecords);
+
+  let createdExercises = 0;
+  for (const [lookupKey, requirement] of [...requiredExerciseDefaults.entries()].sort((a, b) =>
+    a[0].localeCompare(b[0]),
+  )) {
+    if (exerciseLookup.has(lookupKey)) {
+      continue;
+    }
+
+    const exerciseId = toStableMigrationId('migrated-exercise', userId, lookupKey);
+    db.insert(exercises)
+      .values({
+        id: exerciseId,
+        userId,
+        name: requirement.displayName,
+        category: requirement.defaults.category,
+        muscleGroups: requirement.defaults.muscleGroups,
+        equipment: requirement.defaults.equipment,
+        instructions: null,
+      })
+      .onConflictDoNothing({
+        target: [exercises.id],
+      })
+      .run();
+
+    exerciseLookup.set(lookupKey, {
+      id: exerciseId,
+      userId,
+    });
+    createdExercises += 1;
+  }
+
+  const templateNameLookup = new Map<string, string>();
+  const summary: WorkoutMigrationSummary = {
+    processedTemplates: 0,
+    failedTemplates: 0,
+    processedSessions: 0,
+    failedSessions: 0,
+    totalTemplateExercises: 0,
+    totalSessionSets: 0,
+    createdExercises,
+  };
+
+  for (const template of templateRecords) {
+    const templateId = toStableMigrationId('migrated-template', userId, template.sourceKey);
+
+    try {
+      const insertedExerciseCount = db.transaction((tx) => {
+        tx.insert(workoutTemplates)
+          .values({
+            id: templateId,
+            userId,
+            name: template.name,
+            description: template.description,
+            tags: template.tags,
+          })
+          .onConflictDoUpdate({
+            target: [workoutTemplates.id],
+            set: {
+              name: template.name,
+              description: template.description,
+              tags: template.tags,
+              updatedAt: Date.now(),
+            },
+          })
+          .run();
+
+        tx.delete(templateExercises).where(eq(templateExercises.templateId, templateId)).run();
+
+        const rows = template.exercises.flatMap((exercise) => {
+          const exerciseLookupEntry = exerciseLookup.get(normalizeLookupKey(exercise.name));
+          if (!exerciseLookupEntry) {
+            logger.warn(`Template "${template.name}" references missing exercise "${exercise.name}"; skipping.`);
+            return [];
+          }
+
+          return [
+            {
+              id: toStableMigrationId(
+                'migrated-template-exercise',
+                templateId,
+                exerciseLookupEntry.id,
+                exercise.section,
+                String(exercise.orderIndex),
+              ),
+              templateId,
+              exerciseId: exerciseLookupEntry.id,
+              orderIndex: exercise.orderIndex,
+              sets: exercise.sets,
+              repsMin: exercise.repsMin,
+              repsMax: exercise.repsMax,
+              tempo: exercise.tempo,
+              restSeconds: exercise.restSeconds,
+              supersetGroup: exercise.supersetGroup,
+              section: exercise.section,
+              notes: exercise.notes,
+              cues: exercise.cues.length > 0 ? exercise.cues : null,
+            },
+          ];
+        });
+
+        if (rows.length > 0) {
+          tx.insert(templateExercises).values(rows).run();
+        }
+
+        return rows.length;
+      });
+
+      summary.processedTemplates += 1;
+      summary.totalTemplateExercises += insertedExerciseCount;
+
+      const templateNameKey = normalizeLookupKey(template.name);
+      if (!templateNameLookup.has(templateNameKey)) {
+        templateNameLookup.set(templateNameKey, templateId);
+      }
+
+      logger.info(`Imported workout template "${template.name}" with ${insertedExerciseCount} exercise(s).`);
+    } catch (error) {
+      summary.failedTemplates += 1;
+      logger.error(`Failed importing workout template "${template.name}": ${String(error)}`);
+    }
+  }
+
+  for (const session of sessionRecords) {
+    const sessionId = toStableMigrationId('migrated-session', userId, session.sourceKey);
+
+    try {
+      const insertedSetCount = db.transaction((tx) => {
+        const templateId =
+          templateNameLookup.get(normalizeLookupKey(session.templateMatchName)) ??
+          templateNameLookup.get(normalizeLookupKey(session.name)) ??
+          null;
+
+        tx.insert(workoutSessions)
+          .values({
+            id: sessionId,
+            userId,
+            templateId,
+            name: session.name,
+            date: session.date,
+            status: 'completed',
+            startedAt: session.startedAt,
+            completedAt: session.completedAt,
+            duration: session.duration,
+            feedback: null,
+            notes: null,
+          })
+          .onConflictDoUpdate({
+            target: [workoutSessions.id],
+            set: {
+              templateId,
+              name: session.name,
+              date: session.date,
+              status: 'completed',
+              startedAt: session.startedAt,
+              completedAt: session.completedAt,
+              duration: session.duration,
+              feedback: null,
+              notes: null,
+              updatedAt: Date.now(),
+            },
+          })
+          .run();
+
+        tx.delete(sessionSets).where(eq(sessionSets.sessionId, sessionId)).run();
+
+        const highestSetNumberByExerciseId = new Map<string, number>();
+        const rows = session.sets.flatMap((set, index) => {
+          const exerciseLookupEntry = exerciseLookup.get(normalizeLookupKey(set.exerciseName));
+          if (!exerciseLookupEntry) {
+            logger.warn(
+              `Workout session "${session.name}" references missing exercise "${set.exerciseName}"; set skipped.`,
+            );
+            return [];
+          }
+
+          const currentHighest = highestSetNumberByExerciseId.get(exerciseLookupEntry.id) ?? 0;
+          const normalizedSetNumber =
+            set.setNumber > currentHighest ? set.setNumber : currentHighest + 1;
+
+          highestSetNumberByExerciseId.set(exerciseLookupEntry.id, normalizedSetNumber);
+
+          return [
+            {
+              id: toStableMigrationId(
+                'migrated-session-set',
+                sessionId,
+                exerciseLookupEntry.id,
+                String(normalizedSetNumber),
+                String(index),
+              ),
+              sessionId,
+              exerciseId: exerciseLookupEntry.id,
+              setNumber: normalizedSetNumber,
+              weight: set.weight,
+              reps: set.reps,
+              completed: set.skipped ? false : set.completed,
+              skipped: set.skipped,
+              section: set.section,
+              notes: set.notes,
+            },
+          ];
+        });
+
+        if (rows.length > 0) {
+          tx.insert(sessionSets).values(rows).run();
+        }
+
+        return rows.length;
+      });
+
+      summary.processedSessions += 1;
+      summary.totalSessionSets += insertedSetCount;
+      logger.info(`Imported workout session "${session.name}" with ${insertedSetCount} set(s).`);
+    } catch (error) {
+      summary.failedSessions += 1;
+      logger.error(`Failed importing workout session "${session.name}": ${String(error)}`);
+    }
+  }
+
+  logger.info(
+    `Workout migration summary: templates ${summary.processedTemplates} (failed ${summary.failedTemplates}), sessions ${summary.processedSessions} (failed ${summary.failedSessions}), template exercises ${summary.totalTemplateExercises}, session sets ${summary.totalSessionSets}, created exercises ${summary.createdExercises}.`,
+  );
+
+  return summary;
+};
+
 export const migrateDailyLogsAndBodyWeight = async ({
   userId,
   dataRoot = DEFAULT_STATIC_DATA_ROOT,
@@ -1143,6 +2363,11 @@ export const parseCliArgs = (args: string[]): CliOptions => {
 const runCli = async () => {
   const options = parseCliArgs(process.argv.slice(2));
   await migrateDailyLogsAndBodyWeight({
+    userId: options.userId,
+    dataRoot: options.dataRoot,
+    logger: console,
+  });
+  await migrateWorkoutTemplatesAndSessions({
     userId: options.userId,
     dataRoot: options.dataRoot,
     logger: console,

--- a/apps/api/src/scripts/run-migration.test.ts
+++ b/apps/api/src/scripts/run-migration.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_STATIC_DATA_ROOT } from './migrate-static.js';
+import {
+  collectVerificationSummary,
+  parseRunMigrationCliArgs,
+  runMigration,
+  type RunMigrationDependencies,
+} from './run-migration.js';
+
+type CapturedLogger = {
+  infoMessages: string[];
+  warnMessages: string[];
+  errorMessages: string[];
+  logger: {
+    info: (...args: unknown[]) => void;
+    warn: (...args: unknown[]) => void;
+    error: (...args: unknown[]) => void;
+  };
+};
+
+const buildLogger = (): CapturedLogger => {
+  const infoMessages: string[] = [];
+  const warnMessages: string[] = [];
+  const errorMessages: string[] = [];
+
+  return {
+    infoMessages,
+    warnMessages,
+    errorMessages,
+    logger: {
+      info: (...args: unknown[]) => {
+        infoMessages.push(args.map((value) => String(value)).join(' '));
+      },
+      warn: (...args: unknown[]) => {
+        warnMessages.push(args.map((value) => String(value)).join(' '));
+      },
+      error: (...args: unknown[]) => {
+        errorMessages.push(args.map((value) => String(value)).join(' '));
+      },
+    },
+  };
+};
+
+const createMockDependencies = (): RunMigrationDependencies => {
+  const mockPrepare = vi.fn((query: string) => ({
+    get: () => {
+      if (query.includes('MIN(date)')) {
+        return { minDate: '2026-03-05', maxDate: '2026-03-07' };
+      }
+
+      if (query.includes('FROM foods')) {
+        return { count: 4 };
+      }
+
+      if (query.includes('FROM nutrition_logs WHERE')) {
+        return { count: 2 };
+      }
+
+      if (query.includes('FROM body_weight')) {
+        return { count: 3 };
+      }
+
+      if (query.includes('FROM workout_templates')) {
+        return { count: 2 };
+      }
+
+      if (query.includes('FROM workout_sessions')) {
+        return { count: 5 };
+      }
+
+      return {};
+    },
+  }));
+
+  return {
+    migrateFoodsDatabase: vi.fn().mockResolvedValue({
+      inserted: 2,
+      skipped: 1,
+      lastUsedAtUpdated: 1,
+    }),
+    migrateDailyLogsAndBodyWeight: vi.fn().mockResolvedValue({
+      processedDays: 3,
+      failedDays: 0,
+      dailyLogDays: 2,
+      bodyWeightFileEntries: 2,
+      totalMeals: 3,
+      totalHabitEntries: 4,
+      totalWeightEntries: 3,
+    }),
+    migrateWorkoutTemplatesAndSessions: vi.fn().mockResolvedValue({
+      processedTemplates: 2,
+      failedTemplates: 0,
+      processedSessions: 2,
+      failedSessions: 0,
+      totalTemplateExercises: 6,
+      totalSessionSets: 10,
+      createdExercises: 1,
+    }),
+    sqlite: {
+      exec: vi.fn(),
+      prepare: mockPrepare,
+    },
+  };
+};
+
+describe('run-migration script', () => {
+  it('parses CLI flags with defaults and optional step values', () => {
+    expect(parseRunMigrationCliArgs(['--user', 'user-1'])).toEqual({
+      userId: 'user-1',
+      dataRoot: DEFAULT_STATIC_DATA_ROOT,
+      dryRun: false,
+      step: null,
+    });
+
+    expect(
+      parseRunMigrationCliArgs([
+        '--user',
+        'user-2',
+        '--source',
+        '/tmp/static-data',
+        '--dry-run',
+        '--step',
+        'daily',
+      ]),
+    ).toEqual({
+      userId: 'user-2',
+      dataRoot: '/tmp/static-data',
+      dryRun: true,
+      step: 'daily',
+    });
+  });
+
+  it('rejects invalid CLI arguments', () => {
+    expect(() => parseRunMigrationCliArgs([])).toThrow('Missing required --user <userId> argument.');
+    expect(() => parseRunMigrationCliArgs(['--user'])).toThrow('Missing value for --user.');
+    expect(() => parseRunMigrationCliArgs(['--user', 'abc', '--step'])).toThrow(
+      'Missing value for --step.',
+    );
+    expect(() => parseRunMigrationCliArgs(['--user', 'abc', '--step', 'unknown'])).toThrow(
+      'Invalid --step value "unknown".',
+    );
+    expect(() => parseRunMigrationCliArgs(['--user', 'abc', '--nope'])).toThrow(
+      'Unknown argument: --nope.',
+    );
+  });
+
+  it('runs all steps in order and prints summaries with verification', async () => {
+    const dependencies = createMockDependencies();
+    const captured = buildLogger();
+
+    const result = await runMigration(
+      {
+        userId: 'user-1',
+        dataRoot: '/tmp/static-data',
+        dryRun: false,
+        step: null,
+      },
+      captured.logger,
+      dependencies,
+    );
+
+    expect(result.stepsRun).toEqual(['foods', 'daily', 'workouts']);
+    expect(result.verification).toEqual({
+      foods: 4,
+      nutritionLogs: 2,
+      bodyWeight: 3,
+      workoutTemplates: 2,
+      workoutSessions: 5,
+      nutritionMinDate: '2026-03-05',
+      nutritionMaxDate: '2026-03-07',
+    });
+
+    expect(dependencies.migrateFoodsDatabase).toHaveBeenCalledTimes(1);
+    expect(dependencies.migrateDailyLogsAndBodyWeight).toHaveBeenCalledTimes(1);
+    expect(dependencies.migrateWorkoutTemplatesAndSessions).toHaveBeenCalledTimes(1);
+
+    const foodsOrder = vi.mocked(dependencies.migrateFoodsDatabase).mock.invocationCallOrder[0];
+    const dailyOrder = vi.mocked(dependencies.migrateDailyLogsAndBodyWeight).mock.invocationCallOrder[0];
+    const workoutsOrder = vi.mocked(dependencies.migrateWorkoutTemplatesAndSessions).mock.invocationCallOrder[0];
+
+    expect(foodsOrder).toBeLessThan(dailyOrder);
+    expect(dailyOrder).toBeLessThan(workoutsOrder);
+    expect(captured.infoMessages.some((line) => line.includes('Foods: 2 imported, 1 skipped'))).toBe(true);
+    expect(captured.infoMessages.some((line) => line.includes('Daily logs: 3 days processed'))).toBe(true);
+    expect(captured.infoMessages.some((line) => line.includes('Workout templates: 2 imported'))).toBe(true);
+    expect(captured.infoMessages.some((line) => line.includes('Verification results'))).toBe(true);
+  });
+
+  it('runs only a selected step when --step is provided', async () => {
+    const dependencies = createMockDependencies();
+    const captured = buildLogger();
+
+    const result = await runMigration(
+      {
+        userId: 'user-1',
+        dataRoot: '/tmp/static-data',
+        dryRun: false,
+        step: 'workouts',
+      },
+      captured.logger,
+      dependencies,
+    );
+
+    expect(result.stepsRun).toEqual(['workouts']);
+    expect(result.foodsSummary).toBeNull();
+    expect(result.dailySummary).toBeNull();
+    expect(result.workoutsSummary).not.toBeNull();
+
+    expect(dependencies.migrateFoodsDatabase).not.toHaveBeenCalled();
+    expect(dependencies.migrateDailyLogsAndBodyWeight).not.toHaveBeenCalled();
+    expect(dependencies.migrateWorkoutTemplatesAndSessions).toHaveBeenCalledTimes(1);
+  });
+
+  it('collects verification counts from explicit SQL queries', () => {
+    const dependencies = createMockDependencies();
+
+    const verification = collectVerificationSummary('user-1', dependencies.sqlite);
+
+    expect(verification).toEqual({
+      foods: 4,
+      nutritionLogs: 2,
+      bodyWeight: 3,
+      workoutTemplates: 2,
+      workoutSessions: 5,
+      nutritionMinDate: '2026-03-05',
+      nutritionMaxDate: '2026-03-07',
+    });
+  });
+
+  it('wraps writes in BEGIN/ROLLBACK for --dry-run and rolls back on failure', async () => {
+    const dependencies = createMockDependencies();
+    const captured = buildLogger();
+
+    vi.mocked(dependencies.migrateFoodsDatabase).mockRejectedValueOnce(new Error('simulated failure'));
+
+    await expect(
+      runMigration(
+        {
+          userId: 'user-1',
+          dataRoot: '/tmp/static-data',
+          dryRun: true,
+          step: 'foods',
+        },
+        captured.logger,
+        dependencies,
+      ),
+    ).rejects.toThrow('simulated failure');
+
+    expect(dependencies.sqlite.exec).toHaveBeenNthCalledWith(1, 'BEGIN');
+    expect(dependencies.sqlite.exec).toHaveBeenNthCalledWith(2, 'ROLLBACK');
+  });
+});

--- a/apps/api/src/scripts/run-migration.ts
+++ b/apps/api/src/scripts/run-migration.ts
@@ -24,9 +24,7 @@ export type RunMigrationCliOptions = {
   step: MigrationStep | null;
 };
 
-type StatementLike = {
-  get: (...parameters: unknown[]) => unknown;
-};
+type StatementLike = Pick<ReturnType<typeof sqlite.prepare>, 'get'>;
 
 type SqliteLike = {
   exec: (source: string) => unknown;
@@ -59,11 +57,16 @@ export type RunMigrationResult = {
   verification: VerificationSummary;
 };
 
+const sqliteAdapter: SqliteLike = {
+  exec: (source) => sqlite.exec(source),
+  prepare: (source) => sqlite.prepare(source),
+};
+
 const defaultDependencies: RunMigrationDependencies = {
   migrateFoodsDatabase,
   migrateDailyLogsAndBodyWeight,
   migrateWorkoutTemplatesAndSessions,
-  sqlite: sqlite as unknown as SqliteLike,
+  sqlite: sqliteAdapter,
 };
 
 const usage = 'Usage: npx tsx src/scripts/run-migration.ts --user <userId> [--source <path>] [--dry-run] [--step foods|daily|workouts]';
@@ -158,7 +161,7 @@ const toDateOrNull = (value: unknown): string | null => (typeof value === 'strin
 
 export const collectVerificationSummary = (
   userId: string,
-  sqliteDatabase: Pick<SqliteLike, 'prepare'> = sqlite as unknown as Pick<SqliteLike, 'prepare'>,
+  sqliteDatabase: Pick<SqliteLike, 'prepare'> = sqliteAdapter,
 ): VerificationSummary => {
   const foodsCountRow = sqliteDatabase
     .prepare('SELECT COUNT(*) AS count FROM foods WHERE userId = ?')

--- a/apps/api/src/scripts/run-migration.ts
+++ b/apps/api/src/scripts/run-migration.ts
@@ -1,0 +1,323 @@
+import { pathToFileURL } from 'node:url';
+
+import { sqlite } from '../db/index.js';
+import {
+  DEFAULT_STATIC_DATA_ROOT,
+  migrateDailyLogsAndBodyWeight,
+  migrateFoodsDatabase,
+  migrateWorkoutTemplatesAndSessions,
+  type FoodsMigrationSummary,
+  type MigrationSummary,
+  type WorkoutMigrationSummary,
+} from './migrate-static.js';
+
+type Logger = Pick<Console, 'info' | 'warn' | 'error'>;
+
+export const MIGRATION_STEPS = ['foods', 'daily', 'workouts'] as const;
+
+export type MigrationStep = (typeof MIGRATION_STEPS)[number];
+
+export type RunMigrationCliOptions = {
+  userId: string;
+  dataRoot: string;
+  dryRun: boolean;
+  step: MigrationStep | null;
+};
+
+type StatementLike = {
+  get: (...parameters: unknown[]) => unknown;
+};
+
+type SqliteLike = {
+  exec: (source: string) => unknown;
+  prepare: (source: string) => StatementLike;
+};
+
+export type RunMigrationDependencies = {
+  migrateFoodsDatabase: typeof migrateFoodsDatabase;
+  migrateDailyLogsAndBodyWeight: typeof migrateDailyLogsAndBodyWeight;
+  migrateWorkoutTemplatesAndSessions: typeof migrateWorkoutTemplatesAndSessions;
+  sqlite: SqliteLike;
+};
+
+export type VerificationSummary = {
+  foods: number;
+  nutritionLogs: number;
+  bodyWeight: number;
+  workoutTemplates: number;
+  workoutSessions: number;
+  nutritionMinDate: string | null;
+  nutritionMaxDate: string | null;
+};
+
+export type RunMigrationResult = {
+  dryRun: boolean;
+  stepsRun: MigrationStep[];
+  foodsSummary: FoodsMigrationSummary | null;
+  dailySummary: MigrationSummary | null;
+  workoutsSummary: WorkoutMigrationSummary | null;
+  verification: VerificationSummary;
+};
+
+const defaultDependencies: RunMigrationDependencies = {
+  migrateFoodsDatabase,
+  migrateDailyLogsAndBodyWeight,
+  migrateWorkoutTemplatesAndSessions,
+  sqlite: sqlite as unknown as SqliteLike,
+};
+
+const usage = 'Usage: npx tsx src/scripts/run-migration.ts --user <userId> [--source <path>] [--dry-run] [--step foods|daily|workouts]';
+
+const isMigrationStep = (value: string): value is MigrationStep =>
+  (MIGRATION_STEPS as readonly string[]).includes(value);
+
+export const parseRunMigrationCliArgs = (args: string[]): RunMigrationCliOptions => {
+  let userId: string | undefined;
+  let dataRoot = DEFAULT_STATIC_DATA_ROOT;
+  let dryRun = false;
+  let step: MigrationStep | null = null;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const current = args[index];
+
+    if (current === '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+
+    if (current === '--user') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('--')) {
+        throw new Error(`Missing value for --user. ${usage}`);
+      }
+
+      userId = next;
+      index += 1;
+      continue;
+    }
+
+    if (current === '--source') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('--')) {
+        throw new Error(`Missing value for --source. ${usage}`);
+      }
+
+      dataRoot = next;
+      index += 1;
+      continue;
+    }
+
+    if (current === '--step') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('--')) {
+        throw new Error(`Missing value for --step. ${usage}`);
+      }
+
+      if (!isMigrationStep(next)) {
+        throw new Error(`Invalid --step value "${next}". Expected one of: ${MIGRATION_STEPS.join(', ')}.`);
+      }
+
+      step = next;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${current}. ${usage}`);
+  }
+
+  if (!userId) {
+    throw new Error(`Missing required --user <userId> argument. ${usage}`);
+  }
+
+  return {
+    userId,
+    dataRoot,
+    dryRun,
+    step,
+  };
+};
+
+const toCount = (value: unknown): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
+};
+
+const toDateOrNull = (value: unknown): string | null => (typeof value === 'string' && value.length > 0 ? value : null);
+
+export const collectVerificationSummary = (
+  userId: string,
+  sqliteDatabase: Pick<SqliteLike, 'prepare'> = sqlite as unknown as Pick<SqliteLike, 'prepare'>,
+): VerificationSummary => {
+  const foodsCountRow = sqliteDatabase
+    .prepare('SELECT COUNT(*) AS count FROM foods WHERE userId = ?')
+    .get(userId) as { count?: unknown } | undefined;
+  const nutritionCountRow = sqliteDatabase
+    .prepare('SELECT COUNT(*) AS count FROM nutrition_logs WHERE userId = ?')
+    .get(userId) as { count?: unknown } | undefined;
+  const bodyWeightCountRow = sqliteDatabase
+    .prepare('SELECT COUNT(*) AS count FROM body_weight WHERE userId = ?')
+    .get(userId) as { count?: unknown } | undefined;
+  const templateCountRow = sqliteDatabase
+    .prepare('SELECT COUNT(*) AS count FROM workout_templates WHERE userId = ?')
+    .get(userId) as { count?: unknown } | undefined;
+  const sessionCountRow = sqliteDatabase
+    .prepare('SELECT COUNT(*) AS count FROM workout_sessions WHERE userId = ?')
+    .get(userId) as { count?: unknown } | undefined;
+  const dateRangeRow = sqliteDatabase
+    .prepare('SELECT MIN(date) AS minDate, MAX(date) AS maxDate FROM nutrition_logs WHERE userId = ?')
+    .get(userId) as { minDate?: unknown; maxDate?: unknown } | undefined;
+
+  return {
+    foods: toCount(foodsCountRow?.count),
+    nutritionLogs: toCount(nutritionCountRow?.count),
+    bodyWeight: toCount(bodyWeightCountRow?.count),
+    workoutTemplates: toCount(templateCountRow?.count),
+    workoutSessions: toCount(sessionCountRow?.count),
+    nutritionMinDate: toDateOrNull(dateRangeRow?.minDate),
+    nutritionMaxDate: toDateOrNull(dateRangeRow?.maxDate),
+  };
+};
+
+export const printVerificationTable = (summary: VerificationSummary, logger: Logger = console) => {
+  const rows: Array<[string, string]> = [
+    ['foods', String(summary.foods)],
+    ['nutrition_logs', String(summary.nutritionLogs)],
+    ['body_weight', String(summary.bodyWeight)],
+    ['workout_templates', String(summary.workoutTemplates)],
+    ['workout_sessions', String(summary.workoutSessions)],
+    [
+      'nutrition_logs.date range',
+      summary.nutritionMinDate || summary.nutritionMaxDate
+        ? `${summary.nutritionMinDate ?? 'n/a'} -> ${summary.nutritionMaxDate ?? 'n/a'}`
+        : 'n/a',
+    ],
+  ];
+
+  const maxLabelLength = rows.reduce((current, [label]) => Math.max(current, label.length), 0);
+
+  logger.info('Verification results');
+  for (const [label, value] of rows) {
+    logger.info(`${label.padEnd(maxLabelLength, ' ')} : ${value}`);
+  }
+};
+
+const printFoodsSummary = (summary: FoodsMigrationSummary, logger: Logger) => {
+  logger.info(`Foods: ${summary.inserted} imported, ${summary.skipped} skipped`);
+};
+
+const printDailySummary = (summary: MigrationSummary, logger: Logger) => {
+  logger.info(
+    `Daily logs: ${summary.processedDays} days processed, ${summary.totalMeals} meals, ${summary.totalHabitEntries} habit entries`,
+  );
+  logger.info(`Body weight: ${summary.totalWeightEntries} entries`);
+};
+
+const printWorkoutSummary = (summary: WorkoutMigrationSummary, logger: Logger) => {
+  logger.info(`Workout templates: ${summary.processedTemplates} imported`);
+  logger.info(`Workout sessions: ${summary.processedSessions} imported, ${summary.totalSessionSets} total sets`);
+};
+
+export const runMigration = async (
+  options: RunMigrationCliOptions,
+  logger: Logger = console,
+  dependencies: RunMigrationDependencies = defaultDependencies,
+): Promise<RunMigrationResult> => {
+  const stepsRun = options.step ? [options.step] : [...MIGRATION_STEPS];
+
+  let openedTransaction = false;
+  if (options.dryRun) {
+    dependencies.sqlite.exec('BEGIN');
+    openedTransaction = true;
+    logger.info('Dry run enabled; all database writes will be rolled back after verification.');
+  }
+
+  let foodsSummary: FoodsMigrationSummary | null = null;
+  let dailySummary: MigrationSummary | null = null;
+  let workoutsSummary: WorkoutMigrationSummary | null = null;
+
+  try {
+    for (const step of stepsRun) {
+      if (step === 'foods') {
+        foodsSummary = await dependencies.migrateFoodsDatabase({
+          userId: options.userId,
+          dataRoot: options.dataRoot,
+          logger,
+        });
+        printFoodsSummary(foodsSummary, logger);
+        continue;
+      }
+
+      if (step === 'daily') {
+        dailySummary = await dependencies.migrateDailyLogsAndBodyWeight({
+          userId: options.userId,
+          dataRoot: options.dataRoot,
+          logger,
+        });
+        printDailySummary(dailySummary, logger);
+        continue;
+      }
+
+      workoutsSummary = await dependencies.migrateWorkoutTemplatesAndSessions({
+        userId: options.userId,
+        dataRoot: options.dataRoot,
+        logger,
+      });
+      printWorkoutSummary(workoutsSummary, logger);
+    }
+
+    const verification = collectVerificationSummary(options.userId, dependencies.sqlite);
+    printVerificationTable(verification, logger);
+
+    if (options.dryRun) {
+      logger.info('Dry run verification shown above; no changes will be persisted.');
+    } else {
+      logger.info('Migration run completed.');
+    }
+
+    return {
+      dryRun: options.dryRun,
+      stepsRun,
+      foodsSummary,
+      dailySummary,
+      workoutsSummary,
+      verification,
+    };
+  } finally {
+    if (openedTransaction) {
+      dependencies.sqlite.exec('ROLLBACK');
+      logger.info('Dry run rollback complete.');
+    }
+  }
+};
+
+const runCli = async () => {
+  const options = parseRunMigrationCliArgs(process.argv.slice(2));
+  await runMigration(options, console);
+};
+
+const isMainModule = () => {
+  if (!process.argv[1]) {
+    return false;
+  }
+
+  return import.meta.url === pathToFileURL(process.argv[1]).href;
+};
+
+if (isMainModule()) {
+  runCli().catch((error) => {
+    console.error(`Migration runner failed: ${String(error)}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
This PR adds a full static-data migration path for the API so a target user can import data from the legacy static app into Pulse’s database. It covers foods, daily logs (meals/habits/body weight), and workout templates plus completed sessions, with robust parsing for multiple legacy JSON shapes. The migration flow is built to be safely re-run by using deterministic IDs, upserts, and controlled replacement of child records where needed. It also introduces a dedicated migration runner with `--step` and `--dry-run` support plus built-in verification output to confirm row counts and date coverage after execution.

## Key Changes
- Added `migrate-static.ts` with three migration entry points:
  - foods import from `foods.json`
  - daily logs + body weight import from `daily/**` and `body-weight.json`
  - workout templates + session import from static workout JSON files
- Added resilient normalization/parsing for legacy schema variants (field aliases, nested shapes, mixed arrays/objects, time/date coercion, numeric/boolean coercion).
- Implemented dedupe/idempotency behavior:
  - stable migration IDs derived from source keys
  - `onConflict` upserts for core entities
  - explicit delete/reinsert for template/session child rows to prevent duplication drift
- Added automatic exercise creation when a migrated template/session references an exercise not already in user/global exercise catalogs.
- Added food dedupe by normalized `name|brand` and `lastUsedAt` backfill from existing meal usage history.
- Added `run-migration.ts` CLI runner to orchestrate steps in order (`foods -> daily -> workouts`), optionally run a single step, and print verification summaries.

## Technical Notes
- `--dry-run` is implemented as `BEGIN ... ROLLBACK` around writes, with rollback guaranteed in `finally`; verification queries still run before rollback to show expected outcomes.
- Daily body-weight data is merged from daily logs and `body-weight.json`; history file values overwrite same-date daily values.
- Missing references are handled non-fatally:
  - unknown foods are imported as meal items with `foodId = null` and warning logs
  - unknown habits are skipped with warning logs
- Workout import links sessions to templates by normalized template/workout name matching; if unmatched, session is still imported with `templateId = null`.
- Defaults are environment-specific unless overridden: migration source defaults to `DEFAULT_STATIC_DATA_ROOT`, and workout session discovery defaults to `workouts/2026/Q1` (override via `--source`).

## Commits

- `c3317a5 feat(api): add migration CLI runner with dry-run and verification`
- `0767761 feat(api): migrate foods database from static source`
- `c26fcc4 feat(api): migrate workout templates and session logs`
- `334cbd1 feat(api): add static daily logs and body weight migration script`

## Tasks

- **Migrate daily logs + body weight**: Parse static app daily JSON logs and body-weight.json, insert into DB
- **Migrate workout templates + session logs**: Parse static app workout templates and completed session JSONs, insert into DB
- **Migrate foods database**: Parse static app foods.json, insert into user's food database
- **Migration CLI runner + verification**: CLI command to run migration for a target user, verify data integrity

## Diff Stats

```
apps/api/src/scripts/migrate-static.test.ts |  853 +++++++++
 apps/api/src/scripts/migrate-static.ts      | 2583 +++++++++++++++++++++++++++
 apps/api/src/scripts/run-migration.test.ts  |  253 +++
 apps/api/src/scripts/run-migration.ts       |  323 ++++
 4 files changed, 4012 insertions(+)
```