### PR TITLE
Agent API

### DIFF
--- a/apps/api/src/__tests__/agent.test.ts
+++ b/apps/api/src/__tests__/agent.test.ts
@@ -1,0 +1,970 @@
+import { createHash } from 'node:crypto';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Shared in-memory state (hoisted so mocks can reference it)
+// ---------------------------------------------------------------------------
+
+type StoredUser = { id: string; username: string; passwordHash: string };
+type StoredAgentToken = {
+  id: string;
+  userId: string;
+  name: string;
+  tokenHash: string;
+  lastUsedAt: number | null;
+};
+type StoredFood = {
+  id: string;
+  userId: string;
+  name: string;
+  brand: string | null;
+  servingSize: string | null;
+  servingGrams: number | null;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  fiber: number | null;
+  sugar: number | null;
+  verified: boolean;
+  source: string | null;
+  notes: string | null;
+  lastUsedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+};
+type StoredExercise = {
+  id: string;
+  userId: string;
+  name: string;
+  category: string;
+};
+type StoredWorkoutTemplate = {
+  id: string;
+  userId: string;
+  name: string;
+  sections: Array<{ type: string; exercises: unknown[] }>;
+};
+type StoredWorkoutSession = {
+  id: string;
+  userId: string;
+  templateId: string | null;
+  name: string;
+  date: string;
+  status: string;
+  startedAt: number;
+  completedAt: number | null;
+  duration: number | null;
+  feedback: string | null;
+  notes: string | null;
+  sets: unknown[];
+};
+
+const testState = vi.hoisted(() => {
+  const users = new Map<string, StoredUser>();
+  const agentTokens = new Map<string, StoredAgentToken>();
+  const foods = new Map<string, StoredFood>();
+  const exercises = new Map<string, StoredExercise>();
+  const workoutTemplates = new Map<string, StoredWorkoutTemplate>();
+  const workoutSessions = new Map<string, StoredWorkoutSession>();
+
+  return {
+    users,
+    agentTokens,
+    foods,
+    exercises,
+    workoutTemplates,
+    workoutSessions,
+    reset() {
+      users.clear();
+      agentTokens.clear();
+      foods.clear();
+      exercises.clear();
+      workoutTemplates.clear();
+      workoutSessions.clear();
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Store mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../routes/auth/store.js', () => ({
+  createUser: vi.fn(
+    async ({
+      id,
+      username,
+      passwordHash,
+    }: {
+      id: string;
+      username: string;
+      passwordHash: string;
+    }) => {
+      testState.users.set(id, { id, username, passwordHash });
+      return { id, username, name: null };
+    },
+  ),
+  findUserByUsername: vi.fn(async (username: string) =>
+    [...testState.users.values()].find((u) => u.username === username),
+  ),
+}));
+
+vi.mock('../routes/agent-tokens/store.js', () => ({
+  createAgentToken: vi.fn(
+    async ({
+      id,
+      userId,
+      name,
+      tokenHash,
+    }: {
+      id: string;
+      userId: string;
+      name: string;
+      tokenHash: string;
+    }) => {
+      testState.agentTokens.set(id, { id, userId, name, tokenHash, lastUsedAt: null });
+      return { id, name };
+    },
+  ),
+  listAgentTokens: vi.fn(async () => []),
+  deleteAgentToken: vi.fn(async (id: string) => {
+    testState.agentTokens.delete(id);
+    return true;
+  }),
+}));
+
+vi.mock('../middleware/store.js', () => ({
+  findAgentTokenByHash: vi.fn(async (tokenHash: string) => {
+    const token = [...testState.agentTokens.values()].find(
+      (candidate) => candidate.tokenHash === tokenHash,
+    );
+    return token ? { id: token.id, userId: token.userId } : undefined;
+  }),
+  updateAgentTokenLastUsedAt: vi.fn(async (id: string) => {
+    const token = testState.agentTokens.get(id);
+    if (token) {
+      token.lastUsedAt = Date.now();
+    }
+  }),
+}));
+
+vi.mock('../routes/agent/store.js', () => ({
+  searchFoodsByName: vi.fn(async (userId: string, query: string | undefined, limit: number) => {
+    const userFoods = [...testState.foods.values()].filter((f) => f.userId === userId);
+    const filtered = query
+      ? userFoods.filter((f) => f.name.toLowerCase().includes(query.toLowerCase()))
+      : userFoods;
+    return filtered.slice(0, limit).map(({ id, name, brand, servingSize, calories, protein, carbs, fat }) => ({
+      id,
+      name,
+      brand,
+      servingSize,
+      calories,
+      protein,
+      carbs,
+      fat,
+    }));
+  }),
+  findFoodByName: vi.fn(async (userId: string, foodName: string) => {
+    const userFoods = [...testState.foods.values()].filter((f) => f.userId === userId);
+    const match = userFoods.find((f) => f.name.toLowerCase() === foodName.trim().toLowerCase());
+    if (!match) return undefined;
+    const { id, name, brand, servingSize, calories, protein, carbs, fat } = match;
+    return { id, name, brand, servingSize, calories, protein, carbs, fat };
+  }),
+}));
+
+vi.mock('../routes/foods/store.js', () => ({
+  createFood: vi.fn(async (input: StoredFood) => {
+    const food = {
+      ...input,
+      lastUsedAt: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    testState.foods.set(food.id, food);
+    return food;
+  }),
+  deleteFood: vi.fn(),
+  listFoods: vi.fn(async () => []),
+  updateFood: vi.fn(),
+  updateFoodLastUsedAt: vi.fn(async (id: string) => {
+    const food = testState.foods.get(id);
+    if (food) {
+      food.lastUsedAt = Date.now();
+    }
+  }),
+}));
+
+vi.mock('../routes/nutrition/store.js', () => ({
+  createMealForDate: vi.fn(
+    async (
+      userId: string,
+      date: string,
+      input: {
+        name: string;
+        time: string | null | undefined;
+        items: Array<{
+          foodId: string;
+          name: string;
+          amount: number;
+          unit: string | null | undefined;
+          calories: number;
+          protein: number;
+          carbs: number;
+          fat: number;
+        }>;
+      },
+    ) => {
+      const mealId = `meal-${Date.now()}`;
+      const logId = `log-${date}-${userId}`;
+      const meal = {
+        id: mealId,
+        nutritionLogId: logId,
+        name: input.name,
+        time: input.time ?? null,
+        notes: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+      const items = input.items.map((item, idx) => ({
+        id: `item-${mealId}-${idx}`,
+        mealId,
+        foodId: item.foodId,
+        name: item.name,
+        amount: item.amount,
+        unit: item.unit ?? null,
+        calories: item.calories,
+        protein: item.protein,
+        carbs: item.carbs,
+        fat: item.fat,
+        fiber: null,
+        sugar: null,
+        createdAt: Date.now(),
+      }));
+      return { meal, items };
+    },
+  ),
+  deleteMealForDate: vi.fn(),
+  getDailyNutritionForDate: vi.fn(async () => null),
+  getDailyNutritionSummaryForDate: vi.fn(async () => ({ calories: 0, protein: 0, carbs: 0, fat: 0 })),
+}));
+
+vi.mock('../routes/exercises/store.js', () => ({
+  createExercise: vi.fn(
+    async (input: { id: string; userId: string; name: string; category: string }) => {
+      testState.exercises.set(input.id, input);
+      return input;
+    },
+  ),
+  deleteOwnedExercise: vi.fn(),
+  findExerciseLastPerformance: vi.fn(),
+  findExerciseOwnership: vi.fn(),
+  findVisibleExerciseById: vi.fn(),
+  findVisibleExerciseByName: vi.fn(async ({ name, userId }: { name: string; userId: string }) => {
+    const match = [...testState.exercises.values()].find(
+      (e) => e.userId === userId && e.name.toLowerCase() === name.toLowerCase(),
+    );
+    return match ?? null;
+  }),
+  listExerciseFilters: vi.fn(),
+  listExercises: vi.fn(async () => []),
+  updateOwnedExercise: vi.fn(),
+}));
+
+vi.mock('../routes/workout-templates/store.js', () => ({
+  allTemplateExercisesAccessible: vi.fn(),
+  createWorkoutTemplate: vi.fn(
+    async ({
+      id,
+      userId,
+      input,
+    }: {
+      id: string;
+      userId: string;
+      input: { name: string; sections: Array<{ type: string; exercises: unknown[] }> };
+    }) => {
+      const template = { id, userId, name: input.name, sections: input.sections };
+      testState.workoutTemplates.set(id, template);
+      return { ...template, description: null, tags: [], createdAt: Date.now(), updatedAt: Date.now() };
+    },
+  ),
+  deleteWorkoutTemplate: vi.fn(),
+  findWorkoutTemplateById: vi.fn(async (id: string, userId: string) => {
+    const template = testState.workoutTemplates.get(id);
+    return template && template.userId === userId ? template : undefined;
+  }),
+  listWorkoutTemplates: vi.fn(async () => []),
+  updateWorkoutTemplate: vi.fn(),
+}));
+
+vi.mock('../routes/workout-sessions/store.js', () => ({
+  allSessionExercisesAccessible: vi.fn(),
+  batchUpsertSessionSets: vi.fn(),
+  createSessionSet: vi.fn(),
+  createWorkoutSession: vi.fn(
+    async ({
+      id,
+      userId,
+      input,
+    }: {
+      id: string;
+      userId: string;
+      input: {
+        templateId: string | null;
+        name: string;
+        date: string;
+        status: string;
+        startedAt: number;
+        completedAt: number | null;
+        duration: number | null;
+        feedback: string | null;
+        notes: string | null;
+        sets: unknown[];
+      };
+    }) => {
+      const session: StoredWorkoutSession = { id, userId, ...input };
+      testState.workoutSessions.set(id, session);
+      return { ...session, createdAt: Date.now(), updatedAt: Date.now() };
+    },
+  ),
+  deleteWorkoutSession: vi.fn(),
+  findWorkoutSessionAccess: vi.fn(),
+  findWorkoutSessionById: vi.fn(async (id: string, userId: string) => {
+    const session = testState.workoutSessions.get(id);
+    return session && session.userId === userId ? { ...session, sets: [], createdAt: Date.now(), updatedAt: Date.now() } : undefined;
+  }),
+  listSessionSetGroups: vi.fn(),
+  SessionSetNotFoundError: class extends Error {},
+  listWorkoutSessions: vi.fn(async () => []),
+  saveCompletedSessionAsTemplate: vi.fn(),
+  updateSessionSet: vi.fn(),
+  updateWorkoutSession: vi.fn(
+    async ({
+      id,
+      userId,
+      input,
+    }: {
+      id: string;
+      userId: string;
+      input: Record<string, unknown>;
+    }) => {
+      const session = testState.workoutSessions.get(id);
+      if (!session || session.userId !== userId) return undefined;
+      Object.assign(session, input);
+      return { ...session, createdAt: Date.now(), updatedAt: Date.now() };
+    },
+  ),
+}));
+
+vi.mock('../routes/agent/context-store.js', () => ({
+  findAgentContextUser: vi.fn(async () => ({ name: 'Derek' })),
+  getAgentContextTodayNutrition: vi.fn(async () => ({
+    actual: { calories: 800, protein: 60, carbs: 90, fat: 30 },
+    target: { calories: 2000, protein: 150, carbs: 200, fat: 70 },
+    meals: [],
+  })),
+  getAgentContextWeight: vi.fn(async () => ({ current: 180, trend7d: -1.5 })),
+  listAgentContextHabits: vi.fn(async () => [
+    { name: 'Morning run', trackingType: 'boolean', streak: 3, todayCompleted: true },
+  ]),
+  listAgentContextRecentWorkouts: vi.fn(async () => [
+    { id: 'session-1', name: 'Push Day', date: '2026-03-08', completedAt: 1741478400000, exercises: [] },
+  ]),
+  listAgentContextScheduledWorkouts: vi.fn(async () => [
+    { date: '2026-03-10', templateName: 'Pull Day' },
+  ]),
+}));
+
+vi.mock('../routes/habit-entries/store.js', () => ({
+  findHabitEntryByHabitAndDate: vi.fn(async () => null),
+  listHabitEntriesByDateRange: vi.fn(async () => []),
+  upsertHabitEntry: vi.fn(async (_userId: string, input: Record<string, unknown>) => ({
+    id: 'entry-1',
+    habitId: input.habitId,
+    userId: _userId,
+    date: input.date,
+    completed: input.completed ?? false,
+    value: input.value ?? null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  })),
+}));
+
+vi.mock('../routes/habits/store.js', () => ({
+  createHabit: vi.fn(),
+  deleteHabit: vi.fn(),
+  findHabitById: vi.fn(async (id: string, userId: string) => ({
+    id,
+    userId,
+    name: 'Morning run',
+    trackingType: 'boolean',
+    active: true,
+    sortOrder: 0,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  })),
+  listActiveHabits: vi.fn(async () => []),
+  listHabits: vi.fn(async () => []),
+  updateHabit: vi.fn(),
+}));
+
+vi.mock('../routes/weight/store.js', () => ({
+  findBodyWeightEntryByDate: vi.fn(async () => null),
+  listBodyWeightEntries: vi.fn(async () => []),
+  upsertBodyWeightEntry: vi.fn(async (_userId: string, input: Record<string, unknown>) => ({
+    id: 'weight-1',
+    userId: _userId,
+    date: input.date,
+    weight: input.weight,
+    notes: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const createTestApp = async () => {
+  process.env.JWT_SECRET = 'agent-integration-test-secret';
+  vi.resetModules();
+  const { buildServer } = await import('../index.js');
+  const app = buildServer();
+  await app.ready();
+  return app;
+};
+
+const PLAIN_TOKEN = 'f'.repeat(64);
+const PLAIN_TOKEN_HASH = createHash('sha256').update(PLAIN_TOKEN).digest('hex');
+
+/** Insert an agent token into the in-memory state and return the plain token. */
+const seedAgentToken = (userId: string, tokenId = 'token-1'): string => {
+  testState.agentTokens.set(tokenId, {
+    id: tokenId,
+    userId,
+    name: 'Test token',
+    tokenHash: PLAIN_TOKEN_HASH,
+    lastUsedAt: null,
+  });
+  return PLAIN_TOKEN;
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('agent integration', () => {
+  beforeEach(() => {
+    testState.reset();
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+    vi.resetModules();
+  });
+
+  // -------------------------------------------------------------------------
+  // Auth tests
+  // -------------------------------------------------------------------------
+
+  describe('agent auth', () => {
+    it('accepts a valid AgentToken and returns data', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/ping',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.json()).toEqual({ data: { userId: 'user-1' } });
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 401 for an invalid agent token', async () => {
+      const app = await createTestApp();
+
+      try {
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/ping',
+          headers: { authorization: 'AgentToken invalid-token' },
+        });
+
+        expect(response.statusCode).toBe(401);
+        expect(response.json()).toEqual({
+          error: { code: 'UNAUTHORIZED', message: 'Authentication required' },
+        });
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 401 when Authorization header is missing', async () => {
+      const app = await createTestApp();
+
+      try {
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/ping',
+        });
+
+        expect(response.statusCode).toBe(401);
+        expect(response.json()).toEqual({
+          error: { code: 'UNAUTHORIZED', message: 'Authentication required' },
+        });
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 401 for a revoked (deleted) token', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+        // Revoke by removing from in-memory state
+        testState.agentTokens.delete('token-1');
+
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/ping',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+        });
+
+        expect(response.statusCode).toBe(401);
+        expect(response.json()).toEqual({
+          error: { code: 'UNAUTHORIZED', message: 'Authentication required' },
+        });
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('also accepts a valid Bearer JWT on agent routes', async () => {
+      const app = await createTestApp();
+
+      try {
+        const jwtToken = app.jwt.sign({ userId: 'user-1' });
+
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/ping',
+          headers: { authorization: `Bearer ${jwtToken}` },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.json()).toEqual({ data: { userId: 'user-1' } });
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Meal logging tests
+  // -------------------------------------------------------------------------
+
+  describe('agent meal logging', () => {
+    it('creates a food via POST /api/agent/foods', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/foods',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+          payload: {
+            name: 'Chicken Breast',
+            servingSize: '100 g',
+            calories: 165,
+            protein: 31,
+            carbs: 0,
+            fat: 3.6,
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+
+        const body = response.json() as { data: { id: string; name: string; calories: number } };
+        expect(body.data.name).toBe('Chicken Breast');
+        expect(body.data.calories).toBe(165);
+
+        // Food was stored in in-memory state
+        const stored = [...testState.foods.values()].find((f) => f.userId === 'user-1');
+        expect(stored?.name).toBe('Chicken Breast');
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('searches foods via GET /api/agent/foods/search', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        // Seed a food directly into state
+        testState.foods.set('food-1', {
+          id: 'food-1',
+          userId: 'user-1',
+          name: 'Chicken Breast',
+          brand: null,
+          servingSize: '100 g',
+          servingGrams: null,
+          calories: 165,
+          protein: 31,
+          carbs: 0,
+          fat: 3.6,
+          fiber: null,
+          sugar: null,
+          verified: false,
+          source: null,
+          notes: null,
+          lastUsedAt: null,
+          createdAt: 1_700_000_000_000,
+          updatedAt: 1_700_000_000_000,
+        });
+
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/foods/search?q=chicken',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+        });
+
+        expect(response.statusCode).toBe(200);
+
+        const body = response.json() as { data: Array<{ name: string }> };
+        expect(body.data).toHaveLength(1);
+        expect(body.data[0].name).toBe('Chicken Breast');
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('logs a meal with food name resolution and returns calculated macros', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        // Seed a food so findFoodByName can resolve it
+        testState.foods.set('food-chicken', {
+          id: 'food-chicken',
+          userId: 'user-1',
+          name: 'Chicken Breast',
+          brand: null,
+          servingSize: '100 g',
+          servingGrams: null,
+          calories: 165,
+          protein: 31,
+          carbs: 0,
+          fat: 3.6,
+          fiber: null,
+          sugar: null,
+          verified: false,
+          source: null,
+          notes: null,
+          lastUsedAt: null,
+          createdAt: 1_700_000_000_000,
+          updatedAt: 1_700_000_000_000,
+        });
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/meals',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+          payload: {
+            name: 'Lunch',
+            date: '2026-03-09',
+            time: '12:00',
+            items: [{ foodName: 'Chicken Breast', quantity: 2, unit: 'serving' }],
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+
+        const body = response.json() as {
+          data: {
+            meal: { name: string; date: string };
+            macros: { calories: number; protein: number; carbs: number; fat: number };
+            items: Array<{ name: string; amount: number }>;
+          };
+        };
+
+        expect(body.data.meal.name).toBe('Lunch');
+        expect(body.data.meal.date).toBe('2026-03-09');
+        // 2 servings × 165 cal each
+        expect(body.data.macros.calories).toBe(330);
+        expect(body.data.macros.protein).toBe(62);
+        expect(body.data.items).toHaveLength(1);
+        expect(body.data.items[0].name).toBe('Chicken Breast');
+        expect(body.data.items[0].amount).toBe(2);
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 422 when a food name cannot be resolved', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/meals',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+          payload: {
+            name: 'Lunch',
+            date: '2026-03-09',
+            time: '12:00',
+            items: [{ foodName: 'Unknown Food XYZ', quantity: 1 }],
+          },
+        });
+
+        expect(response.statusCode).toBe(422);
+
+        const body = response.json() as { error: { code: string; message: string } };
+        expect(body.error.code).toBe('UNRESOLVED_FOODS');
+        expect(body.error.message).toContain('Unknown Food XYZ');
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Workout tests
+  // -------------------------------------------------------------------------
+
+  describe('agent workout management', () => {
+    it('creates a workout template and auto-creates missing exercises', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/workout-templates',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+          payload: {
+            name: 'Push Day',
+            sections: [
+              {
+                name: 'Main',
+                exercises: [
+                  { name: 'Bench Press', sets: 3, reps: 8 },
+                  { name: 'Overhead Press', sets: 3, reps: 10 },
+                ],
+              },
+            ],
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+
+        const body = response.json() as { data: { name: string } };
+        expect(body.data.name).toBe('Push Day');
+
+        // Both exercises should have been auto-created
+        const createdExercises = [...testState.exercises.values()].filter(
+          (e) => e.userId === 'user-1',
+        );
+        expect(createdExercises.map((e) => e.name).sort()).toEqual(
+          ['Bench Press', 'Overhead Press'].sort(),
+        );
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('creates a workout session', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/workout-sessions',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+          payload: {
+            name: 'Push Day Session',
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+
+        const body = response.json() as { data: { name: string; status: string } };
+        expect(body.data.name).toBe('Push Day Session');
+        expect(body.data.status).toBe('in-progress');
+
+        expect(testState.workoutSessions.size).toBe(1);
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('patches a workout session with set data', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        // Seed a session
+        testState.workoutSessions.set('session-1', {
+          id: 'session-1',
+          userId: 'user-1',
+          templateId: null,
+          name: 'Push Day',
+          date: '2026-03-09',
+          status: 'in-progress',
+          startedAt: 1_741_478_400_000,
+          completedAt: null,
+          duration: null,
+          feedback: null,
+          notes: null,
+          sets: [],
+        });
+
+        // Seed the exercise so name resolves without auto-create
+        testState.exercises.set('exercise-bench', {
+          id: 'exercise-bench',
+          userId: 'user-1',
+          name: 'Bench Press',
+          category: 'compound',
+        });
+
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/workout-sessions/session-1',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+          payload: {
+            status: 'completed',
+            sets: [{ exerciseName: 'Bench Press', setNumber: 1, weight: 135, reps: 8 }],
+          },
+        });
+
+        expect(response.statusCode).toBe(200);
+
+        const body = response.json() as { data: { status: string } };
+        expect(body.data.status).toBe('completed');
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Context tests
+  // -------------------------------------------------------------------------
+
+  describe('agent context endpoint', () => {
+    it('returns a comprehensive context snapshot with all sections populated', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/context',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+        });
+
+        expect(response.statusCode).toBe(200);
+
+        const body = response.json() as {
+          data: {
+            user: { name: string | null };
+            recentWorkouts: unknown[];
+            todayNutrition: {
+              actual: { calories: number };
+              target: { calories: number };
+              meals: unknown[];
+            };
+            weight: { current: number; trend7d: number };
+            habits: Array<{ name: string; streak: number; todayCompleted: boolean }>;
+            scheduledWorkouts: Array<{ date: string; templateName: string }>;
+          };
+        };
+
+        expect(body.data.user.name).toBe('Derek');
+        expect(body.data.recentWorkouts).toHaveLength(1);
+        expect(body.data.recentWorkouts[0]).toMatchObject({ name: 'Push Day' });
+        expect(body.data.todayNutrition.actual.calories).toBe(800);
+        expect(body.data.todayNutrition.target.calories).toBe(2000);
+        expect(body.data.weight.current).toBe(180);
+        expect(body.data.weight.trend7d).toBe(-1.5);
+        expect(body.data.habits).toHaveLength(1);
+        expect(body.data.habits[0].name).toBe('Morning run');
+        expect(body.data.habits[0].todayCompleted).toBe(true);
+        expect(body.data.scheduledWorkouts).toHaveLength(1);
+        expect(body.data.scheduledWorkouts[0].templateName).toBe('Pull Day');
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('also accepts a Bearer JWT on the context endpoint', async () => {
+      const app = await createTestApp();
+
+      try {
+        const jwtToken = app.jwt.sign({ userId: 'user-1' });
+
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/context',
+          headers: { authorization: `Bearer ${jwtToken}` },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.json()).toHaveProperty('data.user');
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // lastUsedAt test
+  // -------------------------------------------------------------------------
+
+  describe('token lastUsedAt', () => {
+    it('updates lastUsedAt on the agent token after a successful request', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        const before = testState.agentTokens.get('token-1');
+        expect(before?.lastUsedAt).toBeNull();
+
+        await app.inject({
+          method: 'GET',
+          url: '/api/agent/ping',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+        });
+
+        const after = testState.agentTokens.get('token-1');
+        expect(after?.lastUsedAt).toBeTypeOf('number');
+      } finally {
+        await app.close();
+      }
+    });
+  });
+});

--- a/apps/api/src/__tests__/agent.test.ts
+++ b/apps/api/src/__tests__/agent.test.ts
@@ -39,12 +39,21 @@ type StoredExercise = {
   userId: string;
   name: string;
   category: string;
+  muscleGroups: string[];
+  equipment: string;
+  instructions: string | null;
+  createdAt: number;
+  updatedAt: number;
 };
 type StoredWorkoutTemplate = {
   id: string;
   userId: string;
   name: string;
+  description: string | null;
+  tags: string[];
   sections: Array<{ type: string; exercises: unknown[] }>;
+  createdAt: number;
+  updatedAt: number;
 };
 type StoredWorkoutSession = {
   id: string;
@@ -254,9 +263,28 @@ vi.mock('../routes/nutrition/store.js', () => ({
 
 vi.mock('../routes/exercises/store.js', () => ({
   createExercise: vi.fn(
-    async (input: { id: string; userId: string; name: string; category: string }) => {
-      testState.exercises.set(input.id, input);
-      return input;
+    async (input: {
+      id: string;
+      userId: string;
+      name: string;
+      category: string;
+      muscleGroups?: string[];
+      equipment?: string;
+      instructions?: string | null;
+    }) => {
+      const exercise: StoredExercise = {
+        id: input.id,
+        userId: input.userId,
+        name: input.name,
+        category: input.category,
+        muscleGroups: input.muscleGroups ?? ['Full Body'],
+        equipment: input.equipment ?? 'Bodyweight',
+        instructions: input.instructions ?? null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+      testState.exercises.set(input.id, exercise);
+      return exercise;
     },
   ),
   deleteOwnedExercise: vi.fn(),
@@ -270,7 +298,33 @@ vi.mock('../routes/exercises/store.js', () => ({
     return match ?? null;
   }),
   listExerciseFilters: vi.fn(),
-  listExercises: vi.fn(async () => []),
+  listExercises: vi.fn(
+    async ({
+      userId,
+      q,
+      page,
+      limit,
+    }: {
+      userId: string;
+      q?: string;
+      page: number;
+      limit: number;
+    }) => {
+      const visible = [...testState.exercises.values()].filter((exercise) => exercise.userId === userId);
+      const filtered = q
+        ? visible.filter((exercise) => exercise.name.toLowerCase().includes(q.toLowerCase()))
+        : visible;
+
+      return {
+        data: filtered.slice(0, limit),
+        meta: {
+          page,
+          limit,
+          total: filtered.length,
+        },
+      };
+    },
+  ),
   updateOwnedExercise: vi.fn(),
 }));
 
@@ -284,11 +338,25 @@ vi.mock('../routes/workout-templates/store.js', () => ({
     }: {
       id: string;
       userId: string;
-      input: { name: string; sections: Array<{ type: string; exercises: unknown[] }> };
+      input: {
+        name: string;
+        description: string | null;
+        tags: string[];
+        sections: Array<{ type: string; exercises: unknown[] }>;
+      };
     }) => {
-      const template = { id, userId, name: input.name, sections: input.sections };
+      const template: StoredWorkoutTemplate = {
+        id,
+        userId,
+        name: input.name,
+        description: input.description,
+        tags: input.tags,
+        sections: input.sections,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
       testState.workoutTemplates.set(id, template);
-      return { ...template, description: null, tags: [], createdAt: Date.now(), updatedAt: Date.now() };
+      return template;
     },
   ),
   deleteWorkoutTemplate: vi.fn(),
@@ -297,7 +365,39 @@ vi.mock('../routes/workout-templates/store.js', () => ({
     return template && template.userId === userId ? template : undefined;
   }),
   listWorkoutTemplates: vi.fn(async () => []),
-  updateWorkoutTemplate: vi.fn(),
+  updateWorkoutTemplate: vi.fn(
+    async ({
+      id,
+      userId,
+      input,
+    }: {
+      id: string;
+      userId: string;
+      input: {
+        name: string;
+        description: string | null;
+        tags: string[];
+        sections: Array<{ type: string; exercises: unknown[] }>;
+      };
+    }) => {
+      const existing = testState.workoutTemplates.get(id);
+      if (!existing || existing.userId !== userId) {
+        return undefined;
+      }
+
+      const updated: StoredWorkoutTemplate = {
+        ...existing,
+        name: input.name,
+        description: input.description,
+        tags: input.tags,
+        sections: input.sections,
+        updatedAt: Date.now(),
+      };
+
+      testState.workoutTemplates.set(id, updated);
+      return updated;
+    },
+  ),
 }));
 
 vi.mock('../routes/workout-sessions/store.js', () => ({
@@ -381,10 +481,10 @@ vi.mock('../routes/agent/context-store.js', () => ({
 vi.mock('../routes/habit-entries/store.js', () => ({
   findHabitEntryByHabitAndDate: vi.fn(async () => null),
   listHabitEntriesByDateRange: vi.fn(async () => []),
-  upsertHabitEntry: vi.fn(async (_userId: string, input: Record<string, unknown>) => ({
+  upsertHabitEntry: vi.fn(async (input: Record<string, unknown>) => ({
     id: 'entry-1',
     habitId: input.habitId,
-    userId: _userId,
+    userId: input.userId,
     date: input.date,
     completed: input.completed ?? false,
     value: input.value ?? null,
@@ -464,7 +564,6 @@ describe('agent integration', () => {
 
   afterEach(() => {
     delete process.env.JWT_SECRET;
-    vi.resetModules();
   });
 
   // -------------------------------------------------------------------------
@@ -610,6 +709,33 @@ describe('agent integration', () => {
       }
     });
 
+    it('returns 400 for invalid food creation payloads', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/foods',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+          payload: {
+            name: 'Chicken Breast',
+            protein: 31,
+            carbs: 0,
+            fat: 3.6,
+          },
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.json()).toEqual({
+          error: { code: 'VALIDATION_ERROR', message: 'Invalid food payload' },
+        });
+      } finally {
+        await app.close();
+      }
+    });
+
     it('searches foods via GET /api/agent/foods/search', async () => {
       const app = await createTestApp();
 
@@ -712,6 +838,39 @@ describe('agent integration', () => {
         expect(body.data.items).toHaveLength(1);
         expect(body.data.items[0].name).toBe('Chicken Breast');
         expect(body.data.items[0].amount).toBe(2);
+
+        const foodsStore = await import('../routes/foods/store.js');
+        expect(vi.mocked(foodsStore.updateFoodLastUsedAt)).toHaveBeenCalledWith(
+          'food-chicken',
+          'user-1',
+        );
+        expect(testState.foods.get('food-chicken')?.lastUsedAt).toBeTypeOf('number');
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 400 for invalid meal payloads', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/meals',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+          payload: {
+            name: 'Lunch',
+            date: '2026-03-09',
+            time: '12:00',
+          },
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.json()).toEqual({
+          error: { code: 'VALIDATION_ERROR', message: 'Invalid meal payload' },
+        });
       } finally {
         await app.close();
       }
@@ -819,6 +978,48 @@ describe('agent integration', () => {
       }
     });
 
+    it('updates an existing workout template via PUT /api/agent/workout-templates/:id', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        testState.workoutTemplates.set('template-1', {
+          id: 'template-1',
+          userId: 'user-1',
+          name: 'Pull Day',
+          description: null,
+          tags: [],
+          sections: [],
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        });
+
+        const response = await app.inject({
+          method: 'PUT',
+          url: '/api/agent/workout-templates/template-1',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+          payload: {
+            name: 'Pull Day Updated',
+            sections: [
+              {
+                name: 'Main',
+                exercises: [{ name: 'Barbell Row', sets: 4, reps: 8 }],
+              },
+            ],
+          },
+        });
+
+        expect(response.statusCode).toBe(200);
+
+        const body = response.json() as { data: { id: string; name: string } };
+        expect(body.data.id).toBe('template-1');
+        expect(body.data.name).toBe('Pull Day Updated');
+      } finally {
+        await app.close();
+      }
+    });
+
     it('patches a workout session with set data', async () => {
       const app = await createTestApp();
 
@@ -847,6 +1048,11 @@ describe('agent integration', () => {
           userId: 'user-1',
           name: 'Bench Press',
           category: 'compound',
+          muscleGroups: ['Chest'],
+          equipment: 'Barbell',
+          instructions: null,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
         });
 
         const response = await app.inject({
@@ -863,6 +1069,188 @@ describe('agent integration', () => {
 
         const body = response.json() as { data: { status: string } };
         expect(body.data.status).toBe('completed');
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Exercise tests
+  // -------------------------------------------------------------------------
+
+  describe('agent exercises', () => {
+    it('creates an exercise via POST /api/agent/exercises', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/exercises',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+          payload: {
+            name: 'Dumbbell Curl',
+            category: 'isolation',
+            muscleGroups: ['Biceps'],
+            equipment: 'Dumbbell',
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+
+        const body = response.json() as {
+          data: { name: string; category: string; muscleGroups: string[]; equipment: string };
+        };
+        expect(body.data.name).toBe('Dumbbell Curl');
+        expect(body.data.category).toBe('isolation');
+        expect(body.data.muscleGroups).toEqual(['Biceps']);
+        expect(body.data.equipment).toBe('Dumbbell');
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('searches exercises via GET /api/agent/exercises/search', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        testState.exercises.set('exercise-curl', {
+          id: 'exercise-curl',
+          userId: 'user-1',
+          name: 'Dumbbell Curl',
+          category: 'isolation',
+          muscleGroups: ['Biceps'],
+          equipment: 'Dumbbell',
+          instructions: null,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        });
+
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/exercises/search?q=curl&limit=5',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+        });
+
+        expect(response.statusCode).toBe(200);
+
+        const body = response.json() as {
+          data: Array<{ name: string; category: string; muscleGroups: string[]; equipment: string }>;
+        };
+        expect(body.data).toHaveLength(1);
+        expect(body.data[0].name).toBe('Dumbbell Curl');
+        expect(body.data[0].category).toBe('isolation');
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Daily tests
+  // -------------------------------------------------------------------------
+
+  describe('agent daily endpoints', () => {
+    it('creates a weight entry via POST /api/agent/weight', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/weight',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+          payload: {
+            date: '2026-03-09',
+            weight: 180.5,
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+
+        const body = response.json() as { data: { date: string; weight: number } };
+        expect(body.data.date).toBe('2026-03-09');
+        expect(body.data.weight).toBe(180.5);
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns active habits via GET /api/agent/habits', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/habits',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.json()).toEqual({ data: [] });
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('upserts a habit entry via PATCH /api/agent/habits/:id/entries', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/habits/habit-1/entries',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+          payload: {
+            date: '2026-03-09',
+            completed: true,
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+
+        const body = response.json() as {
+          data: { habitId: string; date: string; completed: boolean };
+        };
+        expect(body.data.habitId).toBe('habit-1');
+        expect(body.data.date).toBe('2026-03-09');
+        expect(body.data.completed).toBe(true);
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns nutrition summary via GET /api/agent/nutrition/:date/summary', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/nutrition/2026-03-09/summary',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+        });
+
+        expect(response.statusCode).toBe(200);
+
+        const body = response.json() as {
+          data: {
+            summary: { calories: number; protein: number; carbs: number; fat: number };
+            meals: unknown[];
+          };
+        };
+        expect(body.data.summary).toEqual({ calories: 0, protein: 0, carbs: 0, fat: 0 });
+        expect(body.data.meals).toEqual([]);
       } finally {
         await app.close();
       }

--- a/apps/api/src/__tests__/auth.test.ts
+++ b/apps/api/src/__tests__/auth.test.ts
@@ -151,21 +151,9 @@ const createTestApp = async () => {
 
   vi.resetModules();
 
-  const [{ buildServer }, { requireAuth }] = await Promise.all([
-    import('../index.js'),
-    import('../middleware/auth.js'),
-  ]);
+  const { buildServer } = await import('../index.js');
 
   const app = buildServer();
-
-  await app.register(async (instance) => {
-    instance.addHook('onRequest', requireAuth);
-    instance.get('/api/agent/ping', async (request) => ({
-      data: {
-        userId: request.userId,
-      },
-    }));
-  });
 
   await app.ready();
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,7 @@ import Fastify from 'fastify';
 import { fileURLToPath } from 'node:url';
 
 import { authRoutes } from './routes/auth/index.js';
+import { agentRoutes } from './routes/agent/index.js';
 import { agentTokenRoutes } from './routes/agent-tokens/index.js';
 import { exerciseRoutes } from './routes/exercises/index.js';
 import { foodsRoutes } from './routes/foods/index.js';
@@ -38,6 +39,7 @@ export const buildServer = () => {
   });
 
   app.get('/health', async () => ({ status: 'ok' }));
+  app.register(agentRoutes, { prefix: '/api/agent' });
   app.register(authRoutes, { prefix: '/api/v1/auth' });
   app.register(agentTokenRoutes, { prefix: '/api/v1/agent-tokens' });
   app.register(exerciseRoutes, { prefix: '/api/v1/exercises' });

--- a/apps/api/src/routes/agent/context-store.test.ts
+++ b/apps/api/src/routes/agent/context-store.test.ts
@@ -42,6 +42,28 @@ describe('agent context store', () => {
     testState.reset();
   });
 
+  it('returns user profile name when user exists', async () => {
+    const { findAgentContextUser } = await import('./context-store.js');
+
+    testState.getQueue.push({
+      name: 'Derek',
+    });
+
+    await expect(findAgentContextUser('user-1')).resolves.toEqual({
+      name: 'Derek',
+    });
+  });
+
+  it('returns null name when user profile does not exist', async () => {
+    const { findAgentContextUser } = await import('./context-store.js');
+
+    testState.getQueue.push(undefined);
+
+    await expect(findAgentContextUser('user-1')).resolves.toEqual({
+      name: null,
+    });
+  });
+
   it('aggregates recent workouts by exercise with set summary counts', async () => {
     const { listAgentContextRecentWorkouts } = await import('./context-store.js');
 
@@ -112,6 +134,123 @@ describe('agent context store', () => {
         ],
       },
     ]);
+  });
+
+  it('returns nutrition totals, target, and meals with nested items for a log date', async () => {
+    const { getAgentContextTodayNutrition } = await import('./context-store.js');
+
+    testState.getQueue.push(
+      {
+        calories: 1450,
+        protein: 120,
+        carbs: 140,
+        fat: 50,
+      },
+      {
+        calories: 2400,
+        protein: 190,
+        carbs: 250,
+        fat: 70,
+      },
+      {
+        id: 'log-1',
+      },
+    );
+    testState.allQueue.push(
+      [
+        { id: 'meal-1', name: 'Breakfast' },
+        { id: 'meal-2', name: 'Lunch' },
+      ],
+      [
+        {
+          mealId: 'meal-1',
+          name: 'Eggs',
+          amount: 2,
+          unit: 'whole',
+          calories: 140,
+          protein: 12,
+          carbs: 1,
+          fat: 10,
+        },
+        {
+          mealId: 'meal-2',
+          name: 'Rice',
+          amount: 1.5,
+          unit: 'cup',
+          calories: 300,
+          protein: 6,
+          carbs: 66,
+          fat: 0.6,
+        },
+      ],
+    );
+
+    await expect(getAgentContextTodayNutrition('user-1', '2026-03-09')).resolves.toEqual({
+      actual: {
+        calories: 1450,
+        protein: 120,
+        carbs: 140,
+        fat: 50,
+      },
+      target: {
+        calories: 2400,
+        protein: 190,
+        carbs: 250,
+        fat: 70,
+      },
+      meals: [
+        {
+          name: 'Breakfast',
+          items: [
+            {
+              name: 'Eggs',
+              amount: 2,
+              unit: 'whole',
+              calories: 140,
+              protein: 12,
+              carbs: 1,
+              fat: 10,
+            },
+          ],
+        },
+        {
+          name: 'Lunch',
+          items: [
+            {
+              name: 'Rice',
+              amount: 1.5,
+              unit: 'cup',
+              calories: 300,
+              protein: 6,
+              carbs: 66,
+              fat: 0.6,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('returns zero defaults and no meals when no nutrition log exists for date', async () => {
+    const { getAgentContextTodayNutrition } = await import('./context-store.js');
+
+    testState.getQueue.push(undefined, undefined, undefined);
+
+    await expect(getAgentContextTodayNutrition('user-1', '2026-03-09')).resolves.toEqual({
+      actual: {
+        calories: 0,
+        protein: 0,
+        carbs: 0,
+        fat: 0,
+      },
+      target: {
+        calories: 0,
+        protein: 0,
+        carbs: 0,
+        fat: 0,
+      },
+      meals: [],
+    });
   });
 
   it('calculates weight trend from the latest and reference entry', async () => {

--- a/apps/api/src/routes/agent/context-store.test.ts
+++ b/apps/api/src/routes/agent/context-store.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testState = vi.hoisted(() => {
+  const getQueue: unknown[] = [];
+  const allQueue: unknown[] = [];
+
+  const db = {
+    select: vi.fn(() => {
+      const query = {
+        from: vi.fn(() => query),
+        leftJoin: vi.fn(() => query),
+        innerJoin: vi.fn(() => query),
+        where: vi.fn(() => query),
+        orderBy: vi.fn(() => query),
+        limit: vi.fn(() => query),
+        get: vi.fn(() => getQueue.shift()),
+        all: vi.fn(() => allQueue.shift() ?? []),
+      };
+
+      return query;
+    }),
+  };
+
+  return {
+    db,
+    getQueue,
+    allQueue,
+    reset() {
+      getQueue.length = 0;
+      allQueue.length = 0;
+      db.select.mockClear();
+    },
+  };
+});
+
+vi.mock('../../db/index.js', () => ({
+  db: testState.db,
+}));
+
+describe('agent context store', () => {
+  beforeEach(() => {
+    testState.reset();
+  });
+
+  it('aggregates recent workouts by exercise with set summary counts', async () => {
+    const { listAgentContextRecentWorkouts } = await import('./context-store.js');
+
+    testState.allQueue.push(
+      [
+        {
+          id: 'session-1',
+          name: 'Push Day',
+          date: '2026-03-08',
+          completedAt: 1000,
+          startedAt: 500,
+          createdAt: 400,
+        },
+      ],
+      [
+        {
+          sessionId: 'session-1',
+          exerciseName: 'Bench Press',
+          completed: true,
+          skipped: false,
+          createdAt: 600,
+          setNumber: 1,
+        },
+        {
+          sessionId: 'session-1',
+          exerciseName: 'Bench Press',
+          completed: true,
+          skipped: false,
+          createdAt: 700,
+          setNumber: 2,
+        },
+        {
+          sessionId: 'session-1',
+          exerciseName: 'Cable Fly',
+          completed: false,
+          skipped: true,
+          createdAt: 800,
+          setNumber: 1,
+        },
+      ],
+    );
+
+    const workouts = await listAgentContextRecentWorkouts('user-1');
+
+    expect(workouts).toEqual([
+      {
+        id: 'session-1',
+        name: 'Push Day',
+        date: '2026-03-08',
+        completedAt: 1000,
+        exercises: [
+          {
+            name: 'Bench Press',
+            sets: {
+              total: 2,
+              completed: 2,
+              skipped: 0,
+            },
+          },
+          {
+            name: 'Cable Fly',
+            sets: {
+              total: 1,
+              completed: 0,
+              skipped: 1,
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('calculates weight trend from the latest and reference entry', async () => {
+    const { getAgentContextWeight } = await import('./context-store.js');
+
+    testState.getQueue.push(
+      {
+        date: '2026-03-09',
+        weight: 182.4,
+      },
+      {
+        weight: 183.1,
+      },
+    );
+
+    const weight = await getAgentContextWeight('user-1');
+
+    expect(weight).toEqual({
+      current: 182.4,
+      trend7d: -0.7,
+    });
+  });
+
+  it('returns zeroed weight values when no weight data exists', async () => {
+    const { getAgentContextWeight } = await import('./context-store.js');
+
+    testState.getQueue.push(undefined);
+
+    await expect(getAgentContextWeight('user-1')).resolves.toEqual({
+      current: 0,
+      trend7d: 0,
+    });
+  });
+
+  it('calculates habit streak ending at today or yesterday', async () => {
+    const { listAgentContextHabits } = await import('./context-store.js');
+
+    testState.allQueue.push(
+      [
+        {
+          id: 'habit-1',
+          name: 'Hydrate',
+          trackingType: 'numeric',
+          sortOrder: 0,
+          createdAt: 1,
+        },
+        {
+          id: 'habit-2',
+          name: 'Walk',
+          trackingType: 'boolean',
+          sortOrder: 1,
+          createdAt: 2,
+        },
+      ],
+      [
+        { habitId: 'habit-1', date: '2026-03-09' },
+        { habitId: 'habit-1', date: '2026-03-08' },
+        { habitId: 'habit-1', date: '2026-03-07' },
+        { habitId: 'habit-2', date: '2026-03-08' },
+        { habitId: 'habit-2', date: '2026-03-07' },
+      ],
+    );
+
+    const habits = await listAgentContextHabits('user-1', '2026-03-09');
+
+    expect(habits).toEqual([
+      {
+        name: 'Hydrate',
+        trackingType: 'numeric',
+        streak: 3,
+        todayCompleted: true,
+      },
+      {
+        name: 'Walk',
+        trackingType: 'boolean',
+        streak: 2,
+        todayCompleted: false,
+      },
+    ]);
+  });
+
+  it('maps scheduled workouts and falls back template names when missing', async () => {
+    const { listAgentContextScheduledWorkouts } = await import('./context-store.js');
+
+    testState.allQueue.push([
+      {
+        date: '2026-03-10',
+        templateName: 'Upper A',
+        createdAt: 1,
+      },
+      {
+        date: '2026-03-11',
+        templateName: null,
+        createdAt: 2,
+      },
+    ]);
+
+    const workouts = await listAgentContextScheduledWorkouts({
+      userId: 'user-1',
+      from: '2026-03-09',
+      to: '2026-03-15',
+    });
+
+    expect(workouts).toEqual([
+      {
+        date: '2026-03-10',
+        templateName: 'Upper A',
+      },
+      {
+        date: '2026-03-11',
+        templateName: 'Unknown template',
+      },
+    ]);
+  });
+});

--- a/apps/api/src/routes/agent/context-store.ts
+++ b/apps/api/src/routes/agent/context-store.ts
@@ -16,6 +16,7 @@ import {
   workoutSessions,
   workoutTemplates,
 } from '../../db/schema/index.js';
+import { shiftDate } from './date-utils.js';
 
 type AgentContextUser = AgentContextResponse['user'];
 type AgentContextRecentWorkout = AgentContextResponse['recentWorkouts'][number];
@@ -23,12 +24,6 @@ type AgentContextMeal = AgentContextResponse['todayNutrition']['meals'][number];
 type AgentContextWeight = AgentContextResponse['weight'];
 type AgentContextHabit = AgentContextResponse['habits'][number];
 type AgentContextScheduledWorkout = AgentContextResponse['scheduledWorkouts'][number];
-
-const addUtcDays = (date: string, days: number) => {
-  const parsed = new Date(`${date}T00:00:00.000Z`);
-  parsed.setUTCDate(parsed.getUTCDate() + days);
-  return parsed.toISOString().slice(0, 10);
-};
 
 const toNumber = (value: number | null | undefined) => Number(value ?? 0);
 
@@ -296,7 +291,7 @@ export const getAgentContextWeight = async (userId: string): Promise<AgentContex
     };
   }
 
-  const referenceDate = addUtcDays(latest.date, -7);
+  const referenceDate = shiftDate(latest.date, -7);
   const reference =
     db
       .select({
@@ -367,11 +362,11 @@ export const listAgentContextHabits = async (
     const completedDates = completedDatesByHabit.get(habit.id) ?? new Set<string>();
     const todayCompleted = completedDates.has(today);
     let streak = 0;
-    let cursor = todayCompleted ? today : addUtcDays(today, -1);
+    let cursor = todayCompleted ? today : shiftDate(today, -1);
 
     while (completedDates.has(cursor)) {
       streak += 1;
-      cursor = addUtcDays(cursor, -1);
+      cursor = shiftDate(cursor, -1);
     }
 
     return {
@@ -416,8 +411,4 @@ export const listAgentContextScheduledWorkouts = async ({
     date: row.date,
     templateName: row.templateName ?? 'Unknown template',
   }));
-};
-
-export const agentContextDateUtils = {
-  addUtcDays,
 };

--- a/apps/api/src/routes/agent/context-store.ts
+++ b/apps/api/src/routes/agent/context-store.ts
@@ -1,0 +1,423 @@
+import { and, asc, desc, eq, gte, inArray, lte, sql } from 'drizzle-orm';
+import type { AgentContextResponse } from '@pulse/shared';
+
+import {
+  bodyWeight,
+  exercises,
+  habitEntries,
+  habits,
+  mealItems,
+  meals,
+  nutritionLogs,
+  nutritionTargets,
+  scheduledWorkouts,
+  sessionSets,
+  users,
+  workoutSessions,
+  workoutTemplates,
+} from '../../db/schema/index.js';
+
+type AgentContextUser = AgentContextResponse['user'];
+type AgentContextRecentWorkout = AgentContextResponse['recentWorkouts'][number];
+type AgentContextMeal = AgentContextResponse['todayNutrition']['meals'][number];
+type AgentContextWeight = AgentContextResponse['weight'];
+type AgentContextHabit = AgentContextResponse['habits'][number];
+type AgentContextScheduledWorkout = AgentContextResponse['scheduledWorkouts'][number];
+
+const addUtcDays = (date: string, days: number) => {
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + days);
+  return parsed.toISOString().slice(0, 10);
+};
+
+const toNumber = (value: number | null | undefined) => Number(value ?? 0);
+
+export const findAgentContextUser = async (userId: string): Promise<AgentContextUser> => {
+  const { db } = await import('../../db/index.js');
+
+  const user =
+    db
+      .select({
+        name: users.name,
+      })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1)
+      .get() ?? null;
+
+  return {
+    name: user?.name ?? null,
+  };
+};
+
+export const listAgentContextRecentWorkouts = async (
+  userId: string,
+  limit = 5,
+): Promise<AgentContextRecentWorkout[]> => {
+  const { db } = await import('../../db/index.js');
+
+  const recentSessions = db
+    .select({
+      id: workoutSessions.id,
+      name: workoutSessions.name,
+      date: workoutSessions.date,
+      completedAt: workoutSessions.completedAt,
+      startedAt: workoutSessions.startedAt,
+      createdAt: workoutSessions.createdAt,
+    })
+    .from(workoutSessions)
+    .where(and(eq(workoutSessions.userId, userId), eq(workoutSessions.status, 'completed')))
+    .orderBy(
+      desc(workoutSessions.date),
+      desc(workoutSessions.completedAt),
+      desc(workoutSessions.startedAt),
+      desc(workoutSessions.createdAt),
+    )
+    .limit(limit)
+    .all();
+
+  if (recentSessions.length === 0) {
+    return [];
+  }
+
+  const sessionIds = recentSessions.map((session) => session.id);
+  const setRows = db
+    .select({
+      sessionId: sessionSets.sessionId,
+      exerciseName: exercises.name,
+      completed: sessionSets.completed,
+      skipped: sessionSets.skipped,
+      createdAt: sessionSets.createdAt,
+      setNumber: sessionSets.setNumber,
+    })
+    .from(sessionSets)
+    .innerJoin(exercises, eq(exercises.id, sessionSets.exerciseId))
+    .where(inArray(sessionSets.sessionId, sessionIds))
+    .orderBy(asc(sessionSets.createdAt), asc(sessionSets.setNumber))
+    .all();
+
+  const setsBySession = new Map<
+    string,
+    Array<{
+      name: string;
+      sets: {
+        total: number;
+        completed: number;
+        skipped: number;
+      };
+    }>
+  >();
+  const exerciseIndexBySession = new Map<string, Map<string, number>>();
+
+  for (const row of setRows) {
+    const existingSessionRows = setsBySession.get(row.sessionId) ?? [];
+    const exerciseIndex = exerciseIndexBySession.get(row.sessionId) ?? new Map<string, number>();
+    const existingIndex = exerciseIndex.get(row.exerciseName);
+
+    if (existingIndex === undefined) {
+      existingSessionRows.push({
+        name: row.exerciseName,
+        sets: {
+          total: 1,
+          completed: row.completed ? 1 : 0,
+          skipped: row.skipped ? 1 : 0,
+        },
+      });
+      exerciseIndex.set(row.exerciseName, existingSessionRows.length - 1);
+      setsBySession.set(row.sessionId, existingSessionRows);
+      exerciseIndexBySession.set(row.sessionId, exerciseIndex);
+      continue;
+    }
+
+    const existingExercise = existingSessionRows[existingIndex];
+    existingExercise.sets.total += 1;
+    if (row.completed) {
+      existingExercise.sets.completed += 1;
+    }
+    if (row.skipped) {
+      existingExercise.sets.skipped += 1;
+    }
+  }
+
+  return recentSessions.map((session) => ({
+    id: session.id,
+    name: session.name,
+    date: session.date,
+    completedAt: session.completedAt,
+    exercises: setsBySession.get(session.id) ?? [],
+  }));
+};
+
+export const getAgentContextTodayNutrition = async (
+  userId: string,
+  date: string,
+): Promise<AgentContextResponse['todayNutrition']> => {
+  const { db } = await import('../../db/index.js');
+
+  const actual =
+    db
+      .select({
+        calories: sql<number>`coalesce(sum(${mealItems.calories}), 0)`,
+        protein: sql<number>`coalesce(sum(${mealItems.protein}), 0)`,
+        carbs: sql<number>`coalesce(sum(${mealItems.carbs}), 0)`,
+        fat: sql<number>`coalesce(sum(${mealItems.fat}), 0)`,
+      })
+      .from(nutritionLogs)
+      .leftJoin(meals, eq(meals.nutritionLogId, nutritionLogs.id))
+      .leftJoin(mealItems, eq(mealItems.mealId, meals.id))
+      .where(and(eq(nutritionLogs.userId, userId), eq(nutritionLogs.date, date)))
+      .get() ?? {
+      calories: 0,
+      protein: 0,
+      carbs: 0,
+      fat: 0,
+    };
+
+  const target =
+    db
+      .select({
+        calories: nutritionTargets.calories,
+        protein: nutritionTargets.protein,
+        carbs: nutritionTargets.carbs,
+        fat: nutritionTargets.fat,
+      })
+      .from(nutritionTargets)
+      .where(and(eq(nutritionTargets.userId, userId), lte(nutritionTargets.effectiveDate, date)))
+      .orderBy(desc(nutritionTargets.effectiveDate))
+      .limit(1)
+      .get() ?? null;
+
+  const nutritionLog =
+    db
+      .select({
+        id: nutritionLogs.id,
+      })
+      .from(nutritionLogs)
+      .where(and(eq(nutritionLogs.userId, userId), eq(nutritionLogs.date, date)))
+      .limit(1)
+      .get() ?? null;
+
+  let mealsWithItems: AgentContextMeal[] = [];
+
+  if (nutritionLog) {
+    const dayMeals = db
+      .select({
+        id: meals.id,
+        name: meals.name,
+      })
+      .from(meals)
+      .where(eq(meals.nutritionLogId, nutritionLog.id))
+      .orderBy(asc(meals.createdAt))
+      .all();
+
+    if (dayMeals.length > 0) {
+      const mealIds = dayMeals.map((meal) => meal.id);
+      const items = db
+        .select({
+          mealId: mealItems.mealId,
+          name: mealItems.name,
+          amount: mealItems.amount,
+          unit: mealItems.unit,
+          calories: mealItems.calories,
+          protein: mealItems.protein,
+          carbs: mealItems.carbs,
+          fat: mealItems.fat,
+        })
+        .from(mealItems)
+        .where(inArray(mealItems.mealId, mealIds))
+        .orderBy(asc(mealItems.createdAt))
+        .all();
+
+      const itemsByMealId = new Map<string, AgentContextMeal['items']>();
+      for (const item of items) {
+        const mealRows = itemsByMealId.get(item.mealId) ?? [];
+        mealRows.push({
+          name: item.name,
+          amount: toNumber(item.amount),
+          unit: item.unit,
+          calories: toNumber(item.calories),
+          protein: toNumber(item.protein),
+          carbs: toNumber(item.carbs),
+          fat: toNumber(item.fat),
+        });
+        itemsByMealId.set(item.mealId, mealRows);
+      }
+
+      mealsWithItems = dayMeals.map((meal) => ({
+        name: meal.name,
+        items: itemsByMealId.get(meal.id) ?? [],
+      }));
+    }
+  }
+
+  return {
+    actual: {
+      calories: toNumber(actual.calories),
+      protein: toNumber(actual.protein),
+      carbs: toNumber(actual.carbs),
+      fat: toNumber(actual.fat),
+    },
+    target: target
+      ? {
+          calories: toNumber(target.calories),
+          protein: toNumber(target.protein),
+          carbs: toNumber(target.carbs),
+          fat: toNumber(target.fat),
+        }
+      : {
+          calories: 0,
+          protein: 0,
+          carbs: 0,
+          fat: 0,
+        },
+    meals: mealsWithItems,
+  };
+};
+
+export const getAgentContextWeight = async (userId: string): Promise<AgentContextWeight> => {
+  const { db } = await import('../../db/index.js');
+
+  const latest =
+    db
+      .select({
+        date: bodyWeight.date,
+        weight: bodyWeight.weight,
+      })
+      .from(bodyWeight)
+      .where(eq(bodyWeight.userId, userId))
+      .orderBy(desc(bodyWeight.date))
+      .limit(1)
+      .get() ?? null;
+
+  if (!latest) {
+    return {
+      current: 0,
+      trend7d: 0,
+    };
+  }
+
+  const referenceDate = addUtcDays(latest.date, -7);
+  const reference =
+    db
+      .select({
+        weight: bodyWeight.weight,
+      })
+      .from(bodyWeight)
+      .where(and(eq(bodyWeight.userId, userId), lte(bodyWeight.date, referenceDate)))
+      .orderBy(desc(bodyWeight.date))
+      .limit(1)
+      .get() ?? null;
+
+  const current = toNumber(latest.weight);
+  const trend7d = reference ? Number((current - toNumber(reference.weight)).toFixed(2)) : 0;
+
+  return {
+    current,
+    trend7d,
+  };
+};
+
+export const listAgentContextHabits = async (
+  userId: string,
+  today: string,
+): Promise<AgentContextHabit[]> => {
+  const { db } = await import('../../db/index.js');
+
+  const activeHabits = db
+    .select({
+      id: habits.id,
+      name: habits.name,
+      trackingType: habits.trackingType,
+      sortOrder: habits.sortOrder,
+      createdAt: habits.createdAt,
+    })
+    .from(habits)
+    .where(and(eq(habits.userId, userId), eq(habits.active, true)))
+    .orderBy(asc(habits.sortOrder), asc(habits.createdAt))
+    .all();
+
+  if (activeHabits.length === 0) {
+    return [];
+  }
+
+  const habitIds = activeHabits.map((habit) => habit.id);
+  const completedRows = db
+    .select({
+      habitId: habitEntries.habitId,
+      date: habitEntries.date,
+    })
+    .from(habitEntries)
+    .where(
+      and(
+        eq(habitEntries.userId, userId),
+        eq(habitEntries.completed, true),
+        inArray(habitEntries.habitId, habitIds),
+      ),
+    )
+    .all();
+
+  const completedDatesByHabit = new Map<string, Set<string>>();
+  for (const row of completedRows) {
+    const existingDates = completedDatesByHabit.get(row.habitId) ?? new Set<string>();
+    existingDates.add(row.date);
+    completedDatesByHabit.set(row.habitId, existingDates);
+  }
+
+  return activeHabits.map((habit) => {
+    const completedDates = completedDatesByHabit.get(habit.id) ?? new Set<string>();
+    const todayCompleted = completedDates.has(today);
+    let streak = 0;
+    let cursor = todayCompleted ? today : addUtcDays(today, -1);
+
+    while (completedDates.has(cursor)) {
+      streak += 1;
+      cursor = addUtcDays(cursor, -1);
+    }
+
+    return {
+      name: habit.name,
+      trackingType: habit.trackingType,
+      streak,
+      todayCompleted,
+    };
+  });
+};
+
+export const listAgentContextScheduledWorkouts = async ({
+  userId,
+  from,
+  to,
+}: {
+  userId: string;
+  from: string;
+  to: string;
+}): Promise<AgentContextScheduledWorkout[]> => {
+  const { db } = await import('../../db/index.js');
+
+  const rows = db
+    .select({
+      date: scheduledWorkouts.date,
+      templateName: workoutTemplates.name,
+      createdAt: scheduledWorkouts.createdAt,
+    })
+    .from(scheduledWorkouts)
+    .leftJoin(workoutTemplates, eq(workoutTemplates.id, scheduledWorkouts.templateId))
+    .where(
+      and(
+        eq(scheduledWorkouts.userId, userId),
+        gte(scheduledWorkouts.date, from),
+        lte(scheduledWorkouts.date, to),
+      ),
+    )
+    .orderBy(asc(scheduledWorkouts.date), asc(scheduledWorkouts.createdAt))
+    .all();
+
+  return rows.map((row) => ({
+    date: row.date,
+    templateName: row.templateName ?? 'Unknown template',
+  }));
+};
+
+export const agentContextDateUtils = {
+  addUtcDays,
+};

--- a/apps/api/src/routes/agent/context-store.ts
+++ b/apps/api/src/routes/agent/context-store.ts
@@ -347,6 +347,7 @@ export const listAgentContextHabits = async (
         eq(habitEntries.userId, userId),
         eq(habitEntries.completed, true),
         inArray(habitEntries.habitId, habitIds),
+        gte(habitEntries.date, shiftDate(today, -365)),
       ),
     )
     .all();

--- a/apps/api/src/routes/agent/context.test.ts
+++ b/apps/api/src/routes/agent/context.test.ts
@@ -1,0 +1,296 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildServer } from '../../index.js';
+import {
+  agentContextDateUtils,
+  findAgentContextUser,
+  getAgentContextTodayNutrition,
+  getAgentContextWeight,
+  listAgentContextHabits,
+  listAgentContextRecentWorkouts,
+  listAgentContextScheduledWorkouts,
+} from './context-store.js';
+
+vi.mock('./context-store.js', () => ({
+  findAgentContextUser: vi.fn(),
+  listAgentContextRecentWorkouts: vi.fn(),
+  getAgentContextTodayNutrition: vi.fn(),
+  getAgentContextWeight: vi.fn(),
+  listAgentContextHabits: vi.fn(),
+  listAgentContextScheduledWorkouts: vi.fn(),
+  agentContextDateUtils: {
+    addUtcDays: vi.fn((date: string, days: number) => {
+      const parsed = new Date(`${date}T00:00:00.000Z`);
+      parsed.setUTCDate(parsed.getUTCDate() + days);
+      return parsed.toISOString().slice(0, 10);
+    }),
+  },
+}));
+
+const createAuthorizationHeader = (token: string) => ({
+  authorization: `Bearer ${token}`,
+});
+
+describe('agent context route', () => {
+  beforeEach(() => {
+    vi.mocked(findAgentContextUser).mockReset();
+    vi.mocked(listAgentContextRecentWorkouts).mockReset();
+    vi.mocked(getAgentContextTodayNutrition).mockReset();
+    vi.mocked(getAgentContextWeight).mockReset();
+    vi.mocked(listAgentContextHabits).mockReset();
+    vi.mocked(listAgentContextScheduledWorkouts).mockReset();
+    vi.mocked(agentContextDateUtils.addUtcDays).mockClear();
+    process.env.JWT_SECRET = 'test-agent-context-secret';
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+    vi.useRealTimers();
+  });
+
+  it('returns 401 without auth', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/agent/context',
+      });
+
+      expect(response.statusCode).toBe(401);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns a comprehensive context snapshot', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-09T13:00:00'));
+
+    vi.mocked(findAgentContextUser).mockResolvedValue({
+      name: 'Derek',
+    });
+    vi.mocked(listAgentContextRecentWorkouts).mockResolvedValue([
+      {
+        id: 'session-1',
+        name: 'Upper A',
+        date: '2026-03-08',
+        completedAt: 1_700_000_000_000,
+        exercises: [
+          {
+            name: 'Bench Press',
+            sets: {
+              total: 4,
+              completed: 4,
+              skipped: 0,
+            },
+          },
+        ],
+      },
+    ]);
+    vi.mocked(getAgentContextTodayNutrition).mockResolvedValue({
+      actual: {
+        calories: 2100,
+        protein: 180,
+        carbs: 210,
+        fat: 70,
+      },
+      target: {
+        calories: 2400,
+        protein: 200,
+        carbs: 250,
+        fat: 80,
+      },
+      meals: [
+        {
+          name: 'Lunch',
+          items: [
+            {
+              name: 'Chicken Breast',
+              amount: 1.5,
+              unit: 'serving',
+              calories: 248,
+              protein: 46.5,
+              carbs: 0,
+              fat: 5.4,
+            },
+          ],
+        },
+      ],
+    });
+    vi.mocked(getAgentContextWeight).mockResolvedValue({
+      current: 182.4,
+      trend7d: -0.8,
+    });
+    vi.mocked(listAgentContextHabits).mockResolvedValue([
+      {
+        name: 'Hydrate',
+        trackingType: 'numeric',
+        streak: 5,
+        todayCompleted: true,
+      },
+    ]);
+    vi.mocked(listAgentContextScheduledWorkouts).mockResolvedValue([
+      {
+        date: '2026-03-10',
+        templateName: 'Lower A',
+      },
+    ]);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+
+      const token = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/agent/context',
+        headers: createAuthorizationHeader(token),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: {
+          user: {
+            name: 'Derek',
+          },
+          recentWorkouts: [
+            {
+              id: 'session-1',
+              name: 'Upper A',
+              date: '2026-03-08',
+              completedAt: 1_700_000_000_000,
+              exercises: [
+                {
+                  name: 'Bench Press',
+                  sets: {
+                    total: 4,
+                    completed: 4,
+                    skipped: 0,
+                  },
+                },
+              ],
+            },
+          ],
+          todayNutrition: {
+            actual: {
+              calories: 2100,
+              protein: 180,
+              carbs: 210,
+              fat: 70,
+            },
+            target: {
+              calories: 2400,
+              protein: 200,
+              carbs: 250,
+              fat: 80,
+            },
+            meals: [
+              {
+                name: 'Lunch',
+                items: [
+                  {
+                    name: 'Chicken Breast',
+                    amount: 1.5,
+                    unit: 'serving',
+                    calories: 248,
+                    protein: 46.5,
+                    carbs: 0,
+                    fat: 5.4,
+                  },
+                ],
+              },
+            ],
+          },
+          weight: {
+            current: 182.4,
+            trend7d: -0.8,
+          },
+          habits: [
+            {
+              name: 'Hydrate',
+              trackingType: 'numeric',
+              streak: 5,
+              todayCompleted: true,
+            },
+          ],
+          scheduledWorkouts: [
+            {
+              date: '2026-03-10',
+              templateName: 'Lower A',
+            },
+          ],
+        },
+      });
+
+      expect(vi.mocked(agentContextDateUtils.addUtcDays)).toHaveBeenCalledWith('2026-03-09', 6);
+      expect(vi.mocked(findAgentContextUser)).toHaveBeenCalledWith('user-1');
+      expect(vi.mocked(listAgentContextRecentWorkouts)).toHaveBeenCalledWith('user-1', 5);
+      expect(vi.mocked(getAgentContextTodayNutrition)).toHaveBeenCalledWith('user-1', '2026-03-09');
+      expect(vi.mocked(getAgentContextWeight)).toHaveBeenCalledWith('user-1');
+      expect(vi.mocked(listAgentContextHabits)).toHaveBeenCalledWith('user-1', '2026-03-09');
+      expect(vi.mocked(listAgentContextScheduledWorkouts)).toHaveBeenCalledWith({
+        userId: 'user-1',
+        from: '2026-03-09',
+        to: '2026-03-15',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns null user name and empty arrays when no context data exists', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-09T09:30:00'));
+
+    vi.mocked(findAgentContextUser).mockResolvedValue({
+      name: null,
+    });
+    vi.mocked(listAgentContextRecentWorkouts).mockResolvedValue([]);
+    vi.mocked(getAgentContextTodayNutrition).mockResolvedValue({
+      actual: { calories: 0, protein: 0, carbs: 0, fat: 0 },
+      target: { calories: 0, protein: 0, carbs: 0, fat: 0 },
+      meals: [],
+    });
+    vi.mocked(getAgentContextWeight).mockResolvedValue({
+      current: 0,
+      trend7d: 0,
+    });
+    vi.mocked(listAgentContextHabits).mockResolvedValue([]);
+    vi.mocked(listAgentContextScheduledWorkouts).mockResolvedValue([]);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+
+      const token = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/agent/context',
+        headers: createAuthorizationHeader(token),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: {
+          user: { name: null },
+          recentWorkouts: [],
+          todayNutrition: {
+            actual: { calories: 0, protein: 0, carbs: 0, fat: 0 },
+            target: { calories: 0, protein: 0, carbs: 0, fat: 0 },
+            meals: [],
+          },
+          weight: { current: 0, trend7d: 0 },
+          habits: [],
+          scheduledWorkouts: [],
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apps/api/src/routes/agent/context.test.ts
+++ b/apps/api/src/routes/agent/context.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildServer } from '../../index.js';
 import {
-  agentContextDateUtils,
   findAgentContextUser,
   getAgentContextTodayNutrition,
   getAgentContextWeight,
@@ -18,13 +17,6 @@ vi.mock('./context-store.js', () => ({
   getAgentContextWeight: vi.fn(),
   listAgentContextHabits: vi.fn(),
   listAgentContextScheduledWorkouts: vi.fn(),
-  agentContextDateUtils: {
-    addUtcDays: vi.fn((date: string, days: number) => {
-      const parsed = new Date(`${date}T00:00:00.000Z`);
-      parsed.setUTCDate(parsed.getUTCDate() + days);
-      return parsed.toISOString().slice(0, 10);
-    }),
-  },
 }));
 
 const createAuthorizationHeader = (token: string) => ({
@@ -39,7 +31,6 @@ describe('agent context route', () => {
     vi.mocked(getAgentContextWeight).mockReset();
     vi.mocked(listAgentContextHabits).mockReset();
     vi.mocked(listAgentContextScheduledWorkouts).mockReset();
-    vi.mocked(agentContextDateUtils.addUtcDays).mockClear();
     process.env.JWT_SECRET = 'test-agent-context-secret';
   });
 
@@ -226,7 +217,6 @@ describe('agent context route', () => {
         },
       });
 
-      expect(vi.mocked(agentContextDateUtils.addUtcDays)).toHaveBeenCalledWith('2026-03-09', 6);
       expect(vi.mocked(findAgentContextUser)).toHaveBeenCalledWith('user-1');
       expect(vi.mocked(listAgentContextRecentWorkouts)).toHaveBeenCalledWith('user-1', 5);
       expect(vi.mocked(getAgentContextTodayNutrition)).toHaveBeenCalledWith('user-1', '2026-03-09');
@@ -287,6 +277,55 @@ describe('agent context route', () => {
           weight: { current: 0, trend7d: 0 },
           habits: [],
           scheduledWorkouts: [],
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns 500 when context payload fails schema validation', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-09T09:30:00'));
+
+    vi.mocked(findAgentContextUser).mockResolvedValue({
+      name: 'Derek',
+    });
+    vi.mocked(listAgentContextRecentWorkouts).mockResolvedValue([]);
+    vi.mocked(getAgentContextTodayNutrition).mockResolvedValue({
+      actual: { calories: 0, protein: 0, carbs: 0, fat: 0 },
+      target: { calories: 0, protein: 0, carbs: 0, fat: 0 },
+      meals: [],
+    });
+    vi.mocked(getAgentContextWeight).mockResolvedValue({
+      current: 0,
+      trend7d: 0,
+    });
+    vi.mocked(listAgentContextHabits).mockResolvedValue([]);
+    vi.mocked(listAgentContextScheduledWorkouts).mockResolvedValue([
+      {
+        date: 'invalid-date',
+        templateName: 'Lower A',
+      },
+    ]);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+
+      const token = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/agent/context',
+        headers: createAuthorizationHeader(token),
+      });
+
+      expect(response.statusCode).toBe(500);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: 'Failed to build agent context payload',
         },
       });
     } finally {

--- a/apps/api/src/routes/agent/context.ts
+++ b/apps/api/src/routes/agent/context.ts
@@ -1,0 +1,69 @@
+import { agentContextResponseSchema } from '@pulse/shared';
+import type { FastifyPluginAsync } from 'fastify';
+
+import { sendError } from '../../lib/reply.js';
+
+import {
+  agentContextDateUtils,
+  findAgentContextUser,
+  getAgentContextTodayNutrition,
+  getAgentContextWeight,
+  listAgentContextHabits,
+  listAgentContextRecentWorkouts,
+  listAgentContextScheduledWorkouts,
+} from './context-store.js';
+
+const padDatePart = (value: number) => String(value).padStart(2, '0');
+
+const getTodayDate = () => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = padDatePart(now.getMonth() + 1);
+  const day = padDatePart(now.getDate());
+  return `${year}-${month}-${day}`;
+};
+
+export const agentContextRoutes: FastifyPluginAsync = async (app) => {
+  app.get('/context', async (request, reply) => {
+    const today = getTodayDate();
+    const scheduleEnd = agentContextDateUtils.addUtcDays(today, 6);
+
+    const [user, recentWorkouts, todayNutrition, weight, habits, scheduledWorkouts] =
+      await Promise.all([
+        findAgentContextUser(request.userId),
+        listAgentContextRecentWorkouts(request.userId, 5),
+        getAgentContextTodayNutrition(request.userId, today),
+        getAgentContextWeight(request.userId),
+        listAgentContextHabits(request.userId, today),
+        listAgentContextScheduledWorkouts({
+          userId: request.userId,
+          from: today,
+          to: scheduleEnd,
+        }),
+      ]);
+
+    const payload = {
+      user,
+      recentWorkouts,
+      todayNutrition,
+      weight,
+      habits,
+      scheduledWorkouts,
+    };
+
+    const parsed = agentContextResponseSchema.safeParse(payload);
+    if (!parsed.success) {
+      request.log.error(
+        {
+          issues: parsed.error.issues,
+        },
+        'Failed to build agent context payload',
+      );
+      return sendError(reply, 500, 'INTERNAL_ERROR', 'Failed to build agent context payload');
+    }
+
+    return reply.send({
+      data: parsed.data,
+    });
+  });
+};

--- a/apps/api/src/routes/agent/context.ts
+++ b/apps/api/src/routes/agent/context.ts
@@ -4,7 +4,6 @@ import type { FastifyPluginAsync } from 'fastify';
 import { sendError } from '../../lib/reply.js';
 
 import {
-  agentContextDateUtils,
   findAgentContextUser,
   getAgentContextTodayNutrition,
   getAgentContextWeight,
@@ -12,21 +11,12 @@ import {
   listAgentContextRecentWorkouts,
   listAgentContextScheduledWorkouts,
 } from './context-store.js';
-
-const padDatePart = (value: number) => String(value).padStart(2, '0');
-
-const getTodayDate = () => {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = padDatePart(now.getMonth() + 1);
-  const day = padDatePart(now.getDate());
-  return `${year}-${month}-${day}`;
-};
+import { getTodayDate, shiftDate } from './date-utils.js';
 
 export const agentContextRoutes: FastifyPluginAsync = async (app) => {
   app.get('/context', async (request, reply) => {
     const today = getTodayDate();
-    const scheduleEnd = agentContextDateUtils.addUtcDays(today, 6);
+    const scheduleEnd = shiftDate(today, 6);
 
     const [user, recentWorkouts, todayNutrition, weight, habits, scheduledWorkouts] =
       await Promise.all([

--- a/apps/api/src/routes/agent/daily.test.ts
+++ b/apps/api/src/routes/agent/daily.test.ts
@@ -1,0 +1,509 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildServer } from '../../index.js';
+import { findHabitEntryByHabitAndDate, listHabitEntriesByDateRange, upsertHabitEntry } from '../habit-entries/store.js';
+import { findHabitById, listActiveHabits } from '../habits/store.js';
+import { getDailyNutritionForDate, getDailyNutritionSummaryForDate } from '../nutrition/store.js';
+import { findBodyWeightEntryByDate, upsertBodyWeightEntry } from '../weight/store.js';
+
+vi.mock('../weight/store.js', () => ({
+  findBodyWeightEntryByDate: vi.fn(),
+  upsertBodyWeightEntry: vi.fn(),
+  listBodyWeightEntries: vi.fn(),
+  getLatestBodyWeightEntry: vi.fn(),
+}));
+
+vi.mock('../habits/store.js', () => ({
+  getNextHabitSortOrder: vi.fn(),
+  createHabit: vi.fn(),
+  listActiveHabits: vi.fn(),
+  findHabitById: vi.fn(),
+  updateHabit: vi.fn(),
+  softDeleteHabit: vi.fn(),
+  reorderHabits: vi.fn(),
+}));
+
+vi.mock('../habit-entries/store.js', () => ({
+  findHabitEntryById: vi.fn(),
+  findHabitEntryByHabitAndDate: vi.fn(),
+  upsertHabitEntry: vi.fn(),
+  listHabitEntriesByDateRange: vi.fn(),
+  listHabitEntriesForHabitByDateRange: vi.fn(),
+  updateHabitEntry: vi.fn(),
+}));
+
+vi.mock('../nutrition/store.js', () => ({
+  createMealForDate: vi.fn(),
+  getDailyNutritionForDate: vi.fn(),
+  getDailyNutritionSummaryForDate: vi.fn(),
+  deleteMealForDate: vi.fn(),
+}));
+
+const createAuthorizationHeader = (token: string) => ({
+  authorization: `Bearer ${token}`,
+});
+
+describe('agent daily routes', () => {
+  beforeEach(() => {
+    vi.mocked(findBodyWeightEntryByDate).mockReset();
+    vi.mocked(upsertBodyWeightEntry).mockReset();
+    vi.mocked(listActiveHabits).mockReset();
+    vi.mocked(findHabitById).mockReset();
+    vi.mocked(findHabitEntryByHabitAndDate).mockReset();
+    vi.mocked(upsertHabitEntry).mockReset();
+    vi.mocked(listHabitEntriesByDateRange).mockReset();
+    vi.mocked(getDailyNutritionSummaryForDate).mockReset();
+    vi.mocked(getDailyNutritionForDate).mockReset();
+    process.env.JWT_SECRET = 'test-agent-daily-secret';
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+    vi.useRealTimers();
+  });
+
+  describe('POST /api/agent/weight', () => {
+    it('returns 401 without auth', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/weight',
+          body: { date: '2026-03-09', weight: 182.4 },
+        });
+
+        expect(response.statusCode).toBe(401);
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('creates a new weight entry and returns 201', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findBodyWeightEntryByDate).mockResolvedValue(null);
+        vi.mocked(upsertBodyWeightEntry).mockResolvedValue({
+          id: 'weight-1',
+          date: '2026-03-09',
+          weight: 182.4,
+          notes: null,
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/weight',
+          headers: createAuthorizationHeader(token),
+          body: { date: '2026-03-09', weight: 182.4 },
+        });
+
+        expect(response.statusCode).toBe(201);
+        expect(response.json()).toEqual({
+          data: {
+            id: 'weight-1',
+            date: '2026-03-09',
+            weight: 182.4,
+            notes: null,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        });
+        expect(vi.mocked(findBodyWeightEntryByDate)).toHaveBeenCalledWith('user-1', '2026-03-09');
+        expect(vi.mocked(upsertBodyWeightEntry)).toHaveBeenCalledWith('user-1', {
+          date: '2026-03-09',
+          weight: 182.4,
+        });
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('updates an existing weight entry and returns 200', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findBodyWeightEntryByDate).mockResolvedValue({
+          id: 'weight-1',
+          date: '2026-03-09',
+          weight: 183,
+          notes: null,
+          createdAt: 1,
+          updatedAt: 1,
+        });
+        vi.mocked(upsertBodyWeightEntry).mockResolvedValue({
+          id: 'weight-1',
+          date: '2026-03-09',
+          weight: 182.4,
+          notes: 'fasted',
+          createdAt: 1,
+          updatedAt: 2,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/weight',
+          headers: createAuthorizationHeader(token),
+          body: { date: '2026-03-09', weight: 182.4, notes: 'fasted' },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(vi.mocked(upsertBodyWeightEntry)).toHaveBeenCalledWith('user-1', {
+          date: '2026-03-09',
+          weight: 182.4,
+          notes: 'fasted',
+        });
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  describe('GET /api/agent/habits', () => {
+    it("returns active habits with today's entry status", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-09T12:00:00Z'));
+
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(listActiveHabits).mockResolvedValue([
+          {
+            id: 'habit-1',
+            userId: 'user-1',
+            name: 'Supplements',
+            emoji: null,
+            trackingType: 'boolean',
+            target: null,
+            unit: null,
+            sortOrder: 0,
+            active: true,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          {
+            id: 'habit-2',
+            userId: 'user-1',
+            name: 'Sleep',
+            emoji: null,
+            trackingType: 'time',
+            target: 8,
+            unit: 'hours',
+            sortOrder: 1,
+            active: true,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ]);
+        vi.mocked(listHabitEntriesByDateRange).mockResolvedValue([
+          {
+            id: 'entry-1',
+            habitId: 'habit-2',
+            userId: 'user-1',
+            date: '2026-03-09',
+            completed: true,
+            value: 8,
+            createdAt: 2,
+          },
+        ]);
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/habits',
+          headers: createAuthorizationHeader(token),
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.json()).toEqual({
+          data: [
+            {
+              id: 'habit-1',
+              name: 'Supplements',
+              trackingType: 'boolean',
+              todayEntry: null,
+            },
+            {
+              id: 'habit-2',
+              name: 'Sleep',
+              trackingType: 'time',
+              todayEntry: {
+                value: 8,
+                completed: true,
+              },
+            },
+          ],
+        });
+        expect(vi.mocked(listHabitEntriesByDateRange)).toHaveBeenCalledWith(
+          'user-1',
+          '2026-03-09',
+          '2026-03-09',
+        );
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  describe('PATCH /api/agent/habits/:id/entries', () => {
+    it('upserts a habit entry while preserving existing completed state if omitted', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findHabitById).mockResolvedValue({
+          id: 'habit-1',
+          userId: 'user-1',
+          name: 'Sleep',
+          emoji: null,
+          trackingType: 'time',
+          target: 8,
+          unit: 'hours',
+          sortOrder: 0,
+          active: true,
+          createdAt: 1,
+          updatedAt: 1,
+        });
+        vi.mocked(findHabitEntryByHabitAndDate).mockResolvedValue({
+          id: 'entry-1',
+          habitId: 'habit-1',
+          userId: 'user-1',
+          date: '2026-03-09',
+          completed: true,
+          value: 7,
+          createdAt: 1,
+        });
+        vi.mocked(upsertHabitEntry).mockResolvedValue({
+          id: 'entry-1',
+          habitId: 'habit-1',
+          userId: 'user-1',
+          date: '2026-03-09',
+          completed: true,
+          value: 8,
+          createdAt: 1,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/habits/habit-1/entries',
+          headers: createAuthorizationHeader(token),
+          body: {
+            date: '2026-03-09',
+            value: 8,
+          },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(vi.mocked(upsertHabitEntry)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            habitId: 'habit-1',
+            userId: 'user-1',
+            date: '2026-03-09',
+            completed: true,
+            value: 8,
+          }),
+        );
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 404 when the habit does not exist', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findHabitById).mockResolvedValue(undefined);
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/habits/missing/entries',
+          headers: createAuthorizationHeader(token),
+          body: {
+            date: '2026-03-09',
+            completed: true,
+          },
+        });
+
+        expect(response.statusCode).toBe(404);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'HABIT_NOT_FOUND',
+            message: 'Habit not found',
+          },
+        });
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  describe('GET /api/agent/nutrition/:date/summary', () => {
+    it('returns nutrition macro totals and meals for the given date', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(getDailyNutritionSummaryForDate).mockResolvedValue({
+          date: '2026-03-09',
+          meals: 1,
+          actual: {
+            calories: 450,
+            protein: 40,
+            carbs: 30,
+            fat: 15,
+          },
+          target: {
+            calories: 2500,
+            protein: 180,
+            carbs: 260,
+            fat: 80,
+          },
+        });
+        vi.mocked(getDailyNutritionForDate).mockResolvedValue({
+          log: {
+            id: 'log-1',
+            userId: 'user-1',
+            date: '2026-03-09',
+            notes: null,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          meals: [
+            {
+              meal: {
+                id: 'meal-1',
+                nutritionLogId: 'log-1',
+                name: 'Lunch',
+                time: '12:00',
+                notes: null,
+                createdAt: 1,
+                updatedAt: 1,
+              },
+              items: [
+                {
+                  id: 'item-1',
+                  mealId: 'meal-1',
+                  foodId: 'food-1',
+                  name: 'Chicken Breast',
+                  amount: 1,
+                  unit: 'serving',
+                  calories: 165,
+                  protein: 31,
+                  carbs: 0,
+                  fat: 3.6,
+                  fiber: null,
+                  sugar: null,
+                  createdAt: 1,
+                },
+              ],
+            },
+          ],
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/nutrition/2026-03-09/summary',
+          headers: createAuthorizationHeader(token),
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.json()).toEqual({
+          data: {
+            summary: {
+              date: '2026-03-09',
+              meals: 1,
+              actual: {
+                calories: 450,
+                protein: 40,
+                carbs: 30,
+                fat: 15,
+              },
+              target: {
+                calories: 2500,
+                protein: 180,
+                carbs: 260,
+                fat: 80,
+              },
+            },
+            meals: [
+              {
+                meal: {
+                  id: 'meal-1',
+                  nutritionLogId: 'log-1',
+                  name: 'Lunch',
+                  time: '12:00',
+                  notes: null,
+                  createdAt: 1,
+                  updatedAt: 1,
+                },
+                items: [
+                  {
+                    id: 'item-1',
+                    mealId: 'meal-1',
+                    foodId: 'food-1',
+                    name: 'Chicken Breast',
+                    amount: 1,
+                    unit: 'serving',
+                    calories: 165,
+                    protein: 31,
+                    carbs: 0,
+                    fat: 3.6,
+                    fiber: null,
+                    sugar: null,
+                    createdAt: 1,
+                  },
+                ],
+              },
+            ],
+          },
+        });
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 400 for an invalid nutrition date', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/nutrition/2026-99-99/summary',
+          headers: createAuthorizationHeader(token),
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Invalid nutrition date',
+          },
+        });
+      } finally {
+        await app.close();
+      }
+    });
+  });
+});

--- a/apps/api/src/routes/agent/daily.test.ts
+++ b/apps/api/src/routes/agent/daily.test.ts
@@ -167,12 +167,57 @@ describe('agent daily routes', () => {
         await app.close();
       }
     });
+
+    it('returns 400 for an invalid calendar date', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/weight',
+          headers: createAuthorizationHeader(token),
+          body: { date: '2026-13-40', weight: 182.4 },
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Invalid weight payload',
+          },
+        });
+        expect(vi.mocked(findBodyWeightEntryByDate)).not.toHaveBeenCalled();
+        expect(vi.mocked(upsertBodyWeightEntry)).not.toHaveBeenCalled();
+      } finally {
+        await app.close();
+      }
+    });
   });
 
   describe('GET /api/agent/habits', () => {
+    it('returns 401 without auth', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/habits',
+        });
+
+        expect(response.statusCode).toBe(401);
+      } finally {
+        await app.close();
+      }
+    });
+
     it("returns active habits with today's entry status", async () => {
       vi.useFakeTimers();
-      vi.setSystemTime(new Date('2026-03-09T12:00:00Z'));
+      vi.setSystemTime(new Date('2026-03-09T12:00:00'));
 
       const app = buildServer();
 
@@ -258,6 +303,84 @@ describe('agent daily routes', () => {
   });
 
   describe('PATCH /api/agent/habits/:id/entries', () => {
+    it('returns 401 without auth', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/habits/habit-1/entries',
+          body: {
+            date: '2026-03-09',
+            completed: true,
+          },
+        });
+
+        expect(response.statusCode).toBe(401);
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 201 when creating a new habit entry', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findHabitById).mockResolvedValue({
+          id: 'habit-1',
+          userId: 'user-1',
+          name: 'Sleep',
+          emoji: null,
+          trackingType: 'time',
+          target: 8,
+          unit: 'hours',
+          sortOrder: 0,
+          active: true,
+          createdAt: 1,
+          updatedAt: 1,
+        });
+        vi.mocked(findHabitEntryByHabitAndDate).mockResolvedValue(undefined);
+        vi.mocked(upsertHabitEntry).mockResolvedValue({
+          id: 'entry-1',
+          habitId: 'habit-1',
+          userId: 'user-1',
+          date: '2026-03-09',
+          completed: true,
+          value: 8,
+          createdAt: 1,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/habits/habit-1/entries',
+          headers: createAuthorizationHeader(token),
+          body: {
+            date: '2026-03-09',
+            completed: true,
+            value: 8,
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+        expect(vi.mocked(upsertHabitEntry)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            habitId: 'habit-1',
+            userId: 'user-1',
+            date: '2026-03-09',
+            completed: true,
+            value: 8,
+          }),
+        );
+      } finally {
+        await app.close();
+      }
+    });
+
     it('upserts a habit entry while preserving existing completed state if omitted', async () => {
       const app = buildServer();
 
@@ -352,9 +475,57 @@ describe('agent daily routes', () => {
         await app.close();
       }
     });
+
+    it('returns 400 for an invalid calendar date', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/habits/habit-1/entries',
+          headers: createAuthorizationHeader(token),
+          body: {
+            date: '2026-13-40',
+            completed: true,
+          },
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Invalid habit entry payload',
+          },
+        });
+        expect(vi.mocked(findHabitById)).not.toHaveBeenCalled();
+        expect(vi.mocked(upsertHabitEntry)).not.toHaveBeenCalled();
+      } finally {
+        await app.close();
+      }
+    });
   });
 
   describe('GET /api/agent/nutrition/:date/summary', () => {
+    it('returns 401 without auth', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/nutrition/2026-03-09/summary',
+        });
+
+        expect(response.statusCode).toBe(401);
+      } finally {
+        await app.close();
+      }
+    });
+
     it('returns nutrition macro totals and meals for the given date', async () => {
       const app = buildServer();
 

--- a/apps/api/src/routes/agent/daily.ts
+++ b/apps/api/src/routes/agent/daily.ts
@@ -1,0 +1,121 @@
+import { randomUUID } from 'node:crypto';
+
+import {
+  agentCreateWeightInputSchema,
+  agentNutritionSummaryParamsSchema,
+  agentUpdateHabitEntryInputSchema,
+} from '@pulse/shared';
+import type { FastifyPluginAsync } from 'fastify';
+
+import { sendError } from '../../lib/reply.js';
+import { findHabitEntryByHabitAndDate, listHabitEntriesByDateRange, upsertHabitEntry } from '../habit-entries/store.js';
+import { findHabitById, listActiveHabits } from '../habits/store.js';
+import { getDailyNutritionForDate, getDailyNutritionSummaryForDate } from '../nutrition/store.js';
+import { findBodyWeightEntryByDate, upsertBodyWeightEntry } from '../weight/store.js';
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const isValidDate = (date: string) => {
+  if (!DATE_PATTERN.test(date)) {
+    return false;
+  }
+
+  const parsed = new Date(`${date}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(date);
+};
+
+const parseId = (value: unknown) =>
+  typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+
+const getTodayDate = () => new Date().toISOString().slice(0, 10);
+
+export const agentDailyRoutes: FastifyPluginAsync = async (app) => {
+  app.post('/weight', async (request, reply) => {
+    const parsed = agentCreateWeightInputSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid weight payload');
+    }
+
+    const existing = await findBodyWeightEntryByDate(request.userId, parsed.data.date);
+    const entry = await upsertBodyWeightEntry(request.userId, parsed.data);
+
+    return reply.code(existing ? 200 : 201).send({ data: entry });
+  });
+
+  app.get('/habits', async (request, reply) => {
+    const habits = await listActiveHabits(request.userId);
+    if (habits.length === 0) {
+      return reply.send({ data: [] });
+    }
+
+    const today = getTodayDate();
+    const entries = await listHabitEntriesByDateRange(request.userId, today, today);
+    const entriesByHabitId = new Map(entries.map((entry) => [entry.habitId, entry]));
+
+    return reply.send({
+      data: habits.map((habit) => {
+        const entry = entriesByHabitId.get(habit.id);
+
+        return {
+          id: habit.id,
+          name: habit.name,
+          trackingType: habit.trackingType,
+          todayEntry: entry
+            ? {
+                value: entry.value,
+                completed: entry.completed,
+              }
+            : null,
+        };
+      }),
+    });
+  });
+
+  app.patch<{ Params: { id: string } }>('/habits/:id/entries', async (request, reply) => {
+    const habitId = parseId(request.params.id);
+    if (!habitId) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit id');
+    }
+
+    const parsed = agentUpdateHabitEntryInputSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit entry payload');
+    }
+
+    const habit = await findHabitById(habitId, request.userId);
+    if (!habit) {
+      return sendError(reply, 404, 'HABIT_NOT_FOUND', 'Habit not found');
+    }
+
+    const existing = await findHabitEntryByHabitAndDate(habitId, request.userId, parsed.data.date);
+    const entry = await upsertHabitEntry({
+      id: existing?.id ?? randomUUID(),
+      habitId,
+      userId: request.userId,
+      date: parsed.data.date,
+      completed: parsed.data.completed ?? existing?.completed ?? false,
+      value: parsed.data.value ?? existing?.value ?? undefined,
+    });
+
+    return reply.send({ data: entry });
+  });
+
+  app.get<{ Params: { date: string } }>('/nutrition/:date/summary', async (request, reply) => {
+    const parsedParams = agentNutritionSummaryParamsSchema.safeParse(request.params);
+    if (!parsedParams.success || !isValidDate(parsedParams.data.date)) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid nutrition date');
+    }
+
+    const [summary, dailyNutrition] = await Promise.all([
+      getDailyNutritionSummaryForDate(request.userId, parsedParams.data.date),
+      getDailyNutritionForDate(request.userId, parsedParams.data.date),
+    ]);
+
+    return reply.send({
+      data: {
+        summary,
+        meals: dailyNutrition?.meals ?? [],
+      },
+    });
+  });
+};

--- a/apps/api/src/routes/agent/daily.ts
+++ b/apps/api/src/routes/agent/daily.ts
@@ -27,12 +27,20 @@ const isValidDate = (date: string) => {
 const parseId = (value: unknown) =>
   typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
 
-const getTodayDate = () => new Date().toISOString().slice(0, 10);
+const padDatePart = (value: number) => String(value).padStart(2, '0');
+
+const getTodayDate = () => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = padDatePart(now.getMonth() + 1);
+  const day = padDatePart(now.getDate());
+  return `${year}-${month}-${day}`;
+};
 
 export const agentDailyRoutes: FastifyPluginAsync = async (app) => {
   app.post('/weight', async (request, reply) => {
     const parsed = agentCreateWeightInputSchema.safeParse(request.body);
-    if (!parsed.success) {
+    if (!parsed.success || !isValidDate(parsed.data.date)) {
       return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid weight payload');
     }
 
@@ -78,7 +86,7 @@ export const agentDailyRoutes: FastifyPluginAsync = async (app) => {
     }
 
     const parsed = agentUpdateHabitEntryInputSchema.safeParse(request.body);
-    if (!parsed.success) {
+    if (!parsed.success || !isValidDate(parsed.data.date)) {
       return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit entry payload');
     }
 
@@ -97,7 +105,7 @@ export const agentDailyRoutes: FastifyPluginAsync = async (app) => {
       value: parsed.data.value ?? existing?.value ?? undefined,
     });
 
-    return reply.send({ data: entry });
+    return reply.code(existing ? 200 : 201).send({ data: entry });
   });
 
   app.get<{ Params: { date: string } }>('/nutrition/:date/summary', async (request, reply) => {

--- a/apps/api/src/routes/agent/daily.ts
+++ b/apps/api/src/routes/agent/daily.ts
@@ -13,29 +13,10 @@ import { findHabitById, listActiveHabits } from '../habits/store.js';
 import { getDailyNutritionForDate, getDailyNutritionSummaryForDate } from '../nutrition/store.js';
 import { findBodyWeightEntryByDate, upsertBodyWeightEntry } from '../weight/store.js';
 
-const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
-
-const isValidDate = (date: string) => {
-  if (!DATE_PATTERN.test(date)) {
-    return false;
-  }
-
-  const parsed = new Date(`${date}T00:00:00Z`);
-  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(date);
-};
+import { getTodayDate, isValidDate } from './date-utils.js';
 
 const parseId = (value: unknown) =>
   typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
-
-const padDatePart = (value: number) => String(value).padStart(2, '0');
-
-const getTodayDate = () => {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = padDatePart(now.getMonth() + 1);
-  const day = padDatePart(now.getDate());
-  return `${year}-${month}-${day}`;
-};
 
 export const agentDailyRoutes: FastifyPluginAsync = async (app) => {
   app.post('/weight', async (request, reply) => {

--- a/apps/api/src/routes/agent/date-utils.ts
+++ b/apps/api/src/routes/agent/date-utils.ts
@@ -1,0 +1,27 @@
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export const isValidDate = (date: string) => {
+  if (!DATE_PATTERN.test(date)) {
+    return false;
+  }
+
+  const parsed = new Date(`${date}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(date);
+};
+
+const padDatePart = (value: number) => String(value).padStart(2, '0');
+
+export const getTodayDate = () => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = padDatePart(now.getMonth() + 1);
+  const day = padDatePart(now.getDate());
+  return `${year}-${month}-${day}`;
+};
+
+// Interpret YYYY-MM-DD input as UTC midnight to keep calendar-day math timezone-safe.
+export const shiftDate = (date: string, days: number) => {
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + days);
+  return parsed.toISOString().slice(0, 10);
+};

--- a/apps/api/src/routes/agent/date-utils.ts
+++ b/apps/api/src/routes/agent/date-utils.ts
@@ -9,14 +9,8 @@ export const isValidDate = (date: string) => {
   return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(date);
 };
 
-const padDatePart = (value: number) => String(value).padStart(2, '0');
-
 export const getTodayDate = () => {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = padDatePart(now.getMonth() + 1);
-  const day = padDatePart(now.getDate());
-  return `${year}-${month}-${day}`;
+  return new Date().toISOString().slice(0, 10);
 };
 
 // Interpret YYYY-MM-DD input as UTC midnight to keep calendar-day math timezone-safe.

--- a/apps/api/src/routes/agent/exercises.test.ts
+++ b/apps/api/src/routes/agent/exercises.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildServer } from '../../index.js';
+import { createExercise, listExercises } from '../exercises/store.js';
+
+vi.mock('../exercises/store.js', () => ({
+  createExercise: vi.fn(),
+  deleteOwnedExercise: vi.fn(),
+  findExerciseLastPerformance: vi.fn(),
+  findExerciseOwnership: vi.fn(),
+  findVisibleExerciseById: vi.fn(),
+  listExerciseFilters: vi.fn(),
+  listExercises: vi.fn(),
+  updateOwnedExercise: vi.fn(),
+  findVisibleExerciseByName: vi.fn(),
+}));
+
+const createAuthorizationHeader = (token: string) => ({
+  authorization: `Bearer ${token}`,
+});
+
+describe('agent exercises routes', () => {
+  beforeEach(() => {
+    vi.mocked(createExercise).mockReset();
+    vi.mocked(listExercises).mockReset();
+    process.env.JWT_SECRET = 'test-agent-exercises-secret';
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  describe('POST /api/agent/exercises', () => {
+    it('creates an exercise with defaults when optional fields are omitted', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(createExercise).mockResolvedValue({
+          id: 'exercise-1',
+          userId: 'user-1',
+          name: 'Dumbbell Row',
+          category: 'compound',
+          muscleGroups: ['Full Body'],
+          equipment: 'Bodyweight',
+          instructions: null,
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/exercises',
+          headers: createAuthorizationHeader(token),
+          body: {
+            name: 'Dumbbell Row',
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+        expect(response.json()).toEqual({
+          data: {
+            id: 'exercise-1',
+            name: 'Dumbbell Row',
+            category: 'compound',
+            muscleGroups: ['Full Body'],
+            equipment: 'Bodyweight',
+          },
+        });
+
+        expect(vi.mocked(createExercise)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            userId: 'user-1',
+            name: 'Dumbbell Row',
+            category: 'compound',
+            muscleGroups: ['Full Body'],
+            equipment: 'Bodyweight',
+            instructions: null,
+          }),
+        );
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  describe('GET /api/agent/exercises/search', () => {
+    it('returns matching exercises by name', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(listExercises).mockResolvedValue({
+          data: [
+            {
+              id: 'exercise-1',
+              userId: null,
+              name: 'Barbell Bench Press',
+              category: 'compound',
+              muscleGroups: ['Chest', 'Triceps'],
+              equipment: 'Barbell',
+              instructions: null,
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          ],
+          meta: {
+            page: 1,
+            limit: 10,
+            total: 1,
+          },
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/exercises/search?q=bench&limit=10',
+          headers: createAuthorizationHeader(token),
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.json()).toEqual({
+          data: [
+            {
+              id: 'exercise-1',
+              name: 'Barbell Bench Press',
+              category: 'compound',
+              muscleGroups: ['Chest', 'Triceps'],
+              equipment: 'Barbell',
+            },
+          ],
+        });
+
+        expect(vi.mocked(listExercises)).toHaveBeenCalledWith({
+          userId: 'user-1',
+          q: 'bench',
+          page: 1,
+          limit: 10,
+        });
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 400 for invalid search query', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/exercises/search',
+          headers: createAuthorizationHeader(token),
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Invalid exercise search query',
+          },
+        });
+      } finally {
+        await app.close();
+      }
+    });
+  });
+});

--- a/apps/api/src/routes/agent/exercises.ts
+++ b/apps/api/src/routes/agent/exercises.ts
@@ -1,0 +1,64 @@
+import { randomUUID } from 'node:crypto';
+
+import { agentCreateExerciseInputSchema, agentExerciseSearchParamsSchema } from '@pulse/shared';
+import type { FastifyPluginAsync } from 'fastify';
+
+import { sendError } from '../../lib/reply.js';
+import { createExercise, listExercises } from '../exercises/store.js';
+
+const DEFAULT_MUSCLE_GROUPS = ['Full Body'];
+const DEFAULT_EQUIPMENT = 'Bodyweight';
+const DEFAULT_CATEGORY = 'compound' as const;
+
+export const agentExerciseRoutes: FastifyPluginAsync = async (app) => {
+  app.post('/', async (request, reply) => {
+    const parsed = agentCreateExerciseInputSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid exercise payload');
+    }
+
+    const exercise = await createExercise({
+      id: randomUUID(),
+      userId: request.userId,
+      name: parsed.data.name,
+      category: parsed.data.category ?? DEFAULT_CATEGORY,
+      muscleGroups: parsed.data.muscleGroups ?? DEFAULT_MUSCLE_GROUPS,
+      equipment: parsed.data.equipment ?? DEFAULT_EQUIPMENT,
+      instructions: null,
+    });
+
+    return reply.code(201).send({
+      data: {
+        id: exercise.id,
+        name: exercise.name,
+        category: exercise.category,
+        muscleGroups: exercise.muscleGroups,
+        equipment: exercise.equipment,
+      },
+    });
+  });
+
+  app.get('/search', async (request, reply) => {
+    const parsed = agentExerciseSearchParamsSchema.safeParse(request.query);
+    if (!parsed.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid exercise search query');
+    }
+
+    const result = await listExercises({
+      userId: request.userId,
+      q: parsed.data.q,
+      page: 1,
+      limit: parsed.data.limit,
+    });
+
+    return reply.send({
+      data: result.data.map((exercise) => ({
+        id: exercise.id,
+        name: exercise.name,
+        category: exercise.category,
+        muscleGroups: exercise.muscleGroups,
+        equipment: exercise.equipment,
+      })),
+    });
+  });
+};

--- a/apps/api/src/routes/agent/foods.test.ts
+++ b/apps/api/src/routes/agent/foods.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildServer } from '../../index.js';
+import { createFood } from '../foods/store.js';
+
+import { searchFoodsByName } from './store.js';
+
+vi.mock('./store.js', () => ({
+  searchFoodsByName: vi.fn(),
+  findFoodByName: vi.fn(),
+}));
+
+vi.mock('../foods/store.js', () => ({
+  createFood: vi.fn(),
+  deleteFood: vi.fn(),
+  listFoods: vi.fn(),
+  updateFood: vi.fn(),
+  updateFoodLastUsedAt: vi.fn(),
+}));
+
+const createAuthorizationHeader = (token: string) => ({
+  authorization: `Bearer ${token}`,
+});
+
+const agentFood = {
+  id: 'food-1',
+  name: 'Chicken Breast',
+  brand: null,
+  servingSize: '100 g',
+  servingGrams: 100,
+  calories: 165,
+  protein: 31,
+  carbs: 0,
+  fat: 3.6,
+  fiber: null,
+  sugar: null,
+  verified: false,
+  source: null,
+  notes: null,
+  lastUsedAt: null,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+  userId: 'user-1',
+};
+
+describe('agent foods routes', () => {
+  beforeEach(() => {
+    vi.mocked(searchFoodsByName).mockReset();
+    vi.mocked(createFood).mockReset();
+    process.env.JWT_SECRET = 'test-agent-foods-secret';
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  describe('GET /api/agent/foods/search', () => {
+    it('returns 401 without auth', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/foods/search',
+        });
+
+        expect(response.statusCode).toBe(401);
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns food search results sorted by recency', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const searchResults = [
+          { id: 'food-1', name: 'Chicken Breast', brand: null, servingSize: '100 g', calories: 165, protein: 31, carbs: 0, fat: 3.6 },
+          { id: 'food-2', name: 'Chicken Thigh', brand: null, servingSize: null, calories: 209, protein: 26, carbs: 0, fat: 11 },
+        ];
+        vi.mocked(searchFoodsByName).mockResolvedValue(searchResults);
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/foods/search?q=chicken&limit=5',
+          headers: createAuthorizationHeader(token),
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.json()).toEqual({ data: searchResults });
+        expect(vi.mocked(searchFoodsByName)).toHaveBeenCalledWith('user-1', 'chicken', 5);
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns all foods when no query provided', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(searchFoodsByName).mockResolvedValue([]);
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/foods/search',
+          headers: createAuthorizationHeader(token),
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(vi.mocked(searchFoodsByName)).toHaveBeenCalledWith('user-1', undefined, 10);
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  describe('POST /api/agent/foods', () => {
+    it('returns 401 without auth', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/foods',
+          body: { name: 'Egg', calories: 70, protein: 6, carbs: 0.5, fat: 5 },
+        });
+
+        expect(response.statusCode).toBe(401);
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('creates a food and returns 201', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(createFood).mockResolvedValue(agentFood);
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/foods',
+          headers: createAuthorizationHeader(token),
+          body: {
+            name: 'Chicken Breast',
+            servingSize: '100 g',
+            calories: 165,
+            protein: 31,
+            carbs: 0,
+            fat: 3.6,
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+        expect(response.json()).toEqual({
+          data: {
+            id: 'food-1',
+            name: 'Chicken Breast',
+            brand: null,
+            servingSize: '100 g',
+            calories: 165,
+            protein: 31,
+            carbs: 0,
+            fat: 3.6,
+          },
+        });
+        expect(vi.mocked(createFood)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            userId: 'user-1',
+            name: 'Chicken Breast',
+            servingSize: '100 g',
+            calories: 165,
+            protein: 31,
+            carbs: 0,
+            fat: 3.6,
+            verified: false,
+          }),
+        );
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 400 for invalid payload', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/foods',
+          headers: createAuthorizationHeader(token),
+          body: { name: 'Missing macros' },
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.json()).toEqual({
+          error: { code: 'VALIDATION_ERROR', message: 'Invalid food payload' },
+        });
+      } finally {
+        await app.close();
+      }
+    });
+  });
+});

--- a/apps/api/src/routes/agent/foods.ts
+++ b/apps/api/src/routes/agent/foods.ts
@@ -1,0 +1,63 @@
+import { randomUUID } from 'node:crypto';
+
+import { agentCreateFoodInputSchema, agentFoodSearchParamsSchema } from '@pulse/shared';
+import type { FastifyPluginAsync } from 'fastify';
+
+import { sendError } from '../../lib/reply.js';
+import { createFood } from '../foods/store.js';
+
+import { searchFoodsByName } from './store.js';
+
+export const agentFoodsRoutes: FastifyPluginAsync = async (app) => {
+  app.get('/search', async (request, reply) => {
+    const parsed = agentFoodSearchParamsSchema.safeParse(request.query);
+    if (!parsed.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid search parameters');
+    }
+
+    const { q, limit } = parsed.data;
+    const results = await searchFoodsByName(request.userId, q, limit);
+
+    return { data: results };
+  });
+
+  app.post('/', async (request, reply) => {
+    const parsed = agentCreateFoodInputSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid food payload');
+    }
+
+    const { name, brand, servingSize, calories, protein, carbs, fat, source, notes } = parsed.data;
+
+    const food = await createFood({
+      id: randomUUID(),
+      userId: request.userId,
+      name,
+      brand: brand ?? null,
+      servingSize: servingSize ?? null,
+      servingGrams: null,
+      calories,
+      protein,
+      carbs,
+      fat,
+      fiber: null,
+      sugar: null,
+      verified: false,
+      source: source ?? null,
+      notes: notes ?? null,
+    });
+
+    return reply.code(201).send({
+      data: {
+        id: food.id,
+        name: food.name,
+        brand: food.brand,
+        servingSize: food.servingSize,
+        calories: food.calories,
+        protein: food.protein,
+        carbs: food.carbs,
+        fat: food.fat,
+      },
+    });
+  });
+};

--- a/apps/api/src/routes/agent/index.test.ts
+++ b/apps/api/src/routes/agent/index.test.ts
@@ -1,0 +1,133 @@
+import { createHash } from 'node:crypto';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildServer } from '../../index.js';
+import { findAgentTokenByHash, updateAgentTokenLastUsedAt } from '../../middleware/store.js';
+
+vi.mock('../../middleware/store.js', () => ({
+  findAgentTokenByHash: vi.fn(),
+  updateAgentTokenLastUsedAt: vi.fn(),
+}));
+
+const createAuthorizationHeader = (token: string, scheme: 'Bearer' | 'AgentToken' = 'Bearer') => ({
+  authorization: `${scheme} ${token}`,
+});
+
+describe('agent route namespace', () => {
+  beforeEach(() => {
+    vi.mocked(findAgentTokenByHash).mockReset();
+    vi.mocked(updateAgentTokenLastUsedAt).mockReset();
+    vi.mocked(updateAgentTokenLastUsedAt).mockResolvedValue(undefined);
+    process.env.JWT_SECRET = 'test-agent-routes-secret';
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  it('rejects requests without auth credentials', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/agent/ping',
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'UNAUTHORIZED',
+          message: 'Authentication required',
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('accepts bearer JWT auth for /api/agent routes', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const token = app.jwt.sign({ userId: 'user-jwt-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/agent/ping',
+        headers: createAuthorizationHeader(token),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: {
+          userId: 'user-jwt-1',
+        },
+      });
+      expect(vi.mocked(findAgentTokenByHash)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('accepts AgentToken auth for /api/agent routes', async () => {
+    vi.mocked(findAgentTokenByHash).mockResolvedValue({
+      id: 'agent-token-1',
+      userId: 'user-agent-1',
+    });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const token = 'plain-agent-token';
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/agent/ping',
+        headers: createAuthorizationHeader(token, 'AgentToken'),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: {
+          userId: 'user-agent-1',
+        },
+      });
+      expect(vi.mocked(findAgentTokenByHash)).toHaveBeenCalledWith(
+        createHash('sha256').update(token).digest('hex'),
+      );
+      expect(vi.mocked(updateAgentTokenLastUsedAt)).toHaveBeenCalledWith('agent-token-1');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects unknown AgentToken credentials', async () => {
+    vi.mocked(findAgentTokenByHash).mockResolvedValue(undefined);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/agent/ping',
+        headers: createAuthorizationHeader('unknown-agent-token', 'AgentToken'),
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'UNAUTHORIZED',
+          message: 'Authentication required',
+        },
+      });
+      expect(vi.mocked(updateAgentTokenLastUsedAt)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apps/api/src/routes/agent/index.ts
+++ b/apps/api/src/routes/agent/index.ts
@@ -1,0 +1,13 @@
+import type { FastifyPluginAsync } from 'fastify';
+
+import { requireAuth } from '../../middleware/auth.js';
+
+export const agentRoutes: FastifyPluginAsync = async (app) => {
+  app.addHook('onRequest', requireAuth);
+
+  app.get('/ping', async (request) => ({
+    data: {
+      userId: request.userId,
+    },
+  }));
+};

--- a/apps/api/src/routes/agent/index.ts
+++ b/apps/api/src/routes/agent/index.ts
@@ -2,6 +2,7 @@ import type { FastifyPluginAsync } from 'fastify';
 
 import { requireAuth } from '../../middleware/auth.js';
 
+import { agentContextRoutes } from './context.js';
 import { agentDailyRoutes } from './daily.js';
 import { agentExerciseRoutes } from './exercises.js';
 import { agentFoodsRoutes } from './foods.js';
@@ -22,4 +23,5 @@ export const agentRoutes: FastifyPluginAsync = async (app) => {
   app.register(agentExerciseRoutes, { prefix: '/exercises' });
   app.register(agentWorkoutRoutes);
   app.register(agentDailyRoutes);
+  app.register(agentContextRoutes);
 };

--- a/apps/api/src/routes/agent/index.ts
+++ b/apps/api/src/routes/agent/index.ts
@@ -2,6 +2,7 @@ import type { FastifyPluginAsync } from 'fastify';
 
 import { requireAuth } from '../../middleware/auth.js';
 
+import { agentDailyRoutes } from './daily.js';
 import { agentExerciseRoutes } from './exercises.js';
 import { agentFoodsRoutes } from './foods.js';
 import { agentMealsRoutes } from './meals.js';
@@ -20,4 +21,5 @@ export const agentRoutes: FastifyPluginAsync = async (app) => {
   app.register(agentMealsRoutes, { prefix: '/meals' });
   app.register(agentExerciseRoutes, { prefix: '/exercises' });
   app.register(agentWorkoutRoutes);
+  app.register(agentDailyRoutes);
 };

--- a/apps/api/src/routes/agent/index.ts
+++ b/apps/api/src/routes/agent/index.ts
@@ -2,8 +2,10 @@ import type { FastifyPluginAsync } from 'fastify';
 
 import { requireAuth } from '../../middleware/auth.js';
 
+import { agentExerciseRoutes } from './exercises.js';
 import { agentFoodsRoutes } from './foods.js';
 import { agentMealsRoutes } from './meals.js';
+import { agentWorkoutRoutes } from './workouts.js';
 
 export const agentRoutes: FastifyPluginAsync = async (app) => {
   app.addHook('onRequest', requireAuth);
@@ -16,4 +18,6 @@ export const agentRoutes: FastifyPluginAsync = async (app) => {
 
   app.register(agentFoodsRoutes, { prefix: '/foods' });
   app.register(agentMealsRoutes, { prefix: '/meals' });
+  app.register(agentExerciseRoutes, { prefix: '/exercises' });
+  app.register(agentWorkoutRoutes);
 };

--- a/apps/api/src/routes/agent/index.ts
+++ b/apps/api/src/routes/agent/index.ts
@@ -2,6 +2,9 @@ import type { FastifyPluginAsync } from 'fastify';
 
 import { requireAuth } from '../../middleware/auth.js';
 
+import { agentFoodsRoutes } from './foods.js';
+import { agentMealsRoutes } from './meals.js';
+
 export const agentRoutes: FastifyPluginAsync = async (app) => {
   app.addHook('onRequest', requireAuth);
 
@@ -10,4 +13,7 @@ export const agentRoutes: FastifyPluginAsync = async (app) => {
       userId: request.userId,
     },
   }));
+
+  app.register(agentFoodsRoutes, { prefix: '/foods' });
+  app.register(agentMealsRoutes, { prefix: '/meals' });
 };

--- a/apps/api/src/routes/agent/meals.test.ts
+++ b/apps/api/src/routes/agent/meals.test.ts
@@ -264,5 +264,32 @@ describe('agent meals routes', () => {
         await app.close();
       }
     });
+
+    it('returns 400 for impossible calendar dates', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/meals',
+          headers: createAuthorizationHeader(token),
+          body: {
+            name: 'Lunch',
+            date: '2026-02-30',
+            items: [{ foodName: 'Chicken Breast', quantity: 1 }],
+          },
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.json()).toEqual({
+          error: { code: 'VALIDATION_ERROR', message: 'Invalid meal payload' },
+        });
+      } finally {
+        await app.close();
+      }
+    });
   });
 });

--- a/apps/api/src/routes/agent/meals.test.ts
+++ b/apps/api/src/routes/agent/meals.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildServer } from '../../index.js';
+import { updateFoodLastUsedAt } from '../foods/store.js';
+import { createMealForDate } from '../nutrition/store.js';
+
+import { findFoodByName } from './store.js';
+
+vi.mock('./store.js', () => ({
+  searchFoodsByName: vi.fn(),
+  findFoodByName: vi.fn(),
+}));
+
+vi.mock('../foods/store.js', () => ({
+  createFood: vi.fn(),
+  deleteFood: vi.fn(),
+  listFoods: vi.fn(),
+  updateFood: vi.fn(),
+  updateFoodLastUsedAt: vi.fn(),
+}));
+
+vi.mock('../nutrition/store.js', () => ({
+  createMealForDate: vi.fn(),
+  deleteMealForDate: vi.fn(),
+  getDailyNutritionForDate: vi.fn(),
+  getDailyNutritionSummaryForDate: vi.fn(),
+}));
+
+const createAuthorizationHeader = (token: string) => ({
+  authorization: `Bearer ${token}`,
+});
+
+const chickenFood = {
+  id: 'food-chicken',
+  name: 'Chicken Breast',
+  brand: null,
+  servingSize: '100 g',
+  calories: 165,
+  protein: 31,
+  carbs: 0,
+  fat: 3.6,
+};
+
+const riceFood = {
+  id: 'food-rice',
+  name: 'White Rice',
+  brand: null,
+  servingSize: '1 cup cooked',
+  calories: 206,
+  protein: 4.3,
+  carbs: 44.5,
+  fat: 0.4,
+};
+
+const createdMeal = {
+  id: 'meal-1',
+  nutritionLogId: 'log-1',
+  name: 'Lunch',
+  time: '12:00',
+  notes: null,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+};
+
+const createdItems = [
+  {
+    id: 'item-1',
+    mealId: 'meal-1',
+    foodId: 'food-chicken',
+    name: 'Chicken Breast',
+    amount: 2,
+    unit: 'serving',
+    calories: 330,
+    protein: 62,
+    carbs: 0,
+    fat: 7.2,
+    fiber: null,
+    sugar: null,
+    createdAt: 1_700_000_000_001,
+  },
+  {
+    id: 'item-2',
+    mealId: 'meal-1',
+    foodId: 'food-rice',
+    name: 'White Rice',
+    amount: 1,
+    unit: 'serving',
+    calories: 206,
+    protein: 4.3,
+    carbs: 44.5,
+    fat: 0.4,
+    fiber: null,
+    sugar: null,
+    createdAt: 1_700_000_000_002,
+  },
+];
+
+describe('agent meals routes', () => {
+  beforeEach(() => {
+    vi.mocked(findFoodByName).mockReset();
+    vi.mocked(createMealForDate).mockReset();
+    vi.mocked(updateFoodLastUsedAt).mockReset();
+    vi.mocked(updateFoodLastUsedAt).mockResolvedValue(undefined);
+    process.env.JWT_SECRET = 'test-agent-meals-secret';
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  describe('POST /api/agent/meals', () => {
+    it('returns 401 without auth', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/meals',
+          body: {
+            name: 'Lunch',
+            date: '2026-03-09',
+            items: [{ foodName: 'Chicken Breast', quantity: 1 }],
+          },
+        });
+
+        expect(response.statusCode).toBe(401);
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('creates a meal with resolved food names and returns macros', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findFoodByName)
+          .mockResolvedValueOnce(chickenFood)
+          .mockResolvedValueOnce(riceFood);
+        vi.mocked(createMealForDate).mockResolvedValue({ meal: createdMeal, items: createdItems });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/meals',
+          headers: createAuthorizationHeader(token),
+          body: {
+            name: 'Lunch',
+            date: '2026-03-09',
+            time: '12:00',
+            items: [
+              { foodName: 'Chicken Breast', quantity: 2 },
+              { foodName: 'White Rice', quantity: 1 },
+            ],
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+        const json = response.json();
+        expect(json.data.meal).toEqual({
+          id: 'meal-1',
+          name: 'Lunch',
+          date: '2026-03-09',
+          time: '12:00',
+        });
+        expect(json.data.macros).toEqual({
+          calories: 536,
+          protein: 66.3,
+          carbs: 44.5,
+          fat: 7.6000000000000005,
+        });
+        expect(json.data.items).toHaveLength(2);
+
+        expect(vi.mocked(createMealForDate)).toHaveBeenCalledWith(
+          'user-1',
+          '2026-03-09',
+          expect.objectContaining({
+            name: 'Lunch',
+            time: '12:00',
+            items: [
+              expect.objectContaining({
+                foodId: 'food-chicken',
+                name: 'Chicken Breast',
+                amount: 2,
+                unit: 'serving',
+                calories: 330,
+                protein: 62,
+              }),
+              expect.objectContaining({
+                foodId: 'food-rice',
+                name: 'White Rice',
+                amount: 1,
+                unit: 'serving',
+                calories: 206,
+              }),
+            ],
+          }),
+        );
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 422 when a food name cannot be resolved', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findFoodByName)
+          .mockResolvedValueOnce(chickenFood)
+          .mockResolvedValueOnce(undefined);
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/meals',
+          headers: createAuthorizationHeader(token),
+          body: {
+            name: 'Breakfast',
+            date: '2026-03-09',
+            items: [
+              { foodName: 'Chicken Breast', quantity: 1 },
+              { foodName: 'Unknown Food XYZ', quantity: 1 },
+            ],
+          },
+        });
+
+        expect(response.statusCode).toBe(422);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'UNRESOLVED_FOODS',
+            message: 'Could not find foods: Unknown Food XYZ',
+          },
+        });
+        expect(vi.mocked(createMealForDate)).not.toHaveBeenCalled();
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 400 for invalid payload', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/meals',
+          headers: createAuthorizationHeader(token),
+          body: { name: 'Missing date and items' },
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.json()).toEqual({
+          error: { code: 'VALIDATION_ERROR', message: 'Invalid meal payload' },
+        });
+      } finally {
+        await app.close();
+      }
+    });
+  });
+});

--- a/apps/api/src/routes/agent/meals.ts
+++ b/apps/api/src/routes/agent/meals.ts
@@ -1,0 +1,103 @@
+import { agentCreateMealInputSchema } from '@pulse/shared';
+import type { FastifyPluginAsync } from 'fastify';
+
+import { sendError } from '../../lib/reply.js';
+import { updateFoodLastUsedAt } from '../foods/store.js';
+import { createMealForDate } from '../nutrition/store.js';
+
+import { findFoodByName } from './store.js';
+
+export const agentMealsRoutes: FastifyPluginAsync = async (app) => {
+  app.post('/', async (request, reply) => {
+    const parsed = agentCreateMealInputSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid meal payload');
+    }
+
+    const { name, date, time, items } = parsed.data;
+    const userId = request.userId;
+
+    // Resolve food names to food records
+    const resolvedFoods = await Promise.all(
+      items.map(async (item) => {
+        const food = await findFoodByName(userId, item.foodName);
+        return { item, food };
+      }),
+    );
+
+    const unresolved = resolvedFoods
+      .filter(({ food }) => food === undefined)
+      .map(({ item }) => item.foodName);
+
+    if (unresolved.length > 0) {
+      return sendError(
+        reply,
+        422,
+        'UNRESOLVED_FOODS',
+        `Could not find foods: ${unresolved.join(', ')}`,
+      );
+    }
+
+    // All foods resolved — safe to cast since we checked above
+    const resolvedItems = resolvedFoods as Array<{
+      item: (typeof resolvedFoods)[number]['item'];
+      food: NonNullable<(typeof resolvedFoods)[number]['food']>;
+    }>;
+
+    // Scale macros by quantity (1 unit = 1 serving as defined by the food record)
+    const mealItems = resolvedItems.map(({ item, food }) => ({
+      foodId: food.id,
+      name: food.name,
+      amount: item.quantity,
+      unit: item.unit,
+      calories: food.calories * item.quantity,
+      protein: food.protein * item.quantity,
+      carbs: food.carbs * item.quantity,
+      fat: food.fat * item.quantity,
+    }));
+
+    const { meal, items: createdItems } = await createMealForDate(userId, date, {
+      name,
+      time,
+      items: mealItems,
+    });
+
+    // Update lastUsedAt for resolved foods (best-effort)
+    await Promise.allSettled(
+      resolvedItems.map(({ food }) => updateFoodLastUsedAt(food.id, userId)),
+    );
+
+    const macros = createdItems.reduce(
+      (acc, item) => ({
+        calories: acc.calories + item.calories,
+        protein: acc.protein + item.protein,
+        carbs: acc.carbs + item.carbs,
+        fat: acc.fat + item.fat,
+      }),
+      { calories: 0, protein: 0, carbs: 0, fat: 0 },
+    );
+
+    return reply.code(201).send({
+      data: {
+        meal: {
+          id: meal.id,
+          name: meal.name,
+          date,
+          time: meal.time,
+        },
+        macros,
+        items: createdItems.map((item) => ({
+          id: item.id,
+          foodId: item.foodId,
+          name: item.name,
+          amount: item.amount,
+          unit: item.unit,
+          calories: item.calories,
+          protein: item.protein,
+          carbs: item.carbs,
+          fat: item.fat,
+        })),
+      },
+    });
+  });
+};

--- a/apps/api/src/routes/agent/meals.ts
+++ b/apps/api/src/routes/agent/meals.ts
@@ -5,12 +5,13 @@ import { sendError } from '../../lib/reply.js';
 import { updateFoodLastUsedAt } from '../foods/store.js';
 import { createMealForDate } from '../nutrition/store.js';
 
+import { isValidDate } from './date-utils.js';
 import { findFoodByName } from './store.js';
 
 export const agentMealsRoutes: FastifyPluginAsync = async (app) => {
   app.post('/', async (request, reply) => {
     const parsed = agentCreateMealInputSchema.safeParse(request.body);
-    if (!parsed.success) {
+    if (!parsed.success || !isValidDate(parsed.data.date)) {
       return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid meal payload');
     }
 

--- a/apps/api/src/routes/agent/store.ts
+++ b/apps/api/src/routes/agent/store.ts
@@ -1,0 +1,81 @@
+import { and, eq, sql } from 'drizzle-orm';
+
+import { foods } from '../../db/schema/index.js';
+
+export type AgentFoodRecord = {
+  id: string;
+  name: string;
+  brand: string | null;
+  servingSize: string | null;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+};
+
+const agentFoodSelection = {
+  id: foods.id,
+  name: foods.name,
+  brand: foods.brand,
+  servingSize: foods.servingSize,
+  calories: foods.calories,
+  protein: foods.protein,
+  carbs: foods.carbs,
+  fat: foods.fat,
+};
+
+const escapeLikePattern = (value: string) => value.toLowerCase().replace(/[%_\\]/g, '\\$&');
+
+const recentSortExpr = sql`case when ${foods.lastUsedAt} is null then 1 else 0 end asc, ${foods.lastUsedAt} desc, lower(${foods.name}) asc`;
+
+export const searchFoodsByName = async (
+  userId: string,
+  query: string | undefined,
+  limit: number,
+): Promise<AgentFoodRecord[]> => {
+  const { db } = await import('../../db/index.js');
+
+  const conditions = [eq(foods.userId, userId)];
+  if (query) {
+    const pattern = `%${escapeLikePattern(query)}%`;
+    conditions.push(
+      sql`(lower(${foods.name}) like ${pattern} escape '\\' or lower(coalesce(${foods.brand}, '')) like ${pattern} escape '\\')`,
+    );
+  }
+
+  const where = conditions.length === 1 ? conditions[0] : and(...conditions);
+
+  return db.select(agentFoodSelection).from(foods).where(where).orderBy(recentSortExpr).limit(limit).all();
+};
+
+export const findFoodByName = async (
+  userId: string,
+  foodName: string,
+): Promise<AgentFoodRecord | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  const nameLower = foodName.trim().toLowerCase();
+
+  const exact = db
+    .select(agentFoodSelection)
+    .from(foods)
+    .where(and(eq(foods.userId, userId), sql`lower(${foods.name}) = ${nameLower}`))
+    .orderBy(recentSortExpr)
+    .limit(1)
+    .get();
+
+  if (exact) {
+    return exact;
+  }
+
+  const pattern = `%${escapeLikePattern(nameLower)}%`;
+  return db
+    .select(agentFoodSelection)
+    .from(foods)
+    .where(
+      and(eq(foods.userId, userId), sql`lower(${foods.name}) like ${pattern} escape '\\'`),
+    )
+    .orderBy(recentSortExpr)
+    .limit(1)
+    .get();
+};

--- a/apps/api/src/routes/agent/workouts.test.ts
+++ b/apps/api/src/routes/agent/workouts.test.ts
@@ -478,6 +478,197 @@ describe('agent workouts routes', () => {
       }
     });
 
+    it('preserves exercise ordering from the existing session when merging sets', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findWorkoutSessionById).mockResolvedValue({
+          id: 'session-1',
+          userId: 'user-1',
+          templateId: null,
+          name: 'Upper Session',
+          date: '2023-11-14',
+          status: 'in-progress',
+          startedAt,
+          completedAt: null,
+          duration: null,
+          feedback: null,
+          notes: null,
+          sets: [
+            {
+              id: 'set-1',
+              exerciseId: 'exercise-z',
+              setNumber: 1,
+              weight: 100,
+              reps: 8,
+              completed: false,
+              skipped: false,
+              section: 'main',
+              notes: null,
+              createdAt: 1,
+            },
+            {
+              id: 'set-2',
+              exerciseId: 'exercise-z',
+              setNumber: 2,
+              weight: 100,
+              reps: 8,
+              completed: false,
+              skipped: false,
+              section: 'main',
+              notes: null,
+              createdAt: 2,
+            },
+            {
+              id: 'set-3',
+              exerciseId: 'exercise-a',
+              setNumber: 1,
+              weight: 50,
+              reps: 12,
+              completed: false,
+              skipped: false,
+              section: 'main',
+              notes: null,
+              createdAt: 3,
+            },
+          ],
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        vi.mocked(findVisibleExerciseByName)
+          .mockResolvedValueOnce({
+            id: 'exercise-z',
+            userId: 'user-1',
+            name: 'Bench Press',
+            category: 'compound',
+            muscleGroups: ['Chest'],
+            equipment: 'Barbell',
+            instructions: null,
+            createdAt: 1,
+            updatedAt: 1,
+          })
+          .mockResolvedValueOnce(undefined);
+
+        vi.mocked(createExercise).mockResolvedValue({
+          id: 'exercise-b',
+          userId: 'user-1',
+          name: 'Squat',
+          category: 'compound',
+          muscleGroups: ['Full Body'],
+          equipment: 'Bodyweight',
+          instructions: null,
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        vi.mocked(updateWorkoutSession).mockResolvedValue({
+          id: 'session-1',
+          userId: 'user-1',
+          templateId: null,
+          name: 'Upper Session',
+          date: '2023-11-14',
+          status: 'in-progress',
+          startedAt,
+          completedAt: null,
+          duration: null,
+          feedback: null,
+          notes: null,
+          sets: [],
+          createdAt: 1,
+          updatedAt: 2,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/workout-sessions/session-1',
+          headers: createAuthorizationHeader(token),
+          body: {
+            sets: [
+              { exerciseName: 'Bench Press', setNumber: 2, weight: 105, reps: 7 },
+              { exerciseName: 'Squat', setNumber: 1, weight: 225, reps: 5 },
+            ],
+          },
+        });
+
+        expect(response.statusCode).toBe(200);
+
+        const updateCall = vi.mocked(updateWorkoutSession).mock.calls.at(0);
+        const setKeys = updateCall?.[0].input.sets.map((set) => `${set.exerciseId}:${set.setNumber}`);
+        expect(setKeys).toEqual([
+          'exercise-z:1',
+          'exercise-z:2',
+          'exercise-a:1',
+          'exercise-b:1',
+        ]);
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('refreshes completedAt when a completed session is patched as completed again', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findWorkoutSessionById).mockResolvedValue({
+          id: 'session-1',
+          userId: 'user-1',
+          templateId: null,
+          name: 'Upper Session',
+          date: '2023-11-14',
+          status: 'completed',
+          startedAt,
+          completedAt: startedAt - 10_000,
+          duration: 10_000,
+          feedback: null,
+          notes: null,
+          sets: [],
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        vi.mocked(updateWorkoutSession).mockResolvedValue({
+          id: 'session-1',
+          userId: 'user-1',
+          templateId: null,
+          name: 'Upper Session',
+          date: '2023-11-14',
+          status: 'completed',
+          startedAt,
+          completedAt: startedAt,
+          duration: 0,
+          feedback: null,
+          notes: null,
+          sets: [],
+          createdAt: 1,
+          updatedAt: 2,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/workout-sessions/session-1',
+          headers: createAuthorizationHeader(token),
+          body: {
+            status: 'completed',
+          },
+        });
+
+        expect(response.statusCode).toBe(200);
+
+        const updateCall = vi.mocked(updateWorkoutSession).mock.calls.at(0);
+        expect(updateCall?.[0].input.completedAt).toBe(startedAt);
+        expect(updateCall?.[0].input.duration).toBe(0);
+      } finally {
+        await app.close();
+      }
+    });
+
     it('returns 404 when the session does not exist', async () => {
       const app = buildServer();
 

--- a/apps/api/src/routes/agent/workouts.test.ts
+++ b/apps/api/src/routes/agent/workouts.test.ts
@@ -1,0 +1,511 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildServer } from '../../index.js';
+import { createExercise, findVisibleExerciseByName } from '../exercises/store.js';
+import {
+  createWorkoutSession,
+  findWorkoutSessionById,
+  updateWorkoutSession,
+} from '../workout-sessions/store.js';
+import {
+  createWorkoutTemplate,
+  findWorkoutTemplateById,
+  updateWorkoutTemplate,
+} from '../workout-templates/store.js';
+
+vi.mock('../exercises/store.js', () => ({
+  createExercise: vi.fn(),
+  deleteOwnedExercise: vi.fn(),
+  findExerciseLastPerformance: vi.fn(),
+  findExerciseOwnership: vi.fn(),
+  findVisibleExerciseById: vi.fn(),
+  findVisibleExerciseByName: vi.fn(),
+  listExerciseFilters: vi.fn(),
+  listExercises: vi.fn(),
+  updateOwnedExercise: vi.fn(),
+}));
+
+vi.mock('../workout-templates/store.js', () => ({
+  allTemplateExercisesAccessible: vi.fn(),
+  createWorkoutTemplate: vi.fn(),
+  deleteWorkoutTemplate: vi.fn(),
+  findWorkoutTemplateById: vi.fn(),
+  listWorkoutTemplates: vi.fn(),
+  updateWorkoutTemplate: vi.fn(),
+}));
+
+vi.mock('../workout-sessions/store.js', () => ({
+  allSessionExercisesAccessible: vi.fn(),
+  batchUpsertSessionSets: vi.fn(),
+  createSessionSet: vi.fn(),
+  createWorkoutSession: vi.fn(),
+  deleteWorkoutSession: vi.fn(),
+  findWorkoutSessionAccess: vi.fn(),
+  findWorkoutSessionById: vi.fn(),
+  listSessionSetGroups: vi.fn(),
+  SessionSetNotFoundError: class extends Error {},
+  listWorkoutSessions: vi.fn(),
+  saveCompletedSessionAsTemplate: vi.fn(),
+  updateSessionSet: vi.fn(),
+  updateWorkoutSession: vi.fn(),
+}));
+
+const createAuthorizationHeader = (token: string) => ({
+  authorization: `Bearer ${token}`,
+});
+
+describe('agent workouts routes', () => {
+  const startedAt = 1_700_000_000_000;
+  let dateNowSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.mocked(createExercise).mockReset();
+    vi.mocked(findVisibleExerciseByName).mockReset();
+    vi.mocked(createWorkoutTemplate).mockReset();
+    vi.mocked(findWorkoutTemplateById).mockReset();
+    vi.mocked(updateWorkoutTemplate).mockReset();
+    vi.mocked(createWorkoutSession).mockReset();
+    vi.mocked(findWorkoutSessionById).mockReset();
+    vi.mocked(updateWorkoutSession).mockReset();
+    process.env.JWT_SECRET = 'test-agent-workouts-secret';
+    dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(startedAt);
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+    dateNowSpy.mockRestore();
+  });
+
+  describe('POST /api/agent/workout-templates', () => {
+    it('creates missing exercises and persists a template', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findVisibleExerciseByName).mockResolvedValue(undefined);
+        vi.mocked(createExercise).mockResolvedValue({
+          id: 'exercise-1',
+          userId: 'user-1',
+          name: 'Bench Press',
+          category: 'compound',
+          muscleGroups: ['Chest'],
+          equipment: 'Barbell',
+          instructions: null,
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        vi.mocked(createWorkoutTemplate).mockResolvedValue({
+          id: 'template-1',
+          userId: 'user-1',
+          name: 'Push Day',
+          description: null,
+          tags: [],
+          sections: [],
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/workout-templates',
+          headers: createAuthorizationHeader(token),
+          body: {
+            name: 'Push Day',
+            sections: [
+              {
+                name: 'Main',
+                exercises: [{ name: 'Bench Press', sets: 4, reps: 8, restSeconds: 120 }],
+              },
+            ],
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+        expect(vi.mocked(createExercise)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            userId: 'user-1',
+            name: 'Bench Press',
+          }),
+        );
+        expect(vi.mocked(createWorkoutTemplate)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            userId: 'user-1',
+            input: expect.objectContaining({
+              name: 'Push Day',
+              sections: [
+                {
+                  type: 'main',
+                  exercises: [
+                    expect.objectContaining({
+                      exerciseId: 'exercise-1',
+                      sets: 4,
+                      repsMin: 8,
+                      repsMax: 8,
+                      restSeconds: 120,
+                    }),
+                  ],
+                },
+              ],
+            }),
+          }),
+        );
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  describe('PUT /api/agent/workout-templates/:id', () => {
+    it('replaces template exercises using resolved exercise names', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findWorkoutTemplateById).mockResolvedValue({
+          id: 'template-1',
+          userId: 'user-1',
+          name: 'Old Template',
+          description: null,
+          tags: [],
+          sections: [],
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        vi.mocked(findVisibleExerciseByName)
+          .mockResolvedValueOnce({
+            id: 'exercise-1',
+            userId: 'user-1',
+            name: 'Incline Press',
+            category: 'compound',
+            muscleGroups: ['Chest'],
+            equipment: 'Dumbbell',
+            instructions: null,
+            createdAt: 1,
+            updatedAt: 1,
+          })
+          .mockResolvedValueOnce({
+            id: 'exercise-2',
+            userId: 'user-1',
+            name: 'Lateral Raise',
+            category: 'isolation',
+            muscleGroups: ['Shoulders'],
+            equipment: 'Dumbbell',
+            instructions: null,
+            createdAt: 1,
+            updatedAt: 1,
+          });
+
+        vi.mocked(updateWorkoutTemplate).mockResolvedValue({
+          id: 'template-1',
+          userId: 'user-1',
+          name: 'Upper A',
+          description: null,
+          tags: [],
+          sections: [],
+          createdAt: 1,
+          updatedAt: 2,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PUT',
+          url: '/api/agent/workout-templates/template-1',
+          headers: createAuthorizationHeader(token),
+          body: {
+            name: 'Upper A',
+            sections: [
+              {
+                name: 'Main',
+                exercises: [
+                  { name: 'Incline Press', sets: 3, reps: 10 },
+                  { name: 'Lateral Raise', sets: 3, reps: 15 },
+                ],
+              },
+            ],
+          },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(vi.mocked(updateWorkoutTemplate)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: 'template-1',
+            userId: 'user-1',
+            input: expect.objectContaining({
+              name: 'Upper A',
+            }),
+          }),
+        );
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  describe('POST /api/agent/workout-sessions', () => {
+    it('starts a session from a template and prebuilds sets', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findWorkoutTemplateById).mockResolvedValue({
+          id: 'template-1',
+          userId: 'user-1',
+          name: 'Leg Day',
+          description: null,
+          tags: [],
+          sections: [
+            {
+              type: 'warmup',
+              exercises: [],
+            },
+            {
+              type: 'main',
+              exercises: [
+                {
+                  id: 'template-exercise-1',
+                  exerciseId: 'exercise-squat',
+                  exerciseName: 'Squat',
+                  sets: 2,
+                  repsMin: 5,
+                  repsMax: 5,
+                  tempo: null,
+                  restSeconds: null,
+                  supersetGroup: null,
+                  notes: null,
+                  cues: [],
+                },
+              ],
+            },
+            {
+              type: 'cooldown',
+              exercises: [],
+            },
+          ],
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        vi.mocked(createWorkoutSession).mockResolvedValue({
+          id: 'session-1',
+          userId: 'user-1',
+          templateId: 'template-1',
+          name: 'Leg Day',
+          date: '2023-11-14',
+          status: 'in-progress',
+          startedAt,
+          completedAt: null,
+          duration: null,
+          feedback: null,
+          notes: null,
+          sets: [],
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/workout-sessions',
+          headers: createAuthorizationHeader(token),
+          body: {
+            templateId: 'template-1',
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+        expect(vi.mocked(createWorkoutSession)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            userId: 'user-1',
+            input: expect.objectContaining({
+              templateId: 'template-1',
+              name: 'Leg Day',
+              date: '2023-11-14',
+              status: 'in-progress',
+              startedAt,
+              sets: [
+                expect.objectContaining({
+                  exerciseId: 'exercise-squat',
+                  setNumber: 1,
+                  section: 'main',
+                }),
+                expect.objectContaining({
+                  exerciseId: 'exercise-squat',
+                  setNumber: 2,
+                  section: 'main',
+                }),
+              ],
+            }),
+          }),
+        );
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  describe('PATCH /api/agent/workout-sessions/:id', () => {
+    it('resolves exercise names and upserts sets', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findWorkoutSessionById).mockResolvedValue({
+          id: 'session-1',
+          userId: 'user-1',
+          templateId: null,
+          name: 'Upper Session',
+          date: '2023-11-14',
+          status: 'in-progress',
+          startedAt,
+          completedAt: null,
+          duration: null,
+          feedback: null,
+          notes: null,
+          sets: [
+            {
+              id: 'set-1',
+              exerciseId: 'exercise-bench',
+              setNumber: 1,
+              weight: 100,
+              reps: 8,
+              completed: false,
+              skipped: false,
+              section: 'main',
+              notes: null,
+              createdAt: 1,
+            },
+          ],
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        vi.mocked(findVisibleExerciseByName)
+          .mockResolvedValueOnce({
+            id: 'exercise-bench',
+            userId: 'user-1',
+            name: 'Bench Press',
+            category: 'compound',
+            muscleGroups: ['Chest'],
+            equipment: 'Barbell',
+            instructions: null,
+            createdAt: 1,
+            updatedAt: 1,
+          })
+          .mockResolvedValueOnce(undefined);
+
+        vi.mocked(createExercise).mockResolvedValue({
+          id: 'exercise-squat',
+          userId: 'user-1',
+          name: 'Squat',
+          category: 'compound',
+          muscleGroups: ['Full Body'],
+          equipment: 'Bodyweight',
+          instructions: null,
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        vi.mocked(updateWorkoutSession).mockResolvedValue({
+          id: 'session-1',
+          userId: 'user-1',
+          templateId: null,
+          name: 'Upper Session',
+          date: '2023-11-14',
+          status: 'completed',
+          startedAt,
+          completedAt: startedAt,
+          duration: 0,
+          feedback: null,
+          notes: 'Solid session',
+          sets: [],
+          createdAt: 1,
+          updatedAt: 2,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/workout-sessions/session-1',
+          headers: createAuthorizationHeader(token),
+          body: {
+            status: 'completed',
+            notes: 'Solid session',
+            sets: [
+              { exerciseName: 'Bench Press', setNumber: 1, weight: 105, reps: 7 },
+              { exerciseName: 'Squat', setNumber: 1, weight: 225, reps: 5 },
+            ],
+          },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(vi.mocked(updateWorkoutSession)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: 'session-1',
+            userId: 'user-1',
+            input: expect.objectContaining({
+              status: 'completed',
+              notes: 'Solid session',
+              completedAt: startedAt,
+              duration: 0,
+              sets: expect.arrayContaining([
+                expect.objectContaining({
+                  exerciseId: 'exercise-bench',
+                  setNumber: 1,
+                  weight: 105,
+                  reps: 7,
+                  completed: true,
+                }),
+                expect.objectContaining({
+                  exerciseId: 'exercise-squat',
+                  setNumber: 1,
+                  weight: 225,
+                  reps: 5,
+                  completed: true,
+                }),
+              ]),
+            }),
+          }),
+        );
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 404 when the session does not exist', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findWorkoutSessionById).mockResolvedValue(undefined);
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/workout-sessions/missing',
+          headers: createAuthorizationHeader(token),
+          body: {
+            notes: 'Missing session',
+          },
+        });
+
+        expect(response.statusCode).toBe(404);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'WORKOUT_SESSION_NOT_FOUND',
+            message: 'Workout session not found',
+          },
+        });
+      } finally {
+        await app.close();
+      }
+    });
+  });
+});

--- a/apps/api/src/routes/agent/workouts.ts
+++ b/apps/api/src/routes/agent/workouts.ts
@@ -96,6 +96,8 @@ const buildTemplateSections = async ({
     WorkoutTemplateSectionType,
     CreateWorkoutTemplateInput['sections'][number]['exercises']
   >();
+  // Intentionally merge repeated agent sections that map to the same canonical type.
+  // The template model stores a single section per type (`warmup`/`main`/`cooldown`).
   groupedByType.set('warmup', []);
   groupedByType.set('main', []);
   groupedByType.set('cooldown', []);
@@ -331,12 +333,21 @@ export const agentWorkoutRoutes: FastifyPluginAsync = async (app) => {
       const setMap = new Map(
         merged.sets.map((set) => [`${set.exerciseId}:${set.setNumber}`, { ...set }]),
       );
+      const exerciseOrder = new Map<string, number>();
+      for (const set of merged.sets) {
+        if (!exerciseOrder.has(set.exerciseId)) {
+          exerciseOrder.set(set.exerciseId, exerciseOrder.size);
+        }
+      }
 
       for (const set of parsed.data.sets) {
         const exerciseId = await resolveExerciseIdByName({
           name: set.exerciseName,
           userId: request.userId,
         });
+        if (!exerciseOrder.has(exerciseId)) {
+          exerciseOrder.set(exerciseId, exerciseOrder.size);
+        }
 
         const key = `${exerciseId}:${set.setNumber}`;
         const previous = setMap.get(key);
@@ -365,10 +376,11 @@ export const agentWorkoutRoutes: FastifyPluginAsync = async (app) => {
       }
 
       merged.sets = Array.from(setMap.values()).sort((left, right) => {
-        if (left.exerciseId !== right.exerciseId) {
-          return left.exerciseId.localeCompare(right.exerciseId);
+        const leftOrder = exerciseOrder.get(left.exerciseId) ?? Number.MAX_SAFE_INTEGER;
+        const rightOrder = exerciseOrder.get(right.exerciseId) ?? Number.MAX_SAFE_INTEGER;
+        if (leftOrder !== rightOrder) {
+          return leftOrder - rightOrder;
         }
-
         return left.setNumber - right.setNumber;
       });
     }
@@ -377,7 +389,7 @@ export const agentWorkoutRoutes: FastifyPluginAsync = async (app) => {
       merged.status = parsed.data.status;
 
       if (parsed.data.status === 'completed') {
-        const completedAt = merged.completedAt ?? Date.now();
+        const completedAt = Date.now();
         merged.completedAt = completedAt;
         merged.duration = Math.max(0, completedAt - merged.startedAt);
       } else {

--- a/apps/api/src/routes/agent/workouts.ts
+++ b/apps/api/src/routes/agent/workouts.ts
@@ -1,0 +1,414 @@
+import { randomUUID } from 'node:crypto';
+
+import {
+  agentCreateWorkoutSessionInputSchema,
+  agentCreateWorkoutTemplateInputSchema,
+  agentUpdateWorkoutSessionInputSchema,
+  agentUpdateWorkoutTemplateInputSchema,
+  createWorkoutSessionInputSchema,
+  type CreateWorkoutTemplateInput,
+  type CreateWorkoutSessionInput,
+  type WorkoutSession,
+  type WorkoutTemplateSectionType,
+} from '@pulse/shared';
+import type { FastifyPluginAsync } from 'fastify';
+
+import { sendError } from '../../lib/reply.js';
+import { createExercise, findVisibleExerciseByName } from '../exercises/store.js';
+import { createWorkoutSession, findWorkoutSessionById, updateWorkoutSession } from '../workout-sessions/store.js';
+import {
+  createWorkoutTemplate,
+  findWorkoutTemplateById,
+  updateWorkoutTemplate,
+} from '../workout-templates/store.js';
+
+const SECTION_ORDER: WorkoutTemplateSectionType[] = ['warmup', 'main', 'cooldown'];
+
+const WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE = {
+  code: 'WORKOUT_TEMPLATE_NOT_FOUND',
+  message: 'Workout template not found',
+} as const;
+
+const WORKOUT_SESSION_NOT_FOUND_RESPONSE = {
+  code: 'WORKOUT_SESSION_NOT_FOUND',
+  message: 'Workout session not found',
+} as const;
+
+const DEFAULT_EXERCISE_CATEGORY = 'compound' as const;
+const DEFAULT_EXERCISE_MUSCLE_GROUPS = ['Full Body'];
+const DEFAULT_EXERCISE_EQUIPMENT = 'Bodyweight';
+
+const inferSectionType = (name: string): WorkoutTemplateSectionType => {
+  const normalized = name.trim().toLowerCase();
+
+  if (normalized.includes('warm')) {
+    return 'warmup';
+  }
+
+  if (normalized.includes('cool')) {
+    return 'cooldown';
+  }
+
+  return 'main';
+};
+
+const resolveExerciseIdByName = async ({
+  name,
+  userId,
+}: {
+  name: string;
+  userId: string;
+}): Promise<string> => {
+  const existingExercise = await findVisibleExerciseByName({ name, userId });
+  if (existingExercise) {
+    return existingExercise.id;
+  }
+
+  const createdExercise = await createExercise({
+    id: randomUUID(),
+    userId,
+    name,
+    category: DEFAULT_EXERCISE_CATEGORY,
+    muscleGroups: DEFAULT_EXERCISE_MUSCLE_GROUPS,
+    equipment: DEFAULT_EXERCISE_EQUIPMENT,
+    instructions: null,
+  });
+
+  return createdExercise.id;
+};
+
+const buildTemplateSections = async ({
+  sections,
+  userId,
+}: {
+  sections: Array<{
+    name: string;
+    exercises: Array<{
+      name: string;
+      sets: number;
+      reps: number;
+      restSeconds?: number;
+    }>;
+  }>;
+  userId: string;
+}) => {
+  const groupedByType = new Map<
+    WorkoutTemplateSectionType,
+    CreateWorkoutTemplateInput['sections'][number]['exercises']
+  >();
+  groupedByType.set('warmup', []);
+  groupedByType.set('main', []);
+  groupedByType.set('cooldown', []);
+
+  for (const section of sections) {
+    const sectionType = inferSectionType(section.name);
+    const existingExercises = groupedByType.get(sectionType);
+    if (!existingExercises) {
+      continue;
+    }
+
+    for (const exercise of section.exercises) {
+      const exerciseId = await resolveExerciseIdByName({
+        name: exercise.name,
+        userId,
+      });
+
+      existingExercises.push({
+        exerciseId,
+        sets: exercise.sets,
+        repsMin: exercise.reps,
+        repsMax: exercise.reps,
+        tempo: null,
+        restSeconds: exercise.restSeconds ?? null,
+        supersetGroup: null,
+        notes: null,
+        cues: [],
+      });
+    }
+  }
+
+  return SECTION_ORDER.flatMap((type) => {
+    const exercises = groupedByType.get(type) ?? [];
+    return exercises.length > 0 ? [{ type, exercises }] : [];
+  });
+};
+
+const toCreateWorkoutSessionInput = (session: WorkoutSession): CreateWorkoutSessionInput => ({
+  templateId: session.templateId,
+  name: session.name,
+  date: session.date,
+  status: session.status,
+  startedAt: session.startedAt,
+  completedAt: session.completedAt,
+  duration: session.duration,
+  feedback: session.feedback,
+  notes: session.notes,
+  sets: session.sets.map((set) => ({
+    exerciseId: set.exerciseId,
+    setNumber: set.setNumber,
+    weight: set.weight,
+    reps: set.reps,
+    completed: set.completed,
+    skipped: set.skipped,
+    section: set.section,
+    notes: set.notes,
+  })),
+});
+
+const buildInitialSessionSets = (
+  sections: Array<{
+    type: WorkoutTemplateSectionType;
+    exercises: Array<{ exerciseId: string; sets: number | null }>;
+  }>,
+): CreateWorkoutSessionInput['sets'] => {
+  const sets: CreateWorkoutSessionInput['sets'] = [];
+
+  for (const section of sections) {
+    for (const exercise of section.exercises) {
+      const setCount = exercise.sets ?? 1;
+
+      for (let setNumber = 1; setNumber <= setCount; setNumber += 1) {
+        sets.push({
+          exerciseId: exercise.exerciseId,
+          setNumber,
+          weight: null,
+          reps: null,
+          completed: false,
+          skipped: false,
+          section: section.type,
+          notes: null,
+        });
+      }
+    }
+  }
+
+  return sets;
+};
+
+export const agentWorkoutRoutes: FastifyPluginAsync = async (app) => {
+  app.post('/workout-templates', async (request, reply) => {
+    const parsed = agentCreateWorkoutTemplateInputSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid workout template payload');
+    }
+
+    const sections = await buildTemplateSections({
+      sections: parsed.data.sections,
+      userId: request.userId,
+    });
+
+    const template = await createWorkoutTemplate({
+      id: randomUUID(),
+      userId: request.userId,
+      input: {
+        name: parsed.data.name,
+        description: null,
+        tags: [],
+        sections,
+      },
+    });
+
+    return reply.code(201).send({ data: template });
+  });
+
+  app.put<{ Params: { id: string } }>('/workout-templates/:id', async (request, reply) => {
+    const parsed = agentUpdateWorkoutTemplateInputSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid workout template payload');
+    }
+
+    const existing = await findWorkoutTemplateById(request.params.id, request.userId);
+    if (!existing) {
+      return sendError(
+        reply,
+        404,
+        WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE.code,
+        WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE.message,
+      );
+    }
+
+    const sections = await buildTemplateSections({
+      sections: parsed.data.sections,
+      userId: request.userId,
+    });
+
+    const template = await updateWorkoutTemplate({
+      id: request.params.id,
+      userId: request.userId,
+      input: {
+        name: parsed.data.name,
+        description: null,
+        tags: [],
+        sections,
+      },
+    });
+
+    if (!template) {
+      return sendError(
+        reply,
+        404,
+        WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE.code,
+        WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE.message,
+      );
+    }
+
+    return reply.send({ data: template });
+  });
+
+  app.post('/workout-sessions', async (request, reply) => {
+    const parsed = agentCreateWorkoutSessionInputSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid workout session payload');
+    }
+
+    const startedAt = Date.now();
+    const date = new Date(startedAt).toISOString().slice(0, 10);
+
+    const templateId: string | null = parsed.data.templateId ?? null;
+    let name = parsed.data.name;
+    let sets: CreateWorkoutSessionInput['sets'] = [];
+
+    if (templateId) {
+      const template = await findWorkoutTemplateById(templateId, request.userId);
+      if (!template) {
+        return sendError(
+          reply,
+          404,
+          WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE.code,
+          WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      name = name ?? template.name;
+      sets = buildInitialSessionSets(template.sections);
+    }
+
+    const payload = createWorkoutSessionInputSchema.safeParse({
+      templateId,
+      name,
+      date,
+      status: 'in-progress',
+      startedAt,
+      completedAt: null,
+      duration: null,
+      feedback: null,
+      notes: null,
+      sets,
+    });
+
+    if (!payload.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid workout session payload');
+    }
+
+    const session = await createWorkoutSession({
+      id: randomUUID(),
+      userId: request.userId,
+      input: payload.data,
+    });
+
+    return reply.code(201).send({ data: session });
+  });
+
+  app.patch<{ Params: { id: string } }>('/workout-sessions/:id', async (request, reply) => {
+    const parsed = agentUpdateWorkoutSessionInputSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid workout session payload');
+    }
+
+    const existing = await findWorkoutSessionById(request.params.id, request.userId);
+    if (!existing) {
+      return sendError(
+        reply,
+        404,
+        WORKOUT_SESSION_NOT_FOUND_RESPONSE.code,
+        WORKOUT_SESSION_NOT_FOUND_RESPONSE.message,
+      );
+    }
+
+    const merged = toCreateWorkoutSessionInput(existing);
+
+    if (parsed.data.sets) {
+      const setMap = new Map(
+        merged.sets.map((set) => [`${set.exerciseId}:${set.setNumber}`, { ...set }]),
+      );
+
+      for (const set of parsed.data.sets) {
+        const exerciseId = await resolveExerciseIdByName({
+          name: set.exerciseName,
+          userId: request.userId,
+        });
+
+        const key = `${exerciseId}:${set.setNumber}`;
+        const previous = setMap.get(key);
+
+        if (previous) {
+          setMap.set(key, {
+            ...previous,
+            weight: set.weight,
+            reps: set.reps,
+            completed: true,
+            skipped: false,
+          });
+          continue;
+        }
+
+        setMap.set(key, {
+          exerciseId,
+          setNumber: set.setNumber,
+          weight: set.weight,
+          reps: set.reps,
+          completed: true,
+          skipped: false,
+          section: null,
+          notes: null,
+        });
+      }
+
+      merged.sets = Array.from(setMap.values()).sort((left, right) => {
+        if (left.exerciseId !== right.exerciseId) {
+          return left.exerciseId.localeCompare(right.exerciseId);
+        }
+
+        return left.setNumber - right.setNumber;
+      });
+    }
+
+    if (parsed.data.status !== undefined) {
+      merged.status = parsed.data.status;
+
+      if (parsed.data.status === 'completed') {
+        const completedAt = merged.completedAt ?? Date.now();
+        merged.completedAt = completedAt;
+        merged.duration = Math.max(0, completedAt - merged.startedAt);
+      } else {
+        merged.completedAt = null;
+        merged.duration = null;
+      }
+    }
+
+    if (parsed.data.notes !== undefined) {
+      merged.notes = parsed.data.notes;
+    }
+
+    const payload = createWorkoutSessionInputSchema.safeParse(merged);
+    if (!payload.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid workout session payload');
+    }
+
+    const session = await updateWorkoutSession({
+      id: request.params.id,
+      userId: request.userId,
+      input: payload.data,
+    });
+    if (!session) {
+      return sendError(
+        reply,
+        404,
+        WORKOUT_SESSION_NOT_FOUND_RESPONSE.code,
+        WORKOUT_SESSION_NOT_FOUND_RESPONSE.message,
+      );
+    }
+
+    return reply.send({ data: session });
+  });
+};

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -235,6 +235,30 @@ export const findVisibleExerciseById = async ({
     .get();
 };
 
+export const findVisibleExerciseByName = async ({
+  name,
+  userId,
+}: {
+  name: string;
+  userId: string;
+}): Promise<Exercise | undefined> => {
+  const { db } = await import('../../db/index.js');
+  const normalizedName = name.trim().toLowerCase();
+
+  return db
+    .select(exerciseSelection)
+    .from(exercises)
+    .where(
+      and(
+        sql`lower(${exercises.name}) = ${normalizedName}`,
+        or(isNull(exercises.userId), eq(exercises.userId, userId)),
+      ),
+    )
+    .orderBy(sql`case when ${exercises.userId} is null then 1 else 0 end asc`, asc(exercises.name))
+    .limit(1)
+    .get();
+};
+
 export const findExerciseLastPerformance = async ({
   exerciseId,
   userId,

--- a/docs/conventions/agent-integration.md
+++ b/docs/conventions/agent-integration.md
@@ -472,10 +472,44 @@ Response (`200`):
 {
   "data": {
     "id": "session-1",
+    "userId": "user-1",
+    "templateId": "template-1",
+    "name": "Leg Day",
+    "date": "2026-03-09",
     "status": "completed",
-    "completedAt": 1700000000000,
-    "duration": 0,
-    "notes": "Solid session"
+    "startedAt": 1700000000000,
+    "completedAt": 1700003720000,
+    "duration": 62,
+    "feedback": null,
+    "notes": "Solid session",
+    "sets": [
+      {
+        "id": "set-1",
+        "exerciseId": "exercise-bench-press",
+        "setNumber": 1,
+        "weight": 105,
+        "reps": 7,
+        "completed": true,
+        "skipped": false,
+        "section": "main",
+        "notes": null,
+        "createdAt": 1700000000000
+      },
+      {
+        "id": "set-2",
+        "exerciseId": "exercise-squat",
+        "setNumber": 1,
+        "weight": 225,
+        "reps": 5,
+        "completed": true,
+        "skipped": false,
+        "section": "main",
+        "notes": null,
+        "createdAt": 1700000000000
+      }
+    ],
+    "createdAt": 1700000000000,
+    "updatedAt": 1700003720000
   }
 }
 ```
@@ -637,7 +671,7 @@ Response:
 
 1. Call `GET /api/agent/context`.
 2. Derive plan from current nutrition/workout/habit/weight state.
-3. Execute one or more write operations (`/meals`, `/weight`, `/workout-sessions`, `/habits/:id/entries`).
+3. Execute one or more write operations (`/api/agent/meals`, `/api/agent/weight`, `/api/agent/workout-sessions`, `/api/agent/habits/:id/entries`).
 4. Optionally re-read context for confirmation.
 
 ### 2) Food Search + Meal Logging
@@ -649,10 +683,10 @@ Response:
 
 ### 3) Workout Creation + Session Logging
 
-1. Search/create exercises (`GET /exercises/search`, `POST /exercises`).
-2. Create/update template (`POST/PUT /workout-templates`).
-3. Start session (`POST /workout-sessions`).
-4. Log sets and status (`PATCH /workout-sessions/:id`).
+1. Search/create exercises (`GET /api/agent/exercises/search`, `POST /api/agent/exercises`).
+2. Create/update template (`POST/PUT /api/agent/workout-templates`).
+3. Start session (`POST /api/agent/workout-sessions`).
+4. Log sets and status (`PATCH /api/agent/workout-sessions/:id`).
 
 ## Error Handling Conventions
 

--- a/docs/conventions/agent-integration.md
+++ b/docs/conventions/agent-integration.md
@@ -1,0 +1,705 @@
+# Agent Integration Conventions
+
+This document defines how external AI agents should authenticate, call `/api/agent/*` endpoints, and handle common success/error patterns.
+
+## Purpose
+
+- Use `/api/agent/*` for programmatic assistant workflows (meal logging, workout logging, daily updates, context retrieval).
+- Use `/api/v1/*` for user-facing app flows and settings management.
+- Treat `GET /api/agent/context` as the first call in most agent sessions.
+
+## Authentication
+
+### How Agent Tokens Are Created
+
+Agent tokens are created by an authenticated app user:
+
+- In the app settings UI, or
+- Via `POST /api/v1/agent-tokens`
+
+Creation response returns the plain token once:
+
+```json
+{
+  "data": {
+    "id": "agent-token-id",
+    "name": "Meal Logger",
+    "token": "plain-token-value"
+  }
+}
+```
+
+Storage model:
+
+- Plain token is shown only at creation time.
+- API stores only SHA-256 hash in `agent_tokens.tokenHash`.
+
+### Supported Auth Schemes
+
+Both are accepted on `/api/agent/*` by `requireAuth` in `apps/api/src/middleware/auth.ts`:
+
+- `Authorization: Bearer <jwt>` (normal app JWT from register/login)
+- `Authorization: AgentToken <token>` (programmatic token)
+
+Sensitive user-only routes use `requireUserAuth` (JWT-only), including `/api/v1/agent-tokens`.
+
+### Auth Failure Contract
+
+On missing/invalid credentials:
+
+```json
+{
+  "error": {
+    "code": "UNAUTHORIZED",
+    "message": "Authentication required"
+  }
+}
+```
+
+## Endpoint Reference
+
+### Auth Check
+
+#### `GET /api/agent/ping`
+
+Minimal authenticated probe route.
+
+Response:
+
+```json
+{
+  "data": {
+    "userId": "user-123"
+  }
+}
+```
+
+### Context
+
+#### `GET /api/agent/context`
+
+Returns a planning snapshot with user profile, recent workouts, today nutrition, weight trend, habits, and upcoming scheduled workouts.
+
+Response:
+
+```json
+{
+  "data": {
+    "user": { "name": "Derek" },
+    "recentWorkouts": [
+      {
+        "id": "session-1",
+        "name": "Upper A",
+        "date": "2026-03-08",
+        "completedAt": 1700000000000,
+        "exercises": [
+          {
+            "name": "Bench Press",
+            "sets": { "total": 4, "completed": 4, "skipped": 0 }
+          }
+        ]
+      }
+    ],
+    "todayNutrition": {
+      "actual": { "calories": 2100, "protein": 180, "carbs": 210, "fat": 70 },
+      "target": { "calories": 2400, "protein": 200, "carbs": 250, "fat": 80 },
+      "meals": [
+        {
+          "name": "Lunch",
+          "items": [
+            {
+              "name": "Chicken Breast",
+              "amount": 1.5,
+              "unit": "serving",
+              "calories": 248,
+              "protein": 46.5,
+              "carbs": 0,
+              "fat": 5.4
+            }
+          ]
+        }
+      ]
+    },
+    "weight": { "current": 182.4, "trend7d": -0.8 },
+    "habits": [
+      { "name": "Hydrate", "trackingType": "numeric", "streak": 5, "todayCompleted": true }
+    ],
+    "scheduledWorkouts": [{ "date": "2026-03-10", "templateName": "Lower A" }]
+  }
+}
+```
+
+Notes:
+
+- Missing data still returns stable defaults (zeros/empty arrays/null name).
+- Scheduled workouts whose template was deleted return `"Unknown template"`.
+
+### Foods And Meals
+
+#### `GET /api/agent/foods/search?q=<term>&limit=<n>`
+
+Searches user foods by name/brand with recency-aware ordering.
+
+Response:
+
+```json
+{
+  "data": [
+    {
+      "id": "food-1",
+      "name": "Chicken Breast",
+      "brand": null,
+      "servingSize": "100 g",
+      "calories": 165,
+      "protein": 31,
+      "carbs": 0,
+      "fat": 3.6
+    }
+  ]
+}
+```
+
+#### `POST /api/agent/foods`
+
+Creates a user-scoped food entry.
+
+Request:
+
+```json
+{
+  "name": "Chicken Breast",
+  "servingSize": "100 g",
+  "calories": 165,
+  "protein": 31,
+  "carbs": 0,
+  "fat": 3.6
+}
+```
+
+Response (`201`):
+
+```json
+{
+  "data": {
+    "id": "food-1",
+    "name": "Chicken Breast",
+    "brand": null,
+    "servingSize": "100 g",
+    "calories": 165,
+    "protein": 31,
+    "carbs": 0,
+    "fat": 3.6
+  }
+}
+```
+
+#### `POST /api/agent/meals`
+
+Logs a meal for a date from food-name references.
+
+Request:
+
+```json
+{
+  "name": "Lunch",
+  "date": "2026-03-09",
+  "time": "12:00",
+  "items": [
+    { "foodName": "Chicken Breast", "quantity": 2, "unit": "serving" },
+    { "foodName": "White Rice", "quantity": 1, "unit": "serving" }
+  ]
+}
+```
+
+Response (`201`):
+
+```json
+{
+  "data": {
+    "meal": {
+      "id": "meal-1",
+      "name": "Lunch",
+      "date": "2026-03-09",
+      "time": "12:00"
+    },
+    "macros": {
+      "calories": 536,
+      "protein": 66.3,
+      "carbs": 44.5,
+      "fat": 7.6
+    },
+    "items": [
+      {
+        "id": "item-1",
+        "foodId": "food-chicken",
+        "name": "Chicken Breast",
+        "amount": 2,
+        "unit": "serving",
+        "calories": 330,
+        "protein": 62,
+        "carbs": 0,
+        "fat": 7.2
+      }
+    ]
+  }
+}
+```
+
+Behavior notes:
+
+- Quantity scales food macros directly (`scaled = foodMacro * quantity`).
+- If any food name cannot be resolved, returns `422 UNRESOLVED_FOODS`.
+
+### Exercises And Workouts
+
+#### `POST /api/agent/exercises`
+
+Creates an exercise. Optional fields default to:
+
+- `category: "compound"`
+- `muscleGroups: ["Full Body"]`
+- `equipment: "Bodyweight"`
+
+Request:
+
+```json
+{
+  "name": "Dumbbell Row"
+}
+```
+
+Response (`201`):
+
+```json
+{
+  "data": {
+    "id": "exercise-1",
+    "name": "Dumbbell Row",
+    "category": "compound",
+    "muscleGroups": ["Full Body"],
+    "equipment": "Bodyweight"
+  }
+}
+```
+
+#### `GET /api/agent/exercises/search?q=<term>&limit=<n>`
+
+Searches visible exercises (shared + user-scoped).
+
+Response:
+
+```json
+{
+  "data": [
+    {
+      "id": "exercise-1",
+      "name": "Barbell Bench Press",
+      "category": "compound",
+      "muscleGroups": ["Chest", "Triceps"],
+      "equipment": "Barbell"
+    }
+  ]
+}
+```
+
+#### `POST /api/agent/workout-templates`
+
+Creates a template from plain-text sections/exercises.
+
+Request:
+
+```json
+{
+  "name": "Push Day",
+  "sections": [
+    {
+      "name": "Main",
+      "exercises": [{ "name": "Bench Press", "sets": 4, "reps": 8, "restSeconds": 120 }]
+    }
+  ]
+}
+```
+
+Response (`201`):
+
+```json
+{
+  "data": {
+    "id": "template-1",
+    "userId": "user-1",
+    "name": "Push Day",
+    "description": null,
+    "tags": [],
+    "sections": [
+      {
+        "type": "main",
+        "exercises": [
+          {
+            "id": "template-exercise-1",
+            "exerciseId": "exercise-1",
+            "exerciseName": "Bench Press",
+            "sets": 4,
+            "repsMin": 8,
+            "repsMax": 8,
+            "tempo": null,
+            "restSeconds": 120,
+            "supersetGroup": null,
+            "notes": null,
+            "cues": []
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Behavior notes:
+
+- Unknown exercise names are auto-created.
+- Section names are normalized to `warmup | main | cooldown` by keyword inference.
+
+#### `PUT /api/agent/workout-templates/:id`
+
+Replaces template content.
+
+Response (`200`):
+
+```json
+{
+  "data": {
+    "id": "template-1",
+    "userId": "user-1",
+    "name": "Upper A",
+    "description": null,
+    "tags": [],
+    "sections": [
+      {
+        "type": "main",
+        "exercises": [
+          {
+            "id": "template-exercise-2",
+            "exerciseId": "exercise-2",
+            "exerciseName": "Incline Press",
+            "sets": 3,
+            "repsMin": 10,
+            "repsMax": 10,
+            "tempo": null,
+            "restSeconds": null,
+            "supersetGroup": null,
+            "notes": null,
+            "cues": []
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- `404 WORKOUT_TEMPLATE_NOT_FOUND` if template is missing or not user-owned.
+
+#### `POST /api/agent/workout-sessions`
+
+Starts an in-progress session.
+
+Request options:
+
+- `{ "templateId": "..." }` to start from template (prebuilds sets), or
+- `{ "name": "Ad hoc Session" }` for a named non-template session.
+
+Example request:
+
+```json
+{
+  "templateId": "template-1"
+}
+```
+
+Response (`201`):
+
+```json
+{
+  "data": {
+    "id": "session-1",
+    "userId": "user-1",
+    "templateId": "template-1",
+    "name": "Leg Day",
+    "date": "2026-03-09",
+    "status": "in-progress",
+    "startedAt": 1700000000000,
+    "completedAt": null,
+    "duration": null,
+    "feedback": null,
+    "notes": null,
+    "sets": [
+      {
+        "id": "set-1",
+        "exerciseId": "exercise-squat",
+        "setNumber": 1,
+        "weight": null,
+        "reps": null,
+        "completed": false,
+        "skipped": false,
+        "section": "main",
+        "notes": null
+      }
+    ]
+  }
+}
+```
+
+#### `PATCH /api/agent/workout-sessions/:id`
+
+Updates session status/notes and upserts set logs by `exerciseName + setNumber`.
+
+Request:
+
+```json
+{
+  "status": "completed",
+  "notes": "Solid session",
+  "sets": [
+    { "exerciseName": "Bench Press", "setNumber": 1, "weight": 105, "reps": 7 },
+    { "exerciseName": "Squat", "setNumber": 1, "weight": 225, "reps": 5 }
+  ]
+}
+```
+
+Response (`200`):
+
+```json
+{
+  "data": {
+    "id": "session-1",
+    "status": "completed",
+    "completedAt": 1700000000000,
+    "duration": 0,
+    "notes": "Solid session"
+  }
+}
+```
+
+Behavior notes:
+
+- Unknown exercise names are auto-created.
+- Upserted sets are marked `completed: true`, `skipped: false`.
+- Completing a session sets `completedAt` and duration.
+- `404 WORKOUT_SESSION_NOT_FOUND` if missing.
+
+### Daily Tracking
+
+#### `POST /api/agent/weight`
+
+Creates or updates weight entry by date.
+
+Request:
+
+```json
+{
+  "date": "2026-03-09",
+  "weight": 182.4,
+  "notes": "fasted"
+}
+```
+
+Response:
+
+- `201` when row is created
+- `200` when existing row is updated
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": "weight-1",
+    "date": "2026-03-09",
+    "weight": 182.4,
+    "notes": "fasted",
+    "createdAt": 1700000000000,
+    "updatedAt": 1700000000000
+  }
+}
+```
+
+#### `GET /api/agent/habits`
+
+Returns active habits with today entry projection:
+
+```json
+{
+  "data": [
+    {
+      "id": "habit-1",
+      "name": "Supplements",
+      "trackingType": "boolean",
+      "todayEntry": null
+    },
+    {
+      "id": "habit-2",
+      "name": "Sleep",
+      "trackingType": "time",
+      "todayEntry": { "value": 8, "completed": true }
+    }
+  ]
+}
+```
+
+#### `PATCH /api/agent/habits/:id/entries`
+
+Upserts one day for one habit.
+
+Request:
+
+```json
+{
+  "date": "2026-03-09",
+  "value": 8
+}
+```
+
+Response (`200` or `201`):
+
+```json
+{
+  "data": {
+    "id": "entry-1",
+    "habitId": "habit-2",
+    "userId": "user-1",
+    "date": "2026-03-09",
+    "completed": true,
+    "value": 8,
+    "createdAt": 1700000000000
+  }
+}
+```
+
+Behavior notes:
+
+- At least one of `completed` or `value` is required.
+- Omitted fields merge from existing entry if present.
+- `201` on insert, `200` on update.
+- `404 HABIT_NOT_FOUND` when habit is missing.
+
+#### `GET /api/agent/nutrition/:date/summary`
+
+Returns aggregate summary + expanded meal rows for one day.
+
+Response:
+
+```json
+{
+  "data": {
+    "summary": {
+      "date": "2026-03-09",
+      "meals": 1,
+      "actual": { "calories": 450, "protein": 40, "carbs": 30, "fat": 15 },
+      "target": { "calories": 2500, "protein": 180, "carbs": 260, "fat": 80 }
+    },
+    "meals": [
+      {
+        "meal": {
+          "id": "meal-1",
+          "nutritionLogId": "log-1",
+          "name": "Lunch",
+          "time": "12:00",
+          "notes": null,
+          "createdAt": 1700000000000,
+          "updatedAt": 1700000000000
+        },
+        "items": [
+          {
+            "id": "item-1",
+            "mealId": "meal-1",
+            "foodId": "food-1",
+            "name": "Chicken Breast",
+            "amount": 1,
+            "unit": "serving",
+            "calories": 165,
+            "protein": 31,
+            "carbs": 0,
+            "fat": 3.6,
+            "fiber": null,
+            "sugar": null,
+            "createdAt": 1700000000000
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Required Workflow Patterns
+
+### 1) Context-First Pattern
+
+1. Call `GET /api/agent/context`.
+2. Derive plan from current nutrition/workout/habit/weight state.
+3. Execute one or more write operations (`/meals`, `/weight`, `/workout-sessions`, `/habits/:id/entries`).
+4. Optionally re-read context for confirmation.
+
+### 2) Food Search + Meal Logging
+
+1. Call `GET /api/agent/foods/search?q=<food>`.
+2. If missing, create via `POST /api/agent/foods`.
+3. Submit all meal items using `POST /api/agent/meals`.
+4. Handle `UNRESOLVED_FOODS` by creating missing foods and retrying.
+
+### 3) Workout Creation + Session Logging
+
+1. Search/create exercises (`GET /exercises/search`, `POST /exercises`).
+2. Create/update template (`POST/PUT /workout-templates`).
+3. Start session (`POST /workout-sessions`).
+4. Log sets and status (`PATCH /workout-sessions/:id`).
+
+## Error Handling Conventions
+
+Standard error envelope:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Invalid request payload",
+    "details": {}
+  }
+}
+```
+
+`details` is optional and may be omitted.
+
+Common base codes:
+
+- `UNAUTHORIZED`
+- `NOT_FOUND`
+- `VALIDATION_ERROR`
+- `CONFLICT`
+- `INTERNAL_ERROR`
+
+Agent-route-specific codes in current implementation:
+
+- `UNRESOLVED_FOODS`
+- `HABIT_NOT_FOUND`
+- `WORKOUT_TEMPLATE_NOT_FOUND`
+- `WORKOUT_SESSION_NOT_FOUND`
+
+## Request Validation Rules
+
+- Dates must be `YYYY-MM-DD` and valid calendar dates.
+- Time fields use `HH:MM` 24-hour format.
+- All writes are user-scoped from `request.userId`.
+- Validation failures return `400 VALIDATION_ERROR`.
+
+## Rate Limiting
+
+Current status:
+
+- No explicit rate-limit middleware is applied to `/api/agent/*` yet.
+
+Planned approach:
+
+- Add per-user/token rate limiting at the Fastify layer (request identity derived from auth).
+- Return `429` with the standard error envelope when limits are exceeded.
+- Start with conservative write limits (`/meals`, `/workout-sessions`, `/weight`, habit entry patch), then tune using production telemetry.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+export * from './schemas/agent.js';
 export * from './schemas/auth.js';
 export * from './schemas/activities.js';
 export * from './schemas/agent-tokens.js';

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { dateSchema } from './common.js';
 import { exerciseCategorySchema } from './exercises.js';
 import { workoutSessionStatusSchema } from './workout-sessions.js';
 
@@ -127,6 +128,26 @@ export const agentExerciseSearchParamsSchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(10),
 });
 
+export const agentCreateWeightInputSchema = z.object({
+  date: dateSchema,
+  weight: z.number().positive().finite().max(1_500),
+  notes: z.string().trim().max(2_000).optional(),
+});
+
+export const agentUpdateHabitEntryInputSchema = z
+  .object({
+    date: dateSchema,
+    completed: z.boolean().optional(),
+    value: z.number().finite().optional(),
+  })
+  .refine((value) => value.completed !== undefined || value.value !== undefined, {
+    message: 'At least one habit entry field must be provided',
+  });
+
+export const agentNutritionSummaryParamsSchema = z.object({
+  date: dateSchema,
+});
+
 export type AgentFoodSearchParams = z.infer<typeof agentFoodSearchParamsSchema>;
 export type AgentFoodResult = z.infer<typeof agentFoodResultSchema>;
 export type AgentCreateFoodInput = z.infer<typeof agentCreateFoodInputSchema>;
@@ -145,3 +166,6 @@ export type AgentWorkoutSetUpsertInput = z.infer<typeof agentWorkoutSetUpsertInp
 export type AgentUpdateWorkoutSessionInput = z.infer<typeof agentUpdateWorkoutSessionInputSchema>;
 export type AgentCreateExerciseInput = z.infer<typeof agentCreateExerciseInputSchema>;
 export type AgentExerciseSearchParams = z.infer<typeof agentExerciseSearchParamsSchema>;
+export type AgentCreateWeightInput = z.infer<typeof agentCreateWeightInputSchema>;
+export type AgentUpdateHabitEntryInput = z.infer<typeof agentUpdateHabitEntryInputSchema>;
+export type AgentNutritionSummaryParams = z.infer<typeof agentNutritionSummaryParamsSchema>;

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -43,7 +43,7 @@ export const agentMealItemInputSchema = z.object({
 
 export const agentCreateMealInputSchema = z.object({
   name: requiredText(120),
-  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  date: dateSchema,
   time: z
     .string()
     .regex(/^([01]\d|2[0-3]):[0-5]\d$/)

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 
+import { exerciseCategorySchema } from './exercises.js';
+import { workoutSessionStatusSchema } from './workout-sessions.js';
+
 const requiredText = (maxLength = 255) => z.string().trim().min(1).max(maxLength);
 
 export const agentFoodSearchParamsSchema = z.object({
@@ -46,8 +49,99 @@ export const agentCreateMealInputSchema = z.object({
   items: z.array(agentMealItemInputSchema).min(1),
 });
 
+export const agentWorkoutTemplateExerciseInputSchema = z.object({
+  name: requiredText(),
+  sets: z.number().int().min(1).max(100),
+  reps: z.number().int().min(1).max(1000),
+  restSeconds: z.number().int().min(0).max(3600).optional(),
+});
+
+export const agentWorkoutTemplateSectionInputSchema = z.object({
+  name: requiredText(120),
+  exercises: z.array(agentWorkoutTemplateExerciseInputSchema).min(1).max(100),
+});
+
+export const agentCreateWorkoutTemplateInputSchema = z.object({
+  name: requiredText(255),
+  sections: z.array(agentWorkoutTemplateSectionInputSchema).min(1).max(20),
+});
+
+export const agentUpdateWorkoutTemplateInputSchema = agentCreateWorkoutTemplateInputSchema;
+
+const optionalText = (maxLength = 4000) =>
+  z.preprocess(
+    (value) => {
+      if (value === undefined) {
+        return undefined;
+      }
+
+      if (value === null) {
+        return null;
+      }
+
+      if (typeof value !== 'string') {
+        return value;
+      }
+
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    },
+    z.string().trim().min(1).max(maxLength).nullable().optional(),
+  );
+
+export const agentCreateWorkoutSessionInputSchema = z
+  .object({
+    templateId: z.string().trim().min(1).optional(),
+    name: z.string().trim().min(1).max(255).optional(),
+  })
+  .refine((value) => value.templateId !== undefined || value.name !== undefined, {
+    message: 'templateId or name is required',
+  });
+
+export const agentWorkoutSetUpsertInputSchema = z.object({
+  exerciseName: requiredText(),
+  setNumber: z.number().int().min(1).max(100),
+  weight: z.number().min(0).nullable(),
+  reps: z.number().int().min(0).nullable(),
+});
+
+export const agentUpdateWorkoutSessionInputSchema = z
+  .object({
+    sets: z.array(agentWorkoutSetUpsertInputSchema).min(1).max(500).optional(),
+    status: workoutSessionStatusSchema.optional(),
+    notes: optionalText(4000),
+  })
+  .refine((value) => value.sets !== undefined || value.status !== undefined || value.notes !== undefined, {
+    message: 'At least one workout session field must be provided',
+  });
+
+export const agentCreateExerciseInputSchema = z.object({
+  name: requiredText(),
+  category: exerciseCategorySchema.optional(),
+  muscleGroups: z.array(requiredText()).min(1).max(20).optional(),
+  equipment: requiredText().optional(),
+});
+
+export const agentExerciseSearchParamsSchema = z.object({
+  q: requiredText(),
+  limit: z.coerce.number().int().min(1).max(100).default(10),
+});
+
 export type AgentFoodSearchParams = z.infer<typeof agentFoodSearchParamsSchema>;
 export type AgentFoodResult = z.infer<typeof agentFoodResultSchema>;
 export type AgentCreateFoodInput = z.infer<typeof agentCreateFoodInputSchema>;
 export type AgentMealItemInput = z.infer<typeof agentMealItemInputSchema>;
 export type AgentCreateMealInput = z.infer<typeof agentCreateMealInputSchema>;
+export type AgentWorkoutTemplateExerciseInput = z.infer<
+  typeof agentWorkoutTemplateExerciseInputSchema
+>;
+export type AgentWorkoutTemplateSectionInput = z.infer<
+  typeof agentWorkoutTemplateSectionInputSchema
+>;
+export type AgentCreateWorkoutTemplateInput = z.infer<typeof agentCreateWorkoutTemplateInputSchema>;
+export type AgentUpdateWorkoutTemplateInput = z.infer<typeof agentUpdateWorkoutTemplateInputSchema>;
+export type AgentCreateWorkoutSessionInput = z.infer<typeof agentCreateWorkoutSessionInputSchema>;
+export type AgentWorkoutSetUpsertInput = z.infer<typeof agentWorkoutSetUpsertInputSchema>;
+export type AgentUpdateWorkoutSessionInput = z.infer<typeof agentUpdateWorkoutSessionInputSchema>;
+export type AgentCreateExerciseInput = z.infer<typeof agentCreateExerciseInputSchema>;
+export type AgentExerciseSearchParams = z.infer<typeof agentExerciseSearchParamsSchema>;

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { dateSchema } from './common.js';
 import { exerciseCategorySchema } from './exercises.js';
+import { habitTrackingTypeSchema } from './habits.js';
 import { workoutSessionStatusSchema } from './workout-sessions.js';
 
 const requiredText = (maxLength = 255) => z.string().trim().min(1).max(maxLength);
@@ -148,6 +149,75 @@ export const agentNutritionSummaryParamsSchema = z.object({
   date: dateSchema,
 });
 
+const agentContextMacroTotalsSchema = z.object({
+  calories: z.number(),
+  protein: z.number(),
+  carbs: z.number(),
+  fat: z.number(),
+});
+
+export const agentContextMealItemSchema = z.object({
+  name: z.string(),
+  amount: z.number(),
+  unit: z.string(),
+  calories: z.number(),
+  protein: z.number(),
+  carbs: z.number(),
+  fat: z.number(),
+});
+
+export const agentContextMealSchema = z.object({
+  name: z.string(),
+  items: z.array(agentContextMealItemSchema),
+});
+
+export const agentContextRecentWorkoutExerciseSchema = z.object({
+  name: z.string(),
+  sets: z.object({
+    total: z.number().int().nonnegative(),
+    completed: z.number().int().nonnegative(),
+    skipped: z.number().int().nonnegative(),
+  }),
+});
+
+export const agentContextRecentWorkoutSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  date: dateSchema,
+  completedAt: z.number().int().nullable(),
+  exercises: z.array(agentContextRecentWorkoutExerciseSchema),
+});
+
+export const agentContextHabitSchema = z.object({
+  name: z.string(),
+  trackingType: habitTrackingTypeSchema,
+  streak: z.number().int().nonnegative(),
+  todayCompleted: z.boolean(),
+});
+
+export const agentContextScheduledWorkoutSchema = z.object({
+  date: dateSchema,
+  templateName: z.string(),
+});
+
+export const agentContextResponseSchema = z.object({
+  user: z.object({
+    name: z.string().nullable(),
+  }),
+  recentWorkouts: z.array(agentContextRecentWorkoutSchema),
+  todayNutrition: z.object({
+    actual: agentContextMacroTotalsSchema,
+    target: agentContextMacroTotalsSchema,
+    meals: z.array(agentContextMealSchema),
+  }),
+  weight: z.object({
+    current: z.number(),
+    trend7d: z.number(),
+  }),
+  habits: z.array(agentContextHabitSchema),
+  scheduledWorkouts: z.array(agentContextScheduledWorkoutSchema),
+});
+
 export type AgentFoodSearchParams = z.infer<typeof agentFoodSearchParamsSchema>;
 export type AgentFoodResult = z.infer<typeof agentFoodResultSchema>;
 export type AgentCreateFoodInput = z.infer<typeof agentCreateFoodInputSchema>;
@@ -169,3 +239,12 @@ export type AgentExerciseSearchParams = z.infer<typeof agentExerciseSearchParams
 export type AgentCreateWeightInput = z.infer<typeof agentCreateWeightInputSchema>;
 export type AgentUpdateHabitEntryInput = z.infer<typeof agentUpdateHabitEntryInputSchema>;
 export type AgentNutritionSummaryParams = z.infer<typeof agentNutritionSummaryParamsSchema>;
+export type AgentContextMealItem = z.infer<typeof agentContextMealItemSchema>;
+export type AgentContextMeal = z.infer<typeof agentContextMealSchema>;
+export type AgentContextRecentWorkoutExercise = z.infer<
+  typeof agentContextRecentWorkoutExerciseSchema
+>;
+export type AgentContextRecentWorkout = z.infer<typeof agentContextRecentWorkoutSchema>;
+export type AgentContextHabit = z.infer<typeof agentContextHabitSchema>;
+export type AgentContextScheduledWorkout = z.infer<typeof agentContextScheduledWorkoutSchema>;
+export type AgentContextResponse = z.infer<typeof agentContextResponseSchema>;

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+const requiredText = (maxLength = 255) => z.string().trim().min(1).max(maxLength);
+
+export const agentFoodSearchParamsSchema = z.object({
+  q: z.string().trim().min(1).max(255).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(10),
+});
+
+export const agentFoodResultSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  brand: z.string().nullable(),
+  servingSize: z.string().nullable(),
+  calories: z.number(),
+  protein: z.number(),
+  carbs: z.number(),
+  fat: z.number(),
+});
+
+export const agentCreateFoodInputSchema = z.object({
+  name: requiredText(),
+  brand: requiredText().nullable().optional(),
+  servingSize: z.string().trim().nullable().optional(),
+  calories: z.number().nonnegative(),
+  protein: z.number().nonnegative(),
+  carbs: z.number().nonnegative(),
+  fat: z.number().nonnegative(),
+  source: z.string().trim().nullable().optional(),
+  notes: z.string().trim().nullable().optional(),
+});
+
+export const agentMealItemInputSchema = z.object({
+  foodName: requiredText(),
+  quantity: z.number().positive().finite(),
+  unit: z.string().trim().min(1).max(50).default('serving'),
+});
+
+export const agentCreateMealInputSchema = z.object({
+  name: requiredText(120),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  time: z
+    .string()
+    .regex(/^([01]\d|2[0-3]):[0-5]\d$/)
+    .optional(),
+  items: z.array(agentMealItemInputSchema).min(1),
+});
+
+export type AgentFoodSearchParams = z.infer<typeof agentFoodSearchParamsSchema>;
+export type AgentFoodResult = z.infer<typeof agentFoodResultSchema>;
+export type AgentCreateFoodInput = z.infer<typeof agentCreateFoodInputSchema>;
+export type AgentMealItemInput = z.infer<typeof agentMealItemInputSchema>;
+export type AgentCreateMealInput = z.infer<typeof agentCreateMealInputSchema>;


### PR DESCRIPTION
**Summary**
This PR introduces a new authenticated `/api/agent` API surface so AI agents can read and write user fitness data through a dedicated namespace. It wires in agent-compatible auth at the route level (supporting both JWT bearer tokens and `AgentToken` credentials), while keeping all operations user-scoped. The implementation adds end-to-end agent workflows for foods/meals, exercises/workouts, daily tracking, and a consolidated context snapshot endpoint for planning. It also adds shared Zod schemas and a conventions document so payloads, error contracts, and route usage are standardized for agent integrations.

**Key Changes**
- Added and registered the `/api/agent` route namespace in the API server with an authenticated `/ping` probe.
- Added foods endpoints:
  - `GET /api/agent/foods/search` with recency-aware ranking.
  - `POST /api/agent/foods` for agent-created food records.
- Added meal logging endpoint:
  - `POST /api/agent/meals` with food-name resolution, macro scaling by quantity, and `UNRESOLVED_FOODS` handling.
- Added exercise/workout endpoints:
  - `POST /api/agent/exercises`, `GET /api/agent/exercises/search`
  - `POST/PUT /api/agent/workout-templates`
  - `POST/PATCH /api/agent/workout-sessions`
- Added daily tracking endpoints:
  - `POST /api/agent/weight`
  - `GET /api/agent/habits`
  - `PATCH /api/agent/habits/:id/entries`
  - `GET /api/agent/nutrition/:date/summary`
- Added `GET /api/agent/context` plus `context-store` query layer to return a unified snapshot (user, recent workouts, nutrition, weight trend, habits, scheduled workouts).
- Added shared agent schemas in `packages/shared/src/schemas/agent.ts` and exported them from `@pulse/shared`.
- Added agent conventions documentation (`docs/conventions/agent-integration.md`) including workflow guidance and endpoint contracts.
- Added extensive test coverage across route suites, context-store logic, auth behavior, and a comprehensive agent integration test file.

**Technical Notes**
- Auth behavior on `/api/agent/*` uses existing `requireAuth` semantics: both `Authorization: Bearer <jwt>` and `Authorization: AgentToken <token>` are accepted; agent token usage updates `lastUsedAt`.
- Food lookup/search uses case-insensitive matching with escaped `LIKE` patterns and ordering that prefers recently used foods (`lastUsedAt`), then name.
- Workout template creation/update infers section type (`warmup|main|cooldown`) from section names and auto-creates exercises when names do not resolve.
- Workout session patching upserts set logs by `(exerciseId, setNumber)` after resolving exercise names; marking a session completed sets `completedAt` and computes `duration` from timestamps.
- Context payload assembly is parallelized via store calls and validated against `agentContextResponseSchema`; invalid assembled payloads fail fast with `500 INTERNAL_ERROR`.
- Date handling adds explicit calendar validation and UTC-safe day shifting utilities to avoid invalid dates and timezone drift in streak/schedule computations.

## Commits

- `55ba305 test(api): address commit-97 review coverage gaps`
- `8a8d653 test(api): add agent endpoint integration tests`
- `476f8ac docs(agent): fix workflow route prefixes and patch response example`
- `9e4441d docs(api): add agent integration conventions guide`
- `fbe8093 fix(api): address commit-87 context review feedback`
- `5e4637a feat(api): add agent context snapshot endpoint`
- `179cbec fix(api): resolve agent daily review feedback`
- `e0531b5 feat(api): add agent daily weight, habits, and nutrition summary endpoints`
- `6c78cf9 feat(api): add agent workout and exercise management endpoints`
- `44c0a02 feat(api): add agent meal logging and food search endpoints`
- `f35c04b feat(api): add authenticated /api/agent route namespace`

## Tasks

- **Agent auth middleware**: Token validation for /api/agent/* routes, user scoping from token
- **Agent meal logging + food search endpoints**: POST meals with food items, GET food search with recency ranking
- **Agent workout management endpoints**: CRUD templates, create/update sessions, manage exercises
- **Agent daily log + weight + habits endpoints**: Log weight, read/update habits, daily log operations
- **Agent context endpoint**: GET comprehensive fitness snapshot (recent workouts, nutrition, weight, habits) for AI planning
- **Agent integration convention doc**: Write docs/conventions/agent-integration.md documenting all agent endpoints
- **API tests: agent endpoints**: Integration tests for agent auth, meal logging, food search, context endpoint

## Diff Stats

```
apps/api/src/__tests__/agent.test.ts            | 1358 +++++++++++++++++++++++
 apps/api/src/__tests__/auth.test.ts             |   14 +-
 apps/api/src/index.ts                           |    2 +
 apps/api/src/routes/agent/context-store.test.ts |  368 ++++++
 apps/api/src/routes/agent/context-store.ts      |  414 +++++++
 apps/api/src/routes/agent/context.test.ts       |  335 ++++++
 apps/api/src/routes/agent/context.ts            |   59 +
 apps/api/src/routes/agent/daily.test.ts         |  680 ++++++++++++
 apps/api/src/routes/agent/daily.ts              |  110 ++
 apps/api/src/routes/agent/date-utils.ts         |   27 +
 apps/api/src/routes/agent/exercises.test.ts     |  173 +++
 apps/api/src/routes/agent/exercises.ts          |   64 ++
 apps/api/src/routes/agent/foods.test.ts         |  220 ++++
 apps/api/src/routes/agent/foods.ts              |   63 ++
 apps/api/src/routes/agent/index.test.ts         |  133 +++
 apps/api/src/routes/agent/index.ts              |   27 +
 apps/api/src/routes/agent/meals.test.ts         |  268 +++++
 apps/api/src/routes/agent/meals.ts              |  103 ++
 apps/api/src/routes/agent/store.ts              |   81 ++
 apps/api/src/routes/agent/workouts.test.ts      |  511 +++++++++
 apps/api/src/routes/agent/workouts.ts           |  414 +++++++
 apps/api/src/routes/exercises/store.ts          |   24 +
 docs/conventions/agent-integration.md           |  739 ++++++++++++
 packages/shared/src/index.ts                    |    1 +
 packages/shared/src/schemas/agent.ts            |  250 +++++
 25 files changed, 6425 insertions(+), 13 deletions(-)
```