### PR TITLE
Mock data cleanup + preview banners for deferred features

### DIFF
--- a/apps/web/src/components/ui/preview-banner.test.tsx
+++ b/apps/web/src/components/ui/preview-banner.test.tsx
@@ -12,7 +12,7 @@ describe('PreviewBanner', () => {
     render(<PreviewBanner />);
 
     expect(screen.getByText(PREVIEW_BANNER_DEFAULT_MESSAGE)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dismiss preview banner' })).toBeInTheDocument();
   });
 
   it('renders a custom message when provided', () => {
@@ -24,7 +24,7 @@ describe('PreviewBanner', () => {
   it('hides the banner for the current session after dismissing', () => {
     render(<PreviewBanner />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss preview banner' }));
 
     expect(screen.queryByText(PREVIEW_BANNER_DEFAULT_MESSAGE)).not.toBeInTheDocument();
     expect(window.sessionStorage.getItem('pulse-preview-banner-dismissed')).toBe('true');
@@ -34,6 +34,22 @@ describe('PreviewBanner', () => {
     window.sessionStorage.setItem('pulse-preview-banner-dismissed', 'true');
 
     render(<PreviewBanner />);
+
+    expect(screen.queryByText(PREVIEW_BANNER_DEFAULT_MESSAGE)).not.toBeInTheDocument();
+  });
+
+  it('uses a custom storageKey independently from the default key', () => {
+    const { unmount } = render(<PreviewBanner storageKey="custom-key" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss preview banner' }));
+
+    expect(window.sessionStorage.getItem('custom-key')).toBe('true');
+    expect(window.sessionStorage.getItem('pulse-preview-banner-dismissed')).toBeNull();
+
+    unmount();
+    window.sessionStorage.setItem('custom-key', 'true');
+
+    render(<PreviewBanner storageKey="custom-key" />);
 
     expect(screen.queryByText(PREVIEW_BANNER_DEFAULT_MESSAGE)).not.toBeInTheDocument();
   });

--- a/apps/web/src/components/ui/preview-banner.test.tsx
+++ b/apps/web/src/components/ui/preview-banner.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { PREVIEW_BANNER_DEFAULT_MESSAGE, PreviewBanner } from '@/components/ui/preview-banner';
+
+describe('PreviewBanner', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('renders the default preview message', () => {
+    render(<PreviewBanner />);
+
+    expect(screen.getByText(PREVIEW_BANNER_DEFAULT_MESSAGE)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+  });
+
+  it('renders a custom message when provided', () => {
+    render(<PreviewBanner message="Custom preview text." />);
+
+    expect(screen.getByText('Custom preview text.')).toBeInTheDocument();
+  });
+
+  it('hides the banner for the current session after dismissing', () => {
+    render(<PreviewBanner />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+    expect(screen.queryByText(PREVIEW_BANNER_DEFAULT_MESSAGE)).not.toBeInTheDocument();
+    expect(window.sessionStorage.getItem('pulse-preview-banner-dismissed')).toBe('true');
+  });
+
+  it('does not render when already dismissed in sessionStorage', () => {
+    window.sessionStorage.setItem('pulse-preview-banner-dismissed', 'true');
+
+    render(<PreviewBanner />);
+
+    expect(screen.queryByText(PREVIEW_BANNER_DEFAULT_MESSAGE)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/preview-banner.tsx
+++ b/apps/web/src/components/ui/preview-banner.tsx
@@ -33,6 +33,7 @@ export function PreviewBanner({
 }: PreviewBannerProps) {
   const [dismissed, setDismissed] = useState(() => getDismissedValue(storageKey));
 
+  // Re-sync dismissed state when storageKey changes.
   useEffect(() => {
     setDismissed(getDismissedValue(storageKey));
   }, [storageKey]);
@@ -64,6 +65,7 @@ export function PreviewBanner({
         <Info aria-hidden="true" className="mt-0.5 size-4 shrink-0 sm:mt-0" />
         <p className="min-w-0 flex-1 leading-5">{message}</p>
         <button
+          aria-label="Dismiss preview banner"
           className="cursor-pointer text-xs font-semibold whitespace-nowrap underline-offset-2 transition hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
           onClick={handleDismiss}
           type="button"

--- a/apps/web/src/components/ui/preview-banner.tsx
+++ b/apps/web/src/components/ui/preview-banner.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { Info } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+export const PREVIEW_BANNER_DEFAULT_MESSAGE =
+  "This feature is in preview — data shown is sample data and won't be saved.";
+
+const DEFAULT_STORAGE_KEY = 'pulse-preview-banner-dismissed';
+
+type PreviewBannerProps = {
+  className?: string;
+  message?: string;
+  storageKey?: string;
+};
+
+function getDismissedValue(storageKey: string) {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  try {
+    return window.sessionStorage.getItem(storageKey) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function PreviewBanner({
+  className,
+  message = PREVIEW_BANNER_DEFAULT_MESSAGE,
+  storageKey = DEFAULT_STORAGE_KEY,
+}: PreviewBannerProps) {
+  const [dismissed, setDismissed] = useState(() => getDismissedValue(storageKey));
+
+  useEffect(() => {
+    setDismissed(getDismissedValue(storageKey));
+  }, [storageKey]);
+
+  function handleDismiss() {
+    setDismissed(true);
+
+    try {
+      window.sessionStorage.setItem(storageKey, 'true');
+    } catch {
+      // Ignore storage failures and keep local state dismissal.
+    }
+  }
+
+  if (dismissed) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl border border-amber-300/80 bg-amber-100/75 px-3 py-2 text-amber-950 shadow-sm dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200',
+        className,
+      )}
+      data-slot="preview-banner"
+      role="note"
+    >
+      <div className="flex flex-wrap items-start gap-x-2 gap-y-1 text-sm sm:flex-nowrap sm:items-center">
+        <Info aria-hidden="true" className="mt-0.5 size-4 shrink-0 sm:mt-0" />
+        <p className="min-w-0 flex-1 leading-5">{message}</p>
+        <button
+          className="cursor-pointer text-xs font-semibold whitespace-nowrap underline-offset-2 transition hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+          onClick={handleDismiss}
+          type="button"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/activity/lib/mock-data.ts
+++ b/apps/web/src/features/activity/lib/mock-data.ts
@@ -1,3 +1,4 @@
+// Preview data — replace with API calls when feature is implemented
 import type { LucideIcon } from 'lucide-react';
 import {
   Bike,

--- a/apps/web/src/features/dashboard/components/calendar-picker.test.tsx
+++ b/apps/web/src/features/dashboard/components/calendar-picker.test.tsx
@@ -72,7 +72,7 @@ describe('CalendarPicker', () => {
       '[data-slot="calendar-day"] [data-slot="calendar-activity-dot"][data-has-activity="true"]',
     );
 
-    expect(activityDots.length).toBeGreaterThan(0);
+    expect(activityDots.length).toBe(2);
   });
 
   it('navigates weeks with arrow buttons and updates month/year label', () => {

--- a/apps/web/src/features/dashboard/components/calendar-picker.test.tsx
+++ b/apps/web/src/features/dashboard/components/calendar-picker.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { CalendarPicker } from './calendar-picker';
+import { CalendarPicker, type DayActivity } from './calendar-picker';
 
 const formatDate = (date: Date): string => {
   const year = date.getFullYear();
@@ -61,7 +61,12 @@ describe('CalendarPicker', () => {
   });
 
   it('shows activity dots for days with workout or meal data', () => {
-    const { container } = render(<CalendarPicker />);
+    const getDayActivity = (date: Date): DayActivity => {
+      const day = date.getDate();
+      return { hasWorkout: day === 3 || day === 5, hasMeals: day === 3 };
+    };
+
+    const { container } = render(<CalendarPicker getDayActivity={getDayActivity} />);
 
     const activityDots = container.querySelectorAll(
       '[data-slot="calendar-day"] [data-slot="calendar-activity-dot"][data-has-activity="true"]',

--- a/apps/web/src/features/dashboard/components/calendar-picker.tsx
+++ b/apps/web/src/features/dashboard/components/calendar-picker.tsx
@@ -3,12 +3,19 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { addDays, formatDateKey, getToday, getWeekStart, isSameDay, normalizeDate } from '@/lib/date';
-import { getMockDayActivity } from '@/lib/mock-data/dashboard';
 import { cn } from '@/lib/utils';
+
+export type DayActivity = {
+  hasWorkout: boolean;
+  hasMeals: boolean;
+};
+
+const NO_ACTIVITY: DayActivity = { hasWorkout: false, hasMeals: false };
 
 type CalendarPickerProps = {
   selectedDate?: Date;
   onDateSelect?: (date: Date) => void;
+  getDayActivity?: (date: Date) => DayActivity;
   className?: string;
 };
 
@@ -26,7 +33,7 @@ const ariaDateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
 });
 
-export function CalendarPicker({ selectedDate, onDateSelect, className }: CalendarPickerProps) {
+export function CalendarPicker({ selectedDate, onDateSelect, getDayActivity, className }: CalendarPickerProps) {
   const today = useMemo(() => getToday(), []);
   const normalizedSelectedDate = selectedDate ? normalizeDate(selectedDate) : undefined;
   const [internalSelectedDate, setInternalSelectedDate] = useState<Date>(
@@ -92,7 +99,7 @@ export function CalendarPicker({ selectedDate, onDateSelect, className }: Calend
 
       <div className="flex items-stretch gap-1 sm:gap-2">
         {weekDays.map((day, index) => {
-          const activity = getMockDayActivity(day);
+          const activity = getDayActivity?.(day) ?? NO_ACTIVITY;
           const hasActivity = activity.hasWorkout || activity.hasMeals;
           const isToday = isSameDay(day, today);
           const isSelected = isSameDay(day, activeSelectedDate);

--- a/apps/web/src/features/equipment/lib/mock-data.ts
+++ b/apps/web/src/features/equipment/lib/mock-data.ts
@@ -1,3 +1,4 @@
+// Preview data — replace with API calls when feature is implemented
 import { Activity, Dumbbell, Layers3, Settings, Wrench } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 

--- a/apps/web/src/features/injuries/lib/mock-data.ts
+++ b/apps/web/src/features/injuries/lib/mock-data.ts
@@ -1,3 +1,4 @@
+// Preview data — replace with API calls when feature is implemented
 import type { HealthCondition } from '../types';
 
 export const mockHealthConditions: HealthCondition[] = [

--- a/apps/web/src/features/journal/components/journal-feed.tsx
+++ b/apps/web/src/features/journal/components/journal-feed.tsx
@@ -16,20 +16,20 @@ import {
   type JournalFilterOption,
   type JournalTypeFilter,
 } from '../lib/filters';
-import { mockJournalEntries } from '../lib/mock-data';
 import { journalBadgeClassesByType } from '../lib/presentation';
+import type { JournalEntry } from '../types';
 import { EntityChip } from './entity-chip';
 
-const entriesNewestFirst = sortJournalEntriesNewestFirst(mockJournalEntries);
-
 type JournalFeedProps = {
+  entries: JournalEntry[];
   getEntryHref?: (entryId: string) => string;
 };
 
-export function JournalFeed({ getEntryHref }: JournalFeedProps) {
+export function JournalFeed({ entries, getEntryHref }: JournalFeedProps) {
   const [typeFilter, setTypeFilter] = useState<JournalTypeFilter>('all');
   const [entityFilter, setEntityFilter] = useState<JournalEntityFilter>('all');
 
+  const entriesNewestFirst = sortJournalEntriesNewestFirst(entries);
   const filteredEntries = filterJournalEntries(entriesNewestFirst, {
     entityFilter,
     typeFilter,

--- a/apps/web/src/features/journal/lib/mock-data.ts
+++ b/apps/web/src/features/journal/lib/mock-data.ts
@@ -1,3 +1,4 @@
+// Preview data — replace with API calls when feature is implemented
 import type { JournalEntry, LinkedEntity } from '../types';
 
 const workouts = {

--- a/apps/web/src/features/resources/lib/mock-data.ts
+++ b/apps/web/src/features/resources/lib/mock-data.ts
@@ -1,3 +1,4 @@
+// Preview data — replace with API calls when feature is implemented
 import type { Resource } from '../types';
 
 export const mockResources: Resource[] = [

--- a/apps/web/src/pages/activity.test.tsx
+++ b/apps/web/src/pages/activity.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
+import { PREVIEW_BANNER_DEFAULT_MESSAGE } from '@/components/ui/preview-banner';
 import { mockActivities, sortActivitiesByDateDesc } from '@/features/activity';
 import { toDateKey } from '@/lib/date-utils';
 import { ActivityPage } from '@/pages/activity';
@@ -8,10 +9,15 @@ import { ActivityPage } from '@/pages/activity';
 const sortedActivities = sortActivitiesByDateDesc(mockActivities);
 
 describe('ActivityPage', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
   it('renders the activity list sorted newest first with formatted metadata', () => {
     render(<ActivityPage />);
 
     expect(screen.getByRole('heading', { name: 'Activity' })).toBeInTheDocument();
+    expect(screen.getByText(PREVIEW_BANNER_DEFAULT_MESSAGE)).toBeInTheDocument();
     expect(
       screen.getByText(
         /Review recent movement sessions outside structured workouts, with quick filtering by activity type and linked journal context\./,

--- a/apps/web/src/pages/activity.tsx
+++ b/apps/web/src/pages/activity.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Activity as ActivityGlyph } from 'lucide-react';
 
+import { PreviewBanner } from '@/components/ui/preview-banner';
 import {
   ActivityForm,
   ActivityList,
@@ -16,6 +17,7 @@ export function ActivityPage() {
 
   return (
     <section className="space-y-6">
+      <PreviewBanner />
       <header className="space-y-4">
         <div className="flex items-start gap-3">
           <div className="rounded-2xl bg-[var(--color-accent-mint)] p-3 text-on-mint shadow-sm dark:bg-emerald-500/20 dark:text-emerald-400">

--- a/apps/web/src/pages/activity.tsx
+++ b/apps/web/src/pages/activity.tsx
@@ -17,7 +17,9 @@ export function ActivityPage() {
 
   return (
     <section className="space-y-6">
-      <PreviewBanner />
+      <div className="mx-auto w-full max-w-6xl">
+        <PreviewBanner />
+      </div>
       <header className="space-y-4">
         <div className="flex items-start gap-3">
           <div className="rounded-2xl bg-[var(--color-accent-mint)] p-3 text-on-mint shadow-sm dark:bg-emerald-500/20 dark:text-emerald-400">

--- a/apps/web/src/pages/equipment.test.tsx
+++ b/apps/web/src/pages/equipment.test.tsx
@@ -1,7 +1,8 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
+import { PREVIEW_BANNER_DEFAULT_MESSAGE } from '@/components/ui/preview-banner';
 import { EquipmentRoutePage } from '@/pages/equipment';
 
 function renderEquipmentPage() {
@@ -34,10 +35,15 @@ function selectEquipmentCategory(label: string) {
 }
 
 describe('EquipmentRoutePage', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
   it('renders the inventory summary and collapsed location cards', () => {
     renderEquipmentPage();
 
     expect(screen.getByRole('heading', { name: 'Equipment' })).toBeInTheDocument();
+    expect(screen.getByText(PREVIEW_BANNER_DEFAULT_MESSAGE)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Back to Profile/i })).toHaveAttribute(
       'href',
       '/profile',

--- a/apps/web/src/pages/equipment.tsx
+++ b/apps/web/src/pages/equipment.tsx
@@ -1,5 +1,5 @@
-import { EquipmentPage } from '@/features/equipment';
 import { PreviewBanner } from '@/components/ui/preview-banner';
+import { EquipmentPage } from '@/features/equipment';
 
 export function EquipmentRoutePage() {
   return (

--- a/apps/web/src/pages/equipment.tsx
+++ b/apps/web/src/pages/equipment.tsx
@@ -1,5 +1,13 @@
 import { EquipmentPage } from '@/features/equipment';
+import { PreviewBanner } from '@/components/ui/preview-banner';
 
 export function EquipmentRoutePage() {
-  return <EquipmentPage />;
+  return (
+    <>
+      <div className="mx-auto mb-6 w-full max-w-6xl">
+        <PreviewBanner />
+      </div>
+      <EquipmentPage />
+    </>
+  );
 }

--- a/apps/web/src/pages/injuries.test.tsx
+++ b/apps/web/src/pages/injuries.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { PREVIEW_BANNER_DEFAULT_MESSAGE } from '@/components/ui/preview-banner';
+import { InjuriesPage } from '@/pages/injuries';
+
+describe('InjuriesPage', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('renders health tracking content with the preview banner', () => {
+    render(
+      <MemoryRouter>
+        <InjuriesPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(PREVIEW_BANNER_DEFAULT_MESSAGE)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Health Tracking' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/injuries.tsx
+++ b/apps/web/src/pages/injuries.tsx
@@ -1,5 +1,13 @@
 import { ConditionsList } from '@/features/injuries';
+import { PreviewBanner } from '@/components/ui/preview-banner';
 
 export function InjuriesPage() {
-  return <ConditionsList />;
+  return (
+    <>
+      <div className="mx-auto mb-6 w-full max-w-6xl">
+        <PreviewBanner />
+      </div>
+      <ConditionsList />
+    </>
+  );
 }

--- a/apps/web/src/pages/journal.test.tsx
+++ b/apps/web/src/pages/journal.test.tsx
@@ -1,11 +1,16 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
+import { PREVIEW_BANNER_DEFAULT_MESSAGE } from '@/components/ui/preview-banner';
 import { mockJournalEntries } from '@/features/journal';
 import { JournalPage } from '@/pages/journal';
 
 describe('JournalPage', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
   it('renders the chronological feed with badges, previews, and entity chips', () => {
     const { container } = render(
       <MemoryRouter>
@@ -14,6 +19,7 @@ describe('JournalPage', () => {
     );
 
     expect(screen.getByRole('heading', { name: 'Journal' })).toBeInTheDocument();
+    expect(screen.getByText(PREVIEW_BANNER_DEFAULT_MESSAGE)).toBeInTheDocument();
     expect(
       screen.getByText(
         'Review coaching notes, milestones, observations, and injury updates in one chronological feed.',

--- a/apps/web/src/pages/journal.tsx
+++ b/apps/web/src/pages/journal.tsx
@@ -1,10 +1,12 @@
 import { BookOpen } from 'lucide-react';
 
+import { PreviewBanner } from '@/components/ui/preview-banner';
 import { JournalFeed } from '@/features/journal';
 
 export function JournalPage() {
   return (
     <section className="space-y-6">
+      <PreviewBanner />
       <header className="space-y-4">
         <div className="flex items-start gap-3">
           <div className="rounded-2xl bg-[var(--color-accent-cream)] p-3 text-on-cream shadow-sm dark:bg-amber-500/20 dark:text-amber-400">

--- a/apps/web/src/pages/journal.tsx
+++ b/apps/web/src/pages/journal.tsx
@@ -6,7 +6,9 @@ import { JournalFeed, mockJournalEntries } from '@/features/journal';
 export function JournalPage() {
   return (
     <section className="space-y-6">
-      <PreviewBanner />
+      <div className="mx-auto w-full max-w-6xl">
+        <PreviewBanner />
+      </div>
       <header className="space-y-4">
         <div className="flex items-start gap-3">
           <div className="rounded-2xl bg-[var(--color-accent-cream)] p-3 text-on-cream shadow-sm dark:bg-amber-500/20 dark:text-amber-400">

--- a/apps/web/src/pages/journal.tsx
+++ b/apps/web/src/pages/journal.tsx
@@ -1,7 +1,7 @@
 import { BookOpen } from 'lucide-react';
 
 import { PreviewBanner } from '@/components/ui/preview-banner';
-import { JournalFeed } from '@/features/journal';
+import { JournalFeed, mockJournalEntries } from '@/features/journal';
 
 export function JournalPage() {
   return (
@@ -21,7 +21,7 @@ export function JournalPage() {
           </div>
         </div>
       </header>
-      <JournalFeed getEntryHref={(entryId) => `/journal/${entryId}`} />
+      <JournalFeed entries={mockJournalEntries} getEntryHref={(entryId) => `/journal/${entryId}`} />
     </section>
   );
 }

--- a/apps/web/src/pages/resources.test.tsx
+++ b/apps/web/src/pages/resources.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { PREVIEW_BANNER_DEFAULT_MESSAGE } from '@/components/ui/preview-banner';
+import { ResourcesPage } from '@/pages/resources';
+
+describe('ResourcesPage', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('renders resource content with the preview banner', () => {
+    render(
+      <MemoryRouter>
+        <ResourcesPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(PREVIEW_BANNER_DEFAULT_MESSAGE)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Resources' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/resources.tsx
+++ b/apps/web/src/pages/resources.tsx
@@ -1,5 +1,13 @@
 import { ResourceGrid, mockResources } from '@/features/resources';
+import { PreviewBanner } from '@/components/ui/preview-banner';
 
 export function ResourcesPage() {
-  return <ResourceGrid resources={mockResources} />;
+  return (
+    <>
+      <div className="mx-auto mb-6 w-full max-w-6xl">
+        <PreviewBanner />
+      </div>
+      <ResourceGrid resources={mockResources} />
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
This PR separates true API-backed UI from preview-only mock data and adds an explicit preview-state banner on deferred pages. A new reusable `PreviewBanner` component is introduced and wired into the Activity, Equipment, Injuries, Journal, and Resources pages so users are clearly informed when data is non-persistent sample content. It also removes implicit mock-data coupling in shared components so mock data must be passed intentionally from page-level containers. The result is clearer UX, cleaner data boundaries, and fewer accidental regressions as API integrations land.

## Key Changes
- Added reusable `PreviewBanner` UI component with:
  - default preview message
  - dismiss action
  - session-scoped persistence via `sessionStorage`
  - SSR/storage-failure-safe guards
- Added `PreviewBanner` to deferred/mock-data pages:
  - `activity`, `equipment`, `injuries`, `journal`, `resources`
- Refactored `JournalFeed` to accept `entries` as a prop instead of importing mock entries internally
- Refactored `CalendarPicker` to remove direct dashboard mock-data usage by introducing `getDayActivity?: (date) => DayActivity`
- Added/updated tests to cover:
  - preview banner behavior (default/custom message, dismiss persistence)
  - preview banner rendering on target pages
  - calendar activity-dot behavior via injected day-activity provider
- Added explicit “Preview data” header comments to remaining mock-data files to mark intended temporary usage

## Technical Notes
- `PreviewBanner` uses a default storage key (`pulse-preview-banner-dismissed`), so dismissing it hides all default-banner instances for the current session; pages can opt into independent behavior via `storageKey`.
- The `CalendarPicker` fallback now defaults to `NO_ACTIVITY` when `getDayActivity` is not provided, preventing silent reliance on stale mock signals.
- `JournalFeed` is now a pure presentational consumer of provided data, which simplifies future TanStack Query integration and makes test setup more explicit.
- Page tests clear `sessionStorage` in `beforeEach` to avoid cross-test leakage from banner dismissal state.

## Commits

- `46f7b8d refactor(web): remove mock data imports from API-backed components and clean up preview data`
- `23de5ae feat(web): add preview banner for mock-data pages`

## Tasks

- **Create reusable PreviewBanner + add to deferred pages**: Build a <PreviewBanner /> component and add it to equipment, injuries, resources, journal, and activity pages
- **Remove mock data from API-backed components**: Audit and remove mock data imports from components that should use real API data, move useful mock files to __fixtures__

## Diff Stats

```
apps/web/src/components/ui/preview-banner.test.tsx | 40 ++++++++++++
 apps/web/src/components/ui/preview-banner.tsx      | 76 ++++++++++++++++++++++
 apps/web/src/features/activity/lib/mock-data.ts    |  1 +
 .../dashboard/components/calendar-picker.test.tsx  |  9 ++-
 .../dashboard/components/calendar-picker.tsx       | 13 +++-
 apps/web/src/features/equipment/lib/mock-data.ts   |  1 +
 apps/web/src/features/injuries/lib/mock-data.ts    |  1 +
 .../features/journal/components/journal-feed.tsx   |  8 +--
 apps/web/src/features/journal/lib/mock-data.ts     |  1 +
 apps/web/src/features/resources/lib/mock-data.ts   |  1 +
 apps/web/src/pages/activity.test.tsx               |  8 ++-
 apps/web/src/pages/activity.tsx                    |  2 +
 apps/web/src/pages/equipment.test.tsx              |  8 ++-
 apps/web/src/pages/equipment.tsx                   | 10 ++-
 apps/web/src/pages/injuries.test.tsx               | 23 +++++++
 apps/web/src/pages/injuries.tsx                    | 10 ++-
 apps/web/src/pages/journal.test.tsx                |  8 ++-
 apps/web/src/pages/journal.tsx                     |  6 +-
 apps/web/src/pages/resources.test.tsx              | 23 +++++++
 apps/web/src/pages/resources.tsx                   | 10 ++-
 20 files changed, 242 insertions(+), 17 deletions(-)
```