### PR TITLE
Profile & user data — real user info, editing, sidebar link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## Project Overview
 
-Pulse is a personal health and fitness tracking app. Two-person household, AI agent-driven data entry, interactive workout logging UI. See `README.md` for full feature list and tech stack.
+Pulse is a personal health and fitness tracking app focused on AI agent-driven data entry and interactive workout logging UI. See `README.md` for full feature list and tech stack.
 
 ## Monorepo Structure
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pulse
 
-A personal health and fitness tracking app for a two-person household. Most data entry happens via AI agents through an authenticated API; the UI is for viewing data, managing configurations, and manually logging workouts during gym sessions.
+A personal health and fitness tracking app. Most data entry happens via AI agents through an authenticated API; the UI is for viewing data, managing configurations, and manually logging workouts during gym sessions.
 
 ## Features
 
@@ -90,7 +90,7 @@ pnpm format     # Format with Prettier
 
 - **Mobile-first** — Designed at 375px, scales to tablet and desktop
 - **Agent-first data entry** — Meals and foods are entered via AI agents; the UI is read-only for nutrition
-- **SQLite** — Simple, sufficient for 2 users, no external database dependency
+- **SQLite** — Simple setup for personal use without an external database dependency
 - **Shared Zod schemas** — Single source of truth for validation on both client and server
 
 ## Deployment

--- a/apps/api/src/routes/users/index.test.ts
+++ b/apps/api/src/routes/users/index.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildServer } from '../../index.js';
+
+import { getUserById, updateUser } from './store.js';
+
+vi.mock('./store.js', () => ({
+  getUserById: vi.fn(),
+  updateUser: vi.fn(),
+}));
+
+const createAuthorizationHeader = (token: string) => ({
+  authorization: `Bearer ${token}`,
+});
+
+describe('users routes', () => {
+  beforeEach(() => {
+    vi.mocked(getUserById).mockReset();
+    vi.mocked(updateUser).mockReset();
+    process.env.JWT_SECRET = 'test-users-routes-secret';
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  it('GET /api/v1/users/me returns the authenticated user', async () => {
+    vi.mocked(getUserById).mockResolvedValue({
+      id: 'user-1',
+      username: 'derek',
+      name: 'Derek',
+      createdAt: 1709913600000,
+    });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/users/me',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: {
+          id: 'user-1',
+          username: 'derek',
+          name: 'Derek',
+          createdAt: 1709913600000,
+        },
+      });
+      expect(vi.mocked(getUserById)).toHaveBeenCalledWith('user-1');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('PATCH /api/v1/users/me updates the name and returns updated user', async () => {
+    vi.mocked(updateUser).mockResolvedValue({
+      id: 'user-1',
+      username: 'derek',
+      name: 'Derek B',
+      createdAt: 1709913600000,
+    });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/users/me',
+        payload: { name: 'Derek B' },
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: {
+          id: 'user-1',
+          username: 'derek',
+          name: 'Derek B',
+          createdAt: 1709913600000,
+        },
+      });
+      expect(vi.mocked(updateUser)).toHaveBeenCalledWith('user-1', { name: 'Derek B' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('PATCH /api/v1/users/me with empty name returns 400', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/users/me',
+        payload: { name: '' },
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid user update payload',
+        },
+      });
+      expect(vi.mocked(updateUser)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('PATCH /api/v1/users/me with invalid body returns 400', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/users/me',
+        payload: { name: 123 },
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid user update payload',
+        },
+      });
+      expect(vi.mocked(updateUser)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const [getResponse, patchResponse, invalidTokenResponse] = await Promise.all([
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/users/me',
+        }),
+        app.inject({
+          method: 'PATCH',
+          url: '/api/v1/users/me',
+          payload: { name: 'Derek' },
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/users/me',
+          headers: createAuthorizationHeader('not-a-valid-token'),
+        }),
+      ]);
+
+      for (const response of [getResponse, patchResponse, invalidTokenResponse]) {
+        expect(response.statusCode).toBe(401);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'UNAUTHORIZED',
+            message: 'Authentication required',
+          },
+        });
+      }
+      expect(vi.mocked(getUserById)).not.toHaveBeenCalled();
+      expect(vi.mocked(updateUser)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apps/api/src/routes/users/index.ts
+++ b/apps/api/src/routes/users/index.ts
@@ -1,0 +1,37 @@
+import { updateUserInputSchema } from '@pulse/shared';
+import type { FastifyPluginAsync } from 'fastify';
+
+import { sendError } from '../../lib/reply.js';
+import { requireUserAuth } from '../../middleware/auth.js';
+
+import { getUserById, updateUser } from './store.js';
+
+export const usersRoutes: FastifyPluginAsync = async (app) => {
+  app.addHook('onRequest', requireUserAuth);
+
+  app.get('/me', async (request, reply) => {
+    const user = await getUserById(request.userId);
+
+    if (!user) {
+      return sendError(reply, 404, 'NOT_FOUND', 'User not found');
+    }
+
+    return reply.send({ data: user });
+  });
+
+  app.patch('/me', async (request, reply) => {
+    const parsed = updateUserInputSchema.safeParse(request.body);
+
+    if (!parsed.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid user update payload');
+    }
+
+    const user = await updateUser(request.userId, parsed.data);
+
+    if (!user) {
+      return sendError(reply, 404, 'NOT_FOUND', 'User not found');
+    }
+
+    return reply.send({ data: user });
+  });
+};

--- a/apps/api/src/routes/users/store.ts
+++ b/apps/api/src/routes/users/store.ts
@@ -15,7 +15,16 @@ export async function getUserById(userId: string) {
 }
 
 export async function updateUser(userId: string, data: { name: string }) {
-  await db.update(users).set({ name: data.name }).where(eq(users.id, userId));
+  const [row] = await db
+    .update(users)
+    .set({ name: data.name })
+    .where(eq(users.id, userId))
+    .returning({
+      id: users.id,
+      username: users.username,
+      name: users.name,
+      createdAt: users.createdAt,
+    });
 
-  return getUserById(userId);
+  return row ?? null;
 }

--- a/apps/api/src/routes/users/store.ts
+++ b/apps/api/src/routes/users/store.ts
@@ -1,0 +1,21 @@
+import { eq } from 'drizzle-orm';
+
+import { db } from '../../db/index.js';
+import { users } from '../../db/schema/index.js';
+
+export async function getUserById(userId: string) {
+  const row = await db.select({
+    id: users.id,
+    username: users.username,
+    name: users.name,
+    createdAt: users.createdAt,
+  }).from(users).where(eq(users.id, userId)).get();
+
+  return row ?? null;
+}
+
+export async function updateUser(userId: string, data: { name: string }) {
+  await db.update(users).set({ name: data.name }).where(eq(users.id, userId));
+
+  return getUserById(userId);
+}

--- a/apps/api/src/routes/v1/index.ts
+++ b/apps/api/src/routes/v1/index.ts
@@ -1,7 +1,10 @@
 import type { FastifyPluginAsync } from 'fastify';
 
+import { usersRoutes } from '../users/index.js';
+
 import { dashboardRoutes } from './dashboard.js';
 
 export const v1Routes: FastifyPluginAsync = async (app) => {
   app.register(dashboardRoutes, { prefix: '/dashboard' });
+  app.register(usersRoutes, { prefix: '/users' });
 };

--- a/apps/web/src/components/layout/sidebar.test.tsx
+++ b/apps/web/src/components/layout/sidebar.test.tsx
@@ -1,7 +1,8 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Sidebar } from '@/components/layout/sidebar';
+import { useUser } from '@/hooks/use-user';
 import { useAuthStore } from '@/store/auth-store';
 
 const mockNavigate = vi.fn();
@@ -17,6 +18,9 @@ vi.mock('react-router', async () => {
 
 vi.mock('@/store/auth-store', () => ({
   useAuthStore: vi.fn(),
+}));
+vi.mock('@/hooks/use-user', () => ({
+  useUser: vi.fn(),
 }));
 
 type MockAuthStore = {
@@ -38,6 +42,7 @@ type MockAuthStore = {
 };
 
 const mockedUseAuthStore = vi.mocked(useAuthStore);
+const mockedUseUser = vi.mocked(useUser);
 
 const navLinks = [
   { label: 'Dashboard', path: '/' },
@@ -85,6 +90,15 @@ describe('Sidebar', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.localStorage.clear();
+    mockedUseUser.mockReturnValue({
+      data: {
+        id: 'user-1',
+        username: 'derek',
+        name: 'Derek',
+        createdAt: 1_709_548_800_000,
+        updatedAt: 1_709_548_800_000,
+      },
+    } as unknown as ReturnType<typeof useUser>);
   });
 
   it('renders all nav links and highlights the active route', () => {
@@ -102,6 +116,7 @@ describe('Sidebar', () => {
     expect(activeLink).toHaveClass('bg-primary');
     expect(screen.getByText('Derek')).toBeInTheDocument();
     expect(screen.getByText('@derek')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Derek/i })).toHaveAttribute('href', '/profile');
   });
 
   it('logs out and navigates to /login', () => {
@@ -145,5 +160,49 @@ describe('Sidebar', () => {
     renderSidebar();
 
     expect(screen.getByLabelText('Derek')).not.toHaveAttribute('tabindex');
+    expect(screen.getByLabelText('Derek')).toHaveAttribute('href', '/profile');
+  });
+
+  it('navigates to the profile page when the account block is clicked', () => {
+    const store = createAuthStore();
+    mockedUseAuthStore.mockReturnValue(store);
+    mockedUseUser.mockReturnValue({
+      data: {
+        id: 'user-1',
+        username: 'derek',
+        name: 'Derek',
+        createdAt: 1_709_548_800_000,
+        updatedAt: 1_709_548_800_000,
+      },
+    } as unknown as ReturnType<typeof useUser>);
+
+    render(
+      <MemoryRouter initialEntries={['/nutrition']}>
+        <Routes>
+          <Route element={<Sidebar />} path="*" />
+          <Route element={<h1>Profile Route</h1>} path="/profile" />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: /Derek/i }));
+
+    expect(screen.getByRole('heading', { name: 'Profile Route' })).toBeInTheDocument();
+  });
+
+  it('falls back to username from useUser when profile name is missing', () => {
+    mockedUseUser.mockReturnValue({
+      data: {
+        id: 'user-1',
+        username: 'derek',
+        name: null,
+        createdAt: 1_709_548_800_000,
+        updatedAt: 1_709_548_800_000,
+      },
+    } as unknown as ReturnType<typeof useUser>);
+
+    renderSidebar();
+
+    expect(screen.getByText('derek')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useId, useRef, useState } from 'react';
-import { NavLink, useNavigate } from 'react-router';
+import { Link, NavLink, useNavigate } from 'react-router';
 import { ChevronLeft, ChevronRight, LogOut, Menu, X } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { sidebarNavItems } from '@/components/layout/nav-items';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useUser } from '@/hooks/use-user';
 import { useAuthStore } from '@/store/auth-store';
 
 function getInitialCollapsed() {
@@ -23,7 +24,8 @@ export function Sidebar() {
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const shouldRestoreFocusRef = useRef(false);
   const navigate = useNavigate();
-  const { logout, user } = useAuthStore();
+  const { logout } = useAuthStore();
+  const { data: user } = useUser();
   const displayName = user?.name?.trim() || user?.username || 'Account';
   const subtitle = user?.name ? `@${user.username}` : 'Signed in';
   const avatarLabel = displayName.charAt(0).toUpperCase();
@@ -162,7 +164,11 @@ export function Sidebar() {
             </nav>
 
             <div className="space-y-3 border-t border-border/40 px-3 py-4">
-              <div className="flex items-center gap-3 rounded-xl border border-border/50 bg-background/70 px-3 py-2">
+              <Link
+                className="flex items-center gap-3 rounded-xl border border-border/50 bg-background/70 px-3 py-2 transition-opacity hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                onClick={closeMobileMenu}
+                to="/profile"
+              >
                 <div className="flex size-10 items-center justify-center rounded-full bg-primary/12 text-sm font-semibold text-primary">
                   {avatarLabel}
                 </div>
@@ -170,7 +176,7 @@ export function Sidebar() {
                   <p className="truncate text-sm font-medium text-foreground">{displayName}</p>
                   <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
                 </div>
-              </div>
+              </Link>
 
               <button
                 className="flex min-h-[44px] w-full cursor-pointer items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium text-muted-foreground transition-all duration-200 hover:bg-secondary hover:text-foreground"
@@ -283,19 +289,23 @@ export function Sidebar() {
               {collapsed ? (
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <span
+                    <Link
                       aria-label={displayName}
-                      className="flex size-10 items-center justify-center rounded-full bg-primary/12 text-sm font-semibold text-primary"
+                      className="flex size-10 items-center justify-center rounded-full bg-primary/12 text-sm font-semibold text-primary transition-opacity hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                      to="/profile"
                     >
                       {avatarLabel}
-                    </span>
+                    </Link>
                   </TooltipTrigger>
                   <TooltipContent side="right" sideOffset={8}>
                     {displayName}
                   </TooltipContent>
                 </Tooltip>
               ) : (
-                <div className="flex items-center gap-3 rounded-xl border border-border/50 bg-background/70 px-3 py-2">
+                <Link
+                  className="flex items-center gap-3 rounded-xl border border-border/50 bg-background/70 px-3 py-2 transition-opacity hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                  to="/profile"
+                >
                   <div className="flex size-10 items-center justify-center rounded-full bg-primary/12 text-sm font-semibold text-primary">
                     {avatarLabel}
                   </div>
@@ -303,7 +313,7 @@ export function Sidebar() {
                     <p className="truncate text-sm font-medium text-foreground">{displayName}</p>
                     <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
                   </div>
-                </div>
+                </Link>
               )}
 
               {collapsed ? (

--- a/apps/web/src/features/profile/components/profile-hub.tsx
+++ b/apps/web/src/features/profile/components/profile-hub.tsx
@@ -3,6 +3,7 @@ import type { LucideIcon } from 'lucide-react';
 import { Link } from 'react-router';
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useUser } from '@/hooks/use-user';
 import { cn } from '@/lib/utils';
 
 type ProfileDestination = {
@@ -14,17 +15,37 @@ type ProfileDestination = {
   title: string;
 };
 
-const mockProfile = {
-  displayName: 'Jordan Lee',
-  initials: 'JL',
-  memberSince: 'March 2024',
-};
+function getInitials(value: string) {
+  const segments = value
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (segments.length === 0) {
+    return 'U';
+  }
+
+  if (segments.length === 1) {
+    return segments[0].slice(0, 2).toUpperCase();
+  }
+
+  return `${segments[0][0] ?? ''}${segments[1][0] ?? ''}`.toUpperCase();
+}
 
 type ProfileHubProps = {
   equipmentSummary: string;
 };
 
 export function ProfileHub({ equipmentSummary }: ProfileHubProps) {
+  const { data: user } = useUser();
+  const displayName = user?.name?.trim() || user?.username || 'User';
+  const initials = getInitials(displayName);
+  const memberSince = user
+    ? new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' }).format(
+        new Date(user.createdAt),
+      )
+    : '--';
+
   const profileDestinations: ProfileDestination[] = [
     {
       description: 'Inventory across every gym setup and storage spot.',
@@ -38,14 +59,14 @@ export function ProfileHub({ equipmentSummary }: ProfileHubProps) {
       description: 'Track injuries, recovery notes, and active protocols.',
       href: '/profile/injuries',
       icon: Heart,
-      summary: '1 active condition',
+      summary: 'Coming soon',
       title: 'Health Tracking',
     },
     {
       description: 'Books, programs, and coaching references to revisit.',
       href: '/profile/resources',
       icon: BookOpen,
-      summary: '8 resources',
+      summary: 'Coming soon',
       title: 'Resources',
     },
     {
@@ -72,21 +93,15 @@ export function ProfileHub({ equipmentSummary }: ProfileHubProps) {
         <CardContent className="flex flex-col gap-5 px-6 py-6 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-4">
             <div className="flex size-16 items-center justify-center rounded-full bg-[var(--color-accent-mint)] text-2xl font-semibold text-on-mint shadow-sm">
-              {mockProfile.initials}
+              {initials}
             </div>
             <div className="space-y-1">
               <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted">
                 Member since
               </p>
-              <h2 className="text-2xl font-semibold text-foreground">{mockProfile.displayName}</h2>
-              <p className="text-sm text-muted-foreground">{mockProfile.memberSince}</p>
+              <h2 className="text-2xl font-semibold text-foreground">{displayName}</h2>
+              <p className="text-sm text-muted-foreground">{memberSince}</p>
             </div>
-          </div>
-          <div className="rounded-2xl border border-border/70 bg-secondary/45 px-4 py-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted">
-              Household
-            </p>
-            <p className="mt-1 text-sm font-medium text-foreground">Two-person Pulse account</p>
           </div>
         </CardContent>
       </Card>

--- a/apps/web/src/hooks/use-user.ts
+++ b/apps/web/src/hooks/use-user.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { userProfileSchema, type UserProfile, type UpdateUserInput } from '@pulse/shared';
+
+import { apiRequest } from '@/lib/api-client';
+
+export const userKeys = {
+  all: ['user'] as const,
+  me: () => [...userKeys.all, 'me'] as const,
+};
+
+const fetchCurrentUser = async (signal?: AbortSignal): Promise<UserProfile> => {
+  const user = await apiRequest<UserProfile>('/api/v1/users/me', {
+    method: 'GET',
+    signal,
+  });
+
+  return userProfileSchema.parse(user);
+};
+
+const patchCurrentUser = async (data: UpdateUserInput): Promise<UserProfile> => {
+  const user = await apiRequest<UserProfile>('/api/v1/users/me', {
+    body: data,
+    method: 'PATCH',
+  });
+
+  return userProfileSchema.parse(user);
+};
+
+export const useUser = () =>
+  useQuery({
+    queryFn: ({ signal }) => fetchCurrentUser(signal),
+    queryKey: userKeys.me(),
+  });
+
+export const useUpdateUser = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: patchCurrentUser,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: userKeys.all });
+    },
+  });
+};

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -234,6 +234,117 @@ describe('api-client', () => {
     expect(requestHeaders.get('Authorization')).toBe('Bearer login-token');
   });
 
+  it('recovers stale sessions when /api/v1/users/me returns NOT_FOUND in DEV mode', async () => {
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('VITE_PULSE_DEV_USERNAME', 'pulse-dev');
+    vi.stubEnv('VITE_PULSE_DEV_PASSWORD', 'pulse-dev-password');
+    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'stale-token');
+    window.localStorage.setItem(
+      AUTH_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          token: 'stale-token',
+          user: {
+            id: 'stale-user',
+            username: 'stale',
+            name: 'Stale User',
+          },
+        },
+        version: 0,
+      }),
+    );
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 'NOT_FOUND',
+              message: 'User not found',
+            },
+          }),
+          { status: 404 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 'USERNAME_TAKEN',
+              message: 'Username is already taken',
+            },
+          }),
+          { status: 409 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: { token: 'fresh-token' } }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              id: 'user-1',
+              username: 'pulse-dev',
+              name: 'Pulse Dev',
+            },
+          }),
+          { status: 200 },
+        ),
+      );
+
+    const payload = await apiRequest<{ id: string; username: string; name: string }>(
+      '/api/v1/users/me',
+      { method: 'GET' },
+    );
+
+    expect(payload).toEqual({
+      id: 'user-1',
+      username: 'pulse-dev',
+      name: 'Pulse Dev',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/users/me');
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('/api/v1/auth/register');
+    expect(fetchMock.mock.calls[2]?.[0]).toBe('/api/v1/auth/login');
+    expect(fetchMock.mock.calls[3]?.[0]).toBe('/api/v1/users/me');
+    expect(window.localStorage.getItem(API_TOKEN_STORAGE_KEY)).toBe('fresh-token');
+    expect(window.localStorage.getItem(AUTH_STORAGE_KEY)).toBeNull();
+
+    const firstHeaders = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    expect(firstHeaders.get('Authorization')).toBe('Bearer stale-token');
+    const secondUserHeaders = new Headers(fetchMock.mock.calls[3]?.[1]?.headers);
+    expect(secondUserHeaders.get('Authorization')).toBe('Bearer fresh-token');
+  });
+
+  it('does not retry non-user NOT_FOUND responses', async () => {
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('VITE_PULSE_DEV_USERNAME', 'pulse-dev');
+    vi.stubEnv('VITE_PULSE_DEV_PASSWORD', 'pulse-dev-password');
+    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'stale-token');
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 'NOT_FOUND',
+            message: 'Missing',
+          },
+        }),
+        { status: 404 },
+      ),
+    );
+
+    await expect(apiRequest('/api/v1/habits/habit-1')).rejects.toMatchObject({
+      status: 404,
+      code: 'NOT_FOUND',
+      message: 'Missing',
+    } satisfies Partial<ApiError>);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('allows empty success bodies for 204 responses', async () => {
     fetchMock.mockResolvedValue(
       new Response(null, {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -272,10 +272,8 @@ function createRequestInit(init: ApiRequestInit | undefined, token: string | nul
 }
 
 async function performRequest<T>(path: string, init?: ApiRequestInit): Promise<T | null> {
-  const token = await resolveSessionToken({
-    allowDevAutoSession: !normalizePath(path).startsWith(AUTH_PATH_PREFIX),
-  });
   const allowDevAutoSession = !normalizePath(path).startsWith(AUTH_PATH_PREFIX);
+  const token = await resolveSessionToken({ allowDevAutoSession });
   let response = await fetch(buildUrl(path), createRequestInit(init, token));
 
   if (!response.ok && !getEnvToken()) {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -223,14 +223,26 @@ async function resolveSessionToken(options?: {
 
 async function toApiError(response: Response): Promise<ApiError> {
   const payload = await parseJson<ApiErrorEnvelope>(response);
-  const code = payload?.error?.code;
-  const message = payload?.error?.message ?? `Request failed with status ${response.status}`;
+  return toApiErrorFromPayload(response.status, payload);
+}
 
-  if (response.status === 401) {
+function toApiErrorFromPayload(status: number, payload: ApiErrorEnvelope | null): ApiError {
+  const code = payload?.error?.code;
+  const message = payload?.error?.message ?? `Request failed with status ${status}`;
+
+  if (status === 401) {
     clearStoredAuthState();
   }
 
-  return new ApiError(response.status, message, code);
+  return new ApiError(status, message, code);
+}
+
+function shouldRecoverStaleUserSession(
+  path: string,
+  status: number,
+  payload: ApiErrorEnvelope | null,
+): boolean {
+  return normalizePath(path) === '/api/v1/users/me' && status === 404 && payload?.error?.code === 'NOT_FOUND';
 }
 
 function createRequestInit(init: ApiRequestInit | undefined, token: string | null): RequestInit {
@@ -263,7 +275,25 @@ async function performRequest<T>(path: string, init?: ApiRequestInit): Promise<T
   const token = await resolveSessionToken({
     allowDevAutoSession: !normalizePath(path).startsWith(AUTH_PATH_PREFIX),
   });
-  const response = await fetch(buildUrl(path), createRequestInit(init, token));
+  const allowDevAutoSession = !normalizePath(path).startsWith(AUTH_PATH_PREFIX);
+  let response = await fetch(buildUrl(path), createRequestInit(init, token));
+
+  if (!response.ok && !getEnvToken()) {
+    const payload = await parseJson<ApiErrorEnvelope>(response);
+
+    if (shouldRecoverStaleUserSession(path, response.status, payload) && token) {
+      clearStoredAuthState();
+      const refreshedToken = await resolveSessionToken({ allowDevAutoSession });
+
+      if (refreshedToken && refreshedToken !== token) {
+        response = await fetch(buildUrl(path), createRequestInit(init, refreshedToken));
+      } else {
+        throw toApiErrorFromPayload(response.status, payload);
+      }
+    } else {
+      throw toApiErrorFromPayload(response.status, payload);
+    }
+  }
 
   if (!response.ok) {
     throw await toApiError(response);

--- a/apps/web/src/pages/profile.test.tsx
+++ b/apps/web/src/pages/profile.test.tsx
@@ -1,26 +1,82 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ProfilePage } from '@/pages/profile';
+import { createQueryClientWrapper } from '@/test/query-client';
+
+type TestUser = {
+  createdAt: number;
+  id: string;
+  name: string | null;
+  username: string;
+};
+
+let user: TestUser;
 
 function renderProfilePage() {
+  const { wrapper } = createQueryClientWrapper();
+
   return render(
     <MemoryRouter>
       <ProfilePage />
     </MemoryRouter>,
+    { wrapper },
   );
 }
 
 describe('ProfilePage', () => {
+  beforeEach(() => {
+    user = {
+      createdAt: 1_713_139_200_000,
+      id: 'user-1',
+      name: 'Jordan Lee',
+      username: 'jordan',
+    };
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: string | URL | Request, init?: RequestInit) => {
+        const rawUrl =
+          typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+        const url = new URL(rawUrl, 'http://localhost');
+
+        if (url.pathname === '/api/v1/users/me' && (!init?.method || init.method === 'GET')) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ data: user }), {
+              headers: { 'Content-Type': 'application/json' },
+              status: 200,
+            }),
+          );
+        }
+
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: null }), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          }),
+        );
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('renders the user summary card and quick access destinations', () => {
     renderProfilePage();
 
     expect(screen.getByRole('heading', { name: 'Profile' })).toBeInTheDocument();
-    expect(screen.getByText('Jordan Lee')).toBeInTheDocument();
-    expect(screen.getByText('JL')).toBeInTheDocument();
     expect(screen.getByText('Member since')).toBeInTheDocument();
-    expect(screen.getByText('March 2024')).toBeInTheDocument();
+  });
+
+  it('shows authenticated user identity and honest destination summaries', async () => {
+    renderProfilePage();
+
+    expect(await screen.findByText('Jordan Lee')).toBeInTheDocument();
+    expect(await screen.findByText('JL')).toBeInTheDocument();
+    expect(screen.getByText('April 2024')).toBeInTheDocument();
 
     expect(screen.getByRole('link', { name: /Equipment/i })).toHaveAttribute(
       'href',
@@ -36,10 +92,23 @@ describe('ProfilePage', () => {
     );
     expect(screen.getByRole('link', { name: /Settings/i })).toHaveAttribute('href', '/settings');
 
-    expect(screen.getByText('2 locations, 32 total items')).toBeInTheDocument();
-    expect(screen.getByText('1 active condition')).toBeInTheDocument();
-    expect(screen.getByText('8 resources')).toBeInTheDocument();
+    expect(screen.getAllByText('Coming soon')).toHaveLength(3);
     expect(screen.getByText('Theme, targets, dashboard')).toBeInTheDocument();
+    expect(screen.queryByText('Household')).not.toBeInTheDocument();
+  });
+
+  it('falls back to username for display name and initials when name is missing', async () => {
+    user = {
+      createdAt: 1_713_139_200_000,
+      id: 'user-1',
+      name: null,
+      username: 'sam',
+    };
+
+    renderProfilePage();
+
+    expect(await screen.findByText('sam')).toBeInTheDocument();
+    expect(await screen.findByText('SA')).toBeInTheDocument();
   });
 
   it('uses the responsive quick access grid classes required by the prototype', () => {

--- a/apps/web/src/pages/profile.tsx
+++ b/apps/web/src/pages/profile.tsx
@@ -1,11 +1,5 @@
-import { equipmentLocations } from '@/features/equipment';
 import { ProfileHub } from '@/features/profile';
 
-const initialEquipmentSummary = `${equipmentLocations.length} locations, ${equipmentLocations.reduce(
-  (count, location) => count + location.equipment.length,
-  0,
-)} total items`;
-
 export function ProfilePage() {
-  return <ProfileHub equipmentSummary={initialEquipmentSummary} />;
+  return <ProfileHub equipmentSummary="Coming soon" />;
 }

--- a/apps/web/src/pages/settings.test.tsx
+++ b/apps/web/src/pages/settings.test.tsx
@@ -407,6 +407,9 @@ describe('SettingsPage', () => {
       expect(screen.getByLabelText('Display name')).toHaveValue('Jordan Lee');
     });
 
+    fireEvent.change(screen.getByLabelText('Display name'), {
+      target: { value: 'Jordan With Error' },
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Save profile' }));
 
     await waitFor(() => {

--- a/apps/web/src/pages/settings.test.tsx
+++ b/apps/web/src/pages/settings.test.tsx
@@ -49,6 +49,13 @@ type TestState = {
     | null;
   shouldFailDashboardSave: boolean;
   shouldFailNutritionSave: boolean;
+  shouldFailProfileSave: boolean;
+  user: {
+    id: string;
+    username: string;
+    name: string | null;
+    createdAt: number;
+  };
 };
 
 function renderSettingsPage() {
@@ -122,6 +129,13 @@ describe('SettingsPage', () => {
       nutritionCurrent: null,
       shouldFailDashboardSave: false,
       shouldFailNutritionSave: false,
+      shouldFailProfileSave: false,
+      user: {
+        id: 'user-1',
+        username: 'jordan',
+        name: 'Jordan Lee',
+        createdAt: 1_713_225_600_000,
+      },
     };
 
     window.localStorage.removeItem(THEME_STORAGE_KEY);
@@ -200,6 +214,38 @@ describe('SettingsPage', () => {
         if (url.pathname === '/api/v1/habits' && init?.method === 'GET') {
           return Promise.resolve(
             new Response(JSON.stringify({ data: state.habits }), {
+              headers: { 'Content-Type': 'application/json' },
+              status: 200,
+            }),
+          );
+        }
+
+        if (url.pathname === '/api/v1/users/me' && (!init?.method || init.method === 'GET')) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ data: state.user }), {
+              headers: { 'Content-Type': 'application/json' },
+              status: 200,
+            }),
+          );
+        }
+
+        if (url.pathname === '/api/v1/users/me' && init?.method === 'PATCH') {
+          if (state.shouldFailProfileSave) {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({ error: { code: 'SERVER_ERROR', message: 'Unavailable' } }),
+                {
+                  headers: { 'Content-Type': 'application/json' },
+                  status: 503,
+                },
+              ),
+            );
+          }
+
+          const body = JSON.parse(String(init.body)) as { name: string };
+          state.user = { ...state.user, name: body.name };
+          return Promise.resolve(
+            new Response(JSON.stringify({ data: state.user }), {
               headers: { 'Content-Type': 'application/json' },
               status: 200,
             }),
@@ -317,6 +363,55 @@ describe('SettingsPage', () => {
         screen.getByText(
           'Nutrition targets could not be saved right now. Dashboard preferences were saved.',
         ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows the user profile with real data from the API', async () => {
+    renderSettingsPage();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Display name')).toHaveValue('Jordan Lee');
+    });
+
+    expect(screen.getByText('jordan')).toBeInTheDocument();
+    expect(screen.getByText('Member since')).toBeInTheDocument();
+    expect(screen.getByText('April 2024')).toBeInTheDocument();
+  });
+
+  it('saves profile changes via PATCH /api/v1/users/me', async () => {
+    renderSettingsPage();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Display name')).toHaveValue('Jordan Lee');
+    });
+
+    fireEvent.change(screen.getByLabelText('Display name'), {
+      target: { value: 'Jordan Updated' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Profile updated.')).toBeInTheDocument();
+    });
+
+    expect(getLatestPostBody('/api/v1/users/me')).toEqual({ name: 'Jordan Updated' });
+  });
+
+  it('shows an error message when profile save fails', async () => {
+    state.shouldFailProfileSave = true;
+
+    renderSettingsPage();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Display name')).toHaveValue('Jordan Lee');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Could not save profile. Please try again.'),
       ).toBeInTheDocument();
     });
   });

--- a/apps/web/src/pages/settings.tsx
+++ b/apps/web/src/pages/settings.tsx
@@ -12,6 +12,7 @@ import { HabitSettings } from '@/features/habits';
 import { useHabits } from '@/features/habits/api/habits';
 import { useNutritionTargets, useUpdateTargets } from '@/features/nutrition/api/targets';
 import { useDashboardConfig, useSaveDashboardConfig } from '@/hooks/use-dashboard-config';
+import { useUpdateUser, useUser } from '@/hooks/use-user';
 import type { Theme } from '@/hooks/useTheme';
 import { useThemeContext } from '@/hooks/useThemeContext';
 import { formatUtcDateKey } from '@/lib/date';
@@ -256,6 +257,11 @@ function ThemeOptionCard({
 
 export function SettingsPage() {
   const { setTheme, theme } = useThemeContext();
+  const { data: user } = useUser();
+  const updateUserMutation = useUpdateUser();
+  const [displayNameDraft, setDisplayNameDraft] = useState<string | null>(null);
+  const [profileMessage, setProfileMessage] = useState('');
+  const displayName = displayNameDraft ?? user?.name ?? '';
   const [storedSettings] = useState<SettingsFormState>(() => loadSettings());
   const [dashboardConfigDraft, setDashboardConfigDraft] = useState<
     SettingsFormState['dashboardConfig'] | null
@@ -299,6 +305,37 @@ export function SettingsPage() {
       window.clearTimeout(timeoutId);
     };
   }, [saveMessage]);
+
+  useEffect(() => {
+    if (!profileMessage) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setProfileMessage('');
+    }, 2400);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [profileMessage]);
+
+  async function handleProfileSave() {
+    const trimmed = displayName.trim();
+
+    if (!trimmed) {
+      setProfileMessage('Display name cannot be empty.');
+      return;
+    }
+
+    try {
+      await updateUserMutation.mutateAsync({ name: trimmed });
+      setDisplayNameDraft(null);
+      setProfileMessage('Profile updated.');
+    } catch {
+      setProfileMessage('Could not save profile. Please try again.');
+    }
+  }
 
   function handleThemeChange(nextValue: string) {
     if (!isTheme(nextValue)) {
@@ -410,18 +447,56 @@ export function SettingsPage() {
             <h2 className="text-xl font-semibold text-foreground">Profile</h2>
           </CardTitle>
           <CardDescription>
-            Profile editing will land in a later phase. This placeholder keeps the future surface
-            visible in the prototype.
+            Update your display name and view account details.
           </CardDescription>
         </CardHeader>
-        <CardContent className="space-y-3">
-          <Label className="text-sm font-medium text-foreground" htmlFor="display-name">
-            Display name
-          </Label>
-          <Input id="display-name" placeholder="User" readOnly value="" />
-          <p className="text-sm text-muted-foreground">
-            Profile details are read-only in this prototype.
-          </p>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label className="text-sm font-medium text-foreground" htmlFor="display-name">
+              Display name
+            </Label>
+            <Input
+              id="display-name"
+              onChange={(e) => {
+                setDisplayNameDraft(e.target.value);
+                setProfileMessage('');
+              }}
+              placeholder="Enter your name"
+              value={displayName}
+            />
+          </div>
+
+          {user?.username && (
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-foreground">Username</p>
+              <p className="text-sm text-muted-foreground">{user.username}</p>
+            </div>
+          )}
+
+          {user?.createdAt && (
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-foreground">Member since</p>
+              <p className="text-sm text-muted-foreground">
+                {new Intl.DateTimeFormat('en-US', {
+                  month: 'long',
+                  year: 'numeric',
+                }).format(new Date(user.createdAt))}
+              </p>
+            </div>
+          )}
+
+          <div className="flex flex-col gap-3 border-t border-border/80 pt-4 sm:flex-row sm:items-center sm:justify-between">
+            <p aria-live="polite" className="text-sm text-muted-foreground">
+              {profileMessage || '\u00A0'}
+            </p>
+            <Button
+              disabled={updateUserMutation.isPending}
+              onClick={handleProfileSave}
+              type="button"
+            >
+              {updateUserMutation.isPending ? 'Saving...' : 'Save profile'}
+            </Button>
+          </div>
         </CardContent>
       </Card>
 

--- a/apps/web/src/pages/settings.tsx
+++ b/apps/web/src/pages/settings.tsx
@@ -262,6 +262,7 @@ export function SettingsPage() {
   const [displayNameDraft, setDisplayNameDraft] = useState<string | null>(null);
   const [profileMessage, setProfileMessage] = useState('');
   const displayName = displayNameDraft ?? user?.name ?? '';
+  const isProfileDirty = displayNameDraft !== null && displayName.trim() !== (user?.name ?? '');
   const [storedSettings] = useState<SettingsFormState>(() => loadSettings());
   const [dashboardConfigDraft, setDashboardConfigDraft] = useState<
     SettingsFormState['dashboardConfig'] | null
@@ -321,6 +322,10 @@ export function SettingsPage() {
   }, [profileMessage]);
 
   async function handleProfileSave() {
+    if (!isProfileDirty) {
+      return;
+    }
+
     const trimmed = displayName.trim();
 
     if (!trimmed) {
@@ -490,7 +495,7 @@ export function SettingsPage() {
               {profileMessage || '\u00A0'}
             </p>
             <Button
-              disabled={updateUserMutation.isPending}
+              disabled={updateUserMutation.isPending || !isProfileDirty}
               onClick={handleProfileSave}
               type="button"
             >

--- a/docs/conventions/data-models.md
+++ b/docs/conventions/data-models.md
@@ -50,7 +50,7 @@ Inherited ownership comes from foreign-key chains:
 - `condition_severity_points` through `health_conditions`
 - `equipment_items` through `equipment_locations`
 
-`entity_links` stores `userId` for direct isolation and cleanup queries. Every read and write must still scope through the owning source entity so links cannot cross household-user boundaries.
+`entity_links` stores `userId` for direct isolation and cleanup queries. Every read and write must still scope through the owning source entity so links cannot cross user boundaries.
 
 ## Table Inventory
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -21,6 +21,7 @@ export * from './schemas/scheduled-workouts.js';
 export * from './schemas/session-set.js';
 export * from './schemas/weight.js';
 export * from './schemas/workout-sessions.js';
+export * from './schemas/users.js';
 export * from './schemas/workout-templates.js';
 
 export const userSchema = z.object({

--- a/packages/shared/src/schemas/users.ts
+++ b/packages/shared/src/schemas/users.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const userProfileSchema = z.object({
+  id: z.string(),
+  username: z.string(),
+  name: z.string().nullable(),
+  createdAt: z.number(),
+});
+
+export type UserProfile = z.infer<typeof userProfileSchema>;
+
+export const updateUserInputSchema = z.object({
+  name: z.string().min(1).max(100).trim(),
+});
+
+export type UpdateUserInput = z.infer<typeof updateUserInputSchema>;

--- a/packages/shared/src/schemas/users.ts
+++ b/packages/shared/src/schemas/users.ts
@@ -10,7 +10,7 @@ export const userProfileSchema = z.object({
 export type UserProfile = z.infer<typeof userProfileSchema>;
 
 export const updateUserInputSchema = z.object({
-  name: z.string().min(1).max(100).trim(),
+  name: z.string().trim().min(1).max(100),
 });
 
 export type UpdateUserInput = z.infer<typeof updateUserInputSchema>;


### PR DESCRIPTION
## Summary
This PR replaces hardcoded profile identity data in the web app with real authenticated user data from new user profile endpoints. It adds `GET /api/v1/users/me` and `PATCH /api/v1/users/me` on the API, then wires a shared `useUser`/`useUpdateUser` hook into Settings, Profile, and Sidebar so identity stays consistent across screens. The Settings profile card is now editable and persists display name changes via `PATCH`, with success/error states in the UI. It also fixes a stale-session edge case in dev where `/api/v1/users/me` returns `NOT_FOUND` by clearing stale auth and re-establishing a fresh session. Alongside the functional changes, copy that assumed a two-person household model was removed from docs and UI text.

## Key Changes
- Added API user routes under `/api/v1/users`:
  - `GET /me` returns the authenticated user profile.
  - `PATCH /me` validates and updates `name`, then returns the updated profile.
- Added shared user schemas/types in `@pulse/shared` (`userProfileSchema`, `updateUserInputSchema`) and exported them from the package index.
- Introduced web `useUser` and `useUpdateUser` hooks using TanStack Query for fetch/mutation and cache invalidation.
- Reworked Settings → Profile card from read-only placeholder to real data + editable display name with save flow and inline status messaging.
- Updated Profile hub to use authenticated user identity (name/username initials, member-since date), and removed household-specific UI content.
- Made Sidebar identity block clickable to `/profile` in both expanded and collapsed states, with tests covering navigation and fallback display behavior.
- Added regression coverage for stale dev session recovery in `api-client` when `/api/v1/users/me` returns `404 NOT_FOUND`.

## Technical Notes
- `PATCH /api/v1/users/me` uses `updateUserInputSchema.safeParse` server-side and returns a structured `VALIDATION_ERROR` on invalid payloads.
- Stale session recovery is intentionally narrow: it only triggers for `404 NOT_FOUND` on `/api/v1/users/me`, only when no env token is present, and retries once after clearing stored auth.
- `useUpdateUser` invalidates `userKeys.all` on success instead of optimistic writes, favoring consistency across all identity consumers (Sidebar, Profile, Settings).
- The profile surface now depends on `createdAt` for “Member since”; UI falls back to username/derived initials when `name` is null.
- Reviewers should pay attention to the updated auth error/recovery path in `api-client.ts`, since it alters behavior only for this specific user bootstrap scenario.

## Commits

- `59b4c6f fix(web): recover stale profile sessions on users/me not found`
- `844a14d fix(web): link sidebar user identity to profile`
- `bfcd835 fix(web): use real profile data and remove household copy`
- `96e0f71 feat(web): wire settings profile card to real user data with editing`
- `8fc8364 feat(api): add GET/PATCH /api/v1/users/me endpoints and useUser hook`

## Tasks

- **Add PATCH /api/v1/users/me endpoint**: Create a user profile endpoint that returns and updates displayName, email, initials, and memberSince from the auth store
- **Wire settings profile section to real user data**: Replace read-only placeholder profile fields in settings with real user data from GET /api/v1/users/me, enable editing via PATCH
- **Fix profile page — real data + remove household**: Replace hardcoded Jordan Lee profile with real user data, remove household/two-person account references from frontend and docs
- **Sidebar username links to profile page**: Make the username/avatar in the sidebar a clickable link to /profile

## Diff Stats

```
AGENTS.md                                          |   2 +-
 README.md                                          |   4 +-
 apps/api/src/routes/users/index.test.ts            | 185 +++++++++++++++++++++
 apps/api/src/routes/users/index.ts                 |  37 +++++
 apps/api/src/routes/users/store.ts                 |  21 +++
 apps/api/src/routes/v1/index.ts                    |   3 +
 apps/web/src/components/layout/sidebar.test.tsx    |  61 ++++++-
 apps/web/src/components/layout/sidebar.tsx         |  28 +++-
 .../features/profile/components/profile-hub.tsx    |  47 ++++--
 apps/web/src/hooks/use-user.ts                     |  44 +++++
 apps/web/src/lib/api-client.test.ts                | 111 +++++++++++++
 apps/web/src/lib/api-client.ts                     |  38 ++++-
 apps/web/src/pages/profile.test.tsx                |  83 ++++++++-
 apps/web/src/pages/profile.tsx                     |   8 +-
 apps/web/src/pages/settings.test.tsx               |  95 +++++++++++
 apps/web/src/pages/settings.tsx                    |  95 +++++++++--
 docs/conventions/data-models.md                    |   2 +-
 packages/shared/src/index.ts                       |   1 +
 packages/shared/src/schemas/users.ts               |  16 ++
 19 files changed, 823 insertions(+), 58 deletions(-)
```