### PR TITLE
Dashboard polish — cards, calendar, sparklines, layout

### DIFF
--- a/apps/web/src/components/ui/stat-card.test.tsx
+++ b/apps/web/src/components/ui/stat-card.test.tsx
@@ -68,8 +68,13 @@ describe('StatCard', () => {
     const value = screen.getByText(
       'This is an extremely long value that should be truncated to avoid overflow',
     );
+    const header = label.closest('[data-slot="card-header"]');
+    const content = value.closest('[data-slot="card-content"]');
+
+    expect(header).toHaveClass('min-w-0');
+    expect(content).toHaveClass('min-w-0');
     expect(label).toHaveClass('truncate');
-    expect(value).toHaveClass('overflow-hidden', 'text-ellipsis', 'whitespace-nowrap');
+    expect(value).toHaveClass('min-w-0', 'overflow-hidden', 'text-ellipsis', 'whitespace-nowrap');
   });
 
   it('applies accentTextClassName to label, value, and trend', () => {

--- a/apps/web/src/components/ui/stat-card.tsx
+++ b/apps/web/src/components/ui/stat-card.tsx
@@ -12,11 +12,13 @@ export type StatTrend = {
 };
 
 export type StatCardProps = Omit<React.ComponentProps<typeof Card>, 'children'> & {
-  value: number | string;
+  value: React.ReactNode;
   label: string;
   trend?: StatTrend;
   icon?: React.ReactNode;
   accentTextClassName?: string;
+  valueClassName?: string;
+  valueTitle?: string;
 };
 
 const TREND_STYLES: Record<
@@ -50,6 +52,8 @@ export function StatCard({
   trend,
   icon,
   accentTextClassName,
+  valueClassName: customValueClassName,
+  valueTitle,
   className,
   ...props
 }: StatCardProps) {
@@ -62,16 +66,18 @@ export function StatCard({
   const labelClassName = hasAccent
     ? cn(accentClass, 'opacity-70 dark:text-muted dark:opacity-100')
     : 'text-muted';
-  const valueClassName = hasAccent ? cn(accentClass, 'dark:text-foreground') : 'text-foreground';
+  const valueTextClassName = hasAccent
+    ? cn(accentClass, 'dark:text-foreground')
+    : 'text-foreground';
   const iconClassName = hasAccent ? cn(accentClass, 'dark:text-muted') : 'text-muted';
   const trendClassName = hasAccent
     ? cn(accentClass, 'opacity-80 dark:text-muted dark:opacity-100')
     : trendStyle?.className;
-  const valueTitle = typeof value === 'string' ? value : undefined;
+  const resolvedValueTitle = valueTitle ?? (typeof value === 'string' ? value : undefined);
 
   return (
     <Card data-slot="stat-card" className={cn('gap-3 py-4 sm:gap-4 sm:py-5', className)} {...props}>
-      <CardHeader className="flex flex-row items-start justify-between gap-2 pb-0">
+      <CardHeader className="min-w-0 flex flex-row items-start justify-between gap-2 pb-0">
         <p
           className={cn(
             'min-w-0 truncate text-xs font-semibold uppercase tracking-wide sm:text-sm sm:normal-case sm:tracking-normal',
@@ -80,15 +86,16 @@ export function StatCard({
         >
           {label}
         </p>
-        {icon ? <div className={iconClassName}>{icon}</div> : null}
+        {icon ? <div className={cn('shrink-0', iconClassName)}>{icon}</div> : null}
       </CardHeader>
-      <CardContent className="space-y-1.5">
+      <CardContent className="min-w-0 space-y-1.5">
         <p
           className={cn(
-            'overflow-hidden text-ellipsis whitespace-nowrap text-lg font-bold tracking-tight sm:text-2xl lg:text-3xl',
-            valueClassName,
+            'min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-lg font-bold tracking-tight sm:text-2xl lg:text-3xl',
+            valueTextClassName,
+            customValueClassName,
           )}
-          title={valueTitle}
+          title={resolvedValueTitle}
         >
           {value}
         </p>

--- a/apps/web/src/features/dashboard/components/calendar-picker.test.tsx
+++ b/apps/web/src/features/dashboard/components/calendar-picker.test.tsx
@@ -46,7 +46,7 @@ describe('CalendarPicker', () => {
     expect(lastDay.getByText('Sun')).toBeInTheDocument();
   });
 
-  it('highlights today and dims future dates', () => {
+  it('highlights the selected day and dims future dates', () => {
     render(<CalendarPicker />);
 
     const todayButton = getDayButton('2026-03-06');
@@ -56,6 +56,7 @@ describe('CalendarPicker', () => {
     expect(todayButton).toHaveClass('bg-[var(--color-primary)]');
     expect(todayButton).toHaveClass('text-[var(--color-on-accent)]');
     expect(todayButton).toHaveAttribute('data-today', 'true');
+    expect(todayButton).toHaveAttribute('data-selected', 'true');
     expect(saturdayButton).toHaveClass('opacity-45');
     expect(sundayButton).toHaveClass('opacity-45');
   });
@@ -87,24 +88,33 @@ describe('CalendarPicker', () => {
     expect(days[6]).toHaveAttribute('data-date', '2026-03-01');
   });
 
-  it('calls onDateSelect with the clicked day and marks non-today selection with primary border', () => {
+  it('moves the full highlight to the clicked day and leaves today plain when not selected', () => {
     const onDateSelect = vi.fn();
     render(<CalendarPicker onDateSelect={onDateSelect} />);
 
     const selectedDay = getDayButton('2026-03-04');
+    const todayButton = getDayButton('2026-03-06');
+
     fireEvent.click(selectedDay);
 
     expect(onDateSelect).toHaveBeenCalledTimes(1);
     expect(formatDate(onDateSelect.mock.calls[0]?.[0] as Date)).toBe('2026-03-04');
-    expect(selectedDay).toHaveClass('border-[var(--color-primary)]');
+    expect(selectedDay).toHaveClass('bg-[var(--color-primary)]');
+    expect(selectedDay).toHaveClass('text-[var(--color-on-accent)]');
     expect(selectedDay).toHaveAttribute('data-selected', 'true');
+    expect(todayButton).toHaveAttribute('data-selected', 'false');
+    expect(todayButton).not.toHaveClass('bg-[var(--color-primary)]');
+    expect(todayButton).not.toHaveClass('ring-2');
   });
 
   it('supports controlled selectedDate and responsive card sizing classes', () => {
     render(<CalendarPicker selectedDate={new Date('2026-03-03T00:00:00')} />);
 
     const selectedDay = getDayButton('2026-03-03');
+    const todayButton = getDayButton('2026-03-06');
     expect(selectedDay).toHaveAttribute('data-selected', 'true');
+    expect(todayButton).toHaveAttribute('data-selected', 'false');
+    expect(todayButton).not.toHaveClass('bg-[var(--color-primary)]');
 
     const calendar = screen.getByLabelText('Calendar day picker');
     expect(calendar).toHaveClass('w-full');

--- a/apps/web/src/features/dashboard/components/calendar-picker.tsx
+++ b/apps/web/src/features/dashboard/components/calendar-picker.tsx
@@ -111,11 +111,9 @@ export function CalendarPicker({ selectedDate, onDateSelect, getDayActivity, cla
               aria-pressed={isSelected}
               className={cn(
                 'flex min-w-0 flex-1 cursor-pointer flex-col items-center rounded-lg border px-1 py-2 transition-colors sm:px-2 sm:py-2.5',
-                isToday
+                isSelected
                   ? 'border-[var(--color-primary)] bg-[var(--color-primary)] text-[var(--color-on-accent)]'
-                  : 'text-foreground',
-                isSelected && !isToday ? 'border-[var(--color-primary)] bg-card' : 'border-transparent',
-                !isToday && 'hover:border-border hover:bg-secondary/50',
+                  : 'border-transparent text-foreground hover:border-border hover:bg-secondary/50',
                 isFuture && 'opacity-45',
               )}
               data-date={formatDateKey(day)}
@@ -144,7 +142,7 @@ export function CalendarPicker({ selectedDate, onDateSelect, getDayActivity, cla
                 className={cn(
                   'mt-1 size-1.5 rounded-full',
                   hasActivity ? 'visible' : 'invisible',
-                  isToday
+                  isSelected
                     ? 'bg-[var(--color-on-accent)]'
                     : activity.hasWorkout && activity.hasMeals
                       ? 'bg-[var(--color-primary)]'

--- a/apps/web/src/features/dashboard/components/recent-workouts.test.tsx
+++ b/apps/web/src/features/dashboard/components/recent-workouts.test.tsx
@@ -89,6 +89,7 @@ describe('RecentWorkouts', () => {
 
     expect(screen.getByRole('heading', { name: 'Recent Workouts' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'View all' })).toHaveAttribute('href', '/workouts');
+    expect(screen.queryByText('Your last five sessions at a glance.')).not.toBeInTheDocument();
 
     const workoutLinks = screen.getAllByRole('link', { name: /^Open / });
     expect(workoutLinks).toHaveLength(5);
@@ -151,6 +152,7 @@ describe('RecentWorkouts', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByText('No completed workouts yet.')).toBeInTheDocument();
+    expect(screen.getByText('No completed workouts yet')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Start a workout' })).toHaveAttribute('href', '/workouts');
   });
 });

--- a/apps/web/src/features/dashboard/components/recent-workouts.test.tsx
+++ b/apps/web/src/features/dashboard/components/recent-workouts.test.tsx
@@ -155,4 +155,22 @@ describe('RecentWorkouts', () => {
     expect(screen.getByText('No completed workouts yet')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Start a workout' })).toHaveAttribute('href', '/workouts');
   });
+
+  it('renders an error state when recent workouts query fails', () => {
+    vi.mocked(useRecentWorkouts).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as ReturnType<typeof useRecentWorkouts>);
+
+    render(
+      <MemoryRouter>
+        <RecentWorkouts />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Unable to load recent workouts.')).toBeInTheDocument();
+    expect(screen.queryByText('No completed workouts yet')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Start a workout' })).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/dashboard/components/recent-workouts.tsx
+++ b/apps/web/src/features/dashboard/components/recent-workouts.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router';
 
 import { Button } from '@/components/ui/button';
-import { Card } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { formatRelativeWorkoutDate } from '@/features/dashboard/lib/recent-workouts';
 import { useRecentWorkouts } from '@/hooks/use-recent-workouts';
 import { parseDateInput } from '@/lib/date';
@@ -49,71 +49,71 @@ export function RecentWorkouts() {
   const recentWorkoutsQuery = useRecentWorkouts(WORKOUTS_TO_SHOW);
 
   return (
-    <section aria-labelledby="recent-workouts-heading" className="space-y-4">
-      <div className="flex items-end justify-between gap-3">
-        <div className="space-y-1">
-          <h2
-            className="text-xl font-semibold text-foreground md:text-2xl"
-            id="recent-workouts-heading"
-          >
+    <Card aria-labelledby="recent-workouts-heading">
+      <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
+        <CardTitle>
+          <h2 className="text-xl font-semibold text-foreground md:text-2xl" id="recent-workouts-heading">
             Recent Workouts
           </h2>
-          <p className="text-sm text-muted">Your last five sessions at a glance.</p>
-        </div>
-
-        <Button asChild className="h-auto px-0 py-0" size="sm" variant="link">
+        </CardTitle>
+        <Button asChild className="h-auto px-0 py-0 text-muted-foreground hover:text-foreground" size="sm" variant="link">
           <Link to="/workouts">View all</Link>
         </Button>
-      </div>
+      </CardHeader>
 
-      {recentWorkoutsQuery.isLoading ? (
-        <RecentWorkoutRowsSkeleton />
-      ) : recentWorkoutsQuery.data && recentWorkoutsQuery.data.length > 0 ? (
-        <ul className="grid gap-3">
-          {recentWorkoutsQuery.data.map((workout) => (
-            <li key={workout.id}>
-              <Link
-                aria-label={`Open ${workout.name}`}
-                className="block cursor-pointer rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-                to={`/workouts/session/${workout.id}`}
-              >
-                <Card
-                  className="h-full gap-4 px-4 py-4 transition-transform duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
-                  data-slot="recent-workout-card"
+      <CardContent>
+        {recentWorkoutsQuery.isLoading ? (
+          <RecentWorkoutRowsSkeleton />
+        ) : recentWorkoutsQuery.data && recentWorkoutsQuery.data.length > 0 ? (
+          <ul className="grid gap-3">
+            {recentWorkoutsQuery.data.map((workout) => (
+              <li key={workout.id}>
+                <Link
+                  aria-label={`Open ${workout.name}`}
+                  className="block cursor-pointer rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                  to={`/workouts/session/${workout.id}`}
                 >
-                  <div className="space-y-3">
-                    <div className="flex items-start justify-between gap-2">
-                      <div className="min-w-0 space-y-1">
-                        <p className="truncate text-base font-semibold text-foreground">{workout.name}</p>
-                        <time className="text-sm text-muted" dateTime={workout.date}>
-                          {formatWorkoutDate(workout.date)}
-                        </time>
+                  <Card
+                    className="h-full gap-4 px-4 py-4 transition-transform duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
+                    data-slot="recent-workout-card"
+                  >
+                    <div className="space-y-3">
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0 space-y-1">
+                          <p className="truncate text-base font-semibold text-foreground">{workout.name}</p>
+                          <time className="text-sm text-muted" dateTime={workout.date}>
+                            {formatWorkoutDate(workout.date)}
+                          </time>
+                        </div>
+
+                        <span className="shrink-0 rounded-full bg-[var(--color-accent-cream)] px-2.5 py-1 text-xs font-semibold text-on-cream dark:bg-amber-500/20 dark:text-amber-400">
+                          {formatRelativeWorkoutDate(workout.date)}
+                        </span>
                       </div>
 
-                      <span className="shrink-0 rounded-full bg-[var(--color-accent-cream)] px-2.5 py-1 text-xs font-semibold text-on-cream dark:bg-amber-500/20 dark:text-amber-400">
-                        {formatRelativeWorkoutDate(workout.date)}
-                      </span>
+                      <div className="flex flex-wrap gap-2 text-sm text-foreground">
+                        <span className="rounded-full bg-secondary px-3 py-1">
+                          {`${workout.exerciseCount} exercises`}
+                        </span>
+                        <span className="rounded-full bg-secondary px-3 py-1">
+                          {workout.duration === null ? 'Duration n/a' : `${workout.duration} min`}
+                        </span>
+                      </div>
                     </div>
-
-                    <div className="flex flex-wrap gap-2 text-sm text-foreground">
-                      <span className="rounded-full bg-secondary px-3 py-1">
-                        {`${workout.exerciseCount} exercises`}
-                      </span>
-                      <span className="rounded-full bg-secondary px-3 py-1">
-                        {workout.duration === null ? 'Duration n/a' : `${workout.duration} min`}
-                      </span>
-                    </div>
-                  </div>
-                </Card>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <Card className="px-4 py-6" data-slot="recent-workout-empty-state">
-          <p className="text-sm text-muted">No completed workouts yet.</p>
-        </Card>
-      )}
-    </section>
+                  </Card>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="space-y-4" data-slot="recent-workout-empty-state">
+            <p className="text-sm text-muted">No completed workouts yet</p>
+            <Button asChild size="sm">
+              <Link to="/workouts">Start a workout</Link>
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/apps/web/src/features/dashboard/components/recent-workouts.tsx
+++ b/apps/web/src/features/dashboard/components/recent-workouts.tsx
@@ -64,6 +64,8 @@ export function RecentWorkouts() {
       <CardContent>
         {recentWorkoutsQuery.isLoading ? (
           <RecentWorkoutRowsSkeleton />
+        ) : recentWorkoutsQuery.isError ? (
+          <p className="text-sm text-muted-foreground">Unable to load recent workouts.</p>
         ) : recentWorkoutsQuery.data && recentWorkoutsQuery.data.length > 0 ? (
           <ul className="grid gap-3">
             {recentWorkoutsQuery.data.map((workout) => (

--- a/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import {
   calculateHabitCompletionPercent,
   calculateWeightTrend,
+  getSnapshotValueClassName,
   SnapshotCards,
 } from './snapshot-cards';
 
@@ -69,6 +70,16 @@ describe('calculateHabitCompletionPercent', () => {
   });
 });
 
+describe('getSnapshotValueClassName', () => {
+  it('returns larger text sizing for shorter values', () => {
+    expect(getSnapshotValueClassName('3/5')).toContain('text-2xl');
+  });
+
+  it('returns compact text sizing for longer values', () => {
+    expect(getSnapshotValueClassName('2,450 / 2,200')).toContain('text-lg');
+  });
+});
+
 describe('SnapshotCards', () => {
   it('renders five snapshot cards with dashboard snapshot API values', () => {
     const { container } = render(
@@ -84,9 +95,9 @@ describe('SnapshotCards', () => {
     expect(cards).toHaveLength(5);
 
     expect(screen.getByText('181.4 lbs')).toBeInTheDocument();
-    expect(screen.getByText('1900 / 2300')).toBeInTheDocument();
+    expect(screen.getByText('1,900 / 2,300')).toBeInTheDocument();
     expect(screen.getByText('170g / 190g')).toBeInTheDocument();
-    expect(screen.getByText('3 / 4 complete')).toBeInTheDocument();
+    expect(screen.getByText('3/4')).toBeInTheDocument();
     expect(screen.getByText('Upper Push A (Completed)')).toBeInTheDocument();
   });
 
@@ -132,6 +143,20 @@ describe('SnapshotCards', () => {
           snapshot={{
             ...snapshotFixture,
             weight: null,
+            macros: {
+              actual: {
+                calories: 1800,
+                protein: 120,
+                carbs: 210,
+                fat: 70,
+              },
+              target: {
+                calories: 0,
+                protein: 0,
+                carbs: 0,
+                fat: 0,
+              },
+            },
             workout: null,
             habits: {
               total: 0,
@@ -146,13 +171,54 @@ describe('SnapshotCards', () => {
     const weightCard = screen
       .getByText('Body Weight')
       .closest('[data-slot="stat-card"]') as HTMLElement;
+    const caloriesCard = screen
+      .getByText('Calories')
+      .closest('[data-slot="stat-card"]') as HTMLElement;
+    const proteinCard = screen
+      .getByText('Protein')
+      .closest('[data-slot="stat-card"]') as HTMLElement;
     const habitsCard = screen.getByText('Habits').closest('[data-slot="stat-card"]') as HTMLElement;
     const workoutCard = screen
       .getByText("Today's Workout")
       .closest('[data-slot="stat-card"]') as HTMLElement;
 
-    expect(within(weightCard).getByText('--')).toBeInTheDocument();
-    expect(within(habitsCard).getByText('0 / 0 complete')).toBeInTheDocument();
+    expect(within(weightCard).getByText('Log weight')).toBeInTheDocument();
+    expect(within(weightCard).queryByLabelText(/trend/i)).not.toBeInTheDocument();
+    expect(within(caloriesCard).getByText('No targets set')).toBeInTheDocument();
+    expect(within(proteinCard).getByText('No targets set')).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: 'Settings' })).toHaveLength(2);
+    expect(within(habitsCard).getByText('No habits')).toBeInTheDocument();
+    expect(within(habitsCard).queryByLabelText(/trend/i)).not.toBeInTheDocument();
     expect(within(workoutCard).getByText('Rest Day')).toBeInTheDocument();
+    expect(weightCard).toHaveClass('border-dashed');
+    expect(caloriesCard).toHaveClass('border-dashed');
+    expect(proteinCard).toHaveClass('border-dashed');
+    expect(habitsCard).toHaveClass('border-dashed');
+  });
+
+  it('applies compact font sizing classes to long macro values to avoid overflow', () => {
+    render(
+      <MemoryRouter>
+        <SnapshotCards
+          snapshot={{
+            ...snapshotFixture,
+            macros: {
+              ...snapshotFixture.macros,
+              actual: {
+                ...snapshotFixture.macros.actual,
+                calories: 2450,
+              },
+              target: {
+                ...snapshotFixture.macros.target,
+                calories: 2200,
+              },
+            },
+          }}
+        />
+      </MemoryRouter>,
+    );
+
+    const caloriesValue = screen.getByText('2,450 / 2,200');
+    expect(caloriesValue).toHaveClass('text-lg', 'sm:text-xl', 'lg:text-2xl');
   });
 });

--- a/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
@@ -96,7 +96,7 @@ describe('SnapshotCards', () => {
 
     expect(screen.getByText('181.4 lbs')).toBeInTheDocument();
     expect(screen.getByText('1,900 / 2,300')).toBeInTheDocument();
-    expect(screen.getByText('170g / 190g')).toBeInTheDocument();
+    expect(screen.getByText('170 g / 190 g')).toBeInTheDocument();
     expect(screen.getByText('3/4')).toBeInTheDocument();
     expect(screen.getByText('Upper Push A (Completed)')).toBeInTheDocument();
   });

--- a/apps/web/src/features/dashboard/components/snapshot-cards.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.tsx
@@ -21,7 +21,8 @@ export const getSnapshotValueClassName = (value: string) => {
 };
 
 const formatMacroProgressValue = (actual: number, target: number, suffix = '') => {
-  return `${numberFormatter.format(actual)}${suffix} / ${numberFormatter.format(target)}${suffix}`;
+  const suffixPart = suffix ? ` ${suffix}` : '';
+  return `${numberFormatter.format(actual)}${suffixPart} / ${numberFormatter.format(target)}${suffixPart}`;
 };
 
 export const calculateWeightTrend = (weight: number, weightYesterday: number): StatTrend => {
@@ -126,7 +127,6 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
       ? `${snapshot.habits.completed}/${snapshot.habits.total}`
       : 'No habits'
     : '--';
-  const habitsValue = habitsValueText;
   const workoutValue = snapshot?.workout
     ? `${snapshot.workout.name} (${formatWorkoutStatus(snapshot.workout.status)})`
     : snapshot
@@ -190,7 +190,7 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
             ? { direction: 'neutral', value: habitCompletionPercent }
             : undefined
         }
-        value={habitsValue}
+        value={habitsValueText}
         valueClassName={getSnapshotValueClassName(habitsValueText)}
         valueTitle={habitsValueText}
       />

--- a/apps/web/src/features/dashboard/components/snapshot-cards.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.tsx
@@ -1,11 +1,27 @@
 /* eslint-disable react-refresh/only-export-components */
 import type { DashboardSnapshot, DashboardWorkoutSnapshot } from '@pulse/shared';
+import { Link } from 'react-router';
 
 import { StatCard, type StatTrend } from '@/components/ui/stat-card';
 import { accentCardStyles } from '@/lib/accent-card-styles';
 
 type SnapshotCardsProps = {
   snapshot?: DashboardSnapshot;
+};
+
+const numberFormatter = new Intl.NumberFormat('en-US');
+const notConfiguredCardClassName =
+  'border-dashed border-border/80 bg-muted/35 text-muted-foreground shadow-none';
+const notConfiguredAccentTextClassName = 'text-muted-foreground';
+const longValueClassName = 'text-lg sm:text-xl lg:text-2xl';
+const shortValueClassName = 'text-2xl sm:text-2xl lg:text-3xl';
+
+export const getSnapshotValueClassName = (value: string) => {
+  return value.length >= 13 ? longValueClassName : shortValueClassName;
+};
+
+const formatMacroProgressValue = (actual: number, target: number, suffix = '') => {
+  return `${numberFormatter.format(actual)}${suffix} / ${numberFormatter.format(target)}${suffix}`;
 };
 
 export const calculateWeightTrend = (weight: number, weightYesterday: number): StatTrend => {
@@ -39,8 +55,12 @@ export const calculateHabitCompletionPercent = (
 };
 
 const formatWeightValue = (snapshot: DashboardSnapshot | undefined) => {
-  if (!snapshot?.weight) {
+  if (!snapshot) {
     return '--';
+  }
+
+  if (!snapshot?.weight) {
+    return 'Log weight';
   }
 
   return `${snapshot.weight.value.toFixed(1)} lbs`;
@@ -54,19 +74,59 @@ const formatWorkoutStatus = (status: DashboardWorkoutSnapshot['status']) => {
 };
 
 export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
+  const hasWeight = !!snapshot?.weight;
+  const hasCaloriesTarget = (snapshot?.macros.target.calories ?? 0) > 0;
+  const hasProteinTarget = (snapshot?.macros.target.protein ?? 0) > 0;
+  const hasHabits = (snapshot?.habits.total ?? 0) > 0;
   const habitCompletionPercent = snapshot
     ? calculateHabitCompletionPercent(snapshot.habits.completed, snapshot.habits.total)
     : 0;
+
   const weightValue = formatWeightValue(snapshot);
+  const caloriesValueText = snapshot
+    ? hasCaloriesTarget
+      ? formatMacroProgressValue(snapshot.macros.actual.calories, snapshot.macros.target.calories)
+      : 'No targets set'
+    : '--';
   const caloriesValue = snapshot
-    ? `${snapshot.macros.actual.calories} / ${snapshot.macros.target.calories}`
+    ? hasCaloriesTarget
+      ? caloriesValueText
+      : [
+          <span key="text">No targets set</span>,
+          ' ',
+          <Link key="link" className="font-semibold underline underline-offset-2" to="/settings">
+            Settings
+          </Link>,
+        ]
+    : '--';
+
+  const proteinValueText = snapshot
+    ? hasProteinTarget
+      ? formatMacroProgressValue(
+          snapshot.macros.actual.protein,
+          snapshot.macros.target.protein,
+          'g',
+        )
+      : 'No targets set'
     : '--';
   const proteinValue = snapshot
-    ? `${snapshot.macros.actual.protein}g / ${snapshot.macros.target.protein}g`
+    ? hasProteinTarget
+      ? proteinValueText
+      : [
+          <span key="text">No targets set</span>,
+          ' ',
+          <Link key="link" className="font-semibold underline underline-offset-2" to="/settings">
+            Settings
+          </Link>,
+        ]
     : '--';
-  const habitsValue = snapshot
-    ? `${snapshot.habits.completed} / ${snapshot.habits.total} complete`
+
+  const habitsValueText = snapshot
+    ? hasHabits
+      ? `${snapshot.habits.completed}/${snapshot.habits.total}`
+      : 'No habits'
     : '--';
+  const habitsValue = habitsValueText;
   const workoutValue = snapshot?.workout
     ? `${snapshot.workout.name} (${formatWorkoutStatus(snapshot.workout.status)})`
     : snapshot
@@ -76,39 +136,63 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
   return (
     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
       <StatCard
-        accentTextClassName="text-on-cream"
-        className={accentCardStyles.cream}
+        accentTextClassName={
+          snapshot && !hasWeight ? notConfiguredAccentTextClassName : 'text-on-cream'
+        }
+        className={snapshot && !hasWeight ? notConfiguredCardClassName : accentCardStyles.cream}
         data-stagger="0"
         label="Body Weight"
-        trend={{ direction: 'neutral', value: 0 }}
+        trend={snapshot && hasWeight ? { direction: 'neutral', value: 0 } : undefined}
         value={weightValue}
+        valueClassName={getSnapshotValueClassName(weightValue)}
+        valueTitle={weightValue}
       />
 
       <StatCard
-        accentTextClassName="text-on-pink"
-        className={accentCardStyles.pink}
+        accentTextClassName={
+          snapshot && !hasCaloriesTarget ? notConfiguredAccentTextClassName : 'text-on-pink'
+        }
+        className={
+          snapshot && !hasCaloriesTarget ? notConfiguredCardClassName : accentCardStyles.pink
+        }
         data-stagger="1"
         label="Calories"
-        trend={{ direction: 'neutral', value: 0 }}
+        trend={snapshot && hasCaloriesTarget ? { direction: 'neutral', value: 0 } : undefined}
         value={caloriesValue}
+        valueClassName={getSnapshotValueClassName(caloriesValueText)}
+        valueTitle={hasCaloriesTarget ? caloriesValueText : undefined}
       />
 
       <StatCard
-        accentTextClassName="text-on-mint"
-        className={accentCardStyles.mint}
+        accentTextClassName={
+          snapshot && !hasProteinTarget ? notConfiguredAccentTextClassName : 'text-on-mint'
+        }
+        className={
+          snapshot && !hasProteinTarget ? notConfiguredCardClassName : accentCardStyles.mint
+        }
         data-stagger="2"
         label="Protein"
-        trend={{ direction: 'neutral', value: 0 }}
+        trend={snapshot && hasProteinTarget ? { direction: 'neutral', value: 0 } : undefined}
         value={proteinValue}
+        valueClassName={getSnapshotValueClassName(proteinValueText)}
+        valueTitle={hasProteinTarget ? proteinValueText : undefined}
       />
 
       <StatCard
-        accentTextClassName="text-on-mint"
-        className={accentCardStyles.mint}
+        accentTextClassName={
+          snapshot && !hasHabits ? notConfiguredAccentTextClassName : 'text-on-mint'
+        }
+        className={snapshot && !hasHabits ? notConfiguredCardClassName : accentCardStyles.mint}
         data-stagger="3"
         label="Habits"
-        trend={{ direction: 'neutral', value: habitCompletionPercent }}
+        trend={
+          snapshot && hasHabits
+            ? { direction: 'neutral', value: habitCompletionPercent }
+            : undefined
+        }
         value={habitsValue}
+        valueClassName={getSnapshotValueClassName(habitsValueText)}
+        valueTitle={habitsValueText}
       />
 
       <StatCard
@@ -116,6 +200,8 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
         data-stagger="4"
         label="Today's Workout"
         value={workoutValue}
+        valueClassName={getSnapshotValueClassName(workoutValue)}
+        valueTitle={workoutValue}
       />
     </div>
   );

--- a/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
@@ -159,7 +159,7 @@ describe('TrendSparklines', () => {
     expect(screen.getByText('Calorie Trend')).toBeInTheDocument();
     expect(screen.getByText('Protein Trend')).toBeInTheDocument();
     expect(screen.getByText('175.2 lbs')).toBeInTheDocument();
-    expect(screen.getByText('2050 kcal')).toBeInTheDocument();
+    expect(screen.getByText('2,050 kcal')).toBeInTheDocument();
     expect(screen.getByText('170 g')).toBeInTheDocument();
 
     const weightCard = screen
@@ -326,6 +326,32 @@ describe('TrendSparklines', () => {
     expect(within(proteinCard).getByText('--')).toBeInTheDocument();
     expect(within(calorieCard).getByRole('img', { name: 'Calorie Trend sparkline' })).toBeInTheDocument();
     expect(within(proteinCard).getByRole('img', { name: 'Protein Trend sparkline' })).toBeInTheDocument();
+  });
+
+  it('shows the selected date weight value instead of the latest in-range value', () => {
+    vi.mocked(useWeightTrend).mockReturnValue({
+      data: [
+        { date: '2026-03-05', value: 174.8 },
+        { date: '2026-03-06', value: 175.2 },
+        { date: '2026-03-07', value: 176.1 },
+      ],
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useWeightTrend>);
+    vi.mocked(useMacroTrend).mockReturnValue({
+      data: sampleMacroTrend,
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useMacroTrend>);
+
+    render(<TrendSparklines endDate="2026-03-06" />);
+
+    const weightCard = screen
+      .getByText('Weight Trend')
+      .closest('[data-slot="trend-sparkline-card"]') as HTMLElement;
+
+    expect(within(weightCard).getByText('175.2 lbs')).toBeInTheDocument();
+    expect(within(weightCard).queryByText('176.1 lbs')).not.toBeInTheDocument();
   });
 
   it('renders a no-data chart state when all macro points in range are zero', () => {

--- a/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
@@ -95,19 +95,42 @@ describe('TrendSparkline', () => {
     expect(container.querySelector('.recharts-legend-wrapper')).not.toBeInTheDocument();
   });
 
-  it('renders empty state text when no trend data exists', () => {
+  it('renders empty state text when no real trend data exists', () => {
     render(
       <TrendSparkline
         changePercent={0}
         color="#3B82F6"
         currentValue="--"
-        data={[]}
+        data={[
+          { date: '2026-03-06', value: 0 },
+          { date: '2026-03-07', value: null },
+        ]}
         label="Weight Trend"
       />,
     );
 
-    expect(screen.getByText('No trend data yet.')).toBeInTheDocument();
+    expect(screen.getByText('No data')).toBeInTheDocument();
     expect(screen.queryByRole('img', { name: 'Weight Trend sparkline' })).not.toBeInTheDocument();
+  });
+
+  it('shows a single dot and hides the line when exactly one real point exists', () => {
+    const { container } = render(
+      <TrendSparkline
+        changePercent={0}
+        color="#3B82F6"
+        currentValue="175.2 lbs"
+        data={[
+          { date: '2026-03-05', value: 0 },
+          { date: '2026-03-06', value: 175.2 },
+          { date: '2026-03-07', value: 0 },
+        ]}
+        label="Weight Trend"
+      />,
+    );
+
+    expect(screen.getByRole('img', { name: 'Weight Trend sparkline' })).toBeInTheDocument();
+    expect(container.querySelector('.recharts-line-dots .recharts-dot')).toBeInTheDocument();
+    expect(container.querySelector('.recharts-line .recharts-curve')).not.toBeInTheDocument();
   });
 });
 
@@ -261,5 +284,85 @@ describe('TrendSparklines', () => {
 
     expect(screen.getByText('Unable to load trend data.')).toBeInTheDocument();
     expect(screen.queryByText('Weight Trend')).not.toBeInTheDocument();
+  });
+
+  it('shows no current macro value when selected date has no logged entries', () => {
+    vi.mocked(useWeightTrend).mockReturnValue({
+      data: sampleWeightTrend,
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useWeightTrend>);
+    vi.mocked(useMacroTrend).mockReturnValue({
+      data: [
+        {
+          date: '2026-03-06',
+          calories: 1900,
+          protein: 160,
+          carbs: 210,
+          fat: 70,
+        },
+        {
+          date: '2026-03-07',
+          calories: 0,
+          protein: 0,
+          carbs: 0,
+          fat: 0,
+        },
+      ],
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useMacroTrend>);
+
+    render(<TrendSparklines endDate="2026-03-07" />);
+
+    const calorieCard = screen
+      .getByText('Calorie Trend')
+      .closest('[data-slot="trend-sparkline-card"]') as HTMLElement;
+    const proteinCard = screen
+      .getByText('Protein Trend')
+      .closest('[data-slot="trend-sparkline-card"]') as HTMLElement;
+
+    expect(within(calorieCard).getByText('--')).toBeInTheDocument();
+    expect(within(proteinCard).getByText('--')).toBeInTheDocument();
+    expect(within(calorieCard).getByRole('img', { name: 'Calorie Trend sparkline' })).toBeInTheDocument();
+    expect(within(proteinCard).getByRole('img', { name: 'Protein Trend sparkline' })).toBeInTheDocument();
+  });
+
+  it('renders a no-data chart state when all macro points in range are zero', () => {
+    vi.mocked(useWeightTrend).mockReturnValue({
+      data: sampleWeightTrend,
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useWeightTrend>);
+    vi.mocked(useMacroTrend).mockReturnValue({
+      data: [
+        {
+          date: '2026-03-06',
+          calories: 0,
+          protein: 0,
+          carbs: 0,
+          fat: 0,
+        },
+        {
+          date: '2026-03-07',
+          calories: 0,
+          protein: 0,
+          carbs: 0,
+          fat: 0,
+        },
+      ],
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useMacroTrend>);
+
+    render(<TrendSparklines endDate="2026-03-07" metrics={['calories']} />);
+
+    const calorieCard = screen
+      .getByText('Calorie Trend')
+      .closest('[data-slot="trend-sparkline-card"]') as HTMLElement;
+
+    expect(within(calorieCard).getByText('--')).toBeInTheDocument();
+    expect(within(calorieCard).getByText('No data')).toBeInTheDocument();
+    expect(within(calorieCard).queryByRole('img', { name: 'Calorie Trend sparkline' })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/dashboard/components/trend-sparkline.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.tsx
@@ -19,14 +19,14 @@ type TrendMetricCardProps = {
   currentValue: string;
   changePercent: number;
   color: string;
-  data: TrendSparklineDatum[];
+  data: TrendSparklineRealDatum[];
   className?: string;
   textClassName?: string;
 };
 
 export type TrendSparklineDatum = {
   date: string;
-  value: number;
+  value: number | null;
 };
 
 export type TrendSparklineProps = {
@@ -53,9 +53,14 @@ const CHANGE_ICONS = {
   neutral: Minus,
 } satisfies Record<ChangeDirection, typeof ArrowUpRight>;
 
+type TrendSparklineRealDatum = {
+  date: string;
+  value: number;
+};
+
 const toMetricSeries = <TEntry extends { date: string }>(
   entries: TEntry[],
-  valueSelector: (entry: TEntry) => number,
+  valueSelector: (entry: TEntry) => number | null,
 ): TrendSparklineDatum[] => {
   return entries.map((entry) => ({
     date: entry.date,
@@ -63,11 +68,20 @@ const toMetricSeries = <TEntry extends { date: string }>(
   }));
 };
 
-const getLatestValue = (series: TrendSparklineDatum[], fallback: number): number => {
+const isTrendValuePresent = (value: number | null | undefined): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value > 0;
+
+const filterSeriesWithData = (series: TrendSparklineDatum[]): TrendSparklineRealDatum[] =>
+  series.filter((entry): entry is TrendSparklineRealDatum => isTrendValuePresent(entry.value));
+
+const getValueForDate = (series: TrendSparklineDatum[], date: string): number | null | undefined =>
+  series.find((entry) => entry.date === date)?.value;
+
+const getLatestValue = (series: TrendSparklineRealDatum[], fallback: number): number => {
   return series.at(-1)?.value ?? fallback;
 };
 
-const getPreviousValue = (series: TrendSparklineDatum[], fallback: number): number => {
+const getPreviousValue = (series: TrendSparklineRealDatum[], fallback: number): number => {
   return series.at(-2)?.value ?? fallback;
 };
 
@@ -109,11 +123,13 @@ export function TrendSparkline({
   changePercent,
   className,
   textClassName,
-  emptyMessage = 'No trend data yet.',
+  emptyMessage = 'No data',
 }: TrendSparklineProps) {
   const direction = getChangeDirection(changePercent);
   const ChangeIcon = CHANGE_ICONS[direction];
   const textClass = textClassName ?? 'text-on-accent';
+  const plottedData = filterSeriesWithData(data);
+  const hasSingleDataPoint = plottedData.length === 1;
 
   return (
     <div className={cn('flex h-full flex-col gap-4', className)} data-slot="trend-sparkline">
@@ -147,7 +163,7 @@ export function TrendSparkline({
         </div>
       </div>
 
-      {data.length === 0 ? (
+      {plottedData.length === 0 ? (
         <div className="flex h-[60px] items-center justify-center rounded-md bg-muted/35" data-slot="trend-sparkline-empty">
           <p className="text-sm text-muted">{emptyMessage}</p>
         </div>
@@ -159,15 +175,15 @@ export function TrendSparkline({
           role="img"
         >
           <ResponsiveContainer height="100%" width="100%">
-            <LineChart data={data} margin={{ top: 6, right: 0, bottom: 2, left: 0 }}>
+            <LineChart data={plottedData} margin={{ top: 6, right: 0, bottom: 2, left: 0 }}>
               <Line
                 dataKey="value"
-                dot={false}
+                dot={hasSingleDataPoint ? { fill: color, r: 4, stroke: color, strokeWidth: 0 } : false}
                 isAnimationActive={false}
                 stroke={color}
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                strokeWidth={3}
+                strokeWidth={hasSingleDataPoint ? 0 : 3}
                 type="monotone"
               />
             </LineChart>
@@ -262,19 +278,25 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
     );
   }
 
-  const weightSeries = needsWeight
+  const weightSeriesRaw = needsWeight
     ? toMetricSeries(weightTrendQuery.data ?? [], (entry) => entry.value)
     : [];
-  const calorieSeries = needsMacros
+  const calorieSeriesRaw = needsMacros
     ? toMetricSeries(macroTrendQuery.data ?? [], (entry) => entry.calories)
     : [];
-  const proteinSeries = needsMacros
+  const proteinSeriesRaw = needsMacros
     ? toMetricSeries(macroTrendQuery.data ?? [], (entry) => entry.protein)
     : [];
-
+  const calorieSeries = filterSeriesWithData(calorieSeriesRaw);
+  const proteinSeries = filterSeriesWithData(proteinSeriesRaw);
+  const weightSeries = filterSeriesWithData(weightSeriesRaw);
   const latestWeight = getLatestValue(weightSeries, 0);
   const latestCalories = getLatestValue(calorieSeries, 0);
   const latestProtein = getLatestValue(proteinSeries, 0);
+  const selectedCalorieValue = getValueForDate(calorieSeriesRaw, range.to);
+  const selectedProteinValue = getValueForDate(proteinSeriesRaw, range.to);
+  const hasSelectedCalorieValue = isTrendValuePresent(selectedCalorieValue);
+  const hasSelectedProteinValue = isTrendValuePresent(selectedProteinValue);
 
   const allConfigs = {
     weight: {
@@ -294,7 +316,7 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
     },
     calories: {
       label: 'Calorie Trend',
-      currentValue: calorieSeries.length > 0 ? `${latestCalories} kcal` : '--',
+      currentValue: hasSelectedCalorieValue ? `${selectedCalorieValue} kcal` : '--',
       changePercent:
         calorieSeries.length > 1
           ? calculateTrendChangePercent(
@@ -309,7 +331,7 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
     },
     protein: {
       label: 'Protein Trend',
-      currentValue: proteinSeries.length > 0 ? `${latestProtein} g` : '--',
+      currentValue: hasSelectedProteinValue ? `${selectedProteinValue} g` : '--',
       changePercent:
         proteinSeries.length > 1
           ? calculateTrendChangePercent(

--- a/apps/web/src/features/dashboard/components/trend-sparkline.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.tsx
@@ -11,6 +11,7 @@ import { calculateTrendChangePercent } from '@/features/dashboard/lib/trend-spar
 import { cn } from '@/lib/utils';
 
 const TREND_DAYS = 30;
+const numberFormatter = new Intl.NumberFormat('en-US');
 
 type ChangeDirection = 'up' | 'down' | 'neutral';
 
@@ -295,13 +296,15 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
   const latestProtein = getLatestValue(proteinSeries, 0);
   const selectedCalorieValue = getValueForDate(calorieSeriesRaw, range.to);
   const selectedProteinValue = getValueForDate(proteinSeriesRaw, range.to);
+  const selectedWeightValue = getValueForDate(weightSeriesRaw, range.to);
   const hasSelectedCalorieValue = isTrendValuePresent(selectedCalorieValue);
   const hasSelectedProteinValue = isTrendValuePresent(selectedProteinValue);
+  const hasSelectedWeightValue = isTrendValuePresent(selectedWeightValue);
 
   const allConfigs = {
     weight: {
       label: 'Weight Trend',
-      currentValue: weightSeries.length > 0 ? `${latestWeight.toFixed(1)} lbs` : '--',
+      currentValue: hasSelectedWeightValue ? `${selectedWeightValue.toFixed(1)} lbs` : '--',
       changePercent:
         weightSeries.length > 1
           ? calculateTrendChangePercent(
@@ -316,7 +319,9 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
     },
     calories: {
       label: 'Calorie Trend',
-      currentValue: hasSelectedCalorieValue ? `${selectedCalorieValue} kcal` : '--',
+      currentValue: hasSelectedCalorieValue
+        ? `${numberFormatter.format(selectedCalorieValue)} kcal`
+        : '--',
       changePercent:
         calorieSeries.length > 1
           ? calculateTrendChangePercent(
@@ -331,7 +336,9 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
     },
     protein: {
       label: 'Protein Trend',
-      currentValue: hasSelectedProteinValue ? `${selectedProteinValue} g` : '--',
+      currentValue: hasSelectedProteinValue
+        ? `${numberFormatter.format(selectedProteinValue)} g`
+        : '--',
       changePercent:
         proteinSeries.length > 1
           ? calculateTrendChangePercent(

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -367,6 +367,8 @@ describe('DashboardPage', () => {
 
     expect(screen.getByRole('heading', { name: 'Dashboard' })).toBeInTheDocument();
     expect(screen.getByText('Good morning')).toBeInTheDocument();
+    expect(screen.getByText('Friday, March 6, 2026')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Back to today' })).not.toBeInTheDocument();
     expect(screen.getByLabelText('Calendar day picker')).toBeInTheDocument();
     expect(screen.getByText('Habits')).toBeInTheDocument();
     expect(screen.getByLabelText('Macro display mode')).toBeInTheDocument();
@@ -573,6 +575,8 @@ describe('DashboardPage', () => {
     expect(within(refreshedBodyWeightCard).getByText('Log weight')).toBeInTheDocument();
     expect(within(refreshedHabitsCard).getByText('0/1')).toBeInTheDocument();
     expect(screen.getByText('Rest Day')).toBeInTheDocument();
+    expect(screen.getByText('Wednesday, March 4, 2026')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Back to today' })).toBeInTheDocument();
 
     const updatedSquares = container.querySelectorAll('[data-slot="habit-chain-day"]');
     expect(updatedSquares[29]).toHaveAttribute('data-date', '2026-03-04');
@@ -590,6 +594,14 @@ describe('DashboardPage', () => {
         return rawUrl.includes('/api/v1/dashboard/snapshot?date=2026-03-04');
       }),
     ).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to today' }));
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(screen.getByText('Friday, March 6, 2026')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Back to today' })).not.toBeInTheDocument();
   });
 
   it('logs a new weight entry and refreshes the body weight card', async () => {

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -377,7 +377,7 @@ describe('DashboardPage', () => {
     expect(screen.getByRole('heading', { name: 'Recent Workouts' })).toBeInTheDocument();
     expect(screen.getByText('Upper Push A (Completed)')).toBeInTheDocument();
     expect(screen.getByText('1,900 / 2,300')).toBeInTheDocument();
-    expect(screen.getByText('170g / 190g')).toBeInTheDocument();
+    expect(screen.getByText('170 g / 190 g')).toBeInTheDocument();
     expect(screen.getByText('1/1')).toBeInTheDocument();
     expect(screen.getByLabelText('Weight (lbs)')).toHaveAttribute('id', 'dashboard-weight-input');
     expect(screen.getByLabelText('Weight (lbs)')).toHaveAttribute('name', 'weight');

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -239,7 +239,9 @@ describe('DashboardPage', () => {
       if (url.pathname === '/api/v1/habit-entries' && init?.method === 'GET') {
         const from = url.searchParams.get('from') ?? '';
         const to = url.searchParams.get('to') ?? '';
-        const entriesInRange = habitEntries.filter((entry) => entry.date >= from && entry.date <= to);
+        const entriesInRange = habitEntries.filter(
+          (entry) => entry.date >= from && entry.date <= to,
+        );
 
         return Promise.resolve(
           new Response(JSON.stringify({ data: entriesInRange }), {
@@ -277,7 +279,10 @@ describe('DashboardPage', () => {
       }
 
       if (url.pathname === '/api/v1/weight' && init?.method === 'POST') {
-        const body = typeof init.body === 'string' ? (JSON.parse(init.body) as { date: string; weight: number }) : null;
+        const body =
+          typeof init.body === 'string'
+            ? (JSON.parse(init.body) as { date: string; weight: number })
+            : null;
         const nextDate = body?.date ?? snapshotForToday.date;
         const nextWeight = body?.weight ?? snapshotForToday.weight?.value ?? 0;
         const previousSnapshot = snapshotsByDate[nextDate] ?? snapshotForToday;
@@ -356,7 +361,9 @@ describe('DashboardPage', () => {
 
     const bodyWeightCard = screen.getByText('Body Weight').closest('[data-slot="stat-card"]');
     expect(bodyWeightCard).toBeInTheDocument();
-    expect(within(bodyWeightCard as HTMLElement).getByText(formatWeight(181.4))).toBeInTheDocument();
+    expect(
+      within(bodyWeightCard as HTMLElement).getByText(formatWeight(181.4)),
+    ).toBeInTheDocument();
 
     expect(screen.getByRole('heading', { name: 'Dashboard' })).toBeInTheDocument();
     expect(screen.getByText('Good morning')).toBeInTheDocument();
@@ -367,9 +374,9 @@ describe('DashboardPage', () => {
     expect(screen.getByLabelText('Trend sparklines')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Recent Workouts' })).toBeInTheDocument();
     expect(screen.getByText('Upper Push A (Completed)')).toBeInTheDocument();
-    expect(screen.getByText('1900 / 2300')).toBeInTheDocument();
+    expect(screen.getByText('1,900 / 2,300')).toBeInTheDocument();
     expect(screen.getByText('170g / 190g')).toBeInTheDocument();
-    expect(screen.getByText('1 / 1 complete')).toBeInTheDocument();
+    expect(screen.getByText('1/1')).toBeInTheDocument();
     expect(screen.getByLabelText('Weight (lbs)')).toHaveAttribute('id', 'dashboard-weight-input');
     expect(screen.getByLabelText('Weight (lbs)')).toHaveAttribute('name', 'weight');
     expect(screen.getByLabelText('Weight (lbs)')).toHaveAttribute(
@@ -543,8 +550,10 @@ describe('DashboardPage', () => {
 
     expect(bodyWeightCard).toBeInTheDocument();
     expect(habitsCard).toBeInTheDocument();
-    expect(within(bodyWeightCard as HTMLElement).getByText(formatWeight(181.4))).toBeInTheDocument();
-    expect(within(habitsCard as HTMLElement).getByText('1 / 1 complete')).toBeInTheDocument();
+    expect(
+      within(bodyWeightCard as HTMLElement).getByText(formatWeight(181.4)),
+    ).toBeInTheDocument();
+    expect(within(habitsCard as HTMLElement).getByText('1/1')).toBeInTheDocument();
 
     const initialSquares = container.querySelectorAll('[data-slot="habit-chain-day"]');
     expect(initialSquares[29]).toHaveAttribute('data-date', '2026-03-06');
@@ -561,8 +570,8 @@ describe('DashboardPage', () => {
       .getByText('Habits')
       .closest('[data-slot="stat-card"]') as HTMLElement;
 
-    expect(within(refreshedBodyWeightCard).getByText('--')).toBeInTheDocument();
-    expect(within(refreshedHabitsCard).getByText('0 / 1 complete')).toBeInTheDocument();
+    expect(within(refreshedBodyWeightCard).getByText('Log weight')).toBeInTheDocument();
+    expect(within(refreshedHabitsCard).getByText('0/1')).toBeInTheDocument();
     expect(screen.getByText('Rest Day')).toBeInTheDocument();
 
     const updatedSquares = container.querySelectorAll('[data-slot="habit-chain-day"]');

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -427,7 +427,12 @@ describe('DashboardPage', () => {
     expect(mainColumn).toHaveClass('order-1', 'md:order-1', 'xl:order-2');
     expect(sidebarColumn).toHaveClass('order-2', 'md:order-2', 'xl:order-1');
     expect(logWeightForm).toBeInTheDocument();
-    expect(recentColumn).toHaveClass('order-3', 'md:col-start-2', 'xl:col-start-3');
+    expect(recentColumn).toHaveClass(
+      'order-3',
+      'md:col-span-2',
+      'xl:col-span-1',
+      'xl:col-start-3',
+    );
     expect(calendarPanel).toHaveClass('order-1', 'md:order-3');
     expect(snapshotPanel).toHaveClass('order-2', 'md:order-1');
     expect(macroPanel).toHaveClass('order-3', 'md:order-2');

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -25,7 +25,14 @@ import {
 } from '@/hooks/use-dashboard-snapshot';
 import { useDashboardConfig } from '@/hooks/use-dashboard-config';
 import { useHabitChains } from '@/hooks/use-habit-chains';
-import { addDays, getToday, toDateKey } from '@/lib/date';
+import { addDays, getToday, isSameDay, toDateKey } from '@/lib/date';
+
+const dashboardDateFormatter = new Intl.DateTimeFormat('en-US', {
+  weekday: 'long',
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+});
 
 export function DashboardPage() {
   const queryClient = useQueryClient();
@@ -35,6 +42,8 @@ export function DashboardPage() {
   const logWeightMutation = useLogWeight();
   const selectedDateKey = toDateKey(selectedDate);
   const habitRangeStart = toDateKey(addDays(selectedDate, -29));
+  const selectedDateLabel = dashboardDateFormatter.format(selectedDate);
+  const isViewingToday = isSameDay(selectedDate, getToday());
   const greeting = getDashboardGreeting();
 
   const snapshotQuery = useDashboardSnapshot(selectedDateKey);
@@ -86,13 +95,21 @@ export function DashboardPage() {
 
   return (
     <main className="flex w-full flex-col gap-8 py-6">
-      <header className="animate-fade-in space-y-1">
+      <header className="animate-fade-in space-y-2">
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted sm:text-sm">
           {greeting}
         </p>
-        <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl lg:text-5xl">
-          Dashboard
-        </h1>
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl lg:text-5xl">
+            Dashboard
+          </h1>
+          {!isViewingToday ? (
+            <Button onClick={() => setSelectedDate(getToday())} size="sm" type="button" variant="outline">
+              Back to today
+            </Button>
+          ) : null}
+        </div>
+        <p className="text-sm text-muted-foreground sm:text-base">{selectedDateLabel}</p>
       </header>
 
       {shouldShowEmptyState ? (

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -223,7 +223,7 @@ export function DashboardPage() {
           </div>
 
           <div
-            className="order-3 min-w-0 md:col-start-2 xl:col-start-3"
+            className="order-3 min-w-0 md:col-span-2 xl:col-span-1 xl:col-start-3"
             data-slot="dashboard-recent-workouts-column"
           >
             <RecentWorkouts />


### PR DESCRIPTION
## Summary
This PR tightens several dashboard UI behaviors that were causing confusing states and mobile layout regressions. Snapshot cards now handle unconfigured data more explicitly (for example, missing macro targets or habits) and avoid text clipping at narrow widths. Calendar selection logic was adjusted so the selected day is always the only fully highlighted day, and the dashboard header now shows the exact viewing date with a quick “Back to today” action. Trend sparklines now ignore zero/null entries so charts reflect real logged data, with clearer no-data handling and selected-day value display. Recent Workouts was also restructured into a card container with a cleaner empty state CTA and improved placement in mid-sized layouts.

## Key Changes
- Updated `StatCard` to support richer value content (`ReactNode`), configurable value title/class, and `min-w-0` safeguards on header/content/value to prevent overflow.
- Reworked snapshot cards to:
  - show dashed “not configured” styling for missing targets/data,
  - render contextual CTAs like “No targets set Settings,”
  - format macro values with thousands separators,
  - shorten habits display to `x/y`,
  - use adaptive value font sizes to prevent truncation.
- Changed calendar picker styling so `isSelected` drives accent background/dot state, while non-selected “today” no longer gets persistent highlight.
- Added selected-date context to dashboard header (`Friday, March 6, 2026`-style label) plus conditional `Back to today` button.
- Filtered sparkline data to positive finite points only, introduced explicit “No data” empty state, and single-point rendering (dot-only, no connecting line).
- Updated macro sparkline “current value” logic to use the selected date’s value (or `--` if none), while trend deltas still use latest valid points in range.
- Wrapped Recent Workouts in `Card`/`CardHeader`/`CardContent`, removed redundant helper text, added empty-state `Start a workout` CTA, and adjusted dashboard grid spans for better responsive behavior.

## Technical Notes
- A key API-level UI change is `StatCardProps.value` moving from `number | string` to `ReactNode`, enabling inline links/CTAs directly inside card values.
- Sparkline filtering treats `0` as “not logged” for dashboard trend visualization; this intentionally favors continuity of real entries over plotting placeholder zeros.
- For macro trends, there is a deliberate split:
  - displayed “current value” is tied to the selected dashboard date,
  - percent-change calculation is based on the most recent valid data points in the fetched window.
- Test coverage was expanded across all touched dashboard components to lock in selection behavior, empty states, overflow protection, and chart edge cases.

## Commits

- `d9fee82 fix(web): wrap recent workouts in dashboard card layout`
- `160dead fix(web): filter zero-value dashboard trend sparkline points`
- `4acbfe3 fix(web): polish dashboard calendar selection and header date`
- `7862ddd fix(web): improve dashboard snapshot empty states and mobile overflow`

## Tasks

- **Fix snapshot cards — empty state + overflow**: Show 'No targets set' CTA when macro targets are 0, fix text overflow/truncation at 375px, add min-w-0 on grid children
- **Fix calendar picker — selected vs today styling**: Selected date gets full highlight, today gets no special styling when not selected, show viewing date in dashboard header
- **Fix trend sparklines — filter zero-value days**: Filter out zero/null data points from sparklines, connect real data points only, show '--' instead of '0' when no data
- **Fix recent workouts — wrap in Card, fix layout**: Wrap Recent Workouts in a Card component, fix positioning at medium viewports, add CTA for empty state

## Diff Stats

```
apps/web/src/components/ui/stat-card.test.tsx      |   7 +-
 apps/web/src/components/ui/stat-card.tsx           |  25 +++--
 .../dashboard/components/calendar-picker.test.tsx  |  16 ++-
 .../dashboard/components/calendar-picker.tsx       |   8 +-
 .../dashboard/components/recent-workouts.test.tsx  |   4 +-
 .../dashboard/components/recent-workouts.tsx       | 116 ++++++++++----------
 .../dashboard/components/snapshot-cards.test.tsx   |  74 ++++++++++++-
 .../dashboard/components/snapshot-cards.tsx        | 120 ++++++++++++++++++---
 .../dashboard/components/trend-sparkline.test.tsx  | 109 ++++++++++++++++++-
 .../dashboard/components/trend-sparkline.tsx       |  54 +++++++---
 apps/web/src/pages/dashboard.test.tsx              |  46 ++++++--
 apps/web/src/pages/dashboard.tsx                   |  29 +++--
 12 files changed, 475 insertions(+), 133 deletions(-)
```