### PR TITLE
Workouts page fixes — mock data, navigation, onboarding

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -65,6 +65,61 @@ const workoutTemplatePayload = {
   },
 };
 
+const completedSessionsPayload = {
+  data: [
+    {
+      id: sessionId,
+      name: 'Upper Push',
+      date: '2026-03-02',
+      status: 'completed',
+      templateId: 'upper-push',
+      templateName: 'Upper Push',
+      startedAt: Date.parse('2026-03-02T18:00:00Z'),
+      completedAt: Date.parse('2026-03-02T19:00:00Z'),
+      duration: 60,
+      exerciseCount: 3,
+      createdAt: 1,
+    },
+  ],
+};
+
+const workoutSessionPayload = {
+  data: {
+    id: sessionId,
+    userId: 'user-1',
+    templateId: 'upper-push',
+    name: 'Upper Push',
+    date: '2026-03-02',
+    status: 'completed',
+    startedAt: Date.parse('2026-03-02T18:00:00Z'),
+    completedAt: Date.parse('2026-03-02T19:00:00Z'),
+    duration: 60,
+    feedback: {
+      energy: 4,
+      recovery: 4,
+      technique: 4,
+      notes: 'Solid session',
+    },
+    notes: 'Felt good.',
+    sets: [
+      {
+        id: 'set-1',
+        exerciseId: 'incline-dumbbell-press',
+        setNumber: 1,
+        weight: 50,
+        reps: 10,
+        completed: true,
+        skipped: false,
+        section: 'main',
+        notes: null,
+        createdAt: 1,
+      },
+    ],
+    createdAt: 1,
+    updatedAt: 1,
+  },
+};
+
 function renderApp() {
   const queryClient = createAppQueryClient();
   queryClient.clear();
@@ -120,6 +175,22 @@ describe('App', () => {
 
       if (url.pathname === '/api/v1/workout-templates/upper-push') {
         return Promise.resolve(jsonResponse(workoutTemplatePayload));
+      }
+
+      if (url.pathname === '/api/v1/workout-templates') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [workoutTemplatePayload.data],
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions' && url.searchParams.get('status') === 'completed') {
+        return Promise.resolve(jsonResponse(completedSessionsPayload));
+      }
+
+      if (url.pathname.startsWith('/api/v1/workout-sessions/')) {
+        return Promise.resolve(jsonResponse(workoutSessionPayload));
       }
 
       if (url.pathname === '/api/v1/exercises') {

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -7,7 +7,9 @@ import {
   type ExerciseQueryParams,
   type WorkoutSession,
   type WorkoutSessionListItem,
+  type WorkoutSessionQueryParams,
   type WorkoutTemplate,
+  workoutSessionQueryParamsSchema,
   workoutSessionListItemSchema,
   workoutSessionSchema,
   workoutTemplateSchema,
@@ -72,6 +74,7 @@ export const workoutQueryKeys = {
   exerciseFilters: () => ['workouts', 'exercise-filters'] as const,
   session: (id: string) => ['workouts', 'session', id] as const,
   sessions: () => ['workouts', 'sessions'] as const,
+  sessionsList: (params: WorkoutSessionQueryParams = {}) => ['workouts', 'sessions', params] as const,
   template: (id: string) => ['workouts', 'template', id] as const,
   templates: () => ['workouts', 'templates'] as const,
 };
@@ -92,6 +95,35 @@ async function getCompletedSessions(signal?: AbortSignal) {
     '/api/v1/workout-sessions?status=completed',
     { method: 'GET', signal },
   );
+  const payload = completedSessionsResponseSchema.parse({ data });
+
+  return payload.data;
+}
+
+async function getWorkoutSessions(params: WorkoutSessionQueryParams = {}, signal?: AbortSignal) {
+  const parsedParams = workoutSessionQueryParamsSchema.parse(params);
+  const searchParams = new URLSearchParams();
+
+  if (parsedParams.from) {
+    searchParams.set('from', parsedParams.from);
+  }
+
+  if (parsedParams.to) {
+    searchParams.set('to', parsedParams.to);
+  }
+
+  if (parsedParams.status) {
+    searchParams.set('status', parsedParams.status);
+  }
+
+  if (parsedParams.limit) {
+    searchParams.set('limit', String(parsedParams.limit));
+  }
+
+  const url = searchParams.size
+    ? `/api/v1/workout-sessions?${searchParams.toString()}`
+    : '/api/v1/workout-sessions';
+  const data = await apiRequest<unknown>(url, { method: 'GET', signal });
   const payload = completedSessionsResponseSchema.parse({ data });
 
   return payload.data;
@@ -174,6 +206,17 @@ export function useCompletedSessions() {
   return useQuery<WorkoutSessionListItem[]>({
     queryFn: ({ signal }) => getCompletedSessions(signal),
     queryKey: workoutQueryKeys.completedSessions(),
+  });
+}
+
+export function useWorkoutSessions(
+  params: WorkoutSessionQueryParams = {},
+  options?: { enabled?: boolean },
+) {
+  return useQuery<WorkoutSessionListItem[]>({
+    enabled: options?.enabled,
+    queryFn: ({ signal }) => getWorkoutSessions(params, signal),
+    queryKey: workoutQueryKeys.sessionsList(params),
   });
 }
 

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -6,7 +6,9 @@ import {
   type Exercise,
   type ExerciseQueryParams,
   type WorkoutSession,
+  type WorkoutSessionListItem,
   type WorkoutTemplate,
+  workoutSessionListItemSchema,
   workoutSessionSchema,
   workoutTemplateSchema,
 } from '@pulse/shared';
@@ -65,8 +67,10 @@ type CreateWorkoutSessionRequest = z.input<typeof createWorkoutSessionInputSchem
 
 export const workoutQueryKeys = {
   all: ['workouts'] as const,
+  completedSessions: () => ['workouts', 'completed-sessions'] as const,
   exercises: (params: ExerciseQueryParams) => ['workouts', 'exercises', params] as const,
   exerciseFilters: () => ['workouts', 'exercise-filters'] as const,
+  session: (id: string) => ['workouts', 'session', id] as const,
   sessions: () => ['workouts', 'sessions'] as const,
   template: (id: string) => ['workouts', 'template', id] as const,
   templates: () => ['workouts', 'templates'] as const,
@@ -79,12 +83,36 @@ async function getWorkoutTemplates() {
   return payload.data;
 }
 
+const completedSessionsResponseSchema = z.object({
+  data: z.array(workoutSessionListItemSchema),
+}) as unknown as z.ZodType<{ data: WorkoutSessionListItem[] }>;
+
+async function getCompletedSessions(signal?: AbortSignal) {
+  const data = await apiRequest<unknown>(
+    '/api/v1/workout-sessions?status=completed',
+    { method: 'GET', signal },
+  );
+  const payload = completedSessionsResponseSchema.parse({ data });
+
+  return payload.data;
+}
+
 async function getWorkoutTemplate(id: string, signal?: AbortSignal) {
   const data = await apiRequest<unknown>(`/api/v1/workout-templates/${id}`, {
     method: 'GET',
     signal,
   });
   const payload = workoutTemplateResponseSchema.parse({ data });
+
+  return payload.data;
+}
+
+async function getWorkoutSession(id: string, signal?: AbortSignal) {
+  const data = await apiRequest<unknown>(`/api/v1/workout-sessions/${id}`, {
+    method: 'GET',
+    signal,
+  });
+  const payload = workoutSessionResponseSchema.parse({ data });
 
   return payload.data;
 }
@@ -142,11 +170,26 @@ export function useWorkoutTemplates() {
   });
 }
 
+export function useCompletedSessions() {
+  return useQuery<WorkoutSessionListItem[]>({
+    queryFn: ({ signal }) => getCompletedSessions(signal),
+    queryKey: workoutQueryKeys.completedSessions(),
+  });
+}
+
 export function useWorkoutTemplate(id: string) {
   return useQuery<WorkoutTemplate>({
     enabled: id.trim().length > 0,
     queryFn: ({ signal }) => getWorkoutTemplate(id, signal),
     queryKey: workoutQueryKeys.template(id),
+  });
+}
+
+export function useWorkoutSession(id: string, options?: { enabled?: boolean }) {
+  return useQuery<WorkoutSession>({
+    enabled: (options?.enabled ?? true) && id.trim().length > 0,
+    queryFn: ({ signal }) => getWorkoutSession(id, signal),
+    queryKey: workoutQueryKeys.session(id),
   });
 }
 

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -86,7 +86,7 @@ async function getWorkoutTemplates() {
   return payload.data;
 }
 
-const completedSessionsResponseSchema = z.object({
+const sessionListResponseSchema = z.object({
   data: z.array(workoutSessionListItemSchema),
 }) as unknown as z.ZodType<{ data: WorkoutSessionListItem[] }>;
 
@@ -95,7 +95,7 @@ async function getCompletedSessions(signal?: AbortSignal) {
     '/api/v1/workout-sessions?status=completed',
     { method: 'GET', signal },
   );
-  const payload = completedSessionsResponseSchema.parse({ data });
+  const payload = sessionListResponseSchema.parse({ data });
 
   return payload.data;
 }
@@ -124,7 +124,7 @@ async function getWorkoutSessions(params: WorkoutSessionQueryParams = {}, signal
     ? `/api/v1/workout-sessions?${searchParams.toString()}`
     : '/api/v1/workout-sessions';
   const data = await apiRequest<unknown>(url, { method: 'GET', signal });
-  const payload = completedSessionsResponseSchema.parse({ data });
+  const payload = sessionListResponseSchema.parse({ data });
 
   return payload.data;
 }

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -264,6 +264,7 @@ export function useStartWorkoutSession() {
   return useMutation<WorkoutSession, Error, CreateWorkoutSessionRequest>({
     mutationFn: createWorkoutSession,
     onSuccess: async () => {
+      // Intentional prefix invalidation: refreshes both `sessions()` and all `sessionsList(params)` caches.
       await queryClient.invalidateQueries({
         queryKey: workoutQueryKeys.sessions(),
       });

--- a/apps/web/src/features/workouts/components/session-comparison.test.tsx
+++ b/apps/web/src/features/workouts/components/session-comparison.test.tsx
@@ -1,31 +1,45 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-
-import type { ActiveWorkoutCompletedSession } from '../types';
+import type { WorkoutSession } from '@pulse/shared';
 
 import { SessionExerciseComparison } from './session-comparison';
 
-function createSession(
-  overrides: Partial<ActiveWorkoutCompletedSession>,
-): ActiveWorkoutCompletedSession {
+function createSession(overrides: Partial<WorkoutSession>): WorkoutSession {
   return {
-    customFeedback: [],
-    duration: 48,
-    exercises: [],
-    feedback: {
-      energy: 4,
-      notes: '',
-      recovery: 4,
-      technique: 4,
-    },
     id: 'session-id',
-    name: 'Session',
-    notes: '',
-    startedAt: '2026-03-01T18:00:00Z',
-    status: 'completed',
-    supplemental: [],
+    userId: 'user-1',
     templateId: 'template-1',
+    name: 'Session',
+    date: '2026-03-01',
+    status: 'completed',
+    startedAt: Date.parse('2026-03-01T18:00:00Z'),
+    completedAt: Date.parse('2026-03-01T19:00:00Z'),
+    duration: 60,
+    feedback: {
+      energy: 4 as const,
+      recovery: 4 as const,
+      technique: 4 as const,
+    },
+    notes: null,
+    sets: [],
+    createdAt: 1,
+    updatedAt: 1,
     ...overrides,
+  };
+}
+
+function createSet(exerciseId: string, setNumber: number, reps: number, weight: number | null = null) {
+  return {
+    id: `set-${exerciseId}-${setNumber}`,
+    exerciseId,
+    setNumber,
+    weight,
+    reps,
+    completed: true,
+    skipped: false,
+    section: 'main' as const,
+    notes: null,
+    createdAt: 1,
   };
 }
 
@@ -33,26 +47,18 @@ describe('SessionExerciseComparison', () => {
   it('matches comparison rows by set number and supports reps-only PRs', () => {
     const previousSession = createSession({
       id: 'previous-session',
-      startedAt: '2026-02-20T18:00:00Z',
-      exercises: [
-        {
-          exerciseId: 'bodyweight-row',
-          sets: [
-            { completed: true, reps: 7, setNumber: 1, timestamp: '2026-02-20T18:05:00Z' },
-            { completed: true, reps: 8, setNumber: 3, timestamp: '2026-02-20T18:10:00Z' },
-          ],
-        },
+      startedAt: Date.parse('2026-02-20T18:00:00Z'),
+      completedAt: Date.parse('2026-02-20T19:00:00Z'),
+      sets: [
+        createSet('bodyweight-row', 1, 7),
+        createSet('bodyweight-row', 3, 8),
       ],
     });
     const currentSession = createSession({
       id: 'current-session',
-      startedAt: '2026-03-01T18:00:00Z',
-      exercises: [
-        {
-          exerciseId: 'bodyweight-row',
-          sets: [{ completed: true, reps: 10, setNumber: 3, timestamp: '2026-03-01T18:12:00Z' }],
-        },
-      ],
+      startedAt: Date.parse('2026-03-01T18:00:00Z'),
+      completedAt: Date.parse('2026-03-01T19:00:00Z'),
+      sets: [createSet('bodyweight-row', 3, 10)],
     });
 
     render(

--- a/apps/web/src/features/workouts/components/session-comparison.tsx
+++ b/apps/web/src/features/workouts/components/session-comparison.tsx
@@ -1,20 +1,19 @@
 import { ArrowDownRight, ArrowUpRight, Minus } from 'lucide-react';
+import type { SessionSet, WorkoutSession } from '@pulse/shared';
 
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 
-import type { ActiveWorkoutCompletedSession } from '../types';
-
 type SessionComparisonProps = {
-  currentSession: ActiveWorkoutCompletedSession;
-  previousSession: ActiveWorkoutCompletedSession | null;
+  currentSession: WorkoutSession;
+  previousSession: WorkoutSession | null;
 };
 
 type SessionExerciseComparisonProps = {
-  currentSession: ActiveWorkoutCompletedSession;
+  currentSession: WorkoutSession;
   exerciseId: string;
-  previousSession: ActiveWorkoutCompletedSession | null;
+  previousSession: WorkoutSession | null;
 };
 
 type ComparisonDirection = 'down' | 'flat' | 'up';
@@ -25,7 +24,7 @@ type DeltaIndicatorProps = {
 };
 
 type SetComparison = {
-  currentReps: number;
+  currentReps: number | null;
   currentWeight: number | null;
   hasPr: boolean;
   repsDelta: number;
@@ -187,52 +186,56 @@ function DeltaIndicator({ direction, label }: DeltaIndicatorProps) {
   );
 }
 
+function getSetsForExercise(session: WorkoutSession, exerciseId: string): SessionSet[] {
+  return session.sets
+    .filter((set) => set.exerciseId === exerciseId)
+    .sort((left, right) => left.setNumber - right.setNumber);
+}
+
 function getExerciseComparison(
-  currentSession: ActiveWorkoutCompletedSession,
-  previousSession: ActiveWorkoutCompletedSession | null,
+  currentSession: WorkoutSession,
+  previousSession: WorkoutSession | null,
   exerciseId: string,
 ) {
   if (!previousSession) {
     return null;
   }
 
-  const currentExercise = currentSession.exercises.find((exercise) => exercise.exerciseId === exerciseId);
-  const previousExercise = previousSession.exercises.find(
-    (exercise) => exercise.exerciseId === exerciseId,
-  );
+  const currentSets = getSetsForExercise(currentSession, exerciseId);
+  const previousSets = getSetsForExercise(previousSession, exerciseId);
 
-  if (!currentExercise || !previousExercise) {
+  if (currentSets.length === 0 || previousSets.length === 0) {
     return null;
   }
 
   return {
     previousSessionDate: dateFormatter.format(new Date(previousSession.startedAt)),
-    setComparisons: currentExercise.sets.map((set) => {
+    setComparisons: currentSets.map((set) => {
       const previousSet =
-        previousExercise.sets.find((candidate) => candidate.setNumber === set.setNumber) ?? null;
+        previousSets.find((candidate) => candidate.setNumber === set.setNumber) ?? null;
 
       return {
         currentReps: set.reps,
         currentWeight: set.weight ?? null,
         hasPr: isPersonalRecord(
           set.weight ?? null,
-          set.reps,
+          set.reps ?? 0,
           previousSet
             ? [
                 {
-                  reps: previousSet.reps,
+                  reps: previousSet.reps ?? 0,
                   weight: previousSet.weight ?? null,
                 },
               ]
             : [],
         ),
-        repsDelta: previousSet ? set.reps - previousSet.reps : 0,
+        repsDelta: previousSet ? (set.reps ?? 0) - (previousSet.reps ?? 0) : 0,
         setNumber: set.setNumber,
         weightDelta:
           set.weight != null && previousSet?.weight != null ? set.weight - previousSet.weight : null,
       };
     }),
-    volumeDelta: getExerciseVolume(currentExercise) - getExerciseVolume(previousExercise),
+    volumeDelta: getExerciseVolumeFromSets(currentSets) - getExerciseVolumeFromSets(previousSets),
   } satisfies ExerciseComparison;
 }
 
@@ -267,14 +270,18 @@ function isPersonalRecord(
   return currentReps > maxPreviousReps;
 }
 
-function getSessionVolume(session: ActiveWorkoutCompletedSession) {
-  return session.exercises.reduce((total, exercise) => total + getExerciseVolume(exercise), 0);
+function getSessionVolume(session: WorkoutSession) {
+  return session.sets.reduce(
+    (total, set) => total + (set.weight != null && set.reps != null ? set.weight * set.reps : 0),
+    0,
+  );
 }
 
-function getExerciseVolume(
-  exercise: ActiveWorkoutCompletedSession['exercises'][number],
-) {
-  return exercise.sets.reduce((total, set) => total + (set.weight != null ? set.weight * set.reps : 0), 0);
+function getExerciseVolumeFromSets(sets: SessionSet[]) {
+  return sets.reduce(
+    (total, set) => total + (set.weight != null && set.reps != null ? set.weight * set.reps : 0),
+    0,
+  );
 }
 
 function getDirection(value: number): ComparisonDirection {

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -53,7 +53,7 @@ describe('SessionDetail', () => {
     expect(await screen.findByText('Session not found', {}, { timeout: 5_000 })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /back to workouts/i })).toHaveAttribute(
       'href',
-      '/workouts',
+      '/workouts?view=calendar',
     );
   });
 

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -1,8 +1,12 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
+import type { WorkoutSession, WorkoutSessionListItem } from '@pulse/shared';
 import { MemoryRouter } from 'react-router';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { workoutCompletedSessions } from '..';
+import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
+import { renderWithQueryClient } from '@/test/render-with-query-client';
+import { jsonResponse } from '@/test/test-utils';
+
 import { SessionDetail } from './session-detail';
 
 vi.mock('recharts', async () => {
@@ -27,31 +31,87 @@ vi.mock('recharts', async () => {
   };
 });
 
-describe('SessionDetail', () => {
-  it('renders a not-found state for unknown sessions', () => {
-    render(
-      <MemoryRouter>
-        <SessionDetail sessionId="missing-session" />
-      </MemoryRouter>,
-    );
+beforeEach(() => {
+  window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
+});
 
-    expect(screen.getByText('Session not found')).toBeInTheDocument();
+afterEach(() => {
+  window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
+  vi.restoreAllMocks();
+});
+
+describe('SessionDetail', () => {
+  it('renders a not-found state for unknown sessions', async () => {
+    mockSessionDetailRequests({
+      sessionId: 'missing-session',
+      sessionStatus: 404,
+      sessions: [],
+    });
+
+    renderSessionDetail('missing-session');
+
+    expect(await screen.findByText('Session not found', {}, { timeout: 5_000 })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /back to workouts/i })).toHaveAttribute(
       'href',
       '/workouts',
     );
   });
 
-  it('renders completed session receipt data from the workout feature mocks', () => {
-    const session = workoutCompletedSessions[0];
+  it('renders completed session receipt data from the workout session API', async () => {
+    const currentSession = createSession({
+      id: 'session-current',
+      templateId: 'template-upper-push',
+      notes: 'Felt strong and stable today.',
+      feedback: {
+        energy: 4,
+        recovery: 4,
+        technique: 5,
+        notes: 'Great pacing and clean reps.',
+      },
+      sets: [
+        createSet({
+          id: 'set-row-1',
+          exerciseId: 'row-erg',
+          setNumber: 1,
+          reps: 240,
+          weight: null,
+          section: 'warmup',
+        }),
+        createSet({
+          id: 'set-press-1',
+          exerciseId: 'incline-dumbbell-press',
+          setNumber: 1,
+          reps: 10,
+          weight: 50,
+          section: 'main',
+        }),
+        createSet({
+          id: 'set-press-2',
+          exerciseId: 'incline-dumbbell-press',
+          setNumber: 2,
+          reps: 9,
+          weight: 45,
+          section: 'main',
+        }),
+      ],
+    });
 
-    render(
-      <MemoryRouter>
-        <SessionDetail sessionId={session.id} />
-      </MemoryRouter>,
-    );
+    mockSessionDetailRequests({
+      sessionId: currentSession.id,
+      session: currentSession,
+      sessions: [
+        createSessionListItem({
+          id: currentSession.id,
+          templateId: currentSession.templateId,
+          templateName: 'Upper Push',
+          startedAt: currentSession.startedAt,
+        }),
+      ],
+    });
 
-    expect(screen.getByText('Workout receipt')).toBeInTheDocument();
+    renderSessionDetail(currentSession.id);
+
+    expect(await screen.findByText('Workout receipt')).toBeInTheDocument();
     expect(screen.getByText('Completed')).toBeInTheDocument();
     expect(screen.getByText('Section breakdown')).toBeInTheDocument();
     expect(screen.getByText('Feedback')).toBeInTheDocument();
@@ -59,55 +119,139 @@ describe('SessionDetail', () => {
     expect(screen.getByLabelText(/show comparison/i)).toBeInTheDocument();
     expect(screen.queryByText('Volume progression')).not.toBeInTheDocument();
     expect(screen.getAllByText(/Set 1:/i).length).toBeGreaterThan(0);
-    expect(screen.getByText('Shoulder feel')).toBeInTheDocument();
-    expect(screen.getByText(session.notes)).toBeInTheDocument();
+    expect(screen.getByText('Great pacing and clean reps.')).toBeInTheDocument();
+    expect(screen.getByText('Felt strong and stable today.')).toBeInTheDocument();
   });
 
-  it('shows volume progression, deltas, and PR badges when comparison is enabled', () => {
-    const session = workoutCompletedSessions[0];
+  it('shows volume progression, deltas, and PR badges when comparison is enabled', async () => {
+    const previousSession = createSession({
+      id: 'session-previous',
+      startedAt: Date.parse('2026-02-20T18:00:00Z'),
+      completedAt: Date.parse('2026-02-20T19:00:00Z'),
+      date: '2026-02-20',
+      templateId: 'template-upper-push',
+      sets: [
+        createSet({
+          id: 'set-prev-press-1',
+          exerciseId: 'incline-dumbbell-press',
+          setNumber: 1,
+          reps: 9,
+          weight: 45,
+          section: 'main',
+        }),
+      ],
+    });
+    const currentSession = createSession({
+      id: 'session-current',
+      startedAt: Date.parse('2026-03-02T18:00:00Z'),
+      completedAt: Date.parse('2026-03-02T19:00:00Z'),
+      date: '2026-03-02',
+      templateId: 'template-upper-push',
+      sets: [
+        createSet({
+          id: 'set-current-press-1',
+          exerciseId: 'incline-dumbbell-press',
+          setNumber: 1,
+          reps: 10,
+          weight: 50,
+          section: 'main',
+        }),
+      ],
+    });
 
-    render(
-      <MemoryRouter>
-        <SessionDetail sessionId={session.id} />
-      </MemoryRouter>,
-    );
+    mockSessionDetailRequests({
+      sessionId: currentSession.id,
+      session: currentSession,
+      previousSession,
+      sessions: [
+        createSessionListItem({
+          id: currentSession.id,
+          templateId: currentSession.templateId,
+          templateName: 'Upper Push',
+          startedAt: currentSession.startedAt,
+          date: currentSession.date,
+        }),
+        createSessionListItem({
+          id: previousSession.id,
+          templateId: previousSession.templateId,
+          templateName: 'Upper Push',
+          startedAt: previousSession.startedAt,
+          date: previousSession.date,
+        }),
+      ],
+    });
+
+    renderSessionDetail(currentSession.id);
+    await screen.findByText('Workout receipt');
 
     fireEvent.click(screen.getByLabelText(/show comparison/i));
 
-    expect(screen.getByText('Volume progression')).toBeInTheDocument();
-    expect(screen.getAllByText(/vs feb 20/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Weight +5 kg').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Reps +1').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('PR').length).toBeGreaterThan(0);
-    expect(screen.queryByText('Weight -')).not.toBeInTheDocument();
+    expect(await screen.findByText('Volume progression')).toBeInTheDocument();
+    expect(screen.getByText('Volume vs Feb 20')).toBeInTheDocument();
+    expect(screen.getByText('Weight +5 kg')).toBeInTheDocument();
+    expect(screen.getByText('Reps +1')).toBeInTheDocument();
+    expect(screen.getByText('PR')).toBeInTheDocument();
   });
 
-  it('shows the first-session fallback when there is no previous session for the template', () => {
-    const session = workoutCompletedSessions.find((candidate) => candidate.templateId === 'full-body');
+  it('shows the first-session fallback when there is no previous session for the template', async () => {
+    const currentSession = createSession({
+      id: 'session-current',
+      templateId: 'template-full-body',
+    });
 
-    if (!session) {
-      throw new Error('Expected a full-body session in workoutCompletedSessions');
-    }
+    mockSessionDetailRequests({
+      sessionId: currentSession.id,
+      session: currentSession,
+      sessions: [
+        createSessionListItem({
+          id: currentSession.id,
+          templateId: currentSession.templateId,
+          templateName: 'Full Body',
+          startedAt: currentSession.startedAt,
+        }),
+      ],
+      templateName: 'Full Body',
+    });
 
-    render(
-      <MemoryRouter>
-        <SessionDetail sessionId={session.id} />
-      </MemoryRouter>,
-    );
+    renderSessionDetail(currentSession.id);
+    await screen.findByText('Workout receipt');
 
     fireEvent.click(screen.getByLabelText(/show comparison/i));
 
-    expect(screen.getByText('First session — no comparison available')).toBeInTheDocument();
+    expect(await screen.findByText('First session — no comparison available')).toBeInTheDocument();
   });
 
-  it('opens an exercise trend chart from the session detail exercise action', () => {
-    const session = workoutCompletedSessions[0];
+  it('opens an exercise trend chart from the session detail exercise action', async () => {
+    const currentSession = createSession({
+      id: 'session-current',
+      templateId: 'template-upper-push',
+      sets: [
+        createSet({
+          id: 'set-current-press-1',
+          exerciseId: 'incline-dumbbell-press',
+          setNumber: 1,
+          reps: 10,
+          weight: 50,
+          section: 'main',
+        }),
+      ],
+    });
 
-    render(
-      <MemoryRouter>
-        <SessionDetail sessionId={session.id} />
-      </MemoryRouter>,
-    );
+    mockSessionDetailRequests({
+      sessionId: currentSession.id,
+      session: currentSession,
+      sessions: [
+        createSessionListItem({
+          id: currentSession.id,
+          templateId: currentSession.templateId,
+          templateName: 'Upper Push',
+          startedAt: currentSession.startedAt,
+        }),
+      ],
+    });
+
+    renderSessionDetail(currentSession.id);
+    await screen.findByText('Workout receipt');
 
     fireEvent.click(screen.getByRole('button', { name: /open incline dumbbell press trend chart/i }));
 
@@ -116,3 +260,181 @@ describe('SessionDetail', () => {
     expect(screen.getByLabelText('Incline Dumbbell Press trend chart')).toBeInTheDocument();
   });
 });
+
+function renderSessionDetail(sessionId: string) {
+  return renderWithQueryClient(
+    <MemoryRouter>
+      <SessionDetail sessionId={sessionId} />
+    </MemoryRouter>,
+  );
+}
+
+function mockSessionDetailRequests({
+  sessionId,
+  session = null,
+  sessionStatus = 200,
+  previousSession = null,
+  sessions,
+  templateName = 'Upper Push',
+}: {
+  sessionId: string;
+  session?: WorkoutSession | null;
+  sessionStatus?: number;
+  previousSession?: WorkoutSession | null;
+  sessions: WorkoutSessionListItem[];
+  templateName?: string;
+}) {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+    const url = String(input);
+
+    if (url.includes('/api/v1/workout-sessions?status=completed')) {
+      return Promise.resolve(jsonResponse({ data: sessions }));
+    }
+
+    if (url.includes(`/api/v1/workout-sessions/${sessionId}`)) {
+      if (sessionStatus !== 200 || session == null) {
+        return Promise.resolve(
+          jsonResponse(
+            {
+              error: {
+                code: 'WORKOUT_SESSION_NOT_FOUND',
+                message: 'Workout session not found',
+              },
+            },
+            { status: sessionStatus },
+          ),
+        );
+      }
+
+      return Promise.resolve(jsonResponse({ data: session }));
+    }
+
+    if (previousSession && url.includes(`/api/v1/workout-sessions/${previousSession.id}`)) {
+      return Promise.resolve(jsonResponse({ data: previousSession }));
+    }
+
+    if (session?.templateId && url.includes(`/api/v1/workout-templates/${session.templateId}`)) {
+      return Promise.resolve(
+        jsonResponse({
+          data: {
+            id: session.templateId,
+            userId: 'user-1',
+            name: templateName,
+            description: null,
+            tags: ['push'],
+            sections: [
+              {
+                type: 'warmup',
+                exercises: [
+                  {
+                    id: 'template-warmup-row',
+                    exerciseId: 'row-erg',
+                    exerciseName: 'Row Erg',
+                    sets: 1,
+                    repsMin: null,
+                    repsMax: null,
+                    tempo: null,
+                    restSeconds: null,
+                    supersetGroup: null,
+                    notes: null,
+                    cues: [],
+                  },
+                ],
+              },
+              {
+                type: 'main',
+                exercises: [
+                  {
+                    id: 'template-main-press',
+                    exerciseId: 'incline-dumbbell-press',
+                    exerciseName: 'Incline Dumbbell Press',
+                    sets: 3,
+                    repsMin: 8,
+                    repsMax: 10,
+                    tempo: '3110',
+                    restSeconds: 90,
+                    supersetGroup: null,
+                    notes: null,
+                    cues: [],
+                  },
+                ],
+              },
+              {
+                type: 'cooldown',
+                exercises: [],
+              },
+            ],
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        }),
+      );
+    }
+
+    throw new Error(`Unhandled request: ${url}`);
+  });
+}
+
+function createSession(overrides: Partial<WorkoutSession>): WorkoutSession {
+  return {
+    id: 'session-default',
+    userId: 'user-1',
+    templateId: 'template-upper-push',
+    name: 'Upper Push',
+    date: '2026-03-02',
+    status: 'completed',
+    startedAt: Date.parse('2026-03-02T18:00:00Z'),
+    completedAt: Date.parse('2026-03-02T19:00:00Z'),
+    duration: 60,
+    feedback: null,
+    notes: null,
+    sets: [
+      createSet({
+        id: 'set-default-1',
+        exerciseId: 'incline-dumbbell-press',
+        setNumber: 1,
+        reps: 10,
+        weight: 50,
+        section: 'main',
+      }),
+    ],
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+function createSet(overrides: Partial<WorkoutSession['sets'][number]>): WorkoutSession['sets'][number] {
+  return {
+    id: 'set-default',
+    exerciseId: 'incline-dumbbell-press',
+    setNumber: 1,
+    weight: 50,
+    reps: 10,
+    completed: true,
+    skipped: false,
+    section: 'main',
+    notes: null,
+    createdAt: 1,
+    ...overrides,
+  };
+}
+
+function createSessionListItem(
+  overrides: Partial<WorkoutSessionListItem>,
+): WorkoutSessionListItem {
+  return {
+    id: 'session-item-default',
+    name: 'Upper Push',
+    date: '2026-03-02',
+    status: 'completed',
+    templateId: 'template-upper-push',
+    templateName: 'Upper Push',
+    startedAt: Date.parse('2026-03-02T18:00:00Z'),
+    completedAt: Date.parse('2026-03-02T19:00:00Z'),
+    duration: 60,
+    exerciseCount: 3,
+    createdAt: 1,
+    ...overrides,
+  };
+}

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -1,5 +1,5 @@
 import { useId, useMemo, useState } from 'react';
-import { Link } from 'react-router';
+import { Link, useSearchParams } from 'react-router';
 import {
   ArrowLeft,
   ChevronDown,
@@ -98,11 +98,15 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
   const comparisonToggleId = useId();
   const [showComparison, setShowComparison] = useState(false);
   const [selectedExerciseId, setSelectedExerciseId] = useState<string | null>(null);
+  const [searchParams] = useSearchParams();
   const sessionQuery = useWorkoutSession(sessionId);
   const completedSessionsQuery = useCompletedSessions();
   const session = sessionQuery.data;
   const templateQuery = useWorkoutTemplate(session?.templateId ?? '');
   const template = templateQuery.data;
+  const viewParam = searchParams.get('view');
+  const backView = viewParam === 'list' || viewParam === 'calendar' ? viewParam : 'calendar';
+  const backToWorkoutsHref = `/workouts?view=${backView}`;
 
   const previousSessionItem = useMemo(() => {
     if (!session || !completedSessionsQuery.data) {
@@ -138,7 +142,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
         </CardHeader>
         <CardContent>
           <Button asChild className="w-full sm:w-auto">
-            <Link to="/workouts">Back to Workouts</Link>
+            <Link to={backToWorkoutsHref}>Back to Workouts</Link>
           </Button>
         </CardContent>
       </Card>
@@ -163,7 +167,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
   return (
     <section className="space-y-6">
       <Button asChild className="gap-2" size="sm" variant="ghost">
-        <Link to="/workouts">
+        <Link to={backToWorkoutsHref}>
           <ArrowLeft aria-hidden="true" className="size-4" />
           Back to Workouts
         </Link>

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from 'react';
+import { useId, useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import {
   ArrowLeft,
@@ -10,6 +10,12 @@ import {
   Scale,
   TrendingUp,
 } from 'lucide-react';
+import type {
+  SessionSet,
+  WorkoutSession,
+  WorkoutTemplate,
+  WorkoutTemplateSectionType,
+} from '@pulse/shared';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -24,16 +30,11 @@ import {
 } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
 import { StatCard } from '@/components/ui/stat-card';
-import { mockExercises, mockTemplates, type WorkoutTemplateSectionType } from '@/lib/mock-data/workouts';
 import { cn } from '@/lib/utils';
 
-import {
-  workoutCompletedSessions,
-  workoutEnhancedExercises,
-  workoutExerciseHistory,
-} from '../lib/mock-data';
+import { useCompletedSessions, useWorkoutSession, useWorkoutTemplate } from '../api/workouts';
 import { findPreviousTemplateSession } from '../lib/session-comparison';
-import type { ActiveWorkoutCompletedSession } from '../types';
+import type { ActiveWorkoutExerciseHistoryPoint } from '../types';
 import { ExerciseTrendChart } from './exercise-trend-chart';
 import { SessionComparison, SessionExerciseComparison } from './session-comparison';
 
@@ -48,7 +49,7 @@ type SessionDetailExercise = {
   name: string;
   notes: string | null;
   phaseBadge: 'moderate' | 'rebuild' | 'recovery' | 'test';
-  sets: ActiveWorkoutCompletedSession['exercises'][number]['sets'];
+  sets: SessionSet[];
 };
 
 type SessionDetailSection = {
@@ -75,12 +76,6 @@ const decimalFormatter = new Intl.NumberFormat('en-US', {
   minimumFractionDigits: 0,
 });
 
-const templateById = new Map(mockTemplates.map((template) => [template.id, template]));
-const exerciseById = new Map(mockExercises.map((exercise) => [exercise.id, exercise]));
-const enhancedExerciseById = new Map(
-  workoutEnhancedExercises.map((exercise) => [exercise.exerciseId, exercise]),
-);
-
 const sectionLabels: Record<SessionDetailSectionType, string> = {
   warmup: 'Warmup',
   main: 'Main',
@@ -103,7 +98,34 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
   const comparisonToggleId = useId();
   const [showComparison, setShowComparison] = useState(false);
   const [selectedExerciseId, setSelectedExerciseId] = useState<string | null>(null);
-  const session = workoutCompletedSessions.find((candidate) => candidate.id === sessionId);
+  const sessionQuery = useWorkoutSession(sessionId);
+  const completedSessionsQuery = useCompletedSessions();
+  const session = sessionQuery.data;
+  const templateQuery = useWorkoutTemplate(session?.templateId ?? '');
+  const template = templateQuery.data;
+
+  const previousSessionItem = useMemo(() => {
+    if (!session || !completedSessionsQuery.data) {
+      return null;
+    }
+
+    return findPreviousTemplateSession(session, completedSessionsQuery.data);
+  }, [completedSessionsQuery.data, session]);
+
+  const previousSessionQuery = useWorkoutSession(previousSessionItem?.id ?? '', {
+    enabled: showComparison && previousSessionItem != null,
+  });
+  const previousSession = previousSessionQuery.data ?? null;
+
+  if (sessionQuery.isLoading) {
+    return (
+      <Card>
+        <CardContent className="py-6">
+          <p className="text-sm text-muted">Loading session…</p>
+        </CardContent>
+      </Card>
+    );
+  }
 
   if (!session) {
     return (
@@ -111,7 +133,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
         <CardHeader className="space-y-2">
           <h1 className="text-2xl font-semibold text-foreground">Session not found</h1>
           <p className="text-sm text-muted">
-            The requested completed workout session is not available in the prototype data.
+            The requested completed workout session could not be loaded.
           </p>
         </CardHeader>
         <CardContent>
@@ -123,14 +145,20 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
     );
   }
 
-  const template = templateById.get(session.templateId);
-  const previousSession = findPreviousTemplateSession(session);
   const sessionDate = new Date(session.startedAt);
   const summary = getSessionSummary(session);
-  const sections = buildSections(session);
+  const sections = buildSections(session, template);
   const selectedExercise = sections
     .flatMap((section) => section.exercises)
     .find((exercise) => exercise.exerciseId === selectedExerciseId);
+  const selectedExerciseHistory =
+    selectedExercise != null
+      ? buildExerciseHistory({
+          currentSession: session,
+          exerciseId: selectedExercise.exerciseId,
+          previousSession,
+        })
+      : [];
 
   return (
     <section className="space-y-6">
@@ -157,12 +185,12 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
                 </Badge>
               </div>
               <h1 className="text-3xl font-semibold tracking-tight">
-                {session.name ?? template?.name ?? 'Workout Session'}
+                {session.name || template?.name || 'Workout Session'}
               </h1>
               <p className="max-w-3xl text-sm opacity-80 sm:text-base dark:text-muted dark:opacity-100">
                 {dateFormatter.format(sessionDate)}
                 {' · '}
-                {`${session.duration} min`}
+                {session.duration != null ? `${session.duration} min` : 'Duration not tracked'}
                 {' · '}
                 {`Started ${timeFormatter.format(sessionDate)}`}
               </p>
@@ -302,9 +330,9 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
                       {exercise.sets.map((set) => (
                         <span
                           className="inline-flex rounded-full border border-border bg-secondary/55 px-3 py-1.5 text-sm text-foreground"
-                          key={set.setNumber}
+                          key={set.id}
                         >
-                          {`Set ${set.setNumber}: ${set.weight != null ? `${formatNumber(set.weight)} kg × ` : ''}${integerFormatter.format(set.reps)} reps`}
+                          {formatSetLabel(set)}
                         </span>
                       ))}
                     </div>
@@ -338,40 +366,26 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
           <CardTitle>Feedback</CardTitle>
         </CardHeader>
         <CardContent className="space-y-5">
-          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-            {session.customFeedback.map((field) => (
-              <div className="rounded-2xl border border-border bg-secondary/35 p-4" key={field.id}>
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
-                  {field.label}
-                </p>
-                <p className="mt-2 text-base font-semibold text-foreground">
-                  {field.type === 'scale'
-                    ? field.value != null
-                      ? `${field.value}/${field.max}`
-                      : 'Not rated'
-                    : field.value?.trim() || 'No response'}
-                </p>
-                {field.notes?.trim() ? (
-                  <p className="mt-2 text-sm leading-6 text-muted">{field.notes}</p>
-                ) : null}
+          {session.feedback ? (
+            <>
+              <div className="grid gap-3 sm:grid-cols-3">
+                <FeedbackScore label="Energy" score={session.feedback.energy} />
+                <FeedbackScore label="Recovery" score={session.feedback.recovery} />
+                <FeedbackScore label="Technique" score={session.feedback.technique} />
               </div>
-            ))}
-          </div>
 
-          <div className="grid gap-3 sm:grid-cols-3">
-            <FeedbackScore label="Energy" score={session.feedback.energy} />
-            <FeedbackScore label="Recovery" score={session.feedback.recovery} />
-            <FeedbackScore label="Technique" score={session.feedback.technique} />
-          </div>
-
-          {session.feedback.notes ? (
-            <div className="rounded-2xl border border-border bg-secondary/35 px-4 py-3 text-sm text-foreground">
-              <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
-                Reflection
-              </p>
-              <p>{session.feedback.notes}</p>
-            </div>
-          ) : null}
+              {session.feedback.notes ? (
+                <div className="rounded-2xl border border-border bg-secondary/35 px-4 py-3 text-sm text-foreground">
+                  <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
+                    Reflection
+                  </p>
+                  <p>{session.feedback.notes}</p>
+                </div>
+              ) : null}
+            </>
+          ) : (
+            <p className="text-sm text-muted">No feedback captured for this session.</p>
+          )}
         </CardContent>
       </Card>
 
@@ -391,9 +405,11 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
         </Card>
       ) : null}
 
-      <Button asChild className="w-full sm:w-auto" size="lg">
-        <Link to={`/workouts/active?template=${session.templateId}`}>Repeat Workout</Link>
-      </Button>
+      {session.templateId ? (
+        <Button asChild className="w-full sm:w-auto" size="lg">
+          <Link to={`/workouts/active?template=${session.templateId}`}>Repeat Workout</Link>
+        </Button>
+      ) : null}
 
       <Dialog onOpenChange={(open) => (!open ? setSelectedExerciseId(null) : null)} open={selectedExercise != null}>
         <DialogContent className="max-h-[90vh] overflow-y-auto rounded-t-3xl border-border p-0 sm:max-w-4xl sm:rounded-3xl">
@@ -408,7 +424,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
               <div className="px-4 pb-4 pt-2 sm:px-6 sm:pb-6">
                 <ExerciseTrendChart
                   exerciseName={selectedExercise.name}
-                  history={workoutExerciseHistory[selectedExercise.exerciseId] ?? []}
+                  history={selectedExerciseHistory}
                 />
               </div>
             </div>
@@ -419,46 +435,48 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
   );
 }
 
-function buildSections(session: ActiveWorkoutCompletedSession): SessionDetailSection[] {
-  const template = templateById.get(session.templateId);
+function buildSections(session: WorkoutSession, template?: WorkoutTemplate): SessionDetailSection[] {
   const templateSectionByExerciseId = new Map<string, WorkoutTemplateSectionType>();
+  const templateExerciseNameById = new Map<string, string>();
 
   template?.sections.forEach((section) => {
     section.exercises.forEach((exercise) => {
       templateSectionByExerciseId.set(exercise.exerciseId, section.type);
+      templateExerciseNameById.set(exercise.exerciseId, exercise.exerciseName);
     });
   });
 
-  const supplementalByExerciseId = new Map(
-    session.supplemental.map((exercise) => [exercise.exerciseId, exercise.details]),
+  const sectionBuckets = new Map<SessionDetailSectionType, Map<string, SessionSet[]>>([
+    ['warmup', new Map()],
+    ['main', new Map()],
+    ['cooldown', new Map()],
+    ['supplemental', new Map()],
+  ]);
+  const sortedSets = [...session.sets].sort(
+    (left, right) => left.setNumber - right.setNumber || left.createdAt - right.createdAt,
   );
 
-  const exercisesBySection = new Map<SessionDetailSectionType, SessionDetailExercise[]>([
-    ['warmup', []],
-    ['main', []],
-    ['cooldown', []],
-    ['supplemental', []],
-  ]);
+  for (const set of sortedSets) {
+    const derivedSection =
+      set.section ?? templateSectionByExerciseId.get(set.exerciseId) ?? 'supplemental';
+    const sectionMap = sectionBuckets.get(derivedSection) ?? new Map<string, SessionSet[]>();
+    const exerciseSets = sectionMap.get(set.exerciseId) ?? [];
 
-  session.exercises.forEach((exerciseLog) => {
-    const sectionType = supplementalByExerciseId.has(exerciseLog.exerciseId)
-      ? 'supplemental'
-      : (templateSectionByExerciseId.get(exerciseLog.exerciseId) ?? 'main');
-    const catalogExercise = exerciseById.get(exerciseLog.exerciseId);
-    const enhancedExercise = enhancedExerciseById.get(exerciseLog.exerciseId);
-
-    exercisesBySection.get(sectionType)?.push({
-      exerciseId: exerciseLog.exerciseId,
-      name: catalogExercise?.name ?? formatLabel(exerciseLog.exerciseId),
-      notes: supplementalByExerciseId.get(exerciseLog.exerciseId) ?? null,
-      phaseBadge: enhancedExercise?.phaseBadge ?? inferPhaseBadge(sectionType),
-      sets: exerciseLog.sets,
-    });
-  });
+    exerciseSets.push(set);
+    sectionMap.set(set.exerciseId, exerciseSets);
+    sectionBuckets.set(derivedSection, sectionMap);
+  }
 
   return (['warmup', 'main', 'cooldown', 'supplemental'] as const)
     .map((sectionType) => {
-      const exercises = exercisesBySection.get(sectionType) ?? [];
+      const groupedExercises = sectionBuckets.get(sectionType) ?? new Map<string, SessionSet[]>();
+      const exercises = [...groupedExercises.entries()].map(([exerciseId, sets]) => ({
+        exerciseId,
+        name: templateExerciseNameById.get(exerciseId) ?? formatLabel(exerciseId),
+        notes: sets.find((set) => set.notes)?.notes ?? null,
+        phaseBadge: inferPhaseBadge(sectionType),
+        sets: [...sets].sort((left, right) => left.setNumber - right.setNumber),
+      }));
 
       return {
         exercises,
@@ -477,18 +495,22 @@ function buildSectionSubtitle(sectionType: SessionDetailSectionType, count: numb
   return `${count} exercise${count === 1 ? '' : 's'} logged`;
 }
 
-function getSessionSummary(session: ActiveWorkoutCompletedSession) {
-  return session.exercises.reduce(
-    (summary, exercise) => {
-      summary.totalExercises += 1;
-      summary.totalSets += exercise.sets.length;
+function getSessionSummary(session: WorkoutSession) {
+  const exerciseIds = new Set<string>();
 
-      exercise.sets.forEach((set) => {
+  return session.sets.reduce(
+    (summary, set) => {
+      exerciseIds.add(set.exerciseId);
+      summary.totalSets += 1;
+      summary.totalExercises = exerciseIds.size;
+
+      if (set.reps != null) {
         summary.totalReps += set.reps;
-        if (set.weight != null) {
-          summary.totalVolume += set.weight * set.reps;
-        }
-      });
+      }
+
+      if (set.weight != null && set.reps != null) {
+        summary.totalVolume += set.weight * set.reps;
+      }
 
       return summary;
     },
@@ -505,7 +527,7 @@ function FeedbackScore({ label, score }: { label: string; score: number }) {
   );
 }
 
-function inferPhaseBadge(sectionType: SessionDetailSectionType) {
+function inferPhaseBadge(sectionType: SessionDetailSectionType): SessionDetailExercise['phaseBadge'] {
   switch (sectionType) {
     case 'warmup':
     case 'cooldown':
@@ -515,6 +537,72 @@ function inferPhaseBadge(sectionType: SessionDetailSectionType) {
     default:
       return 'moderate';
   }
+}
+
+function buildExerciseHistory({
+  currentSession,
+  exerciseId,
+  previousSession,
+}: {
+  currentSession: WorkoutSession;
+  exerciseId: string;
+  previousSession: WorkoutSession | null;
+}): ActiveWorkoutExerciseHistoryPoint[] {
+  const history: ActiveWorkoutExerciseHistoryPoint[] = [];
+
+  const previousPoint =
+    previousSession != null ? buildHistoryPoint(previousSession, exerciseId) : null;
+  const currentPoint = buildHistoryPoint(currentSession, exerciseId);
+
+  if (previousPoint) {
+    history.push(previousPoint);
+  }
+
+  if (currentPoint) {
+    history.push(currentPoint);
+  }
+
+  return history;
+}
+
+function buildHistoryPoint(session: WorkoutSession, exerciseId: string): ActiveWorkoutExerciseHistoryPoint | null {
+  const sets = session.sets.filter((set) => set.exerciseId === exerciseId && set.reps != null);
+
+  if (sets.length === 0) {
+    return null;
+  }
+
+  const topSet = sets.reduce<SessionSet>((best, current) => {
+    const bestWeight = best.weight ?? 0;
+    const currentWeight = current.weight ?? 0;
+
+    if (currentWeight > bestWeight) {
+      return current;
+    }
+
+    if (currentWeight === bestWeight && (current.reps ?? 0) > (best.reps ?? 0)) {
+      return current;
+    }
+
+    return best;
+  }, sets[0]);
+
+  return {
+    date: session.date,
+    reps: topSet.reps ?? 0,
+    weight: topSet.weight ?? 0,
+  };
+}
+
+function formatSetLabel(set: SessionSet) {
+  if (set.skipped) {
+    return `Set ${set.setNumber}: Skipped`;
+  }
+
+  const repsLabel = set.reps != null ? `${integerFormatter.format(set.reps)} reps` : 'No reps';
+  const weightLabel = set.weight != null ? `${formatNumber(set.weight)} kg × ` : '';
+
+  return `Set ${set.setNumber}: ${weightLabel}${repsLabel}`;
 }
 
 function formatLabel(value: string) {

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -120,6 +120,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
     enabled: showComparison && previousSessionItem != null,
   });
   const previousSession = previousSessionQuery.data ?? null;
+  const comparisonToggleDisabled = completedSessionsQuery.isLoading;
 
   if (sessionQuery.isLoading) {
     return (
@@ -252,6 +253,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
           <div className="flex items-center gap-3">
             <Checkbox
               checked={showComparison}
+              disabled={comparisonToggleDisabled}
               id={comparisonToggleId}
               onCheckedChange={(checked) => setShowComparison(checked === true)}
             />
@@ -262,7 +264,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
         </CardContent>
       </Card>
 
-      {showComparison ? (
+      {showComparison && !comparisonToggleDisabled ? (
         <SessionComparison currentSession={session} previousSession={previousSession} />
       ) : null}
 

--- a/apps/web/src/features/workouts/components/template-browser.test.tsx
+++ b/apps/web/src/features/workouts/components/template-browser.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { TemplateBrowser } from './template-browser';
+
+describe('TemplateBrowser', () => {
+  it('renders updated copy and empty state for users without templates', () => {
+    render(
+      <MemoryRouter>
+        <TemplateBrowser buildTemplateHref={(templateId) => `/workouts/template/${templateId}`} />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByText(
+        'Launch one of your saved templates and jump straight into an active workout.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('No templates yet — create your first one.')).toBeInTheDocument();
+    expect(screen.getByLabelText('Search templates by name')).toHaveClass('pl-9');
+  });
+
+  it('filters templates by search query', () => {
+    render(
+      <MemoryRouter>
+        <TemplateBrowser
+          buildTemplateHref={(templateId) => `/workouts/template/${templateId}`}
+          templates={[
+            {
+              id: 'template-1',
+              name: 'Upper Push',
+              description: 'Chest and shoulders',
+              tags: ['push'],
+              sections: [{ exercises: [] }],
+            },
+            {
+              id: 'template-2',
+              name: 'Lower Body',
+              description: 'Leg training',
+              tags: ['legs'],
+              sections: [{ exercises: [] }],
+            },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText('Search templates by name'), {
+      target: { value: 'lower' },
+    });
+
+    expect(screen.getByRole('link', { name: 'Lower Body' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Upper Push' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/workouts/components/template-browser.tsx
+++ b/apps/web/src/features/workouts/components/template-browser.tsx
@@ -5,7 +5,6 @@ import { Link } from 'react-router';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
-import { mockTemplates } from '@/lib/mock-data/workouts';
 import { cn } from '@/lib/utils';
 
 // Minimal structural interface — satisfied by both mock and API WorkoutTemplate shapes.
@@ -26,7 +25,7 @@ type TemplateBrowserProps = {
 export function TemplateBrowser({
   buildTemplateHref,
   className,
-  templates = mockTemplates as TemplateSummary[],
+  templates = [],
 }: TemplateBrowserProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const normalizedQuery = searchQuery.trim().toLowerCase();
@@ -53,7 +52,7 @@ export function TemplateBrowser({
       <div className="space-y-2">
         <h2 className="text-2xl font-semibold text-foreground">Templates</h2>
         <p className="max-w-2xl text-sm text-muted">
-          Launch one of the saved mock templates and jump straight into an active workout.
+          Launch one of your saved templates and jump straight into an active workout.
         </p>
       </div>
 
@@ -65,6 +64,7 @@ export function TemplateBrowser({
         <Input
           aria-label="Search templates by name"
           autoComplete="off"
+          className="pl-9"
           id="template-search"
           onChange={(event) => setSearchQuery(event.target.value)}
           placeholder="Search templates by name"
@@ -76,7 +76,7 @@ export function TemplateBrowser({
       {templates.length === 0 ? (
         <Card>
           <CardContent className="py-6">
-            <p className="text-sm text-muted">No workout templates are available yet.</p>
+            <p className="text-sm text-muted">No templates yet — create your first one.</p>
           </CardContent>
         </Card>
       ) : filteredTemplates.length === 0 ? (

--- a/apps/web/src/features/workouts/components/workout-calendar.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.test.tsx
@@ -1,65 +1,134 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { parseDateKey } from '@/lib/date-utils';
-import { mockSchedule } from '@/lib/mock-data/workouts';
+import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
+import { toDateKey } from '@/lib/date-utils';
+import { renderWithQueryClient } from '@/test/render-with-query-client';
+import { jsonResponse } from '@/test/test-utils';
 
-import { workoutCompletedSessions } from '..';
 import { WorkoutCalendar } from './workout-calendar';
 
+beforeEach(() => {
+  window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
+});
+
+afterEach(() => {
+  window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
+  vi.restoreAllMocks();
+});
+
 describe('WorkoutCalendar', () => {
-  it('renders the month grid, workout indicators, and today highlight', () => {
-    render(<WorkoutCalendar />);
+  it('renders completed sessions from the API and links to session details', async () => {
+    const sessionDate = new Date();
+    sessionDate.setDate(Math.min(sessionDate.getDate(), 10));
+    const sessionDateKey = toDateKey(sessionDate);
+    const completedSession = {
+      id: 'session-1',
+      name: 'Upper Push',
+      date: sessionDateKey,
+      status: 'completed' as const,
+      templateId: 'template-1',
+      templateName: 'Upper Push',
+      startedAt: Date.parse(`${sessionDateKey}T18:00:00Z`),
+      completedAt: Date.parse(`${sessionDateKey}T19:00:00Z`),
+      duration: 60,
+      exerciseCount: 6,
+      createdAt: 1,
+    };
 
-    expect(screen.getByText('Workout Calendar')).toBeInTheDocument();
-    expect(screen.getByText('Mon')).toBeInTheDocument();
-    expect(screen.getByText('Sun')).toBeInTheDocument();
-    expect(screen.getAllByLabelText('Completed workout').length).toBeGreaterThan(0);
-    expect(screen.getAllByLabelText('Scheduled workout').length).toBeGreaterThan(0);
-    expect(screen.getByRole('button', { name: formatFullDate(new Date()) })).toHaveAttribute(
-      'aria-current',
-      'date',
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = String(input);
+
+      if (url.includes('/api/v1/workout-sessions?status=completed')) {
+        return Promise.resolve(jsonResponse({ data: [completedSession] }));
+      }
+
+      if (url.includes('/api/v1/workout-templates')) {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'template-1',
+                userId: 'user-1',
+                name: 'Upper Push',
+                description: null,
+                tags: ['push'],
+                sections: [
+                  { type: 'warmup', exercises: [] },
+                  { type: 'main', exercises: [] },
+                  { type: 'cooldown', exercises: [] },
+                ],
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            ],
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    renderWithQueryClient(
+      <WorkoutCalendar buildSessionHref={(sessionId) => `/workouts/session/${sessionId}`} />,
     );
-  });
 
-  it('updates the day detail panel when a scheduled workout is selected', () => {
-    const scheduledDay = mockSchedule.find((entry) => entry.status === 'scheduled');
-
-    expect(scheduledDay).toBeDefined();
-
-    render(<WorkoutCalendar buildDayHref={(date) => `/workouts?date=${date}`} />);
+    expect(await screen.findByText('Workout Calendar')).toBeInTheDocument();
+    expect((await screen.findAllByLabelText('Completed workout')).length).toBeGreaterThan(0);
 
     fireEvent.click(
-      screen.getByRole('button', { name: formatFullDate(parseDateKey(scheduledDay?.date ?? '')) }),
+      screen.getByRole('button', {
+        name: formatFullDate(new Date(`${sessionDateKey}T12:00:00`)),
+      }),
     );
 
-    expect(
-      screen.getByRole('heading', { name: scheduledDay?.templateName ?? '' }),
-    ).toBeInTheDocument();
-    expect(screen.getByText('Scheduled')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'View Details' })).toHaveAttribute(
-      'href',
-      `/workouts?date=${scheduledDay?.date}`,
-    );
-  });
-
-  it('links completed workout days to the session detail route', () => {
-    const completedSession = workoutCompletedSessions[0];
-    const completedDate = parseDateKey(completedSession.startedAt.slice(0, 10));
-
-    render(<WorkoutCalendar buildSessionHref={(sessionId) => `/workouts/session/${sessionId}`} />);
-
-    fireEvent.click(screen.getByRole('button', { name: formatFullDate(completedDate) }));
-
+    expect(screen.getByRole('heading', { name: 'Upper Push' })).toBeInTheDocument();
     expect(screen.getByText('Completed')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'View Session' })).toHaveAttribute(
       'href',
-      `/workouts/session/${completedSession.id}`,
+      '/workouts/session/session-1',
     );
   });
 
-  it('navigates between months', () => {
-    render(<WorkoutCalendar />);
+  it('shows empty calendar details when no completed sessions exist', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = String(input);
+
+      if (url.includes('/api/v1/workout-sessions?status=completed')) {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (url.includes('/api/v1/workout-templates')) {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    renderWithQueryClient(<WorkoutCalendar />);
+
+    expect(await screen.findByText('Workout Calendar')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Completed workout')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'No workout planned' })).toBeInTheDocument();
+  });
+
+  it('navigates between months', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = String(input);
+
+      if (url.includes('/api/v1/workout-sessions?status=completed')) {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (url.includes('/api/v1/workout-templates')) {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    renderWithQueryClient(<WorkoutCalendar />);
+    await screen.findByText('Workout Calendar');
 
     const today = new Date();
     const nextMonth = new Date(today.getFullYear(), today.getMonth() + 1, 1);

--- a/apps/web/src/features/workouts/components/workout-calendar.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
@@ -70,7 +71,9 @@ describe('WorkoutCalendar', () => {
     });
 
     renderWithQueryClient(
-      <WorkoutCalendar buildSessionHref={(sessionId) => `/workouts/session/${sessionId}`} />,
+      <MemoryRouter>
+        <WorkoutCalendar buildSessionHref={(sessionId) => `/workouts/session/${sessionId}`} />
+      </MemoryRouter>,
     );
 
     expect(await screen.findByText('Workout Calendar')).toBeInTheDocument();
@@ -105,7 +108,11 @@ describe('WorkoutCalendar', () => {
       throw new Error(`Unhandled request: ${url}`);
     });
 
-    renderWithQueryClient(<WorkoutCalendar />);
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutCalendar />
+      </MemoryRouter>,
+    );
 
     expect(await screen.findByText('Workout Calendar')).toBeInTheDocument();
     expect(screen.queryByLabelText('Completed workout')).not.toBeInTheDocument();
@@ -127,7 +134,11 @@ describe('WorkoutCalendar', () => {
       throw new Error(`Unhandled request: ${url}`);
     });
 
-    renderWithQueryClient(<WorkoutCalendar />);
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutCalendar />
+      </MemoryRouter>,
+    );
     await screen.findByText('Workout Calendar');
 
     const today = new Date();

--- a/apps/web/src/features/workouts/components/workout-calendar.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.test.tsx
@@ -117,6 +117,7 @@ describe('WorkoutCalendar', () => {
     expect(await screen.findByText('Workout Calendar')).toBeInTheDocument();
     expect(screen.queryByLabelText('Completed workout')).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'No workout planned' })).toBeInTheDocument();
+    expect(document.getElementById('workout-day-details')).toHaveClass('order-first');
   });
 
   it('navigates between months', async () => {

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -230,7 +230,7 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
 
         <aside
           className={cn(
-            'flex min-h-0 flex-col gap-4 rounded-3xl border p-5 shadow-sm',
+            'order-first flex min-h-0 flex-col gap-4 rounded-3xl border p-5 shadow-sm lg:order-none',
             accentPanel,
           )}
           id="workout-day-details"

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
+import type { WorkoutSessionListItem } from '@pulse/shared';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -11,14 +12,8 @@ import {
   toDateKey,
 } from '@/lib/date-utils';
 import { accentCardStyles } from '@/lib/accent-card-styles';
-import {
-  mockSchedule,
-  mockTemplates,
-  type WorkoutScheduleEntry,
-} from '@/lib/mock-data/workouts';
 import { cn } from '@/lib/utils';
-import { workoutCompletedSessions } from '../lib/mock-data';
-import type { ActiveWorkoutCompletedSession } from '../types';
+import { useCompletedSessions, useWorkoutTemplates } from '../api/workouts';
 
 const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
 const TODAY_KEY = toDateKey(new Date());
@@ -32,53 +27,70 @@ const fullDateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
   year: 'numeric',
 });
+const timeFormatter = new Intl.DateTimeFormat('en-US', {
+  hour: 'numeric',
+  minute: '2-digit',
+});
 
 type WorkoutCalendarProps = {
   buildDayHref?: (date: string) => string;
   buildSessionHref?: (sessionId: string) => string;
 };
 
-type DayStatus = 'completed' | 'scheduled' | 'rest' | 'none';
+type DayStatus = 'completed' | 'none';
 
 type DayDetails = {
   date: Date;
   dateKey: string;
-  schedule?: WorkoutScheduleEntry;
-  session?: ActiveWorkoutCompletedSession;
+  session?: WorkoutSessionListItem;
   status: DayStatus;
   templateName: string | null;
   notes: string | null;
 };
 
-const templateNameById = new Map(mockTemplates.map((template) => [template.id, template.name]));
-const scheduleByDate = new Map(mockSchedule.map((entry) => [entry.date, entry]));
-const sessionByDate = new Map(
-  workoutCompletedSessions.map((session) => [session.startedAt.slice(0, 10), session]),
-);
+type DayLookupContext = {
+  sessionByDate: Map<string, WorkoutSessionListItem>;
+  templateNameById: Map<string, string>;
+};
 
 export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalendarProps) {
+  const completedQuery = useCompletedSessions();
+  const templatesQuery = useWorkoutTemplates();
   const initialMonth = startOfMonth(parseDateKey(TODAY_KEY));
   const [visibleMonth, setVisibleMonth] = useState(initialMonth);
-  const [selectedDateKey, setSelectedDateKey] = useState(getDefaultSelectedDateKey(initialMonth));
+
+  const templateNameById = useMemo(
+    () => new Map((templatesQuery.data ?? []).map((template) => [template.id, template.name])),
+    [templatesQuery.data],
+  );
+  const sessionByDate = useMemo(
+    () => new Map((completedQuery.data ?? []).map((session) => [session.date, session])),
+    [completedQuery.data],
+  );
+  const lookupContext = useMemo(
+    () => ({
+      sessionByDate,
+      templateNameById,
+    }),
+    [sessionByDate, templateNameById],
+  );
+
+  const [selectedDateKey, setSelectedDateKey] = useState(getDefaultSelectedDateKey(initialMonth, sessionByDate));
 
   const calendarDays = buildCalendarDays(visibleMonth);
-  const selectedDay = getDayDetails(selectedDateKey);
+  const selectedDay = getDayDetails(selectedDateKey, lookupContext);
   const detailHref = selectedDay.session
     ? (buildSessionHref?.(selectedDay.session.id) ?? `/workouts/session/${selectedDay.session.id}`)
     : (buildDayHref?.(selectedDateKey) ?? `?date=${selectedDateKey}`);
   const detailStats = getDetailStats(selectedDay);
-  const hasWorkout = selectedDay.status === 'completed' || selectedDay.status === 'scheduled';
+  const hasWorkout = selectedDay.status === 'completed';
 
-  const accentPanel = hasWorkout
-    ? selectedDay.status === 'completed'
-      ? accentCardStyles.mint
-      : accentCardStyles.cream
-    : 'bg-card text-foreground';
+  const accentPanel = hasWorkout ? accentCardStyles.mint : 'bg-card text-foreground';
 
   function handleMonthChange(offset: number) {
     const nextMonth = addMonths(visibleMonth, offset);
     setVisibleMonth(nextMonth);
-    setSelectedDateKey(getDefaultSelectedDateKey(nextMonth));
+    setSelectedDateKey(getDefaultSelectedDateKey(nextMonth, sessionByDate));
   }
 
   return (
@@ -88,7 +100,7 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
           <div className="space-y-1">
             <CardTitle>Workout Calendar</CardTitle>
             <p className="text-sm text-muted">
-              Track completed sessions, upcoming plans, and recovery days in one monthly view.
+              Track completed sessions and review workout activity in one monthly view.
             </p>
           </div>
 
@@ -119,7 +131,6 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
 
         <div className="flex flex-wrap items-center gap-3 text-xs text-muted">
           <LegendDot className="bg-emerald-500" label="Completed workout" />
-          <LegendDot className="bg-blue-500" label="Scheduled workout" />
           <span className="rounded-full border border-primary/30 px-2 py-1 text-foreground">
             Today
           </span>
@@ -142,11 +153,11 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
           <div className="grid grid-cols-7 gap-2">
             {calendarDays.map((day) => {
               const dateKey = toDateKey(day);
-              const details = getDayDetails(dateKey);
+              const details = getDayDetails(dateKey, lookupContext);
               const isSelected = selectedDateKey === dateKey;
               const isToday = dateKey === TODAY_KEY;
               const isInMonth = day.getMonth() === visibleMonth.getMonth();
-              const isWorkoutDay = details.status === 'completed' || details.status === 'scheduled';
+              const isWorkoutDay = details.status === 'completed';
 
               return (
                 <button
@@ -177,15 +188,8 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
                       {day.getDate()}
                     </span>
                     {isWorkoutDay ? (
-                      <span
-                        className={cn(
-                          'hidden shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-bold uppercase leading-none tracking-wide sm:inline',
-                          details.status === 'completed'
-                            ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
-                            : 'bg-blue-500/15 text-blue-700 dark:text-blue-400',
-                        )}
-                      >
-                        {details.status === 'completed' ? 'Done' : 'Plan'}
+                      <span className="hidden shrink-0 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[9px] font-bold uppercase leading-none tracking-wide text-emerald-700 dark:text-emerald-400 sm:inline">
+                        Done
                       </span>
                     ) : null}
                   </div>
@@ -197,8 +201,7 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
                         isInMonth ? 'text-foreground' : 'text-muted',
                       )}
                     >
-                      {details.templateName ??
-                        (details.status === 'rest' ? 'Rest day' : 'No workout')}
+                      {details.templateName ?? 'No workout'}
                     </p>
                     <p className="truncate text-[10px] leading-snug text-muted">
                       {details.notes ?? (isWorkoutDay ? 'Tap for details' : '')}
@@ -210,12 +213,6 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
                       <span
                         aria-label="Completed workout"
                         className="size-2 rounded-full bg-emerald-500 sm:size-2.5"
-                      />
-                    ) : null}
-                    {details.status === 'scheduled' ? (
-                      <span
-                        aria-label="Scheduled workout"
-                        className="size-2 rounded-full bg-blue-500 sm:size-2.5"
                       />
                     ) : null}
                     {isToday ? (
@@ -247,8 +244,7 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
               Day details
             </p>
             <h3 className="text-2xl font-semibold">
-              {selectedDay.templateName ??
-                (selectedDay.status === 'rest' ? 'Recovery day' : 'No workout planned')}
+              {selectedDay.templateName ?? 'No workout planned'}
             </h3>
             <p
               className={cn(
@@ -291,9 +287,7 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
             )}
           >
             {selectedDay.notes ??
-              (selectedDay.status === 'rest'
-                ? 'Recovery focus: keep steps up, get meals in, and stay ready for the next lift.'
-                : 'No workout is attached to this day yet. Navigate months or select a marked day to inspect the plan.')}
+              'No workout is attached to this day yet. Complete a session to see it on the calendar.'}
           </p>
 
           {hasWorkout ? (
@@ -303,7 +297,7 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
               size="sm"
               variant="secondary"
             >
-              <a href={detailHref}>{selectedDay.session ? 'View Session' : 'View Details'}</a>
+              <a href={detailHref}>View Session</a>
             </Button>
           ) : null}
         </aside>
@@ -321,72 +315,45 @@ function LegendDot({ className, label }: { className: string; label: string }) {
   );
 }
 
-function getDayDetails(dateKey: string): DayDetails {
+function getDayDetails(dateKey: string, context: DayLookupContext): DayDetails {
   const date = parseDateKey(dateKey);
-  const schedule = scheduleByDate.get(dateKey);
-  const session = sessionByDate.get(dateKey);
-
-  let status: DayStatus = 'none';
-
-  if (session || schedule?.status === 'completed') {
-    status = 'completed';
-  } else if (schedule?.status === 'scheduled') {
-    status = 'scheduled';
-  } else if (schedule?.status === 'rest') {
-    status = 'rest';
-  }
-
+  const session = context.sessionByDate.get(dateKey);
   const templateName =
-    schedule?.templateName ?? (session ? (templateNameById.get(session.templateId) ?? null) : null);
+    session?.templateName ??
+    (session?.templateId ? (context.templateNameById.get(session.templateId) ?? null) : null);
+  const status: DayStatus = session ? 'completed' : 'none';
+  const notes =
+    session != null
+      ? `${session.exerciseCount} exercise${session.exerciseCount === 1 ? '' : 's'} logged`
+      : null;
 
   return {
     date,
     dateKey,
-    schedule,
     session,
     status,
     templateName,
-    notes: schedule?.notes ?? session?.notes ?? session?.feedback?.notes ?? null,
+    notes,
   };
 }
 
 function getDetailStats(selectedDay: DayDetails) {
   if (selectedDay.session) {
-    const exerciseCount = selectedDay.session.exercises.length;
-    const completedSets = selectedDay.session.exercises.reduce((total, exercise) => {
-      return total + exercise.sets.filter((set) => set.completed).length;
-    }, 0);
-    const feedback = selectedDay.session.feedback;
-    const averageFeedback = feedback
-      ? ((feedback.energy + feedback.recovery + feedback.technique) / 3).toFixed(1)
-      : null;
-
     return [
       { label: 'Status', value: 'Completed' },
-      { label: 'Duration', value: `${selectedDay.session.duration} min` },
-      { label: 'Volume', value: `${exerciseCount} exercises / ${completedSets} sets` },
-      { label: 'Feedback', value: averageFeedback ? `${averageFeedback}/5` : 'Not rated' },
-    ];
-  }
-
-  if (selectedDay.status === 'scheduled') {
-    return [
-      { label: 'Status', value: 'Scheduled' },
-      { label: 'Plan', value: '1 session queued' },
-      { label: 'Focus', value: selectedDay.templateName ?? 'Workout block' },
       {
-        label: 'Day',
-        value: fullDateFormatter.format(selectedDay.date).split(',')[0] ?? 'Planned',
+        label: 'Duration',
+        value:
+          selectedDay.session.duration != null ? `${selectedDay.session.duration} min` : 'Not tracked',
       },
-    ];
-  }
-
-  if (selectedDay.status === 'rest') {
-    return [
-      { label: 'Status', value: 'Recovery' },
-      { label: 'Focus', value: 'Walking + mobility' },
-      { label: 'Plan', value: 'No lifting block' },
-      { label: 'Readiness', value: 'Reset for next session' },
+      {
+        label: 'Exercises',
+        value: `${selectedDay.session.exerciseCount}`,
+      },
+      {
+        label: 'Started',
+        value: timeFormatter.format(new Date(selectedDay.session.startedAt)),
+      },
     ];
   }
 
@@ -398,13 +365,13 @@ function getDetailStats(selectedDay: DayDetails) {
   ];
 }
 
-function getDefaultSelectedDateKey(month: Date): string {
-  const monthActivity = [...new Set([...scheduleByDate.keys(), ...sessionByDate.keys()])]
+function getDefaultSelectedDateKey(month: Date, sessionByDate: Map<string, WorkoutSessionListItem>): string {
+  const monthActivity = [...sessionByDate.keys()]
     .map((dateKey) => parseDateKey(dateKey))
     .filter((date) => isSameMonth(date, month))
     .sort((left, right) => left.getTime() - right.getTime());
 
-  if (isSameMonth(parseDateKey(TODAY_KEY), month) && hasWorkoutEntry(TODAY_KEY)) {
+  if (isSameMonth(parseDateKey(TODAY_KEY), month) && hasWorkoutEntry(TODAY_KEY, sessionByDate)) {
     return TODAY_KEY;
   }
 
@@ -415,9 +382,8 @@ function getDefaultSelectedDateKey(month: Date): string {
   return isSameMonth(parseDateKey(TODAY_KEY), month) ? TODAY_KEY : toDateKey(month);
 }
 
-function hasWorkoutEntry(dateKey: string) {
-  const details = getDayDetails(dateKey);
-  return details.status === 'completed' || details.status === 'scheduled';
+function hasWorkoutEntry(dateKey: string, sessionByDate: Map<string, WorkoutSessionListItem>) {
+  return sessionByDate.has(dateKey);
 }
 
 function buildCalendarDays(month: Date): Date[] {

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import type { WorkoutSessionListItem } from '@pulse/shared';
+import { Link } from 'react-router';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -297,7 +298,7 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
               size="sm"
               variant="secondary"
             >
-              <a href={detailHref}>View Session</a>
+              <Link to={detailHref}>View Session</Link>
             </Button>
           ) : null}
         </aside>

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -65,6 +65,7 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
     [templatesQuery.data],
   );
   const sessionByDate = useMemo(
+    // Calendar displays one completed session per day; if multiple exist, the latest item in the array wins.
     () => new Map((completedQuery.data ?? []).map((session) => [session.date, session])),
     [completedQuery.data],
   );

--- a/apps/web/src/features/workouts/components/workout-list.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.test.tsx
@@ -1,74 +1,154 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import type { WorkoutSessionListItem } from '@pulse/shared';
 import { MemoryRouter } from 'react-router';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
 import { parseDateKey, startOfWeek, toDateKey } from '@/lib/date-utils';
-import { mockTemplates } from '@/lib/mock-data/workouts';
+import { renderWithQueryClient } from '@/test/render-with-query-client';
+import { jsonResponse } from '@/test/test-utils';
 
-import { workoutCompletedSessions } from '..';
 import { WorkoutList } from './workout-list';
 
+beforeEach(() => {
+  window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
+});
+
+afterEach(() => {
+  window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
+  vi.restoreAllMocks();
+});
+
 describe('WorkoutList', () => {
-  it('groups completed sessions by Monday-based week in reverse chronological order', () => {
+  it('groups completed sessions by Monday-based week in reverse chronological order', async () => {
+    const sessions = [
+      createSession({
+        id: 'session-1',
+        date: '2026-03-08',
+        templateId: 'template-push',
+        templateName: 'Upper Push',
+      }),
+      createSession({
+        id: 'session-2',
+        date: '2026-03-04',
+        templateId: 'template-push',
+        templateName: 'Upper Push',
+      }),
+      createSession({
+        id: 'session-3',
+        date: '2026-02-26',
+        templateId: 'template-legs',
+        templateName: 'Lower Body',
+      }),
+    ];
+
+    mockWorkoutListRequests({ sessions });
     renderWorkoutList();
+
+    expect((await screen.findAllByRole('link', { name: /upper push/i })).length).toBeGreaterThan(0);
 
     const headings = screen
       .getAllByRole('heading', { level: 2 })
       .map((heading) => heading.textContent);
 
-    expect(headings).toEqual(getExpectedWeekHeadings(workoutCompletedSessions));
+    expect(headings).toEqual(getExpectedWeekHeadings(sessions));
   });
 
-  it('renders each workout card with summary stats and a session detail link', () => {
-    const session = workoutCompletedSessions[workoutCompletedSessions.length - 1];
-    const template = mockTemplates.find((item) => item.id === session?.templateId);
-    const totalSets =
-      session?.exercises.reduce((count, exercise) => count + exercise.sets.length, 0) ?? 0;
+  it('renders a workout card with summary stats and session detail link', async () => {
+    const sessions = [
+      createSession({
+        id: 'session-10',
+        date: '2026-03-10',
+        templateId: 'template-push',
+        templateName: 'Upper Push',
+        exerciseCount: 7,
+        duration: 53,
+      }),
+    ];
 
+    mockWorkoutListRequests({ sessions });
     renderWorkoutList();
 
-    expect(
-      screen
-        .getAllByRole('link')
-        .some((link) => link.getAttribute('href') === `/workouts/session/${session?.id}`),
-    ).toBe(true);
-    expect(screen.getAllByText(template?.name ?? '').length).toBeGreaterThan(0);
-    expect(
-      screen.getAllByText(`${template?.sections.length ?? 0} sections`).length,
-    ).toBeGreaterThan(0);
-    expect(
-      screen.getAllByText(`${session?.exercises.length ?? 0} exercises`).length,
-    ).toBeGreaterThan(0);
-    expect(screen.getAllByText(`${totalSets} sets`).length).toBeGreaterThan(0);
+    expect(await screen.findByRole('link', { name: /upper push/i })).toHaveAttribute(
+      'href',
+      '/workouts/session/session-10',
+    );
+    expect(screen.getByText('53 min')).toBeInTheDocument();
+    expect(screen.getByText('7 exercises')).toBeInTheDocument();
   });
 
-  it('omits empty weeks instead of rendering gap headers', () => {
-    renderWorkoutList(
-      [workoutCompletedSessions[0], workoutCompletedSessions[workoutCompletedSessions.length - 1]]
-        .filter(isDefined),
-    );
+  it('shows an empty state when no completed sessions are returned', async () => {
+    mockWorkoutListRequests({ sessions: [] });
+    renderWorkoutList();
 
-    expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(2);
+    expect(await screen.findByText('No completed workouts yet.')).toBeInTheDocument();
   });
 });
 
-function renderWorkoutList(sessions = workoutCompletedSessions) {
-  return render(
+function renderWorkoutList() {
+  return renderWithQueryClient(
     <MemoryRouter>
-      <WorkoutList sessions={sessions} />
+      <WorkoutList />
     </MemoryRouter>,
   );
 }
 
-function getExpectedWeekHeadings(sessions: typeof workoutCompletedSessions) {
+function mockWorkoutListRequests({ sessions }: { sessions: WorkoutSessionListItem[] }) {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+    const url = String(input);
+
+    if (url.includes('/api/v1/workout-sessions?status=completed')) {
+      return Promise.resolve(jsonResponse({ data: sessions }));
+    }
+
+    if (url.includes('/api/v1/workout-templates')) {
+      return Promise.resolve(
+        jsonResponse({
+          data: [
+            {
+              id: 'template-push',
+              userId: 'user-1',
+              name: 'Upper Push',
+              description: null,
+              tags: ['push'],
+              sections: [
+                { type: 'warmup', exercises: [] },
+                { type: 'main', exercises: [] },
+                { type: 'cooldown', exercises: [] },
+              ],
+              createdAt: 1,
+              updatedAt: 1,
+            },
+            {
+              id: 'template-legs',
+              userId: 'user-1',
+              name: 'Lower Body',
+              description: null,
+              tags: ['legs'],
+              sections: [
+                { type: 'warmup', exercises: [] },
+                { type: 'main', exercises: [] },
+                { type: 'cooldown', exercises: [] },
+              ],
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          ],
+        }),
+      );
+    }
+
+    throw new Error(`Unhandled request: ${url}`);
+  });
+}
+
+function getExpectedWeekHeadings(sessions: WorkoutSessionListItem[]) {
   const formatter = new Intl.DateTimeFormat('en-US', {
     month: 'short',
     day: 'numeric',
   });
 
-  const weekStarts = [
-    ...new Set(sessions.map((session) => toWeekKey(session.startedAt.slice(0, 10)))),
-  ]
+  const weekStarts = [...new Set(sessions.map((session) => toWeekKey(session.date)))]
     .map(parseDateKey)
     .sort((left, right) => right.getTime() - left.getTime());
 
@@ -79,6 +159,19 @@ function toWeekKey(dateKey: string) {
   return toDateKey(startOfWeek(parseDateKey(dateKey)));
 }
 
-function isDefined<T>(value: T | undefined): value is T {
-  return value !== undefined;
+function createSession(overrides: Partial<WorkoutSessionListItem>): WorkoutSessionListItem {
+  return {
+    id: 'session-default',
+    name: 'Workout Session',
+    date: '2026-03-10',
+    status: 'completed',
+    templateId: null,
+    templateName: null,
+    startedAt: Date.parse('2026-03-10T18:00:00Z'),
+    completedAt: Date.parse('2026-03-10T19:00:00Z'),
+    duration: 60,
+    exerciseCount: 5,
+    createdAt: 1,
+    ...overrides,
+  };
 }

--- a/apps/web/src/features/workouts/components/workout-list.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.test.tsx
@@ -1,57 +1,48 @@
 import { screen } from '@testing-library/react';
 import type { WorkoutSessionListItem } from '@pulse/shared';
 import { MemoryRouter } from 'react-router';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
-import { parseDateKey, startOfWeek, toDateKey } from '@/lib/date-utils';
 import { renderWithQueryClient } from '@/test/render-with-query-client';
-import { jsonResponse } from '@/test/test-utils';
 
 import { WorkoutList } from './workout-list';
 
-beforeEach(() => {
-  window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
-});
-
-afterEach(() => {
-  window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
-  vi.restoreAllMocks();
-});
-
 describe('WorkoutList', () => {
-  it('groups completed sessions by Monday-based week in reverse chronological order', async () => {
+  it('groups sessions into upcoming and completed sections with status-specific indicators', async () => {
     const sessions = [
       createSession({
-        id: 'session-1',
-        date: '2026-03-08',
+        id: 'session-upcoming',
+        date: '2026-03-14',
+        status: 'scheduled',
         templateId: 'template-push',
         templateName: 'Upper Push',
       }),
       createSession({
-        id: 'session-2',
-        date: '2026-03-04',
+        id: 'session-in-progress',
+        date: '2026-03-12',
+        status: 'in-progress',
         templateId: 'template-push',
         templateName: 'Upper Push',
       }),
       createSession({
-        id: 'session-3',
-        date: '2026-02-26',
+        id: 'session-completed',
+        date: '2026-03-10',
+        status: 'completed',
         templateId: 'template-legs',
         templateName: 'Lower Body',
+        duration: 49,
       }),
     ];
 
-    mockWorkoutListRequests({ sessions });
-    renderWorkoutList();
+    renderWorkoutList(sessions);
 
-    expect((await screen.findAllByRole('link', { name: /upper push/i })).length).toBeGreaterThan(0);
-
-    const headings = screen
-      .getAllByRole('heading', { level: 2 })
-      .map((heading) => heading.textContent);
-
-    expect(headings).toEqual(getExpectedWeekHeadings(sessions));
+    expect(await screen.findByRole('heading', { level: 2, name: 'Upcoming' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Completed' })).toBeInTheDocument();
+    expect(screen.getByText('Planned')).toBeInTheDocument();
+    expect(screen.getAllByText('In Progress').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Completed').length).toBeGreaterThan(0);
+    expect(screen.getByText(/Scheduled /)).toBeInTheDocument();
+    expect(screen.getByText('49 min')).toBeInTheDocument();
   });
 
   it('renders a workout card with summary stats and session detail link', async () => {
@@ -59,6 +50,7 @@ describe('WorkoutList', () => {
       createSession({
         id: 'session-10',
         date: '2026-03-10',
+        status: 'completed',
         templateId: 'template-push',
         templateName: 'Upper Push',
         exerciseCount: 7,
@@ -66,8 +58,7 @@ describe('WorkoutList', () => {
       }),
     ];
 
-    mockWorkoutListRequests({ sessions });
-    renderWorkoutList();
+    renderWorkoutList(sessions);
 
     expect(await screen.findByRole('link', { name: /upper push/i })).toHaveAttribute(
       'href',
@@ -77,86 +68,39 @@ describe('WorkoutList', () => {
     expect(screen.getByText('7 exercises')).toBeInTheDocument();
   });
 
-  it('shows an empty state when no completed sessions are returned', async () => {
-    mockWorkoutListRequests({ sessions: [] });
-    renderWorkoutList();
+  it('shows planned-workout onboarding when no scheduled sessions exist', async () => {
+    renderWorkoutList([
+      createSession({
+        id: 'session-11',
+        status: 'completed',
+        date: '2026-03-01',
+      }),
+    ]);
 
-    expect(await screen.findByText('No completed workouts yet.')).toBeInTheDocument();
+    expect(await screen.findByText('No workouts planned')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Plan a workout' })).toHaveAttribute(
+      'href',
+      '/workouts?view=templates',
+    );
+    expect(screen.getByRole('link', { name: 'Browse templates' })).toHaveAttribute(
+      'href',
+      '/workouts?view=templates',
+    );
+  });
+
+  it('shows an empty state when no workout sessions are returned', async () => {
+    renderWorkoutList([]);
+
+    expect(await screen.findByText('No workouts yet. Plan one to get started.')).toBeInTheDocument();
   });
 });
 
-function renderWorkoutList() {
+function renderWorkoutList(sessions: WorkoutSessionListItem[]) {
   return renderWithQueryClient(
     <MemoryRouter>
-      <WorkoutList />
+      <WorkoutList sessions={sessions} />
     </MemoryRouter>,
   );
-}
-
-function mockWorkoutListRequests({ sessions }: { sessions: WorkoutSessionListItem[] }) {
-  vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
-    const url = String(input);
-
-    if (url.includes('/api/v1/workout-sessions?status=completed')) {
-      return Promise.resolve(jsonResponse({ data: sessions }));
-    }
-
-    if (url.includes('/api/v1/workout-templates')) {
-      return Promise.resolve(
-        jsonResponse({
-          data: [
-            {
-              id: 'template-push',
-              userId: 'user-1',
-              name: 'Upper Push',
-              description: null,
-              tags: ['push'],
-              sections: [
-                { type: 'warmup', exercises: [] },
-                { type: 'main', exercises: [] },
-                { type: 'cooldown', exercises: [] },
-              ],
-              createdAt: 1,
-              updatedAt: 1,
-            },
-            {
-              id: 'template-legs',
-              userId: 'user-1',
-              name: 'Lower Body',
-              description: null,
-              tags: ['legs'],
-              sections: [
-                { type: 'warmup', exercises: [] },
-                { type: 'main', exercises: [] },
-                { type: 'cooldown', exercises: [] },
-              ],
-              createdAt: 1,
-              updatedAt: 1,
-            },
-          ],
-        }),
-      );
-    }
-
-    throw new Error(`Unhandled request: ${url}`);
-  });
-}
-
-function getExpectedWeekHeadings(sessions: WorkoutSessionListItem[]) {
-  const formatter = new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-  });
-
-  const weekStarts = [...new Set(sessions.map((session) => toWeekKey(session.date)))]
-    .map(parseDateKey)
-    .sort((left, right) => right.getTime() - left.getTime());
-
-  return weekStarts.map((weekStart) => `Week of ${formatter.format(weekStart)}`);
-}
-
-function toWeekKey(dateKey: string) {
-  return toDateKey(startOfWeek(parseDateKey(dateKey)));
 }
 
 function createSession(overrides: Partial<WorkoutSessionListItem>): WorkoutSessionListItem {

--- a/apps/web/src/features/workouts/components/workout-list.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.test.tsx
@@ -88,6 +88,19 @@ describe('WorkoutList', () => {
     );
   });
 
+  it('does not show planned-workout onboarding when an in-progress session exists', async () => {
+    renderWorkoutList([
+      createSession({
+        id: 'session-12',
+        status: 'in-progress',
+        date: '2026-03-11',
+      }),
+    ]);
+
+    expect(screen.getAllByText('In Progress').length).toBeGreaterThan(0);
+    expect(screen.queryByText('No workouts planned')).not.toBeInTheDocument();
+  });
+
   it('shows an empty state when no workout sessions are returned', async () => {
     renderWorkoutList([]);
 

--- a/apps/web/src/features/workouts/components/workout-list.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.tsx
@@ -1,15 +1,12 @@
-import { CalendarDays, Dumbbell, Layers3, ListChecks } from 'lucide-react';
+import { CalendarDays, Dumbbell, Timer } from 'lucide-react';
 import { Link } from 'react-router';
+import type { WorkoutSessionListItem, WorkoutTemplate } from '@pulse/shared';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { addDays, parseDateKey, startOfWeek, toDateKey } from '@/lib/date-utils';
 import { cn } from '@/lib/utils';
-import {
-  mockTemplates,
-  type WorkoutTemplate,
-} from '@/lib/mock-data/workouts';
-import { workoutCompletedSessions } from '../lib/mock-data';
-import type { ActiveWorkoutCompletedSession } from '../types';
+
+import { useCompletedSessions, useWorkoutTemplates } from '../api/workouts';
 
 const weekOfFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'short',
@@ -24,35 +21,50 @@ const sessionDateFormatter = new Intl.DateTimeFormat('en-US', {
 
 type WorkoutListProps = {
   buildSessionHref?: (sessionId: string) => string;
-  sessions?: ActiveWorkoutCompletedSession[];
+  sessions?: WorkoutSessionListItem[];
 };
 
 type WorkoutWeekGroup = {
   weekKey: string;
   weekStart: Date;
   weekEnd: Date;
-  sessions: WorkoutListItem[];
+  sessions: WorkoutListViewItem[];
 };
 
-type WorkoutListItem = {
+type WorkoutListViewItem = {
   accentColor: string;
   badgeClass: string;
   date: Date;
+  duration: number | null;
   exerciseCount: number;
   id: string;
   name: string;
-  sectionCount: number;
-  totalSets: number;
   typeLabel: string;
 };
 
-const templateById = new Map(mockTemplates.map((template) => [template.id, template]));
-
 export function WorkoutList({
   buildSessionHref = (sessionId) => `/workouts/session/${sessionId}`,
-  sessions = workoutCompletedSessions,
+  sessions,
 }: WorkoutListProps) {
-  const weekGroups = groupSessionsByWeek(sessions);
+  const completedQuery = useCompletedSessions();
+  const templatesQuery = useWorkoutTemplates();
+
+  const resolvedSessions = sessions ?? completedQuery.data ?? [];
+  const templateById = new Map(
+    (templatesQuery.data ?? []).map((template) => [template.id, template]),
+  );
+
+  const weekGroups = groupSessionsByWeek(resolvedSessions, templateById);
+
+  if (completedQuery.isLoading && !sessions) {
+    return (
+      <Card>
+        <CardContent className="py-6">
+          <p className="text-sm text-muted">Loading completed workouts…</p>
+        </CardContent>
+      </Card>
+    );
+  }
 
   if (weekGroups.length === 0) {
     return (
@@ -118,11 +130,12 @@ export function WorkoutList({
                     <ul className="flex flex-wrap gap-3 text-sm text-muted">
                       <WorkoutStat
                         icon={CalendarDays}
-                        label={`${sessionDateFormatter.format(session.date)}`}
+                        label={sessionDateFormatter.format(session.date)}
                       />
-                      <WorkoutStat icon={Layers3} label={`${session.sectionCount} sections`} />
+                      {session.duration != null ? (
+                        <WorkoutStat icon={Timer} label={`${session.duration} min`} />
+                      ) : null}
                       <WorkoutStat icon={Dumbbell} label={`${session.exerciseCount} exercises`} />
-                      <WorkoutStat icon={ListChecks} label={`${session.totalSets} sets`} />
                     </ul>
                   </CardContent>
                 </Card>
@@ -144,11 +157,14 @@ function WorkoutStat({ icon: Icon, label }: { icon: typeof CalendarDays; label: 
   );
 }
 
-function groupSessionsByWeek(sessions: ActiveWorkoutCompletedSession[]): WorkoutWeekGroup[] {
+function groupSessionsByWeek(
+  sessions: WorkoutSessionListItem[],
+  templateById: Map<string, WorkoutTemplate>,
+): WorkoutWeekGroup[] {
   const groups = new Map<string, WorkoutWeekGroup>();
 
   for (const session of sessions) {
-    const sessionDate = parseDateKey(session.startedAt.slice(0, 10));
+    const sessionDate = parseDateKey(session.date);
     const weekStart = startOfWeek(sessionDate);
     const weekKey = toDateKey(weekStart);
     const weekEnd = addDays(weekStart, 6);
@@ -159,7 +175,7 @@ function groupSessionsByWeek(sessions: ActiveWorkoutCompletedSession[]): Workout
       sessions: [],
     };
 
-    group.sessions.push(buildWorkoutListItem(session));
+    group.sessions.push(buildWorkoutListItem(session, templateById));
     groups.set(weekKey, group);
   }
 
@@ -171,22 +187,22 @@ function groupSessionsByWeek(sessions: ActiveWorkoutCompletedSession[]): Workout
     .sort((left, right) => right.weekStart.getTime() - left.weekStart.getTime());
 }
 
-function buildWorkoutListItem(session: ActiveWorkoutCompletedSession): WorkoutListItem {
-  const template = templateById.get(session.templateId);
-  const date = parseDateKey(session.startedAt.slice(0, 10));
-  const exerciseCount = session.exercises.length;
-  const totalSets = session.exercises.reduce((count, exercise) => count + exercise.sets.length, 0);
+function buildWorkoutListItem(
+  session: WorkoutSessionListItem,
+  templateById: Map<string, WorkoutTemplate>,
+): WorkoutListViewItem {
+  const template = session.templateId ? templateById.get(session.templateId) : undefined;
+  const date = parseDateKey(session.date);
   const presentation = getWorkoutPresentation(template);
 
   return {
     accentColor: presentation.accentColor,
     badgeClass: presentation.badgeClass,
     date,
-    exerciseCount,
+    duration: session.duration,
+    exerciseCount: session.exerciseCount,
     id: session.id,
-    name: template?.name ?? 'Workout Session',
-    sectionCount: template?.sections.length ?? 0,
-    totalSets,
+    name: session.templateName ?? session.name,
     typeLabel: presentation.typeLabel,
   };
 }

--- a/apps/web/src/features/workouts/components/workout-list.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.tsx
@@ -1,4 +1,4 @@
-import { CalendarCheck2, CalendarDays, CalendarPlus2, CheckCircle2, Dot, Dumbbell, Timer } from 'lucide-react';
+import { Activity, CalendarCheck2, CalendarDays, CalendarPlus2, CheckCircle2, Dumbbell, Timer } from 'lucide-react';
 import { Link } from 'react-router';
 import type { WorkoutSessionListItem, WorkoutSessionStatus } from '@pulse/shared';
 
@@ -50,7 +50,9 @@ export function WorkoutList({
   const completedSessions = listItems
     .filter((session) => session.status === 'completed')
     .sort((left, right) => right.date.getTime() - left.date.getTime());
-  const hasPlannedWorkouts = listItems.some((session) => session.status === 'scheduled');
+  const hasPlannedWorkouts = listItems.some(
+    (session) => session.status === 'scheduled' || session.status === 'in-progress',
+  );
 
   if (sessionsQuery.isLoading && !sessions) {
     return (
@@ -260,7 +262,7 @@ function buildStatusStats(session: WorkoutListViewItem) {
   if (session.status === 'in-progress') {
     return [
       { icon: CalendarDays, label: sessionDateFormatter.format(session.date) },
-      { icon: Dot, label: 'In Progress' },
+      { icon: Activity, label: 'In Progress' },
       { icon: Dumbbell, label: `${session.exerciseCount} exercises` },
     ];
   }

--- a/apps/web/src/features/workouts/components/workout-list.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.tsx
@@ -1,17 +1,12 @@
-import { CalendarDays, Dumbbell, Timer } from 'lucide-react';
+import { CalendarCheck2, CalendarDays, CalendarPlus2, CheckCircle2, Dot, Dumbbell, Timer } from 'lucide-react';
 import { Link } from 'react-router';
-import type { WorkoutSessionListItem, WorkoutTemplate } from '@pulse/shared';
+import type { WorkoutSessionListItem, WorkoutSessionStatus } from '@pulse/shared';
 
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { addDays, parseDateKey, startOfWeek, toDateKey } from '@/lib/date-utils';
 import { cn } from '@/lib/utils';
 
-import { useCompletedSessions, useWorkoutTemplates } from '../api/workouts';
-
-const weekOfFormatter = new Intl.DateTimeFormat('en-US', {
-  month: 'short',
-  day: 'numeric',
-});
+import { useWorkoutSessions } from '../api/workouts';
 
 const sessionDateFormatter = new Intl.DateTimeFormat('en-US', {
   weekday: 'short',
@@ -21,56 +16,57 @@ const sessionDateFormatter = new Intl.DateTimeFormat('en-US', {
 
 type WorkoutListProps = {
   buildSessionHref?: (sessionId: string) => string;
+  buildTemplatesHref?: () => string;
+  buildPlanWorkoutHref?: () => string;
   sessions?: WorkoutSessionListItem[];
-};
-
-type WorkoutWeekGroup = {
-  weekKey: string;
-  weekStart: Date;
-  weekEnd: Date;
-  sessions: WorkoutListViewItem[];
 };
 
 type WorkoutListViewItem = {
   accentColor: string;
-  badgeClass: string;
+  cardClass: string;
   date: Date;
   duration: number | null;
   exerciseCount: number;
   id: string;
   name: string;
-  typeLabel: string;
+  status: WorkoutSessionStatus;
+  statusBadgeClass: string;
+  statusLabel: string;
 };
 
 export function WorkoutList({
   buildSessionHref = (sessionId) => `/workouts/session/${sessionId}`,
+  buildTemplatesHref = () => '/workouts?view=templates',
+  buildPlanWorkoutHref = () => '/workouts?view=templates',
   sessions,
 }: WorkoutListProps) {
-  const completedQuery = useCompletedSessions();
-  const templatesQuery = useWorkoutTemplates();
+  const sessionsQuery = useWorkoutSessions({}, { enabled: sessions === undefined });
 
-  const resolvedSessions = sessions ?? completedQuery.data ?? [];
-  const templateById = new Map(
-    (templatesQuery.data ?? []).map((template) => [template.id, template]),
-  );
+  const resolvedSessions = sessions ?? sessionsQuery.data ?? [];
+  const listItems = resolvedSessions.map((session) => buildWorkoutListItem(session));
+  const upcomingSessions = listItems
+    .filter((session) => session.status !== 'completed')
+    .sort((left, right) => left.date.getTime() - right.date.getTime());
+  const completedSessions = listItems
+    .filter((session) => session.status === 'completed')
+    .sort((left, right) => right.date.getTime() - left.date.getTime());
+  const hasPlannedWorkouts = listItems.some((session) => session.status === 'scheduled');
 
-  const weekGroups = groupSessionsByWeek(resolvedSessions, templateById);
-
-  if (completedQuery.isLoading && !sessions) {
+  if (sessionsQuery.isLoading && !sessions) {
     return (
       <Card>
         <CardContent className="py-6">
-          <p className="text-sm text-muted">Loading completed workouts…</p>
+          <p className="text-sm text-muted">Loading workouts…</p>
         </CardContent>
       </Card>
     );
   }
 
-  if (weekGroups.length === 0) {
+  if (listItems.length === 0) {
     return (
       <Card>
         <CardContent className="py-6">
-          <p className="text-sm text-muted">No completed workouts yet.</p>
+          <p className="text-sm text-muted">No workouts yet. Plan one to get started.</p>
         </CardContent>
       </Card>
     );
@@ -78,73 +74,121 @@ export function WorkoutList({
 
   return (
     <div className="space-y-6">
-      {weekGroups.map((group) => (
-        <section className="space-y-3" key={group.weekKey}>
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <div className="space-y-1">
-              <h2 className="text-xl font-semibold text-foreground">
-                {`Week of ${weekOfFormatter.format(group.weekStart)}`}
-              </h2>
-              <p className="text-sm text-muted">
-                {formatWeekRange(group.weekStart, group.weekEnd)}
-              </p>
-            </div>
-
-            <span className="inline-flex w-fit rounded-full bg-[var(--color-accent-cream)] px-3 py-1 text-xs font-semibold tracking-[0.18em] text-on-cream uppercase dark:bg-amber-500/20 dark:text-amber-400">
-              {`${group.sessions.length} workout${group.sessions.length === 1 ? '' : 's'}`}
-            </span>
-          </div>
-
+      <section className="space-y-3">
+        <SectionHeading count={upcomingSessions.length} title="Upcoming" />
+        {!hasPlannedWorkouts ? (
+          <Card className="border-dashed">
+            <CardContent className="space-y-4 py-5">
+              <div className="space-y-1">
+                <h3 className="text-base font-semibold">No workouts planned</h3>
+                <p className="text-sm text-muted">
+                  Start by picking a template and scheduling your next session.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button asChild size="sm">
+                  <Link to={buildPlanWorkoutHref()}>Plan a workout</Link>
+                </Button>
+                <Button asChild size="sm" variant="secondary">
+                  <Link to={buildTemplatesHref()}>Browse templates</Link>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ) : null}
+        {upcomingSessions.length > 0 ? (
           <div className="grid gap-3">
-            {group.sessions.map((session) => (
-              <Link
-                className="block cursor-pointer rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+            {upcomingSessions.map((session) => (
+              <WorkoutListCard
+                buildSessionHref={buildSessionHref}
                 key={session.id}
-                to={buildSessionHref(session.id)}
-              >
-                <Card
-                  className="h-full gap-4 border-l-4 py-0 transition-transform duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
-                  style={{ borderLeftColor: session.accentColor }}
-                >
-                  <CardHeader className="gap-3 py-5">
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                      <div className="space-y-1">
-                        <CardTitle>{session.name}</CardTitle>
-                        <p className="text-sm text-muted">
-                          {sessionDateFormatter.format(session.date)}
-                        </p>
-                      </div>
-
-                      <span
-                        className={cn(
-                          'inline-flex w-fit rounded-full px-3 py-1 text-[11px] font-semibold tracking-[0.18em] uppercase',
-                          session.badgeClass,
-                        )}
-                      >
-                        {session.typeLabel}
-                      </span>
-                    </div>
-                  </CardHeader>
-
-                  <CardContent className="pb-5">
-                    <ul className="flex flex-wrap gap-3 text-sm text-muted">
-                      <WorkoutStat
-                        icon={CalendarDays}
-                        label={sessionDateFormatter.format(session.date)}
-                      />
-                      {session.duration != null ? (
-                        <WorkoutStat icon={Timer} label={`${session.duration} min`} />
-                      ) : null}
-                      <WorkoutStat icon={Dumbbell} label={`${session.exerciseCount} exercises`} />
-                    </ul>
-                  </CardContent>
-                </Card>
-              </Link>
+                session={session}
+              />
             ))}
           </div>
-        </section>
-      ))}
+        ) : (
+          <p className="text-sm text-muted">No upcoming sessions right now.</p>
+        )}
+      </section>
+
+      <section className="space-y-3">
+        <SectionHeading count={completedSessions.length} title="Completed" />
+        {completedSessions.length > 0 ? (
+          <div className="grid gap-3">
+            {completedSessions.map((session) => (
+              <WorkoutListCard
+                buildSessionHref={buildSessionHref}
+                key={session.id}
+                session={session}
+              />
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-muted">No completed workouts yet.</p>
+        )}
+      </section>
     </div>
+  );
+}
+
+function SectionHeading({ count, title }: { count: number; title: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <h2 className="text-xl font-semibold text-foreground">{title}</h2>
+      <span className="rounded-full border border-border bg-secondary/50 px-2.5 py-1 text-xs font-semibold text-muted">
+        {`${count} workout${count === 1 ? '' : 's'}`}
+      </span>
+    </div>
+  );
+}
+
+function WorkoutListCard({
+  buildSessionHref,
+  session,
+}: {
+  buildSessionHref: (sessionId: string) => string;
+  session: WorkoutListViewItem;
+}) {
+  return (
+    <Link
+      className="block cursor-pointer rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+      to={buildSessionHref(session.id)}
+    >
+      <Card
+        className={cn(
+          'h-full gap-4 border-l-4 py-0 transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-md',
+          session.cardClass,
+        )}
+        style={{ borderLeftColor: session.accentColor }}
+      >
+        <CardHeader className="gap-3 py-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-1">
+              <CardTitle>{session.name}</CardTitle>
+              <p className="text-sm text-muted">{sessionDateFormatter.format(session.date)}</p>
+            </div>
+
+            <span
+              className={cn(
+                'inline-flex w-fit items-center gap-1 rounded-full px-3 py-1 text-[11px] font-semibold tracking-[0.18em] uppercase',
+                session.statusBadgeClass,
+              )}
+            >
+              {getStatusBadgeIcon(session.status)}
+              {session.statusLabel}
+            </span>
+          </div>
+        </CardHeader>
+
+        <CardContent className="pb-5">
+          <ul className="flex flex-wrap gap-3 text-sm text-muted">
+            {buildStatusStats(session).map((stat) => (
+              <WorkoutStat icon={stat.icon} key={`${session.id}-${stat.label}`} label={stat.label} />
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+    </Link>
   );
 }
 
@@ -157,90 +201,84 @@ function WorkoutStat({ icon: Icon, label }: { icon: typeof CalendarDays; label: 
   );
 }
 
-function groupSessionsByWeek(
-  sessions: WorkoutSessionListItem[],
-  templateById: Map<string, WorkoutTemplate>,
-): WorkoutWeekGroup[] {
-  const groups = new Map<string, WorkoutWeekGroup>();
-
-  for (const session of sessions) {
-    const sessionDate = parseDateKey(session.date);
-    const weekStart = startOfWeek(sessionDate);
-    const weekKey = toDateKey(weekStart);
-    const weekEnd = addDays(weekStart, 6);
-    const group = groups.get(weekKey) ?? {
-      weekKey,
-      weekStart,
-      weekEnd,
-      sessions: [],
-    };
-
-    group.sessions.push(buildWorkoutListItem(session, templateById));
-    groups.set(weekKey, group);
-  }
-
-  return [...groups.values()]
-    .map((group) => ({
-      ...group,
-      sessions: group.sessions.sort((left, right) => right.date.getTime() - left.date.getTime()),
-    }))
-    .sort((left, right) => right.weekStart.getTime() - left.weekStart.getTime());
-}
-
-function buildWorkoutListItem(
-  session: WorkoutSessionListItem,
-  templateById: Map<string, WorkoutTemplate>,
-): WorkoutListViewItem {
-  const template = session.templateId ? templateById.get(session.templateId) : undefined;
-  const date = parseDateKey(session.date);
-  const presentation = getWorkoutPresentation(template);
+function buildWorkoutListItem(session: WorkoutSessionListItem): WorkoutListViewItem {
+  const date = new Date(`${session.date}T12:00:00`);
+  const presentation = getWorkoutPresentation(session.status);
 
   return {
     accentColor: presentation.accentColor,
-    badgeClass: presentation.badgeClass,
+    cardClass: presentation.cardClass,
     date,
     duration: session.duration,
     exerciseCount: session.exerciseCount,
     id: session.id,
     name: session.templateName ?? session.name,
-    typeLabel: presentation.typeLabel,
+    status: session.status,
+    statusBadgeClass: presentation.statusBadgeClass,
+    statusLabel: presentation.statusLabel,
   };
 }
 
-function getWorkoutPresentation(template?: WorkoutTemplate) {
-  if (template?.tags.includes('legs')) {
+function getWorkoutPresentation(status: WorkoutSessionStatus) {
+  if (status === 'completed') {
     return {
-      accentColor: 'var(--color-accent-mint)',
-      badgeClass:
-        'bg-[var(--color-accent-mint)] text-on-mint dark:bg-emerald-500/20 dark:text-emerald-400',
-      typeLabel: 'Legs',
+      accentColor: 'rgb(16 185 129)',
+      cardClass: 'border-emerald-500/40',
+      statusBadgeClass:
+        'bg-emerald-500/15 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400',
+      statusLabel: 'Completed',
     };
   }
 
-  if (template?.tags.includes('push')) {
+  if (status === 'in-progress') {
     return {
-      accentColor: 'var(--color-accent-pink)',
-      badgeClass:
-        'bg-[var(--color-accent-pink)] text-on-pink dark:bg-pink-500/20 dark:text-pink-400',
-      typeLabel: 'Push',
+      accentColor: 'rgb(249 115 22)',
+      cardClass: 'border-orange-500/40',
+      statusBadgeClass:
+        'bg-orange-500/15 text-orange-700 dark:bg-orange-500/20 dark:text-orange-300',
+      statusLabel: 'In Progress',
     };
   }
 
   return {
-    accentColor: 'var(--color-accent-cream)',
-    badgeClass:
-      'bg-[var(--color-accent-cream)] text-on-cream dark:bg-amber-500/20 dark:text-amber-400',
-    typeLabel: 'Full Body',
+    accentColor: 'rgb(148 163 184)',
+    cardClass: 'border-slate-300/70 dark:border-slate-700/70',
+    statusBadgeClass: 'bg-secondary text-muted-foreground',
+    statusLabel: 'Planned',
   };
 }
 
-function formatWeekRange(weekStart: Date, weekEnd: Date) {
-  const startLabel = weekOfFormatter.format(weekStart);
-  const endLabel = weekOfFormatter.format(weekEnd);
-
-  if (weekStart.getFullYear() === weekEnd.getFullYear()) {
-    return `${startLabel} - ${endLabel}, ${weekEnd.getFullYear()}`;
+function buildStatusStats(session: WorkoutListViewItem) {
+  if (session.status === 'completed') {
+    return [
+      { icon: CalendarCheck2, label: sessionDateFormatter.format(session.date) },
+      { icon: Timer, label: session.duration != null ? `${session.duration} min` : 'Duration n/a' },
+      { icon: Dumbbell, label: `${session.exerciseCount} exercises` },
+    ];
   }
 
-  return `${startLabel}, ${weekStart.getFullYear()} - ${endLabel}, ${weekEnd.getFullYear()}`;
+  if (session.status === 'in-progress') {
+    return [
+      { icon: CalendarDays, label: sessionDateFormatter.format(session.date) },
+      { icon: Dot, label: 'In Progress' },
+      { icon: Dumbbell, label: `${session.exerciseCount} exercises` },
+    ];
+  }
+
+  return [
+    { icon: CalendarPlus2, label: `Scheduled ${sessionDateFormatter.format(session.date)}` },
+    { icon: Dumbbell, label: `${session.exerciseCount} exercises` },
+  ];
+}
+
+function getStatusBadgeIcon(status: WorkoutSessionStatus) {
+  if (status === 'completed') {
+    return <CheckCircle2 aria-hidden="true" className="size-3.5" />;
+  }
+
+  if (status === 'in-progress') {
+    return <span aria-hidden="true" className="size-2 rounded-full bg-current animate-pulse" />;
+  }
+
+  return <CalendarDays aria-hidden="true" className="size-3.5" />;
 }

--- a/apps/web/src/features/workouts/lib/session-comparison.ts
+++ b/apps/web/src/features/workouts/lib/session-comparison.ts
@@ -1,21 +1,21 @@
-import { workoutCompletedSessions } from './mock-data';
-
-import type { ActiveWorkoutCompletedSession } from '../types';
+import type { WorkoutSession, WorkoutSessionListItem } from '@pulse/shared';
 
 export function findPreviousTemplateSession(
-  currentSession: ActiveWorkoutCompletedSession,
-): ActiveWorkoutCompletedSession | null {
-  const currentTime = new Date(currentSession.startedAt).getTime();
+  currentSession: WorkoutSession,
+  completedSessions: WorkoutSessionListItem[],
+): WorkoutSessionListItem | null {
+  if (!currentSession.templateId) {
+    return null;
+  }
 
   return (
-    [...workoutCompletedSessions]
-    .filter(
-      (session) =>
-        session.id !== currentSession.id &&
-        session.templateId === currentSession.templateId &&
-        new Date(session.startedAt).getTime() < currentTime,
-    )
-    .sort((left, right) => new Date(right.startedAt).getTime() - new Date(left.startedAt).getTime())[0] ??
-    null
+    [...completedSessions]
+      .filter(
+        (session) =>
+          session.id !== currentSession.id &&
+          session.templateId === currentSession.templateId &&
+          session.startedAt < currentSession.startedAt,
+      )
+      .sort((left, right) => right.startedAt - left.startedAt)[0] ?? null
   );
 }

--- a/apps/web/src/pages/workout-session-detail.test.tsx
+++ b/apps/web/src/pages/workout-session-detail.test.tsx
@@ -143,9 +143,10 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-function renderWithRoute(sessionId: string) {
+function renderWithRoute(sessionId: string, view?: 'list' | 'calendar') {
+  const search = view ? `?view=${view}` : '';
   return renderWithQueryClient(
-    <MemoryRouter initialEntries={[`/workouts/session/${sessionId}`]}>
+    <MemoryRouter initialEntries={[`/workouts/session/${sessionId}${search}`]}>
       <Routes>
         <Route element={<WorkoutSessionDetailPage />} path="/workouts/session/:sessionId" />
       </Routes>
@@ -160,7 +161,17 @@ describe('WorkoutSessionDetailPage', () => {
     expect(await screen.findByText('Session not found', {}, { timeout: 5_000 })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /back to workouts/i })).toHaveAttribute(
       'href',
-      '/workouts',
+      '/workouts?view=calendar',
+    );
+  });
+
+  it('links back to the originating workouts view when view param is present', async () => {
+    renderWithRoute(currentSession.id, 'list');
+
+    expect(await screen.findByText('Upper Push')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /back to workouts/i })).toHaveAttribute(
+      'href',
+      '/workouts?view=list',
     );
   });
 

--- a/apps/web/src/pages/workout-session-detail.test.tsx
+++ b/apps/web/src/pages/workout-session-detail.test.tsx
@@ -1,98 +1,268 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import type { WorkoutSession } from '@pulse/shared';
 import { MemoryRouter, Route, Routes } from 'react-router';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { workoutCompletedSessions } from '@/features/workouts';
-import { mockTemplates } from '@/lib/mock-data/workouts';
+import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
+import { renderWithQueryClient } from '@/test/render-with-query-client';
+import { jsonResponse } from '@/test/test-utils';
+
 import { WorkoutSessionDetailPage } from './workout-session-detail';
 
+const currentSession = createSession();
+const previousSession = createSession({
+  id: 'session-previous',
+  date: '2026-02-20',
+  startedAt: Date.parse('2026-02-20T18:00:00Z'),
+  completedAt: Date.parse('2026-02-20T19:00:00Z'),
+  sets: [
+    createSet({
+      id: 'set-prev-1',
+      exerciseId: 'incline-dumbbell-press',
+      setNumber: 1,
+      reps: 8,
+      weight: 45,
+      section: 'main',
+    }),
+  ],
+});
+
+beforeEach(() => {
+  window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
+
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+    const url = String(input);
+
+    if (url.includes('/api/v1/workout-sessions?status=completed')) {
+      return Promise.resolve(
+        jsonResponse({
+          data: [
+            {
+              id: currentSession.id,
+              name: currentSession.name,
+              date: currentSession.date,
+              status: currentSession.status,
+              templateId: currentSession.templateId,
+              templateName: 'Upper Push',
+              startedAt: currentSession.startedAt,
+              completedAt: currentSession.completedAt,
+              duration: currentSession.duration,
+              exerciseCount: 2,
+              createdAt: currentSession.createdAt,
+            },
+            {
+              id: previousSession.id,
+              name: previousSession.name,
+              date: previousSession.date,
+              status: previousSession.status,
+              templateId: previousSession.templateId,
+              templateName: 'Upper Push',
+              startedAt: previousSession.startedAt,
+              completedAt: previousSession.completedAt,
+              duration: previousSession.duration,
+              exerciseCount: 1,
+              createdAt: previousSession.createdAt,
+            },
+          ],
+        }),
+      );
+    }
+
+    if (url.includes(`/api/v1/workout-sessions/${currentSession.id}`)) {
+      return Promise.resolve(jsonResponse({ data: currentSession }));
+    }
+
+    if (url.includes(`/api/v1/workout-sessions/${previousSession.id}`)) {
+      return Promise.resolve(jsonResponse({ data: previousSession }));
+    }
+
+    if (url.includes('/api/v1/workout-sessions/nonexistent-id')) {
+      return Promise.resolve(
+        jsonResponse(
+          {
+            error: {
+              code: 'WORKOUT_SESSION_NOT_FOUND',
+              message: 'Workout session not found',
+            },
+          },
+          { status: 404 },
+        ),
+      );
+    }
+
+    if (url.includes('/api/v1/workout-templates/template-upper-push')) {
+      return Promise.resolve(
+        jsonResponse({
+          data: {
+            id: 'template-upper-push',
+            userId: 'user-1',
+            name: 'Upper Push',
+            description: null,
+            tags: ['upper-body', 'push'],
+            sections: [
+              {
+                type: 'warmup',
+                exercises: [],
+              },
+              {
+                type: 'main',
+                exercises: [
+                  {
+                    id: 'template-main-1',
+                    exerciseId: 'incline-dumbbell-press',
+                    exerciseName: 'Incline Dumbbell Press',
+                    sets: 3,
+                    repsMin: 8,
+                    repsMax: 10,
+                    tempo: null,
+                    restSeconds: 90,
+                    supersetGroup: null,
+                    notes: null,
+                    cues: [],
+                  },
+                ],
+              },
+              {
+                type: 'cooldown',
+                exercises: [],
+              },
+            ],
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        }),
+      );
+    }
+
+    throw new Error(`Unhandled request: ${url}`);
+  });
+});
+
+afterEach(() => {
+  window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
+  vi.restoreAllMocks();
+});
+
 function renderWithRoute(sessionId: string) {
-  return render(
+  return renderWithQueryClient(
     <MemoryRouter initialEntries={[`/workouts/session/${sessionId}`]}>
       <Routes>
-        <Route path="/workouts/session/:sessionId" element={<WorkoutSessionDetailPage />} />
+        <Route element={<WorkoutSessionDetailPage />} path="/workouts/session/:sessionId" />
       </Routes>
     </MemoryRouter>,
   );
 }
 
 describe('WorkoutSessionDetailPage', () => {
-  it('renders not-found state for unknown sessionId', () => {
+  it('renders not-found state for unknown sessionId', async () => {
     renderWithRoute('nonexistent-id');
 
-    expect(screen.getByText('Session not found')).toBeInTheDocument();
+    expect(await screen.findByText('Session not found', {}, { timeout: 5_000 })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /back to workouts/i })).toHaveAttribute(
       'href',
       '/workouts',
     );
   });
 
-  it('renders session header, summary stats, and tags', () => {
-    const session = workoutCompletedSessions[0];
-    const template = mockTemplates.find((t) => t.id === session.templateId);
-    const totalReps = session.exercises.reduce(
-      (count, exercise) => count + exercise.sets.reduce((sum, set) => sum + set.reps, 0),
-      0,
-    );
+  it('renders session header, summary stats, and tags', async () => {
+    renderWithRoute(currentSession.id);
 
-    renderWithRoute(session.id);
-
-    expect(screen.getByText(template?.name ?? 'Workout Session')).toBeInTheDocument();
-    expect(screen.getByText(`${session.exercises.length}`)).toBeInTheDocument();
-    expect(screen.getByText(`${totalReps}`)).toBeInTheDocument();
-    if (template?.tags) {
-      for (const tag of template.tags) {
-        const formatted = tag
-          .split(/[- ]+/)
-          .filter(Boolean)
-          .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-          .join(' ');
-        expect(screen.getByText(formatted)).toBeInTheDocument();
-      }
-    }
+    expect(await screen.findByText('Upper Push')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('19')).toBeInTheDocument();
+    expect(await screen.findByText('Upper Body')).toBeInTheDocument();
+    expect(screen.getAllByText('Push').length).toBeGreaterThan(0);
   });
 
-  it('renders collapsible section breakdown with logged sets', () => {
-    const session = workoutCompletedSessions[0];
-    renderWithRoute(session.id);
+  it('renders collapsible section breakdown with logged sets', async () => {
+    renderWithRoute(currentSession.id);
 
-    expect(screen.getByText('Section breakdown')).toBeInTheDocument();
+    expect(await screen.findByText('Section breakdown')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Main' }).closest('details')).toHaveAttribute(
       'open',
     );
     expect(screen.getAllByText(/Set 1:/i).length).toBeGreaterThan(0);
-    expect(screen.getByText('Supplemental')).toBeInTheDocument();
   });
 
-  it('renders feedback card when session has feedback', () => {
-    const session = workoutCompletedSessions.find((s) => s.feedback !== null);
-    if (!session || !session.feedback) return;
+  it('renders feedback card when session has feedback', async () => {
+    renderWithRoute(currentSession.id);
 
-    renderWithRoute(session.id);
-
-    expect(screen.getByText('Feedback')).toBeInTheDocument();
-    expect(screen.getByText('Shoulder feel')).toBeInTheDocument();
-    expect(screen.getByText('Coach note')).toBeInTheDocument();
+    expect(await screen.findByText('Feedback')).toBeInTheDocument();
     expect(screen.getByText('Energy')).toBeInTheDocument();
-    expect(screen.getAllByText('Recovery').length).toBeGreaterThan(0);
+    expect(screen.getByText('Recovery')).toBeInTheDocument();
     expect(screen.getByText('Technique')).toBeInTheDocument();
-    expect(screen.getByText(session.feedback.notes ?? '')).toBeInTheDocument();
+    expect(screen.getByText(currentSession.feedback?.notes ?? '')).toBeInTheDocument();
   });
 
-  it('renders session notes when present', () => {
-    const session = workoutCompletedSessions[0];
+  it('renders session notes when present', async () => {
+    renderWithRoute(currentSession.id);
 
-    renderWithRoute(session.id);
-
-    expect(screen.getByText('Session notes')).toBeInTheDocument();
-    expect(screen.getByText(session.notes)).toBeInTheDocument();
+    expect(await screen.findByText('Session notes')).toBeInTheDocument();
+    expect(screen.getByText(currentSession.notes ?? '')).toBeInTheDocument();
   });
 
-  it('renders Repeat Workout button with correct link', () => {
-    const session = workoutCompletedSessions[0];
-    renderWithRoute(session.id);
+  it('renders Repeat Workout button with correct link', async () => {
+    renderWithRoute(currentSession.id);
 
-    const repeatButton = screen.getByRole('link', { name: /repeat workout/i });
-    expect(repeatButton).toHaveAttribute('href', `/workouts/active?template=${session.templateId}`);
+    const repeatButton = await screen.findByRole('link', { name: /repeat workout/i });
+    expect(repeatButton).toHaveAttribute('href', '/workouts/active?template=template-upper-push');
   });
 });
+
+function createSession(overrides: Partial<WorkoutSession> = {}): WorkoutSession {
+  return {
+    id: 'session-current',
+    userId: 'user-1',
+    templateId: 'template-upper-push',
+    name: 'Upper Push',
+    date: '2026-03-02',
+    status: 'completed',
+    startedAt: Date.parse('2026-03-02T18:00:00Z'),
+    completedAt: Date.parse('2026-03-02T19:00:00Z'),
+    duration: 60,
+    feedback: {
+      energy: 4,
+      recovery: 4,
+      technique: 5,
+      notes: 'Strong pressing day.',
+    },
+    notes: 'Solid control and tempo.',
+    sets: [
+      createSet({
+        id: 'set-current-1',
+        exerciseId: 'incline-dumbbell-press',
+        setNumber: 1,
+        reps: 10,
+        weight: 50,
+        section: 'main',
+      }),
+      createSet({
+        id: 'set-current-2',
+        exerciseId: 'incline-dumbbell-press',
+        setNumber: 2,
+        reps: 9,
+        weight: 45,
+        section: 'main',
+      }),
+    ],
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+function createSet(overrides: Partial<WorkoutSession['sets'][number]>): WorkoutSession['sets'][number] {
+  return {
+    id: 'set-default',
+    exerciseId: 'incline-dumbbell-press',
+    setNumber: 1,
+    weight: 50,
+    reps: 10,
+    completed: true,
+    skipped: false,
+    section: 'main',
+    notes: null,
+    createdAt: 1,
+    ...overrides,
+  };
+}

--- a/apps/web/src/pages/workouts.test.tsx
+++ b/apps/web/src/pages/workouts.test.tsx
@@ -102,6 +102,22 @@ const templatesResponse = [
   },
 ];
 
+const completedSessionsResponse = [
+  {
+    id: 'session-1',
+    name: 'Upper Push',
+    date: '2026-03-02',
+    status: 'completed',
+    templateId: 'upper-push',
+    templateName: 'Upper Push',
+    startedAt: Date.parse('2026-03-02T18:00:00Z'),
+    completedAt: Date.parse('2026-03-02T19:00:00Z'),
+    duration: 60,
+    exerciseCount: 6,
+    createdAt: 1,
+  },
+];
+
 describe('WorkoutsPage', () => {
   beforeEach(() => {
     window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
@@ -137,6 +153,17 @@ describe('WorkoutsPage', () => {
         return Promise.resolve(
           jsonResponse({
             data: templatesResponse,
+          }),
+        );
+      }
+
+      if (
+        url.pathname === '/api/v1/workout-sessions' &&
+        url.searchParams.get('status') === 'completed'
+      ) {
+        return Promise.resolve(
+          jsonResponse({
+            data: completedSessionsResponse,
           }),
         );
       }
@@ -197,7 +224,7 @@ describe('WorkoutsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'List' }));
 
     expect(screen.getByRole('button', { name: 'List' })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getAllByRole('heading', { level: 2 }).length).toBeGreaterThan(0);
+    expect(await screen.findByRole('heading', { level: 2, name: /week of/i })).toBeInTheDocument();
     expect(screen.queryByText('Workout Calendar')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Templates' }));
@@ -265,6 +292,17 @@ describe('WorkoutsPage', () => {
         return deferredTemplates.promise;
       }
 
+      if (
+        url.pathname === '/api/v1/workout-sessions' &&
+        url.searchParams.get('status') === 'completed'
+      ) {
+        return Promise.resolve(
+          jsonResponse({
+            data: completedSessionsResponse,
+          }),
+        );
+      }
+
       if (url.pathname === '/api/v1/exercises') {
         return Promise.resolve(
           jsonResponse({
@@ -319,6 +357,17 @@ describe('WorkoutsPage', () => {
         return Promise.resolve(
           jsonResponse({
             data: [],
+          }),
+        );
+      }
+
+      if (
+        url.pathname === '/api/v1/workout-sessions' &&
+        url.searchParams.get('status') === 'completed'
+      ) {
+        return Promise.resolve(
+          jsonResponse({
+            data: completedSessionsResponse,
           }),
         );
       }

--- a/apps/web/src/pages/workouts.test.tsx
+++ b/apps/web/src/pages/workouts.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes, useParams } from 'react-router';
+import { MemoryRouter, Route, Routes, useLocation, useParams } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
@@ -208,6 +208,7 @@ describe('WorkoutsPage', () => {
   it('switches between the workouts views', async () => {
     renderWithQueryClient(
       <MemoryRouter initialEntries={['/workouts']}>
+        <LocationProbe />
         <Routes>
           <Route element={<WorkoutsPage />} path="/workouts" />
         </Routes>
@@ -219,11 +220,13 @@ describe('WorkoutsPage', () => {
       'aria-pressed',
       'true',
     );
+    expect(await screen.findByTestId('location-search')).toHaveTextContent('?view=calendar');
     expect(screen.getByText('Workout Calendar')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'List' }));
 
     expect(screen.getByRole('button', { name: 'List' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('location-search')).toHaveTextContent('?view=list');
     expect(await screen.findByRole('heading', { level: 2, name: /week of/i })).toBeInTheDocument();
     expect(screen.queryByText('Workout Calendar')).not.toBeInTheDocument();
 
@@ -234,6 +237,29 @@ describe('WorkoutsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Exercises' }));
 
     expect(screen.getByRole('heading', { level: 2, name: 'Exercise Library' })).toBeInTheDocument();
+    expect(screen.getByTestId('location-search')).toHaveTextContent('?view=exercises');
+  });
+
+  it('includes the current view in session detail links', async () => {
+    renderWithQueryClient(
+      <MemoryRouter initialEntries={['/workouts?view=list']}>
+        <Routes>
+          <Route element={<WorkoutsPage />} path="/workouts" />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole('button', { name: 'List' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    const detailsLink = (await screen.findAllByRole('link')).find(
+      (link) => link.getAttribute('href') === '/workouts/session/session-1?view=list',
+    );
+    if (!detailsLink) {
+      throw new Error('Expected session detail link with view=list query param');
+    }
+    expect(detailsLink).toHaveAttribute('href', '/workouts/session/session-1?view=list');
   });
 
   it('opens template detail when selecting a template card from the templates view', async () => {
@@ -466,6 +492,11 @@ function TemplateRouteProbe() {
 
 function ActiveWorkoutRouteProbe() {
   return <h1>Active workout page</h1>;
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return <p data-testid="location-search">{location.search}</p>;
 }
 
 function createDeferredResponse() {

--- a/apps/web/src/pages/workouts.test.tsx
+++ b/apps/web/src/pages/workouts.test.tsx
@@ -11,6 +11,8 @@ import { renderWithQueryClient } from '@/test/render-with-query-client';
 import { jsonResponse } from '@/test/test-utils';
 import { WorkoutsPage } from './workouts';
 
+const WORKOUTS_ONBOARDING_DISMISSED_KEY = 'pulse.workouts.onboarding.dismissed';
+
 const templatesResponse = [
   {
     id: 'upper-push',
@@ -118,9 +120,40 @@ const completedSessionsResponse = [
   },
 ];
 
+const allSessionsResponse = [
+  ...completedSessionsResponse,
+  {
+    id: 'session-2',
+    name: 'Lower Quad-Dominant',
+    date: '2026-03-12',
+    status: 'in-progress',
+    templateId: 'lower-quad-dominant',
+    templateName: 'Lower Quad-Dominant',
+    startedAt: Date.parse('2026-03-12T18:00:00Z'),
+    completedAt: null,
+    duration: null,
+    exerciseCount: 4,
+    createdAt: 2,
+  },
+  {
+    id: 'session-3',
+    name: 'Upper Push',
+    date: '2026-03-14',
+    status: 'scheduled',
+    templateId: 'upper-push',
+    templateName: 'Upper Push',
+    startedAt: Date.parse('2026-03-14T18:00:00Z'),
+    completedAt: null,
+    duration: null,
+    exerciseCount: 5,
+    createdAt: 3,
+  },
+];
+
 describe('WorkoutsPage', () => {
   beforeEach(() => {
     window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
+    window.localStorage.removeItem(WORKOUTS_ONBOARDING_DISMISSED_KEY);
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
       const url = new URL(String(input), 'https://pulse.test');
@@ -157,13 +190,13 @@ describe('WorkoutsPage', () => {
         );
       }
 
-      if (
-        url.pathname === '/api/v1/workout-sessions' &&
-        url.searchParams.get('status') === 'completed'
-      ) {
+      if (url.pathname === '/api/v1/workout-sessions') {
         return Promise.resolve(
           jsonResponse({
-            data: completedSessionsResponse,
+            data:
+              url.searchParams.get('status') === 'completed'
+                ? completedSessionsResponse
+                : allSessionsResponse,
           }),
         );
       }
@@ -202,6 +235,7 @@ describe('WorkoutsPage', () => {
 
   afterEach(() => {
     window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
+    window.localStorage.removeItem(WORKOUTS_ONBOARDING_DISMISSED_KEY);
     vi.restoreAllMocks();
   });
 
@@ -227,7 +261,7 @@ describe('WorkoutsPage', () => {
 
     expect(screen.getByRole('button', { name: 'List' })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByTestId('location-search')).toHaveTextContent('?view=list');
-    expect(await screen.findByRole('heading', { level: 2, name: /week of/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: 'Upcoming' })).toBeInTheDocument();
     expect(screen.queryByText('Workout Calendar')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Templates' }));
@@ -318,13 +352,13 @@ describe('WorkoutsPage', () => {
         return deferredTemplates.promise;
       }
 
-      if (
-        url.pathname === '/api/v1/workout-sessions' &&
-        url.searchParams.get('status') === 'completed'
-      ) {
+      if (url.pathname === '/api/v1/workout-sessions') {
         return Promise.resolve(
           jsonResponse({
-            data: completedSessionsResponse,
+            data:
+              url.searchParams.get('status') === 'completed'
+                ? completedSessionsResponse
+                : allSessionsResponse,
           }),
         );
       }
@@ -387,13 +421,13 @@ describe('WorkoutsPage', () => {
         );
       }
 
-      if (
-        url.pathname === '/api/v1/workout-sessions' &&
-        url.searchParams.get('status') === 'completed'
-      ) {
+      if (url.pathname === '/api/v1/workout-sessions') {
         return Promise.resolve(
           jsonResponse({
-            data: completedSessionsResponse,
+            data:
+              url.searchParams.get('status') === 'completed'
+                ? completedSessionsResponse
+                : allSessionsResponse,
           }),
         );
       }
@@ -454,6 +488,75 @@ describe('WorkoutsPage', () => {
     );
 
     expect(screen.getByText('Session was completed on another device.')).toBeInTheDocument();
+  });
+
+  it('shows onboarding for users with no completed workouts and persists dismissal', async () => {
+    vi.restoreAllMocks();
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/workout-templates') {
+        return Promise.resolve(jsonResponse({ data: templatesResponse }));
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions') {
+        return Promise.resolve(
+          jsonResponse({
+            data: url.searchParams.get('status') === 'completed' ? [] : [],
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/exercises') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [],
+            meta: {
+              page: Number(url.searchParams.get('page') ?? '1'),
+              limit: Number(url.searchParams.get('limit') ?? '8'),
+              total: 0,
+            },
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/exercises/filters') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              equipment: [],
+              muscleGroups: [],
+            },
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    const view = renderWithQueryClient(
+      <MemoryRouter initialEntries={['/workouts']}>
+        <Routes>
+          <Route element={<WorkoutsPage />} path="/workouts" />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('How workouts flow in Pulse')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss workouts onboarding' }));
+    expect(screen.queryByText('How workouts flow in Pulse')).not.toBeInTheDocument();
+
+    view.unmount();
+
+    renderWithQueryClient(
+      <MemoryRouter initialEntries={['/workouts']}>
+        <Routes>
+          <Route element={<WorkoutsPage />} path="/workouts" />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText('How workouts flow in Pulse')).not.toBeInTheDocument();
   });
 
   it('prefetches top template details when the list view is active', async () => {

--- a/apps/web/src/pages/workouts.test.tsx
+++ b/apps/web/src/pages/workouts.test.tsx
@@ -544,10 +544,11 @@ describe('WorkoutsPage', () => {
     );
 
     expect(await screen.findByText('How workouts flow in Pulse')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Create a template' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Browse templates' }));
     expect(await screen.findByRole('heading', { level: 2, name: 'Templates' })).toBeInTheDocument();
     expect(screen.getByTestId('location-search')).toHaveTextContent('?view=templates');
 
+    fireEvent.click(screen.getByRole('button', { name: 'Calendar' }));
     fireEvent.click(screen.getByRole('button', { name: 'Dismiss workouts onboarding' }));
     expect(screen.queryByText('How workouts flow in Pulse')).not.toBeInTheDocument();
 
@@ -562,6 +563,65 @@ describe('WorkoutsPage', () => {
     );
 
     expect(screen.queryByText('How workouts flow in Pulse')).not.toBeInTheDocument();
+  });
+
+  it('navigates to active workout flow from onboarding create CTA', async () => {
+    vi.restoreAllMocks();
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/workout-templates') {
+        return Promise.resolve(jsonResponse({ data: templatesResponse }));
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions') {
+        return Promise.resolve(
+          jsonResponse({
+            data: url.searchParams.get('status') === 'completed' ? [] : [],
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/exercises') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [],
+            meta: {
+              page: Number(url.searchParams.get('page') ?? '1'),
+              limit: Number(url.searchParams.get('limit') ?? '8'),
+              total: 0,
+            },
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/exercises/filters') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              equipment: [],
+              muscleGroups: [],
+            },
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter initialEntries={['/workouts']}>
+        <Routes>
+          <Route element={<WorkoutsPage />} path="/workouts" />
+          <Route element={<ActiveWorkoutRouteProbe />} path="/workouts/active" />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('How workouts flow in Pulse')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Create a template' }));
+
+    expect(await screen.findByRole('heading', { name: 'Active workout page' })).toBeInTheDocument();
   });
 
   it('prefetches top template details when the list view is active', async () => {

--- a/apps/web/src/pages/workouts.test.tsx
+++ b/apps/web/src/pages/workouts.test.tsx
@@ -536,6 +536,7 @@ describe('WorkoutsPage', () => {
 
     const view = renderWithQueryClient(
       <MemoryRouter initialEntries={['/workouts']}>
+        <LocationProbe />
         <Routes>
           <Route element={<WorkoutsPage />} path="/workouts" />
         </Routes>
@@ -543,6 +544,10 @@ describe('WorkoutsPage', () => {
     );
 
     expect(await screen.findByText('How workouts flow in Pulse')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Create a template' }));
+    expect(await screen.findByRole('heading', { level: 2, name: 'Templates' })).toBeInTheDocument();
+    expect(screen.getByTestId('location-search')).toHaveTextContent('?view=templates');
+
     fireEvent.click(screen.getByRole('button', { name: 'Dismiss workouts onboarding' }));
     expect(screen.queryByText('How workouts flow in Pulse')).not.toBeInTheDocument();
 

--- a/apps/web/src/pages/workouts.tsx
+++ b/apps/web/src/pages/workouts.tsx
@@ -134,7 +134,7 @@ export function WorkoutsPage() {
             </Button>
           </div>
           <div className="mt-4 flex flex-wrap gap-2">
-            <Button onClick={() => navigate('/workouts/active')} size="sm" type="button">
+            <Button onClick={() => setActiveView('templates')} size="sm" type="button">
               Create a template
             </Button>
             <Button onClick={() => setActiveView('templates')} size="sm" type="button" variant="secondary">

--- a/apps/web/src/pages/workouts.tsx
+++ b/apps/web/src/pages/workouts.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect } from 'react';
-import { Dumbbell } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Dumbbell, X } from 'lucide-react';
 import { useNavigate, useSearchParams } from 'react-router';
 
 import { WorkoutCardSkeleton } from '@/components/skeletons';
@@ -18,10 +18,12 @@ import {
 } from '@/features/workouts';
 import {
   prefetchWorkoutTemplate,
+  useCompletedSessions,
   useWorkoutTemplates,
 } from '@/features/workouts/api/workouts';
 
 const WORKOUT_VIEWS = ['calendar', 'list', 'templates', 'exercises'] as const;
+const WORKOUTS_ONBOARDING_DISMISSED_KEY = 'pulse.workouts.onboarding.dismissed';
 type WorkoutView = (typeof WORKOUT_VIEWS)[number];
 
 function isWorkoutView(value: string | null): value is WorkoutView {
@@ -32,15 +34,32 @@ export function WorkoutsPage() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+  const [onboardingDismissed, setOnboardingDismissed] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+
+    try {
+      return window.localStorage.getItem(WORKOUTS_ONBOARDING_DISMISSED_KEY) === '1';
+    } catch {
+      return false;
+    }
+  });
   const viewParam = searchParams.get('view');
   const activeView: WorkoutView = isWorkoutView(viewParam) ? viewParam : 'calendar';
   const templatesQuery = useWorkoutTemplates();
+  const completedSessionsQuery = useCompletedSessions();
   const showCompletedSessionNotice =
     searchParams.get(WORKOUT_SESSION_NOTICE_QUERY_KEY) === WORKOUT_SESSION_COMPLETED_NOTICE;
   const shouldShowTemplatesEmptyState =
     !templatesQuery.isLoading &&
     !templatesQuery.isError &&
     (templatesQuery.data?.length ?? 0) === 0;
+  const shouldShowOnboardingCard =
+    !onboardingDismissed &&
+    !completedSessionsQuery.isLoading &&
+    !completedSessionsQuery.isError &&
+    (completedSessionsQuery.data?.length ?? 0) === 0;
 
   useEffect(() => {
     if (isWorkoutView(viewParam)) {
@@ -75,6 +94,15 @@ export function WorkoutsPage() {
     return `/workouts/session/${sessionId}?${sessionSearchParams.toString()}`;
   }
 
+  function dismissOnboardingCard() {
+    setOnboardingDismissed(true);
+    try {
+      window.localStorage.setItem(WORKOUTS_ONBOARDING_DISMISSED_KEY, '1');
+    } catch {
+      // Ignore localStorage failures and keep the UI responsive.
+    }
+  }
+
   return (
     <section className="space-y-6">
       <div className="space-y-2">
@@ -84,6 +112,37 @@ export function WorkoutsPage() {
           shared exercise library.
         </p>
       </div>
+
+      {shouldShowOnboardingCard ? (
+        <div className="rounded-2xl border border-border bg-card p-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold text-foreground">How workouts flow in Pulse</h2>
+              <p className="text-sm text-muted">
+                Create a template, start a session from it, then log sets as you go.
+              </p>
+            </div>
+            <Button
+              aria-label="Dismiss workouts onboarding"
+              className="h-8 w-8 rounded-full"
+              onClick={dismissOnboardingCard}
+              size="icon"
+              type="button"
+              variant="ghost"
+            >
+              <X aria-hidden="true" className="size-4" />
+            </Button>
+          </div>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Button onClick={() => navigate('/workouts/active')} size="sm" type="button">
+              Create a template
+            </Button>
+            <Button onClick={() => setActiveView('templates')} size="sm" type="button" variant="secondary">
+              Browse templates
+            </Button>
+          </div>
+        </div>
+      ) : null}
 
       {showCompletedSessionNotice ? (
         <p className="rounded-2xl border border-border bg-card px-4 py-3 text-sm text-foreground">

--- a/apps/web/src/pages/workouts.tsx
+++ b/apps/web/src/pages/workouts.tsx
@@ -134,7 +134,7 @@ export function WorkoutsPage() {
             </Button>
           </div>
           <div className="mt-4 flex flex-wrap gap-2">
-            <Button onClick={() => setActiveView('templates')} size="sm" type="button">
+            <Button onClick={() => navigate('/workouts/active')} size="sm" type="button">
               Create a template
             </Button>
             <Button onClick={() => setActiveView('templates')} size="sm" type="button" variant="secondary">

--- a/apps/web/src/pages/workouts.tsx
+++ b/apps/web/src/pages/workouts.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Dumbbell } from 'lucide-react';
 import { useNavigate, useSearchParams } from 'react-router';
 
@@ -21,13 +21,19 @@ import {
   useWorkoutTemplates,
 } from '@/features/workouts/api/workouts';
 
+const WORKOUT_VIEWS = ['calendar', 'list', 'templates', 'exercises'] as const;
+type WorkoutView = (typeof WORKOUT_VIEWS)[number];
+
+function isWorkoutView(value: string | null): value is WorkoutView {
+  return value != null && WORKOUT_VIEWS.includes(value as WorkoutView);
+}
+
 export function WorkoutsPage() {
   const queryClient = useQueryClient();
-  const [activeView, setActiveView] = useState<'calendar' | 'list' | 'templates' | 'exercises'>(
-    'calendar',
-  );
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const viewParam = searchParams.get('view');
+  const activeView: WorkoutView = isWorkoutView(viewParam) ? viewParam : 'calendar';
   const templatesQuery = useWorkoutTemplates();
   const showCompletedSessionNotice =
     searchParams.get(WORKOUT_SESSION_NOTICE_QUERY_KEY) === WORKOUT_SESSION_COMPLETED_NOTICE;
@@ -35,6 +41,16 @@ export function WorkoutsPage() {
     !templatesQuery.isLoading &&
     !templatesQuery.isError &&
     (templatesQuery.data?.length ?? 0) === 0;
+
+  useEffect(() => {
+    if (isWorkoutView(viewParam)) {
+      return;
+    }
+
+    const nextSearchParams = new URLSearchParams(searchParams);
+    nextSearchParams.set('view', 'calendar');
+    setSearchParams(nextSearchParams, { replace: true });
+  }, [searchParams, setSearchParams, viewParam]);
 
   useEffect(() => {
     if (activeView !== 'list') {
@@ -46,6 +62,18 @@ export function WorkoutsPage() {
       void prefetchWorkoutTemplate(queryClient, templateId);
     }
   }, [activeView, queryClient, templatesQuery.data]);
+
+  function setActiveView(view: WorkoutView) {
+    const nextSearchParams = new URLSearchParams(searchParams);
+    nextSearchParams.set('view', view);
+    setSearchParams(nextSearchParams);
+  }
+
+  function buildSessionHref(sessionId: string) {
+    const sessionSearchParams = new URLSearchParams();
+    sessionSearchParams.set('view', activeView);
+    return `/workouts/session/${sessionId}?${sessionSearchParams.toString()}`;
+  }
 
   return (
     <section className="space-y-6">
@@ -113,10 +141,10 @@ export function WorkoutsPage() {
       {activeView === 'calendar' ? (
         <WorkoutCalendar
           buildDayHref={(date) => `/workouts?date=${date}`}
-          buildSessionHref={(sessionId) => `/workouts/session/${sessionId}`}
+          buildSessionHref={buildSessionHref}
         />
       ) : activeView === 'list' ? (
-        <WorkoutList buildSessionHref={(sessionId) => `/workouts/session/${sessionId}`} />
+        <WorkoutList buildSessionHref={buildSessionHref} />
       ) : activeView === 'templates' ? (
         templatesQuery.isLoading ? (
           <div aria-label="Loading workout templates" className="grid gap-4 xl:grid-cols-2">


### PR DESCRIPTION
## Summary
This PR removes prototype workout mock data from the workouts experience and switches the key views to live API-backed session/template data. It fixes navigation regressions by preserving the originating workouts view (`calendar` or `list`) in the URL when opening session details, so the back path returns users to the right context. It also improves first-time and low-data UX by adding an onboarding card when a user has no completed workouts and by introducing clearer planned/in-progress/completed status treatments in the list view. Calendar and session detail behaviors were tightened to reflect real completed-session data rather than mixed mock schedule states. The result is a more production-aligned workouts flow with better continuity and clearer state signaling.

## Key Changes
- Replaced workout mock-data usage in `WorkoutCalendar`, `WorkoutList`, `TemplateBrowser`, and `SessionDetail` with real API hooks (`useCompletedSessions`, `useWorkoutSessions`, `useWorkoutSession`, `useWorkoutTemplate`).
- Added new workouts API/query capabilities for:
  - fetching filtered session lists (`/api/v1/workout-sessions` with query params),
  - fetching completed sessions,
  - fetching individual session detail by ID.
- Made workouts view state URL-driven via `?view=...` and defaulted invalid/missing values to `calendar`.
- Fixed “View Details / View Session” navigation from workouts views to session detail by propagating `view` in the session link and using it for “Back to Workouts”.
- Added zero-history onboarding card (“How workouts flow in Pulse”) with dismiss persistence via localStorage (`pulse.workouts.onboarding.dismissed`).
- Redesigned workout list sections into `Upcoming` and `Completed`, with distinct status badges/cards/stats for planned, in-progress, and completed sessions.
- Updated template browser empty/search UI copy and fixed search icon/input overlap.
- Expanded tests across app/page/component levels to cover API-backed behavior, onboarding visibility/dismissal persistence, view-param navigation, and session comparison/detail rendering.

## Technical Notes
- Query keys were expanded (`completedSessions`, `sessionsList(params)`, `session(id)`) to keep cache boundaries explicit across list/detail use cases.
- Session list responses are now validated against shared Zod schemas (`workoutSessionListItemSchema`, `workoutSessionQueryParamsSchema`), which reduces shape drift between frontend and API.
- `SessionDetail` now derives previous-session comparison from API list data, and lazily fetches the previous full session only when comparison is enabled.
- Calendar intentionally now visualizes completed-session history only (scheduled/rest mock states removed), which matches current backend data availability and avoids fake planning signals.
- The onboarding dismissal is intentionally tolerant of localStorage failures (wrapped in try/catch) so UI interaction does not break in restricted environments.

## Commits

- `8a4cfd6 fix(web): resolve workouts list/onboarding review feedback`
- `335372a feat(web): improve workouts status indicators and onboarding`
- `8650007 fix(workouts): preserve view context for session navigation`
- `34b48bb refactor(web): remove mock data from workout components and use real API`

## Tasks

- **Remove mock data from workout views**: Remove mock data imports from workout calendar, list, template browser, and session detail components; replace with API data or empty states
- **Fix workout navigation — view details + back button**: Fix broken View Details link in calendar view, preserve active view (list/calendar) in URL params for back navigation
- **Workout list — onboarding + planned vs completed styling**: Add onboarding card for zero workouts, add visual distinction for planned/completed/in-progress workouts, fix template search icon overlap

## Diff Stats

```
apps/web/src/App.test.tsx                          |  71 ++++
 apps/web/src/features/workouts/api/workouts.ts     |  86 +++++
 .../components/session-comparison.test.tsx         |  74 ++--
 .../workouts/components/session-comparison.tsx     |  59 +--
 .../workouts/components/session-detail.test.tsx    | 426 ++++++++++++++++++---
 .../workouts/components/session-detail.tsx         | 292 +++++++++-----
 .../workouts/components/template-browser.test.tsx  |  56 +++
 .../workouts/components/template-browser.tsx       |   8 +-
 .../workouts/components/workout-calendar.test.tsx  | 163 ++++++--
 .../workouts/components/workout-calendar.tsx       | 181 ++++-----
 .../workouts/components/workout-list.test.tsx      | 170 +++++---
 .../features/workouts/components/workout-list.tsx  | 358 +++++++++--------
 .../features/workouts/lib/session-comparison.ts    |  30 +-
 apps/web/src/pages/workout-session-detail.test.tsx | 297 +++++++++++---
 apps/web/src/pages/workouts.test.tsx               | 192 +++++++++-
 apps/web/src/pages/workouts.tsx                    | 101 ++++-
 16 files changed, 1907 insertions(+), 657 deletions(-)
```