### PR TITLE
Dashboard enhancements — EWMA weight trend + configurable widgets

### DIFF
--- a/apps/api/drizzle/0011_hissing_molten_man.sql
+++ b/apps/api/drizzle/0011_hissing_molten_man.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `dashboard_config` ADD `visible_widgets` text;

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1773098400000,
       "tag": "0010_equal_stingray",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1773158400000,
+      "tag": "0011_hissing_molten_man",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/__tests__/habits-weight-targets.test.ts
+++ b/apps/api/src/__tests__/habits-weight-targets.test.ts
@@ -104,6 +104,12 @@ const getTodayDate = () => {
   return new Date().toISOString().slice(0, 10);
 };
 
+const addUtcDays = (date: string, days: number) => {
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + days);
+  return parsed.toISOString().slice(0, 10);
+};
+
 vi.mock('../routes/auth/store.js', () => ({
   createUser: vi.fn(
     async ({
@@ -238,11 +244,19 @@ vi.mock('../routes/weight/store.js', () => ({
       return withoutUserId(entry);
     },
   ),
-  listBodyWeightEntries: vi.fn(async (userId: string, query: { from?: string; to?: string }) =>
+  listBodyWeightEntries: vi.fn(async (userId: string, query: { from?: string; to?: string; days?: number }) =>
     [...testState.weightEntries.values()]
       .filter((entry) => {
         if (entry.userId !== userId) {
           return false;
+        }
+
+        if (query.days !== undefined) {
+          const rangeEnd = query.to ?? getTodayDate();
+          const rangeStart = addUtcDays(rangeEnd, -(query.days - 1));
+          if (entry.date < rangeStart) {
+            return false;
+          }
         }
 
         if (query.from && entry.date < query.from) {
@@ -509,6 +523,57 @@ describe('weight and nutrition target integration', () => {
         createHash('sha256').update(agentToken.token).digest('hex'),
       );
       expect(storedToken?.lastUsedAt).not.toBeNull();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('filters weight entries by days lookback', async () => {
+    const { app } = await createTestApp();
+
+    try {
+      const user = await registerAndLogin(app, 'days-range');
+      const today = getTodayDate();
+      const withinSevenDaysDate = new Date(`${today}T00:00:00.000Z`);
+      withinSevenDaysDate.setUTCDate(withinSevenDaysDate.getUTCDate() - 5);
+      const outsideSevenDaysDate = new Date(`${today}T00:00:00.000Z`);
+      outsideSevenDaysDate.setUTCDate(outsideSevenDaysDate.getUTCDate() - 9);
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/v1/weight',
+        headers: createAuthorizationHeader(user.token),
+        payload: {
+          date: outsideSevenDaysDate.toISOString().slice(0, 10),
+          weight: 183.2,
+        },
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/v1/weight',
+        headers: createAuthorizationHeader(user.token),
+        payload: {
+          date: withinSevenDaysDate.toISOString().slice(0, 10),
+          weight: 181.4,
+        },
+      });
+
+      const listResponse = await app.inject({
+        method: 'GET',
+        url: '/api/v1/weight?days=7',
+        headers: createAuthorizationHeader(user.token),
+      });
+
+      expect(listResponse.statusCode).toBe(200);
+      expect(listResponse.json()).toEqual({
+        data: [
+          expect.objectContaining({
+            date: withinSevenDaysDate.toISOString().slice(0, 10),
+            weight: 181.4,
+          }),
+        ],
+      });
     } finally {
       await app.close();
     }

--- a/apps/api/src/__tests__/habits-weight-targets.test.ts
+++ b/apps/api/src/__tests__/habits-weight-targets.test.ts
@@ -3,6 +3,8 @@ import { createHash } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { addUtcDays, getTodayDate } from '../lib/date.js';
+
 type StoredUser = {
   id: string;
   username: string;
@@ -98,16 +100,6 @@ const withoutUserId = <T extends { userId: string }>(value: T) => {
   void userId;
 
   return rest;
-};
-
-const getTodayDate = () => {
-  return new Date().toISOString().slice(0, 10);
-};
-
-const addUtcDays = (date: string, days: number) => {
-  const parsed = new Date(`${date}T00:00:00.000Z`);
-  parsed.setUTCDate(parsed.getUTCDate() + days);
-  return parsed.toISOString().slice(0, 10);
 };
 
 vi.mock('../routes/auth/store.js', () => ({

--- a/apps/api/src/db/schema.test.ts
+++ b/apps/api/src/db/schema.test.ts
@@ -673,6 +673,7 @@ describe('dashboardConfig schema', () => {
       'userId',
       'habitChainIds',
       'trendMetrics',
+      'visibleWidgets',
       'widgetOrder',
       'createdAt',
       'updatedAt',
@@ -681,6 +682,7 @@ describe('dashboardConfig schema', () => {
     expect(columns.id.defaultFn).toBeTypeOf('function');
     expect(columns.habitChainIds.default).toEqual([]);
     expect(columns.trendMetrics.default).toEqual([]);
+    expect(columns.visibleWidgets.notNull).toBe(false);
     expect(columns.widgetOrder.notNull).toBe(false);
     expect(columns.createdAt.default).toBeDefined();
     expect(columns.createdAt.defaultFn).toBeTypeOf('function');

--- a/apps/api/src/db/schema/dashboard-config.ts
+++ b/apps/api/src/db/schema/dashboard-config.ts
@@ -19,6 +19,7 @@ export const dashboardConfig = sqliteTable(
       .notNull()
       .default([]),
     trendMetrics: text('trend_metrics', { mode: 'json' }).$type<string[]>().notNull().default([]),
+    visibleWidgets: text('visible_widgets', { mode: 'json' }).$type<string[] | null>(),
     widgetOrder: text('widget_order', { mode: 'json' }).$type<string[] | null>(),
     createdAt: integer('created_at', { mode: 'number' })
       .notNull()

--- a/apps/api/src/lib/date.ts
+++ b/apps/api/src/lib/date.ts
@@ -1,0 +1,7 @@
+export const addUtcDays = (date: string, days: number) => {
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + days);
+  return parsed.toISOString().slice(0, 10);
+};
+
+export const getTodayDate = () => new Date().toISOString().slice(0, 10);

--- a/apps/api/src/routes/v1/dashboard-store.test.ts
+++ b/apps/api/src/routes/v1/dashboard-store.test.ts
@@ -1,4 +1,7 @@
+import { DASHBOARD_WIDGET_IDS } from '@pulse/shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const DEFAULT_VISIBLE_WIDGETS = Object.keys(DASHBOARD_WIDGET_IDS);
 
 const testState = vi.hoisted(() => {
   const selectGetResults: unknown[] = [];
@@ -252,6 +255,7 @@ describe('dashboard store', () => {
     testState.selectGetResults.push({
       habitChainIds: ['habit-1', 'habit-2'],
       trendMetrics: ['weight', 'protein'],
+      visibleWidgets: ['weight-trend'],
       widgetOrder: ['snapshot', 'trends', 'habits'],
     });
 
@@ -261,6 +265,7 @@ describe('dashboard store', () => {
     expect(config).toEqual({
       habitChainIds: ['habit-1', 'habit-2'],
       trendMetrics: ['weight', 'protein'],
+      visibleWidgets: ['weight-trend'],
       widgetOrder: ['snapshot', 'trends', 'habits'],
     });
     expect(testState.select).toHaveBeenCalledTimes(1);
@@ -270,6 +275,7 @@ describe('dashboard store', () => {
     testState.selectGetResults.push({
       habitChainIds: ['habit-1'],
       trendMetrics: [],
+      visibleWidgets: null,
       widgetOrder: null,
     });
 
@@ -279,6 +285,7 @@ describe('dashboard store', () => {
     expect(config).toEqual({
       habitChainIds: ['habit-1'],
       trendMetrics: [],
+      visibleWidgets: DEFAULT_VISIBLE_WIDGETS,
     });
     expect(testState.select).toHaveBeenCalledTimes(1);
   });
@@ -287,6 +294,7 @@ describe('dashboard store', () => {
     testState.selectGetResults.push({
       habitChainIds: ['habit-1'],
       trendMetrics: ['unknown-metric'],
+      visibleWidgets: null,
       widgetOrder: null,
     });
 
@@ -296,6 +304,7 @@ describe('dashboard store', () => {
     expect(config).toEqual({
       habitChainIds: ['habit-1'],
       trendMetrics: [],
+      visibleWidgets: DEFAULT_VISIBLE_WIDGETS,
     });
     expect(testState.select).toHaveBeenCalledTimes(1);
   });
@@ -310,7 +319,7 @@ describe('dashboard store', () => {
     expect(config).toEqual({
       habitChainIds: ['habit-1', 'habit-3'],
       trendMetrics: ['weight', 'calories', 'protein'],
-      visibleWidgets: ['weight-trend'],
+      visibleWidgets: DEFAULT_VISIBLE_WIDGETS,
     });
     expect(testState.select).toHaveBeenCalledTimes(2);
   });
@@ -319,6 +328,7 @@ describe('dashboard store', () => {
     testState.selectGetResults.push({
       habitChainIds: ['habit-1'],
       trendMetrics: ['calories'],
+      visibleWidgets: ['weight-trend'],
       widgetOrder: ['trends', 'snapshot'],
     });
 
@@ -326,12 +336,14 @@ describe('dashboard store', () => {
     const config = await upsertDashboardConfig('user-1', {
       habitChainIds: ['habit-1'],
       trendMetrics: ['calories'],
+      visibleWidgets: ['weight-trend'],
       widgetOrder: ['trends', 'snapshot'],
     });
 
     expect(config).toEqual({
       habitChainIds: ['habit-1'],
       trendMetrics: ['calories'],
+      visibleWidgets: ['weight-trend'],
       widgetOrder: ['trends', 'snapshot'],
     });
     expect(testState.db.insert).toHaveBeenCalledTimes(1);

--- a/apps/api/src/routes/v1/dashboard-store.test.ts
+++ b/apps/api/src/routes/v1/dashboard-store.test.ts
@@ -310,6 +310,7 @@ describe('dashboard store', () => {
     expect(config).toEqual({
       habitChainIds: ['habit-1', 'habit-3'],
       trendMetrics: ['weight', 'calories', 'protein'],
+      visibleWidgets: ['weight-trend'],
     });
     expect(testState.select).toHaveBeenCalledTimes(2);
   });

--- a/apps/api/src/routes/v1/dashboard-store.ts
+++ b/apps/api/src/routes/v1/dashboard-store.ts
@@ -99,6 +99,7 @@ const getDateRangeForUtcDay = (date: string) => {
 // TODO: Source this from user preferences once kg/lb switching is introduced.
 const DEFAULT_WEIGHT_UNIT: DashboardWeightSnapshot['unit'] = 'lb';
 const DEFAULT_DASHBOARD_TREND_METRICS: DashboardTrendMetric[] = ['weight', 'calories', 'protein'];
+const DEFAULT_DASHBOARD_VISIBLE_WIDGETS = ['weight-trend'];
 
 const toMacroTotals = (
   value:
@@ -396,6 +397,7 @@ export const getDashboardConfig = async (userId: string): Promise<DashboardConfi
   return dashboardConfigSchema.parse({
     habitChainIds: activeHabitIds,
     trendMetrics: DEFAULT_DASHBOARD_TREND_METRICS,
+    visibleWidgets: DEFAULT_DASHBOARD_VISIBLE_WIDGETS,
   });
 };
 

--- a/apps/api/src/routes/v1/dashboard-store.ts
+++ b/apps/api/src/routes/v1/dashboard-store.ts
@@ -78,6 +78,7 @@ const consistencyTrendSelection = {
 const dashboardConfigSelection = {
   habitChainIds: dashboardConfigTable.habitChainIds,
   trendMetrics: dashboardConfigTable.trendMetrics,
+  visibleWidgets: dashboardConfigTable.visibleWidgets,
   widgetOrder: dashboardConfigTable.widgetOrder,
 };
 
@@ -99,7 +100,6 @@ const getDateRangeForUtcDay = (date: string) => {
 // TODO: Source this from user preferences once kg/lb switching is introduced.
 const DEFAULT_WEIGHT_UNIT: DashboardWeightSnapshot['unit'] = 'lb';
 const DEFAULT_DASHBOARD_TREND_METRICS: DashboardTrendMetric[] = ['weight', 'calories', 'protein'];
-const DEFAULT_DASHBOARD_VISIBLE_WIDGETS = ['weight-trend'];
 
 const toMacroTotals = (
   value:
@@ -212,12 +212,14 @@ const toDashboardConfig = (
   value: {
     habitChainIds: string[] | null;
     trendMetrics: string[] | null;
+    visibleWidgets: string[] | null;
     widgetOrder: string[] | null;
   },
 ): DashboardConfig => {
   const parsed = dashboardConfigSchema.parse({
     habitChainIds: value.habitChainIds ?? [],
     trendMetrics: toDashboardTrendMetrics(value.trendMetrics),
+    visibleWidgets: value.visibleWidgets ?? undefined,
     widgetOrder: value.widgetOrder ?? undefined,
   });
 
@@ -397,7 +399,6 @@ export const getDashboardConfig = async (userId: string): Promise<DashboardConfi
   return dashboardConfigSchema.parse({
     habitChainIds: activeHabitIds,
     trendMetrics: DEFAULT_DASHBOARD_TREND_METRICS,
-    visibleWidgets: DEFAULT_DASHBOARD_VISIBLE_WIDGETS,
   });
 };
 
@@ -410,6 +411,7 @@ export const upsertDashboardConfig = async (
       userId,
       habitChainIds: input.habitChainIds,
       trendMetrics: input.trendMetrics,
+      visibleWidgets: input.visibleWidgets ?? null,
       widgetOrder: input.widgetOrder ?? null,
     })
     .onConflictDoUpdate({
@@ -417,6 +419,7 @@ export const upsertDashboardConfig = async (
       set: {
         habitChainIds: input.habitChainIds,
         trendMetrics: input.trendMetrics,
+        visibleWidgets: input.visibleWidgets ?? null,
         widgetOrder: input.widgetOrder ?? null,
         updatedAt: Date.now(),
       },

--- a/apps/api/src/routes/v1/dashboard.test.ts
+++ b/apps/api/src/routes/v1/dashboard.test.ts
@@ -1,3 +1,4 @@
+import { DASHBOARD_WIDGET_IDS } from '@pulse/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildServer } from '../../index.js';
@@ -23,6 +24,7 @@ vi.mock('./dashboard-store.js', () => ({
 const createAuthorizationHeader = (token: string) => ({
   authorization: `Bearer ${token}`,
 });
+const DEFAULT_VISIBLE_WIDGETS = Object.keys(DASHBOARD_WIDGET_IDS);
 
 describe('dashboard routes', () => {
   beforeEach(() => {
@@ -130,6 +132,7 @@ describe('dashboard routes', () => {
     vi.mocked(getDashboardConfig).mockResolvedValue({
       habitChainIds: ['habit-1', 'habit-2'],
       trendMetrics: ['weight', 'protein'],
+      visibleWidgets: DEFAULT_VISIBLE_WIDGETS,
       widgetOrder: ['snapshot', 'trends'],
     });
 
@@ -149,6 +152,7 @@ describe('dashboard routes', () => {
         data: {
           habitChainIds: ['habit-1', 'habit-2'],
           trendMetrics: ['weight', 'protein'],
+          visibleWidgets: DEFAULT_VISIBLE_WIDGETS,
           widgetOrder: ['snapshot', 'trends'],
         },
       });
@@ -162,6 +166,7 @@ describe('dashboard routes', () => {
     vi.mocked(upsertDashboardConfig).mockResolvedValue({
       habitChainIds: ['habit-1'],
       trendMetrics: ['calories'],
+      visibleWidgets: DEFAULT_VISIBLE_WIDGETS,
       widgetOrder: ['trends', 'snapshot'],
     });
 
@@ -173,6 +178,7 @@ describe('dashboard routes', () => {
       const payload = {
         habitChainIds: ['habit-1'],
         trendMetrics: ['calories'],
+        visibleWidgets: DEFAULT_VISIBLE_WIDGETS,
         widgetOrder: ['trends', 'snapshot'],
       };
 
@@ -214,6 +220,69 @@ describe('dashboard routes', () => {
         payload: {
           habitChainIds: ['habit-1'],
           trendMetrics: ['steps'],
+        },
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid dashboard config payload',
+        },
+      });
+      expect(vi.mocked(upsertDashboardConfig)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('accepts PUT dashboard config payloads with an empty visibleWidgets array', async () => {
+    vi.mocked(upsertDashboardConfig).mockResolvedValue({
+      habitChainIds: ['habit-1'],
+      trendMetrics: ['weight'],
+      visibleWidgets: [],
+    });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-2' });
+      const payload = {
+        habitChainIds: ['habit-1'],
+        trendMetrics: ['weight'],
+        visibleWidgets: [],
+      };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/v1/dashboard/config',
+        payload,
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ data: payload });
+      expect(vi.mocked(upsertDashboardConfig)).toHaveBeenCalledWith('user-2', payload);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects dashboard configs containing empty widget ids', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-2' });
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/v1/dashboard/config',
+        payload: {
+          habitChainIds: ['habit-1'],
+          trendMetrics: ['weight'],
+          visibleWidgets: [''],
         },
         headers: createAuthorizationHeader(authToken),
       });

--- a/apps/api/src/routes/weight/index.test.ts
+++ b/apps/api/src/routes/weight/index.test.ts
@@ -288,6 +288,31 @@ describe('weight routes', () => {
     }
   });
 
+  it('rejects from and days query params when both are provided', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/weight?from=2026-03-01&days=30',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid weight query params',
+        },
+      });
+      expect(vi.mocked(listBodyWeightEntries)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
   it('returns the latest body weight entry or null', async () => {
     vi.mocked(getLatestBodyWeightEntry)
       .mockResolvedValueOnce({

--- a/apps/api/src/routes/weight/index.test.ts
+++ b/apps/api/src/routes/weight/index.test.ts
@@ -233,6 +233,36 @@ describe('weight routes', () => {
     }
   });
 
+  it('accepts days query params and forwards parsed values to the store', async () => {
+    vi.mocked(listBodyWeightEntries).mockResolvedValue([
+      {
+        id: 'entry-2',
+        date: '2026-03-03',
+        weight: 182.7,
+        notes: 'After cardio',
+        createdAt: 1_700_000_100_000,
+        updatedAt: 1_700_000_100_000,
+      },
+    ]);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/weight?days=7',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(vi.mocked(listBodyWeightEntries)).toHaveBeenCalledWith('user-1', { days: 7 });
+    } finally {
+      await app.close();
+    }
+  });
+
   it('rejects invalid date range queries', async () => {
     const app = buildServer();
 

--- a/apps/api/src/routes/weight/store.ts
+++ b/apps/api/src/routes/weight/store.ts
@@ -3,6 +3,7 @@ import { and, asc, desc, eq, gte, lte } from 'drizzle-orm';
 import type { BodyWeightEntry, CreateWeightInput, WeightQueryParams } from '@pulse/shared';
 
 import { bodyWeight } from '../../db/schema/index.js';
+import { addUtcDays, getTodayDate } from '../../lib/date.js';
 
 const bodyWeightEntrySelection = {
   id: bodyWeight.id,
@@ -12,14 +13,6 @@ const bodyWeightEntrySelection = {
   createdAt: bodyWeight.createdAt,
   updatedAt: bodyWeight.updatedAt,
 };
-
-const addUtcDays = (date: string, days: number) => {
-  const parsed = new Date(`${date}T00:00:00.000Z`);
-  parsed.setUTCDate(parsed.getUTCDate() + days);
-  return parsed.toISOString().slice(0, 10);
-};
-
-const getTodayDate = () => new Date().toISOString().slice(0, 10);
 
 export const findBodyWeightEntryByDate = async (
   userId: string,

--- a/apps/api/src/routes/weight/store.ts
+++ b/apps/api/src/routes/weight/store.ts
@@ -13,6 +13,14 @@ const bodyWeightEntrySelection = {
   updatedAt: bodyWeight.updatedAt,
 };
 
+const addUtcDays = (date: string, days: number) => {
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + days);
+  return parsed.toISOString().slice(0, 10);
+};
+
+const getTodayDate = () => new Date().toISOString().slice(0, 10);
+
 export const findBodyWeightEntryByDate = async (
   userId: string,
   date: string,
@@ -70,6 +78,12 @@ export const listBodyWeightEntries = async (
   const { db } = await import('../../db/index.js');
 
   const conditions = [eq(bodyWeight.userId, userId)];
+
+  if (query.days !== undefined) {
+    const rangeEnd = query.to ?? getTodayDate();
+    const rangeStart = addUtcDays(rangeEnd, -(query.days - 1));
+    conditions.push(gte(bodyWeight.date, rangeStart));
+  }
 
   if (query.from) {
     conditions.push(gte(bodyWeight.date, query.from));

--- a/apps/web/src/components/ui/toggle.tsx
+++ b/apps/web/src/components/ui/toggle.tsx
@@ -1,0 +1,58 @@
+/* eslint-disable react-refresh/only-export-components */
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const toggleVariants = cva(
+  "inline-flex min-h-[36px] cursor-pointer items-center justify-center gap-2 rounded-md border text-sm font-medium transition-colors outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground hover:bg-primary/90',
+        outline:
+          'border-border bg-card text-card-foreground hover:bg-accent hover:text-accent-foreground',
+      },
+      size: {
+        default: 'h-9 px-3',
+        sm: 'h-8 px-2.5 text-xs',
+        lg: 'h-10 px-4',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+type ToggleProps = Omit<React.ComponentProps<'button'>, 'onChange'> &
+  VariantProps<typeof toggleVariants> & {
+    onPressedChange?: (pressed: boolean) => void;
+    pressed?: boolean;
+  };
+
+function Toggle({
+  className,
+  onPressedChange,
+  pressed = false,
+  size,
+  type = 'button',
+  variant,
+  ...props
+}: ToggleProps) {
+  return (
+    <button
+      aria-pressed={pressed}
+      className={cn(toggleVariants({ variant, size, className }))}
+      data-slot="toggle"
+      onClick={() => {
+        onPressedChange?.(!pressed);
+      }}
+      type={type}
+      {...props}
+    />
+  );
+}
+
+export { Toggle, toggleVariants };

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.test.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.test.tsx
@@ -1,0 +1,202 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { WeightTrendChart } from './weight-trend-chart';
+
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<typeof import('recharts')>('recharts');
+  const React = await vi.importActual<typeof import('react')>('react');
+
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="responsive-container">
+        {React.isValidElement(children)
+          ? React.cloneElement(
+              children as React.ReactElement<{ height?: number; width?: number }>,
+              {
+                height: 320,
+                width: 720,
+              },
+            )
+          : children}
+      </div>
+    ),
+  };
+});
+
+const weightEntriesFixture = [
+  {
+    id: 'weight-1',
+    date: '2026-03-04',
+    weight: 181.2,
+    notes: null,
+    createdAt: 1,
+    updatedAt: 1,
+  },
+  {
+    id: 'weight-2',
+    date: '2026-03-05',
+    weight: 180.4,
+    notes: null,
+    createdAt: 2,
+    updatedAt: 2,
+  },
+  {
+    id: 'weight-3',
+    date: '2026-03-06',
+    weight: 180.9,
+    notes: null,
+    createdAt: 3,
+    updatedAt: 3,
+  },
+  {
+    id: 'weight-4',
+    date: '2026-03-07',
+    weight: 180.2,
+    notes: null,
+    createdAt: 4,
+    updatedAt: 4,
+  },
+];
+
+describe('WeightTrendChart', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      const rawUrl =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url = new URL(rawUrl, 'http://localhost');
+
+      if (url.pathname === '/api/v1/weight' && init?.method === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: weightEntriesFixture }), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          }),
+        );
+      }
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 'NOT_FOUND',
+              message: 'Not found',
+            },
+          }),
+          { headers: { 'Content-Type': 'application/json' }, status: 404 },
+        ),
+      );
+    });
+
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches 1M range by default and renders header + insight metrics', async () => {
+    const { wrapper } = createQueryClientWrapper();
+
+    render(<WeightTrendChart />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole('img', { name: 'Weight trend chart' })).toBeInTheDocument();
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/weight?days=30',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(screen.getByRole('heading', { name: 'Weight Trend' })).toBeInTheDocument();
+    expect(screen.getByText('Current trend')).toBeInTheDocument();
+    expect(screen.getByText('Period average')).toBeInTheDocument();
+    expect(screen.getByText(/3-day change:/)).toBeInTheDocument();
+    expect(screen.getByText(/7-day change:/)).toBeInTheDocument();
+    expect(screen.getByLabelText('3-day direction down')).toBeInTheDocument();
+    expect(screen.getByLabelText('7-day direction down')).toBeInTheDocument();
+  });
+
+  it('switches ranges and re-fetches weight entries with selected days', async () => {
+    const { wrapper } = createQueryClientWrapper();
+
+    render(<WeightTrendChart />, { wrapper });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/v1/weight?days=30', expect.any(Object));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '1W' }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/v1/weight?days=7', expect.any(Object));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/v1/weight', expect.any(Object));
+    });
+  });
+
+  it('allows toggling each legend series', async () => {
+    const { wrapper } = createQueryClientWrapper();
+
+    render(<WeightTrendChart />, { wrapper });
+
+    const scaleToggle = await screen.findByRole('button', { name: 'Scale Weight' });
+    const trendToggle = screen.getByRole('button', { name: 'Trend Weight' });
+
+    expect(scaleToggle).toHaveAttribute('aria-pressed', 'true');
+    expect(trendToggle).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(scaleToggle);
+    fireEvent.click(trendToggle);
+
+    expect(scaleToggle).toHaveAttribute('aria-pressed', 'false');
+    expect(trendToggle).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('renders empty state when no weight entries exist', async () => {
+    mockFetch.mockImplementation((input: string | URL | Request, init?: RequestInit) => {
+      const rawUrl =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url = new URL(rawUrl, 'http://localhost');
+
+      if (url.pathname === '/api/v1/weight' && init?.method === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: [] }), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          }),
+        );
+      }
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 'NOT_FOUND',
+              message: 'Not found',
+            },
+          }),
+          { headers: { 'Content-Type': 'application/json' }, status: 404 },
+        ),
+      );
+    });
+
+    const { wrapper } = createQueryClientWrapper();
+    render(<WeightTrendChart />, { wrapper });
+
+    expect(await screen.findByText('Log your weight to see trends')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Go to weight entry' })).toHaveAttribute(
+      'href',
+      '#dashboard-log-weight-card',
+    );
+  });
+});

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.test.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.test.tsx
@@ -118,7 +118,7 @@ describe('WeightTrendChart', () => {
     expect(screen.getByText('Period average')).toBeInTheDocument();
     expect(screen.getByText(/3-day change:/)).toBeInTheDocument();
     expect(screen.getByText(/7-day change:/)).toBeInTheDocument();
-    expect(screen.getByLabelText('3-day direction down')).toBeInTheDocument();
+    expect(screen.getByLabelText('3-day direction stable')).toBeInTheDocument();
     expect(screen.getByLabelText('7-day direction down')).toBeInTheDocument();
   });
 
@@ -160,6 +160,10 @@ describe('WeightTrendChart', () => {
 
     expect(scaleToggle).toHaveAttribute('aria-pressed', 'false');
     expect(trendToggle).toHaveAttribute('aria-pressed', 'false');
+    expect(
+      screen.getByText('Enable at least one series to display the chart.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('img', { name: 'Weight trend chart' })).not.toBeInTheDocument();
   });
 
   it('renders empty state when no weight entries exist', async () => {

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
@@ -77,10 +77,10 @@ const fetchWeightEntries = async (days: number | null) => {
 const formatWeight = (value: number) => `${numberFormatter.format(value)} lbs`;
 
 const formatInsightChange = (change: number) => {
-  const roundedChange = Number(change.toFixed(INSIGHT_PRECISION));
-  const signPrefix = roundedChange > 0 ? '+' : '';
-
-  return `${signPrefix}${roundedChange.toFixed(INSIGHT_PRECISION)} lbs`;
+  const formatted = change.toFixed(INSIGHT_PRECISION);
+  const numeric = Number(formatted);
+  const signPrefix = numeric > 0 ? '+' : '';
+  return `${signPrefix}${formatted} lbs`;
 };
 
 const getDirectionGlyph = (direction: 'up' | 'down' | 'stable') => {
@@ -230,77 +230,83 @@ export function WeightTrendChart() {
           </div>
         ) : (
           <>
-            <div aria-label="Weight trend chart" className="h-[280px] w-full sm:h-[320px]" role="img">
-              <ResponsiveContainer height="100%" width="100%">
-                <LineChart data={chartData} margin={{ top: 12, right: 8, bottom: 6, left: 2 }}>
-                  <CartesianGrid stroke="var(--color-border)" strokeDasharray="3 3" />
-                  <XAxis
-                    axisLine={false}
-                    dataKey="date"
-                    minTickGap={20}
-                    tick={{ fill: 'var(--color-muted)', fontSize: 12 }}
-                    tickFormatter={(value: string) => axisDateFormatter.format(new Date(`${value}T12:00:00`))}
-                    tickLine={false}
-                  />
-                  <YAxis
-                    axisLine={false}
-                    domain={yDomain}
-                    tick={{ fill: 'var(--color-muted)', fontSize: 12 }}
-                    tickFormatter={(value: number) => numberFormatter.format(value)}
-                    tickLine={false}
-                    width={50}
-                  />
-                  <Tooltip
-                    contentStyle={{
-                      backgroundColor: 'var(--color-card)',
-                      border: '1px solid var(--color-border)',
-                      borderRadius: '14px',
-                      color: 'var(--color-foreground)',
-                    }}
-                    formatter={(value: number | undefined, name: string | undefined) => {
-                      if (name === 'scale') {
-                        return [formatWeight(value ?? 0), 'Scale Weight'];
-                      }
+            {!visibleSeries.scale && !visibleSeries.trend ? (
+              <div className="flex h-[280px] items-center justify-center text-sm text-muted-foreground sm:h-[320px]">
+                Enable at least one series to display the chart.
+              </div>
+            ) : (
+              <div aria-label="Weight trend chart" className="h-[280px] w-full sm:h-[320px]" role="img">
+                <ResponsiveContainer height="100%" width="100%">
+                  <LineChart data={chartData} margin={{ top: 12, right: 8, bottom: 6, left: 2 }}>
+                    <CartesianGrid stroke="var(--color-border)" strokeDasharray="3 3" />
+                    <XAxis
+                      axisLine={false}
+                      dataKey="date"
+                      minTickGap={20}
+                      tick={{ fill: 'var(--color-muted)', fontSize: 12 }}
+                      tickFormatter={(value: string) => axisDateFormatter.format(new Date(`${value}T12:00:00`))}
+                      tickLine={false}
+                    />
+                    <YAxis
+                      axisLine={false}
+                      domain={yDomain}
+                      tick={{ fill: 'var(--color-muted)', fontSize: 12 }}
+                      tickFormatter={(value: number) => numberFormatter.format(value)}
+                      tickLine={false}
+                      width={50}
+                    />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: 'var(--color-card)',
+                        border: '1px solid var(--color-border)',
+                        borderRadius: '14px',
+                        color: 'var(--color-foreground)',
+                      }}
+                      formatter={(value: number | undefined, name: string | undefined) => {
+                        if (name === 'scale') {
+                          return [formatWeight(value ?? 0), 'Scale Weight'];
+                        }
 
-                      return [formatWeight(value ?? 0), 'Trend Weight'];
-                    }}
-                    labelFormatter={(label) =>
-                      typeof label === 'string'
-                        ? tooltipDateFormatter.format(new Date(`${label}T12:00:00`))
-                        : ''
-                    }
-                    separator=": "
-                  />
-                  {visibleSeries.scale ? (
-                    <Line
-                      dataKey="scale"
-                      dot={{ fill: SERIES_COLORS.scale, r: 3.5, strokeWidth: 0 }}
-                      isAnimationActive={false}
-                      name="scale"
-                      stroke={SERIES_COLORS.scale}
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2.5}
-                      type="monotone"
+                        return [formatWeight(value ?? 0), 'Trend Weight'];
+                      }}
+                      labelFormatter={(label) =>
+                        typeof label === 'string'
+                          ? tooltipDateFormatter.format(new Date(`${label}T12:00:00`))
+                          : ''
+                      }
+                      separator=": "
                     />
-                  ) : null}
-                  {visibleSeries.trend ? (
-                    <Line
-                      dataKey="trend"
-                      dot={{ fill: SERIES_COLORS.trend, r: 4, stroke: 'var(--color-card)', strokeWidth: 1.5 }}
-                      isAnimationActive={false}
-                      name="trend"
-                      stroke={SERIES_COLORS.trend}
-                      strokeDasharray="6 4"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2.5}
-                      type="monotone"
-                    />
-                  ) : null}
-                </LineChart>
-              </ResponsiveContainer>
-            </div>
+                    {visibleSeries.scale ? (
+                      <Line
+                        dataKey="scale"
+                        dot={{ fill: SERIES_COLORS.scale, r: 3.5, strokeWidth: 0 }}
+                        isAnimationActive={false}
+                        name="scale"
+                        stroke={SERIES_COLORS.scale}
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2.5}
+                        type="monotone"
+                      />
+                    ) : null}
+                    {visibleSeries.trend ? (
+                      <Line
+                        dataKey="trend"
+                        dot={{ fill: SERIES_COLORS.trend, r: 4, stroke: 'var(--color-card)', strokeWidth: 1.5 }}
+                        isAnimationActive={false}
+                        name="trend"
+                        stroke={SERIES_COLORS.trend}
+                        strokeDasharray="6 4"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2.5}
+                        type="monotone"
+                      />
+                    ) : null}
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            )}
 
             <div className="flex flex-wrap items-center gap-2" data-slot="weight-trend-legend">
               <LegendToggle

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
@@ -1,0 +1,366 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { BodyWeightEntry } from '@pulse/shared';
+import { computeEWMA, computeWeightInsights } from '@pulse/shared';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { apiRequest } from '@/lib/api-client';
+import { cn } from '@/lib/utils';
+
+type RangeOption = {
+  value: '1w' | '1m' | '3m' | '6m' | '1y' | 'all';
+  label: '1W' | '1M' | '3M' | '6M' | '1Y' | 'All';
+  days: number | null;
+};
+
+type ChartPoint = {
+  date: string;
+  scale: number;
+  trend: number;
+};
+
+const RANGE_OPTIONS: RangeOption[] = [
+  { value: '1w', label: '1W', days: 7 },
+  { value: '1m', label: '1M', days: 30 },
+  { value: '3m', label: '3M', days: 90 },
+  { value: '6m', label: '6M', days: 180 },
+  { value: '1y', label: '1Y', days: 365 },
+  { value: 'all', label: 'All', days: null },
+];
+
+const DEFAULT_RANGE: RangeOption = RANGE_OPTIONS[1];
+const INSIGHT_PRECISION = 1;
+const SERIES_COLORS = {
+  scale: 'var(--color-primary)',
+  trend: 'var(--color-accent-cream)',
+} as const;
+
+const axisDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+});
+
+const tooltipDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+const numberFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 1,
+  minimumFractionDigits: 1,
+});
+
+const fetchWeightEntries = async (days: number | null) => {
+  const params = new URLSearchParams();
+
+  if (days !== null) {
+    params.set('days', String(days));
+  }
+
+  const query = params.toString();
+  const path = query ? `/api/v1/weight?${query}` : '/api/v1/weight';
+
+  return apiRequest<BodyWeightEntry[]>(path, { method: 'GET' });
+};
+
+const formatWeight = (value: number) => `${numberFormatter.format(value)} lbs`;
+
+const formatInsightChange = (change: number) => {
+  const roundedChange = Number(change.toFixed(INSIGHT_PRECISION));
+  const signPrefix = roundedChange > 0 ? '+' : '';
+
+  return `${signPrefix}${roundedChange.toFixed(INSIGHT_PRECISION)} lbs`;
+};
+
+const getDirectionGlyph = (direction: 'up' | 'down' | 'stable') => {
+  if (direction === 'up') {
+    return '↑';
+  }
+
+  if (direction === 'down') {
+    return '↓';
+  }
+
+  return '→';
+};
+
+const computeYAxisDomain = (data: ChartPoint[]): [number, number] => {
+  if (data.length === 0) {
+    return [0, 1];
+  }
+
+  const values = data.flatMap((entry) => [entry.scale, entry.trend]);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+
+  if (min === max) {
+    const baselinePadding = Math.max(1, min * 0.02);
+    return [min - baselinePadding, max + baselinePadding];
+  }
+
+  const dynamicPadding = Math.max(0.5, (max - min) * 0.1);
+  return [Number((min - dynamicPadding).toFixed(1)), Number((max + dynamicPadding).toFixed(1))];
+};
+
+export function WeightTrendChart() {
+  const [selectedRange, setSelectedRange] = useState<RangeOption>(DEFAULT_RANGE);
+  const [visibleSeries, setVisibleSeries] = useState({
+    scale: true,
+    trend: true,
+  });
+
+  const weightEntriesQuery = useQuery({
+    queryKey: ['dashboard', 'weight-trend-chart', selectedRange.value],
+    queryFn: () => fetchWeightEntries(selectedRange.days),
+  });
+
+  const chartData = useMemo(() => {
+    const entries = weightEntriesQuery.data ?? [];
+
+    return computeEWMA(entries.map((entry) => ({ date: entry.date, weight: entry.weight })));
+  }, [weightEntriesQuery.data]);
+
+  const threeDayInsights = useMemo(() => computeWeightInsights(chartData, 3), [chartData]);
+  const sevenDayInsights = useMemo(() => computeWeightInsights(chartData, 7), [chartData]);
+
+  const headerInsights = useMemo(() => {
+    if (chartData.length === 0) {
+      return {
+        avgWeight: 0,
+        currentTrend: 0,
+      };
+    }
+
+    const avgPeriod = selectedRange.days ?? chartData.length;
+    const summary = computeWeightInsights(chartData, avgPeriod);
+
+    return {
+      avgWeight: summary.avgWeight,
+      currentTrend: chartData[chartData.length - 1]?.trend ?? 0,
+    };
+  }, [chartData, selectedRange.days]);
+
+  const yDomain = useMemo(() => computeYAxisDomain(chartData), [chartData]);
+
+  const toggleSeries = (series: 'scale' | 'trend') => {
+    setVisibleSeries((current) => ({
+      ...current,
+      [series]: !current[series],
+    }));
+  };
+
+  return (
+    <Card aria-labelledby="weight-trend-chart-heading" data-slot="weight-trend-chart">
+      <CardHeader className="gap-4 border-b border-border/70 pb-5">
+        <div className="space-y-1">
+          <CardTitle>
+            <h2 className="text-xl font-semibold text-foreground md:text-2xl" id="weight-trend-chart-heading">
+              Weight Trend
+            </h2>
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">Scale weight with EWMA smoothing.</p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="rounded-xl bg-secondary/45 px-4 py-3">
+            <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              Current trend
+            </p>
+            <p className="mt-1 text-2xl font-semibold text-foreground" data-slot="weight-trend-current-trend">
+              {chartData.length > 0 ? formatWeight(headerInsights.currentTrend) : '--'}
+            </p>
+          </div>
+          <div className="rounded-xl bg-secondary/45 px-4 py-3">
+            <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              Period average
+            </p>
+            <p className="mt-1 text-2xl font-semibold text-foreground" data-slot="weight-trend-period-average">
+              {chartData.length > 0 ? formatWeight(headerInsights.avgWeight) : '--'}
+            </p>
+          </div>
+        </div>
+
+        <div
+          aria-label="Weight trend range"
+          className="inline-flex w-full flex-wrap items-center gap-2 rounded-full border border-border bg-secondary/35 p-1"
+          role="group"
+        >
+          {RANGE_OPTIONS.map((option) => (
+            <Button
+              aria-pressed={selectedRange.value === option.value}
+              className="rounded-full"
+              key={option.value}
+              onClick={() => setSelectedRange(option)}
+              size="sm"
+              type="button"
+              variant={selectedRange.value === option.value ? 'default' : 'ghost'}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-5 px-4 py-5 sm:px-6">
+        {weightEntriesQuery.isLoading ? (
+          <div className="h-[280px] w-full animate-pulse rounded-2xl bg-muted/50" data-slot="weight-trend-loading" />
+        ) : weightEntriesQuery.isError ? (
+          <div className="flex min-h-[220px] items-center justify-center rounded-2xl border border-border/70 bg-muted/20 px-6 text-center">
+            <p className="text-sm text-muted-foreground">Unable to load weight trend data.</p>
+          </div>
+        ) : chartData.length === 0 ? (
+          <div className="flex min-h-[220px] items-center justify-center rounded-2xl border border-dashed border-border bg-muted/15 px-6 text-center">
+            <div className="space-y-2">
+              <p className="text-base font-semibold text-foreground">Log your weight to see trends</p>
+              <a className="text-sm font-medium text-primary hover:underline" href="#dashboard-log-weight-card">
+                Go to weight entry
+              </a>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div aria-label="Weight trend chart" className="h-[280px] w-full sm:h-[320px]" role="img">
+              <ResponsiveContainer height="100%" width="100%">
+                <LineChart data={chartData} margin={{ top: 12, right: 8, bottom: 6, left: 2 }}>
+                  <CartesianGrid stroke="var(--color-border)" strokeDasharray="3 3" />
+                  <XAxis
+                    axisLine={false}
+                    dataKey="date"
+                    minTickGap={20}
+                    tick={{ fill: 'var(--color-muted)', fontSize: 12 }}
+                    tickFormatter={(value: string) => axisDateFormatter.format(new Date(`${value}T12:00:00`))}
+                    tickLine={false}
+                  />
+                  <YAxis
+                    axisLine={false}
+                    domain={yDomain}
+                    tick={{ fill: 'var(--color-muted)', fontSize: 12 }}
+                    tickFormatter={(value: number) => numberFormatter.format(value)}
+                    tickLine={false}
+                    width={50}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: 'var(--color-card)',
+                      border: '1px solid var(--color-border)',
+                      borderRadius: '14px',
+                      color: 'var(--color-foreground)',
+                    }}
+                    formatter={(value: number | undefined, name: string | undefined) => {
+                      if (name === 'scale') {
+                        return [formatWeight(value ?? 0), 'Scale Weight'];
+                      }
+
+                      return [formatWeight(value ?? 0), 'Trend Weight'];
+                    }}
+                    labelFormatter={(label) =>
+                      typeof label === 'string'
+                        ? tooltipDateFormatter.format(new Date(`${label}T12:00:00`))
+                        : ''
+                    }
+                    separator=": "
+                  />
+                  {visibleSeries.scale ? (
+                    <Line
+                      dataKey="scale"
+                      dot={{ fill: SERIES_COLORS.scale, r: 3.5, strokeWidth: 0 }}
+                      isAnimationActive={false}
+                      name="scale"
+                      stroke={SERIES_COLORS.scale}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2.5}
+                      type="monotone"
+                    />
+                  ) : null}
+                  {visibleSeries.trend ? (
+                    <Line
+                      dataKey="trend"
+                      dot={{ fill: SERIES_COLORS.trend, r: 4, stroke: 'var(--color-card)', strokeWidth: 1.5 }}
+                      isAnimationActive={false}
+                      name="trend"
+                      stroke={SERIES_COLORS.trend}
+                      strokeDasharray="6 4"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2.5}
+                      type="monotone"
+                    />
+                  ) : null}
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2" data-slot="weight-trend-legend">
+              <LegendToggle
+                active={visibleSeries.scale}
+                color={SERIES_COLORS.scale}
+                label="Scale Weight"
+                onClick={() => toggleSeries('scale')}
+              />
+              <LegendToggle
+                active={visibleSeries.trend}
+                color={SERIES_COLORS.trend}
+                label="Trend Weight"
+                onClick={() => toggleSeries('trend')}
+              />
+            </div>
+
+            <div className="grid gap-2 rounded-xl border border-border/70 bg-secondary/25 px-4 py-3" data-slot="weight-trend-insights">
+              <p className="text-sm text-foreground">
+                3-day change: {formatInsightChange(threeDayInsights.periodChange)}{' '}
+                <span aria-label={`3-day direction ${threeDayInsights.direction}`}>
+                  {getDirectionGlyph(threeDayInsights.direction)}
+                </span>
+              </p>
+              <p className="text-sm text-foreground">
+                7-day change: {formatInsightChange(sevenDayInsights.periodChange)}{' '}
+                <span aria-label={`7-day direction ${sevenDayInsights.direction}`}>
+                  {getDirectionGlyph(sevenDayInsights.direction)}
+                </span>
+              </p>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function LegendToggle({
+  active,
+  color,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  color: string;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      aria-pressed={active}
+      className={cn(
+        'inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors',
+        active ? 'border-border bg-secondary/55 text-foreground' : 'border-border/70 bg-background text-muted-foreground',
+      )}
+      onClick={onClick}
+      type="button"
+    >
+      <span aria-hidden="true" className="size-2.5 rounded-full" style={{ backgroundColor: color }} />
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/apps/web/src/hooks/use-dashboard-config.test.tsx
+++ b/apps/web/src/hooks/use-dashboard-config.test.tsx
@@ -26,6 +26,7 @@ describe('dashboard config hooks', () => {
       createJsonResponse({
         habitChainIds: ['habit-1', 'habit-2'],
         trendMetrics: ['weight', 'calories'],
+        visibleWidgets: ['snapshot', 'weight-trend'],
         widgetOrder: ['snapshot', 'habits'],
       }),
     );
@@ -49,6 +50,7 @@ describe('dashboard config hooks', () => {
     expect(result.current.data).toEqual({
       habitChainIds: ['habit-1', 'habit-2'],
       trendMetrics: ['weight', 'calories'],
+      visibleWidgets: ['snapshot', 'weight-trend'],
       widgetOrder: ['snapshot', 'habits'],
     });
   });

--- a/apps/web/src/hooks/use-dashboard-config.test.tsx
+++ b/apps/web/src/hooks/use-dashboard-config.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook, waitFor } from '@testing-library/react';
+import { DASHBOARD_WIDGET_IDS } from '@pulse/shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createQueryClientWrapper } from '@/test/query-client';
@@ -6,6 +7,7 @@ import { createQueryClientWrapper } from '@/test/query-client';
 import { useDashboardConfig, useSaveDashboardConfig } from './use-dashboard-config';
 
 const mockFetch = vi.fn();
+const DEFAULT_VISIBLE_WIDGETS = Object.keys(DASHBOARD_WIDGET_IDS);
 
 const createJsonResponse = (data: unknown, status = 200) =>
   new Response(JSON.stringify({ data }), {
@@ -26,7 +28,7 @@ describe('dashboard config hooks', () => {
       createJsonResponse({
         habitChainIds: ['habit-1', 'habit-2'],
         trendMetrics: ['weight', 'calories'],
-        visibleWidgets: ['snapshot', 'weight-trend'],
+        visibleWidgets: ['snapshot-cards', 'weight-trend'],
         widgetOrder: ['snapshot', 'habits'],
       }),
     );
@@ -50,7 +52,7 @@ describe('dashboard config hooks', () => {
     expect(result.current.data).toEqual({
       habitChainIds: ['habit-1', 'habit-2'],
       trendMetrics: ['weight', 'calories'],
-      visibleWidgets: ['snapshot', 'weight-trend'],
+      visibleWidgets: ['snapshot-cards', 'weight-trend'],
       widgetOrder: ['snapshot', 'habits'],
     });
   });
@@ -60,6 +62,7 @@ describe('dashboard config hooks', () => {
       createJsonResponse({
         habitChainIds: ['habit-1'],
         trendMetrics: ['protein'],
+        visibleWidgets: DEFAULT_VISIBLE_WIDGETS,
       }),
     );
 
@@ -78,6 +81,7 @@ describe('dashboard config hooks', () => {
     await result.current.mutateAsync({
       habitChainIds: ['habit-1'],
       trendMetrics: ['protein'],
+      visibleWidgets: DEFAULT_VISIBLE_WIDGETS,
     });
 
     expect(mockFetch).toHaveBeenCalledWith(

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -168,6 +168,33 @@ const macroTrendData = [
   },
 ];
 
+const weightEntriesData = [
+  {
+    id: 'weight-entry-1',
+    date: '2026-03-04',
+    weight: 181.8,
+    notes: null,
+    createdAt: 1,
+    updatedAt: 1,
+  },
+  {
+    id: 'weight-entry-2',
+    date: '2026-03-05',
+    weight: 181.2,
+    notes: null,
+    createdAt: 2,
+    updatedAt: 2,
+  },
+  {
+    id: 'weight-entry-3',
+    date: '2026-03-06',
+    weight: 181.4,
+    notes: null,
+    createdAt: 3,
+    updatedAt: 3,
+  },
+];
+
 const recentWorkoutsListData = [
   {
     id: 'recent-workout-1',
@@ -263,6 +290,15 @@ describe('DashboardPage', () => {
       if (url.pathname === '/api/v1/dashboard/trends/macros' && init?.method === 'GET') {
         return Promise.resolve(
           new Response(JSON.stringify({ data: macroTrendData }), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/weight' && init?.method === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: weightEntriesData }), {
             headers: { 'Content-Type': 'application/json' },
             status: 200,
           }),
@@ -374,6 +410,7 @@ describe('DashboardPage', () => {
     expect(screen.getByLabelText('Macro display mode')).toBeInTheDocument();
     expect(screen.getByLabelText('Habit chains')).toBeInTheDocument();
     expect(screen.getByLabelText('Trend sparklines')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Weight Trend' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Recent Workouts' })).toBeInTheDocument();
     expect(screen.getByText('Upper Push A (Completed)')).toBeInTheDocument();
     expect(screen.getByText('1,900 / 2,300')).toBeInTheDocument();
@@ -489,6 +526,15 @@ describe('DashboardPage', () => {
       if (url.pathname === '/api/v1/dashboard/trends/macros' && init?.method === 'GET') {
         return Promise.resolve(
           new Response(JSON.stringify({ data: macroTrendData }), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/weight' && init?.method === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: weightEntriesData }), {
             headers: { 'Content-Type': 'application/json' },
             status: 200,
           }),
@@ -663,9 +709,11 @@ describe('DashboardPage', () => {
     await vi.runAllTimersAsync();
     await Promise.resolve();
 
+    const trendSparklinesSection = screen.getByLabelText('Trend sparklines');
+
     expect(screen.getByText('Protein Trend')).toBeInTheDocument();
-    expect(screen.queryByText('Weight Trend')).not.toBeInTheDocument();
-    expect(screen.queryByText('Calorie Trend')).not.toBeInTheDocument();
+    expect(within(trendSparklinesSection).queryByText('Weight Trend')).not.toBeInTheDocument();
+    expect(within(trendSparklinesSection).queryByText('Calorie Trend')).not.toBeInTheDocument();
     expect(screen.getByText('No matching habits.')).toBeInTheDocument();
   });
 
@@ -755,6 +803,15 @@ describe('DashboardPage', () => {
       }
 
       if (url.pathname === '/api/v1/dashboard/trends/macros' && init?.method === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: [] }), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/weight' && init?.method === 'GET') {
         return Promise.resolve(
           new Response(JSON.stringify({ data: [] }), {
             headers: { 'Content-Type': 'application/json' },

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -256,6 +256,17 @@ describe('DashboardPage', () => {
         );
       }
 
+      if (url.pathname === '/api/v1/dashboard/config' && init?.method === 'PUT') {
+        dashboardConfig = JSON.parse(String(init.body)) as DashboardConfig;
+
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: dashboardConfig }), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          }),
+        );
+      }
+
       if (url.pathname === '/api/v1/habits' && init?.method === 'GET') {
         return Promise.resolve(
           new Response(JSON.stringify({ data: habits }), {
@@ -742,6 +753,60 @@ describe('DashboardPage', () => {
 
     expect(screen.queryByRole('heading', { name: 'Weight Trend' })).not.toBeInTheDocument();
     expect(container.querySelector('[data-slot="dashboard-weight-trend-row"]')).not.toBeInTheDocument();
+  });
+
+  it('supports dashboard widget edit mode with save and cancel behavior', async () => {
+    const { wrapper } = createQueryClientWrapper();
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+      { wrapper },
+    );
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit dashboard widgets' }));
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide Recent Workouts widget' }));
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+    expect(screen.queryByRole('heading', { name: 'Recent Workouts' })).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Hidden widgets' })).toBeInTheDocument();
+    expect(screen.getByText('Recent Workouts')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show' }));
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+    expect(screen.getByRole('heading', { name: 'Recent Workouts' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide Recent Workouts widget' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Recent Workouts' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit dashboard widgets' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Hide Recent Workouts widget' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+    expect(screen.queryByRole('heading', { name: 'Recent Workouts' })).not.toBeInTheDocument();
+
+    const saveRequest = mockFetch.mock.calls.find(([url, init]) => {
+      const raw = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      return raw.includes('/api/v1/dashboard/config') && init?.method === 'PUT';
+    });
+
+    expect(saveRequest).toBeDefined();
+    expect(JSON.parse(String(saveRequest?.[1]?.body))).toMatchObject({
+      visibleWidgets: expect.not.arrayContaining(['recent-workouts']),
+    });
   });
 
   it('renders the dashboard empty state when there are no habits and no recent workouts', async () => {

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -216,6 +216,7 @@ describe('DashboardPage', () => {
   let mockFetch: ReturnType<typeof vi.fn>;
   let dashboardConfig: DashboardConfig;
   let snapshotsByDate: Record<string, DashboardSnapshot>;
+  let shouldFailDashboardConfigSave: boolean;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -229,6 +230,7 @@ describe('DashboardPage', () => {
       trendMetrics: ['weight', 'calories', 'protein'],
       visibleWidgets: DEFAULT_VISIBLE_WIDGETS,
     };
+    shouldFailDashboardConfigSave = false;
 
     mockFetch = vi.fn((input: string | URL | Request, init?: RequestInit) => {
       const rawUrl =
@@ -257,6 +259,20 @@ describe('DashboardPage', () => {
       }
 
       if (url.pathname === '/api/v1/dashboard/config' && init?.method === 'PUT') {
+        if (shouldFailDashboardConfigSave) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                error: {
+                  code: 'SERVER_ERROR',
+                  message: 'Unavailable',
+                },
+              }),
+              { headers: { 'Content-Type': 'application/json' }, status: 503 },
+            ),
+          );
+        }
+
         dashboardConfig = JSON.parse(String(init.body)) as DashboardConfig;
 
         return Promise.resolve(
@@ -807,6 +823,32 @@ describe('DashboardPage', () => {
     expect(JSON.parse(String(saveRequest?.[1]?.body))).toMatchObject({
       visibleWidgets: expect.not.arrayContaining(['recent-workouts']),
     });
+  });
+
+  it('stays in edit mode and shows an error when widget visibility save fails', async () => {
+    shouldFailDashboardConfigSave = true;
+    const { wrapper } = createQueryClientWrapper();
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+      { wrapper },
+    );
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit dashboard widgets' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Hide Recent Workouts widget' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+    expect(
+      screen.getByText('Unable to save widget visibility. Please try again.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Hidden widgets' })).toBeInTheDocument();
   });
 
   it('renders the dashboard empty state when there are no habits and no recent workouts', async () => {

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -1,4 +1,4 @@
-import type { DashboardConfig, DashboardSnapshot, Habit, HabitEntry } from '@pulse/shared';
+import { type DashboardConfig, DASHBOARD_WIDGET_IDS, type DashboardSnapshot, type Habit, type HabitEntry } from '@pulse/shared';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -9,6 +9,7 @@ import { createQueryClientWrapper } from '@/test/query-client';
 import { DashboardPage } from './dashboard';
 
 const formatWeight = (value: number): string => `${value.toFixed(1)} lbs`;
+const DEFAULT_VISIBLE_WIDGETS = Object.keys(DASHBOARD_WIDGET_IDS);
 
 function createDeferredResponse() {
   let resolve: (value: Response) => void = () => {};
@@ -226,6 +227,7 @@ describe('DashboardPage', () => {
     dashboardConfig = {
       habitChainIds: ['habit-meditate'],
       trendMetrics: ['weight', 'calories', 'protein'],
+      visibleWidgets: DEFAULT_VISIBLE_WIDGETS,
     };
 
     mockFetch = vi.fn((input: string | URL | Request, init?: RequestInit) => {
@@ -698,6 +700,7 @@ describe('DashboardPage', () => {
     dashboardConfig = {
       habitChainIds: [],
       trendMetrics: ['protein'],
+      visibleWidgets: DEFAULT_VISIBLE_WIDGETS,
     };
 
     const { wrapper } = createQueryClientWrapper();

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -449,6 +449,7 @@ describe('DashboardPage', () => {
     const sidebarColumn = container.querySelector('[data-slot="dashboard-sidebar-column"]');
     const logWeightForm = container.querySelector('[data-qa="dashboard-log-weight-form"]');
     const recentColumn = container.querySelector('[data-slot="dashboard-recent-workouts-column"]');
+    const weightTrendRow = container.querySelector('[data-slot="dashboard-weight-trend-row"]');
     const calendarPanel = container.querySelector('[data-slot="dashboard-calendar-panel"]');
     const snapshotPanel = container.querySelector('[data-slot="dashboard-snapshot-panel"]');
     const macroPanel = container.querySelector('[data-slot="dashboard-macro-panel"]');
@@ -470,6 +471,7 @@ describe('DashboardPage', () => {
       'xl:col-span-1',
       'xl:col-start-3',
     );
+    expect(weightTrendRow).toHaveClass('order-4', 'md:col-span-2', 'xl:col-span-3');
     expect(calendarPanel).toHaveClass('order-1', 'md:order-3');
     expect(snapshotPanel).toHaveClass('order-2', 'md:order-1');
     expect(macroPanel).toHaveClass('order-3', 'md:order-2');
@@ -715,6 +717,28 @@ describe('DashboardPage', () => {
     expect(within(trendSparklinesSection).queryByText('Weight Trend')).not.toBeInTheDocument();
     expect(within(trendSparklinesSection).queryByText('Calorie Trend')).not.toBeInTheDocument();
     expect(screen.getByText('No matching habits.')).toBeInTheDocument();
+  });
+
+  it('hides the weight trend widget when it is excluded from visible widgets', async () => {
+    dashboardConfig = {
+      habitChainIds: ['habit-meditate'],
+      trendMetrics: ['weight', 'calories', 'protein'],
+      visibleWidgets: ['snapshot', 'macro-rings', 'habit-chain', 'trend-sparklines'],
+    };
+
+    const { wrapper } = createQueryClientWrapper();
+    const { container } = render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+      { wrapper },
+    );
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(screen.queryByRole('heading', { name: 'Weight Trend' })).not.toBeInTheDocument();
+    expect(container.querySelector('[data-slot="dashboard-weight-trend-row"]')).not.toBeInTheDocument();
   });
 
   it('renders the dashboard empty state when there are no habits and no recent workouts', async () => {

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -1,7 +1,7 @@
 import { DASHBOARD_WIDGET_IDS } from '@pulse/shared';
 import { useQueryClient } from '@tanstack/react-query';
-import { LayoutDashboard } from 'lucide-react';
-import { type FormEvent, useEffect, useState } from 'react';
+import { EyeOff, LayoutDashboard, Pencil, Plus } from 'lucide-react';
+import { type FormEvent, type ReactNode, useEffect, useState } from 'react';
 
 import { StatCardSkeleton } from '@/components/skeletons';
 import { Button } from '@/components/ui/button';
@@ -9,6 +9,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { EmptyState } from '@/components/ui/empty-state';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Toggle } from '@/components/ui/toggle';
 import { CalendarPicker } from '@/features/dashboard/components/calendar-picker';
 import { HabitChain } from '@/features/dashboard/components/habit-chain';
 import { MacroRings } from '@/features/dashboard/components/macro-rings';
@@ -25,9 +26,10 @@ import {
   useDashboardSnapshot,
   dashboardSnapshotKeys,
 } from '@/hooks/use-dashboard-snapshot';
-import { useDashboardConfig } from '@/hooks/use-dashboard-config';
+import { useDashboardConfig, useSaveDashboardConfig } from '@/hooks/use-dashboard-config';
 import { useHabitChains } from '@/hooks/use-habit-chains';
 import { addDays, getToday, isSameDay, toDateKey } from '@/lib/date';
+import { cn } from '@/lib/utils';
 
 const dashboardDateFormatter = new Intl.DateTimeFormat('en-US', {
   weekday: 'long',
@@ -35,14 +37,77 @@ const dashboardDateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
   year: 'numeric',
 });
-const DEFAULT_VISIBLE_WIDGETS = Object.keys(DASHBOARD_WIDGET_IDS);
+type DashboardWidgetId = keyof typeof DASHBOARD_WIDGET_IDS;
+const DEFAULT_VISIBLE_WIDGETS = Object.keys(DASHBOARD_WIDGET_IDS) as DashboardWidgetId[];
+const DEFAULT_DASHBOARD_CONFIG = {
+  habitChainIds: [],
+  trendMetrics: ['weight', 'calories', 'protein'] as const,
+  visibleWidgets: DEFAULT_VISIBLE_WIDGETS,
+};
+
+function DashboardWidgetEditOverlay({
+  onHide,
+  widgetLabel,
+}: {
+  onHide: () => void;
+  widgetLabel: string;
+}) {
+  return (
+    <div className="pointer-events-none absolute inset-0 rounded-2xl bg-background/60">
+      <div className="pointer-events-auto absolute top-3 right-3">
+        <Toggle
+          aria-label={`Hide ${widgetLabel} widget`}
+          onPressedChange={() => {
+            onHide();
+          }}
+          pressed={false}
+          size="sm"
+          variant="outline"
+        >
+          <EyeOff />
+          Hide
+        </Toggle>
+      </div>
+    </div>
+  );
+}
+
+function isDashboardWidgetId(value: string): value is DashboardWidgetId {
+  return value in DASHBOARD_WIDGET_IDS;
+}
+
+function DashboardWidgetFrame({
+  children,
+  className,
+  dataSlot,
+  isEditMode,
+  onHide,
+  widgetLabel,
+}: {
+  children: ReactNode;
+  className?: string;
+  dataSlot?: string;
+  isEditMode: boolean;
+  onHide: () => void;
+  widgetLabel: string;
+}) {
+  return (
+    <div className={cn('relative', className)} data-slot={dataSlot} data-widget-label={widgetLabel}>
+      {children}
+      {isEditMode ? <DashboardWidgetEditOverlay onHide={onHide} widgetLabel={widgetLabel} /> : null}
+    </div>
+  );
+}
 
 export function DashboardPage() {
   const queryClient = useQueryClient();
   const [selectedDate, setSelectedDate] = useState<Date>(() => getToday());
   const [weightInput, setWeightInput] = useState('');
   const [weightMessage, setWeightMessage] = useState('');
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [visibleWidgetsDraft, setVisibleWidgetsDraft] = useState<DashboardWidgetId[] | null>(null);
   const logWeightMutation = useLogWeight();
+  const saveDashboardConfigMutation = useSaveDashboardConfig();
   const selectedDateKey = toDateKey(selectedDate);
   const habitRangeStart = toDateKey(addDays(selectedDate, -29));
   const selectedDateLabel = dashboardDateFormatter.format(selectedDate);
@@ -55,8 +120,53 @@ export function DashboardPage() {
   const habitsQuery = useHabits();
   const habitChainEntriesQuery = useHabitChains(habitRangeStart, selectedDateKey);
   const recentWorkoutsQuery = useRecentWorkouts();
-  const visibleWidgets = dashboardConfigQuery.data?.visibleWidgets ?? DEFAULT_VISIBLE_WIDGETS;
+  const persistedVisibleWidgets = (dashboardConfigQuery.data?.visibleWidgets ?? DEFAULT_VISIBLE_WIDGETS)
+    .filter(isDashboardWidgetId);
+  const visibleWidgets = visibleWidgetsDraft ?? persistedVisibleWidgets;
+  const hiddenWidgets = DEFAULT_VISIBLE_WIDGETS.filter((widgetId) => !visibleWidgets.includes(widgetId));
   const showWeightTrendChart = visibleWidgets.includes('weight-trend');
+  const isSavingDashboardConfig = saveDashboardConfigMutation.isPending;
+
+  function showWidget(widgetId: DashboardWidgetId) {
+    setVisibleWidgetsDraft((currentDraft) => {
+      const current = currentDraft ?? persistedVisibleWidgets;
+      if (current.includes(widgetId)) {
+        return current;
+      }
+
+      return [...current, widgetId];
+    });
+  }
+
+  function hideWidget(widgetId: DashboardWidgetId) {
+    setVisibleWidgetsDraft((currentDraft) => {
+      const current = currentDraft ?? persistedVisibleWidgets;
+      return current.filter((value) => value !== widgetId);
+    });
+  }
+
+  function handleStartEditMode() {
+    setVisibleWidgetsDraft(persistedVisibleWidgets);
+    setIsEditMode(true);
+  }
+
+  function handleCancelEditMode() {
+    setVisibleWidgetsDraft(null);
+    setIsEditMode(false);
+  }
+
+  async function handleSaveWidgetVisibility() {
+    const sourceConfig = dashboardConfigQuery.data ?? DEFAULT_DASHBOARD_CONFIG;
+
+    await saveDashboardConfigMutation.mutateAsync({
+      ...sourceConfig,
+      trendMetrics: [...sourceConfig.trendMetrics],
+      visibleWidgets,
+    });
+
+    setVisibleWidgetsDraft(null);
+    setIsEditMode(false);
+  }
 
   useEffect(() => {
     const previousDateKey = toDateKey(addDays(selectedDate, -1));
@@ -104,16 +214,56 @@ export function DashboardPage() {
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted sm:text-sm">
           {greeting}
         </p>
-        <div className="flex flex-wrap items-center gap-3">
-          <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl lg:text-5xl">
-            Dashboard
-          </h1>
-          {!isViewingToday ? (
-            <Button onClick={() => setSelectedDate(getToday())} size="sm" type="button" variant="outline">
-              Back to today
-            </Button>
-          ) : null}
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-wrap items-center gap-3">
+            <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl lg:text-5xl">
+              Dashboard
+            </h1>
+            {!isViewingToday ? (
+              <Button onClick={() => setSelectedDate(getToday())} size="sm" type="button" variant="outline">
+                Back to today
+              </Button>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-2">
+            {isEditMode ? (
+              <>
+                <Button
+                  disabled={isSavingDashboardConfig}
+                  onClick={handleCancelEditMode}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  disabled={isSavingDashboardConfig}
+                  onClick={() => {
+                    void handleSaveWidgetVisibility();
+                  }}
+                  size="sm"
+                  type="button"
+                >
+                  {isSavingDashboardConfig ? 'Saving...' : 'Save'}
+                </Button>
+              </>
+            ) : (
+              <Button
+                aria-label="Edit dashboard widgets"
+                onClick={handleStartEditMode}
+                size="icon-sm"
+                type="button"
+                variant="outline"
+              >
+                <Pencil />
+              </Button>
+            )}
+          </div>
         </div>
+        {isEditMode ? (
+          <p className="text-sm text-muted-foreground">Hide or restore widgets, then save changes.</p>
+        ) : null}
         <p className="text-sm text-muted-foreground sm:text-base">{selectedDateLabel}</p>
       </header>
 
@@ -132,118 +282,206 @@ export function DashboardPage() {
             className="order-1 flex min-w-0 flex-col gap-6 md:order-1 xl:order-2"
             data-slot="dashboard-main-column"
           >
-            <div className="order-1 md:order-3" data-slot="dashboard-calendar-panel">
-              <CalendarPicker onDateSelect={setSelectedDate} selectedDate={selectedDate} />
-            </div>
+            {visibleWidgets.includes('calendar') ? (
+              <DashboardWidgetFrame
+                className="order-1 md:order-3"
+                dataSlot="dashboard-calendar-panel"
+                isEditMode={isEditMode}
+                onHide={() => hideWidget('calendar')}
+                widgetLabel={DASHBOARD_WIDGET_IDS.calendar}
+              >
+                <CalendarPicker onDateSelect={setSelectedDate} selectedDate={selectedDate} />
+              </DashboardWidgetFrame>
+            ) : null}
 
-            <div className="order-2 md:order-1" data-slot="dashboard-snapshot-panel">
-              <div className="flex flex-col gap-6">
-                {snapshotQuery.isLoading ? (
-                  <div
-                    aria-label="Loading dashboard snapshots"
-                    className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4"
-                  >
-                    {Array.from({ length: 5 }).map((_, index) => (
-                      <StatCardSkeleton key={index} showTrend={index !== 4} />
-                    ))}
-                  </div>
-                ) : (
-                  <SnapshotCards snapshot={snapshotQuery.data} />
-                )}
-                <Card data-qa="dashboard-log-weight-card" data-testid="dashboard-log-weight-card">
-                  <CardHeader className="space-y-1">
-                    <CardTitle>Log Weight</CardTitle>
-                    <CardDescription>Track your body weight for the selected day.</CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <form
-                      className="space-y-3"
-                      data-qa="dashboard-log-weight-form"
-                      data-testid="dashboard-log-weight-form"
-                      onSubmit={handleWeightSubmit}
+            {visibleWidgets.includes('snapshot-cards') || visibleWidgets.includes('log-weight') ? (
+              <div className="order-2 md:order-1" data-slot="dashboard-snapshot-panel">
+                <div className="flex flex-col gap-6">
+                  {visibleWidgets.includes('snapshot-cards') ? (
+                    <DashboardWidgetFrame
+                      isEditMode={isEditMode}
+                      onHide={() => hideWidget('snapshot-cards')}
+                      widgetLabel={DASHBOARD_WIDGET_IDS['snapshot-cards']}
                     >
-                      <div className="space-y-2">
-                        <Label htmlFor="dashboard-weight-input">Weight (lbs)</Label>
-                        <Input
-                          aria-describedby="dashboard-weight-status"
-                          data-qa="dashboard-weight-input"
-                          data-testid="dashboard-weight-input"
-                          id="dashboard-weight-input"
-                          inputMode="decimal"
-                          min="0.1"
-                          name="weight"
-                          onChange={(event) => {
-                            setWeightInput(event.currentTarget.value);
-                            setWeightMessage('');
-                          }}
-                          placeholder="e.g. 175.5"
-                          step="0.1"
-                          type="number"
-                          value={weightInput}
-                        />
-                      </div>
-                      <Button
-                        data-qa="dashboard-save-weight"
-                        data-testid="dashboard-save-weight"
-                        id="dashboard-save-weight"
-                        disabled={logWeightMutation.isPending}
-                        type="submit"
-                      >
-                        {logWeightMutation.isPending ? 'Saving...' : 'Save Weight'}
-                      </Button>
-                      {weightMessage ? (
-                        <p
-                          className="text-sm text-muted-foreground"
-                          id="dashboard-weight-status"
-                          role="status"
+                      {snapshotQuery.isLoading ? (
+                        <div
+                          aria-label="Loading dashboard snapshots"
+                          className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4"
                         >
-                          {weightMessage}
-                        </p>
-                      ) : null}
-                    </form>
-                  </CardContent>
-                </Card>
+                          {Array.from({ length: 5 }).map((_, index) => (
+                            <StatCardSkeleton key={index} showTrend={index !== 4} />
+                          ))}
+                        </div>
+                      ) : (
+                        <SnapshotCards snapshot={snapshotQuery.data} />
+                      )}
+                    </DashboardWidgetFrame>
+                  ) : null}
+                  {visibleWidgets.includes('log-weight') ? (
+                    <DashboardWidgetFrame
+                      isEditMode={isEditMode}
+                      onHide={() => hideWidget('log-weight')}
+                      widgetLabel={DASHBOARD_WIDGET_IDS['log-weight']}
+                    >
+                      <Card data-qa="dashboard-log-weight-card" data-testid="dashboard-log-weight-card">
+                        <CardHeader className="space-y-1">
+                          <CardTitle>Log Weight</CardTitle>
+                          <CardDescription>Track your body weight for the selected day.</CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                          <form
+                            className="space-y-3"
+                            data-qa="dashboard-log-weight-form"
+                            data-testid="dashboard-log-weight-form"
+                            onSubmit={handleWeightSubmit}
+                          >
+                            <div className="space-y-2">
+                              <Label htmlFor="dashboard-weight-input">Weight (lbs)</Label>
+                              <Input
+                                aria-describedby="dashboard-weight-status"
+                                data-qa="dashboard-weight-input"
+                                data-testid="dashboard-weight-input"
+                                id="dashboard-weight-input"
+                                inputMode="decimal"
+                                min="0.1"
+                                name="weight"
+                                onChange={(event) => {
+                                  setWeightInput(event.currentTarget.value);
+                                  setWeightMessage('');
+                                }}
+                                placeholder="e.g. 175.5"
+                                step="0.1"
+                                type="number"
+                                value={weightInput}
+                              />
+                            </div>
+                            <Button
+                              data-qa="dashboard-save-weight"
+                              data-testid="dashboard-save-weight"
+                              id="dashboard-save-weight"
+                              disabled={logWeightMutation.isPending}
+                              type="submit"
+                            >
+                              {logWeightMutation.isPending ? 'Saving...' : 'Save Weight'}
+                            </Button>
+                            {weightMessage ? (
+                              <p
+                                className="text-sm text-muted-foreground"
+                                id="dashboard-weight-status"
+                                role="status"
+                              >
+                                {weightMessage}
+                              </p>
+                            ) : null}
+                          </form>
+                        </CardContent>
+                      </Card>
+                    </DashboardWidgetFrame>
+                  ) : null}
+                </div>
               </div>
-            </div>
+            ) : null}
 
-            <div className="order-3 md:order-2" data-slot="dashboard-macro-panel">
-              <MacroRings snapshot={snapshotQuery.data} />
-            </div>
+            {visibleWidgets.includes('macro-rings') ? (
+              <DashboardWidgetFrame
+                className="order-3 md:order-2"
+                dataSlot="dashboard-macro-panel"
+                isEditMode={isEditMode}
+                onHide={() => hideWidget('macro-rings')}
+                widgetLabel={DASHBOARD_WIDGET_IDS['macro-rings']}
+              >
+                <MacroRings snapshot={snapshotQuery.data} />
+              </DashboardWidgetFrame>
+            ) : null}
           </div>
 
           <div
             className="order-2 flex min-w-0 flex-col gap-6 md:order-2 xl:order-1"
             data-slot="dashboard-sidebar-column"
           >
-            <HabitChain
-              endDate={selectedDateKey}
-              habitIds={dashboardConfigQuery.data?.habitChainIds}
-              habits={habitsQuery.data ?? []}
-              entries={habitChainEntriesQuery.data ?? []}
-            />
-            <TrendSparklines
-              endDate={selectedDateKey}
-              metrics={dashboardConfigQuery.data?.trendMetrics}
-            />
+            {visibleWidgets.includes('habit-chain') ? (
+              <DashboardWidgetFrame
+                isEditMode={isEditMode}
+                onHide={() => hideWidget('habit-chain')}
+                widgetLabel={DASHBOARD_WIDGET_IDS['habit-chain']}
+              >
+                <HabitChain
+                  endDate={selectedDateKey}
+                  habitIds={dashboardConfigQuery.data?.habitChainIds}
+                  habits={habitsQuery.data ?? []}
+                  entries={habitChainEntriesQuery.data ?? []}
+                />
+              </DashboardWidgetFrame>
+            ) : null}
+            {visibleWidgets.includes('trend-sparklines') ? (
+              <DashboardWidgetFrame
+                isEditMode={isEditMode}
+                onHide={() => hideWidget('trend-sparklines')}
+                widgetLabel={DASHBOARD_WIDGET_IDS['trend-sparklines']}
+              >
+                <TrendSparklines
+                  endDate={selectedDateKey}
+                  metrics={dashboardConfigQuery.data?.trendMetrics}
+                />
+              </DashboardWidgetFrame>
+            ) : null}
           </div>
 
-          <div
-            className="order-3 min-w-0 md:col-span-2 xl:col-span-1 xl:col-start-3"
-            data-slot="dashboard-recent-workouts-column"
-          >
-            <RecentWorkouts />
-          </div>
+          {visibleWidgets.includes('recent-workouts') ? (
+            <DashboardWidgetFrame
+              className="order-3 min-w-0 md:col-span-2 xl:col-span-1 xl:col-start-3"
+              dataSlot="dashboard-recent-workouts-column"
+              isEditMode={isEditMode}
+              onHide={() => hideWidget('recent-workouts')}
+              widgetLabel={DASHBOARD_WIDGET_IDS['recent-workouts']}
+            >
+              <RecentWorkouts />
+            </DashboardWidgetFrame>
+          ) : null}
 
           {showWeightTrendChart ? (
-            <div
+            <DashboardWidgetFrame
               className="order-4 min-w-0 md:col-span-2 xl:col-span-3"
-              data-slot="dashboard-weight-trend-row"
+              dataSlot="dashboard-weight-trend-row"
+              isEditMode={isEditMode}
+              onHide={() => hideWidget('weight-trend')}
+              widgetLabel={DASHBOARD_WIDGET_IDS['weight-trend']}
             >
               <WeightTrendChart />
-            </div>
+            </DashboardWidgetFrame>
           ) : null}
         </div>
       )}
+
+      {isEditMode ? (
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-foreground">Hidden widgets</h2>
+          {hiddenWidgets.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No hidden widgets.</p>
+          ) : (
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+              {hiddenWidgets.map((widgetId) => (
+                <Card
+                  key={widgetId}
+                  className="border-dashed border-border/80 bg-muted/30 py-4"
+                  data-slot={`dashboard-hidden-widget-${widgetId}`}
+                >
+                  <CardContent className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-medium text-foreground">{DASHBOARD_WIDGET_IDS[widgetId]}</p>
+                      <p className="text-xs text-muted-foreground">Currently hidden</p>
+                    </div>
+                    <Button onClick={() => showWidget(widgetId)} size="sm" type="button" variant="outline">
+                      <Plus />
+                      Show
+                    </Button>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </section>
+      ) : null}
     </main>
   );
 }

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -15,6 +15,7 @@ import { RecentWorkouts } from '@/features/dashboard/components/recent-workouts'
 import { SnapshotCards } from '@/features/dashboard/components/snapshot-cards';
 import { getDashboardGreeting } from '@/features/dashboard/lib/greeting';
 import { TrendSparklines } from '@/features/dashboard/components/trend-sparkline';
+import { WeightTrendChart } from '@/features/dashboard/components/weight-trend-chart';
 import { useHabits } from '@/features/habits/api/habits';
 import { useRecentWorkouts } from '@/hooks/use-recent-workouts';
 import { useLogWeight } from '@/features/weight/api/weight';
@@ -220,6 +221,7 @@ export function DashboardPage() {
               endDate={selectedDateKey}
               metrics={dashboardConfigQuery.data?.trendMetrics}
             />
+            <WeightTrendChart />
           </div>
 
           <div

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -106,6 +106,7 @@ export function DashboardPage() {
   const [weightMessage, setWeightMessage] = useState('');
   const [isEditMode, setIsEditMode] = useState(false);
   const [visibleWidgetsDraft, setVisibleWidgetsDraft] = useState<DashboardWidgetId[] | null>(null);
+  const [widgetVisibilityMessage, setWidgetVisibilityMessage] = useState('');
   const logWeightMutation = useLogWeight();
   const saveDashboardConfigMutation = useSaveDashboardConfig();
   const selectedDateKey = toDateKey(selectedDate);
@@ -147,25 +148,30 @@ export function DashboardPage() {
 
   function handleStartEditMode() {
     setVisibleWidgetsDraft(persistedVisibleWidgets);
+    setWidgetVisibilityMessage('');
     setIsEditMode(true);
   }
 
   function handleCancelEditMode() {
     setVisibleWidgetsDraft(null);
+    setWidgetVisibilityMessage('');
     setIsEditMode(false);
   }
 
   async function handleSaveWidgetVisibility() {
     const sourceConfig = dashboardConfigQuery.data ?? DEFAULT_DASHBOARD_CONFIG;
-
-    await saveDashboardConfigMutation.mutateAsync({
-      ...sourceConfig,
-      trendMetrics: [...sourceConfig.trendMetrics],
-      visibleWidgets,
-    });
-
-    setVisibleWidgetsDraft(null);
-    setIsEditMode(false);
+    try {
+      await saveDashboardConfigMutation.mutateAsync({
+        ...sourceConfig,
+        trendMetrics: [...sourceConfig.trendMetrics],
+        visibleWidgets,
+      });
+      setVisibleWidgetsDraft(null);
+      setWidgetVisibilityMessage('');
+      setIsEditMode(false);
+    } catch {
+      setWidgetVisibilityMessage('Unable to save widget visibility. Please try again.');
+    }
   }
 
   useEffect(() => {
@@ -262,7 +268,15 @@ export function DashboardPage() {
           </div>
         </div>
         {isEditMode ? (
-          <p className="text-sm text-muted-foreground">Hide or restore widgets, then save changes.</p>
+          <p
+            className={cn(
+              'text-sm',
+              widgetVisibilityMessage ? 'text-destructive' : 'text-muted-foreground',
+            )}
+            role="status"
+          >
+            {widgetVisibilityMessage || 'Hide or restore widgets, then save changes.'}
+          </p>
         ) : null}
         <p className="text-sm text-muted-foreground sm:text-base">{selectedDateLabel}</p>
       </header>

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -1,3 +1,4 @@
+import { DASHBOARD_WIDGET_IDS } from '@pulse/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { LayoutDashboard } from 'lucide-react';
 import { type FormEvent, useEffect, useState } from 'react';
@@ -34,8 +35,7 @@ const dashboardDateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
   year: 'numeric',
 });
-const DEFAULT_VISIBLE_WIDGETS = ['weight-trend'] as const;
-const WEIGHT_TREND_WIDGET_ID = 'weight-trend';
+const DEFAULT_VISIBLE_WIDGETS = Object.keys(DASHBOARD_WIDGET_IDS);
 
 export function DashboardPage() {
   const queryClient = useQueryClient();
@@ -56,7 +56,7 @@ export function DashboardPage() {
   const habitChainEntriesQuery = useHabitChains(habitRangeStart, selectedDateKey);
   const recentWorkoutsQuery = useRecentWorkouts();
   const visibleWidgets = dashboardConfigQuery.data?.visibleWidgets ?? DEFAULT_VISIBLE_WIDGETS;
-  const showWeightTrendChart = visibleWidgets.includes(WEIGHT_TREND_WIDGET_ID);
+  const showWeightTrendChart = visibleWidgets.includes('weight-trend');
 
   useEffect(() => {
     const previousDateKey = toDateKey(addDays(selectedDate, -1));

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -34,6 +34,8 @@ const dashboardDateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
   year: 'numeric',
 });
+const DEFAULT_VISIBLE_WIDGETS = ['weight-trend'] as const;
+const WEIGHT_TREND_WIDGET_ID = 'weight-trend';
 
 export function DashboardPage() {
   const queryClient = useQueryClient();
@@ -53,6 +55,8 @@ export function DashboardPage() {
   const habitsQuery = useHabits();
   const habitChainEntriesQuery = useHabitChains(habitRangeStart, selectedDateKey);
   const recentWorkoutsQuery = useRecentWorkouts();
+  const visibleWidgets = dashboardConfigQuery.data?.visibleWidgets ?? DEFAULT_VISIBLE_WIDGETS;
+  const showWeightTrendChart = visibleWidgets.includes(WEIGHT_TREND_WIDGET_ID);
 
   useEffect(() => {
     const previousDateKey = toDateKey(addDays(selectedDate, -1));
@@ -221,7 +225,6 @@ export function DashboardPage() {
               endDate={selectedDateKey}
               metrics={dashboardConfigQuery.data?.trendMetrics}
             />
-            <WeightTrendChart />
           </div>
 
           <div
@@ -230,6 +233,15 @@ export function DashboardPage() {
           >
             <RecentWorkouts />
           </div>
+
+          {showWeightTrendChart ? (
+            <div
+              className="order-4 min-w-0 md:col-span-2 xl:col-span-3"
+              data-slot="dashboard-weight-trend-row"
+            >
+              <WeightTrendChart />
+            </div>
+          ) : null}
         </div>
       )}
     </main>

--- a/apps/web/src/pages/settings.test.tsx
+++ b/apps/web/src/pages/settings.test.tsx
@@ -282,10 +282,10 @@ describe('SettingsPage', () => {
       screen.getByRole('checkbox', { name: /Track your daily protein intake trend/i }),
     ).toBeChecked();
     expect(
-      screen.getByRole('checkbox', { name: /Daily Snapshot Dashboard widget visibility/i }),
+      screen.getByRole('checkbox', { name: /Daily Snapshot.*daily body weight/i }),
     ).toBeChecked();
     expect(
-      screen.getByRole('checkbox', { name: /Date Picker Dashboard widget visibility/i }),
+      screen.getByRole('checkbox', { name: /Date Picker.*date picker for navigating/i }),
     ).toBeChecked();
   });
 
@@ -296,16 +296,16 @@ describe('SettingsPage', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('checkbox', { name: /Daily Snapshot Dashboard widget visibility/i }),
+        screen.getByRole('checkbox', { name: /Daily Snapshot.*daily body weight/i }),
       ).not.toBeChecked();
     });
 
     expect(screen.getByRole('checkbox', { name: /Weight Trend/i })).toBeChecked();
     expect(
-      screen.getByRole('checkbox', { name: /Recent Workouts Dashboard widget visibility/i }),
+      screen.getByRole('checkbox', { name: /Recent Workouts.*latest workout sessions/i }),
     ).toBeChecked();
     expect(
-      screen.getByRole('checkbox', { name: /Date Picker Dashboard widget visibility/i }),
+      screen.getByRole('checkbox', { name: /Date Picker.*date picker for navigating/i }),
     ).not.toBeChecked();
   });
 
@@ -329,7 +329,7 @@ describe('SettingsPage', () => {
     fireEvent.change(screen.getByLabelText('Daily calories'), { target: { value: '2250' } });
     fireEvent.click(screen.getByRole('checkbox', { name: /Sleep/i }));
     fireEvent.click(screen.getByRole('checkbox', { name: /Track your recent body weight direction/i }));
-    fireEvent.click(screen.getByRole('checkbox', { name: /Date Picker Dashboard widget visibility/i }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /Date Picker.*date picker for navigating/i }));
     fireEvent.click(screen.getByRole('button', { name: 'Save settings' }));
 
     await waitFor(() => {

--- a/apps/web/src/pages/settings.test.tsx
+++ b/apps/web/src/pages/settings.test.tsx
@@ -316,6 +316,7 @@ describe('SettingsPage', () => {
     expect(getLatestPostBody('/api/v1/dashboard/config')).toEqual({
       habitChainIds: ['habit-hydrate', 'habit-sleep'],
       trendMetrics: ['calories', 'protein'],
+      visibleWidgets: DEFAULT_SETTINGS.dashboardConfig.visibleWidgets,
     });
   });
 

--- a/apps/web/src/pages/settings.test.tsx
+++ b/apps/web/src/pages/settings.test.tsx
@@ -11,6 +11,7 @@ type TestState = {
   dashboardConfig: {
     habitChainIds: string[];
     trendMetrics: Array<'weight' | 'calories' | 'protein'>;
+    visibleWidgets?: string[];
     widgetOrder?: string[];
   };
   habits: Array<{

--- a/apps/web/src/pages/settings.test.tsx
+++ b/apps/web/src/pages/settings.test.tsx
@@ -272,9 +272,41 @@ describe('SettingsPage', () => {
     });
 
     expect(screen.getByRole('checkbox', { name: /Sleep/i })).not.toBeChecked();
-    expect(screen.getByRole('checkbox', { name: /Weight/i })).toBeChecked();
-    expect(screen.getByRole('checkbox', { name: /Calories/i })).toBeChecked();
-    expect(screen.getByRole('checkbox', { name: /Protein/i })).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: /Track your recent body weight direction/i }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: /Track your daily calorie intake trend/i }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: /Track your daily protein intake trend/i }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: /Daily Snapshot Dashboard widget visibility/i }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: /Date Picker Dashboard widget visibility/i }),
+    ).toBeChecked();
+  });
+
+  it('reflects persisted widget visibility choices from dashboard config', async () => {
+    state.dashboardConfig.visibleWidgets = ['weight-trend', 'recent-workouts'];
+
+    renderSettingsPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('checkbox', { name: /Daily Snapshot Dashboard widget visibility/i }),
+      ).not.toBeChecked();
+    });
+
+    expect(screen.getByRole('checkbox', { name: /Weight Trend/i })).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: /Recent Workouts Dashboard widget visibility/i }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: /Date Picker Dashboard widget visibility/i }),
+    ).not.toBeChecked();
   });
 
   it('reflects the persisted theme on first render', () => {
@@ -296,7 +328,8 @@ describe('SettingsPage', () => {
 
     fireEvent.change(screen.getByLabelText('Daily calories'), { target: { value: '2250' } });
     fireEvent.click(screen.getByRole('checkbox', { name: /Sleep/i }));
-    fireEvent.click(screen.getByRole('checkbox', { name: /Weight/i }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /Track your recent body weight direction/i }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /Date Picker Dashboard widget visibility/i }));
     fireEvent.click(screen.getByRole('button', { name: 'Save settings' }));
 
     await waitFor(() => {
@@ -316,7 +349,9 @@ describe('SettingsPage', () => {
     expect(getLatestPostBody('/api/v1/dashboard/config')).toEqual({
       habitChainIds: ['habit-hydrate', 'habit-sleep'],
       trendMetrics: ['calories', 'protein'],
-      visibleWidgets: DEFAULT_SETTINGS.dashboardConfig.visibleWidgets,
+      visibleWidgets: DEFAULT_SETTINGS.dashboardConfig.visibleWidgets.filter(
+        (widgetId) => widgetId !== 'calendar',
+      ),
     });
   });
 

--- a/apps/web/src/pages/settings.tsx
+++ b/apps/web/src/pages/settings.tsx
@@ -98,6 +98,7 @@ type SettingsFormState = {
   dashboardConfig: {
     habitChainIds: string[];
     trendMetrics: DashboardTrendMetric[];
+    visibleWidgets?: string[];
     widgetOrder?: string[];
   };
   nutritionTargets: {
@@ -112,6 +113,7 @@ const DEFAULT_SETTINGS: SettingsFormState = {
   dashboardConfig: {
     habitChainIds: [],
     trendMetrics: ['weight', 'calories', 'protein'],
+    visibleWidgets: ['weight-trend'],
   },
   nutritionTargets: {
     calories: 2000,

--- a/apps/web/src/pages/settings.tsx
+++ b/apps/web/src/pages/settings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import type { CreateNutritionTargetInput, DashboardTrendMetric } from '@pulse/shared';
+import { DASHBOARD_WIDGET_IDS, type CreateNutritionTargetInput, type DashboardTrendMetric } from '@pulse/shared';
 import { BackLink } from '@/components/layout/back-link';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -98,7 +98,7 @@ type SettingsFormState = {
   dashboardConfig: {
     habitChainIds: string[];
     trendMetrics: DashboardTrendMetric[];
-    visibleWidgets?: string[];
+    visibleWidgets: string[];
     widgetOrder?: string[];
   };
   nutritionTargets: {
@@ -113,7 +113,7 @@ const DEFAULT_SETTINGS: SettingsFormState = {
   dashboardConfig: {
     habitChainIds: [],
     trendMetrics: ['weight', 'calories', 'protein'],
-    visibleWidgets: ['weight-trend'],
+    visibleWidgets: Object.keys(DASHBOARD_WIDGET_IDS),
   },
   nutritionTargets: {
     calories: 2000,

--- a/apps/web/src/pages/settings.tsx
+++ b/apps/web/src/pages/settings.tsx
@@ -394,6 +394,21 @@ export function SettingsPage() {
     });
   }
 
+  function toggleWidgetVisibility(widgetId: string, checked: boolean) {
+    setSaveMessage('');
+    setDashboardConfigDraft((currentDashboardConfig) => {
+      const sourceConfig =
+        currentDashboardConfig ?? persistedDashboardConfig ?? DEFAULT_SETTINGS.dashboardConfig;
+
+      return {
+        ...sourceConfig,
+        visibleWidgets: checked
+          ? Array.from(new Set([...sourceConfig.visibleWidgets, widgetId]))
+          : sourceConfig.visibleWidgets.filter((value) => value !== widgetId),
+      };
+    });
+  }
+
   async function handleSave() {
     const nextTargets: CreateNutritionTargetInput = {
       ...settings.nutritionTargets,
@@ -681,6 +696,38 @@ export function SettingsPage() {
                     <div className="space-y-1">
                       <span className="text-sm font-medium text-foreground">{metric.label}</span>
                       <p className="text-sm text-muted-foreground">{metric.description}</p>
+                    </div>
+                  </Label>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <h3 className="text-base font-semibold text-foreground">Widget Visibility</h3>
+              <p className="text-sm text-muted-foreground">
+                Show or hide dashboard widgets from settings.
+              </p>
+            </div>
+            <div className="grid gap-3 md:grid-cols-2">
+              {Object.entries(DASHBOARD_WIDGET_IDS).map(([widgetId, widgetName]) => {
+                const checkboxId = `widget-visibility-${widgetId}`;
+
+                return (
+                  <Label
+                    key={widgetId}
+                    className="flex cursor-pointer items-start gap-3 rounded-xl border border-border/80 p-3"
+                    htmlFor={checkboxId}
+                  >
+                    <Checkbox
+                      checked={settings.dashboardConfig.visibleWidgets.includes(widgetId)}
+                      id={checkboxId}
+                      onCheckedChange={(checked) => toggleWidgetVisibility(widgetId, checked === true)}
+                    />
+                    <div className="space-y-1">
+                      <span className="text-sm font-medium text-foreground">{widgetName}</span>
+                      <p className="text-sm text-muted-foreground">Dashboard widget visibility</p>
                     </div>
                   </Label>
                 );

--- a/apps/web/src/pages/settings.tsx
+++ b/apps/web/src/pages/settings.tsx
@@ -94,6 +94,20 @@ const TREND_SPARKLINE_OPTIONS: Array<{
   },
 ];
 
+const DASHBOARD_WIDGET_DESCRIPTIONS: Record<keyof typeof DASHBOARD_WIDGET_IDS, string> = {
+  'snapshot-cards': 'Daily body weight, macros, workout, and habit completion snapshot.',
+  'macro-rings': 'Macro progress rings against your current daily targets.',
+  'habit-chain': 'Streak chains for habits selected in this settings page.',
+  'trend-sparklines': 'Compact trend charts for your chosen dashboard metrics.',
+  'recent-workouts': 'Latest workout sessions with completion status and duration.',
+  calendar: 'Date picker for navigating historical dashboard data.',
+  'log-weight': 'Quick form to log body weight for the selected date.',
+  'weight-trend': 'Detailed chart with raw scale and smoothed trend lines.',
+};
+const DASHBOARD_WIDGET_ENTRIES = Object.entries(DASHBOARD_WIDGET_IDS) as Array<
+  [keyof typeof DASHBOARD_WIDGET_IDS, string]
+>;
+
 type SettingsFormState = {
   dashboardConfig: {
     habitChainIds: string[];
@@ -711,7 +725,7 @@ export function SettingsPage() {
               </p>
             </div>
             <div className="grid gap-3 md:grid-cols-2">
-              {Object.entries(DASHBOARD_WIDGET_IDS).map(([widgetId, widgetName]) => {
+              {DASHBOARD_WIDGET_ENTRIES.map(([widgetId, widgetName]) => {
                 const checkboxId = `widget-visibility-${widgetId}`;
 
                 return (
@@ -727,7 +741,7 @@ export function SettingsPage() {
                     />
                     <div className="space-y-1">
                       <span className="text-sm font-medium text-foreground">{widgetName}</span>
-                      <p className="text-sm text-muted-foreground">Dashboard widget visibility</p>
+                      <p className="text-sm text-muted-foreground">{DASHBOARD_WIDGET_DESCRIPTIONS[widgetId]}</p>
                     </div>
                   </Label>
                 );

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -23,6 +23,7 @@ export * from './schemas/weight.js';
 export * from './schemas/workout-sessions.js';
 export * from './schemas/users.js';
 export * from './schemas/workout-templates.js';
+export * from './utils/ewma.js';
 
 export const userSchema = z.object({
   id: z.string(),

--- a/packages/shared/src/schemas/dashboard-config.test.ts
+++ b/packages/shared/src/schemas/dashboard-config.test.ts
@@ -1,25 +1,40 @@
 import { describe, expect, it } from 'vitest';
 
-import { type DashboardConfig, dashboardConfigSchema } from './dashboard-config';
+import {
+  DASHBOARD_WIDGET_IDS,
+  type DashboardConfig,
+  dashboardConfigSchema,
+} from './dashboard-config';
+
+const DEFAULT_VISIBLE_WIDGETS = [
+  'snapshot-cards',
+  'macro-rings',
+  'habit-chain',
+  'trend-sparklines',
+  'recent-workouts',
+  'calendar',
+  'log-weight',
+  'weight-trend',
+];
 
 describe('dashboardConfigSchema', () => {
   it('parses a complete dashboard config payload', () => {
     const config = dashboardConfigSchema.parse({
       habitChainIds: ['habit-1', 'habit-2'],
       trendMetrics: ['weight', 'calories', 'protein'],
-      visibleWidgets: ['snapshot', 'macro-rings', 'weight-trend'],
+      visibleWidgets: ['snapshot-cards', 'macro-rings', 'weight-trend'],
       widgetOrder: ['snapshot', 'habits', 'trends'],
     });
 
     expect(config).toEqual({
       habitChainIds: ['habit-1', 'habit-2'],
       trendMetrics: ['weight', 'calories', 'protein'],
-      visibleWidgets: ['snapshot', 'macro-rings', 'weight-trend'],
+      visibleWidgets: ['snapshot-cards', 'macro-rings', 'weight-trend'],
       widgetOrder: ['snapshot', 'habits', 'trends'],
     });
   });
 
-  it('accepts config without widget order', () => {
+  it('defaults visible widgets when omitted', () => {
     expect(
       dashboardConfigSchema.parse({
         habitChainIds: ['habit-1'],
@@ -28,7 +43,46 @@ describe('dashboardConfigSchema', () => {
     ).toEqual({
       habitChainIds: ['habit-1'],
       trendMetrics: ['weight'],
+      visibleWidgets: DEFAULT_VISIBLE_WIDGETS,
     });
+  });
+
+  it('preserves custom visible widget ids', () => {
+    expect(
+      dashboardConfigSchema.parse({
+        habitChainIds: ['habit-1'],
+        trendMetrics: ['weight'],
+        visibleWidgets: ['recent-workouts', 'weight-trend'],
+      }),
+    ).toEqual({
+      habitChainIds: ['habit-1'],
+      trendMetrics: ['weight'],
+      visibleWidgets: ['recent-workouts', 'weight-trend'],
+    });
+  });
+
+  it('accepts an empty visible widget list', () => {
+    expect(
+      dashboardConfigSchema.parse({
+        habitChainIds: ['habit-1'],
+        trendMetrics: ['weight'],
+        visibleWidgets: [],
+      }),
+    ).toEqual({
+      habitChainIds: ['habit-1'],
+      trendMetrics: ['weight'],
+      visibleWidgets: [],
+    });
+  });
+
+  it('rejects empty visible widget ids', () => {
+    expect(() =>
+      dashboardConfigSchema.parse({
+        habitChainIds: ['habit-1'],
+        trendMetrics: ['weight'],
+        visibleWidgets: [''],
+      }),
+    ).toThrow();
   });
 
   it('rejects unsupported trend metrics', () => {
@@ -40,10 +94,16 @@ describe('dashboardConfigSchema', () => {
     ).toThrow();
   });
 
+  it('exports dashboard widget labels by id', () => {
+    expect(DASHBOARD_WIDGET_IDS['weight-trend']).toBe('Weight Trend');
+    expect(Object.keys(DASHBOARD_WIDGET_IDS)).toEqual(DEFAULT_VISIBLE_WIDGETS);
+  });
+
   it('infers DashboardConfig from the schema', () => {
     const config: DashboardConfig = {
       habitChainIds: ['habit-1'],
       trendMetrics: ['protein'],
+      visibleWidgets: ['weight-trend'],
     };
 
     expect(config.trendMetrics).toEqual(['protein']);

--- a/packages/shared/src/schemas/dashboard-config.test.ts
+++ b/packages/shared/src/schemas/dashboard-config.test.ts
@@ -2,20 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   DASHBOARD_WIDGET_IDS,
+  DEFAULT_VISIBLE_WIDGETS,
   type DashboardConfig,
   dashboardConfigSchema,
 } from './dashboard-config';
-
-const DEFAULT_VISIBLE_WIDGETS = [
-  'snapshot-cards',
-  'macro-rings',
-  'habit-chain',
-  'trend-sparklines',
-  'recent-workouts',
-  'calendar',
-  'log-weight',
-  'weight-trend',
-];
 
 describe('dashboardConfigSchema', () => {
   it('parses a complete dashboard config payload', () => {

--- a/packages/shared/src/schemas/dashboard-config.test.ts
+++ b/packages/shared/src/schemas/dashboard-config.test.ts
@@ -7,12 +7,14 @@ describe('dashboardConfigSchema', () => {
     const config = dashboardConfigSchema.parse({
       habitChainIds: ['habit-1', 'habit-2'],
       trendMetrics: ['weight', 'calories', 'protein'],
+      visibleWidgets: ['snapshot', 'macro-rings', 'weight-trend'],
       widgetOrder: ['snapshot', 'habits', 'trends'],
     });
 
     expect(config).toEqual({
       habitChainIds: ['habit-1', 'habit-2'],
       trendMetrics: ['weight', 'calories', 'protein'],
+      visibleWidgets: ['snapshot', 'macro-rings', 'weight-trend'],
       widgetOrder: ['snapshot', 'habits', 'trends'],
     });
   });

--- a/packages/shared/src/schemas/dashboard-config.ts
+++ b/packages/shared/src/schemas/dashboard-config.ts
@@ -15,19 +15,12 @@ export const DASHBOARD_WIDGET_IDS = {
   'weight-trend': 'Weight Trend',
 } as const;
 
+export const DEFAULT_VISIBLE_WIDGETS = Object.keys(DASHBOARD_WIDGET_IDS);
+
 export const dashboardConfigSchema = z.object({
   habitChainIds: nonEmptyStringArraySchema,
   trendMetrics: z.array(trendMetricSchema),
-  visibleWidgets: z.array(z.string().min(1)).default([
-    'snapshot-cards',
-    'macro-rings',
-    'habit-chain',
-    'trend-sparklines',
-    'recent-workouts',
-    'calendar',
-    'log-weight',
-    'weight-trend',
-  ]),
+  visibleWidgets: z.array(z.string().min(1)).default(() => [...DEFAULT_VISIBLE_WIDGETS]),
   widgetOrder: nonEmptyStringArraySchema.optional(),
 });
 

--- a/packages/shared/src/schemas/dashboard-config.ts
+++ b/packages/shared/src/schemas/dashboard-config.ts
@@ -7,6 +7,7 @@ const nonEmptyStringArraySchema = z.array(z.string().min(1));
 export const dashboardConfigSchema = z.object({
   habitChainIds: nonEmptyStringArraySchema,
   trendMetrics: z.array(trendMetricSchema),
+  visibleWidgets: nonEmptyStringArraySchema.optional(),
   widgetOrder: nonEmptyStringArraySchema.optional(),
 });
 

--- a/packages/shared/src/schemas/dashboard-config.ts
+++ b/packages/shared/src/schemas/dashboard-config.ts
@@ -4,10 +4,30 @@ const trendMetricSchema = z.enum(['weight', 'calories', 'protein']);
 
 const nonEmptyStringArraySchema = z.array(z.string().min(1));
 
+export const DASHBOARD_WIDGET_IDS = {
+  'snapshot-cards': 'Daily Snapshot',
+  'macro-rings': 'Macro Progress',
+  'habit-chain': 'Habit Streaks',
+  'trend-sparklines': 'Trend Charts',
+  'recent-workouts': 'Recent Workouts',
+  calendar: 'Date Picker',
+  'log-weight': 'Log Weight',
+  'weight-trend': 'Weight Trend',
+} as const;
+
 export const dashboardConfigSchema = z.object({
   habitChainIds: nonEmptyStringArraySchema,
   trendMetrics: z.array(trendMetricSchema),
-  visibleWidgets: nonEmptyStringArraySchema.optional(),
+  visibleWidgets: z.array(z.string().min(1)).default([
+    'snapshot-cards',
+    'macro-rings',
+    'habit-chain',
+    'trend-sparklines',
+    'recent-workouts',
+    'calendar',
+    'log-weight',
+    'weight-trend',
+  ]),
   widgetOrder: nonEmptyStringArraySchema.optional(),
 });
 

--- a/packages/shared/src/schemas/weight.test.ts
+++ b/packages/shared/src/schemas/weight.test.ts
@@ -128,9 +128,17 @@ describe('weightQueryParamsSchema', () => {
     ).toThrow();
   });
 
+  it('rejects combined from and days params', () => {
+    expect(() =>
+      weightQueryParamsSchema.parse({
+        from: '2026-03-01',
+        days: 30,
+      }),
+    ).toThrow();
+  });
+
   it('infers the WeightQueryParams type from the schema', () => {
     const params: WeightQueryParams = {
-      from: '2026-03-01',
       to: '2026-03-07',
       days: 30,
     };

--- a/packages/shared/src/schemas/weight.test.ts
+++ b/packages/shared/src/schemas/weight.test.ts
@@ -110,12 +110,32 @@ describe('weightQueryParamsSchema', () => {
     ).toThrow();
   });
 
+  it('parses an integer days query value from string input', () => {
+    const params = weightQueryParamsSchema.parse({
+      days: '30',
+    });
+
+    expect(params).toEqual({
+      days: 30,
+    });
+  });
+
+  it('rejects non-positive days', () => {
+    expect(() =>
+      weightQueryParamsSchema.parse({
+        days: 0,
+      }),
+    ).toThrow();
+  });
+
   it('infers the WeightQueryParams type from the schema', () => {
     const params: WeightQueryParams = {
       from: '2026-03-01',
       to: '2026-03-07',
+      days: 30,
     };
 
     expect(params.to).toBe('2026-03-07');
+    expect(params.days).toBe(30);
   });
 });

--- a/packages/shared/src/schemas/weight.ts
+++ b/packages/shared/src/schemas/weight.ts
@@ -31,6 +31,7 @@ export const weightQueryParamsSchema = z
   .object({
     from: dateSchema.optional(),
     to: dateSchema.optional(),
+    days: z.coerce.number().int().positive().max(3650).optional(),
   })
   .refine(({ from, to }) => !from || !to || from <= to, {
     message: '`from` must be on or before `to`',

--- a/packages/shared/src/schemas/weight.ts
+++ b/packages/shared/src/schemas/weight.ts
@@ -36,6 +36,10 @@ export const weightQueryParamsSchema = z
   .refine(({ from, to }) => !from || !to || from <= to, {
     message: '`from` must be on or before `to`',
     path: ['from'],
+  })
+  .refine(({ from, days }) => from === undefined || days === undefined, {
+    message: '`from` and `days` cannot be used together',
+    path: ['from'],
   });
 
 export type BodyWeightEntry = z.infer<typeof bodyWeightEntrySchema>;

--- a/packages/shared/src/utils/ewma.test.ts
+++ b/packages/shared/src/utils/ewma.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeEWMA, computeWeightInsights, type WeightEntry } from './ewma';
+
+describe('computeEWMA', () => {
+  it('returns trend equal to scale for a single entry', () => {
+    const entries: WeightEntry[] = [{ date: '2026-01-01', weight: 180 }];
+
+    const result = computeEWMA(entries);
+
+    expect(result).toEqual([{ date: '2026-01-01', scale: 180, trend: 180 }]);
+  });
+
+  it('smooths multiple entries', () => {
+    const entries: WeightEntry[] = [
+      { date: '2026-01-01', weight: 180 },
+      { date: '2026-01-02', weight: 185 },
+      { date: '2026-01-03', weight: 175 },
+    ];
+
+    const result = computeEWMA(entries, { alpha: 0.2 });
+
+    expect(result[0].trend).toBe(180);
+    expect(result[1].trend).toBeCloseTo(181);
+    expect(result[2].trend).toBeCloseTo(179.8);
+    expect(result[1].trend).not.toBe(result[1].scale);
+    expect(result[2].trend).not.toBe(result[2].scale);
+  });
+
+  it('matches raw values when alpha is 1.0', () => {
+    const entries: WeightEntry[] = [
+      { date: '2026-01-01', weight: 180 },
+      { date: '2026-01-02', weight: 185 },
+      { date: '2026-01-03', weight: 175 },
+    ];
+
+    const result = computeEWMA(entries, { alpha: 1.0 });
+
+    expect(result.map((entry) => entry.trend)).toEqual([180, 185, 175]);
+  });
+
+  it('keeps trend at the first value when alpha is 0.0', () => {
+    const entries: WeightEntry[] = [
+      { date: '2026-01-01', weight: 180 },
+      { date: '2026-01-02', weight: 185 },
+      { date: '2026-01-03', weight: 175 },
+    ];
+
+    const result = computeEWMA(entries, { alpha: 0.0 });
+
+    expect(result.map((entry) => entry.trend)).toEqual([180, 180, 180]);
+  });
+
+  it('carries forward trend across date gaps without creating missing entries', () => {
+    const entries: WeightEntry[] = [
+      { date: '2026-01-01', weight: 180 },
+      { date: '2026-01-05', weight: 184 },
+    ];
+
+    const result = computeEWMA(entries, { alpha: 0.25 });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].trend).toBe(180);
+    expect(result[1].trend).toBeCloseTo(181);
+  });
+});
+
+describe('computeWeightInsights', () => {
+  it('computes average, change, and direction for a lookback period', () => {
+    const ewmaResults = [
+      { date: '2026-01-01', scale: 180, trend: 180 },
+      { date: '2026-01-02', scale: 181, trend: 180.4 },
+      { date: '2026-01-03', scale: 182, trend: 180.9 },
+      { date: '2026-01-04', scale: 183, trend: 181.5 },
+    ];
+
+    const insights = computeWeightInsights(ewmaResults, 3);
+
+    expect(insights.avgWeight).toBeCloseTo((180.4 + 180.9 + 181.5) / 3);
+    expect(insights.periodChange).toBeCloseTo(181.5 - 180.4);
+    expect(insights.direction).toBe('up');
+  });
+
+  it('returns stable when change magnitude is below 0.1 pounds', () => {
+    const ewmaResults = [
+      { date: '2026-01-01', scale: 180, trend: 180 },
+      { date: '2026-01-02', scale: 180.2, trend: 180.04 },
+      { date: '2026-01-03', scale: 180.1, trend: 180.07 },
+    ];
+
+    const insights = computeWeightInsights(ewmaResults, 3);
+
+    expect(insights.periodChange).toBeCloseTo(0.07);
+    expect(insights.direction).toBe('stable');
+  });
+});

--- a/packages/shared/src/utils/ewma.test.ts
+++ b/packages/shared/src/utils/ewma.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { computeEWMA, computeWeightInsights, type WeightEntry } from './ewma';
 
@@ -66,6 +66,15 @@ describe('computeEWMA', () => {
 });
 
 describe('computeWeightInsights', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-04T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('computes average, change, and direction for a lookback period', () => {
     const ewmaResults = [
       { date: '2026-01-01', scale: 180, trend: 180 },
@@ -90,7 +99,24 @@ describe('computeWeightInsights', () => {
 
     const insights = computeWeightInsights(ewmaResults, 3);
 
-    expect(insights.periodChange).toBeCloseTo(0.07);
+    expect(insights.periodChange).toBeCloseTo(0.03);
     expect(insights.direction).toBe('stable');
+  });
+
+  it('returns zeroed insights when no entries fall within the requested period', () => {
+    const ewmaResults = [
+      { date: '2026-01-01', scale: 180, trend: 180 },
+      { date: '2026-01-02', scale: 181, trend: 180.4 },
+      { date: '2026-01-03', scale: 182, trend: 180.9 },
+    ];
+
+    vi.setSystemTime(new Date('2026-03-10T12:00:00.000Z'));
+    const insights = computeWeightInsights(ewmaResults, 7);
+
+    expect(insights).toEqual({
+      avgWeight: 0,
+      periodChange: 0,
+      direction: 'stable',
+    });
   });
 });

--- a/packages/shared/src/utils/ewma.ts
+++ b/packages/shared/src/utils/ewma.ts
@@ -1,0 +1,75 @@
+export type WeightEntry = { date: string; weight: number };
+export type EWMAOptions = { alpha?: number };
+export type EWMAResult = { date: string; scale: number; trend: number }[];
+
+function clampAlpha(alpha: number): number {
+  if (alpha < 0) return 0;
+  if (alpha > 1) return 1;
+  return alpha;
+}
+
+export function computeEWMA(entries: WeightEntry[], options: EWMAOptions = {}): EWMAResult {
+  if (entries.length === 0) {
+    return [];
+  }
+
+  const alpha = clampAlpha(options.alpha ?? 0.1);
+  const sortedEntries = [...entries].sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+  );
+
+  let previousTrend = sortedEntries[0].weight;
+
+  return sortedEntries.map((entry, index) => {
+    const scale = entry.weight;
+    const trend = index === 0 ? scale : alpha * scale + (1 - alpha) * previousTrend;
+
+    previousTrend = trend;
+
+    return {
+      date: entry.date,
+      scale,
+      trend,
+    };
+  });
+}
+
+export function computeWeightInsights(
+  ewmaResults: EWMAResult,
+  periodDays: number,
+): { avgWeight: number; periodChange: number; direction: 'up' | 'down' | 'stable' } {
+  if (ewmaResults.length === 0) {
+    return {
+      avgWeight: 0,
+      periodChange: 0,
+      direction: 'stable',
+    };
+  }
+
+  const sortedResults = [...ewmaResults].sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+  );
+  const latestDate = new Date(sortedResults[sortedResults.length - 1].date);
+  const startDate = new Date(latestDate);
+  startDate.setDate(startDate.getDate() - Math.max(periodDays - 1, 0));
+
+  const periodResults = sortedResults.filter(
+    (result) => new Date(result.date).getTime() >= startDate.getTime(),
+  );
+  const scopedResults = periodResults.length > 0 ? periodResults : sortedResults;
+
+  const totalTrend = scopedResults.reduce((sum, result) => sum + result.trend, 0);
+  const avgWeight = totalTrend / scopedResults.length;
+  const firstTrend = scopedResults[0].trend;
+  const lastTrend = scopedResults[scopedResults.length - 1].trend;
+  const periodChange = lastTrend - firstTrend;
+
+  const direction: 'up' | 'down' | 'stable' =
+    Math.abs(periodChange) < 0.1 ? 'stable' : periodChange > 0 ? 'up' : 'down';
+
+  return {
+    avgWeight,
+    periodChange,
+    direction,
+  };
+}

--- a/packages/shared/src/utils/ewma.ts
+++ b/packages/shared/src/utils/ewma.ts
@@ -49,19 +49,23 @@ export function computeWeightInsights(
   const sortedResults = [...ewmaResults].sort(
     (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
   );
-  const latestDate = new Date(sortedResults[sortedResults.length - 1].date);
-  const startDate = new Date(latestDate);
-  startDate.setDate(startDate.getDate() - Math.max(periodDays - 1, 0));
+  const startDate = new Date();
+  startDate.setUTCDate(startDate.getUTCDate() - Math.max(periodDays - 1, 0));
+  const periodStartDate = startDate.toISOString().slice(0, 10);
 
-  const periodResults = sortedResults.filter(
-    (result) => new Date(result.date).getTime() >= startDate.getTime(),
-  );
-  const scopedResults = periodResults.length > 0 ? periodResults : sortedResults;
+  const periodResults = sortedResults.filter((result) => result.date >= periodStartDate);
+  if (periodResults.length === 0) {
+    return {
+      avgWeight: 0,
+      periodChange: 0,
+      direction: 'stable',
+    };
+  }
 
-  const totalTrend = scopedResults.reduce((sum, result) => sum + result.trend, 0);
-  const avgWeight = totalTrend / scopedResults.length;
-  const firstTrend = scopedResults[0].trend;
-  const lastTrend = scopedResults[scopedResults.length - 1].trend;
+  const totalTrend = periodResults.reduce((sum, result) => sum + result.trend, 0);
+  const avgWeight = totalTrend / periodResults.length;
+  const firstTrend = periodResults[0].trend;
+  const lastTrend = periodResults[periodResults.length - 1].trend;
   const periodChange = lastTrend - firstTrend;
 
   const direction: 'up' | 'down' | 'stable' =


### PR DESCRIPTION
## Summary
This PR upgrades the dashboard with a new weight trend experience and user-controlled widget visibility, while fixing a backend filtering gap for weight lookback queries. The new Weight Trend widget renders raw scale entries alongside an EWMA-smoothed trend line, adds selectable time ranges (`1W` to `All`), and surfaces short-term trend insights. Dashboard widget visibility is now configurable in both the dashboard (edit mode) and Settings, then persisted in user dashboard config so layout choices survive reloads and devices. On the API side, weight list queries now correctly honor `days` lookback filtering, which the chart relies on for range-specific data.

## Key Changes
- Added shared EWMA utilities in `@pulse/shared`:
  - `computeEWMA` for smoothed trend calculation.
  - `computeWeightInsights` for average/change/direction summaries.
  - Comprehensive unit tests for smoothing behavior and insight calculations.
- Built a new `WeightTrendChart` dashboard component:
  - Dual-line Recharts plot (raw scale + EWMA trend).
  - Range selector (`1W`, `1M`, `3M`, `6M`, `1Y`, `All`) that maps to `/api/v1/weight?days=...`.
  - Toggleable legend series, loading/empty/error states, and 3-day/7-day change indicators.
- Added configurable dashboard widget visibility:
  - New shared widget ID map (`DASHBOARD_WIDGET_IDS`) and `visibleWidgets` in dashboard config schema.
  - Dashboard edit mode with hide overlays, save/cancel flow, and hidden-widgets restore section.
  - Settings page checklist for widget visibility, saved through existing dashboard config API.
- Persisted widget visibility in backend storage:
  - Added `visible_widgets` column and store read/write support.
  - GET/PUT dashboard config tests expanded for `visibleWidgets` behaviors, including empty-array acceptance.
- Fixed weight trend query behavior in API/store:
  - `weightQueryParamsSchema` now supports validated `days`.
  - `listBodyWeightEntries` now applies a UTC lookback window when `days` is provided.
  - Route/store/integration tests added to verify parsing and filtering semantics.

## Technical Notes
- `visible_widgets` is nullable in DB for backward compatibility; defaults are applied at parse time via `dashboardConfigSchema`, so existing rows without this field still return a full default widget set.
- Widget visibility is intentionally string-array based (not enum-restricted in schema), while UI filtering uses shared IDs to guard rendering against unknown values.
- When `days` is present, the weight query computes `rangeStart = (to || today) - (days - 1)` and combines it with optional `from`/`to` filters, effectively intersecting constraints.
- EWMA currently uses `alpha=0.1` by default, sorts by date, and does not synthesize missing-day points; insight direction is classified as `stable` when absolute change is under `0.1 lbs`.

## Commits

- `9079ea1 fix(api): honor days filter for weight trend queries`
- `95ca7a4 feat(web): add dashboard widget visibility edit mode`
- `b7055cc feat(dashboard): persist visible widget config defaults`
- `fee7fdf feat(dashboard): wire weight trend widget visibility`
- `553e0b1 feat(web): add dashboard weight trend chart`
- `6aeb369 feat(shared): add EWMA utility and insights with tests`

## Tasks

- **EWMA utility function + tests**: Create computeEWMA and computeWeightInsights utilities in @pulse/shared with comprehensive tests
- **Weight trend chart component (MacroFactor-style)**: Build a dual-line Recharts chart with raw scale weight + EWMA trend, time range selector, and insights section
- **Wire weight trend chart into dashboard**: Add WeightTrendChart to dashboard layout, conditionally render based on visibleWidgets config
- **Dashboard config — add visibleWidgets to schema**: Expand dashboard config Zod schema and backend to support visibleWidgets string array with sensible defaults
- **Dashboard edit mode — toggle widget visibility**: Add pencil icon toggle for edit mode with show/hide overlays on widgets, save/cancel, and settings page widget checklist

## Diff Stats

```
apps/api/drizzle/0011_hissing_molten_man.sql       |   1 +
 apps/api/drizzle/meta/_journal.json                |   7 +
 .../src/__tests__/habits-weight-targets.test.ts    |  67 ++-
 apps/api/src/db/schema.test.ts                     |   2 +
 apps/api/src/db/schema/dashboard-config.ts         |   1 +
 apps/api/src/routes/v1/dashboard-store.test.ts     |  13 +
 apps/api/src/routes/v1/dashboard-store.ts          |   5 +
 apps/api/src/routes/v1/dashboard.test.ts           |  69 ++++
 apps/api/src/routes/weight/index.test.ts           |  30 ++
 apps/api/src/routes/weight/store.ts                |  14 +
 apps/web/src/components/ui/toggle.tsx              |  58 +++
 .../components/weight-trend-chart.test.tsx         | 202 +++++++++
 .../dashboard/components/weight-trend-chart.tsx    | 366 +++++++++++++++++
 apps/web/src/hooks/use-dashboard-config.test.tsx   |   6 +
 apps/web/src/pages/dashboard.test.tsx              | 155 ++++++-
 apps/web/src/pages/dashboard.tsx                   | 452 ++++++++++++++++-----
 apps/web/src/pages/settings.test.tsx               |  45 +-
 apps/web/src/pages/settings.tsx                    |  51 ++-
 packages/shared/src/index.ts                       |   1 +
 .../shared/src/schemas/dashboard-config.test.ts    |  66 ++-
 packages/shared/src/schemas/dashboard-config.ts    |  21 +
 packages/shared/src/schemas/weight.test.ts         |  20 +
 packages/shared/src/schemas/weight.ts              |   1 +
 packages/shared/src/utils/ewma.test.ts             |  96 +++++
 packages/shared/src/utils/ewma.ts                  |  75 ++++
 25 files changed, 1713 insertions(+), 111 deletions(-)
```