### PR TITLE
Workout notes and feedback redesign

### DIFF
--- a/apps/api/src/db/schema.test.ts
+++ b/apps/api/src/db/schema.test.ts
@@ -1148,11 +1148,28 @@ describe('workout session feedback helpers', () => {
       recovery: 3,
       technique: 5,
       notes: 'Moved well today.',
+      responses: [
+        {
+          id: 'session-rpe',
+          label: 'Session RPE',
+          type: 'scale',
+          value: 8,
+        },
+        {
+          id: 'pain-discomfort',
+          label: 'Any pain or discomfort?',
+          type: 'yes_no',
+          value: true,
+          notes: 'Right knee discomfort during split squats.',
+        },
+      ],
     };
 
     const serialized = serializeWorkoutSessionFeedback(feedback);
 
-    expect(serialized).toBe('{"energy":4,"recovery":3,"technique":5,"notes":"Moved well today."}');
+    expect(serialized).toBe(
+      '{"energy":4,"recovery":3,"technique":5,"notes":"Moved well today.","responses":[{"id":"session-rpe","label":"Session RPE","type":"scale","value":8},{"id":"pain-discomfort","label":"Any pain or discomfort?","type":"yes_no","value":true,"notes":"Right knee discomfort during split squats."}]}',
+    );
     expect(parseWorkoutSessionFeedback(serialized)).toEqual(feedback);
     expect(parseWorkoutSessionFeedback(null)).toBeNull();
     expect(serializeWorkoutSessionFeedback(null)).toBeNull();
@@ -1169,6 +1186,16 @@ describe('workout session feedback helpers', () => {
     expect(() =>
       parseWorkoutSessionFeedback(
         '{"energy":4,"recovery":3,"technique":4,"notes":"ok","extra":true}',
+      ),
+    ).toThrow(TypeError);
+    expect(() =>
+      parseWorkoutSessionFeedback(
+        '{"energy":4,"recovery":3,"technique":4,"responses":[{"id":"session-rpe","label":"Session RPE","type":"invalid","value":8}]}',
+      ),
+    ).toThrow(TypeError);
+    expect(() =>
+      parseWorkoutSessionFeedback(
+        '{"energy":4,"recovery":3,"technique":4,"responses":[{"id":"session-rpe","label":"Session RPE","type":"scale","value":{"bad":true}}]}',
       ),
     ).toThrow(TypeError);
   });

--- a/apps/api/src/db/schema/workout-session-feedback.ts
+++ b/apps/api/src/db/schema/workout-session-feedback.ts
@@ -32,24 +32,22 @@ function isFeedbackResponseType(value: unknown): value is string {
   return typeof value === 'string' && WORKOUT_SESSION_FEEDBACK_RESPONSE_TYPES.has(value);
 }
 
-function isFeedbackResponseValue(value: unknown) {
-  if (value === null) {
-    return true;
+function isFeedbackResponseValueByType(type: string, value: unknown) {
+  switch (type) {
+    case 'scale':
+    case 'slider':
+      return typeof value === 'number' && Number.isFinite(value);
+    case 'yes_no':
+      return typeof value === 'boolean';
+    case 'emoji':
+      return typeof value === 'string' && value.trim().length > 0;
+    case 'text':
+      return value === null || typeof value === 'string';
+    case 'multi_select':
+      return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+    default:
+      return false;
   }
-
-  if (typeof value === 'number') {
-    return Number.isFinite(value);
-  }
-
-  if (typeof value === 'boolean' || typeof value === 'string') {
-    return true;
-  }
-
-  if (Array.isArray(value)) {
-    return value.every((entry) => typeof entry === 'string');
-  }
-
-  return false;
 }
 
 export function serializeWorkoutSessionFeedback(
@@ -94,7 +92,7 @@ export function parseWorkoutSessionFeedback(
             typeof response.label === 'string' &&
             response.label.length > 0 &&
             isFeedbackResponseType(response.type) &&
-            isFeedbackResponseValue(response.value) &&
+            isFeedbackResponseValueByType(response.type, response.value) &&
             (!('notes' in response) ||
               response.notes === undefined ||
               typeof response.notes === 'string') &&
@@ -116,19 +114,49 @@ export function parseWorkoutSessionFeedback(
 
   const notes = typeof parsed.notes === 'string' ? parsed.notes : undefined;
   const responses = Array.isArray(parsed.responses)
-    ? parsed.responses.map((response) => ({
-        id: response.id as string,
-        label: response.label as string,
-        type: response.type as
-          | 'scale'
-          | 'text'
-          | 'yes_no'
-          | 'emoji'
-          | 'slider'
-          | 'multi_select',
-        value: response.value as number | boolean | string | string[] | null,
-        ...(typeof response.notes === 'string' ? { notes: response.notes } : {}),
-      }))
+    ? parsed.responses.map((response) => {
+        const base = {
+          id: response.id as string,
+          label: response.label as string,
+          ...(typeof response.notes === 'string' ? { notes: response.notes } : {}),
+        };
+
+        switch (response.type) {
+          case 'scale':
+          case 'slider':
+            return {
+              ...base,
+              type: response.type,
+              value: response.value as number,
+            };
+          case 'yes_no':
+            return {
+              ...base,
+              type: 'yes_no' as const,
+              value: response.value as boolean,
+            };
+          case 'emoji':
+            return {
+              ...base,
+              type: 'emoji' as const,
+              value: response.value as string,
+            };
+          case 'text':
+            return {
+              ...base,
+              type: 'text' as const,
+              value: response.value as string | null,
+            };
+          case 'multi_select':
+            return {
+              ...base,
+              type: 'multi_select' as const,
+              value: response.value as string[],
+            };
+          default:
+            throw new TypeError(INVALID_WORKOUT_SESSION_FEEDBACK_ERROR);
+        }
+      })
     : undefined;
 
   return {

--- a/apps/api/src/db/schema/workout-session-feedback.ts
+++ b/apps/api/src/db/schema/workout-session-feedback.ts
@@ -3,7 +3,22 @@ import type { WorkoutSessionFeedback } from './workout-sessions.js';
 const INVALID_WORKOUT_SESSION_FEEDBACK_ERROR =
   'Expected a JSON-encoded workout session feedback object.';
 
-const WORKOUT_SESSION_FEEDBACK_KEYS = ['energy', 'recovery', 'technique', 'notes'] as const;
+const WORKOUT_SESSION_FEEDBACK_KEYS = [
+  'energy',
+  'recovery',
+  'technique',
+  'notes',
+  'responses',
+] as const;
+const WORKOUT_SESSION_FEEDBACK_RESPONSE_KEYS = ['id', 'label', 'type', 'value', 'notes'] as const;
+const WORKOUT_SESSION_FEEDBACK_RESPONSE_TYPES = new Set([
+  'scale',
+  'text',
+  'yes_no',
+  'emoji',
+  'slider',
+  'multi_select',
+]);
 
 function isFeedbackRating(value: unknown): value is 1 | 2 | 3 | 4 | 5 {
   return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 5;
@@ -11,6 +26,30 @@ function isFeedbackRating(value: unknown): value is 1 | 2 | 3 | 4 | 5 {
 
 function isFeedbackRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isFeedbackResponseType(value: unknown): value is string {
+  return typeof value === 'string' && WORKOUT_SESSION_FEEDBACK_RESPONSE_TYPES.has(value);
+}
+
+function isFeedbackResponseValue(value: unknown) {
+  if (value === null) {
+    return true;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value);
+  }
+
+  if (typeof value === 'boolean' || typeof value === 'string') {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.every((entry) => typeof entry === 'string');
+  }
+
+  return false;
 }
 
 export function serializeWorkoutSessionFeedback(
@@ -44,6 +83,27 @@ export function parseWorkoutSessionFeedback(
     !isFeedbackRating(parsed.recovery) ||
     !isFeedbackRating(parsed.technique) ||
     ('notes' in parsed && parsed.notes !== undefined && typeof parsed.notes !== 'string') ||
+    ('responses' in parsed &&
+      parsed.responses !== undefined &&
+      (!Array.isArray(parsed.responses) ||
+        !parsed.responses.every(
+          (response) =>
+            isFeedbackRecord(response) &&
+            typeof response.id === 'string' &&
+            response.id.length > 0 &&
+            typeof response.label === 'string' &&
+            response.label.length > 0 &&
+            isFeedbackResponseType(response.type) &&
+            isFeedbackResponseValue(response.value) &&
+            (!('notes' in response) ||
+              response.notes === undefined ||
+              typeof response.notes === 'string') &&
+            Object.keys(response).every((key) =>
+              WORKOUT_SESSION_FEEDBACK_RESPONSE_KEYS.includes(
+                key as (typeof WORKOUT_SESSION_FEEDBACK_RESPONSE_KEYS)[number],
+              ),
+            ),
+        ))) ||
     Object.keys(parsed).some(
       (key) =>
         !WORKOUT_SESSION_FEEDBACK_KEYS.includes(
@@ -55,11 +115,27 @@ export function parseWorkoutSessionFeedback(
   }
 
   const notes = typeof parsed.notes === 'string' ? parsed.notes : undefined;
+  const responses = Array.isArray(parsed.responses)
+    ? parsed.responses.map((response) => ({
+        id: response.id as string,
+        label: response.label as string,
+        type: response.type as
+          | 'scale'
+          | 'text'
+          | 'yes_no'
+          | 'emoji'
+          | 'slider'
+          | 'multi_select',
+        value: response.value as number | boolean | string | string[] | null,
+        ...(typeof response.notes === 'string' ? { notes: response.notes } : {}),
+      }))
+    : undefined;
 
   return {
     energy: parsed.energy,
     recovery: parsed.recovery,
     technique: parsed.technique,
     ...(notes === undefined ? {} : { notes }),
+    ...(responses === undefined ? {} : { responses }),
   };
 }

--- a/apps/api/src/db/schema/workout-sessions.ts
+++ b/apps/api/src/db/schema/workout-sessions.ts
@@ -15,13 +15,43 @@ export type WorkoutSessionFeedback = {
   recovery: 1 | 2 | 3 | 4 | 5;
   technique: 1 | 2 | 3 | 4 | 5;
   notes?: string;
-  responses?: Array<{
-    id: string;
-    label: string;
-    type: 'scale' | 'text' | 'yes_no' | 'emoji' | 'slider' | 'multi_select';
-    value: number | boolean | string | string[] | null;
-    notes?: string;
-  }>;
+  responses?: Array<
+    | {
+        id: string;
+        label: string;
+        type: 'scale' | 'slider';
+        value: number;
+        notes?: string;
+      }
+    | {
+        id: string;
+        label: string;
+        type: 'yes_no';
+        value: boolean;
+        notes?: string;
+      }
+    | {
+        id: string;
+        label: string;
+        type: 'emoji';
+        value: string;
+        notes?: string;
+      }
+    | {
+        id: string;
+        label: string;
+        type: 'text';
+        value: string | null;
+        notes?: string;
+      }
+    | {
+        id: string;
+        label: string;
+        type: 'multi_select';
+        value: string[];
+        notes?: string;
+      }
+  >;
 };
 
 export const workoutSessions = sqliteTable(

--- a/apps/api/src/db/schema/workout-sessions.ts
+++ b/apps/api/src/db/schema/workout-sessions.ts
@@ -15,6 +15,13 @@ export type WorkoutSessionFeedback = {
   recovery: 1 | 2 | 3 | 4 | 5;
   technique: 1 | 2 | 3 | 4 | 5;
   notes?: string;
+  responses?: Array<{
+    id: string;
+    label: string;
+    type: 'scale' | 'text' | 'yes_no' | 'emoji' | 'slider' | 'multi_select';
+    value: number | boolean | string | string[] | null;
+    notes?: string;
+  }>;
 };
 
 export const workoutSessions = sqliteTable(

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -1497,6 +1497,74 @@ describe('workout session routes', () => {
     });
   });
 
+  it('does not overwrite first-set notes when exerciseNotes are normalized to null', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    seedWorkoutSession({
+      id: 'session-1',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: 1000,
+      completedAt: 4000,
+      duration: 50,
+    });
+    seedSessionSet({
+      id: 'set-1',
+      sessionId: 'session-1',
+      exerciseId: 'user-1-lat-pulldown',
+      setNumber: 1,
+      weight: 150,
+      reps: 10,
+      completed: true,
+      section: 'main',
+      notes: 'Keep chest high',
+    });
+    seedSessionSet({
+      id: 'set-2',
+      sessionId: 'session-1',
+      exerciseId: 'user-1-lat-pulldown',
+      setNumber: 2,
+      weight: 145,
+      reps: 9,
+      completed: true,
+      section: 'main',
+      notes: null,
+    });
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-sessions/session-1',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        exerciseNotes: {
+          'user-1-lat-pulldown': '   ',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        id: 'session-1',
+        sets: [
+          expect.objectContaining({
+            exerciseId: 'user-1-lat-pulldown',
+            setNumber: 1,
+            notes: 'Keep chest high',
+          }),
+          expect.objectContaining({
+            exerciseId: 'user-1-lat-pulldown',
+            setNumber: 2,
+            notes: null,
+          }),
+        ],
+      }),
+    });
+  });
+
   it('deletes owned workout sessions, cascades set rows, and unlinks scheduled workouts', async () => {
     const authToken = context.app.jwt.sign({ userId: 'user-1' });
 

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -1426,6 +1426,77 @@ describe('workout session routes', () => {
     });
   });
 
+  it('patches session notes and exercise notes on an existing completed session', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    seedWorkoutSession({
+      id: 'session-1',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: 1000,
+      completedAt: 4000,
+      duration: 50,
+      notes: 'Old summary',
+    });
+    seedSessionSet({
+      id: 'set-1',
+      sessionId: 'session-1',
+      exerciseId: 'user-1-lat-pulldown',
+      setNumber: 1,
+      weight: 150,
+      reps: 10,
+      completed: true,
+      section: 'main',
+      notes: 'Old exercise cue',
+    });
+    seedSessionSet({
+      id: 'set-2',
+      sessionId: 'session-1',
+      exerciseId: 'user-1-lat-pulldown',
+      setNumber: 2,
+      weight: 150,
+      reps: 9,
+      completed: true,
+      section: 'main',
+      notes: null,
+    });
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-sessions/session-1',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        notes: ' Better setup today ',
+        exerciseNotes: {
+          'user-1-lat-pulldown': ' Keep elbows tucked ',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        id: 'session-1',
+        notes: 'Better setup today',
+        sets: [
+          expect.objectContaining({
+            exerciseId: 'user-1-lat-pulldown',
+            setNumber: 1,
+            notes: 'Keep elbows tucked',
+          }),
+          expect.objectContaining({
+            exerciseId: 'user-1-lat-pulldown',
+            setNumber: 2,
+            notes: null,
+          }),
+        ],
+      }),
+    });
+  });
+
   it('deletes owned workout sessions, cascades set rows, and unlinks scheduled workouts', async () => {
     const authToken = context.app.jwt.sign({ userId: 'user-1' });
 

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -1497,6 +1497,40 @@ describe('workout session routes', () => {
     });
   });
 
+  it('rejects reverting a completed session back to in-progress', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    seedWorkoutSession({
+      id: 'session-1',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: 1000,
+      completedAt: 4000,
+      duration: 50,
+    });
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-sessions/session-1',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        status: 'in-progress',
+        completedAt: null,
+      },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'WORKOUT_SESSION_NOT_ACTIVE',
+        message: 'Cannot revert a completed session',
+      },
+    });
+  });
+
   it('does not overwrite first-set notes when exerciseNotes are normalized to null', async () => {
     const authToken = context.app.jwt.sign({ userId: 'user-1' });
 

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -6,6 +6,7 @@ import {
   saveWorkoutSessionAsTemplateInputSchema,
   createWorkoutSessionInputSchema,
   type CreateWorkoutSessionInput,
+  type SessionSetInput,
   updateSetSchema,
   updateWorkoutSessionInputSchema,
   workoutSessionQueryParamsSchema,
@@ -94,6 +95,47 @@ const toCreateWorkoutSessionInput = (
 
 const getReferencedExerciseIds = (sets: CreateWorkoutSessionInput['sets']) =>
   sets.map((set) => set.exerciseId);
+
+const applyExerciseNotesToSets = ({
+  sets,
+  exerciseNotes,
+}: {
+  sets: SessionSetInput[];
+  exerciseNotes: Record<string, string | null>;
+}) => {
+  const firstSetIndexByExerciseId = new Map<string, number>();
+
+  sets.forEach((set, index) => {
+    const existingIndex = firstSetIndexByExerciseId.get(set.exerciseId);
+    if (existingIndex === undefined) {
+      firstSetIndexByExerciseId.set(set.exerciseId, index);
+      return;
+    }
+
+    const existingSet = sets[existingIndex];
+    if (!existingSet) {
+      return;
+    }
+
+    if (set.setNumber < existingSet.setNumber) {
+      firstSetIndexByExerciseId.set(set.exerciseId, index);
+    }
+  });
+
+  return sets.map((set, index) => {
+    if (
+      firstSetIndexByExerciseId.get(set.exerciseId) !== index ||
+      !Object.hasOwn(exerciseNotes, set.exerciseId)
+    ) {
+      return set;
+    }
+
+    return {
+      ...set,
+      notes: exerciseNotes[set.exerciseId] ?? null,
+    };
+  });
+};
 
 const ensureOwnedSession = async ({
   sessionId,
@@ -446,9 +488,20 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid workout session payload');
     }
 
-    if (mergedPayload.data.templateId !== null) {
+    const input =
+      parsedBody.data.exerciseNotes && Object.keys(parsedBody.data.exerciseNotes).length > 0
+        ? {
+            ...mergedPayload.data,
+            sets: applyExerciseNotesToSets({
+              sets: mergedPayload.data.sets,
+              exerciseNotes: parsedBody.data.exerciseNotes,
+            }),
+          }
+        : mergedPayload.data;
+
+    if (input.templateId !== null) {
       const templateAccessible = await templateBelongsToUser(
-        mergedPayload.data.templateId,
+        input.templateId,
         request.userId,
       );
       if (!templateAccessible) {
@@ -463,7 +516,7 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
 
     const exercisesAccessible = await allSessionExercisesAccessible({
       userId: request.userId,
-      exerciseIds: getReferencedExerciseIds(mergedPayload.data.sets),
+      exerciseIds: getReferencedExerciseIds(input.sets),
     });
     if (!exercisesAccessible) {
       return sendError(
@@ -477,7 +530,7 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
     const session = await updateWorkoutSession({
       id: request.params.id,
       userId: request.userId,
-      input: mergedPayload.data,
+      input,
     });
     if (!session) {
       return sendError(

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -123,16 +123,19 @@ const applyExerciseNotesToSets = ({
   });
 
   return sets.map((set, index) => {
+    const nextExerciseNote = exerciseNotes[set.exerciseId];
+
     if (
       firstSetIndexByExerciseId.get(set.exerciseId) !== index ||
-      !Object.hasOwn(exerciseNotes, set.exerciseId)
+      !Object.hasOwn(exerciseNotes, set.exerciseId) ||
+      nextExerciseNote === null
     ) {
       return set;
     }
 
     return {
       ...set,
-      notes: exerciseNotes[set.exerciseId] ?? null,
+      notes: nextExerciseNote,
     };
   });
 };

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -483,6 +483,18 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       );
     }
 
+    if (
+      existingSession.status === 'completed' &&
+      parsedBody.data.status === 'in-progress'
+    ) {
+      return sendError(
+        reply,
+        409,
+        WORKOUT_SESSION_NOT_ACTIVE_RESPONSE.code,
+        'Cannot revert a completed session',
+      );
+    }
+
     const mergedPayload = createWorkoutSessionInputSchema.safeParse({
       ...toCreateWorkoutSessionInput(existingSession),
       ...parsedBody.data,

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -265,6 +265,46 @@ describe('SessionDetail', () => {
     expect(screen.getByText('Incline Dumbbell Press trends')).toBeInTheDocument();
     expect(screen.getByLabelText('Incline Dumbbell Press trend chart')).toBeInTheDocument();
   });
+
+  it('keeps sections with exercise notes expanded by default', async () => {
+    const currentSession = createSession({
+      id: 'session-notes-visible',
+      templateId: 'template-upper-push',
+      sets: [
+        createSet({
+          id: 'set-warmup-note',
+          exerciseId: 'row-erg',
+          setNumber: 1,
+          notes: 'Felt strong on this set, increased weight by 5lbs',
+          reps: 240,
+          section: 'warmup',
+          weight: null,
+        }),
+      ],
+    });
+
+    mockSessionDetailRequests({
+      sessionId: currentSession.id,
+      session: currentSession,
+      sessions: [
+        createSessionListItem({
+          id: currentSession.id,
+          templateId: currentSession.templateId,
+          templateName: 'Upper Push',
+          startedAt: currentSession.startedAt,
+        }),
+      ],
+    });
+
+    renderSessionDetail(currentSession.id);
+
+    expect(
+      await screen.findByText('Felt strong on this set, increased weight by 5lbs'),
+    ).toBeInTheDocument();
+    const warmupHeading = screen.getByRole('heading', { name: 'Warmup' });
+    const warmupDetails = warmupHeading.closest('details');
+    expect(warmupDetails).toHaveAttribute('open');
+  });
 });
 
 function renderSessionDetail(sessionId: string) {

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -118,7 +118,7 @@ describe('SessionDetail', () => {
     expect(screen.getByText('Completed')).toBeInTheDocument();
     expect(screen.getByText('Section breakdown')).toBeInTheDocument();
     expect(screen.getByText('Feedback')).toBeInTheDocument();
-    expect(screen.getByText('Session notes')).toBeInTheDocument();
+    expect(screen.getByText('Session Notes')).toBeInTheDocument();
     expect(screen.getByLabelText(/show comparison/i)).toBeInTheDocument();
     expect(screen.queryByText('Volume progression')).not.toBeInTheDocument();
     expect(screen.getAllByText(/Set 1:/i).length).toBeGreaterThan(0);

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -50,7 +50,9 @@ describe('SessionDetail', () => {
 
     renderSessionDetail('missing-session');
 
-    expect(await screen.findByText('Session not found', {}, { timeout: 5_000 })).toBeInTheDocument();
+    expect(
+      await screen.findByText('Session not found', {}, { timeout: 5_000 }),
+    ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /back to workouts/i })).toHaveAttribute(
       'href',
       '/workouts?view=calendar',
@@ -81,6 +83,7 @@ describe('SessionDetail', () => {
           id: 'set-press-1',
           exerciseId: 'incline-dumbbell-press',
           setNumber: 1,
+          notes: 'Bench at setting 5; keep elbows tucked.',
           reps: 10,
           weight: 50,
           section: 'main',
@@ -121,6 +124,7 @@ describe('SessionDetail', () => {
     expect(screen.getAllByText(/Set 1:/i).length).toBeGreaterThan(0);
     expect(screen.getByText('Great pacing and clean reps.')).toBeInTheDocument();
     expect(screen.getByText('Felt strong and stable today.')).toBeInTheDocument();
+    expect(screen.getByText('Bench at setting 5; keep elbows tucked.')).toBeInTheDocument();
   });
 
   it('shows volume progression, deltas, and PR badges when comparison is enabled', async () => {
@@ -253,7 +257,9 @@ describe('SessionDetail', () => {
     renderSessionDetail(currentSession.id);
     await screen.findByText('Workout receipt');
 
-    fireEvent.click(screen.getByRole('button', { name: /open incline dumbbell press trend chart/i }));
+    fireEvent.click(
+      screen.getByRole('button', { name: /open incline dumbbell press trend chart/i }),
+    );
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('Incline Dumbbell Press trends')).toBeInTheDocument();
@@ -404,7 +410,9 @@ function createSession(overrides: Partial<WorkoutSession>): WorkoutSession {
   };
 }
 
-function createSet(overrides: Partial<WorkoutSession['sets'][number]>): WorkoutSession['sets'][number] {
+function createSet(
+  overrides: Partial<WorkoutSession['sets'][number]>,
+): WorkoutSession['sets'][number] {
   return {
     id: 'set-default',
     exerciseId: 'incline-dumbbell-press',
@@ -420,9 +428,7 @@ function createSet(overrides: Partial<WorkoutSession['sets'][number]>): WorkoutS
   };
 }
 
-function createSessionListItem(
-  overrides: Partial<WorkoutSessionListItem>,
-): WorkoutSessionListItem {
+function createSessionListItem(overrides: Partial<WorkoutSessionListItem>): WorkoutSessionListItem {
   return {
     id: 'session-item-default',
     name: 'Upper Push',

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -127,6 +127,64 @@ describe('SessionDetail', () => {
     expect(screen.getByText('Bench at setting 5; keep elbows tucked.')).toBeInTheDocument();
   });
 
+  it('renders structured feedback responses when available', async () => {
+    const currentSession = createSession({
+      id: 'session-structured-feedback',
+      templateId: 'template-upper-push',
+      feedback: {
+        energy: 4,
+        recovery: 3,
+        technique: 4,
+        notes: 'Felt strong overall.',
+        responses: [
+          {
+            id: 'session-rpe',
+            label: 'Session RPE',
+            type: 'scale',
+            value: 8,
+          },
+          {
+            id: 'energy-post-workout',
+            label: 'Energy post workout',
+            type: 'emoji',
+            value: '💪',
+          },
+          {
+            id: 'pain-discomfort',
+            label: 'Any pain or discomfort?',
+            type: 'yes_no',
+            value: true,
+            notes: 'Mild right knee discomfort during split squats.',
+          },
+        ],
+      },
+    });
+
+    mockSessionDetailRequests({
+      sessionId: currentSession.id,
+      session: currentSession,
+      sessions: [
+        createSessionListItem({
+          id: currentSession.id,
+          templateId: currentSession.templateId,
+          templateName: 'Upper Push',
+          startedAt: currentSession.startedAt,
+        }),
+      ],
+    });
+
+    renderSessionDetail(currentSession.id);
+
+    expect(await screen.findByText('Session RPE')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+    expect(screen.getByText('Energy post workout')).toBeInTheDocument();
+    expect(screen.getByText('💪')).toBeInTheDocument();
+    expect(screen.getByText('Any pain or discomfort?')).toBeInTheDocument();
+    expect(screen.getByText('Yes')).toBeInTheDocument();
+    expect(screen.getByText('Mild right knee discomfort during split squats.')).toBeInTheDocument();
+    expect(screen.getByText('Felt strong overall.')).toBeInTheDocument();
+  });
+
   it('shows volume progression, deltas, and PR badges when comparison is enabled', async () => {
     const previousSession = createSession({
       id: 'session-previous',

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -255,6 +255,22 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
         />
       </div>
 
+      {session.notes ? (
+        <Card>
+          <CardHeader className="gap-2">
+            <CardTitle className="flex items-center gap-2">
+              <NotebookPen aria-hidden="true" className="size-5 text-primary" />
+              Session Notes
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="rounded-2xl border border-border bg-secondary/35 px-4 py-3 text-sm leading-6 text-foreground">
+              {session.notes}
+            </p>
+          </CardContent>
+        </Card>
+      ) : null}
+
       <Card>
         <CardContent className="flex flex-col gap-4 py-5 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-1">
@@ -414,22 +430,6 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
           )}
         </CardContent>
       </Card>
-
-      {session.notes ? (
-        <Card>
-          <CardHeader className="gap-2">
-            <CardTitle className="flex items-center gap-2">
-              <NotebookPen aria-hidden="true" className="size-5 text-primary" />
-              Session notes
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="rounded-2xl border border-border bg-secondary/35 px-4 py-3 text-sm leading-6 text-foreground">
-              {session.notes}
-            </p>
-          </CardContent>
-        </Card>
-      ) : null}
 
       {session.templateId ? (
         <Button asChild className="w-full sm:w-auto" size="lg">

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -15,6 +15,7 @@ import {
   type SessionSet,
   type WeightUnit,
   type WorkoutSession,
+  type WorkoutSessionFeedbackResponse,
   type WorkoutTemplate,
   type WorkoutTemplateSectionType,
 } from '@pulse/shared';
@@ -414,11 +415,32 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
         <CardContent className="space-y-5">
           {session.feedback ? (
             <>
-              <div className="grid gap-3 sm:grid-cols-3">
-                <FeedbackScore label="Energy" score={session.feedback.energy} />
-                <FeedbackScore label="Recovery" score={session.feedback.recovery} />
-                <FeedbackScore label="Technique" score={session.feedback.technique} />
-              </div>
+              {session.feedback.responses && session.feedback.responses.length > 0 ? (
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {session.feedback.responses.map((response) => (
+                    <div
+                      className="rounded-2xl border border-border bg-secondary/35 p-4"
+                      key={response.id}
+                    >
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
+                        {response.label}
+                      </p>
+                      <p className="mt-2 text-base font-semibold text-foreground">
+                        {formatFeedbackResponseValue(response)}
+                      </p>
+                      {response.notes?.trim() ? (
+                        <p className="mt-2 text-sm text-muted">{response.notes.trim()}</p>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <FeedbackScore label="Energy" score={session.feedback.energy} />
+                  <FeedbackScore label="Recovery" score={session.feedback.recovery} />
+                  <FeedbackScore label="Technique" score={session.feedback.technique} />
+                </div>
+              )}
 
               {session.feedback.notes ? (
                 <div className="rounded-2xl border border-border bg-secondary/35 px-4 py-3 text-sm text-foreground">
@@ -596,6 +618,32 @@ function FeedbackScore({ label, score }: { label: string; score: number }) {
       <p className="mt-2 text-base font-semibold text-foreground">{`${score}/5`}</p>
     </div>
   );
+}
+
+function formatFeedbackResponseValue(response: WorkoutSessionFeedbackResponse) {
+  if (response.value === null) {
+    return '-';
+  }
+
+  if (typeof response.value === 'boolean') {
+    return response.value ? 'Yes' : 'No';
+  }
+
+  if (typeof response.value === 'number') {
+    return Number.isInteger(response.value)
+      ? `${response.value}`
+      : decimalFormatter.format(response.value);
+  }
+
+  if (typeof response.value === 'string') {
+    return response.value.trim().length > 0 ? response.value : '-';
+  }
+
+  if (Array.isArray(response.value)) {
+    return response.value.length > 0 ? response.value.join(', ') : '-';
+  }
+
+  return '-';
 }
 
 function inferPhaseBadge(sectionType: SessionDetailSectionType): SessionDetailExercise['phaseBadge'] {

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -309,10 +309,14 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
         </div>
 
         {sections.map((section) => (
+          // Keep note-bearing sections expanded so logged notes are immediately visible.
+          // This avoids hiding notes behind collapsed warmup/cooldown groups.
+          // Main remains expanded by default even when it has no notes.
+          // Users can still collapse sections manually after first render.
           <details
             className="group overflow-hidden rounded-3xl border border-border bg-card shadow-sm"
             key={section.type}
-            open={section.type === 'main'}
+            open={section.type === 'main' || section.exercises.some((exercise) => Boolean(exercise.notes))}
           >
             <summary className="cursor-pointer list-none px-5 py-4 sm:px-6 sm:py-5">
               <div className="flex items-center justify-between gap-3">

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -122,19 +122,14 @@ describe('SessionExerciseList', () => {
     );
 
     fireEvent.click(within(currentCard as HTMLElement).getByRole('button', { name: /Form Cues/i }));
-    expect(within(currentCard as HTMLElement).getByText('Technique')).toBeVisible();
+    expect(within(currentCard as HTMLElement).getByText('Technique & coaching cues')).toBeVisible();
     expect(
       within(currentCard as HTMLElement).getByText(
-        'Press with a slight neutral grip, keep forearms stacked, and control a 3-second eccentric into the upper chest.',
+        'Drive feet into the floor',
       ),
     ).toBeVisible();
-    expect(within(currentCard as HTMLElement).getByText('Mental Cues')).toBeVisible();
     expect(
-      within(currentCard as HTMLElement).getByText('Drive upper back into the bench'),
-    ).toBeVisible();
-    expect(within(currentCard as HTMLElement).getByText('Common Mistakes')).toBeVisible();
-    expect(
-      within(currentCard as HTMLElement).getByText('Losing the shoulder blade set-up'),
+      within(currentCard as HTMLElement).getByText('Keep wrists stacked over elbows'),
     ).toBeVisible();
     expect(within(currentCard as HTMLElement).getByText('Injury-aware cues')).toBeVisible();
     expect(
@@ -399,7 +394,7 @@ describe('SessionExerciseList', () => {
               badges: ['compound'],
               category: 'compound',
               completedSets: 0,
-              formCues: null,
+              formCues: [],
               id: 'tempo-squat',
               injuryCues: [],
               lastPerformance: {
@@ -476,7 +471,7 @@ describe('SessionExerciseList', () => {
               badges: ['mobility'],
               category: 'mobility',
               completedSets: 1,
-              formCues: null,
+              formCues: [],
               id: 'plank-hold',
               injuryCues: [],
               lastPerformance: {

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -372,8 +372,8 @@ function ExerciseCardItem({
     focusTargetExerciseId === exercise.id
       ? true
       : (expandedExercises[exercise.id] ?? exercise.id === sessionCurrentExerciseId);
-  const formCueDetails = exercise.formCues;
-  const hasFormCues = formCueDetails !== null;
+  const formCues = exercise.formCues;
+  const hasFormCues = formCues.length > 0;
   const hasInjuryCues = exercise.injuryCues.length > 0;
   const isCuePanelOpen = hasFormCues && (visibleCuePanels[exercise.id] ?? false);
   const isNotesPanelOpen = visibleNotesPanels[exercise.id] ?? exercise.notes.length > 0;
@@ -591,22 +591,7 @@ function ExerciseCardItem({
               >
                 <div className="overflow-hidden">
                   <div className="rounded-2xl border border-border bg-background/80 p-4">
-                    <div className="space-y-4">
-                      <div className="space-y-2">
-                        <p className="text-xs font-semibold tracking-[0.18em] text-muted uppercase">
-                          Technique
-                        </p>
-                        <p className="text-sm text-foreground">{formCueDetails?.technique}</p>
-                      </div>
-
-                      <div className="grid gap-4 md:grid-cols-2">
-                        <CueList items={formCueDetails?.mentalCues ?? []} title="Mental Cues" />
-                        <CueList
-                          items={formCueDetails?.commonMistakes ?? []}
-                          title="Common Mistakes"
-                        />
-                      </div>
-                    </div>
+                    <CueList items={formCues} title="Technique & coaching cues" />
                   </div>
                 </div>
               </div>

--- a/apps/web/src/features/workouts/components/session-feedback.test.tsx
+++ b/apps/web/src/features/workouts/components/session-feedback.test.tsx
@@ -50,7 +50,9 @@ describe('SessionFeedback', () => {
       }),
     );
     fireEvent.click(
-      within(screen.getByRole('group', { name: 'Energy Level options' })).getByRole('button', {
+      within(
+        screen.getByRole('group', { name: 'Energy post workout options' }),
+      ).getByRole('button', {
         name: '🙂',
       }),
     );
@@ -98,7 +100,7 @@ describe('SessionFeedback', () => {
 
     expect(submittedFeedback.map((field) => field.id)).toEqual([
       'session-rpe',
-      'energy-level',
+      'energy-post-workout',
       'pain-discomfort',
       'sleep-quality',
       'effort',
@@ -149,7 +151,9 @@ describe('SessionFeedback', () => {
       }),
     );
     fireEvent.click(
-      within(screen.getByRole('group', { name: 'Energy Level options' })).getByRole('button', {
+      within(
+        screen.getByRole('group', { name: 'Energy post workout options' }),
+      ).getByRole('button', {
         name: '😐',
       }),
     );
@@ -179,8 +183,8 @@ describe('SessionFeedback', () => {
         value: 5,
       },
       {
-        id: 'energy-level',
-        label: 'Energy Level',
+        id: 'energy-post-workout',
+        label: 'Energy post workout',
         notes: '',
         optional: false,
         options: ['😫', '😕', '😐', '🙂', '💪'],
@@ -196,5 +200,45 @@ describe('SessionFeedback', () => {
         value: false,
       },
     ]);
+  });
+
+  it('drops legacy custom fields that overlap standard prompts', () => {
+    const onSubmit = vi.fn();
+
+    render(
+      <SessionFeedback
+        fields={[
+          {
+            id: 'energy-post',
+            label: 'Energy post workout',
+            max: 5,
+            min: 1,
+            type: 'scale',
+            value: 3,
+          },
+          {
+            id: 'knee-pain',
+            label: 'Knee pain',
+            max: 5,
+            min: 1,
+            type: 'scale',
+            value: 2,
+          },
+          {
+            id: 'coach-note',
+            label: 'Coach note',
+            optional: true,
+            type: 'text',
+            value: '',
+          },
+        ]}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    expect(screen.queryByRole('group', { name: 'Energy post workout rating' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('group', { name: 'Knee pain rating' })).not.toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Energy post workout options' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: 'Coach note' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/workouts/components/session-feedback.test.tsx
+++ b/apps/web/src/features/workouts/components/session-feedback.test.tsx
@@ -241,4 +241,34 @@ describe('SessionFeedback', () => {
     expect(screen.getByRole('group', { name: 'Energy post workout options' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 3, name: 'Coach note' })).toBeInTheDocument();
   });
+
+  it('keeps custom fields whose ids include pain/discomfort substrings', () => {
+    render(
+      <SessionFeedback
+        fields={[
+          {
+            id: 'muscle-pain-scale',
+            label: 'Muscle pain scale',
+            max: 10,
+            min: 1,
+            type: 'slider',
+            value: null,
+          },
+          {
+            id: 'joint-discomfort-check',
+            label: 'Joint discomfort check',
+            optional: true,
+            type: 'text',
+            value: '',
+          },
+        ]}
+        onSubmit={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { level: 3, name: 'Muscle pain scale' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Joint discomfort check' }),
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/workouts/components/session-feedback.test.tsx
+++ b/apps/web/src/features/workouts/components/session-feedback.test.tsx
@@ -1,106 +1,200 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { workoutFeedbackFields } from '../lib/mock-data';
+import type { ActiveWorkoutCustomFeedbackField } from '../types';
 import { SessionFeedback } from './session-feedback';
 
 describe('SessionFeedback', () => {
-  it('renders dynamic feedback fields and collects values before finalizing the session', () => {
+  it('renders standard questions first and supports richer question types', () => {
     const onSubmit = vi.fn();
+    const templateFields: ActiveWorkoutCustomFeedbackField[] = [
+      {
+        id: 'sleep-quality',
+        label: 'Slept well last night?',
+        type: 'yes_no',
+        value: null,
+      },
+      {
+        id: 'effort',
+        label: 'Effort slider',
+        max: 10,
+        min: 1,
+        step: 1,
+        type: 'slider',
+        value: null,
+      },
+      {
+        id: 'limited-muscles',
+        label: 'What limited performance?',
+        options: ['Shoulders', 'Grip', 'Cardio', 'Nothing'],
+        type: 'multi_select',
+        value: [],
+      },
+      {
+        id: 'coach-note',
+        label: 'Coach note',
+        optional: true,
+        type: 'text',
+        value: '',
+      },
+    ];
 
-    render(<SessionFeedback fields={workoutFeedbackFields} onSubmit={onSubmit} />);
+    render(<SessionFeedback fields={templateFields} onSubmit={onSubmit} />);
 
     const finalizeButton = screen.getByRole('button', { name: 'Finalize session' });
-    expect(finalizeButton).toBeEnabled();
-
-    expect(screen.getByRole('group', { name: 'Knee pain rating' })).toBeInTheDocument();
-    expect(screen.getByRole('group', { name: 'Shoulder feel rating' })).toBeInTheDocument();
-    expect(screen.getByRole('group', { name: 'Energy post workout rating' })).toBeInTheDocument();
-    expect(
-      screen.getByDisplayValue('Keep incline press to a 2-count pause on the chest next week.'),
-    ).toBeInTheDocument();
+    expect(finalizeButton).toBeDisabled();
 
     fireEvent.click(
-      within(screen.getByRole('group', { name: 'Knee pain rating' })).getByRole('button', {
+      within(screen.getByRole('group', { name: 'Session RPE rating' })).getByRole('button', {
+        name: '7',
+      }),
+    );
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Energy Level options' })).getByRole('button', {
+        name: '🙂',
+      }),
+    );
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Any pain or discomfort? response' })).getByRole(
+        'button',
+        {
+          name: 'Yes',
+        },
+      ),
+    );
+
+    expect(screen.getByLabelText('Pain/discomfort details')).toBeInTheDocument();
+    expect(finalizeButton).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Pain/discomfort details'), {
+      target: { value: 'Mild right-knee discomfort during split squats.' },
+    });
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Slept well last night? response' })).getByRole(
+        'button',
+        {
+          name: 'No',
+        },
+      ),
+    );
+    fireEvent.change(screen.getByLabelText('Effort slider slider'), {
+      target: { value: '8' },
+    });
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'What limited performance? options' })).getByRole(
+        'button',
+        {
+          name: 'Shoulders',
+        },
+      ),
+    );
+
+    expect(finalizeButton).toBeEnabled();
+
+    fireEvent.click(finalizeButton);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const submittedFeedback = onSubmit.mock.calls[0][0] as ActiveWorkoutCustomFeedbackField[];
+
+    expect(submittedFeedback.map((field) => field.id)).toEqual([
+      'session-rpe',
+      'energy-level',
+      'pain-discomfort',
+      'sleep-quality',
+      'effort',
+      'limited-muscles',
+      'coach-note',
+    ]);
+    expect(
+      submittedFeedback.find((field) => field.id === 'pain-discomfort' && field.type === 'yes_no'),
+    ).toEqual(
+      expect.objectContaining({
+        notes: 'Mild right-knee discomfort during split squats.',
+        value: true,
+      }),
+    );
+    expect(
+      submittedFeedback.find((field) => field.id === 'sleep-quality' && field.type === 'yes_no'),
+    ).toEqual(
+      expect.objectContaining({
+        value: false,
+      }),
+    );
+    expect(submittedFeedback.find((field) => field.id === 'effort' && field.type === 'slider')).toEqual(
+      expect.objectContaining({
+        value: 8,
+      }),
+    );
+    expect(
+      submittedFeedback.find(
+        (field) => field.id === 'limited-muscles' && field.type === 'multi_select',
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        value: ['Shoulders'],
+      }),
+    );
+  });
+
+  it('allows completion without pain details when pain is no', () => {
+    const onSubmit = vi.fn();
+
+    render(<SessionFeedback fields={[]} onSubmit={onSubmit} />);
+
+    const finalizeButton = screen.getByRole('button', { name: 'Finalize session' });
+
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Session RPE rating' })).getByRole('button', {
         name: '5',
       }),
     );
-    fireEvent.change(screen.getByLabelText('Optional notes', { selector: '#knee-pain-notes' }), {
-      target: { value: 'Pain spiked during the final split squat set.' },
-    });
-    fireEvent.change(
-      screen.getByDisplayValue('Keep incline press to a 2-count pause on the chest next week.'),
-      {
-        target: { value: 'Stay tucked and keep the pause honest next week.' },
-      },
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Energy Level options' })).getByRole('button', {
+        name: '😐',
+      }),
     );
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Any pain or discomfort? response' })).getByRole(
+        'button',
+        {
+          name: 'No',
+        },
+      ),
+    );
+
+    expect(screen.queryByLabelText('Pain/discomfort details')).not.toBeInTheDocument();
+    expect(finalizeButton).toBeEnabled();
 
     fireEvent.click(finalizeButton);
 
     expect(onSubmit).toHaveBeenCalledWith([
       {
-        id: 'knee-pain',
-        label: 'Knee pain',
-        max: 5,
+        id: 'session-rpe',
+        label: 'Session RPE',
+        max: 10,
         min: 1,
-        notes: 'Pain spiked during the final split squat set.',
+        notes: '',
+        optional: false,
         type: 'scale',
         value: 5,
       },
       {
-        id: 'shoulder-feel',
-        label: 'Shoulder feel',
-        max: 5,
-        min: 1,
-        notes: 'Left shoulder stayed stable with neutral-grip pressing.',
-        type: 'scale',
-        value: 4,
+        id: 'energy-level',
+        label: 'Energy Level',
+        notes: '',
+        optional: false,
+        options: ['😫', '😕', '😐', '🙂', '💪'],
+        type: 'emoji',
+        value: '😐',
       },
       {
-        id: 'energy-post',
-        label: 'Energy post workout',
-        max: 5,
-        min: 1,
+        id: 'pain-discomfort',
+        label: 'Any pain or discomfort?',
         notes: '',
-        type: 'scale',
-        value: 4,
-      },
-      {
-        id: 'session-note',
-        label: 'Coach note',
-        notes: '',
-        optional: true,
-        type: 'text',
-        value: 'Stay tucked and keep the pause honest next week.',
+        optional: false,
+        type: 'yes_no',
+        value: false,
       },
     ]);
-  });
-
-  it('allows optional text feedback fields to be cleared without blocking finalization', () => {
-    const onSubmit = vi.fn();
-
-    render(<SessionFeedback fields={workoutFeedbackFields} onSubmit={onSubmit} />);
-
-    const finalizeButton = screen.getByRole('button', { name: 'Finalize session' });
-    const coachNoteInput = screen.getByDisplayValue(
-      'Keep incline press to a 2-count pause on the chest next week.',
-    );
-
-    fireEvent.change(coachNoteInput, { target: { value: '' } });
-
-    expect(finalizeButton).toBeEnabled();
-
-    fireEvent.click(finalizeButton);
-
-    expect(onSubmit).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: 'session-note',
-          optional: true,
-          type: 'text',
-          value: '',
-        }),
-      ]),
-    );
   });
 });

--- a/apps/web/src/features/workouts/components/session-feedback.tsx
+++ b/apps/web/src/features/workouts/components/session-feedback.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type Dispatch, type SetStateAction } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -6,6 +6,33 @@ import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
 
 import type { ActiveWorkoutCustomFeedbackField, ActiveWorkoutFeedbackDraft } from '../types';
+
+export const STANDARD_FEEDBACK_QUESTIONS: ActiveWorkoutCustomFeedbackField[] = [
+  {
+    id: 'session-rpe',
+    label: 'Session RPE',
+    max: 10,
+    min: 1,
+    optional: false,
+    type: 'scale',
+    value: null,
+  },
+  {
+    id: 'energy-level',
+    label: 'Energy Level',
+    optional: false,
+    options: ['😫', '😕', '😐', '🙂', '💪'],
+    type: 'emoji',
+    value: null,
+  },
+  {
+    id: 'pain-discomfort',
+    label: 'Any pain or discomfort?',
+    optional: false,
+    type: 'yes_no',
+    value: null,
+  },
+];
 
 type SessionFeedbackProps = {
   className?: string;
@@ -15,31 +42,33 @@ type SessionFeedbackProps = {
 
 export function SessionFeedback({ className, fields, onSubmit }: SessionFeedbackProps) {
   const [feedback, setFeedback] = useState<ActiveWorkoutFeedbackDraft>(() =>
-    fields.map((field) =>
-      field.type === 'scale'
-        ? {
-            ...field,
-            notes: field.notes ?? '',
-            value: field.value ?? null,
-          }
-        : {
-            ...field,
-            notes: field.notes ?? '',
-            value: field.value ?? '',
-          },
-    ),
+    mergeFeedbackFields(fields).map(normalizeFeedbackField),
   );
 
   const isComplete = feedback.every((field) => {
-    if (field.type === 'scale') {
-      return field.value !== null && field.value !== undefined;
-    }
-
     if (field.optional) {
       return true;
     }
 
-    return (field.value ?? '').trim().length > 0;
+    if (field.id === 'pain-discomfort' && field.type === 'yes_no' && field.value === true) {
+      return (field.notes ?? '').trim().length > 0;
+    }
+
+    switch (field.type) {
+      case 'scale':
+      case 'slider':
+        return field.value !== null && field.value !== undefined;
+      case 'text':
+        return (field.value ?? '').trim().length > 0;
+      case 'yes_no':
+        return field.value !== null && field.value !== undefined;
+      case 'emoji':
+        return (field.value ?? '').trim().length > 0;
+      case 'multi_select':
+        return (field.value ?? []).length > 0;
+      default:
+        return false;
+    }
   });
 
   return (
@@ -51,7 +80,7 @@ export function SessionFeedback({ className, fields, onSubmit }: SessionFeedback
           </p>
           <h2 className="text-3xl font-semibold tracking-tight">How did this session feel?</h2>
           <p className="max-w-2xl text-sm opacity-75 dark:text-muted dark:opacity-100">
-            Capture the custom check-ins for this session before you wrap the workout.
+            Capture the session check-ins before you wrap the workout.
           </p>
         </div>
       </CardHeader>
@@ -62,94 +91,66 @@ export function SessionFeedback({ className, fields, onSubmit }: SessionFeedback
             <div className="space-y-3">
               <div className="space-y-1">
                 <h3 className="text-lg font-semibold text-foreground">{field.label}</h3>
-                <p className="text-sm text-muted">
-                  {field.type === 'scale'
-                    ? `Rate ${field.label.toLowerCase()} from ${field.min} to ${field.max}.`
-                    : `Add a note for ${field.label.toLowerCase()}.`}
-                </p>
+                <p className="text-sm text-muted">{getFeedbackDescription(field)}</p>
               </div>
 
-              {field.type === 'scale' ? (
-                <div
-                  aria-label={`${field.label} rating`}
-                  className="flex flex-wrap gap-2"
-                  role="group"
-                >
-                  {Array.from(
-                    { length: field.max - field.min + 1 },
-                    (_, index) => field.min + index,
-                  ).map((score) => {
-                    const isSelected = field.value === score;
+              {renderFeedbackInput(field, setFeedback)}
 
-                    return (
-                      <Button
-                        aria-pressed={isSelected}
-                        className={cn(
-                          'min-w-11',
-                          isSelected &&
-                            'border-transparent bg-[var(--color-accent-cream)] text-on-cream hover:bg-[var(--color-accent-cream)]/90 dark:bg-amber-500/20 dark:text-amber-400 dark:hover:bg-amber-500/30',
-                        )}
-                        key={score}
-                        onClick={() =>
-                          setFeedback((current) =>
-                            current.map((entry) =>
-                              entry.id === field.id && entry.type === 'scale'
-                                ? { ...entry, value: score }
-                                : entry,
-                            ),
-                          )
-                        }
-                        size="sm"
-                        type="button"
-                        variant={isSelected ? 'secondary' : 'outline'}
-                      >
-                        {score}
-                      </Button>
-                    );
-                  })}
+              {field.id === 'pain-discomfort' && field.type === 'yes_no' && field.value === true ? (
+                <div className="space-y-2">
+                  <label
+                    className="text-xs font-semibold tracking-[0.18em] text-muted uppercase"
+                    htmlFor="pain-discomfort-details"
+                  >
+                    Pain/discomfort details
+                  </label>
+                  <Textarea
+                    id="pain-discomfort-details"
+                    onChange={(event) =>
+                      setFeedback((current) =>
+                        current.map((entry) =>
+                          entry.id === field.id && entry.type === 'yes_no'
+                            ? {
+                                ...entry,
+                                notes: event.target.value,
+                              }
+                            : entry,
+                        ),
+                      )
+                    }
+                    placeholder="Describe where it happened and what movements triggered it."
+                    value={field.notes ?? ''}
+                  />
                 </div>
-              ) : (
-                <Textarea
-                  id={`${field.id}-value`}
-                  onChange={(event) =>
-                    setFeedback((current) =>
-                      current.map((entry) =>
-                        entry.id === field.id && entry.type === 'text'
-                          ? { ...entry, value: event.target.value }
-                          : entry,
-                      ),
-                    )
-                  }
-                  placeholder={`Add your ${field.label.toLowerCase()} notes.`}
-                  value={field.value}
-                />
-              )}
+              ) : null}
 
-              <div className="space-y-2">
-                <label
-                  className="text-xs font-semibold tracking-[0.18em] text-muted uppercase"
-                  htmlFor={`${field.id}-notes`}
-                >
-                  Optional notes
-                </label>
-                <Textarea
-                  id={`${field.id}-notes`}
-                  onChange={(event) =>
-                    setFeedback((current) =>
-                      current.map((entry) =>
-                        entry.id === field.id
-                          ? {
-                              ...entry,
-                              notes: event.target.value,
-                            }
-                          : entry,
-                      ),
-                    )
-                  }
-                  placeholder={`Add context about ${field.label.toLowerCase()} if it mattered today.`}
-                  value={field.notes ?? ''}
-                />
-              </div>
+              {!(field.id === 'pain-discomfort' && field.type === 'yes_no' && field.value === true) ? (
+                <div className="space-y-2">
+                  <label
+                    className="text-xs font-semibold tracking-[0.18em] text-muted uppercase"
+                    htmlFor={`${field.id}-notes`}
+                  >
+                    Optional notes
+                  </label>
+                  <Textarea
+                    id={`${field.id}-notes`}
+                    onChange={(event) =>
+                      setFeedback((current) =>
+                        current.map((entry) =>
+                          entry.id === field.id
+                            ? {
+                                ...entry,
+                                notes: event.target.value,
+                              }
+                            : entry,
+                        ),
+                      )
+                    }
+                    placeholder={`Add context about ${field.label.toLowerCase()} if it mattered today.`}
+                    value={field.notes ?? ''}
+                  />
+                </div>
+              ) : null}
             </div>
           </section>
         ))}
@@ -165,4 +166,274 @@ export function SessionFeedback({ className, fields, onSubmit }: SessionFeedback
       </CardContent>
     </Card>
   );
+}
+
+function mergeFeedbackFields(fields: ActiveWorkoutCustomFeedbackField[]) {
+  const standardIds = new Set(STANDARD_FEEDBACK_QUESTIONS.map((field) => field.id));
+  const templateFields = fields.filter((field) => !standardIds.has(field.id));
+
+  return [...STANDARD_FEEDBACK_QUESTIONS, ...templateFields];
+}
+
+function normalizeFeedbackField(field: ActiveWorkoutCustomFeedbackField): ActiveWorkoutCustomFeedbackField {
+  switch (field.type) {
+    case 'scale':
+      return {
+        ...field,
+        notes: field.notes ?? '',
+        value: field.value ?? null,
+      };
+    case 'text':
+      return {
+        ...field,
+        notes: field.notes ?? '',
+        value: field.value ?? '',
+      };
+    case 'yes_no':
+      return {
+        ...field,
+        notes: field.notes ?? '',
+        value: field.value ?? null,
+      };
+    case 'emoji':
+      return {
+        ...field,
+        notes: field.notes ?? '',
+        value: field.value ?? null,
+      };
+    case 'slider':
+      return {
+        ...field,
+        notes: field.notes ?? '',
+        step: field.step ?? 1,
+        value: field.value ?? null,
+      };
+    case 'multi_select':
+      return {
+        ...field,
+        notes: field.notes ?? '',
+        value: field.value ?? [],
+      };
+    default:
+      return field;
+  }
+}
+
+function getFeedbackDescription(field: ActiveWorkoutCustomFeedbackField) {
+  switch (field.type) {
+    case 'scale':
+      return `Rate ${field.label.toLowerCase()} from ${field.min} to ${field.max}.`;
+    case 'text':
+      return `Add a note for ${field.label.toLowerCase()}.`;
+    case 'yes_no':
+      return 'Select yes or no.';
+    case 'emoji':
+      return 'Choose the option that best matches how you felt.';
+    case 'slider':
+      return `Slide from ${field.min} to ${field.max}.`;
+    case 'multi_select':
+      return 'Select all that apply.';
+    default:
+      return '';
+  }
+}
+
+function renderFeedbackInput(
+  field: ActiveWorkoutCustomFeedbackField,
+  setFeedback: Dispatch<SetStateAction<ActiveWorkoutFeedbackDraft>>,
+) {
+  switch (field.type) {
+    case 'scale':
+      return (
+        <div aria-label={`${field.label} rating`} className="flex flex-wrap gap-2" role="group">
+          {Array.from({ length: field.max - field.min + 1 }, (_, index) => field.min + index).map(
+            (score) => {
+              const isSelected = field.value === score;
+
+              return (
+                <Button
+                  aria-pressed={isSelected}
+                  className={cn(
+                    'min-w-11',
+                    isSelected &&
+                      'border-transparent bg-[var(--color-accent-cream)] text-on-cream hover:bg-[var(--color-accent-cream)]/90 dark:bg-amber-500/20 dark:text-amber-400 dark:hover:bg-amber-500/30',
+                  )}
+                  key={score}
+                  onClick={() =>
+                    setFeedback((current) =>
+                      current.map((entry) =>
+                        entry.id === field.id && entry.type === 'scale'
+                          ? { ...entry, value: score }
+                          : entry,
+                      ),
+                    )
+                  }
+                  size="sm"
+                  type="button"
+                  variant={isSelected ? 'secondary' : 'outline'}
+                >
+                  {score}
+                </Button>
+              );
+            },
+          )}
+        </div>
+      );
+    case 'text':
+      return (
+        <Textarea
+          id={`${field.id}-value`}
+          onChange={(event) =>
+            setFeedback((current) =>
+              current.map((entry) =>
+                entry.id === field.id && entry.type === 'text'
+                  ? { ...entry, value: event.target.value }
+                  : entry,
+              ),
+            )
+          }
+          placeholder={`Add your ${field.label.toLowerCase()} notes.`}
+          value={field.value}
+        />
+      );
+    case 'yes_no':
+      return (
+        <div aria-label={`${field.label} response`} className="flex gap-2" role="group">
+          <Button
+            aria-pressed={field.value === true}
+            onClick={() =>
+              setFeedback((current) =>
+                current.map((entry) =>
+                  entry.id === field.id && entry.type === 'yes_no'
+                    ? { ...entry, value: true }
+                    : entry,
+                ),
+              )
+            }
+            type="button"
+            variant={field.value === true ? 'secondary' : 'outline'}
+          >
+            Yes
+          </Button>
+          <Button
+            aria-pressed={field.value === false}
+            onClick={() =>
+              setFeedback((current) =>
+                current.map((entry) =>
+                  entry.id === field.id && entry.type === 'yes_no'
+                    ? { ...entry, value: false }
+                    : entry,
+                ),
+              )
+            }
+            type="button"
+            variant={field.value === false ? 'secondary' : 'outline'}
+          >
+            No
+          </Button>
+        </div>
+      );
+    case 'emoji':
+      return (
+        <div aria-label={`${field.label} options`} className="flex flex-wrap gap-2" role="group">
+          {field.options.map((option) => {
+            const isSelected = field.value === option;
+
+            return (
+              <Button
+                aria-pressed={isSelected}
+                className="min-w-11 px-3"
+                key={option}
+                onClick={() =>
+                  setFeedback((current) =>
+                    current.map((entry) =>
+                      entry.id === field.id && entry.type === 'emoji'
+                        ? { ...entry, value: option }
+                        : entry,
+                    ),
+                  )
+                }
+                size="sm"
+                type="button"
+                variant={isSelected ? 'secondary' : 'outline'}
+              >
+                <span aria-hidden="true" className="text-lg leading-none">
+                  {option}
+                </span>
+                <span className="sr-only">{option}</span>
+              </Button>
+            );
+          })}
+        </div>
+      );
+    case 'slider':
+      return (
+        <div className="space-y-2">
+          <input
+            aria-label={`${field.label} slider`}
+            className="h-2 w-full cursor-pointer accent-[var(--color-accent-peach)]"
+            max={field.max}
+            min={field.min}
+            onChange={(event) => {
+              const nextValue = Number(event.target.value);
+
+              setFeedback((current) =>
+                current.map((entry) =>
+                  entry.id === field.id && entry.type === 'slider'
+                    ? { ...entry, value: Number.isNaN(nextValue) ? null : nextValue }
+                    : entry,
+                ),
+              );
+            }}
+            step={field.step ?? 1}
+            type="range"
+            value={field.value ?? field.min}
+          />
+          <div className="flex items-center justify-between text-xs text-muted">
+            <span>{field.min}</span>
+            <span className="font-medium text-foreground">{field.value ?? '-'}</span>
+            <span>{field.max}</span>
+          </div>
+        </div>
+      );
+    case 'multi_select':
+      return (
+        <div aria-label={`${field.label} options`} className="flex flex-wrap gap-2" role="group">
+          {field.options.map((option) => {
+            const selectedValues = field.value ?? [];
+            const isSelected = selectedValues.includes(option);
+
+            return (
+              <Button
+                aria-pressed={isSelected}
+                key={option}
+                onClick={() =>
+                  setFeedback((current) =>
+                    current.map((entry) => {
+                      if (entry.id !== field.id || entry.type !== 'multi_select') {
+                        return entry;
+                      }
+
+                      return {
+                        ...entry,
+                        value: (entry.value ?? []).includes(option)
+                          ? (entry.value ?? []).filter((item) => item !== option)
+                          : [...(entry.value ?? []), option],
+                      };
+                    }),
+                  )
+                }
+                size="sm"
+                type="button"
+                variant={isSelected ? 'secondary' : 'outline'}
+              >
+                {option}
+              </Button>
+            );
+          })}
+        </div>
+      );
+    default:
+      return null;
+  }
 }

--- a/apps/web/src/features/workouts/components/session-feedback.tsx
+++ b/apps/web/src/features/workouts/components/session-feedback.tsx
@@ -185,33 +185,31 @@ function mergeFeedbackFields(fields: ActiveWorkoutCustomFeedbackField[]) {
 
 function getCanonicalStandardFieldId(field: ActiveWorkoutCustomFeedbackField) {
   const normalizedId = field.id.trim().toLowerCase();
-  const normalizedLabel = field.label.trim().toLowerCase();
-  const normalizedHaystack = `${normalizedId} ${normalizedLabel}`;
+  const normalizedLabel = field.label.trim().toLowerCase().replace(/\s+/g, ' ');
 
-  if (
-    normalizedId === 'session-rpe' ||
-    normalizedHaystack.includes('session rpe') ||
-    normalizedHaystack.includes('rpe')
-  ) {
+  const sessionRpeIds = new Set(['session-rpe', 'rpe', 'session_rpe']);
+  const energyIds = new Set([
+    'energy-post-workout',
+    'energy-level',
+    'energy-post',
+    'energy_post_workout',
+    'energy_level',
+  ]);
+  const painIds = new Set(['pain-discomfort', 'pain_discomfort', 'knee-pain', 'knee_pain']);
+
+  const sessionRpeLabels = new Set(['session rpe', 'rpe']);
+  const energyLabels = new Set(['energy post workout', 'energy level']);
+  const painLabels = new Set(['any pain or discomfort?', 'pain/discomfort', 'knee pain']);
+
+  if (sessionRpeIds.has(normalizedId) || sessionRpeLabels.has(normalizedLabel)) {
     return 'session-rpe';
   }
 
-  if (
-    normalizedId === 'energy-post-workout' ||
-    normalizedId === 'energy-level' ||
-    normalizedId === 'energy-post' ||
-    normalizedHaystack.includes('energy post workout') ||
-    normalizedHaystack.includes('energy level')
-  ) {
+  if (energyIds.has(normalizedId) || energyLabels.has(normalizedLabel)) {
     return 'energy-post-workout';
   }
 
-  if (
-    normalizedId === 'pain-discomfort' ||
-    normalizedId === 'knee-pain' ||
-    normalizedHaystack.includes('pain') ||
-    normalizedHaystack.includes('discomfort')
-  ) {
+  if (painIds.has(normalizedId) || painLabels.has(normalizedLabel)) {
     return 'pain-discomfort';
   }
 
@@ -249,7 +247,7 @@ function normalizeFeedbackField(field: ActiveWorkoutCustomFeedbackField): Active
         ...field,
         notes: field.notes ?? '',
         step: field.step ?? 1,
-        value: field.value ?? null,
+        value: field.value ?? field.min,
       };
     case 'multi_select':
       return {

--- a/apps/web/src/features/workouts/components/session-feedback.tsx
+++ b/apps/web/src/features/workouts/components/session-feedback.tsx
@@ -18,8 +18,8 @@ export const STANDARD_FEEDBACK_QUESTIONS: ActiveWorkoutCustomFeedbackField[] = [
     value: null,
   },
   {
-    id: 'energy-level',
-    label: 'Energy Level',
+    id: 'energy-post-workout',
+    label: 'Energy post workout',
     optional: false,
     options: ['😫', '😕', '😐', '🙂', '💪'],
     type: 'emoji',
@@ -170,9 +170,52 @@ export function SessionFeedback({ className, fields, onSubmit }: SessionFeedback
 
 function mergeFeedbackFields(fields: ActiveWorkoutCustomFeedbackField[]) {
   const standardIds = new Set(STANDARD_FEEDBACK_QUESTIONS.map((field) => field.id));
-  const templateFields = fields.filter((field) => !standardIds.has(field.id));
+  const templateFields = fields.filter((field) => {
+    if (standardIds.has(field.id)) {
+      return false;
+    }
+
+    const canonicalId = getCanonicalStandardFieldId(field);
+
+    return canonicalId === null;
+  });
 
   return [...STANDARD_FEEDBACK_QUESTIONS, ...templateFields];
+}
+
+function getCanonicalStandardFieldId(field: ActiveWorkoutCustomFeedbackField) {
+  const normalizedId = field.id.trim().toLowerCase();
+  const normalizedLabel = field.label.trim().toLowerCase();
+  const normalizedHaystack = `${normalizedId} ${normalizedLabel}`;
+
+  if (
+    normalizedId === 'session-rpe' ||
+    normalizedHaystack.includes('session rpe') ||
+    normalizedHaystack.includes('rpe')
+  ) {
+    return 'session-rpe';
+  }
+
+  if (
+    normalizedId === 'energy-post-workout' ||
+    normalizedId === 'energy-level' ||
+    normalizedId === 'energy-post' ||
+    normalizedHaystack.includes('energy post workout') ||
+    normalizedHaystack.includes('energy level')
+  ) {
+    return 'energy-post-workout';
+  }
+
+  if (
+    normalizedId === 'pain-discomfort' ||
+    normalizedId === 'knee-pain' ||
+    normalizedHaystack.includes('pain') ||
+    normalizedHaystack.includes('discomfort')
+  ) {
+    return 'pain-discomfort';
+  }
+
+  return null;
 }
 
 function normalizeFeedbackField(field: ActiveWorkoutCustomFeedbackField): ActiveWorkoutCustomFeedbackField {

--- a/apps/web/src/features/workouts/components/session-summary.test.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.test.tsx
@@ -26,6 +26,39 @@ describe('SessionSummary', () => {
             value: 2,
           },
           {
+            id: 'energy-level',
+            label: 'Energy level',
+            notes: '',
+            options: ['😫', '😕', '😐', '🙂', '💪'],
+            type: 'emoji',
+            value: '🙂',
+          },
+          {
+            id: 'pain-discomfort',
+            label: 'Any pain or discomfort?',
+            notes: '',
+            type: 'yes_no',
+            value: false,
+          },
+          {
+            id: 'effort',
+            label: 'Effort',
+            max: 10,
+            min: 1,
+            notes: '',
+            step: 1,
+            type: 'slider',
+            value: 8,
+          },
+          {
+            id: 'limited-muscles',
+            label: 'What limited performance?',
+            notes: '',
+            options: ['Shoulders', 'Grip', 'Cardio'],
+            type: 'multi_select',
+            value: ['Shoulders', 'Grip'],
+          },
+          {
             id: 'coach-note',
             label: 'Coach note',
             notes: '',
@@ -43,6 +76,10 @@ describe('SessionSummary', () => {
 
     expect(screen.getByRole('heading', { name: 'Session feedback' })).toBeInTheDocument();
     expect(screen.getByText('2 / 5')).toBeInTheDocument();
+    expect(screen.getByText('🙂')).toBeInTheDocument();
+    expect(screen.getByText('No')).toBeInTheDocument();
+    expect(screen.getByText('8 (1 - 10)')).toBeInTheDocument();
+    expect(screen.getByText('Shoulders, Grip')).toBeInTheDocument();
     expect(
       screen.getByText('Pause the first rep of each incline set next time.'),
     ).toBeInTheDocument();

--- a/apps/web/src/features/workouts/components/session-summary.test.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.test.tsx
@@ -8,6 +8,7 @@ import { SessionSummary } from './session-summary';
 describe('SessionSummary', () => {
   it('opens the save-as-template dialog with prefilled fields and performs a mock save', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const notesChangeSpy = vi.fn();
 
     renderWithQueryClient(
       <SessionSummary
@@ -68,6 +69,8 @@ describe('SessionSummary', () => {
         ]}
         onDone={() => {}}
         completedSets={14}
+        onNotesChange={notesChangeSpy}
+        sessionNotes=""
         totalReps={124}
         totalSets={14}
         workoutName="Upper Push"
@@ -83,6 +86,14 @@ describe('SessionSummary', () => {
     expect(
       screen.getByText('Pause the first rep of each incline set next time.'),
     ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('How did it feel? What would you change?'),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('How did it feel? What would you change?'), {
+      target: { value: 'Tempo was good but shoulders fatigued early.' },
+    });
+    expect(notesChangeSpy).toHaveBeenCalledWith('Tempo was good but shoulders fatigued early.');
 
     fireEvent.click(screen.getByRole('button', { name: 'Save as Template' }));
 

--- a/apps/web/src/features/workouts/components/session-summary.test.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.test.tsx
@@ -89,6 +89,8 @@ describe('SessionSummary', () => {
     expect(
       screen.getByPlaceholderText('How did it feel? What would you change?'),
     ).toBeInTheDocument();
+    expect(screen.getByTestId('session-summary-notes')).toHaveAttribute('id', 'session-summary-notes');
+    expect(screen.getByTestId('session-summary-notes')).toHaveAttribute('name', 'session-summary-notes');
     expect(screen.getByLabelText('Session notes')).toHaveValue('');
     expect(screen.getByRole('textbox', { name: 'Session notes' })).toHaveValue('');
 

--- a/apps/web/src/features/workouts/components/session-summary.test.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.test.tsx
@@ -7,7 +7,6 @@ import { SessionSummary } from './session-summary';
 
 describe('SessionSummary', () => {
   it('opens the save-as-template dialog with prefilled fields and performs a mock save', () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const notesChangeSpy = vi.fn();
 
     renderWithQueryClient(
@@ -118,13 +117,6 @@ describe('SessionSummary', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-    expect(logSpy).toHaveBeenCalledWith('Mock save workout template', {
-      description: 'Heavy upper emphasis with a slower incline press tempo.',
-      name: 'Upper Push',
-      tags: ['strength', 'push', 'hypertrophy'],
-    });
     expect(screen.getByText('Saved "Upper Push" to mock templates.')).toBeInTheDocument();
-
-    logSpy.mockRestore();
   });
 });

--- a/apps/web/src/features/workouts/components/session-summary.test.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.test.tsx
@@ -89,6 +89,7 @@ describe('SessionSummary', () => {
     expect(
       screen.getByPlaceholderText('How did it feel? What would you change?'),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText('Session notes')).toHaveValue('');
 
     fireEvent.change(screen.getByPlaceholderText('How did it feel? What would you change?'), {
       target: { value: 'Tempo was good but shoulders fatigued early.' },

--- a/apps/web/src/features/workouts/components/session-summary.test.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.test.tsx
@@ -90,6 +90,7 @@ describe('SessionSummary', () => {
       screen.getByPlaceholderText('How did it feel? What would you change?'),
     ).toBeInTheDocument();
     expect(screen.getByLabelText('Session notes')).toHaveValue('');
+    expect(screen.getByRole('textbox', { name: 'Session notes' })).toHaveValue('');
 
     fireEvent.change(screen.getByPlaceholderText('How did it feel? What would you change?'), {
       target: { value: 'Tempo was good but shoulders fatigued early.' },

--- a/apps/web/src/features/workouts/components/session-summary.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.tsx
@@ -107,9 +107,7 @@ export function SessionSummary({
                       {field.label}
                     </p>
                     <p className="mt-2 text-base font-semibold text-foreground">
-                      {field.type === 'scale'
-                        ? `${field.value ?? '-'} / ${field.max}`
-                        : field.value}
+                      {formatFeedbackFieldValue(field)}
                     </p>
                     {field.notes?.trim() ? (
                       <p className="mt-2 text-sm text-muted">{field.notes.trim()}</p>
@@ -249,6 +247,31 @@ export function SessionSummary({
       </Dialog>
     </>
   );
+}
+
+function formatFeedbackFieldValue(field: ActiveWorkoutFeedbackDraft[number]) {
+  switch (field.type) {
+    case 'scale':
+      return `${field.value ?? '-'} / ${field.max}`;
+    case 'text':
+      return field.value?.trim() ? field.value : '-';
+    case 'yes_no':
+      if (field.value === null || field.value === undefined) {
+        return '-';
+      }
+
+      return field.value ? 'Yes' : 'No';
+    case 'emoji':
+      return field.value?.trim() ? field.value : '-';
+    case 'slider':
+      return field.value === null || field.value === undefined
+        ? '-'
+        : `${field.value} (${field.min} - ${field.max})`;
+    case 'multi_select':
+      return (field.value ?? []).length > 0 ? (field.value ?? []).join(', ') : '-';
+    default:
+      return '-';
+  }
 }
 
 function SummaryStat({

--- a/apps/web/src/features/workouts/components/session-summary.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.tsx
@@ -100,12 +100,6 @@ export function SessionSummary({
             <h2 className="text-sm font-semibold tracking-[0.18em] uppercase opacity-70 dark:text-muted dark:opacity-100">
               Session notes
             </h2>
-            <label
-              className="text-xs font-medium text-muted"
-              htmlFor="session-summary-notes"
-            >
-              Session notes
-            </label>
             <Textarea
               aria-label="Session notes"
               data-testid="session-summary-notes"
@@ -268,7 +262,6 @@ export function SessionSummary({
                   return;
                 }
 
-                console.log('Mock save workout template', payload);
                 setSaveMessage(`Saved "${payload.name}" to mock templates.`);
                 setIsSaveDialogOpen(false);
               }}

--- a/apps/web/src/features/workouts/components/session-summary.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.tsx
@@ -107,6 +107,7 @@ export function SessionSummary({
               Session notes
             </label>
             <Textarea
+              aria-label="Session notes"
               id="session-summary-notes"
               className="rounded-2xl border-black/10 bg-card dark:border-border"
               onChange={(event) => {

--- a/apps/web/src/features/workouts/components/session-summary.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { CheckCircle2, Clock3, Dumbbell, ListChecks, Save } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -28,8 +28,11 @@ type SessionSummaryProps = {
   exercisesCompleted: number;
   feedback?: ActiveWorkoutFeedbackDraft;
   onDone: () => void;
+  onNotesChange?: (notes: string) => void;
+  sessionNotes?: string;
   sessionId?: string | null;
-  completedSets: number;
+  completedSets?: number;
+  summarySaving?: boolean;
   totalReps: number;
   totalSets: number;
   workoutName: string;
@@ -43,8 +46,11 @@ export function SessionSummary({
   exercisesCompleted,
   feedback = [],
   onDone,
+  onNotesChange,
+  sessionNotes: initialSessionNotes = '',
   sessionId = null,
   completedSets,
+  summarySaving = false,
   totalReps,
   totalSets,
   workoutName,
@@ -55,6 +61,11 @@ export function SessionSummary({
   const [templateDescription, setTemplateDescription] = useState(defaultDescription);
   const [templateTags, setTemplateTags] = useState(defaultTags.join(', '));
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [sessionNotes, setSessionNotes] = useState(initialSessionNotes);
+
+  useEffect(() => {
+    setSessionNotes(initialSessionNotes);
+  }, [initialSessionNotes]);
 
   return (
     <>
@@ -82,11 +93,30 @@ export function SessionSummary({
             <SummaryStat
               icon={ListChecks}
               label="Sets completed"
-              value={`${completedSets}/${totalSets}`}
+              value={
+                completedSets === undefined ? `${totalSets}` : `${completedSets}/${totalSets}`
+              }
             />
             <SummaryStat icon={CheckCircle2} label="Total reps" value={`${totalReps}`} />
             <SummaryStat icon={Clock3} label="Duration" value={duration} />
           </div>
+
+          <section className="space-y-2 rounded-3xl border border-black/10 bg-white/35 p-4 dark:border-border dark:bg-secondary/50">
+            <h2 className="text-sm font-semibold tracking-[0.18em] uppercase opacity-70 dark:text-muted dark:opacity-100">
+              Session notes
+            </h2>
+            <Textarea
+              className="rounded-2xl border-black/10 bg-card dark:border-border"
+              onChange={(event) => {
+                const nextValue = event.target.value;
+                setSessionNotes(nextValue);
+                onNotesChange?.(nextValue);
+              }}
+              placeholder="How did it feel? What would you change?"
+              rows={4}
+              value={sessionNotes}
+            />
+          </section>
 
           {feedback.length > 0 ? (
             <section className="space-y-3 rounded-3xl border border-black/10 bg-white/35 p-4 dark:border-border dark:bg-secondary/50">
@@ -137,11 +167,12 @@ export function SessionSummary({
 
             <Button
               className="w-full border-black/10 bg-white/60 hover:bg-white/75 sm:w-auto dark:bg-secondary dark:text-foreground dark:hover:bg-secondary/80"
+              disabled={summarySaving}
               onClick={onDone}
               type="button"
               variant="secondary"
             >
-              Done
+              {summarySaving ? 'Saving...' : 'Done'}
             </Button>
           </div>
 

--- a/apps/web/src/features/workouts/components/session-summary.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { CheckCircle2, Clock3, Dumbbell, ListChecks, Save } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -61,11 +61,6 @@ export function SessionSummary({
   const [templateDescription, setTemplateDescription] = useState(defaultDescription);
   const [templateTags, setTemplateTags] = useState(defaultTags.join(', '));
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
-  const [sessionNotes, setSessionNotes] = useState(initialSessionNotes);
-
-  useEffect(() => {
-    setSessionNotes(initialSessionNotes);
-  }, [initialSessionNotes]);
 
   return (
     <>
@@ -115,13 +110,11 @@ export function SessionSummary({
               id="session-summary-notes"
               className="rounded-2xl border-black/10 bg-card dark:border-border"
               onChange={(event) => {
-                const nextValue = event.target.value;
-                setSessionNotes(nextValue);
-                onNotesChange?.(nextValue);
+                onNotesChange?.(event.target.value);
               }}
               placeholder="How did it feel? What would you change?"
               rows={4}
-              value={sessionNotes}
+              value={initialSessionNotes}
             />
           </section>
 

--- a/apps/web/src/features/workouts/components/session-summary.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.tsx
@@ -105,7 +105,14 @@ export function SessionSummary({
             <h2 className="text-sm font-semibold tracking-[0.18em] uppercase opacity-70 dark:text-muted dark:opacity-100">
               Session notes
             </h2>
+            <label
+              className="text-xs font-medium text-muted"
+              htmlFor="session-summary-notes"
+            >
+              Session notes
+            </label>
             <Textarea
+              id="session-summary-notes"
               className="rounded-2xl border-black/10 bg-card dark:border-border"
               onChange={(event) => {
                 const nextValue = event.target.value;

--- a/apps/web/src/features/workouts/components/session-summary.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.tsx
@@ -108,7 +108,9 @@ export function SessionSummary({
             </label>
             <Textarea
               aria-label="Session notes"
+              data-testid="session-summary-notes"
               id="session-summary-notes"
+              name="session-summary-notes"
               className="rounded-2xl border-black/10 bg-card dark:border-border"
               onChange={(event) => {
                 onNotesChange?.(event.target.value);

--- a/apps/web/src/features/workouts/lib/active-session.test.ts
+++ b/apps/web/src/features/workouts/lib/active-session.test.ts
@@ -89,12 +89,7 @@ describe('active-session helpers', () => {
       .find((exercise) => exercise.id === 'incline-dumbbell-press');
 
     expect(incline).toMatchObject({
-      formCues: {
-        commonMistakes: ['Flared elbows at the bottom', 'Losing the shoulder blade set-up'],
-        mentalCues: ['Crack the handles', 'Drive upper back into the bench'],
-        technique:
-          'Press with a slight neutral grip, keep forearms stacked, and control a 3-second eccentric into the upper chest.',
-      },
+      formCues: ['Drive feet into the floor', 'Keep wrists stacked over elbows'],
       injuryCues: [
         'Avoid the last 10 degrees of lockout if the left shoulder feels unstable.',
         'Cap the top set at RPE 8 while the SLAP tear is still active.',
@@ -141,7 +136,7 @@ describe('active-session helpers', () => {
     expect(countCompletedReps(drafts)).toBe(10);
   });
 
-  it('leaves enhanced cue fields empty when an exercise has no enhanced mock entry', () => {
+  it('uses template cue arrays even when enhanced injury metadata is unavailable', () => {
     const lowerTemplate = mockTemplates.find((template) => template.id === 'lower-quad-dominant');
 
     if (!lowerTemplate) {
@@ -157,7 +152,7 @@ describe('active-session helpers', () => {
       .flatMap((section) => section.exercises)
       .find((exercise) => exercise.id === 'high-bar-back-squat');
 
-    expect(squat?.formCues).toBeNull();
+    expect(squat?.formCues.length).toBeGreaterThan(0);
     expect(squat?.injuryCues).toEqual([]);
   });
 
@@ -182,7 +177,8 @@ describe('active-session helpers', () => {
       unknownExerciseTemplate,
       createInitialWorkoutSetDrafts(unknownExerciseTemplate, new Set()),
     );
-    const firstMainExercise = session.sections.find((section) => section.type === 'main')?.exercises[0];
+    const firstMainExercise = session.sections.find((section) => section.type === 'main')
+      ?.exercises[0];
 
     expect(firstMainExercise?.name).toBe('DB Bench Press QA');
   });
@@ -210,7 +206,8 @@ describe('active-session helpers', () => {
       unknownExerciseTemplate,
       createInitialWorkoutSetDrafts(unknownExerciseTemplate, new Set()),
     );
-    const firstMainExercise = session.sections.find((section) => section.type === 'main')?.exercises[0];
+    const firstMainExercise = session.sections.find((section) => section.type === 'main')
+      ?.exercises[0];
 
     expect(firstMainExercise?.trackingType).toBe('seconds_only');
   });

--- a/apps/web/src/features/workouts/lib/active-session.ts
+++ b/apps/web/src/features/workouts/lib/active-session.ts
@@ -69,7 +69,7 @@ export function buildActiveWorkoutSession(
         badges: templateExercise.badges,
         category: exercise?.category ?? 'compound',
         completedSets,
-        formCues: enhancedExercise?.formCues ?? null,
+        formCues: templateExercise.formCues,
         id: templateExercise.exerciseId,
         injuryCues: enhancedExercise?.injuryCues ?? [],
         lastPerformance: sessions

--- a/apps/web/src/features/workouts/lib/mock-data.ts
+++ b/apps/web/src/features/workouts/lib/mock-data.ts
@@ -144,15 +144,6 @@ const sharedLowerSupplemental: ActiveWorkoutSupplementalExercise[] = [
 
 export const workoutFeedbackFields: ActiveWorkoutCustomFeedbackField[] = [
   {
-    id: 'knee-pain',
-    label: 'Knee pain',
-    type: 'scale',
-    min: 1,
-    max: 5,
-    value: 2,
-    notes: 'Right patellar tendon stayed warm after split squats.',
-  },
-  {
     id: 'shoulder-feel',
     label: 'Shoulder feel',
     type: 'scale',
@@ -160,14 +151,6 @@ export const workoutFeedbackFields: ActiveWorkoutCustomFeedbackField[] = [
     max: 5,
     value: 4,
     notes: 'Left shoulder stayed stable with neutral-grip pressing.',
-  },
-  {
-    id: 'energy-post',
-    label: 'Energy post workout',
-    type: 'scale',
-    min: 1,
-    max: 5,
-    value: 4,
   },
   {
     id: 'session-note',

--- a/apps/web/src/features/workouts/lib/session-notes.ts
+++ b/apps/web/src/features/workouts/lib/session-notes.ts
@@ -1,0 +1,83 @@
+import type {
+  ExerciseTrackingType,
+  SessionSet,
+  SessionSetInput,
+  WorkoutTemplateSectionType,
+} from '@pulse/shared';
+
+import type { ActiveWorkoutSetDrafts } from '@/features/workouts/types';
+import type { WorkoutTemplate as MockWorkoutTemplate } from '@/lib/mock-data/workouts';
+
+type TemplateExerciseLookup = Map<
+  string,
+  {
+    exercise: MockWorkoutTemplate['sections'][number]['exercises'][number];
+    section: WorkoutTemplateSectionType;
+    trackingType: ExerciseTrackingType;
+  }
+>;
+
+export function extractExerciseNotes(sessionSets: SessionSet[]) {
+  const exerciseNotes: Record<string, string> = {};
+  const sortedSessionSets = [...sessionSets].sort((left, right) => {
+    if (left.exerciseId !== right.exerciseId) {
+      return left.exerciseId.localeCompare(right.exerciseId);
+    }
+
+    if (left.setNumber !== right.setNumber) {
+      return left.setNumber - right.setNumber;
+    }
+
+    return left.createdAt - right.createdAt;
+  });
+
+  for (const set of sortedSessionSets) {
+    const normalizedNotes = normalizeExerciseNote(set.notes);
+    if (!normalizedNotes || exerciseNotes[set.exerciseId]) {
+      continue;
+    }
+
+    exerciseNotes[set.exerciseId] = normalizedNotes;
+  }
+
+  return exerciseNotes;
+}
+
+export function buildSessionSetInputs(
+  setDrafts: ActiveWorkoutSetDrafts,
+  templateExerciseById: TemplateExerciseLookup,
+  exerciseNotes: Record<string, string>,
+): SessionSetInput[] {
+  const sessionSets: SessionSetInput[] = [];
+
+  for (const [exerciseId, draftSets] of Object.entries(setDrafts)) {
+    const templateExercise = templateExerciseById.get(exerciseId);
+    const normalizedExerciseNote = normalizeExerciseNote(exerciseNotes[exerciseId]);
+    const trackingType = templateExercise?.trackingType ?? 'weight_reps';
+    const isTimeBased =
+      trackingType === 'weight_seconds' ||
+      trackingType === 'reps_seconds' ||
+      trackingType === 'seconds_only' ||
+      trackingType === 'cardio';
+
+    for (const draftSet of [...draftSets].sort((left, right) => left.number - right.number)) {
+      sessionSets.push({
+        completed: draftSet.completed,
+        exerciseId,
+        notes: normalizedExerciseNote && draftSet.number === 1 ? normalizedExerciseNote : null,
+        reps: isTimeBased ? draftSet.seconds : draftSet.reps,
+        section: templateExercise?.section ?? null,
+        setNumber: draftSet.number,
+        skipped: false,
+        weight: draftSet.weight,
+      });
+    }
+  }
+
+  return sessionSets;
+}
+
+function normalizeExerciseNote(note: string | null | undefined) {
+  const normalized = note?.trim();
+  return normalized ? normalized : null;
+}

--- a/apps/web/src/features/workouts/lib/session-persistence.test.ts
+++ b/apps/web/src/features/workouts/lib/session-persistence.test.ts
@@ -2,15 +2,14 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import type { ActiveWorkoutSetDrafts } from '../types';
 import {
-  clearExerciseNotes,
-  clearSetDrafts,
-  clearStoredActiveWorkoutSessionId,
-  loadExerciseNotes,
-  loadSetDrafts,
-  saveExerciseNotes,
-  saveSetDrafts,
-  setStoredActiveWorkoutSessionId,
+  ACTIVE_WORKOUT_DRAFT_STORAGE_PREFIX,
   ACTIVE_WORKOUT_SESSION_STORAGE_KEY,
+  clearStoredActiveWorkoutDraft,
+  clearStoredActiveWorkoutSessionId,
+  getActiveWorkoutDraftStorageKey,
+  getStoredActiveWorkoutDraft,
+  setStoredActiveWorkoutDraft,
+  setStoredActiveWorkoutSessionId,
 } from './session-persistence';
 
 describe('session-persistence', () => {
@@ -26,8 +25,8 @@ describe('session-persistence', () => {
     expect(window.localStorage.getItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY)).toBeNull();
   });
 
-  it('saves, loads, and clears set drafts by session id', () => {
-    const drafts: ActiveWorkoutSetDrafts = {
+  it('saves, loads, and clears active workout drafts by id', () => {
+    const setDrafts: ActiveWorkoutSetDrafts = {
       'incline-dumbbell-press': [
         {
           completed: true,
@@ -41,60 +40,43 @@ describe('session-persistence', () => {
       ],
     };
 
-    saveSetDrafts('session-a', drafts);
-    expect(loadSetDrafts('session-a')).toEqual(drafts);
-    expect(loadSetDrafts('session-b')).toBeNull();
+    setStoredActiveWorkoutDraft('session-a', {
+      exerciseNotes: {
+        'incline-dumbbell-press': 'Keep elbows tucked.',
+      },
+      setDrafts,
+    });
 
-    clearSetDrafts('session-a');
-    expect(loadSetDrafts('session-a')).toBeNull();
+    expect(getStoredActiveWorkoutDraft('session-a')).toEqual({
+      exerciseNotes: {
+        'incline-dumbbell-press': 'Keep elbows tucked.',
+      },
+      setDrafts,
+    });
+    expect(getStoredActiveWorkoutDraft('session-b')).toBeNull();
+
+    clearStoredActiveWorkoutDraft('session-a');
+    expect(getStoredActiveWorkoutDraft('session-a')).toBeNull();
   });
 
   it('returns null for invalid draft payloads', () => {
-    window.localStorage.setItem('pulse.workout-drafts.session-a', '{bad json');
-    expect(loadSetDrafts('session-a')).toBeNull();
+    const key = `${ACTIVE_WORKOUT_DRAFT_STORAGE_PREFIX}:session-a`;
+    window.localStorage.setItem(key, '{bad json');
+    expect(getStoredActiveWorkoutDraft('session-a')).toBeNull();
   });
 
-  it('returns null for tampered draft shapes', () => {
-    window.localStorage.setItem(
-      'pulse.workout-drafts.session-a',
-      JSON.stringify({
-        'incline-dumbbell-press': [{ id: 'set-1', completed: true }],
-      }),
-    );
-    expect(loadSetDrafts('session-a')).toBeNull();
+  it('normalizes missing draft fields', () => {
+    const key = `${ACTIVE_WORKOUT_DRAFT_STORAGE_PREFIX}:session-a`;
+    window.localStorage.setItem(key, JSON.stringify({}));
 
-    window.localStorage.setItem('pulse.workout-drafts.session-a', JSON.stringify([]));
-    expect(loadSetDrafts('session-a')).toBeNull();
+    expect(getStoredActiveWorkoutDraft('session-a')).toEqual({
+      exerciseNotes: {},
+      setDrafts: {},
+    });
   });
 
-  it('saves, loads, and clears exercise notes by session id', () => {
-    const notes = {
-      'incline-dumbbell-press': 'Keep elbows tucked.',
-    };
-
-    saveExerciseNotes('session-a', notes);
-    expect(loadExerciseNotes('session-a')).toEqual(notes);
-    expect(loadExerciseNotes('session-b')).toBeNull();
-
-    clearExerciseNotes('session-a');
-    expect(loadExerciseNotes('session-a')).toBeNull();
-  });
-
-  it('returns null for invalid notes payloads', () => {
-    window.localStorage.setItem('pulse.workout-notes.session-a', '{bad json');
-    expect(loadExerciseNotes('session-a')).toBeNull();
-  });
-
-  it('returns null for tampered notes payload shapes', () => {
-    window.localStorage.setItem(
-      'pulse.workout-notes.session-a',
-      JSON.stringify({
-        'incline-dumbbell-press': 42,
-      }),
-    );
-    expect(loadExerciseNotes('session-a')).toBeNull();
-
-    window.localStorage.setItem('pulse.workout-notes.session-a', JSON.stringify([]));
-    expect(loadExerciseNotes('session-a')).toBeNull();
+  it('returns null for blank draft ids', () => {
+    expect(getActiveWorkoutDraftStorageKey('  ')).toBeNull();
+    expect(getStoredActiveWorkoutDraft('  ')).toBeNull();
   });
 });

--- a/apps/web/src/features/workouts/lib/session-persistence.ts
+++ b/apps/web/src/features/workouts/lib/session-persistence.ts
@@ -1,56 +1,26 @@
-import type { ActiveWorkoutSetDrafts } from '../types';
-
 export const ACTIVE_WORKOUT_SESSION_STORAGE_KEY = 'pulse.active-workout-session-id';
+export const ACTIVE_WORKOUT_DRAFT_STORAGE_PREFIX = 'pulse.active-workout-draft';
 export const WORKOUT_SESSION_NOTICE_QUERY_KEY = 'sessionNotice';
 export const WORKOUT_SESSION_COMPLETED_NOTICE = 'completed';
 
+type ActiveWorkoutDraft = {
+  exerciseNotes: Record<string, string>;
+  setDrafts: Record<
+    string,
+    Array<{
+      completed: boolean;
+      distance: number | null;
+      id: string;
+      number: number;
+      reps: number | null;
+      seconds: number | null;
+      weight: number | null;
+    }>
+  >;
+};
+
 function canUseLocalStorage() {
   return typeof window !== 'undefined';
-}
-
-function getSetDraftsStorageKey(sessionId: string) {
-  return `pulse.workout-drafts.${sessionId}`;
-}
-
-function getExerciseNotesStorageKey(sessionId: string) {
-  return `pulse.workout-notes.${sessionId}`;
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-
-  const prototype = Object.getPrototypeOf(value);
-  return prototype === Object.prototype || prototype === null;
-}
-
-function isValidSetDraft(value: unknown): boolean {
-  if (!isPlainObject(value)) {
-    return false;
-  }
-
-  // Keep this in sync with required ActiveWorkoutSetDraft fields when that type changes.
-  return (
-    typeof value.id === 'string' &&
-    typeof value.completed === 'boolean' &&
-    typeof value.number === 'number' &&
-    (typeof value.reps === 'number' || value.reps === null) &&
-    (typeof value.weight === 'number' || value.weight === null) &&
-    (typeof value.distance === 'number' || value.distance === null) &&
-    (typeof value.seconds === 'number' || value.seconds === null)
-  );
-}
-
-function isActiveWorkoutSetDrafts(value: unknown): value is ActiveWorkoutSetDrafts {
-  if (!isPlainObject(value)) {
-    return false;
-  }
-
-  return Object.values(value).every(
-    (draftsForExercise) =>
-      Array.isArray(draftsForExercise) && draftsForExercise.every((setDraft) => isValidSetDraft(setDraft)),
-  );
 }
 
 export function getStoredActiveWorkoutSessionId() {
@@ -84,108 +54,68 @@ export function clearStoredActiveWorkoutSessionId() {
   window.localStorage.removeItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY);
 }
 
-export function saveSetDrafts(sessionId: string, drafts: ActiveWorkoutSetDrafts) {
-  if (!canUseLocalStorage()) {
-    return;
+export function getActiveWorkoutDraftStorageKey(id: string) {
+  const normalizedId = id.trim();
+
+  if (!normalizedId) {
+    return null;
   }
 
-  const normalizedSessionId = sessionId.trim();
-  if (!normalizedSessionId) {
-    return;
-  }
-
-  window.localStorage.setItem(getSetDraftsStorageKey(normalizedSessionId), JSON.stringify(drafts));
+  return `${ACTIVE_WORKOUT_DRAFT_STORAGE_PREFIX}:${normalizedId}`;
 }
 
-export function loadSetDrafts(sessionId: string): ActiveWorkoutSetDrafts | null {
+export function getStoredActiveWorkoutDraft(id: string): ActiveWorkoutDraft | null {
   if (!canUseLocalStorage()) {
     return null;
   }
 
-  const normalizedSessionId = sessionId.trim();
-  if (!normalizedSessionId) {
+  const key = getActiveWorkoutDraftStorageKey(id);
+  if (!key) {
     return null;
   }
 
-  const serializedDrafts = window.localStorage.getItem(getSetDraftsStorageKey(normalizedSessionId));
-  if (!serializedDrafts) {
+  const rawValue = window.localStorage.getItem(key);
+  if (!rawValue) {
     return null;
   }
 
   try {
-    const parsed = JSON.parse(serializedDrafts);
-    return isActiveWorkoutSetDrafts(parsed) ? parsed : null;
-  } catch {
-    return null;
-  }
-}
-
-export function clearSetDrafts(sessionId: string) {
-  if (!canUseLocalStorage()) {
-    return;
-  }
-
-  const normalizedSessionId = sessionId.trim();
-  if (!normalizedSessionId) {
-    return;
-  }
-
-  window.localStorage.removeItem(getSetDraftsStorageKey(normalizedSessionId));
-}
-
-export function saveExerciseNotes(sessionId: string, notes: Record<string, string>) {
-  if (!canUseLocalStorage()) {
-    return;
-  }
-
-  const normalizedSessionId = sessionId.trim();
-  if (!normalizedSessionId) {
-    return;
-  }
-
-  window.localStorage.setItem(
-    getExerciseNotesStorageKey(normalizedSessionId),
-    JSON.stringify(notes),
-  );
-}
-
-export function loadExerciseNotes(sessionId: string): Record<string, string> | null {
-  if (!canUseLocalStorage()) {
-    return null;
-  }
-
-  const normalizedSessionId = sessionId.trim();
-  if (!normalizedSessionId) {
-    return null;
-  }
-
-  const serializedNotes = window.localStorage.getItem(getExerciseNotesStorageKey(normalizedSessionId));
-  if (!serializedNotes) {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(serializedNotes);
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    const parsed = JSON.parse(rawValue) as ActiveWorkoutDraft | null;
+    if (!parsed || typeof parsed !== 'object') {
       return null;
     }
 
-    const isValid = Object.values(parsed).every((value) => typeof value === 'string');
-    return isValid ? (parsed as Record<string, string>) : null;
+    return {
+      exerciseNotes: parsed.exerciseNotes ?? {},
+      setDrafts: parsed.setDrafts ?? {},
+    };
   } catch {
     return null;
   }
 }
 
-export function clearExerciseNotes(sessionId: string) {
+export function setStoredActiveWorkoutDraft(id: string, draft: ActiveWorkoutDraft) {
   if (!canUseLocalStorage()) {
     return;
   }
 
-  const normalizedSessionId = sessionId.trim();
-  if (!normalizedSessionId) {
+  const key = getActiveWorkoutDraftStorageKey(id);
+  if (!key) {
     return;
   }
 
-  window.localStorage.removeItem(getExerciseNotesStorageKey(normalizedSessionId));
+  window.localStorage.setItem(key, JSON.stringify(draft));
+}
+
+export function clearStoredActiveWorkoutDraft(id: string) {
+  if (!canUseLocalStorage()) {
+    return;
+  }
+
+  const key = getActiveWorkoutDraftStorageKey(id);
+  if (!key) {
+    return;
+  }
+
+  window.localStorage.removeItem(key);
 }

--- a/apps/web/src/features/workouts/lib/session-persistence.ts
+++ b/apps/web/src/features/workouts/lib/session-persistence.ts
@@ -1,3 +1,5 @@
+import type { ActiveWorkoutSetDrafts } from '@/features/workouts/types';
+
 export const ACTIVE_WORKOUT_SESSION_STORAGE_KEY = 'pulse.active-workout-session-id';
 export const ACTIVE_WORKOUT_DRAFT_STORAGE_PREFIX = 'pulse.active-workout-draft';
 export const WORKOUT_SESSION_NOTICE_QUERY_KEY = 'sessionNotice';
@@ -5,18 +7,7 @@ export const WORKOUT_SESSION_COMPLETED_NOTICE = 'completed';
 
 type ActiveWorkoutDraft = {
   exerciseNotes: Record<string, string>;
-  setDrafts: Record<
-    string,
-    Array<{
-      completed: boolean;
-      distance: number | null;
-      id: string;
-      number: number;
-      reps: number | null;
-      seconds: number | null;
-      weight: number | null;
-    }>
-  >;
+  setDrafts: ActiveWorkoutSetDrafts;
 };
 
 function canUseLocalStorage() {

--- a/apps/web/src/features/workouts/lib/time-estimates.test.ts
+++ b/apps/web/src/features/workouts/lib/time-estimates.test.ts
@@ -17,7 +17,7 @@ function makeExercise(overrides: Partial<ActiveWorkoutExercise> = {}): ActiveWor
     badges: ['compound'],
     category: 'compound',
     completedSets: 0,
-    formCues: null,
+    formCues: [],
     id: 'exercise-1',
     injuryCues: [],
     lastPerformance: null,

--- a/apps/web/src/features/workouts/types.ts
+++ b/apps/web/src/features/workouts/types.ts
@@ -36,7 +36,7 @@ export type ActiveWorkoutLastPerformance = {
 export type ActiveWorkoutExerciseMetadata = {
   badges: WorkoutBadgeType[];
   category: WorkoutExerciseCategory;
-  formCues: ActiveWorkoutFormCueDetails | null;
+  formCues: string[];
   injuryCues: string[];
   lastPerformance: ActiveWorkoutLastPerformance | null;
   name: string;
@@ -48,6 +48,12 @@ export type ActiveWorkoutExerciseMetadata = {
   supersetGroup: string | null;
   tempo: string | null;
   trackingType: ExerciseTrackingType;
+};
+
+export type ActiveWorkoutFormCueDetails = {
+  commonMistakes: string[];
+  mentalCues: string[];
+  technique: string;
 };
 
 export type ActiveWorkoutExercise = ActiveWorkoutExerciseMetadata & {
@@ -108,14 +114,9 @@ export type ActiveWorkoutReversePyramidTarget = {
   targetWeight: number;
 };
 
-export type ActiveWorkoutFormCueDetails = {
-  commonMistakes: string[];
-  mentalCues: string[];
-  technique: string;
-};
-
-export type ActiveWorkoutEnhancedExercise = ActiveWorkoutExerciseMetadata & {
+export type ActiveWorkoutEnhancedExercise = Omit<ActiveWorkoutExerciseMetadata, 'formCues'> & {
   exerciseId: string;
+  formCues: ActiveWorkoutFormCueDetails | null;
   section: WorkoutTemplateSectionType;
   sets: number;
   tempo: string;

--- a/apps/web/src/features/workouts/types.ts
+++ b/apps/web/src/features/workouts/types.ts
@@ -122,6 +122,14 @@ export type ActiveWorkoutEnhancedExercise = Omit<ActiveWorkoutExerciseMetadata, 
   tempo: string;
 };
 
+export type FeedbackFieldType =
+  | 'scale'
+  | 'text'
+  | 'yes_no'
+  | 'emoji'
+  | 'slider'
+  | 'multi_select';
+
 export type ActiveWorkoutCustomFeedbackField =
   | {
       id: string;
@@ -129,6 +137,7 @@ export type ActiveWorkoutCustomFeedbackField =
       max: number;
       min: number;
       notes?: string;
+      optional?: boolean;
       type: 'scale';
       value?: number | null;
     }
@@ -139,6 +148,43 @@ export type ActiveWorkoutCustomFeedbackField =
       optional?: boolean;
       type: 'text';
       value?: string;
+    }
+  | {
+      id: string;
+      label: string;
+      notes?: string;
+      optional?: boolean;
+      type: 'yes_no';
+      value?: boolean | null;
+    }
+  | {
+      id: string;
+      label: string;
+      notes?: string;
+      optional?: boolean;
+      options: string[];
+      type: 'emoji';
+      value?: string | null;
+    }
+  | {
+      id: string;
+      label: string;
+      max: number;
+      min: number;
+      notes?: string;
+      optional?: boolean;
+      step?: number;
+      type: 'slider';
+      value?: number | null;
+    }
+  | {
+      id: string;
+      label: string;
+      notes?: string;
+      optional?: boolean;
+      options: string[];
+      type: 'multi_select';
+      value?: string[];
     };
 
 export type ActiveWorkoutFeedbackDraft = ActiveWorkoutCustomFeedbackField[];

--- a/apps/web/src/hooks/use-complete-session.test.tsx
+++ b/apps/web/src/hooks/use-complete-session.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { workoutQueryKeys } from '@/features/workouts/api/workouts';
 import { ACTIVE_WORKOUT_SESSION_STORAGE_KEY } from '@/features/workouts/lib/session-persistence';
 import { createQueryClientWrapper } from '@/test/query-client';
 
@@ -96,6 +97,7 @@ describe('use-complete-session hook', () => {
       status: 'completed',
     });
 
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutQueryKeys.all });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutSessionQueryKeys.all });
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: workoutSessionQueryKeys.detail('session-1'),

--- a/apps/web/src/hooks/use-complete-session.test.tsx
+++ b/apps/web/src/hooks/use-complete-session.test.tsx
@@ -62,6 +62,9 @@ describe('use-complete-session hook', () => {
           recovery: 3,
           technique: 5,
         },
+        exerciseNotes: {
+          'incline-dumbbell-press': 'Keep shoulders packed',
+        },
         notes: 'Strong finish',
       });
     });
@@ -85,6 +88,9 @@ describe('use-complete-session hook', () => {
         energy: 4,
         recovery: 3,
         technique: 5,
+      },
+      exerciseNotes: {
+        'incline-dumbbell-press': 'Keep shoulders packed',
       },
       notes: 'Strong finish',
       status: 'completed',

--- a/apps/web/src/hooks/use-complete-session.test.tsx
+++ b/apps/web/src/hooks/use-complete-session.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkoutSessionListItem } from '@pulse/shared';
 
 import { workoutQueryKeys } from '@/features/workouts/api/workouts';
 import { ACTIVE_WORKOUT_SESSION_STORAGE_KEY } from '@/features/workouts/lib/session-persistence';
@@ -51,6 +52,36 @@ describe('use-complete-session hook', () => {
     mockFetch.mockResolvedValueOnce(createJsonResponse(completedSessionResponse));
 
     const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.sessionsList({}), [
+      {
+        completedAt: null,
+        createdAt: 100,
+        date: '2026-03-08',
+        duration: null,
+        exerciseCount: 2,
+        id: 'session-1',
+        name: 'Upper Push',
+        startedAt: 100,
+        status: 'in-progress',
+        templateId: 'template-1',
+        templateName: 'Upper Push Template',
+      },
+    ]);
+    queryClient.setQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.completedSessions(), [
+      {
+        completedAt: 1_000,
+        createdAt: 90,
+        date: '2026-03-07',
+        duration: 41,
+        exerciseCount: 5,
+        id: 'session-old',
+        name: 'Upper Push',
+        startedAt: 90,
+        status: 'completed',
+        templateId: 'template-1',
+        templateName: 'Upper Push Template',
+      },
+    ]);
     const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
     const { result } = renderHook(() => useCompleteSession('session-1'), { wrapper });
 
@@ -103,5 +134,49 @@ describe('use-complete-session hook', () => {
       queryKey: workoutSessionQueryKeys.detail('session-1'),
     });
     expect(window.localStorage.getItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY)).toBeNull();
+
+    expect(queryClient.getQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.sessionsList({}))).toEqual([
+      {
+        completedAt: 2_700_000,
+        createdAt: 100,
+        date: '2026-03-08',
+        duration: 45,
+        exerciseCount: 2,
+        id: 'session-1',
+        name: 'Upper Push',
+        startedAt: 100,
+        status: 'completed',
+        templateId: 'template-1',
+        templateName: 'Upper Push Template',
+      },
+    ]);
+    expect(queryClient.getQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.completedSessions())).toEqual([
+      {
+        completedAt: 2_700_000,
+        createdAt: 100,
+        date: '2026-03-08',
+        duration: 45,
+        exerciseCount: 0,
+        id: 'session-1',
+        name: 'Upper Push',
+        startedAt: 100,
+        status: 'completed',
+        templateId: 'template-1',
+        templateName: null,
+      },
+      {
+        completedAt: 1_000,
+        createdAt: 90,
+        date: '2026-03-07',
+        duration: 41,
+        exerciseCount: 5,
+        id: 'session-old',
+        name: 'Upper Push',
+        startedAt: 90,
+        status: 'completed',
+        templateId: 'template-1',
+        templateName: 'Upper Push Template',
+      },
+    ]);
   });
 });

--- a/apps/web/src/hooks/use-complete-session.test.tsx
+++ b/apps/web/src/hooks/use-complete-session.test.tsx
@@ -150,7 +150,71 @@ describe('use-complete-session hook', () => {
         templateName: 'Upper Push Template',
       },
     ]);
+    expect(queryClient.getQueryData(workoutQueryKeys.session('session-1'))).toEqual(
+      completedSessionResponse,
+    );
     expect(queryClient.getQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.completedSessions())).toEqual([
+      {
+        completedAt: 2_700_000,
+        createdAt: 100,
+        date: '2026-03-08',
+        duration: 45,
+        exerciseCount: 0,
+        id: 'session-1',
+        name: 'Upper Push',
+        startedAt: 100,
+        status: 'completed',
+        templateId: 'template-1',
+        templateName: null,
+      },
+      {
+        completedAt: 1_000,
+        createdAt: 90,
+        date: '2026-03-07',
+        duration: 41,
+        exerciseCount: 5,
+        id: 'session-old',
+        name: 'Upper Push',
+        startedAt: 90,
+        status: 'completed',
+        templateId: 'template-1',
+        templateName: 'Upper Push Template',
+      },
+    ]);
+  });
+
+  it('upserts the completed session into list caches when it was missing', async () => {
+    mockFetch.mockResolvedValueOnce(createJsonResponse(completedSessionResponse));
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.sessionsList({}), [
+      {
+        completedAt: 1_000,
+        createdAt: 90,
+        date: '2026-03-07',
+        duration: 41,
+        exerciseCount: 5,
+        id: 'session-old',
+        name: 'Upper Push',
+        startedAt: 90,
+        status: 'completed',
+        templateId: 'template-1',
+        templateName: 'Upper Push Template',
+      },
+    ]);
+    const { result } = renderHook(() => useCompleteSession('session-1'), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        feedback: {
+          energy: 4,
+          recovery: 3,
+          technique: 5,
+        },
+      });
+    });
+
+    expect(queryClient.getQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.sessionsList({}))).toEqual([
       {
         completedAt: 2_700_000,
         createdAt: 100,

--- a/apps/web/src/hooks/use-complete-session.ts
+++ b/apps/web/src/hooks/use-complete-session.ts
@@ -9,6 +9,7 @@ import {
 import { toast } from 'sonner';
 import { z } from 'zod';
 
+import { workoutQueryKeys } from '@/features/workouts/api/workouts';
 import { clearStoredActiveWorkoutSessionId } from '@/features/workouts/lib/session-persistence';
 import { apiRequest } from '@/lib/api-client';
 
@@ -67,6 +68,7 @@ export function useCompleteSession(sessionId: string | null | undefined) {
       queryClient.setQueryData(workoutSessionQueryKeys.detail(session.id), session);
 
       await Promise.all([
+        queryClient.invalidateQueries({ queryKey: workoutQueryKeys.all }),
         queryClient.invalidateQueries({ queryKey: workoutSessionQueryKeys.all }),
         queryClient.invalidateQueries({ queryKey: workoutSessionQueryKeys.detail(session.id) }),
       ]);

--- a/apps/web/src/hooks/use-complete-session.ts
+++ b/apps/web/src/hooks/use-complete-session.ts
@@ -113,6 +113,20 @@ export function useCompleteSession(sessionId: string | null | undefined) {
         clearStoredActiveWorkoutSessionId();
       }
 
+      const fallbackItem: WorkoutSessionListItem = {
+        completedAt: session.completedAt,
+        createdAt: session.createdAt,
+        date: session.date,
+        duration: session.duration,
+        exerciseCount: countDistinctSessionExercises(session),
+        id: session.id,
+        name: session.name,
+        startedAt: session.startedAt,
+        status: session.status,
+        templateId: session.templateId,
+        templateName: null,
+      };
+
       queryClient.setQueryData(workoutSessionQueryKeys.detail(session.id), session);
       queryClient.setQueryData(workoutQueryKeys.session(session.id), session);
       queryClient.setQueriesData<WorkoutSessionListItem[]>(
@@ -121,19 +135,6 @@ export function useCompleteSession(sessionId: string | null | undefined) {
         },
         (current) => {
           const existing = current?.find((item) => item.id === session.id);
-          const fallbackItem: WorkoutSessionListItem = {
-            completedAt: session.completedAt,
-            createdAt: session.createdAt,
-            date: session.date,
-            duration: session.duration,
-            exerciseCount: countDistinctSessionExercises(session),
-            id: session.id,
-            name: session.name,
-            startedAt: session.startedAt,
-            status: session.status,
-            templateId: session.templateId,
-            templateName: null,
-          };
           const nextItem = mergeSessionListItem(session, existing ?? fallbackItem);
 
           return upsertWorkoutSessionList(current, nextItem);
@@ -143,19 +144,6 @@ export function useCompleteSession(sessionId: string | null | undefined) {
         workoutQueryKeys.sessionsList({}),
         (current) => {
           const existing = current?.find((item) => item.id === session.id);
-          const fallbackItem: WorkoutSessionListItem = {
-            completedAt: session.completedAt,
-            createdAt: session.createdAt,
-            date: session.date,
-            duration: session.duration,
-            exerciseCount: countDistinctSessionExercises(session),
-            id: session.id,
-            name: session.name,
-            startedAt: session.startedAt,
-            status: session.status,
-            templateId: session.templateId,
-            templateName: null,
-          };
           const nextItem = mergeSessionListItem(session, existing ?? fallbackItem);
 
           return upsertWorkoutSessionList(current, nextItem);
@@ -165,19 +153,6 @@ export function useCompleteSession(sessionId: string | null | undefined) {
         workoutQueryKeys.completedSessions(),
         (current) => {
           const existing = current?.find((item) => item.id === session.id);
-          const fallbackItem: WorkoutSessionListItem = {
-            completedAt: session.completedAt,
-            createdAt: session.createdAt,
-            date: session.date,
-            duration: session.duration,
-            exerciseCount: countDistinctSessionExercises(session),
-            id: session.id,
-            name: session.name,
-            startedAt: session.startedAt,
-            status: session.status,
-            templateId: session.templateId,
-            templateName: null,
-          };
           const nextItem = mergeSessionListItem(session, existing ?? fallbackItem);
 
           return upsertWorkoutSessionList(current, nextItem);

--- a/apps/web/src/hooks/use-complete-session.ts
+++ b/apps/web/src/hooks/use-complete-session.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   type SessionSetInput,
   type WorkoutSession,
+  type WorkoutSessionListItem,
   type WorkoutSessionFeedback,
   updateWorkoutSessionInputSchema,
   workoutSessionSchema,
@@ -48,6 +49,25 @@ async function completeSession(sessionId: string, input: CompleteSessionInput) {
   return payload.data;
 }
 
+function mergeSessionListItem(
+  session: WorkoutSession,
+  item?: WorkoutSessionListItem,
+): WorkoutSessionListItem {
+  return {
+    id: session.id,
+    name: session.name,
+    date: session.date,
+    status: session.status,
+    templateId: session.templateId,
+    templateName: item?.templateName ?? null,
+    startedAt: session.startedAt,
+    completedAt: session.completedAt,
+    duration: session.duration,
+    exerciseCount: item?.exerciseCount ?? session.sets.length,
+    createdAt: item?.createdAt ?? session.createdAt,
+  };
+}
+
 export function useCompleteSession(sessionId: string | null | undefined) {
   const queryClient = useQueryClient();
   const normalizedSessionId = sessionId?.trim() ?? '';
@@ -66,6 +86,30 @@ export function useCompleteSession(sessionId: string | null | undefined) {
       }
 
       queryClient.setQueryData(workoutSessionQueryKeys.detail(session.id), session);
+      queryClient.setQueriesData<WorkoutSessionListItem[]>(
+        {
+          queryKey: workoutQueryKeys.sessions(),
+        },
+        (current) =>
+          current?.map((item) =>
+            item.id === session.id ? mergeSessionListItem(session, item) : item,
+          ) ?? current,
+      );
+      queryClient.setQueryData<WorkoutSessionListItem[]>(
+        workoutQueryKeys.completedSessions(),
+        (current) => {
+          const existing = current?.find((item) => item.id === session.id);
+          const nextItem = mergeSessionListItem(session, existing);
+          const withoutCurrent = current?.filter((item) => item.id !== session.id) ?? [];
+
+          return [nextItem, ...withoutCurrent].sort(
+            (left, right) =>
+              right.date.localeCompare(left.date) ||
+              right.startedAt - left.startedAt ||
+              right.createdAt - left.createdAt,
+          );
+        },
+      );
 
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: workoutQueryKeys.all }),

--- a/apps/web/src/hooks/use-complete-session.ts
+++ b/apps/web/src/hooks/use-complete-session.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
+  type SessionSetInput,
   type WorkoutSession,
   type WorkoutSessionFeedback,
   updateWorkoutSessionInputSchema,
@@ -22,6 +23,7 @@ type CompleteSessionInput = {
   duration?: number | null;
   feedback: WorkoutSessionFeedback;
   notes?: string | null;
+  sets?: SessionSetInput[];
 };
 
 async function completeSession(sessionId: string, input: CompleteSessionInput) {
@@ -30,6 +32,7 @@ async function completeSession(sessionId: string, input: CompleteSessionInput) {
     duration: input.duration ?? null,
     feedback: input.feedback,
     notes: input.notes ?? null,
+    sets: input.sets,
     status: 'completed',
   });
 

--- a/apps/web/src/hooks/use-complete-session.ts
+++ b/apps/web/src/hooks/use-complete-session.ts
@@ -21,6 +21,7 @@ const workoutSessionResponseSchema = z.object({
 type CompleteSessionInput = {
   completedAt?: number;
   duration?: number | null;
+  exerciseNotes?: Record<string, string>;
   feedback: WorkoutSessionFeedback;
   notes?: string | null;
   sets?: SessionSetInput[];
@@ -31,6 +32,7 @@ async function completeSession(sessionId: string, input: CompleteSessionInput) {
     completedAt: input.completedAt ?? Date.now(),
     duration: input.duration ?? null,
     feedback: input.feedback,
+    exerciseNotes: input.exerciseNotes,
     notes: input.notes ?? null,
     sets: input.sets,
     status: 'completed',

--- a/apps/web/src/hooks/use-complete-session.ts
+++ b/apps/web/src/hooks/use-complete-session.ts
@@ -68,6 +68,34 @@ function mergeSessionListItem(
   };
 }
 
+function countDistinctSessionExercises(session: WorkoutSession) {
+  return new Set(session.sets.map((set) => set.exerciseId)).size;
+}
+
+function sortWorkoutSessionListItems(left: WorkoutSessionListItem, right: WorkoutSessionListItem) {
+  return (
+    right.date.localeCompare(left.date) ||
+    right.startedAt - left.startedAt ||
+    right.createdAt - left.createdAt
+  );
+}
+
+function upsertWorkoutSessionList(
+  current: WorkoutSessionListItem[] | undefined,
+  nextItem: WorkoutSessionListItem,
+) {
+  const nextList = current ? [...current] : [];
+  const existingIndex = nextList.findIndex((item) => item.id === nextItem.id);
+
+  if (existingIndex === -1) {
+    nextList.unshift(nextItem);
+  } else {
+    nextList[existingIndex] = nextItem;
+  }
+
+  return nextList.sort(sortWorkoutSessionListItems);
+}
+
 export function useCompleteSession(sessionId: string | null | undefined) {
   const queryClient = useQueryClient();
   const normalizedSessionId = sessionId?.trim() ?? '';
@@ -86,28 +114,73 @@ export function useCompleteSession(sessionId: string | null | undefined) {
       }
 
       queryClient.setQueryData(workoutSessionQueryKeys.detail(session.id), session);
+      queryClient.setQueryData(workoutQueryKeys.session(session.id), session);
       queryClient.setQueriesData<WorkoutSessionListItem[]>(
         {
           queryKey: workoutQueryKeys.sessions(),
         },
-        (current) =>
-          current?.map((item) =>
-            item.id === session.id ? mergeSessionListItem(session, item) : item,
-          ) ?? current,
+        (current) => {
+          const existing = current?.find((item) => item.id === session.id);
+          const fallbackItem: WorkoutSessionListItem = {
+            completedAt: session.completedAt,
+            createdAt: session.createdAt,
+            date: session.date,
+            duration: session.duration,
+            exerciseCount: countDistinctSessionExercises(session),
+            id: session.id,
+            name: session.name,
+            startedAt: session.startedAt,
+            status: session.status,
+            templateId: session.templateId,
+            templateName: null,
+          };
+          const nextItem = mergeSessionListItem(session, existing ?? fallbackItem);
+
+          return upsertWorkoutSessionList(current, nextItem);
+        },
+      );
+      queryClient.setQueryData<WorkoutSessionListItem[]>(
+        workoutQueryKeys.sessionsList({}),
+        (current) => {
+          const existing = current?.find((item) => item.id === session.id);
+          const fallbackItem: WorkoutSessionListItem = {
+            completedAt: session.completedAt,
+            createdAt: session.createdAt,
+            date: session.date,
+            duration: session.duration,
+            exerciseCount: countDistinctSessionExercises(session),
+            id: session.id,
+            name: session.name,
+            startedAt: session.startedAt,
+            status: session.status,
+            templateId: session.templateId,
+            templateName: null,
+          };
+          const nextItem = mergeSessionListItem(session, existing ?? fallbackItem);
+
+          return upsertWorkoutSessionList(current, nextItem);
+        },
       );
       queryClient.setQueryData<WorkoutSessionListItem[]>(
         workoutQueryKeys.completedSessions(),
         (current) => {
           const existing = current?.find((item) => item.id === session.id);
-          const nextItem = mergeSessionListItem(session, existing);
-          const withoutCurrent = current?.filter((item) => item.id !== session.id) ?? [];
+          const fallbackItem: WorkoutSessionListItem = {
+            completedAt: session.completedAt,
+            createdAt: session.createdAt,
+            date: session.date,
+            duration: session.duration,
+            exerciseCount: countDistinctSessionExercises(session),
+            id: session.id,
+            name: session.name,
+            startedAt: session.startedAt,
+            status: session.status,
+            templateId: session.templateId,
+            templateName: null,
+          };
+          const nextItem = mergeSessionListItem(session, existing ?? fallbackItem);
 
-          return [nextItem, ...withoutCurrent].sort(
-            (left, right) =>
-              right.date.localeCompare(left.date) ||
-              right.startedAt - left.startedAt ||
-              right.createdAt - left.createdAt,
-          );
+          return upsertWorkoutSessionList(current, nextItem);
         },
       );
 

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -6,7 +6,7 @@ import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
 import { renderWithQueryClient } from '@/test/render-with-query-client';
 import { jsonResponse } from '@/test/test-utils';
 
-import { ActiveWorkoutPage } from './active-workout';
+import { ActiveWorkoutPage, buildSessionSetInputs, extractExerciseNotes } from './active-workout';
 
 describe('ActiveWorkoutPage', () => {
   beforeEach(() => {
@@ -18,7 +18,17 @@ describe('ActiveWorkoutPage', () => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
-    window.localStorage.clear();
+    window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
+    const draftKeys: string[] = [];
+    for (let index = 0; index < window.localStorage.length; index += 1) {
+      const key = window.localStorage.key(index);
+      if (key?.startsWith('pulse.active-workout-draft:')) {
+        draftKeys.push(key);
+      }
+    }
+    for (const key of draftKeys) {
+      window.localStorage.removeItem(key);
+    }
   });
 
   it('renders the active workout UI and advances focus after the rest timer completes', () => {
@@ -89,7 +99,7 @@ describe('ActiveWorkoutPage', () => {
 
     const inclineCard = getExerciseCard('Incline Dumbbell Press');
 
-    fireEvent.click(within(inclineCard).getByRole('button', { name: 'Notes' }));
+    fireEvent.click(within(inclineCard).getByRole('button', { name: /Notes/i }));
     fireEvent.change(within(inclineCard).getByLabelText('Session notes'), {
       target: { value: 'Lower the bench by one notch before the top set.' },
     });
@@ -107,6 +117,9 @@ describe('ActiveWorkoutPage', () => {
     completeSet('Rope Triceps Pushdown', 1);
     completeSet('Rope Triceps Pushdown', 2);
     completeSet('Rope Triceps Pushdown', 3);
+    if (!screen.queryByRole('heading', { level: 3, name: 'Couch Stretch' })) {
+      fireEvent.click(screen.getByRole('button', { name: /Cooldown/i }));
+    }
     completeSet('Couch Stretch', 1);
 
     fireEvent.change(within(getExerciseCard('Couch Stretch')).getByLabelText('Seconds for set 2'), {
@@ -262,6 +275,121 @@ describe('ActiveWorkoutPage', () => {
 
     expect(await screen.findByRole('heading', { level: 1, name: 'API Full Body' })).toBeVisible();
     expect(screen.getByText('Exercise 1 of 1')).toBeInTheDocument();
+  });
+
+  it('extracts one exercise note per exercise from persisted session set rows', () => {
+    expect(
+      extractExerciseNotes([
+        {
+          completed: true,
+          createdAt: 1,
+          exerciseId: 'incline-dumbbell-press',
+          id: 'set-1',
+          notes: ' Keep shoulders packed ',
+          reps: 10,
+          section: 'main',
+          setNumber: 1,
+          skipped: false,
+          weight: 50,
+        },
+        {
+          completed: true,
+          createdAt: 2,
+          exerciseId: 'incline-dumbbell-press',
+          id: 'set-2',
+          notes: 'ignored later note',
+          reps: 9,
+          section: 'main',
+          setNumber: 2,
+          skipped: false,
+          weight: 45,
+        },
+        {
+          completed: true,
+          createdAt: 3,
+          exerciseId: 'row-erg',
+          id: 'set-3',
+          notes: null,
+          reps: 240,
+          section: 'warmup',
+          setNumber: 1,
+          skipped: false,
+          weight: null,
+        },
+      ]),
+    ).toEqual({
+      'incline-dumbbell-press': 'Keep shoulders packed',
+    });
+  });
+
+  it('maps exercise notes into completion payload session sets', () => {
+    const payloadSets = buildSessionSetInputs(
+      {
+        'incline-dumbbell-press': [
+          {
+            completed: true,
+            distance: null,
+            id: 'set-1',
+            number: 1,
+            reps: 10,
+            seconds: null,
+            weight: 50,
+          },
+          {
+            completed: true,
+            distance: null,
+            id: 'set-2',
+            number: 2,
+            reps: 9,
+            seconds: null,
+            weight: 45,
+          },
+        ],
+      },
+      new Map([
+        [
+          'incline-dumbbell-press',
+          {
+            exercise: {
+              badges: ['compound', 'push'],
+              exerciseId: 'incline-dumbbell-press',
+              exerciseName: 'Incline Dumbbell Press',
+              formCues: [],
+              reps: '8-10',
+              restSeconds: 90,
+              sets: 2,
+              tempo: '3110',
+            },
+            section: 'main',
+            trackingType: 'weight_reps',
+          },
+        ],
+      ]),
+      { 'incline-dumbbell-press': ' Keep shoulders packed ' },
+    );
+
+    expect(payloadSets).toEqual([
+      {
+        completed: true,
+        exerciseId: 'incline-dumbbell-press',
+        notes: 'Keep shoulders packed',
+        reps: 10,
+        section: 'main',
+        setNumber: 1,
+        skipped: false,
+        weight: 50,
+      },
+      {
+        completed: true,
+        exerciseId: 'incline-dumbbell-press',
+        notes: null,
+        reps: 9,
+        section: 'main',
+        setNumber: 2,
+        skipped: false,
+        weight: 45,
+      },
+    ]);
   });
 });
 

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -262,6 +262,42 @@ describe('ActiveWorkoutPage', () => {
     expect(within(setsCompletedStat as HTMLElement).getByText(/\d+\/\d+/)).toBeInTheDocument();
   });
 
+  it('shows standard feedback controls and requires pain details when pain is yes', () => {
+    renderActiveWorkoutPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Finish Workout' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }));
+
+    const rpeGroup = screen.getByRole('group', { name: 'Session RPE rating' });
+    expect(rpeGroup).toBeInTheDocument();
+    expect(within(rpeGroup).getByRole('button', { name: '1' })).toBeInTheDocument();
+    expect(within(rpeGroup).getByRole('button', { name: '10' })).toBeInTheDocument();
+
+    const energyGroup = screen.getByRole('group', { name: 'Energy post workout options' });
+    expect(energyGroup).toBeInTheDocument();
+    fireEvent.click(within(energyGroup).getByRole('button', { name: '💪' }));
+
+    const painGroup = screen.getByRole('group', { name: 'Any pain or discomfort? response' });
+    expect(painGroup).toBeInTheDocument();
+    fireEvent.click(within(rpeGroup).getByRole('button', { name: '7' }));
+    fireEvent.click(within(painGroup).getByRole('button', { name: 'Yes' }));
+
+    expect(screen.getByLabelText('Pain/discomfort details')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Finalize session' })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Pain/discomfort details'), {
+      target: { value: 'Mild discomfort on deep knee bend during split squats.' },
+    });
+
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Shoulder feel rating' })).getByRole('button', {
+        name: '3',
+      }),
+    );
+
+    expect(screen.getByRole('button', { name: 'Finalize session' })).toBeEnabled();
+  });
+
   it('loads API templates for UUID template ids instead of falling back to mock defaults', async () => {
     vi.useRealTimers();
 

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -134,11 +134,10 @@ describe('ActiveWorkoutPage', () => {
       screen.getByRole('heading', { level: 2, name: 'How did this session feel?' }),
     ).toBeInTheDocument();
     expect(screen.getByRole('group', { name: 'Session RPE rating' })).toBeInTheDocument();
-    expect(screen.getByRole('group', { name: 'Energy Level options' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Energy post workout options' })).toBeInTheDocument();
     expect(
       screen.getByRole('group', { name: 'Any pain or discomfort? response' }),
     ).toBeInTheDocument();
-    expect(screen.getByRole('group', { name: 'Knee pain rating' })).toBeInTheDocument();
 
     fireEvent.click(
       within(screen.getByRole('group', { name: 'Session RPE rating' })).getByRole('button', {
@@ -146,7 +145,9 @@ describe('ActiveWorkoutPage', () => {
       }),
     );
     fireEvent.click(
-      within(screen.getByRole('group', { name: 'Energy Level options' })).getByRole('button', {
+      within(
+        screen.getByRole('group', { name: 'Energy post workout options' }),
+      ).getByRole('button', {
         name: '🙂',
       }),
     );
@@ -160,22 +161,9 @@ describe('ActiveWorkoutPage', () => {
     );
 
     fireEvent.click(
-      within(screen.getByRole('group', { name: 'Knee pain rating' })).getByRole('button', {
-        name: '4',
-      }),
-    );
-    fireEvent.click(
       within(screen.getByRole('group', { name: 'Shoulder feel rating' })).getByRole('button', {
         name: '3',
       }),
-    );
-    fireEvent.click(
-      within(screen.getByRole('group', { name: 'Energy post workout rating' })).getByRole(
-        'button',
-        {
-          name: '5',
-        },
-      ),
     );
     fireEvent.change(
       screen.getByDisplayValue('Keep incline press to a 2-count pause on the chest next week.'),
@@ -192,7 +180,7 @@ describe('ActiveWorkoutPage', () => {
     expect(screen.getByText('Total reps')).toBeInTheDocument();
     expect(screen.getByText('Duration')).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 2, name: 'Session feedback' })).toBeInTheDocument();
-    expect(screen.getByText('4 / 5')).toBeInTheDocument();
+    expect(screen.getByText('3 / 5')).toBeInTheDocument();
     expect(screen.getByText('Shoulders stayed stable, keep the same setup.')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Done' }));

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -16,10 +16,33 @@ describe('ActiveWorkoutPage', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-06T12:00:00.000Z'));
+    vi.stubEnv('VITE_PULSE_DEV_USERNAME', 'dev-user');
+    vi.stubEnv('VITE_PULSE_DEV_PASSWORD', 'dev-pass');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+
+        if (url.endsWith('/api/v1/auth/register')) {
+          return Promise.resolve(jsonResponse({ data: { token: 'dev-generated-token' } }));
+        }
+
+        if (url.endsWith('/api/v1/workout-sessions') && init?.method === 'POST') {
+          return Promise.resolve(jsonResponse({ data: buildCompletedSessionResponse() }));
+        }
+
+        if (url.includes('/api/v1/workout-sessions/') && init?.method === 'PATCH') {
+          return Promise.resolve(jsonResponse({ data: null }));
+        }
+
+        return Promise.reject(new Error(`Unexpected fetch request: ${url}`));
+      }),
+    );
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllEnvs();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
     window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
@@ -98,7 +121,8 @@ describe('ActiveWorkoutPage', () => {
     ).toBeChecked();
   });
 
-  it('moves from session logging to feedback, summary, and back to workouts', () => {
+  it('moves from session logging to feedback, summary, and back to workouts', async () => {
+    vi.useRealTimers();
     renderActiveWorkoutPage();
 
     const inclineCard = getExerciseCard('Incline Dumbbell Press');
@@ -174,7 +198,7 @@ describe('ActiveWorkoutPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Finalize session' }));
 
-    expect(screen.getByRole('heading', { level: 1, name: 'Workout summary' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 1, name: 'Workout summary' })).toBeVisible();
     expect(screen.getByText('Exercises completed')).toBeInTheDocument();
     expect(screen.getByText('Sets completed')).toBeInTheDocument();
     expect(screen.getByText('Total reps')).toBeInTheDocument();
@@ -182,9 +206,15 @@ describe('ActiveWorkoutPage', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Session feedback' })).toBeInTheDocument();
     expect(screen.getByText('3 / 5')).toBeInTheDocument();
     expect(screen.getByText('Shoulders stayed stable, keep the same setup.')).toBeInTheDocument();
+    const summaryNotesInput = screen.getByRole('textbox', { name: 'Session notes' });
+    expect(summaryNotesInput).toHaveAttribute('id', 'session-summary-notes');
+    fireEvent.change(summaryNotesInput, {
+      target: { value: 'Session summary note from integration test.' },
+    });
+    expect(summaryNotesInput).toHaveValue('Session summary note from integration test.');
 
     fireEvent.click(screen.getByRole('button', { name: 'Done' }));
-    expect(screen.getByRole('heading', { level: 1, name: 'Workouts' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 1, name: 'Workouts' })).toBeVisible();
   }, 15_000);
 
   it('uses the selected template from the route query string', () => {
@@ -206,7 +236,8 @@ describe('ActiveWorkoutPage', () => {
     expect(screen.getByText('00:00')).toBeInTheDocument();
   });
 
-  it('supports manually finishing an active workout with confirmation and set summary ratio', () => {
+  it('supports manually finishing an active workout with confirmation and set summary ratio', async () => {
+    vi.useRealTimers();
     renderActiveWorkoutPage();
 
     const finishButton = screen.getByRole('button', { name: 'Finish Workout' });
@@ -255,7 +286,7 @@ describe('ActiveWorkoutPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Finalize session' }));
 
-    expect(screen.getByRole('heading', { level: 1, name: 'Workout summary' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 1, name: 'Workout summary' })).toBeVisible();
     const setsCompletedLabel = screen.getByText('Sets completed');
     const setsCompletedStat = setsCompletedLabel.closest('div')?.parentElement ?? null;
     expect(setsCompletedStat).not.toBeNull();
@@ -352,6 +383,69 @@ describe('ActiveWorkoutPage', () => {
 
     expect(await screen.findByRole('heading', { level: 1, name: 'API Full Body' })).toBeVisible();
     expect(screen.getByText('Exercise 1 of 1')).toBeInTheDocument();
+  });
+
+  it('creates a completed session without a pre-stored token by using dev auto-session auth', async () => {
+    vi.useRealTimers();
+    window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
+    vi.stubEnv('VITE_PULSE_DEV_USERNAME', 'dev-user');
+    vi.stubEnv('VITE_PULSE_DEV_PASSWORD', 'dev-pass');
+
+    const mockFetch = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.endsWith('/api/v1/auth/register')) {
+        return Promise.resolve(jsonResponse({ data: { token: 'dev-generated-token' } }));
+      }
+
+      if (url.endsWith('/api/v1/workout-sessions') && init?.method === 'POST') {
+        return Promise.resolve(jsonResponse({ data: buildCompletedSessionResponse() }));
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch request: ${url}`));
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    renderActiveWorkoutPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Finish Workout' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }));
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Session RPE rating' })).getByRole('button', {
+        name: '7',
+      }),
+    );
+    fireEvent.click(
+      within(
+        screen.getByRole('group', { name: 'Energy post workout options' }),
+      ).getByRole('button', {
+        name: '🙂',
+      }),
+    );
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Any pain or discomfort? response' })).getByRole(
+        'button',
+        {
+          name: 'No',
+        },
+      ),
+    );
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Shoulder feel rating' })).getByRole('button', {
+        name: '3',
+      }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Finalize session' }));
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Workout summary' })).toBeVisible();
+    expect(screen.getByRole('textbox', { name: 'Session notes' })).toBeInTheDocument();
+    expect(window.localStorage.getItem(API_TOKEN_STORAGE_KEY)).toBe('dev-generated-token');
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/workout-sessions',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    );
   });
 
   it('extracts one exercise note per exercise from persisted session set rows', () => {
@@ -540,4 +634,23 @@ function completeSet(exerciseName: string, setNumber: number) {
   if (skipButton) {
     fireEvent.click(skipButton);
   }
+}
+
+function buildCompletedSessionResponse() {
+  return {
+    id: 'created-session-id',
+    userId: 'user-1',
+    templateId: null,
+    name: 'Upper Push',
+    date: '2026-03-06',
+    status: 'completed' as const,
+    startedAt: 1_000,
+    completedAt: 2_000,
+    duration: 16,
+    feedback: null,
+    notes: null,
+    sets: [],
+    createdAt: 2_000,
+    updatedAt: 2_000,
+  };
 }

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -227,6 +227,32 @@ describe('ActiveWorkoutPage', () => {
       screen.getByRole('heading', { level: 2, name: 'How did this session feel?' }),
     ).toBeInTheDocument();
 
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Session RPE rating' })).getByRole('button', {
+        name: '6',
+      }),
+    );
+    fireEvent.click(
+      within(
+        screen.getByRole('group', { name: 'Energy post workout options' }),
+      ).getByRole('button', {
+        name: '😐',
+      }),
+    );
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Any pain or discomfort? response' })).getByRole(
+        'button',
+        {
+          name: 'No',
+        },
+      ),
+    );
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Shoulder feel rating' })).getByRole('button', {
+        name: '3',
+      }),
+    );
+
     fireEvent.click(screen.getByRole('button', { name: 'Finalize session' }));
 
     expect(screen.getByRole('heading', { level: 1, name: 'Workout summary' })).toBeInTheDocument();

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -5,8 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
 import { renderWithQueryClient } from '@/test/render-with-query-client';
 import { jsonResponse } from '@/test/test-utils';
+import {
+  buildSessionSetInputs,
+  extractExerciseNotes,
+} from '@/features/workouts/lib/session-notes';
 
-import { ActiveWorkoutPage, buildSessionSetInputs, extractExerciseNotes } from './active-workout';
+import { ActiveWorkoutPage } from './active-workout';
 
 describe('ActiveWorkoutPage', () => {
   beforeEach(() => {
@@ -282,18 +286,6 @@ describe('ActiveWorkoutPage', () => {
       extractExerciseNotes([
         {
           completed: true,
-          createdAt: 1,
-          exerciseId: 'incline-dumbbell-press',
-          id: 'set-1',
-          notes: ' Keep shoulders packed ',
-          reps: 10,
-          section: 'main',
-          setNumber: 1,
-          skipped: false,
-          weight: 50,
-        },
-        {
-          completed: true,
           createdAt: 2,
           exerciseId: 'incline-dumbbell-press',
           id: 'set-2',
@@ -303,6 +295,18 @@ describe('ActiveWorkoutPage', () => {
           setNumber: 2,
           skipped: false,
           weight: 45,
+        },
+        {
+          completed: true,
+          createdAt: 1,
+          exerciseId: 'incline-dumbbell-press',
+          id: 'set-1',
+          notes: ' Keep shoulders packed ',
+          reps: 10,
+          section: 'main',
+          setNumber: 1,
+          skipped: false,
+          weight: 50,
         },
         {
           completed: true,

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -133,8 +133,31 @@ describe('ActiveWorkoutPage', () => {
     expect(
       screen.getByRole('heading', { level: 2, name: 'How did this session feel?' }),
     ).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Session RPE rating' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Energy Level options' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('group', { name: 'Any pain or discomfort? response' }),
+    ).toBeInTheDocument();
     expect(screen.getByRole('group', { name: 'Knee pain rating' })).toBeInTheDocument();
-    expect(screen.getAllByRole('textbox', { name: 'Optional notes' })).toHaveLength(4);
+
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Session RPE rating' })).getByRole('button', {
+        name: '8',
+      }),
+    );
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Energy Level options' })).getByRole('button', {
+        name: '🙂',
+      }),
+    );
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Any pain or discomfort? response' })).getByRole(
+        'button',
+        {
+          name: 'No',
+        },
+      ),
+    );
 
     fireEvent.click(
       within(screen.getByRole('group', { name: 'Knee pain rating' })).getByRole('button', {

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -459,20 +459,22 @@ export function ActiveWorkoutPage() {
             }
 
             if (activeSessionId) {
-              setSessionError(null);
-              setSummarySaving(true);
-              try {
-                await persistCompletedSessionNotes({
-                  exerciseNotes,
-                  notes: sessionNotes,
-                  sessionId: activeSessionId,
-                });
-              } catch {
-                setSessionError('Unable to save session notes. Try again.');
+              const trimmedSessionNotes = sessionNotes.trim();
+              if (trimmedSessionNotes.length > 0) {
+                setSessionError(null);
+                setSummarySaving(true);
+                try {
+                  await persistCompletedSessionNotes({
+                    notes: trimmedSessionNotes,
+                    sessionId: activeSessionId,
+                  });
+                } catch {
+                  setSessionError('Unable to save session notes. Try again.');
+                  setSummarySaving(false);
+                  return;
+                }
                 setSummarySaving(false);
-                return;
               }
-              setSummarySaving(false);
             }
 
             clearStoredActiveWorkoutDraft(activeWorkoutDraftId);
@@ -940,14 +942,11 @@ function extractFeedbackNotes(draft: ActiveWorkoutFeedbackDraft) {
 async function persistCompletedSessionNotes({
   sessionId,
   notes,
-  exerciseNotes,
 }: {
   sessionId: string;
   notes: string;
-  exerciseNotes: Record<string, string>;
 }) {
   const payload = updateWorkoutSessionInputSchema.parse({
-    exerciseNotes,
     notes,
   });
 

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -57,7 +57,11 @@ import {
 import { useCompleteSession } from '@/hooks/use-complete-session';
 import { useLogSet, useUpdateSet } from '@/hooks/use-session-sets';
 import { useWeightUnit } from '@/hooks/use-weight-unit';
-import { useUpdateSessionStartTime, useWorkoutSession } from '@/hooks/use-workout-session';
+import {
+  useUpdateSessionStartTime,
+  useWorkoutSession,
+  workoutSessionQueryKeys,
+} from '@/hooks/use-workout-session';
 import {
   WORKOUT_SESSION_COMPLETED_NOTICE,
   WORKOUT_SESSION_NOTICE_QUERY_KEY,
@@ -72,7 +76,6 @@ import {
   extractExerciseNotes,
 } from '@/features/workouts/lib/session-notes';
 import { ApiError, apiRequest } from '@/lib/api-client';
-import { API_TOKEN_STORAGE_KEY } from '@/lib/auth-storage';
 import {
   mockExercises,
   mockTemplates,
@@ -419,32 +422,28 @@ export function ActiveWorkoutPage() {
             );
 
             if (!activeSessionId) {
-              const authToken = getStoredApiToken();
-
-              if (authToken) {
-                setSessionError(null);
-                try {
-                  const createdSession = await createCompletedWorkoutSession({
-                    completedAt,
-                    date: completedAtIso.slice(0, 10),
-                    duration,
-                    feedback: {
-                      ...mapFeedbackDraftToSessionFeedback(feedback),
-                      notes: feedbackNotes ?? undefined,
-                    },
-                    name: session.workoutName,
-                    sets: sessionSetInputs,
-                    startedAt: new Date(startTime).getTime(),
-                    templateId: shouldLoadApiTemplate ? template.id : null,
-                  });
-                  setCompletedSessionId(createdSession.id);
-                } catch {
-                  setSessionError('Unable to complete this workout. Try again.');
-                  return;
-                }
-
-                void queryClient.invalidateQueries({ queryKey: workoutQueryKeys.all });
+              setSessionError(null);
+              try {
+                const createdSession = await createCompletedWorkoutSession({
+                  completedAt,
+                  date: completedAtIso.slice(0, 10),
+                  duration,
+                  feedback: {
+                    ...mapFeedbackDraftToSessionFeedback(feedback),
+                    notes: feedbackNotes ?? undefined,
+                  },
+                  name: session.workoutName,
+                  sets: sessionSetInputs,
+                  startedAt: new Date(startTime).getTime(),
+                  templateId: shouldLoadApiTemplate ? template.id : null,
+                });
+                setCompletedSessionId(createdSession.id);
+              } catch {
+                setSessionError('Unable to complete this workout. Try again.');
+                return;
               }
+
+              void queryClient.invalidateQueries({ queryKey: workoutQueryKeys.all });
 
               clearStoredActiveWorkoutDraft(activeWorkoutDraftId);
               setSessionFeedback(feedback);
@@ -511,6 +510,14 @@ export function ActiveWorkoutPage() {
                     notes: trimmedSessionNotes,
                     sessionId: persistedSessionId,
                   });
+                  await Promise.all([
+                    queryClient.invalidateQueries({
+                      queryKey: workoutSessionQueryKeys.detail(persistedSessionId),
+                    }),
+                    queryClient.invalidateQueries({
+                      queryKey: workoutQueryKeys.session(persistedSessionId),
+                    }),
+                  ]);
                 } catch {
                   setSessionError('Unable to save session notes. Try again.');
                   setSummarySaving(false);
@@ -947,53 +954,76 @@ function mapFeedbackDraftToSessionFeedback(
         scaleEntries.at(1)?.value ??
         scaleEntries.at(0)?.value,
     ),
-    responses: draft.map(toWorkoutSessionFeedbackResponse),
+    responses: draft
+      .map(toWorkoutSessionFeedbackResponse)
+      .filter((response): response is WorkoutSessionFeedbackResponse => response !== null),
   };
 }
 
 function toWorkoutSessionFeedbackResponse(
   field: ActiveWorkoutCustomFeedbackField,
-): WorkoutSessionFeedbackResponse {
+): WorkoutSessionFeedbackResponse | null {
   const notes = field.notes?.trim();
   const base = {
     id: field.id,
     label: field.label,
-    type: field.type,
     ...(notes ? { notes } : {}),
   };
 
   switch (field.type) {
     case 'scale':
-    case 'slider':
+      if (field.value === null || field.value === undefined) {
+        return field.optional ? null : { ...base, type: 'scale', value: field.min };
+      }
       return {
         ...base,
-        value: field.value ?? null,
+        type: 'scale',
+        value: field.value,
+      };
+    case 'slider':
+      if (field.value === null || field.value === undefined) {
+        return field.optional ? null : { ...base, type: 'slider', value: field.min };
+      }
+      return {
+        ...base,
+        type: 'slider',
+        value: field.value,
       };
     case 'text':
       return {
         ...base,
+        type: 'text',
         value: field.value?.trim() ? field.value.trim() : null,
       };
     case 'yes_no':
+      if (field.value === null || field.value === undefined) {
+        return field.optional ? null : { ...base, type: 'yes_no', value: false };
+      }
       return {
         ...base,
-        value: field.value ?? null,
+        type: 'yes_no',
+        value: field.value,
       };
     case 'emoji':
+      if (!field.value?.trim()) {
+        return field.optional ? null : { ...base, type: 'emoji', value: field.options[0] ?? '😐' };
+      }
       return {
         ...base,
-        value: field.value?.trim() ? field.value.trim() : null,
+        type: 'emoji',
+        value: field.value.trim(),
       };
     case 'multi_select':
+      if ((field.value ?? []).length === 0) {
+        return field.optional ? null : { ...base, type: 'multi_select', value: [] };
+      }
       return {
         ...base,
+        type: 'multi_select',
         value: field.value ?? [],
       };
     default:
-      return {
-        ...base,
-        value: null,
-      };
+      return null;
   }
 }
 
@@ -1111,18 +1141,6 @@ async function createCompletedWorkoutSession(
   });
 
   return workoutSessionSchema.parse(data);
-}
-
-function getStoredApiToken() {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-
-  try {
-    return window.localStorage.getItem(API_TOKEN_STORAGE_KEY);
-  } catch {
-    return null;
-  }
 }
 
 function isSessionNotActiveError(error: unknown) {

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -3,7 +3,6 @@ import { useNavigate, useSearchParams } from 'react-router';
 
 import type {
   ExerciseTrackingType,
-  SessionSetInput,
   SessionSet,
   WorkoutSessionFeedback,
   WorkoutTemplate as ApiWorkoutTemplate,
@@ -61,6 +60,10 @@ import {
   setStoredActiveWorkoutSessionId,
   setStoredActiveWorkoutDraft,
 } from '@/features/workouts/lib/session-persistence';
+import {
+  buildSessionSetInputs,
+  extractExerciseNotes,
+} from '@/features/workouts/lib/session-notes';
 import { ApiError } from '@/lib/api-client';
 import {
   mockExercises,
@@ -202,11 +205,20 @@ export function ActiveWorkoutPage() {
     );
     const serverExerciseNotes = extractExerciseNotes(activeSession.sets);
     const autosavedDraft = getStoredActiveWorkoutDraft(activeSession.id);
+    const previousDraftKey = hydratedDraftKeyRef.current;
 
     setSetDrafts(autosavedDraft?.setDrafts ?? serverSetDrafts);
     setExerciseNotes(autosavedDraft?.exerciseNotes ?? serverExerciseNotes);
     hydratedSessionIdRef.current = activeSession.id;
     hydratedDraftKeyRef.current = activeSession.id;
+
+    if (previousDraftKey && previousDraftKey !== activeSession.id) {
+      clearStoredActiveWorkoutDraft(previousDraftKey);
+    }
+
+    if (template.id !== activeSession.id) {
+      clearStoredActiveWorkoutDraft(template.id);
+    }
   }, [activeSession, template, templateExerciseById]);
 
   useEffect(() => {
@@ -820,66 +832,6 @@ function createSessionSetDrafts(
   return drafts;
 }
 
-export function extractExerciseNotes(sessionSets: SessionSet[]) {
-  const exerciseNotes: Record<string, string> = {};
-
-  for (const set of sessionSets) {
-    const normalizedNotes = normalizeExerciseNote(set.notes);
-    if (!normalizedNotes || exerciseNotes[set.exerciseId]) {
-      continue;
-    }
-
-    exerciseNotes[set.exerciseId] = normalizedNotes;
-  }
-
-  return exerciseNotes;
-}
-
-export function buildSessionSetInputs(
-  setDrafts: ActiveWorkoutSetDrafts,
-  templateExerciseById: Map<
-    string,
-    {
-      exercise: MockWorkoutTemplate['sections'][number]['exercises'][number];
-      section: WorkoutTemplateSectionType;
-      trackingType: ExerciseTrackingType;
-    }
-  >,
-  exerciseNotes: Record<string, string>,
-): SessionSetInput[] {
-  const sessionSets: SessionSetInput[] = [];
-
-  for (const [exerciseId, draftSets] of Object.entries(setDrafts)) {
-    const templateExercise = templateExerciseById.get(exerciseId);
-    const normalizedExerciseNote = normalizeExerciseNote(exerciseNotes[exerciseId]);
-    const trackingType = templateExercise?.trackingType ?? 'weight_reps';
-    const isTimeBased =
-      trackingType === 'weight_seconds' ||
-      trackingType === 'reps_seconds' ||
-      trackingType === 'seconds_only' ||
-      trackingType === 'cardio';
-
-    for (const draftSet of [...draftSets].sort((left, right) => left.number - right.number)) {
-      sessionSets.push({
-        completed: draftSet.completed,
-        exerciseId,
-        notes: normalizedExerciseNote && draftSet.number === 1 ? normalizedExerciseNote : null,
-        reps: isTimeBased ? draftSet.seconds : draftSet.reps,
-        section: templateExercise?.section ?? null,
-        setNumber: draftSet.number,
-        skipped: false,
-        weight: draftSet.weight,
-      });
-    }
-  }
-
-  return sessionSets;
-}
-
-function normalizeExerciseNote(note: string | null | undefined) {
-  const normalized = note?.trim();
-  return normalized ? normalized : null;
-}
 function mapFeedbackDraftToSessionFeedback(
   draft: ActiveWorkoutFeedbackDraft,
 ): WorkoutSessionFeedback {

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -909,17 +909,6 @@ function toFeedbackScore(value: number | null | undefined): 1 | 2 | 3 | 4 | 5 {
 }
 
 function extractFeedbackNotes(draft: ActiveWorkoutFeedbackDraft) {
-  const textField = draft.find(
-    (
-      field,
-    ): field is Extract<ActiveWorkoutFeedbackDraft[number], { type: 'text'; value?: string }> =>
-      field.type === 'text' && (field.value ?? '').trim().length > 0,
-  );
-
-  if (textField) {
-    return textField.value?.trim() ?? null;
-  }
-
   const painDetailsField = draft.find(
     (field) =>
       field.id === 'pain-discomfort' &&
@@ -930,6 +919,17 @@ function extractFeedbackNotes(draft: ActiveWorkoutFeedbackDraft) {
 
   if (painDetailsField) {
     return painDetailsField.notes?.trim() ?? null;
+  }
+
+  const textField = draft.find(
+    (
+      field,
+    ): field is Extract<ActiveWorkoutFeedbackDraft[number], { type: 'text'; value?: string }> =>
+      field.type === 'text' && (field.value ?? '').trim().length > 0,
+  );
+
+  if (textField) {
+    return textField.value?.trim() ?? null;
   }
 
   const fieldWithNotes = draft.find((field) => (field.notes ?? '').trim().length > 0);

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -1,10 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
+import { useQueryClient } from '@tanstack/react-query';
+import { z } from 'zod';
 
 import {
+  createWorkoutSessionInputSchema,
   updateWorkoutSessionInputSchema,
   type ExerciseTrackingType,
   type SessionSet,
+  workoutSessionSchema,
   type WorkoutSessionFeedback,
   type WorkoutSessionFeedbackResponse,
   WorkoutTemplate as ApiWorkoutTemplate,
@@ -45,7 +49,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
-import { useWorkoutTemplate } from '@/features/workouts/api/workouts';
+import { workoutQueryKeys, useWorkoutTemplate } from '@/features/workouts/api/workouts';
 import {
   isSetCompleteForTrackingType,
   resolveTrackingType,
@@ -68,6 +72,7 @@ import {
   extractExerciseNotes,
 } from '@/features/workouts/lib/session-notes';
 import { ApiError, apiRequest } from '@/lib/api-client';
+import { API_TOKEN_STORAGE_KEY } from '@/lib/auth-storage';
 import {
   mockExercises,
   mockTemplates,
@@ -112,6 +117,7 @@ type RestTimerState = {
 };
 
 export function ActiveWorkoutPage() {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const sessionId = searchParams.get('sessionId');
@@ -146,6 +152,7 @@ export function ActiveWorkoutPage() {
   const [sessionCompletedAt, setSessionCompletedAt] = useState<string | null>(null);
   const [sessionFeedback, setSessionFeedback] = useState<ActiveWorkoutFeedbackDraft>([]);
   const [sessionNotes, setSessionNotes] = useState('');
+  const [completedSessionId, setCompletedSessionId] = useState<string | null>(null);
   const [summarySaving, setSummarySaving] = useState(false);
   const [restTimer, setRestTimer] = useState<RestTimerState | null>(null);
   const [restTimerTargetSetId, setRestTimerTargetSetId] = useState<string | null>(null);
@@ -396,7 +403,7 @@ export function ActiveWorkoutPage() {
       {stage === 'feedback' ? (
         <SessionFeedback
           fields={workoutFeedbackFields}
-          onSubmit={(feedback) => {
+          onSubmit={async (feedback) => {
             if (completeSessionMutation.isPending) {
               return;
             }
@@ -405,8 +412,40 @@ export function ActiveWorkoutPage() {
             const completedAtIso = new Date(completedAt).toISOString();
             const duration = Math.floor(getElapsedSeconds(startTime, completedAt) / 60);
             const feedbackNotes = extractFeedbackNotes(feedback);
+            const sessionSetInputs = buildSessionSetInputs(
+              setDrafts,
+              templateExerciseById,
+              exerciseNotes,
+            );
 
             if (!activeSessionId) {
+              const authToken = getStoredApiToken();
+
+              if (authToken) {
+                setSessionError(null);
+                try {
+                  const createdSession = await createCompletedWorkoutSession({
+                    completedAt,
+                    date: completedAtIso.slice(0, 10),
+                    duration,
+                    feedback: {
+                      ...mapFeedbackDraftToSessionFeedback(feedback),
+                      notes: feedbackNotes ?? undefined,
+                    },
+                    name: session.workoutName,
+                    sets: sessionSetInputs,
+                    startedAt: new Date(startTime).getTime(),
+                    templateId: shouldLoadApiTemplate ? template.id : null,
+                  });
+                  setCompletedSessionId(createdSession.id);
+                } catch {
+                  setSessionError('Unable to complete this workout. Try again.');
+                  return;
+                }
+
+                void queryClient.invalidateQueries({ queryKey: workoutQueryKeys.all });
+              }
+
               clearStoredActiveWorkoutDraft(activeWorkoutDraftId);
               setSessionFeedback(feedback);
               setSessionCompletedAt(completedAtIso);
@@ -425,7 +464,7 @@ export function ActiveWorkoutPage() {
                 },
                 exerciseNotes,
                 notes: null,
-                sets: buildSessionSetInputs(setDrafts, templateExerciseById, exerciseNotes),
+                sets: sessionSetInputs,
               },
               {
                 onError: (error) => {
@@ -438,6 +477,7 @@ export function ActiveWorkoutPage() {
                 },
                 onSuccess: () => {
                   clearStoredActiveWorkoutDraft(activeWorkoutDraftId);
+                  setCompletedSessionId(activeSessionId);
                   setSessionFeedback(feedback);
                   setSessionCompletedAt(completedAtIso);
                   setStage('summary');
@@ -460,7 +500,8 @@ export function ActiveWorkoutPage() {
               return;
             }
 
-            if (activeSessionId) {
+            const persistedSessionId = activeSessionId ?? completedSessionId;
+            if (persistedSessionId) {
               const trimmedSessionNotes = sessionNotes.trim();
               if (trimmedSessionNotes.length > 0) {
                 setSessionError(null);
@@ -468,7 +509,7 @@ export function ActiveWorkoutPage() {
                 try {
                   await persistCompletedSessionNotes({
                     notes: trimmedSessionNotes,
-                    sessionId: activeSessionId,
+                    sessionId: persistedSessionId,
                   });
                 } catch {
                   setSessionError('Unable to save session notes. Try again.');
@@ -1055,6 +1096,33 @@ async function persistCompletedSessionNotes({
     body: JSON.stringify(payload),
     method: 'PATCH',
   });
+}
+
+async function createCompletedWorkoutSession(
+  input: z.input<typeof createWorkoutSessionInputSchema>,
+) {
+  const payload = createWorkoutSessionInputSchema.parse({
+    ...input,
+    status: 'completed',
+  });
+  const data = await apiRequest<unknown>('/api/v1/workout-sessions', {
+    body: JSON.stringify(payload),
+    method: 'POST',
+  });
+
+  return workoutSessionSchema.parse(data);
+}
+
+function getStoredApiToken() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(API_TOKEN_STORAGE_KEY);
+  } catch {
+    return null;
+  }
 }
 
 function isSessionNotActiveError(error: unknown) {

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -6,6 +6,7 @@ import {
   type ExerciseTrackingType,
   type SessionSet,
   type WorkoutSessionFeedback,
+  type WorkoutSessionFeedbackResponse,
   WorkoutTemplate as ApiWorkoutTemplate,
   type WorkoutTemplateSectionType,
 } from '@pulse/shared';
@@ -25,6 +26,7 @@ import {
   workoutFeedbackFields,
   workoutSessionContext,
   workoutSupplementalExercises,
+  type ActiveWorkoutCustomFeedbackField,
   type ActiveWorkoutFeedbackDraft,
   type ActiveWorkoutSetDrafts,
 } from '@/features/workouts';
@@ -865,6 +867,18 @@ function createSessionSetDrafts(
 function mapFeedbackDraftToSessionFeedback(
   draft: ActiveWorkoutFeedbackDraft,
 ): WorkoutSessionFeedback {
+  const sessionRpeField = draft.find(
+    (field): field is Extract<ActiveWorkoutFeedbackDraft[number], { type: 'scale' }> =>
+      field.id === 'session-rpe' && field.type === 'scale',
+  );
+  const energyEmojiField = draft.find(
+    (field): field is Extract<ActiveWorkoutFeedbackDraft[number], { type: 'emoji' }> =>
+      field.id === 'energy-post-workout' && field.type === 'emoji',
+  );
+  const painField = draft.find(
+    (field): field is Extract<ActiveWorkoutFeedbackDraft[number], { type: 'yes_no' }> =>
+      field.id === 'pain-discomfort' && field.type === 'yes_no',
+  );
   const scaleEntries = draft.filter(
     (
       field,
@@ -876,20 +890,70 @@ function mapFeedbackDraftToSessionFeedback(
 
   return {
     energy: toFeedbackScore(
-      scaleEntries.find((field) => field.id.toLowerCase().includes('energy'))?.value ??
+      toEmojiFeedbackScore(energyEmojiField?.value) ??
+        scaleEntries.find((field) => field.id.toLowerCase().includes('energy'))?.value ??
         scaleEntries.at(2)?.value ??
         scaleEntries.at(0)?.value,
     ),
     recovery: toFeedbackScore(
-      scaleEntries.find((field) => field.id.toLowerCase().includes('recovery'))?.value ??
+      toPainFeedbackScore(painField?.value) ??
+        scaleEntries.find((field) => field.id.toLowerCase().includes('recovery'))?.value ??
         scaleEntries.at(0)?.value,
     ),
     technique: toFeedbackScore(
-      scaleEntries.find((field) => field.id.toLowerCase().includes('technique'))?.value ??
+      toRpeFeedbackScore(sessionRpeField?.value) ??
+        scaleEntries.find((field) => field.id.toLowerCase().includes('technique'))?.value ??
         scaleEntries.at(1)?.value ??
         scaleEntries.at(0)?.value,
     ),
+    responses: draft.map(toWorkoutSessionFeedbackResponse),
   };
+}
+
+function toWorkoutSessionFeedbackResponse(
+  field: ActiveWorkoutCustomFeedbackField,
+): WorkoutSessionFeedbackResponse {
+  const notes = field.notes?.trim();
+  const base = {
+    id: field.id,
+    label: field.label,
+    type: field.type,
+    ...(notes ? { notes } : {}),
+  };
+
+  switch (field.type) {
+    case 'scale':
+    case 'slider':
+      return {
+        ...base,
+        value: field.value ?? null,
+      };
+    case 'text':
+      return {
+        ...base,
+        value: field.value?.trim() ? field.value.trim() : null,
+      };
+    case 'yes_no':
+      return {
+        ...base,
+        value: field.value ?? null,
+      };
+    case 'emoji':
+      return {
+        ...base,
+        value: field.value?.trim() ? field.value.trim() : null,
+      };
+    case 'multi_select':
+      return {
+        ...base,
+        value: field.value ?? [],
+      };
+    default:
+      return {
+        ...base,
+        value: null,
+      };
+  }
 }
 
 function toFeedbackScore(value: number | null | undefined): 1 | 2 | 3 | 4 | 5 {
@@ -908,6 +972,43 @@ function toFeedbackScore(value: number | null | undefined): 1 | 2 | 3 | 4 | 5 {
   }
 
   return rounded as 1 | 2 | 3 | 4 | 5;
+}
+
+function toRpeFeedbackScore(value: number | null | undefined) {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return null;
+  }
+
+  return Math.max(1, Math.min(5, Math.round(value / 2)));
+}
+
+function toEmojiFeedbackScore(value: string | null | undefined) {
+  switch (value) {
+    case '😫':
+      return 1;
+    case '😕':
+      return 2;
+    case '😐':
+      return 3;
+    case '🙂':
+      return 4;
+    case '💪':
+      return 5;
+    default:
+      return null;
+  }
+}
+
+function toPainFeedbackScore(value: boolean | null | undefined) {
+  if (value === true) {
+    return 2;
+  }
+
+  if (value === false) {
+    return 4;
+  }
+
+  return null;
 }
 
 function extractFeedbackNotes(draft: ActiveWorkoutFeedbackDraft) {

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -892,14 +892,21 @@ function extractFeedbackNotes(draft: ActiveWorkoutFeedbackDraft) {
     return textField.value?.trim() ?? null;
   }
 
-  const scaleFieldWithNotes = draft.find(
-    (
-      field,
-    ): field is Extract<ActiveWorkoutFeedbackDraft[number], { type: 'scale'; notes?: string }> =>
-      field.type === 'scale' && (field.notes ?? '').trim().length > 0,
+  const painDetailsField = draft.find(
+    (field) =>
+      field.id === 'pain-discomfort' &&
+      field.type === 'yes_no' &&
+      field.value === true &&
+      (field.notes ?? '').trim().length > 0,
   );
 
-  return scaleFieldWithNotes?.notes?.trim() ?? null;
+  if (painDetailsField) {
+    return painDetailsField.notes?.trim() ?? null;
+  }
+
+  const fieldWithNotes = draft.find((field) => (field.notes ?? '').trim().length > 0);
+
+  return fieldWithNotes?.notes?.trim() ?? null;
 }
 
 function isSessionNotActiveError(error: unknown) {

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router';
 
 import type {
   ExerciseTrackingType,
+  SessionSetInput,
   SessionSet,
   WorkoutSessionFeedback,
   WorkoutTemplate as ApiWorkoutTemplate,
@@ -54,14 +55,11 @@ import { useUpdateSessionStartTime, useWorkoutSession } from '@/hooks/use-workou
 import {
   WORKOUT_SESSION_COMPLETED_NOTICE,
   WORKOUT_SESSION_NOTICE_QUERY_KEY,
-  clearExerciseNotes,
-  clearSetDrafts,
+  clearStoredActiveWorkoutDraft,
   clearStoredActiveWorkoutSessionId,
-  loadExerciseNotes,
-  loadSetDrafts,
-  saveExerciseNotes,
-  saveSetDrafts,
+  getStoredActiveWorkoutDraft,
   setStoredActiveWorkoutSessionId,
+  setStoredActiveWorkoutDraft,
 } from '@/features/workouts/lib/session-persistence';
 import { ApiError } from '@/lib/api-client';
 import {
@@ -149,29 +147,22 @@ export function ActiveWorkoutPage() {
   const [supplementalChecks, setSupplementalChecks] = useState<Record<string, boolean>>({});
   const restTimerTokenRef = useRef(0);
   const hydratedSessionIdRef = useRef<string | null>(null);
+  const hydratedDraftKeyRef = useRef<string | null>(null);
   const supplementalExercises = workoutSupplementalExercises;
 
   const activeSession = sessionQuery.data;
   const activeSessionId = activeSession?.id ?? null;
-  const persistedSessionId = activeSessionId ?? sessionId;
+  const activeWorkoutDraftId = activeSessionId ?? sessionId ?? template.id;
   const startTime =
     startTimeOverride ??
     (activeSession ? new Date(activeSession.startedAt).toISOString() : fallbackStartTime);
-  const clearSessionDraftPersistence = useCallback((targetSessionId: string | null) => {
-    if (!targetSessionId) {
-      return;
-    }
-
-    clearSetDrafts(targetSessionId);
-    clearExerciseNotes(targetSessionId);
-  }, []);
   const redirectToCompletedSessionNotice = useCallback(() => {
-    clearSessionDraftPersistence(activeSessionId ?? sessionId);
+    clearStoredActiveWorkoutDraft(activeWorkoutDraftId);
     clearStoredActiveWorkoutSessionId();
     navigate(`/workouts?${WORKOUT_SESSION_NOTICE_QUERY_KEY}=${WORKOUT_SESSION_COMPLETED_NOTICE}`, {
       replace: true,
     });
-  }, [activeSessionId, clearSessionDraftPersistence, navigate, sessionId]);
+  }, [activeWorkoutDraftId, navigate]);
 
   const templateExerciseById = useMemo(
     () =>
@@ -204,14 +195,18 @@ export function ActiveWorkoutPage() {
       return;
     }
 
-    const restoredDrafts = loadSetDrafts(activeSession.id);
-    const restoredNotes = loadExerciseNotes(activeSession.id);
-
-    setSetDrafts(
-      restoredDrafts ?? createSessionSetDrafts(template, activeSession.sets, templateExerciseById),
+    const serverSetDrafts = createSessionSetDrafts(
+      template,
+      activeSession.sets,
+      templateExerciseById,
     );
-    setExerciseNotes(restoredNotes ?? {});
+    const serverExerciseNotes = extractExerciseNotes(activeSession.sets);
+    const autosavedDraft = getStoredActiveWorkoutDraft(activeSession.id);
+
+    setSetDrafts(autosavedDraft?.setDrafts ?? serverSetDrafts);
+    setExerciseNotes(autosavedDraft?.exerciseNotes ?? serverExerciseNotes);
     hydratedSessionIdRef.current = activeSession.id;
+    hydratedDraftKeyRef.current = activeSession.id;
   }, [activeSession, template, templateExerciseById]);
 
   useEffect(() => {
@@ -219,50 +214,16 @@ export function ActiveWorkoutPage() {
       return;
     }
 
-    setSetDrafts(
-      createInitialWorkoutSetDrafts(
-        template,
-        requestedTemplateId || sessionId ? new Set<string>() : new Set(completedSetIds),
-      ),
+    const initialSetDrafts = createInitialWorkoutSetDrafts(
+      template,
+      requestedTemplateId || sessionId ? new Set<string>() : new Set(completedSetIds),
     );
-    setExerciseNotes({});
-  }, [activeSession, requestedTemplateId, sessionId, template]);
+    const autosavedDraft = getStoredActiveWorkoutDraft(activeWorkoutDraftId);
 
-  useEffect(() => {
-    if (!persistedSessionId || stage !== 'active') {
-      return;
-    }
-
-    if (sessionId && hydratedSessionIdRef.current === null) {
-      return;
-    }
-
-    const timeoutId = window.setTimeout(() => {
-      saveSetDrafts(persistedSessionId, setDrafts);
-    }, 500);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [persistedSessionId, sessionId, setDrafts, stage]);
-
-  useEffect(() => {
-    if (!persistedSessionId || stage !== 'active') {
-      return;
-    }
-
-    if (sessionId && hydratedSessionIdRef.current === null) {
-      return;
-    }
-
-    const timeoutId = window.setTimeout(() => {
-      saveExerciseNotes(persistedSessionId, exerciseNotes);
-    }, 500);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [exerciseNotes, persistedSessionId, sessionId, stage]);
+    setSetDrafts(autosavedDraft?.setDrafts ?? initialSetDrafts);
+    setExerciseNotes(autosavedDraft?.exerciseNotes ?? {});
+    hydratedDraftKeyRef.current = activeWorkoutDraftId;
+  }, [activeSession, activeWorkoutDraftId, requestedTemplateId, sessionId, template]);
 
   useEffect(() => {
     if (!activeSession || !sessionId) {
@@ -280,6 +241,21 @@ export function ActiveWorkoutPage() {
       redirectToCompletedSessionNotice();
     }
   }, [activeSession, redirectToCompletedSessionNotice, sessionId, stage]);
+
+  useEffect(() => {
+    if (stage !== 'active') {
+      return;
+    }
+
+    if (hydratedDraftKeyRef.current !== activeWorkoutDraftId) {
+      return;
+    }
+
+    setStoredActiveWorkoutDraft(activeWorkoutDraftId, {
+      exerciseNotes,
+      setDrafts,
+    });
+  }, [activeWorkoutDraftId, exerciseNotes, setDrafts, stage]);
 
   const session = useMemo(
     () =>
@@ -414,8 +390,7 @@ export function ActiveWorkoutPage() {
             const notes = extractFeedbackNotes(feedback);
 
             if (!activeSessionId) {
-              // Local-only sessions persist under the route/session fallback ID.
-              clearSessionDraftPersistence(persistedSessionId);
+              clearStoredActiveWorkoutDraft(activeWorkoutDraftId);
               setSessionFeedback(feedback);
               setSessionCompletedAt(completedAtIso);
               setStage('summary');
@@ -432,6 +407,7 @@ export function ActiveWorkoutPage() {
                   notes: notes ?? undefined,
                 },
                 notes,
+                sets: buildSessionSetInputs(setDrafts, templateExerciseById, exerciseNotes),
               },
               {
                 onError: (error) => {
@@ -443,8 +419,7 @@ export function ActiveWorkoutPage() {
                   setSessionError('Unable to complete this workout. Try again.');
                 },
                 onSuccess: () => {
-                  // API-backed sessions always clear persistence using the canonical server session ID.
-                  clearSessionDraftPersistence(activeSessionId);
+                  clearStoredActiveWorkoutDraft(activeWorkoutDraftId);
                   setSessionFeedback(feedback);
                   setSessionCompletedAt(completedAtIso);
                   setStage('summary');
@@ -462,7 +437,10 @@ export function ActiveWorkoutPage() {
           duration={summaryDuration}
           exercisesCompleted={session.totalExercises}
           feedback={sessionFeedback}
-          onDone={() => navigate('/workouts')}
+          onDone={() => {
+            clearStoredActiveWorkoutDraft(activeWorkoutDraftId);
+            navigate('/workouts');
+          }}
           sessionId={activeSessionId}
           totalReps={totalCompletedReps}
           completedSets={session.completedSets}
@@ -842,6 +820,66 @@ function createSessionSetDrafts(
   return drafts;
 }
 
+export function extractExerciseNotes(sessionSets: SessionSet[]) {
+  const exerciseNotes: Record<string, string> = {};
+
+  for (const set of sessionSets) {
+    const normalizedNotes = normalizeExerciseNote(set.notes);
+    if (!normalizedNotes || exerciseNotes[set.exerciseId]) {
+      continue;
+    }
+
+    exerciseNotes[set.exerciseId] = normalizedNotes;
+  }
+
+  return exerciseNotes;
+}
+
+export function buildSessionSetInputs(
+  setDrafts: ActiveWorkoutSetDrafts,
+  templateExerciseById: Map<
+    string,
+    {
+      exercise: MockWorkoutTemplate['sections'][number]['exercises'][number];
+      section: WorkoutTemplateSectionType;
+      trackingType: ExerciseTrackingType;
+    }
+  >,
+  exerciseNotes: Record<string, string>,
+): SessionSetInput[] {
+  const sessionSets: SessionSetInput[] = [];
+
+  for (const [exerciseId, draftSets] of Object.entries(setDrafts)) {
+    const templateExercise = templateExerciseById.get(exerciseId);
+    const normalizedExerciseNote = normalizeExerciseNote(exerciseNotes[exerciseId]);
+    const trackingType = templateExercise?.trackingType ?? 'weight_reps';
+    const isTimeBased =
+      trackingType === 'weight_seconds' ||
+      trackingType === 'reps_seconds' ||
+      trackingType === 'seconds_only' ||
+      trackingType === 'cardio';
+
+    for (const draftSet of [...draftSets].sort((left, right) => left.number - right.number)) {
+      sessionSets.push({
+        completed: draftSet.completed,
+        exerciseId,
+        notes: normalizedExerciseNote && draftSet.number === 1 ? normalizedExerciseNote : null,
+        reps: isTimeBased ? draftSet.seconds : draftSet.reps,
+        section: templateExercise?.section ?? null,
+        setNumber: draftSet.number,
+        skipped: false,
+        weight: draftSet.weight,
+      });
+    }
+  }
+
+  return sessionSets;
+}
+
+function normalizeExerciseNote(note: string | null | undefined) {
+  const normalized = note?.trim();
+  return normalized ? normalized : null;
+}
 function mapFeedbackDraftToSessionFeedback(
   draft: ActiveWorkoutFeedbackDraft,
 ): WorkoutSessionFeedback {

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 
-import type {
-  ExerciseTrackingType,
-  SessionSet,
-  WorkoutSessionFeedback,
+import {
+  updateWorkoutSessionInputSchema,
+  type ExerciseTrackingType,
+  type SessionSet,
+  type WorkoutSessionFeedback,
   WorkoutTemplate as ApiWorkoutTemplate,
-  WorkoutTemplateSectionType,
+  type WorkoutTemplateSectionType,
 } from '@pulse/shared';
 
 import {
@@ -64,7 +65,7 @@ import {
   buildSessionSetInputs,
   extractExerciseNotes,
 } from '@/features/workouts/lib/session-notes';
-import { ApiError } from '@/lib/api-client';
+import { ApiError, apiRequest } from '@/lib/api-client';
 import {
   mockExercises,
   mockTemplates,
@@ -142,6 +143,8 @@ export function ActiveWorkoutPage() {
   const [stage, setStage] = useState<'active' | 'feedback' | 'summary'>('active');
   const [sessionCompletedAt, setSessionCompletedAt] = useState<string | null>(null);
   const [sessionFeedback, setSessionFeedback] = useState<ActiveWorkoutFeedbackDraft>([]);
+  const [sessionNotes, setSessionNotes] = useState('');
+  const [summarySaving, setSummarySaving] = useState(false);
   const [restTimer, setRestTimer] = useState<RestTimerState | null>(null);
   const [restTimerTargetSetId, setRestTimerTargetSetId] = useState<string | null>(null);
   const [focusSetId, setFocusSetId] = useState<string | null>(null);
@@ -399,7 +402,7 @@ export function ActiveWorkoutPage() {
             const completedAt = Date.now();
             const completedAtIso = new Date(completedAt).toISOString();
             const duration = Math.floor(getElapsedSeconds(startTime, completedAt) / 60);
-            const notes = extractFeedbackNotes(feedback);
+            const feedbackNotes = extractFeedbackNotes(feedback);
 
             if (!activeSessionId) {
               clearStoredActiveWorkoutDraft(activeWorkoutDraftId);
@@ -416,9 +419,10 @@ export function ActiveWorkoutPage() {
                 duration,
                 feedback: {
                   ...mapFeedbackDraftToSessionFeedback(feedback),
-                  notes: notes ?? undefined,
+                  notes: feedbackNotes ?? undefined,
                 },
-                notes,
+                exerciseNotes,
+                notes: null,
                 sets: buildSessionSetInputs(setDrafts, templateExerciseById, exerciseNotes),
               },
               {
@@ -449,11 +453,35 @@ export function ActiveWorkoutPage() {
           duration={summaryDuration}
           exercisesCompleted={session.totalExercises}
           feedback={sessionFeedback}
-          onDone={() => {
+          onDone={async () => {
+            if (summarySaving) {
+              return;
+            }
+
+            if (activeSessionId) {
+              setSessionError(null);
+              setSummarySaving(true);
+              try {
+                await persistCompletedSessionNotes({
+                  exerciseNotes,
+                  notes: sessionNotes,
+                  sessionId: activeSessionId,
+                });
+              } catch {
+                setSessionError('Unable to save session notes. Try again.');
+                setSummarySaving(false);
+                return;
+              }
+              setSummarySaving(false);
+            }
+
             clearStoredActiveWorkoutDraft(activeWorkoutDraftId);
             navigate('/workouts');
           }}
+          onNotesChange={setSessionNotes}
+          sessionNotes={sessionNotes}
           sessionId={activeSessionId}
+          summarySaving={summarySaving}
           totalReps={totalCompletedReps}
           completedSets={session.completedSets}
           totalSets={session.totalSets}
@@ -907,6 +935,26 @@ function extractFeedbackNotes(draft: ActiveWorkoutFeedbackDraft) {
   const fieldWithNotes = draft.find((field) => (field.notes ?? '').trim().length > 0);
 
   return fieldWithNotes?.notes?.trim() ?? null;
+}
+
+async function persistCompletedSessionNotes({
+  sessionId,
+  notes,
+  exerciseNotes,
+}: {
+  sessionId: string;
+  notes: string;
+  exerciseNotes: Record<string, string>;
+}) {
+  const payload = updateWorkoutSessionInputSchema.parse({
+    exerciseNotes,
+    notes,
+  });
+
+  await apiRequest(`/api/v1/workout-sessions/${sessionId}`, {
+    body: JSON.stringify(payload),
+    method: 'PATCH',
+  });
 }
 
 function isSessionNotActiveError(error: unknown) {

--- a/apps/web/src/pages/workout-session-detail.test.tsx
+++ b/apps/web/src/pages/workout-session-detail.test.tsx
@@ -208,7 +208,7 @@ describe('WorkoutSessionDetailPage', () => {
   it('renders session notes when present', async () => {
     renderWithRoute(currentSession.id);
 
-    expect(await screen.findByText('Session notes')).toBeInTheDocument();
+    expect(await screen.findByText('Session Notes')).toBeInTheDocument();
     expect(screen.getByText(currentSession.notes ?? '')).toBeInTheDocument();
   });
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
   },
   server: {
     host: true,
+    strictPort: true,
     proxy: {
       '/api': {
         changeOrigin: true,

--- a/packages/shared/src/schemas/workout-sessions.test.ts
+++ b/packages/shared/src/schemas/workout-sessions.test.ts
@@ -75,6 +75,40 @@ describe('workoutSessionFeedbackSchema', () => {
       ],
     });
   });
+
+  it('rejects null values for non-text response types', () => {
+    expect(() =>
+      workoutSessionFeedbackSchema.parse({
+        energy: 4,
+        recovery: 3,
+        technique: 5,
+        responses: [
+          {
+            id: 'session-rpe',
+            label: 'Session RPE',
+            type: 'scale',
+            value: null,
+          },
+        ],
+      }),
+    ).toThrow();
+
+    expect(() =>
+      workoutSessionFeedbackSchema.parse({
+        energy: 4,
+        recovery: 3,
+        technique: 5,
+        responses: [
+          {
+            id: 'pain-discomfort',
+            label: 'Any pain or discomfort?',
+            type: 'yes_no',
+            value: null,
+          },
+        ],
+      }),
+    ).toThrow();
+  });
 });
 
 describe('sessionSetInputSchema', () => {

--- a/packages/shared/src/schemas/workout-sessions.test.ts
+++ b/packages/shared/src/schemas/workout-sessions.test.ts
@@ -239,12 +239,20 @@ describe('updateWorkoutSessionInputSchema', () => {
       templateId: null,
       feedback: null,
       notes: '   ',
+      exerciseNotes: {
+        'incline-dumbbell-press': ' Keep elbows tucked ',
+        'seated-dumbbell-shoulder-press': '   ',
+      },
     });
 
     expect(payload).toEqual({
       templateId: null,
       feedback: null,
       notes: null,
+      exerciseNotes: {
+        'incline-dumbbell-press': 'Keep elbows tucked',
+        'seated-dumbbell-shoulder-press': null,
+      },
     });
   });
 

--- a/packages/shared/src/schemas/workout-sessions.test.ts
+++ b/packages/shared/src/schemas/workout-sessions.test.ts
@@ -24,6 +24,27 @@ describe('workoutSessionFeedbackSchema', () => {
       recovery: 3,
       technique: 5,
       notes: ' Strong focus today. ',
+      responses: [
+        {
+          id: 'session-rpe',
+          label: 'Session RPE',
+          type: 'scale',
+          value: 8,
+        },
+        {
+          id: 'energy-post-workout',
+          label: 'Energy post workout',
+          type: 'emoji',
+          value: ' 🙂 ',
+        },
+        {
+          id: 'pain-discomfort',
+          label: 'Any pain or discomfort?',
+          type: 'yes_no',
+          value: true,
+          notes: ' Mild right knee discomfort on split squats. ',
+        },
+      ],
     });
 
     expect(feedback).toEqual({
@@ -31,6 +52,27 @@ describe('workoutSessionFeedbackSchema', () => {
       recovery: 3,
       technique: 5,
       notes: 'Strong focus today.',
+      responses: [
+        {
+          id: 'session-rpe',
+          label: 'Session RPE',
+          type: 'scale',
+          value: 8,
+        },
+        {
+          id: 'energy-post-workout',
+          label: 'Energy post workout',
+          type: 'emoji',
+          value: '🙂',
+        },
+        {
+          id: 'pain-discomfort',
+          label: 'Any pain or discomfort?',
+          type: 'yes_no',
+          value: true,
+          notes: 'Mild right knee discomfort on split squats.',
+        },
+      ],
     });
   });
 });

--- a/packages/shared/src/schemas/workout-sessions.ts
+++ b/packages/shared/src/schemas/workout-sessions.ts
@@ -84,11 +84,36 @@ export const workoutSessionFeedbackScoreSchema = z.union([
   z.literal(5),
 ]);
 
+export const workoutSessionFeedbackResponseTypeSchema = z.enum([
+  'scale',
+  'text',
+  'yes_no',
+  'emoji',
+  'slider',
+  'multi_select',
+]);
+
+export const workoutSessionFeedbackResponseValueSchema = z.union([
+  z.number(),
+  z.boolean(),
+  z.array(requiredStringSchema).max(20),
+  nullableLongStringSchema,
+]);
+
+export const workoutSessionFeedbackResponseSchema = z.object({
+  id: requiredStringSchema,
+  label: requiredStringSchema,
+  type: workoutSessionFeedbackResponseTypeSchema,
+  value: workoutSessionFeedbackResponseValueSchema,
+  notes: optionalLongStringSchema.optional(),
+});
+
 export const workoutSessionFeedbackSchema = z.object({
   energy: workoutSessionFeedbackScoreSchema,
   recovery: workoutSessionFeedbackScoreSchema,
   technique: workoutSessionFeedbackScoreSchema,
   notes: optionalLongStringSchema.optional(),
+  responses: z.array(workoutSessionFeedbackResponseSchema).max(50).optional(),
 });
 
 export const sessionSetSchema = z
@@ -216,6 +241,7 @@ export const workoutSessionQueryParamsSchema = z
 
 export type WorkoutSessionStatus = z.infer<typeof workoutSessionStatusSchema>;
 export type WorkoutSessionFeedback = z.infer<typeof workoutSessionFeedbackSchema>;
+export type WorkoutSessionFeedbackResponse = z.infer<typeof workoutSessionFeedbackResponseSchema>;
 export type SessionSet = z.infer<typeof sessionSetSchema>;
 export type WorkoutSession = z.infer<typeof workoutSessionSchema>;
 export type WorkoutSessionListItem = z.infer<typeof workoutSessionListItemSchema>;

--- a/packages/shared/src/schemas/workout-sessions.ts
+++ b/packages/shared/src/schemas/workout-sessions.ts
@@ -40,6 +40,7 @@ const nullableTemplateIdSchema = z.preprocess(
   requiredStringSchema.nullable(),
 );
 const nullableIntegerSchema = z.number().int().min(0).nullable();
+const exerciseNotesInputSchema = z.record(requiredStringSchema, nullableLongStringSchema);
 
 const validateWorkoutSessionTiming = (
   value: {
@@ -185,6 +186,7 @@ export const updateWorkoutSessionInputSchema = z
     duration: nullableIntegerSchema.optional(),
     feedback: workoutSessionFeedbackSchema.nullable().optional(),
     notes: nullableLongStringSchema.optional(),
+    exerciseNotes: exerciseNotesInputSchema.optional(),
     sets: z.array(sessionSetInputSchema).max(500).optional(),
   })
   .refine((value) => Object.values(value).some((field) => field !== undefined), {

--- a/packages/shared/src/schemas/workout-sessions.ts
+++ b/packages/shared/src/schemas/workout-sessions.ts
@@ -93,20 +93,46 @@ export const workoutSessionFeedbackResponseTypeSchema = z.enum([
   'multi_select',
 ]);
 
+const workoutSessionFeedbackResponseBaseSchema = z.object({
+  id: requiredStringSchema,
+  label: requiredStringSchema,
+  notes: optionalLongStringSchema.optional(),
+});
+
+export const workoutSessionFeedbackResponseSchema = z.discriminatedUnion('type', [
+  workoutSessionFeedbackResponseBaseSchema.extend({
+    type: z.literal('scale'),
+    value: z.number(),
+  }),
+  workoutSessionFeedbackResponseBaseSchema.extend({
+    type: z.literal('slider'),
+    value: z.number(),
+  }),
+  workoutSessionFeedbackResponseBaseSchema.extend({
+    type: z.literal('yes_no'),
+    value: z.boolean(),
+  }),
+  workoutSessionFeedbackResponseBaseSchema.extend({
+    type: z.literal('emoji'),
+    value: requiredStringSchema,
+  }),
+  workoutSessionFeedbackResponseBaseSchema.extend({
+    type: z.literal('text'),
+    value: nullableLongStringSchema,
+  }),
+  workoutSessionFeedbackResponseBaseSchema.extend({
+    type: z.literal('multi_select'),
+    value: z.array(requiredStringSchema).max(20),
+  }),
+]);
+
 export const workoutSessionFeedbackResponseValueSchema = z.union([
   z.number(),
   z.boolean(),
-  z.array(requiredStringSchema).max(20),
+  requiredStringSchema,
   nullableLongStringSchema,
+  z.array(requiredStringSchema).max(20),
 ]);
-
-export const workoutSessionFeedbackResponseSchema = z.object({
-  id: requiredStringSchema,
-  label: requiredStringSchema,
-  type: workoutSessionFeedbackResponseTypeSchema,
-  value: workoutSessionFeedbackResponseValueSchema,
-  notes: optionalLongStringSchema.optional(),
-});
 
 export const workoutSessionFeedbackSchema = z.object({
   energy: workoutSessionFeedbackScoreSchema,


### PR DESCRIPTION
## Summary
This PR redesigns the workout completion flow so notes and richer feedback are captured reliably and persisted end-to-end. It adds structured feedback responses (scale, yes/no, emoji, slider, multi-select, text) while preserving compatibility with existing energy/recovery/technique scoring. It also introduces a dedicated session-summary notes step after completion and ensures both session-level notes and exercise-level notes are saved to completed sessions without clobbering existing data. The result is a more consistent post-workout UX and more complete session records in both API and UI.

## Key Changes
- Added structured `feedback.responses` support in shared schemas, API parsing/serialization, and DB feedback typing.
- Expanded feedback UI to support richer question types plus standard required prompts (`Session RPE`, `Energy post workout`, `Any pain or discomfort?`) on every session.
- Added summary-stage session notes input and wired final note persistence via `PATCH /api/v1/workout-sessions/:id`.
- Updated completion flow to persist full set payloads and exercise notes (including seeded/local completion paths), then surface completed sessions correctly.
- Added `exerciseNotes` to update schema and server update handling, applying note updates to the first set per exercise with normalization safeguards.
- Prevented null/blank note payloads from overwriting existing first-set notes on completed sessions.
- Updated session detail rendering to show session notes, exercise notes, and structured feedback responses; note-bearing sections now default open.
- Consolidated local draft persistence into a single active-workout draft object and cleaned up stale draft keys.
- Set `vite.server.strictPort = true` to avoid silent dev-server port fallback.

## Technical Notes
- `PUT`/`PATCH` session updates share one merge/validation path; partial updates are merged with existing session state before validation and persistence.
- `exerciseNotes` are intentionally mapped only to the first set per exercise to keep note semantics stable and avoid duplicating notes across sets.
- Completion cache sync was hardened in `useCompleteSession` by upserting detail/list caches first, then invalidating broader workout/session query keys.
- Feedback storage now carries both legacy aggregate scores and typed per-question responses; reviewers should focus on compatibility between fallback score display and new structured response rendering.
- The summary notes save runs as a follow-up `PATCH` on Done when notes are non-empty, with explicit loading/error handling to avoid silent loss.

## Commits

- `3c60717 test(workouts): lock feedback controls userflow regression`
- `ed7c04b fix(workouts): persist seeded active workout completions`
- `96aa8a5 fix(web): enable strictPort to prevent silent Vite port fallback`
- `0ae872d fix(workouts): harden completion cache sync and summary notes targeting`
- `eb2f876 fix(workouts): persist structured feedback responses in completed sessions`
- `2c81939 fix(workouts): stabilize post-completion notes and session visibility`
- `761db00 fix(workouts): avoid redundant summary PATCH and null note overwrite`
- `eededad fix(workouts): align feedback flow with notes userflow`
- `5a033f4 fix(workouts): keep note-bearing session sections expanded`
- `54f9a8e fix(workouts): expose summary notes field and refresh completed sessions`
- `2aed3c4 feat(workouts): wire session summary notes through completion flow`
- `6936631 feat(web): add richer workout session feedback questions`
- `982f75a fix(web): resolve workout notes review follow-ups`
- `8745616 fix(workouts): persist exercise notes and template cues`

## Tasks

- **Fix exercise notes + form cues persistence**: Wire exercise notes to persist and save with session, display form cues as read-only from template, show notes in session detail
- **Richer feedback question types + standard session questions**: Add yes/no, emoji, slider, multi-select feedback types, add standard RPE/energy/pain questions that always appear
- **Session summary notes + completion wiring**: Add session notes textarea with prompt placeholder to summary, wire all notes/feedback through to API, display in session detail

## Diff Stats

```
apps/api/src/db/schema.test.ts                     |  29 +-
 apps/api/src/db/schema/workout-session-feedback.ts |  78 ++-
 apps/api/src/db/schema/workout-sessions.ts         |   7 +
 apps/api/src/routes/workout-sessions/index.test.ts | 139 ++++++
 apps/api/src/routes/workout-sessions/index.ts      |  64 ++-
 .../workouts/components/session-detail.test.tsx    | 118 ++++-
 .../workouts/components/session-detail.tsx         |  96 +++-
 .../components/session-exercise-list.test.tsx      |  15 +-
 .../workouts/components/session-exercise-list.tsx  |  21 +-
 .../workouts/components/session-feedback.test.tsx  | 262 ++++++++---
 .../workouts/components/session-feedback.tsx       | 524 ++++++++++++++++-----
 .../workouts/components/session-summary.test.tsx   |  52 ++
 .../workouts/components/session-summary.tsx        |  69 ++-
 .../features/workouts/lib/active-session.test.ts   |  17 +-
 .../src/features/workouts/lib/active-session.ts    |   2 +-
 apps/web/src/features/workouts/lib/mock-data.ts    |  17 -
 .../web/src/features/workouts/lib/session-notes.ts |  83 ++++
 .../workouts/lib/session-persistence.test.ts       |  94 ++--
 .../features/workouts/lib/session-persistence.ts   | 147 ++----
 .../features/workouts/lib/time-estimates.test.ts   |   2 +-
 apps/web/src/features/workouts/types.ts            |  63 ++-
 apps/web/src/hooks/use-complete-session.test.tsx   | 147 ++++++
 apps/web/src/hooks/use-complete-session.ts         | 124 +++++
 apps/web/src/pages/active-workout.test.tsx         | 227 ++++++++-
 apps/web/src/pages/active-workout.tsx              | 393 ++++++++++++----
 apps/web/src/pages/workout-session-detail.test.tsx |   2 +-
 apps/web/vite.config.ts                            |   1 +
 .../shared/src/schemas/workout-sessions.test.ts    |  50 ++
 packages/shared/src/schemas/workout-sessions.ts    |  28 ++
 29 files changed, 2327 insertions(+), 544 deletions(-)
```