### PR TITLE
fix: bug fixes and quick wins (QA #3, #4, #5, #6, #8, #9, #20)

### DIFF
--- a/apps/api/drizzle/0017_fix_exercise_categories.sql
+++ b/apps/api/drizzle/0017_fix_exercise_categories.sql
@@ -1,33 +1,18 @@
 UPDATE `exercises`
 SET `category` = 'isolation'
-WHERE `name` = 'Band Pull-Aparts'
-  AND `category` = 'mobility';
+WHERE `category` = 'mobility'
+  AND `name` IN (
+    'Band Pull-Aparts',
+    'Band Pull-Aparts (Underhand)',
+    'Bird Dogs',
+    'Dead Bug',
+    'Spanish Squat'
+  );
 
 --> statement-breakpoint
-UPDATE `exercises`
-SET `category` = 'isolation'
-WHERE `name` = 'Band Pull-Aparts (Underhand)'
-  AND `category` = 'mobility';
-
---> statement-breakpoint
-UPDATE `exercises`
-SET `category` = 'isolation'
-WHERE `name` = 'Bird Dogs'
-  AND `category` = 'mobility';
-
---> statement-breakpoint
-UPDATE `exercises`
-SET `category` = 'isolation'
-WHERE `name` = 'Dead Bug'
-  AND `category` = 'mobility';
-
---> statement-breakpoint
-UPDATE `exercises`
-SET `category` = 'isolation'
-WHERE `name` = 'Spanish Squat'
-  AND `category` = 'mobility';
-
---> statement-breakpoint
+-- Project taxonomy currently maps accessory core stability work (for example
+-- Bird Dogs and Dead Bug) to `isolation` because the enum has no `stability`
+-- category yet.
 UPDATE `exercises`
 SET `category` = 'isolation'
 WHERE `name` = 'Single-Leg Glute Bridge'

--- a/apps/api/drizzle/0017_fix_exercise_categories.sql
+++ b/apps/api/drizzle/0017_fix_exercise_categories.sql
@@ -1,0 +1,34 @@
+UPDATE `exercises`
+SET `category` = 'isolation'
+WHERE `name` = 'Band Pull-Aparts'
+  AND `category` = 'mobility';
+
+--> statement-breakpoint
+UPDATE `exercises`
+SET `category` = 'isolation'
+WHERE `name` = 'Band Pull-Aparts (Underhand)'
+  AND `category` = 'mobility';
+
+--> statement-breakpoint
+UPDATE `exercises`
+SET `category` = 'isolation'
+WHERE `name` = 'Bird Dogs'
+  AND `category` = 'mobility';
+
+--> statement-breakpoint
+UPDATE `exercises`
+SET `category` = 'isolation'
+WHERE `name` = 'Dead Bug'
+  AND `category` = 'mobility';
+
+--> statement-breakpoint
+UPDATE `exercises`
+SET `category` = 'isolation'
+WHERE `name` = 'Spanish Squat'
+  AND `category` = 'mobility';
+
+--> statement-breakpoint
+UPDATE `exercises`
+SET `category` = 'isolation'
+WHERE `name` = 'Single-Leg Glute Bridge'
+  AND `category` = 'compound';

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1773173000000,
       "tag": "0016_add_habit_description",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1773273600000,
+      "tag": "0017_fix_exercise_categories",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/migrations.test.ts
+++ b/apps/api/src/db/migrations.test.ts
@@ -238,3 +238,175 @@ describe('migration 0015_parched_katie_power', () => {
     }
   });
 });
+
+describe('migration 0017_fix_exercise_categories', () => {
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('fixes miscategorized exercises and is idempotent', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'pulse-migration-0017-'));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, 'migration.db');
+    const db = new Database(dbPath);
+
+    try {
+      db.exec(`
+        CREATE TABLE exercises (
+          id TEXT PRIMARY KEY NOT NULL,
+          user_id TEXT,
+          name TEXT NOT NULL,
+          muscle_groups TEXT NOT NULL,
+          equipment TEXT NOT NULL,
+          category TEXT NOT NULL,
+          instructions TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+      `);
+
+      const insertExercise = db.prepare(
+        `
+          INSERT INTO exercises (
+            id,
+            user_id,
+            name,
+            muscle_groups,
+            equipment,
+            category,
+            instructions,
+            created_at,
+            updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+      );
+
+      const now = Date.now();
+      insertExercise.run(
+        'exercise-1',
+        'user-1',
+        'Band Pull-Aparts',
+        JSON.stringify(['rear-delts']),
+        'band',
+        'mobility',
+        null,
+        now,
+        now,
+      );
+      insertExercise.run(
+        'exercise-2',
+        'user-1',
+        'Band Pull-Aparts (Underhand)',
+        JSON.stringify(['rear-delts']),
+        'band',
+        'mobility',
+        null,
+        now,
+        now,
+      );
+      insertExercise.run(
+        'exercise-3',
+        'user-2',
+        'Bird Dogs',
+        JSON.stringify(['core']),
+        'bodyweight',
+        'mobility',
+        null,
+        now,
+        now,
+      );
+      insertExercise.run(
+        'exercise-4',
+        'user-2',
+        'Dead Bug',
+        JSON.stringify(['core']),
+        'bodyweight',
+        'mobility',
+        null,
+        now,
+        now,
+      );
+      insertExercise.run(
+        'exercise-5',
+        'user-3',
+        'Spanish Squat',
+        JSON.stringify(['quads']),
+        'band',
+        'mobility',
+        null,
+        now,
+        now,
+      );
+      insertExercise.run(
+        'exercise-6',
+        'user-3',
+        'Single-Leg Glute Bridge',
+        JSON.stringify(['glutes']),
+        'bodyweight',
+        'compound',
+        null,
+        now,
+        now,
+      );
+      insertExercise.run(
+        'exercise-7',
+        'user-4',
+        'Band Pull-Aparts',
+        JSON.stringify(['rear-delts']),
+        'band',
+        'cardio',
+        null,
+        now,
+        now,
+      );
+      insertExercise.run(
+        'exercise-8',
+        'user-4',
+        'Single-Leg Glute Bridge',
+        JSON.stringify(['glutes']),
+        'bodyweight',
+        'mobility',
+        null,
+        now,
+        now,
+      );
+
+      const migrationSql = readFileSync(
+        join(process.cwd(), 'drizzle/0017_fix_exercise_categories.sql'),
+        'utf8',
+      );
+
+      runSqlStatements(db, migrationSql);
+      runSqlStatements(db, migrationSql);
+
+      const rows = db
+        .prepare(
+          `
+            SELECT id, category
+            FROM exercises
+            ORDER BY id ASC
+          `,
+        )
+        .all() as Array<{ id: string; category: string }>;
+
+      expect(rows).toEqual([
+        { id: 'exercise-1', category: 'isolation' },
+        { id: 'exercise-2', category: 'isolation' },
+        { id: 'exercise-3', category: 'isolation' },
+        { id: 'exercise-4', category: 'isolation' },
+        { id: 'exercise-5', category: 'isolation' },
+        { id: 'exercise-6', category: 'isolation' },
+        { id: 'exercise-7', category: 'cardio' },
+        { id: 'exercise-8', category: 'mobility' },
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -21,7 +21,7 @@ const protectedRoutes = [
   { heading: 'Dashboard', path: '/' },
   { heading: 'Design System', path: '/design-system' },
   { heading: 'Workouts', path: '/workouts' },
-  { heading: 'Upper Push', path: '/workouts/active' },
+  { heading: 'No active workout', path: '/workouts/active' },
   { heading: 'Upper Push', path: `/workouts/session/${sessionId}` },
   { heading: 'Upper Push', path: '/workouts/template/upper-push' },
   { heading: 'Nutrition', path: '/nutrition' },

--- a/apps/web/src/components/ui/progress-ring.test.tsx
+++ b/apps/web/src/components/ui/progress-ring.test.tsx
@@ -38,4 +38,11 @@ describe('ProgressRing', () => {
     expect(progress).toHaveClass('custom-ring');
     expect(progress).toHaveAttribute('aria-valuenow', '0');
   });
+
+  it('scales label max-width proportionally to ring size', () => {
+    render(<ProgressRing value={40} size={116} strokeWidth={10} label="1850 cal" />);
+
+    const label = screen.getByText('1850 cal') as HTMLElement;
+    expect(label.style.maxWidth).toMatch(/^74\.13/);
+  });
 });

--- a/apps/web/src/components/ui/progress-ring.tsx
+++ b/apps/web/src/components/ui/progress-ring.tsx
@@ -28,7 +28,7 @@ export function ProgressRing({
   const circumference = 2 * Math.PI * radius;
   const strokeDashoffset = circumference - (progress / 100) * circumference;
   const centerText = label ?? `${Math.round(progress)}%`;
-  const labelWidth = Math.max(size - strokeWidth * 3, 0);
+  const labelWidthPercent = Math.max(((size - strokeWidth * 3) / size) * 100, 0);
 
   return (
     <div
@@ -74,7 +74,7 @@ export function ProgressRing({
           'pointer-events-none absolute inline-flex items-center justify-center text-center text-sm font-semibold text-foreground',
           labelClassName,
         )}
-        style={{ maxWidth: `${labelWidth}px` }}
+        style={{ maxWidth: `${labelWidthPercent}%` }}
       >
         {centerText}
       </span>

--- a/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
@@ -95,8 +95,8 @@ describe('SnapshotCards', () => {
     expect(cards).toHaveLength(5);
 
     expect(screen.getByText('181.4 lbs')).toBeInTheDocument();
-    expect(screen.getByText('1,900 / 2,300')).toBeInTheDocument();
-    expect(screen.getByText('170 g / 190 g')).toBeInTheDocument();
+    expect(screen.getByText('1900 / 2300')).toBeInTheDocument();
+    expect(screen.getByText('170g / 190g')).toBeInTheDocument();
     expect(screen.getByText('3/4')).toBeInTheDocument();
     expect(screen.getByText('Upper Push A (Completed)')).toBeInTheDocument();
   });
@@ -206,11 +206,11 @@ describe('SnapshotCards', () => {
               ...snapshotFixture.macros,
               actual: {
                 ...snapshotFixture.macros.actual,
-                calories: 2450,
+                calories: 12450,
               },
               target: {
                 ...snapshotFixture.macros.target,
-                calories: 2200,
+                calories: 11200,
               },
             },
           }}
@@ -218,7 +218,7 @@ describe('SnapshotCards', () => {
       </MemoryRouter>,
     );
 
-    const caloriesValue = screen.getByText('2,450 / 2,200');
+    const caloriesValue = screen.getByText('12450 / 11200');
     expect(caloriesValue).toHaveClass('text-lg', 'sm:text-xl', 'lg:text-2xl');
   });
 });

--- a/apps/web/src/features/dashboard/components/snapshot-cards.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.tsx
@@ -4,12 +4,12 @@ import { Link } from 'react-router';
 
 import { StatCard, type StatTrend } from '@/components/ui/stat-card';
 import { accentCardStyles } from '@/lib/accent-card-styles';
+import { formatCalories, formatGrams, formatTrendChange, formatWeight } from '@/lib/format-utils';
 
 type SnapshotCardsProps = {
   snapshot?: DashboardSnapshot;
 };
 
-const numberFormatter = new Intl.NumberFormat('en-US');
 const notConfiguredCardClassName =
   'border-dashed border-border/80 bg-muted/35 text-muted-foreground shadow-none';
 const notConfiguredAccentTextClassName = 'text-muted-foreground';
@@ -20,9 +20,12 @@ export const getSnapshotValueClassName = (value: string) => {
   return value.length >= 13 ? longValueClassName : shortValueClassName;
 };
 
-const formatMacroProgressValue = (actual: number, target: number, suffix = '') => {
-  const suffixPart = suffix ? ` ${suffix}` : '';
-  return `${numberFormatter.format(actual)}${suffixPart} / ${numberFormatter.format(target)}${suffixPart}`;
+const formatMacroProgressValue = (actual: number, target: number, mode: 'calories' | 'grams') => {
+  if (mode === 'grams') {
+    return `${formatGrams(actual)} / ${formatGrams(target)}`;
+  }
+
+  return `${formatCalories(actual)} / ${formatCalories(target)}`;
 };
 
 export const calculateWeightTrend = (weight: number, weightYesterday: number): StatTrend => {
@@ -36,7 +39,7 @@ export const calculateWeightTrend = (weight: number, weightYesterday: number): S
     return { direction: 'neutral', value: 0 };
   }
 
-  const percent = Number(((Math.abs(change) / weightYesterday) * 100).toFixed(1));
+  const percent = Number(formatTrendChange((Math.abs(change) / weightYesterday) * 100));
 
   return {
     direction: change > 0 ? 'up' : 'down',
@@ -64,7 +67,7 @@ const formatWeightValue = (snapshot: DashboardSnapshot | undefined) => {
     return 'Log weight';
   }
 
-  return `${snapshot.weight.value.toFixed(1)} lbs`;
+  return formatWeight(snapshot.weight.value, 'lbs');
 };
 
 const formatWorkoutStatus = (status: DashboardWorkoutSnapshot['status']) => {
@@ -86,7 +89,11 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
   const weightValue = formatWeightValue(snapshot);
   const caloriesValueText = snapshot
     ? hasCaloriesTarget
-      ? formatMacroProgressValue(snapshot.macros.actual.calories, snapshot.macros.target.calories)
+      ? formatMacroProgressValue(
+          snapshot.macros.actual.calories,
+          snapshot.macros.target.calories,
+          'calories',
+        )
       : 'No targets set'
     : '--';
   const caloriesValue = snapshot
@@ -106,7 +113,7 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
       ? formatMacroProgressValue(
           snapshot.macros.actual.protein,
           snapshot.macros.target.protein,
-          'g',
+          'grams',
         )
       : 'No targets set'
     : '--';

--- a/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
@@ -87,7 +87,7 @@ describe('TrendSparkline', () => {
 
     expect(screen.getByText('Weight Trend')).toBeInTheDocument();
     expect(screen.getByText('175.2 lbs')).toBeInTheDocument();
-    expect(screen.getByText('-0.4%')).toBeInTheDocument();
+    expect(screen.getByText('0%')).toBeInTheDocument();
     expect(screen.getByRole('img', { name: 'Weight Trend sparkline' })).toBeInTheDocument();
     expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
     expect(container.querySelector('.recharts-line .recharts-curve')).toBeInTheDocument();
@@ -159,8 +159,8 @@ describe('TrendSparklines', () => {
     expect(screen.getByText('Calorie Trend')).toBeInTheDocument();
     expect(screen.getByText('Protein Trend')).toBeInTheDocument();
     expect(screen.getByText('175.2 lbs')).toBeInTheDocument();
-    expect(screen.getByText('2,050 kcal')).toBeInTheDocument();
-    expect(screen.getByText('170 g')).toBeInTheDocument();
+    expect(screen.getByText('2050 kcal')).toBeInTheDocument();
+    expect(screen.getByText('170g')).toBeInTheDocument();
 
     const weightCard = screen
       .getByText('Weight Trend')
@@ -185,16 +185,12 @@ describe('TrendSparklines', () => {
     expect(
       within(weightCard as HTMLElement).getByRole('img', { name: 'Weight Trend sparkline' }),
     ).toBeInTheDocument();
-    expect(vi.mocked(useWeightTrend)).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.any(String),
-      { enabled: true },
-    );
-    expect(vi.mocked(useMacroTrend)).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.any(String),
-      { enabled: true },
-    );
+    expect(vi.mocked(useWeightTrend)).toHaveBeenCalledWith(expect.any(String), expect.any(String), {
+      enabled: true,
+    });
+    expect(vi.mocked(useMacroTrend)).toHaveBeenCalledWith(expect.any(String), expect.any(String), {
+      enabled: true,
+    });
   });
 
   it('shows skeleton cards while trend queries are loading', () => {
@@ -209,7 +205,9 @@ describe('TrendSparklines', () => {
 
     const { container } = render(<TrendSparklines />);
 
-    expect(container.querySelectorAll('[data-slot="trend-sparkline-card-skeleton"]')).toHaveLength(3);
+    expect(container.querySelectorAll('[data-slot="trend-sparkline-card-skeleton"]')).toHaveLength(
+      3,
+    );
     expect(screen.queryByText('Weight Trend')).not.toBeInTheDocument();
   });
 
@@ -230,16 +228,12 @@ describe('TrendSparklines', () => {
     expect(screen.getByText('Protein Trend')).toBeInTheDocument();
     expect(screen.queryByText('Weight Trend')).not.toBeInTheDocument();
     expect(screen.queryByText('Calorie Trend')).not.toBeInTheDocument();
-    expect(vi.mocked(useWeightTrend)).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.any(String),
-      { enabled: false },
-    );
-    expect(vi.mocked(useMacroTrend)).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.any(String),
-      { enabled: true },
-    );
+    expect(vi.mocked(useWeightTrend)).toHaveBeenCalledWith(expect.any(String), expect.any(String), {
+      enabled: false,
+    });
+    expect(vi.mocked(useMacroTrend)).toHaveBeenCalledWith(expect.any(String), expect.any(String), {
+      enabled: true,
+    });
   });
 
   it('renders an empty state when no metrics are selected', () => {
@@ -256,16 +250,12 @@ describe('TrendSparklines', () => {
 
     expect(screen.getByText('No trend metrics selected.')).toBeInTheDocument();
     expect(screen.queryByText('Weight Trend')).not.toBeInTheDocument();
-    expect(vi.mocked(useWeightTrend)).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.any(String),
-      { enabled: false },
-    );
-    expect(vi.mocked(useMacroTrend)).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.any(String),
-      { enabled: false },
-    );
+    expect(vi.mocked(useWeightTrend)).toHaveBeenCalledWith(expect.any(String), expect.any(String), {
+      enabled: false,
+    });
+    expect(vi.mocked(useMacroTrend)).toHaveBeenCalledWith(expect.any(String), expect.any(String), {
+      enabled: false,
+    });
   });
 
   it('renders an error state when a required trend query fails', () => {
@@ -324,8 +314,12 @@ describe('TrendSparklines', () => {
 
     expect(within(calorieCard).getByText('--')).toBeInTheDocument();
     expect(within(proteinCard).getByText('--')).toBeInTheDocument();
-    expect(within(calorieCard).getByRole('img', { name: 'Calorie Trend sparkline' })).toBeInTheDocument();
-    expect(within(proteinCard).getByRole('img', { name: 'Protein Trend sparkline' })).toBeInTheDocument();
+    expect(
+      within(calorieCard).getByRole('img', { name: 'Calorie Trend sparkline' }),
+    ).toBeInTheDocument();
+    expect(
+      within(proteinCard).getByRole('img', { name: 'Protein Trend sparkline' }),
+    ).toBeInTheDocument();
   });
 
   it('shows the selected date weight value instead of the latest in-range value', () => {
@@ -389,6 +383,8 @@ describe('TrendSparklines', () => {
 
     expect(within(calorieCard).getByText('--')).toBeInTheDocument();
     expect(within(calorieCard).getByText('No data')).toBeInTheDocument();
-    expect(within(calorieCard).queryByRole('img', { name: 'Calorie Trend sparkline' })).not.toBeInTheDocument();
+    expect(
+      within(calorieCard).queryByRole('img', { name: 'Calorie Trend sparkline' }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
@@ -87,7 +87,7 @@ describe('TrendSparkline', () => {
 
     expect(screen.getByText('Weight Trend')).toBeInTheDocument();
     expect(screen.getByText('175.2 lbs')).toBeInTheDocument();
-    expect(screen.getByText('0%')).toBeInTheDocument();
+    expect(screen.getByText('-0.4%')).toBeInTheDocument();
     expect(screen.getByRole('img', { name: 'Weight Trend sparkline' })).toBeInTheDocument();
     expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
     expect(container.querySelector('.recharts-line .recharts-curve')).toBeInTheDocument();

--- a/apps/web/src/features/dashboard/components/trend-sparkline.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.tsx
@@ -7,12 +7,11 @@ import { useMacroTrend } from '@/hooks/use-macro-trend';
 import { useWeightTrend } from '@/hooks/use-weight-trend';
 import { accentCardStyles } from '@/lib/accent-card-styles';
 import { addDays, parseDateInput, toDateKey } from '@/lib/date';
+import { formatCalories, formatGrams, formatPercent, formatWeight } from '@/lib/format-utils';
 import { calculateTrendChangePercent } from '@/features/dashboard/lib/trend-sparklines';
 import { cn } from '@/lib/utils';
 
 const TREND_DAYS = 30;
-const numberFormatter = new Intl.NumberFormat('en-US');
-
 type ChangeDirection = 'up' | 'down' | 'neutral';
 
 type TrendMetricCardProps = {
@@ -88,10 +87,10 @@ const getPreviousValue = (series: TrendSparklineRealDatum[], fallback: number): 
 
 const formatChangePercent = (changePercent: number): string => {
   if (changePercent > 0) {
-    return `+${changePercent}%`;
+    return `+${formatPercent(changePercent)}`;
   }
 
-  return `${changePercent}%`;
+  return formatPercent(changePercent);
 };
 
 const getChangeDirection = (changePercent: number): ChangeDirection => {
@@ -165,7 +164,10 @@ export function TrendSparkline({
       </div>
 
       {plottedData.length === 0 ? (
-        <div className="flex h-[60px] items-center justify-center rounded-md bg-muted/35" data-slot="trend-sparkline-empty">
+        <div
+          className="flex h-[60px] items-center justify-center rounded-md bg-muted/35"
+          data-slot="trend-sparkline-empty"
+        >
           <p className="text-sm text-muted">{emptyMessage}</p>
         </div>
       ) : (
@@ -179,7 +181,9 @@ export function TrendSparkline({
             <LineChart data={plottedData} margin={{ top: 6, right: 0, bottom: 2, left: 0 }}>
               <Line
                 dataKey="value"
-                dot={hasSingleDataPoint ? { fill: color, r: 4, stroke: color, strokeWidth: 0 } : false}
+                dot={
+                  hasSingleDataPoint ? { fill: color, r: 4, stroke: color, strokeWidth: 0 } : false
+                }
                 isAnimationActive={false}
                 stroke={color}
                 strokeLinecap="round"
@@ -229,7 +233,10 @@ function TrendMetricCard({
 
 function TrendMetricCardSkeleton() {
   return (
-    <Card className="gap-0 border-transparent py-5 shadow-sm" data-slot="trend-sparkline-card-skeleton">
+    <Card
+      className="gap-0 border-transparent py-5 shadow-sm"
+      data-slot="trend-sparkline-card-skeleton"
+    >
       <CardContent className="h-full px-5">
         <div className="flex h-full flex-col gap-4" data-slot="trend-sparkline-skeleton">
           <div className="flex items-start justify-between gap-4">
@@ -249,8 +256,7 @@ function TrendMetricCardSkeleton() {
 export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
   const resolvedMetrics = metrics ?? DEFAULT_TREND_METRICS;
   const needsWeight = resolvedMetrics.includes('weight');
-  const needsMacros =
-    resolvedMetrics.includes('calories') || resolvedMetrics.includes('protein');
+  const needsMacros = resolvedMetrics.includes('calories') || resolvedMetrics.includes('protein');
   const range = resolveTrendRange(endDate);
   const weightTrendQuery = useWeightTrend(range.from, range.to, { enabled: needsWeight });
   const macroTrendQuery = useMacroTrend(range.from, range.to, { enabled: needsMacros });
@@ -304,13 +310,10 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
   const allConfigs = {
     weight: {
       label: 'Weight Trend',
-      currentValue: hasSelectedWeightValue ? `${selectedWeightValue.toFixed(1)} lbs` : '--',
+      currentValue: hasSelectedWeightValue ? formatWeight(selectedWeightValue, 'lbs') : '--',
       changePercent:
         weightSeries.length > 1
-          ? calculateTrendChangePercent(
-              latestWeight,
-              getPreviousValue(weightSeries, latestWeight),
-            )
+          ? calculateTrendChangePercent(latestWeight, getPreviousValue(weightSeries, latestWeight))
           : 0,
       color: 'var(--color-on-cream)',
       data: weightSeries,
@@ -319,9 +322,7 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
     },
     calories: {
       label: 'Calorie Trend',
-      currentValue: hasSelectedCalorieValue
-        ? `${numberFormatter.format(selectedCalorieValue)} kcal`
-        : '--',
+      currentValue: hasSelectedCalorieValue ? `${formatCalories(selectedCalorieValue)} kcal` : '--',
       changePercent:
         calorieSeries.length > 1
           ? calculateTrendChangePercent(
@@ -336,9 +337,7 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
     },
     protein: {
       label: 'Protein Trend',
-      currentValue: hasSelectedProteinValue
-        ? `${numberFormatter.format(selectedProteinValue)} g`
-        : '--',
+      currentValue: hasSelectedProteinValue ? formatGrams(selectedProteinValue) : '--',
       changePercent:
         proteinSeries.length > 1
           ? calculateTrendChangePercent(

--- a/apps/web/src/features/dashboard/components/trend-sparkline.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.tsx
@@ -7,7 +7,7 @@ import { useMacroTrend } from '@/hooks/use-macro-trend';
 import { useWeightTrend } from '@/hooks/use-weight-trend';
 import { accentCardStyles } from '@/lib/accent-card-styles';
 import { addDays, parseDateInput, toDateKey } from '@/lib/date';
-import { formatCalories, formatGrams, formatPercent, formatWeight } from '@/lib/format-utils';
+import { formatCalories, formatGrams, formatTrendChange, formatWeight } from '@/lib/format-utils';
 import { calculateTrendChangePercent } from '@/features/dashboard/lib/trend-sparklines';
 import { cn } from '@/lib/utils';
 
@@ -86,11 +86,13 @@ const getPreviousValue = (series: TrendSparklineRealDatum[], fallback: number): 
 };
 
 const formatChangePercent = (changePercent: number): string => {
+  const formatted = formatTrendChange(changePercent);
+
   if (changePercent > 0) {
-    return `+${formatPercent(changePercent)}`;
+    return `+${formatted}%`;
   }
 
-  return formatPercent(changePercent);
+  return `${formatted}%`;
 };
 
 const getChangeDirection = (changePercent: number): ChangeDirection => {

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
@@ -15,6 +15,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { apiRequest } from '@/lib/api-client';
+import { formatTrendChange, formatWeight } from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
 
 type RangeOption = {
@@ -39,7 +40,6 @@ const RANGE_OPTIONS: RangeOption[] = [
 ];
 
 const DEFAULT_RANGE: RangeOption = RANGE_OPTIONS[1];
-const INSIGHT_PRECISION = 1;
 const SERIES_COLORS = {
   scale: 'var(--color-primary)',
   trend: 'var(--color-accent-cream)',
@@ -56,11 +56,6 @@ const tooltipDateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
 });
 
-const numberFormatter = new Intl.NumberFormat('en-US', {
-  maximumFractionDigits: 1,
-  minimumFractionDigits: 1,
-});
-
 const fetchWeightEntries = async (days: number | null) => {
   const params = new URLSearchParams();
 
@@ -74,10 +69,10 @@ const fetchWeightEntries = async (days: number | null) => {
   return apiRequest<BodyWeightEntry[]>(path, { method: 'GET' });
 };
 
-const formatWeight = (value: number) => `${numberFormatter.format(value)} lbs`;
+const formatWeightLabel = (value: number) => formatWeight(value, 'lbs');
 
 const formatInsightChange = (change: number) => {
-  const formatted = change.toFixed(INSIGHT_PRECISION);
+  const formatted = formatTrendChange(change);
   const numeric = Number(formatted);
   const signPrefix = numeric > 0 ? '+' : '';
   return `${signPrefix}${formatted} lbs`;
@@ -165,7 +160,10 @@ export function WeightTrendChart() {
       <CardHeader className="gap-4 border-b border-border/70 pb-5">
         <div className="space-y-1">
           <CardTitle>
-            <h2 className="text-xl font-semibold text-foreground md:text-2xl" id="weight-trend-chart-heading">
+            <h2
+              className="text-xl font-semibold text-foreground md:text-2xl"
+              id="weight-trend-chart-heading"
+            >
               Weight Trend
             </h2>
           </CardTitle>
@@ -177,16 +175,22 @@ export function WeightTrendChart() {
             <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
               Current trend
             </p>
-            <p className="mt-1 text-2xl font-semibold text-foreground" data-slot="weight-trend-current-trend">
-              {chartData.length > 0 ? formatWeight(headerInsights.currentTrend) : '--'}
+            <p
+              className="mt-1 text-2xl font-semibold text-foreground"
+              data-slot="weight-trend-current-trend"
+            >
+              {chartData.length > 0 ? formatWeightLabel(headerInsights.currentTrend) : '--'}
             </p>
           </div>
           <div className="rounded-xl bg-secondary/45 px-4 py-3">
             <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
               Period average
             </p>
-            <p className="mt-1 text-2xl font-semibold text-foreground" data-slot="weight-trend-period-average">
-              {chartData.length > 0 ? formatWeight(headerInsights.avgWeight) : '--'}
+            <p
+              className="mt-1 text-2xl font-semibold text-foreground"
+              data-slot="weight-trend-period-average"
+            >
+              {chartData.length > 0 ? formatWeightLabel(headerInsights.avgWeight) : '--'}
             </p>
           </div>
         </div>
@@ -214,7 +218,10 @@ export function WeightTrendChart() {
 
       <CardContent className="space-y-5 px-4 py-5 sm:px-6">
         {weightEntriesQuery.isLoading ? (
-          <div className="h-[280px] w-full animate-pulse rounded-2xl bg-muted/50" data-slot="weight-trend-loading" />
+          <div
+            className="h-[280px] w-full animate-pulse rounded-2xl bg-muted/50"
+            data-slot="weight-trend-loading"
+          />
         ) : weightEntriesQuery.isError ? (
           <div className="flex min-h-[220px] items-center justify-center rounded-2xl border border-border/70 bg-muted/20 px-6 text-center">
             <p className="text-sm text-muted-foreground">Unable to load weight trend data.</p>
@@ -222,8 +229,13 @@ export function WeightTrendChart() {
         ) : chartData.length === 0 ? (
           <div className="flex min-h-[220px] items-center justify-center rounded-2xl border border-dashed border-border bg-muted/15 px-6 text-center">
             <div className="space-y-2">
-              <p className="text-base font-semibold text-foreground">Log your weight to see trends</p>
-              <a className="text-sm font-medium text-primary hover:underline" href="#dashboard-log-weight-card">
+              <p className="text-base font-semibold text-foreground">
+                Log your weight to see trends
+              </p>
+              <a
+                className="text-sm font-medium text-primary hover:underline"
+                href="#dashboard-log-weight-card"
+              >
                 Go to weight entry
               </a>
             </div>
@@ -235,7 +247,11 @@ export function WeightTrendChart() {
                 Enable at least one series to display the chart.
               </div>
             ) : (
-              <div aria-label="Weight trend chart" className="h-[280px] w-full sm:h-[320px]" role="img">
+              <div
+                aria-label="Weight trend chart"
+                className="h-[280px] w-full sm:h-[320px]"
+                role="img"
+              >
                 <ResponsiveContainer height="100%" width="100%">
                   <LineChart data={chartData} margin={{ top: 12, right: 8, bottom: 6, left: 2 }}>
                     <CartesianGrid stroke="var(--color-border)" strokeDasharray="3 3" />
@@ -244,14 +260,16 @@ export function WeightTrendChart() {
                       dataKey="date"
                       minTickGap={20}
                       tick={{ fill: 'var(--color-muted)', fontSize: 12 }}
-                      tickFormatter={(value: string) => axisDateFormatter.format(new Date(`${value}T12:00:00`))}
+                      tickFormatter={(value: string) =>
+                        axisDateFormatter.format(new Date(`${value}T12:00:00`))
+                      }
                       tickLine={false}
                     />
                     <YAxis
                       axisLine={false}
                       domain={yDomain}
                       tick={{ fill: 'var(--color-muted)', fontSize: 12 }}
-                      tickFormatter={(value: number) => numberFormatter.format(value)}
+                      tickFormatter={(value: number) => formatTrendChange(value)}
                       tickLine={false}
                       width={50}
                     />
@@ -264,10 +282,10 @@ export function WeightTrendChart() {
                       }}
                       formatter={(value: number | undefined, name: string | undefined) => {
                         if (name === 'scale') {
-                          return [formatWeight(value ?? 0), 'Scale Weight'];
+                          return [formatWeightLabel(value ?? 0), 'Scale Weight'];
                         }
 
-                        return [formatWeight(value ?? 0), 'Trend Weight'];
+                        return [formatWeightLabel(value ?? 0), 'Trend Weight'];
                       }}
                       labelFormatter={(label) =>
                         typeof label === 'string'
@@ -292,7 +310,12 @@ export function WeightTrendChart() {
                     {visibleSeries.trend ? (
                       <Line
                         dataKey="trend"
-                        dot={{ fill: SERIES_COLORS.trend, r: 4, stroke: 'var(--color-card)', strokeWidth: 1.5 }}
+                        dot={{
+                          fill: SERIES_COLORS.trend,
+                          r: 4,
+                          stroke: 'var(--color-card)',
+                          strokeWidth: 1.5,
+                        }}
                         isAnimationActive={false}
                         name="trend"
                         stroke={SERIES_COLORS.trend}
@@ -323,7 +346,10 @@ export function WeightTrendChart() {
               />
             </div>
 
-            <div className="grid gap-2 rounded-xl border border-border/70 bg-secondary/25 px-4 py-3" data-slot="weight-trend-insights">
+            <div
+              className="grid gap-2 rounded-xl border border-border/70 bg-secondary/25 px-4 py-3"
+              data-slot="weight-trend-insights"
+            >
               <p className="text-sm text-foreground">
                 3-day change: {formatInsightChange(threeDayInsights.periodChange)}{' '}
                 <span aria-label={`3-day direction ${threeDayInsights.direction}`}>
@@ -360,12 +386,18 @@ function LegendToggle({
       aria-pressed={active}
       className={cn(
         'inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors',
-        active ? 'border-border bg-secondary/55 text-foreground' : 'border-border/70 bg-background text-muted-foreground',
+        active
+          ? 'border-border bg-secondary/55 text-foreground'
+          : 'border-border/70 bg-background text-muted-foreground',
       )}
       onClick={onClick}
       type="button"
     >
-      <span aria-hidden="true" className="size-2.5 rounded-full" style={{ backgroundColor: color }} />
+      <span
+        aria-hidden="true"
+        className="size-2.5 rounded-full"
+        style={{ backgroundColor: color }}
+      />
       <span>{label}</span>
     </button>
   );

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
@@ -73,8 +73,7 @@ const formatWeightLabel = (value: number) => formatWeight(value, 'lbs');
 
 const formatInsightChange = (change: number) => {
   const formatted = formatTrendChange(change);
-  const numeric = Number(formatted);
-  const signPrefix = numeric > 0 ? '+' : '';
+  const signPrefix = change > 0 ? '+' : '';
   return `${signPrefix}${formatted} lbs`;
 };
 

--- a/apps/web/src/features/habits/components/daily-habits.tsx
+++ b/apps/web/src/features/habits/components/daily-habits.tsx
@@ -22,6 +22,7 @@ import {
 import type { HabitConfig } from '@/features/habits/types';
 import { accentCardStyles } from '@/lib/accent-card-styles';
 import { getToday, isSameDay, normalizeDate, toDateKey } from '@/lib/date';
+import { formatPercent, formatServing } from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
 
 import { HabitCardMenu } from './habit-card-menu';
@@ -45,7 +46,7 @@ const todayFormatter = new Intl.DateTimeFormat('en-US', {
 });
 
 function formatNumber(value: number) {
-  return Number.isInteger(value) ? value.toString() : value.toFixed(1);
+  return formatServing(value);
 }
 
 function getDisplayUnit(habit: DailyHabit) {
@@ -434,7 +435,7 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
               const progressPercent = getProgressPercent(habit, value);
               const hasTargetProgress =
                 habit.trackingType !== 'boolean' && habit.target !== null && habit.target > 0;
-              const percentageLabel = hasTargetProgress ? `${Math.round(progressPercent)}%` : null;
+              const percentageLabel = hasTargetProgress ? formatPercent(progressPercent) : null;
               const progressTone = hasTargetProgress ? getPercentTone(progressPercent) : null;
               const progressFillTone = hasTargetProgress
                 ? getProgressBarTone(progressPercent)

--- a/apps/web/src/features/habits/components/habit-history.tsx
+++ b/apps/web/src/features/habits/components/habit-history.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useHabitEntries, useHabits } from '@/features/habits/api/habits';
 import { addDays, getToday, toDateKey } from '@/lib/date';
+import { formatPercent, formatServing } from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
 
 const HISTORY_DAYS = 90;
@@ -43,7 +44,7 @@ function clampPercent(percent: number) {
 }
 
 function formatNumber(value: number) {
-  return Number.isInteger(value) ? value.toString() : value.toFixed(1);
+  return formatServing(value);
 }
 
 function getCompletionPercent(habit: Habit, entry: HabitEntry | undefined, isScheduled: boolean) {
@@ -173,7 +174,8 @@ function getProgressCellColor(percent: number) {
 function getCellPresentation(habit: Habit, entry: HabitHistoryEntry) {
   if (!entry.isScheduled) {
     return {
-      className: 'border-slate-300/50 bg-slate-200/45 dark:border-slate-700/60 dark:bg-slate-700/35',
+      className:
+        'border-slate-300/50 bg-slate-200/45 dark:border-slate-700/60 dark:bg-slate-700/35',
       style: undefined,
     };
   }
@@ -254,7 +256,11 @@ export function HabitHistory() {
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
             Habit history
           </p>
-          <CardTitle aria-level={2} className="text-2xl font-semibold text-foreground" role="heading">
+          <CardTitle
+            aria-level={2}
+            className="text-2xl font-semibold text-foreground"
+            role="heading"
+          >
             Last 90 days
           </CardTitle>
           <CardDescription>Loading habit history.</CardDescription>
@@ -277,7 +283,11 @@ export function HabitHistory() {
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
             Habit history
           </p>
-          <CardTitle aria-level={2} className="text-2xl font-semibold text-foreground" role="heading">
+          <CardTitle
+            aria-level={2}
+            className="text-2xl font-semibold text-foreground"
+            role="heading"
+          >
             Last 90 days
           </CardTitle>
           <CardDescription>{message}</CardDescription>
@@ -304,7 +314,11 @@ export function HabitHistory() {
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
             Habit history
           </p>
-          <CardTitle aria-level={2} className="text-2xl font-semibold text-foreground" role="heading">
+          <CardTitle
+            aria-level={2}
+            className="text-2xl font-semibold text-foreground"
+            role="heading"
+          >
             Last 90 days
           </CardTitle>
           <CardDescription>No habits yet. Add a habit to start tracking history.</CardDescription>
@@ -321,7 +335,11 @@ export function HabitHistory() {
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
               Habit history
             </p>
-            <CardTitle aria-level={2} className="text-2xl font-semibold text-foreground" role="heading">
+            <CardTitle
+              aria-level={2}
+              className="text-2xl font-semibold text-foreground"
+              role="heading"
+            >
               Last 90 days
             </CardTitle>
             <CardDescription className="max-w-2xl">
@@ -357,14 +375,17 @@ export function HabitHistory() {
                       </span>
                       {habit.name}
                     </p>
-                    <p className="text-xs font-medium text-muted-foreground" data-testid={`habit-streak-${habit.id}`}>
+                    <p
+                      className="text-xs font-medium text-muted-foreground"
+                      data-testid={`habit-streak-${habit.id}`}
+                    >
                       {habit.streakCount}-day streak
                     </p>
                     <p
                       className="text-xs font-medium text-muted-foreground"
                       data-testid={`habit-completion-rate-${habit.id}`}
                     >
-                      {habit.completionRate}% completion rate (last 90 days)
+                      {formatPercent(habit.completionRate)} completion rate (last 90 days)
                     </p>
                   </div>
 

--- a/apps/web/src/features/nutrition/components/macro-rings.test.tsx
+++ b/apps/web/src/features/nutrition/components/macro-rings.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MacroRings } from '@/features/nutrition/components/macro-rings';
+
+describe('MacroRings', () => {
+  it('renders a responsive grid layout for ring cards', () => {
+    const { container } = render(
+      <MacroRings
+        actual={{ protein: 140, carbs: 210, fat: 65 }}
+        targets={{ protein: 180, carbs: 250, fat: 73 }}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Macro rings' })).toBeInTheDocument();
+
+    const ringsGrid = container.querySelector('.grid.grid-cols-2.md\\:grid-cols-4');
+    expect(ringsGrid).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/nutrition/components/macro-rings.test.tsx
+++ b/apps/web/src/features/nutrition/components/macro-rings.test.tsx
@@ -14,7 +14,7 @@ describe('MacroRings', () => {
 
     expect(screen.getByRole('heading', { name: 'Macro rings' })).toBeInTheDocument();
 
-    const ringsGrid = container.querySelector('.grid.grid-cols-2.md\\:grid-cols-4');
+    const ringsGrid = container.querySelector('.grid.grid-cols-2.md\\:grid-cols-3');
     expect(ringsGrid).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/nutrition/components/macro-rings.tsx
+++ b/apps/web/src/features/nutrition/components/macro-rings.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { ProgressRing } from '@/components/ui/progress-ring';
 import { Button } from '@/components/ui/button';
 import { accentCardStyles } from '@/lib/accent-card-styles';
+import { formatGrams } from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
 
 type MacroKey = 'protein' | 'carbs' | 'fat';
@@ -26,7 +27,7 @@ const macroConfig: Array<{
 ];
 
 function formatMacroValue(value: number) {
-  return `${Number.isInteger(value) ? value : value.toFixed(1)}g`;
+  return formatGrams(value);
 }
 
 export function MacroRings({ actual, targets }: MacroRingsProps) {

--- a/apps/web/src/features/nutrition/components/macro-rings.tsx
+++ b/apps/web/src/features/nutrition/components/macro-rings.tsx
@@ -77,7 +77,7 @@ export function MacroRings({ actual, targets }: MacroRingsProps) {
           </div>
         </div>
       </CardHeader>
-      <CardContent className="grid gap-3 sm:grid-cols-3">
+      <CardContent className="grid grid-cols-2 gap-4 md:grid-cols-4">
         {macroConfig.map((macro) => {
           const target = targets[macro.key];
           const eaten = actual[macro.key];

--- a/apps/web/src/features/nutrition/components/macro-rings.tsx
+++ b/apps/web/src/features/nutrition/components/macro-rings.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card';
 import { ProgressRing } from '@/components/ui/progress-ring';
 import { Button } from '@/components/ui/button';
 import { accentCardStyles } from '@/lib/accent-card-styles';
@@ -38,9 +38,9 @@ export function MacroRings({ actual, targets }: MacroRingsProps) {
       <CardHeader className="gap-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-1">
-            <CardTitle aria-level={2} className="text-2xl font-semibold" role="heading">
+            <h2 className="text-2xl leading-none font-semibold">
               Macro rings
-            </CardTitle>
+            </h2>
             <CardDescription className="text-sm opacity-70 dark:text-muted dark:opacity-100">
               Toggle between what you&apos;ve eaten and what remains to hit today&apos;s targets.
             </CardDescription>
@@ -77,7 +77,7 @@ export function MacroRings({ actual, targets }: MacroRingsProps) {
           </div>
         </div>
       </CardHeader>
-      <CardContent className="grid grid-cols-2 gap-4 md:grid-cols-4">
+      <CardContent className="grid grid-cols-2 gap-4 md:grid-cols-3">
         {macroConfig.map((macro) => {
           const target = targets[macro.key];
           const eaten = actual[macro.key];

--- a/apps/web/src/features/nutrition/components/nutrition-macro-rings.test.tsx
+++ b/apps/web/src/features/nutrition/components/nutrition-macro-rings.test.tsx
@@ -67,4 +67,22 @@ describe('NutritionMacroRings', () => {
     const indicator = proteinCard.querySelector('[data-slot="progress-ring-indicator"]');
     expect(indicator).toHaveAttribute('stroke', 'var(--color-destructive)');
   });
+
+  it('uses responsive grid layout and ring sizing classes for mobile and desktop', () => {
+    const { container } = render(
+      <NutritionMacroRings
+        actuals={{ calories: 1850, protein: 160, carbs: 190, fat: 60 }}
+        targets={{ calories: 2200, protein: 180, carbs: 250, fat: 73 }}
+      />,
+    );
+
+    const ringsGrid = container.querySelector('.grid.grid-cols-2.md\\:grid-cols-4');
+    expect(ringsGrid).toBeInTheDocument();
+
+    const progressRings = screen.getAllByRole('progressbar');
+
+    for (const ring of progressRings) {
+      expect(ring).toHaveClass('w-[90px]', 'sm:w-[104px]', 'md:w-[116px]');
+    }
+  });
 });

--- a/apps/web/src/features/nutrition/components/nutrition-macro-rings.tsx
+++ b/apps/web/src/features/nutrition/components/nutrition-macro-rings.tsx
@@ -64,7 +64,7 @@ export function NutritionMacroRings({ actuals, targets }: NutritionMacroRingsPro
         </div>
       </div>
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
         {MACRO_RING_CONFIG.map((macro) => {
           const actual = actuals[macro.key];
           const target = targets[macro.key];
@@ -96,6 +96,7 @@ export function NutritionMacroRings({ actuals, targets }: NutritionMacroRingsPro
                   />
                 }
                 labelClassName="leading-none"
+                className="w-[90px] sm:w-[104px] md:w-[116px]"
                 size={116}
                 strokeWidth={10}
                 value={progress}

--- a/apps/web/src/features/nutrition/components/nutrition-macro-rings.tsx
+++ b/apps/web/src/features/nutrition/components/nutrition-macro-rings.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { ProgressRing } from '@/components/ui/progress-ring';
+import { formatCalories, formatGrams } from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
 
 type MacroValues = {
@@ -70,7 +71,14 @@ export function NutritionMacroRings({ actuals, targets }: NutritionMacroRingsPro
           const isOverTarget = target <= 0 ? actual > 0 : actual > target;
           const remaining = Math.max(target - actual, 0);
           const progress = getProgressValue({ actual, target, isOverTarget, view });
-          const display = getDisplayValue({ actual, remaining, target, isOverTarget, unit: macro.unit, view });
+          const display = getDisplayValue({
+            actual,
+            remaining,
+            target,
+            isOverTarget,
+            unit: macro.unit,
+            view,
+          });
 
           return (
             <article
@@ -80,7 +88,13 @@ export function NutritionMacroRings({ actuals, targets }: NutritionMacroRingsPro
               <ProgressRing
                 aria-label={`${macro.label} ${view} progress`}
                 color={isOverTarget ? OVER_TARGET_COLOR : macro.color}
-                label={<RingValue primary={display.primary} secondary={display.secondary} tone={display.tone} />}
+                label={
+                  <RingValue
+                    primary={display.primary}
+                    secondary={display.secondary}
+                    tone={display.tone}
+                  />
+                }
                 labelClassName="leading-none"
                 size={116}
                 strokeWidth={10}
@@ -108,7 +122,9 @@ function ToggleButton({ isActive, label, onClick }: ToggleButtonProps) {
       aria-pressed={isActive}
       className={cn(
         'min-h-[44px] min-w-[44px] cursor-pointer rounded-full px-3 py-1.5 text-xs font-semibold transition-colors sm:px-4',
-        isActive ? 'bg-primary text-primary-foreground shadow-sm' : 'text-muted hover:text-foreground',
+        isActive
+          ? 'bg-primary text-primary-foreground shadow-sm'
+          : 'text-muted hover:text-foreground',
       )}
       type="button"
       onClick={onClick}
@@ -127,7 +143,14 @@ type DisplayValueArgs = {
   view: MacroView;
 };
 
-function getDisplayValue({ actual, remaining, target, isOverTarget, unit, view }: DisplayValueArgs) {
+function getDisplayValue({
+  actual,
+  remaining,
+  target,
+  isOverTarget,
+  unit,
+  view,
+}: DisplayValueArgs) {
   if (isOverTarget) {
     return {
       primary: `+${formatValue(actual - target, unit)}`,
@@ -176,7 +199,7 @@ function getProgressValue({
 }
 
 function formatValue(value: number, unit: 'cal' | 'g') {
-  return `${Math.round(value)}${unit === 'cal' ? ' cal' : 'g'}`;
+  return unit === 'cal' ? `${formatCalories(value)} cal` : formatGrams(value);
 }
 
 function RingValue({

--- a/apps/web/src/features/nutrition/components/nutrition-macro-rings.tsx
+++ b/apps/web/src/features/nutrition/components/nutrition-macro-rings.tsx
@@ -200,7 +200,7 @@ function getProgressValue({
 }
 
 function formatValue(value: number, unit: 'cal' | 'g') {
-  return unit === 'cal' ? `${formatCalories(value)} cal` : formatGrams(value);
+  return unit === 'cal' ? formatCalories(value, 'cal') : formatGrams(value);
 }
 
 function RingValue({

--- a/apps/web/src/features/nutrition/lib/nutrition-utils.ts
+++ b/apps/web/src/features/nutrition/lib/nutrition-utils.ts
@@ -1,3 +1,9 @@
+import {
+  formatCalories as formatCaloriesValue,
+  formatGrams as formatGramsValue,
+  formatServing as formatServingValue,
+} from '@/lib/format-utils';
+
 export type MacroTotals = {
   calories: number;
   protein: number;
@@ -23,9 +29,7 @@ const DEFAULT_TOTALS: MacroTotals = {
   fat: 0,
 };
 
-export function calculateMacroTotals(
-  sources: Array<MacroSource | MealSource>,
-): MacroTotals {
+export function calculateMacroTotals(sources: Array<MacroSource | MealSource>): MacroTotals {
   return sources.reduce<MacroTotals>((totals, source) => {
     const macrosToAdd = 'items' in source ? calculateMacroTotals(source.items) : source;
 
@@ -68,15 +72,15 @@ export function sortMeals<T extends { name: string }>(meals: T[]): T[] {
 }
 
 export function formatCalories(value: number): string {
-  return `${Math.round(value)} cal`;
+  return `${formatCaloriesValue(value)} cal`;
 }
 
 export function formatGrams(value: number): string {
-  return `${Math.round(value)}g`;
+  return formatGramsValue(value);
 }
 
 export function formatServing(item: ServingSource): string {
-  return `${formatNumber(item.amount)} ${item.unit}`;
+  return `${formatServingValue(item.amount)} ${item.unit}`;
 }
 
 export function formatDayLabel(date: string): string {
@@ -120,10 +124,4 @@ export function startOfDay(date: Date): Date {
   normalizedDate.setHours(0, 0, 0, 0);
 
   return normalizedDate;
-}
-
-function formatNumber(value: number): string {
-  const rounded = Number(value.toFixed(2));
-
-  return `${rounded}`;
 }

--- a/apps/web/src/features/workouts/components/session-comparison.test.tsx
+++ b/apps/web/src/features/workouts/components/session-comparison.test.tsx
@@ -28,7 +28,12 @@ function createSession(overrides: Partial<WorkoutSession>): WorkoutSession {
   };
 }
 
-function createSet(exerciseId: string, setNumber: number, reps: number, weight: number | null = null) {
+function createSet(
+  exerciseId: string,
+  setNumber: number,
+  reps: number,
+  weight: number | null = null,
+) {
   return {
     id: `set-${exerciseId}-${setNumber}`,
     exerciseId,
@@ -49,10 +54,7 @@ describe('SessionExerciseComparison', () => {
       id: 'previous-session',
       startedAt: Date.parse('2026-02-20T18:00:00Z'),
       completedAt: Date.parse('2026-02-20T19:00:00Z'),
-      sets: [
-        createSet('bodyweight-row', 1, 7),
-        createSet('bodyweight-row', 3, 8),
-      ],
+      sets: [createSet('bodyweight-row', 1, 7), createSet('bodyweight-row', 3, 8)],
     });
     const currentSession = createSession({
       id: 'current-session',
@@ -96,8 +98,8 @@ describe('SessionComparison', () => {
       />,
     );
 
-    expect(screen.getByText('850 kg')).toBeInTheDocument();
-    expect(screen.getByText('640 kg')).toBeInTheDocument();
+    expect(screen.getByText('850.0 kg')).toBeInTheDocument();
+    expect(screen.getByText('640.0 kg')).toBeInTheDocument();
   });
 
   it('uses seconds metric labels for time-based sessions', () => {

--- a/apps/web/src/features/workouts/components/session-comparison.tsx
+++ b/apps/web/src/features/workouts/components/session-comparison.tsx
@@ -1,6 +1,5 @@
 import { ArrowDownRight, ArrowUpRight, Minus } from 'lucide-react';
 import {
-  formatWeight,
   type ExerciseTrackingType,
   type SessionSet,
   type WeightUnit,
@@ -9,9 +8,19 @@ import {
 
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  formatPercent,
+  formatServing,
+  formatWeight as formatWeightValue,
+} from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
 
-import { getSetSeconds, getSetVolume, getTrackingVolumeLabel, resolveTrackingType } from '../lib/tracking';
+import {
+  getSetSeconds,
+  getSetVolume,
+  getTrackingVolumeLabel,
+  resolveTrackingType,
+} from '../lib/tracking';
 
 type SessionComparisonProps = {
   currentSession: WorkoutSession;
@@ -57,10 +66,6 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 });
 
 const integerFormatter = new Intl.NumberFormat('en-US');
-const decimalFormatter = new Intl.NumberFormat('en-US', {
-  maximumFractionDigits: 1,
-  minimumFractionDigits: 0,
-});
 
 export function SessionComparison({
   currentSession,
@@ -125,7 +130,7 @@ export function SessionComparison({
             />
             {percentChange != null ? (
               <span className="text-sm font-medium opacity-80 dark:text-muted dark:opacity-100">
-                {`${percentChange > 0 ? '+' : ''}${percentChange}%`}
+                {`${percentChange > 0 ? '+' : ''}${formatPercent(percentChange)}`}
               </span>
             ) : null}
           </div>
@@ -259,11 +264,15 @@ function getExerciseComparison(
         metricLabel,
         setNumber: set.setNumber,
         weightDelta:
-          set.weight != null && previousSet?.weight != null ? set.weight - previousSet.weight : null,
+          set.weight != null && previousSet?.weight != null
+            ? set.weight - previousSet.weight
+            : null,
       };
     }),
     trackingType,
-    volumeDelta: getExerciseVolumeFromSets(currentSets, trackingType) - getExerciseVolumeFromSets(previousSets, trackingType),
+    volumeDelta:
+      getExerciseVolumeFromSets(currentSets, trackingType) -
+      getExerciseVolumeFromSets(previousSets, trackingType),
   } satisfies ExerciseComparison;
 }
 
@@ -283,14 +292,18 @@ function isPersonalRecord(
       return false;
     }
 
-    const currentMetric = trackingType === 'weight_seconds' ? (getSetSeconds(currentSet) ?? 0) : (currentSet.reps ?? 0);
-    const comparableSets = previousSets.reduce<Array<{ metric: number; weight: number }>>((sets, set) => {
-      if (set.weight != null && currentMetric >= getPrimarySetMetric(set, trackingType)) {
-        sets.push({ metric: getPrimarySetMetric(set, trackingType), weight: set.weight });
-      }
+    const currentMetric =
+      trackingType === 'weight_seconds' ? (getSetSeconds(currentSet) ?? 0) : (currentSet.reps ?? 0);
+    const comparableSets = previousSets.reduce<Array<{ metric: number; weight: number }>>(
+      (sets, set) => {
+        if (set.weight != null && currentMetric >= getPrimarySetMetric(set, trackingType)) {
+          sets.push({ metric: getPrimarySetMetric(set, trackingType), weight: set.weight });
+        }
 
-      return sets;
-    }, []);
+        return sets;
+      },
+      [],
+    );
 
     if (comparableSets.length > 0) {
       return currentWeight > Math.max(...comparableSets.map((set) => set.weight));
@@ -300,7 +313,10 @@ function isPersonalRecord(
   }
 
   const currentMetric = getPrimarySetMetric(currentSet, trackingType);
-  const maxPreviousMetric = Math.max(0, ...previousSets.map((set) => getPrimarySetMetric(set, trackingType)));
+  const maxPreviousMetric = Math.max(
+    0,
+    ...previousSets.map((set) => getPrimarySetMetric(set, trackingType)),
+  );
 
   return currentMetric > maxPreviousMetric;
 }
@@ -310,7 +326,10 @@ function getSessionVolume(session: WorkoutSession) {
   // exercise IDs, resolveTrackingType({ exerciseId }) often falls back to weight_reps.
   // Replace this inference once the API includes tracking metadata on session sets.
   const trackingByExerciseId = new Map(
-    session.sets.map((set) => [set.exerciseId, resolveTrackingType({ exerciseId: set.exerciseId })]),
+    session.sets.map((set) => [
+      set.exerciseId,
+      resolveTrackingType({ exerciseId: set.exerciseId }),
+    ]),
   );
 
   return session.sets.reduce((total, set) => {
@@ -337,7 +356,11 @@ function getPrimarySetMetric(set: SessionSet, trackingType: ExerciseTrackingType
 }
 
 function getSetDeltaLabel(trackingType: ExerciseTrackingType) {
-  if (trackingType === 'weight_seconds' || trackingType === 'seconds_only' || trackingType === 'cardio') {
+  if (
+    trackingType === 'weight_seconds' ||
+    trackingType === 'seconds_only' ||
+    trackingType === 'cardio'
+  ) {
     return 'Seconds';
   }
 
@@ -355,7 +378,9 @@ function getSessionVolumeLabel(session: WorkoutSession) {
 
   // TODO: same metadata gap as getSessionVolume; volume labels can be inaccurate for UUID IDs
   // until session sets include trackingType or exercise metadata in the API payload.
-  const trackingTypes = new Set(session.sets.map((set) => resolveTrackingType({ exerciseId: set.exerciseId })));
+  const trackingTypes = new Set(
+    session.sets.map((set) => resolveTrackingType({ exerciseId: set.exerciseId })),
+  );
 
   if (trackingTypes.size === 1) {
     const only = [...trackingTypes][0];
@@ -367,7 +392,7 @@ function getSessionVolumeLabel(session: WorkoutSession) {
 
 function formatVolume(value: number, label: string, weightUnit: WeightUnit) {
   if (label === 'volume') {
-    return formatWeight(value, weightUnit);
+    return `${formatWeightValue(value)} ${weightUnit}`;
   }
 
   if (label === 'seconds') {
@@ -406,7 +431,11 @@ function getDirection(value: number): ComparisonDirection {
 }
 
 function formatNumber(value: number) {
-  return Number.isInteger(value) ? integerFormatter.format(value) : decimalFormatter.format(value);
+  if (Number.isInteger(value)) {
+    return integerFormatter.format(value);
+  }
+
+  return formatServing(value);
 }
 
 function formatSignedInteger(value: number) {

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -34,6 +34,7 @@ import {
 import { Label } from '@/components/ui/label';
 import { StatCard } from '@/components/ui/stat-card';
 import { useWeightUnit } from '@/hooks/use-weight-unit';
+import { formatServing, formatWeight as formatWeightValue } from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
 
 import { useCompletedSessions, useWorkoutSession, useWorkoutTemplate } from '../api/workouts';
@@ -103,8 +104,7 @@ const phaseBadgeStyles = {
     'border-transparent bg-[var(--color-accent-cream)] text-on-cream dark:bg-amber-500/20 dark:text-amber-400',
   moderate:
     'border-transparent bg-secondary text-secondary-foreground dark:bg-secondary/80 dark:text-foreground',
-  test:
-    'border-transparent bg-[var(--color-accent-pink)] text-on-pink dark:bg-pink-500/20 dark:text-pink-400',
+  test: 'border-transparent bg-[var(--color-accent-pink)] text-on-pink dark:bg-pink-500/20 dark:text-pink-400',
 } as const;
 
 export function SessionDetail({ sessionId }: SessionDetailProps) {
@@ -317,12 +317,17 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
           <details
             className="group overflow-hidden rounded-3xl border border-border bg-card shadow-sm"
             key={section.type}
-            open={section.type === 'main' || section.exercises.some((exercise) => Boolean(exercise.notes))}
+            open={
+              section.type === 'main' ||
+              section.exercises.some((exercise) => Boolean(exercise.notes))
+            }
           >
             <summary className="cursor-pointer list-none px-5 py-4 sm:px-6 sm:py-5">
               <div className="flex items-center justify-between gap-3">
                 <div className="space-y-1">
-                  <h3 className="text-lg font-semibold text-foreground">{sectionLabels[section.type]}</h3>
+                  <h3 className="text-lg font-semibold text-foreground">
+                    {sectionLabels[section.type]}
+                  </h3>
                   <p className="text-sm text-muted">{section.subtitle}</p>
                 </div>
                 <div className="flex items-center gap-3">
@@ -346,7 +351,10 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
                         <div className="flex flex-wrap items-center gap-2">
                           <CardTitle>{exercise.name}</CardTitle>
                           <Badge
-                            className={cn('border-transparent', phaseBadgeStyles[exercise.phaseBadge])}
+                            className={cn(
+                              'border-transparent',
+                              phaseBadgeStyles[exercise.phaseBadge],
+                            )}
                             variant="outline"
                           >
                             {formatLabel(exercise.phaseBadge)}
@@ -463,7 +471,10 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
         </Button>
       ) : null}
 
-      <Dialog onOpenChange={(open) => (!open ? setSelectedExerciseId(null) : null)} open={selectedExercise != null}>
+      <Dialog
+        onOpenChange={(open) => (!open ? setSelectedExerciseId(null) : null)}
+        open={selectedExercise != null}
+      >
         <DialogContent className="max-h-[90vh] overflow-y-auto rounded-t-3xl border-border p-0 sm:max-w-4xl sm:rounded-3xl">
           {selectedExercise ? (
             <div className="space-y-0">
@@ -489,7 +500,10 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
   );
 }
 
-function buildSections(session: WorkoutSession, template?: WorkoutTemplate): SessionDetailSection[] {
+function buildSections(
+  session: WorkoutSession,
+  template?: WorkoutTemplate,
+): SessionDetailSection[] {
   const templateSectionByExerciseId = new Map<string, WorkoutTemplateSectionType>();
   const templateExerciseNameById = new Map<string, string>();
 
@@ -646,7 +660,9 @@ function formatFeedbackResponseValue(response: WorkoutSessionFeedbackResponse) {
   return '-';
 }
 
-function inferPhaseBadge(sectionType: SessionDetailSectionType): SessionDetailExercise['phaseBadge'] {
+function inferPhaseBadge(
+  sectionType: SessionDetailSectionType,
+): SessionDetailExercise['phaseBadge'] {
   switch (sectionType) {
     case 'warmup':
     case 'cooldown':
@@ -748,7 +764,11 @@ function buildHistoryPoint(
   };
 }
 
-function formatSetLabel(set: SessionSet, trackingType: ExerciseTrackingType, weightUnit: WeightUnit) {
+function formatSetLabel(
+  set: SessionSet,
+  trackingType: ExerciseTrackingType,
+  weightUnit: WeightUnit,
+) {
   if (set.skipped) {
     return `Set ${set.setNumber}: Skipped`;
   }
@@ -767,23 +787,28 @@ function formatSetLabel(set: SessionSet, trackingType: ExerciseTrackingType, wei
   }
 
   if (trackingType === 'weight_seconds') {
-    const weightLabel = set.weight != null ? `${formatNumber(set.weight)} ${weightUnit} × ` : '';
+    const weightLabel =
+      set.weight != null ? `${formatWeightValue(set.weight)} ${weightUnit} × ` : '';
     return `Set ${set.setNumber}: ${weightLabel}${secondsValue} sec`;
   }
 
   const repsLabel = `${repsValue} reps`;
-  const weightLabel = set.weight != null ? `${formatNumber(set.weight)} ${weightUnit} × ` : '';
+  const weightLabel = set.weight != null ? `${formatWeightValue(set.weight)} ${weightUnit} × ` : '';
 
   return `Set ${set.setNumber}: ${weightLabel}${repsLabel}`;
 }
 
-function formatSummaryMetric(value: number, label: 'reps' | 'seconds' | 'volume', weightUnit: WeightUnit) {
+function formatSummaryMetric(
+  value: number,
+  label: 'reps' | 'seconds' | 'volume',
+  weightUnit: WeightUnit,
+) {
   if (label === 'volume') {
-    return `${formatNumber(value)} ${weightUnit}`;
+    return `${formatWeightValue(value)} ${weightUnit}`;
   }
 
   if (label === 'seconds') {
-    return `${formatNumber(value)} sec`;
+    return `${formatServing(value)} sec`;
   }
 
   return integerFormatter.format(value);
@@ -798,5 +823,9 @@ function formatLabel(value: string) {
 }
 
 function formatNumber(value: number) {
-  return Number.isInteger(value) ? integerFormatter.format(value) : decimalFormatter.format(value);
+  if (Number.isInteger(value)) {
+    return integerFormatter.format(value);
+  }
+
+  return formatServing(value);
 }

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -109,25 +109,21 @@ describe('SessionExerciseList', () => {
       within(currentCard as HTMLElement).getAllByRole('button', { name: 'Add Set' }).length,
     ).toBeGreaterThan(0);
     expect(
-      within(currentCard as HTMLElement).getByText(/3 × 8-10 \| 50 → 45 → 40 kg/i),
+      within(currentCard as HTMLElement).getByText(/3 × 8-10 \| 50\.0 → 45\.0 → 40\.0 kg/i),
     ).toBeInTheDocument();
     expect(within(currentCard as HTMLElement).getByText('Tempo: 3-1-1-0')).toBeInTheDocument();
     expect(within(currentCard as HTMLElement).getByText('Rest: 1:30')).toBeInTheDocument();
     expect(within(currentCard as HTMLElement).getByText('~5 min')).toBeInTheDocument();
     expect(
-      within(currentCard as HTMLElement).getByText(/Last: 50x12, 45x10, 40x9/i),
+      within(currentCard as HTMLElement).getByText(/Last: 50\.0x12, 45\.0x10, 40\.0x9/i),
     ).toBeInTheDocument();
-    expect(within(currentCard as HTMLElement).getByTestId('set-grid-incline-dumbbell-press')).toHaveClass(
-      'grid-cols-2',
-    );
+    expect(
+      within(currentCard as HTMLElement).getByTestId('set-grid-incline-dumbbell-press'),
+    ).toHaveClass('grid-cols-2');
 
     fireEvent.click(within(currentCard as HTMLElement).getByRole('button', { name: /Form Cues/i }));
     expect(within(currentCard as HTMLElement).getByText('Technique & coaching cues')).toBeVisible();
-    expect(
-      within(currentCard as HTMLElement).getByText(
-        'Drive feet into the floor',
-      ),
-    ).toBeVisible();
+    expect(within(currentCard as HTMLElement).getByText('Drive feet into the floor')).toBeVisible();
     expect(
       within(currentCard as HTMLElement).getByText('Keep wrists stacked over elbows'),
     ).toBeVisible();
@@ -187,7 +183,9 @@ describe('SessionExerciseList', () => {
     fireEvent.click(addSetItem);
     expect(onAddSet).toHaveBeenCalledWith('row-erg');
 
-    expect(within(rowErgCardElement).getByRole('button', { name: 'Remove Last Set' })).toBeDisabled();
+    expect(
+      within(rowErgCardElement).getByRole('button', { name: 'Remove Last Set' }),
+    ).toBeDisabled();
     expect(onRemoveSet).not.toHaveBeenCalled();
   });
 
@@ -455,7 +453,9 @@ describe('SessionExerciseList', () => {
       within(card as HTMLElement).getByText(/1 × 10 reps \+ 30 sec hold • Last: 10 reps/i),
     ).toBeInTheDocument();
     expect(
-      within(card as HTMLElement).queryByText((_, element) => element?.textContent === '10 x 10 sec'),
+      within(card as HTMLElement).queryByText(
+        (_, element) => element?.textContent === '10 x 10 sec',
+      ),
     ).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -22,6 +22,7 @@ import {
 import { Textarea } from '@/components/ui/textarea';
 import { accentCardStyles } from '@/lib/accent-card-styles';
 import { useLastPerformance } from '@/hooks/use-last-performance';
+import { formatWeight as formatWeightValue } from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
 
 import type {
@@ -900,7 +901,7 @@ function formatPerformedReps(reps: number, prescribedReps: string) {
 }
 
 function formatWeight(weight: number) {
-  return Number.isInteger(weight) ? `${weight}` : weight.toFixed(1);
+  return formatWeightValue(weight);
 }
 
 function formatPhaseBadge(phaseBadge: ActiveWorkoutPhaseBadge) {

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -35,6 +35,8 @@ const timeFormatter = new Intl.DateTimeFormat('en-US', {
 
 type WorkoutCalendarProps = {
   buildDayHref?: (date: string) => string;
+  // Calendar only renders completed sessions from `useCompletedSessions`,
+  // so the session link does not need status-aware routing.
   buildSessionHref?: (sessionId: string) => string;
 };
 

--- a/apps/web/src/features/workouts/components/workout-list.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.test.tsx
@@ -43,6 +43,10 @@ describe('WorkoutList', () => {
     expect(screen.getAllByText('Completed').length).toBeGreaterThan(0);
     expect(screen.getByText(/Scheduled /)).toBeInTheDocument();
     expect(screen.getByText('49 min')).toBeInTheDocument();
+    const inProgressLink = screen
+      .getAllByRole('link', { name: /upper push/i })
+      .find((link) => link.getAttribute('href') === '/workouts/active?sessionId=session-in-progress');
+    expect(inProgressLink).toBeDefined();
   });
 
   it('renders a workout card with summary stats and session detail link', async () => {

--- a/apps/web/src/features/workouts/components/workout-list.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.tsx
@@ -15,7 +15,7 @@ const sessionDateFormatter = new Intl.DateTimeFormat('en-US', {
 });
 
 type WorkoutListProps = {
-  buildSessionHref?: (sessionId: string) => string;
+  buildSessionHref?: (sessionId: string, status: WorkoutSessionStatus) => string;
   buildTemplatesHref?: () => string;
   buildPlanWorkoutHref?: () => string;
   sessions?: WorkoutSessionListItem[];
@@ -35,7 +35,8 @@ type WorkoutListViewItem = {
 };
 
 export function WorkoutList({
-  buildSessionHref = (sessionId) => `/workouts/session/${sessionId}`,
+  buildSessionHref = (sessionId, status) =>
+    status === 'in-progress' ? `/workouts/active?sessionId=${sessionId}` : `/workouts/session/${sessionId}`,
   buildTemplatesHref = () => '/workouts?view=templates',
   buildPlanWorkoutHref = () => '/workouts?view=templates',
   sessions,
@@ -148,13 +149,13 @@ function WorkoutListCard({
   buildSessionHref,
   session,
 }: {
-  buildSessionHref: (sessionId: string) => string;
+  buildSessionHref: (sessionId: string, status: WorkoutSessionStatus) => string;
   session: WorkoutListViewItem;
 }) {
   return (
     <Link
       className="block cursor-pointer rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-      to={buildSessionHref(session.id)}
+      to={buildSessionHref(session.id, session.status)}
     >
       <Card
         className={cn(

--- a/apps/web/src/lib/format-utils.test.ts
+++ b/apps/web/src/lib/format-utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatCalories,
+  formatGrams,
+  formatPercent,
+  formatServing,
+  formatTrendChange,
+  formatWeight,
+} from '@/lib/format-utils';
+
+describe('format-utils', () => {
+  it('formats calories as rounded whole numbers', () => {
+    expect(formatCalories(899.88)).toBe('900');
+  });
+
+  it('formats grams as rounded whole numbers with unit', () => {
+    expect(formatGrams(83.958)).toBe('84g');
+    expect(formatGrams(31.7)).toBe('32g');
+  });
+
+  it('formats weight with one decimal place', () => {
+    expect(formatWeight(182.45)).toBe('182.5');
+  });
+
+  it('formats percentages as rounded whole numbers', () => {
+    expect(formatPercent(73.6)).toBe('74%');
+  });
+
+  it('formats trend changes with one decimal place', () => {
+    expect(formatTrendChange(2.34)).toBe('2.3');
+  });
+
+  it('formats serving values with up to two decimals', () => {
+    expect(formatServing(1.5)).toBe('1.5');
+    expect(formatServing(2.0)).toBe('2');
+  });
+});

--- a/apps/web/src/lib/format-utils.test.ts
+++ b/apps/web/src/lib/format-utils.test.ts
@@ -14,6 +14,11 @@ describe('format-utils', () => {
     expect(formatCalories(899.88)).toBe('900');
   });
 
+  it('formats calories with unit suffix', () => {
+    expect(formatCalories(500, 'cal')).toBe('500 cal');
+    expect(formatCalories(500, 'kcal')).toBe('500 kcal');
+  });
+
   it('formats grams as rounded whole numbers with unit', () => {
     expect(formatGrams(83.958)).toBe('84g');
     expect(formatGrams(31.7)).toBe('32g');

--- a/apps/web/src/lib/format-utils.ts
+++ b/apps/web/src/lib/format-utils.ts
@@ -1,0 +1,46 @@
+type CaloriesUnit = 'none' | 'cal' | 'kcal';
+type WeightUnit = 'none' | 'lbs';
+
+function normalizeNumber(value: number): number {
+  return Number.isFinite(value) ? value : 0;
+}
+
+export function formatCalories(value: number, unit: CaloriesUnit = 'none'): string {
+  const rounded = `${Math.round(normalizeNumber(value))}`;
+
+  if (unit === 'none') {
+    return rounded;
+  }
+
+  return `${rounded} ${unit}`;
+}
+
+export function formatGrams(value: number): string {
+  return `${Math.round(normalizeNumber(value))}g`;
+}
+
+export function formatWeight(value: number, unit: WeightUnit = 'none'): string {
+  const rounded = Math.round(normalizeNumber(value) * 10) / 10;
+  const formatted = rounded.toFixed(1);
+
+  if (unit === 'none') {
+    return formatted;
+  }
+
+  return `${formatted} ${unit}`;
+}
+
+export function formatPercent(value: number): string {
+  return `${Math.round(normalizeNumber(value))}%`;
+}
+
+export function formatTrendChange(value: number): string {
+  const rounded = Math.round(normalizeNumber(value) * 10) / 10;
+  return rounded.toFixed(1);
+}
+
+export function formatServing(value: number): string {
+  return normalizeNumber(value)
+    .toFixed(2)
+    .replace(/\.?0+$/, '');
+}

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -68,14 +68,14 @@ describe('ActiveWorkoutPage', () => {
 
     expect(headerCard).not.toHaveClass('sticky');
     expect(stickyProgressStrip).toHaveClass('sticky', 'top-0', 'z-20');
-    expect(screen.getByText('Exercise 3 of 7')).toBeInTheDocument();
+    expect(screen.getByText('Exercise 1 of 7')).toBeInTheDocument();
     expect(screen.getByText(/~\d+ min total estimate/i)).toBeInTheDocument();
     expect(screen.getByRole('region', { name: 'Session context' })).toBeInTheDocument();
     expect(screen.getByText('Recent Training')).toBeInTheDocument();
     expect(screen.getByText('Recovery Status')).toBeInTheDocument();
     expect(screen.getByText('Active Injuries')).toBeInTheDocument();
     expect(screen.getByText('Training Phase')).toBeInTheDocument();
-    expect(screen.getByText('Warmup (2/2 exercises done)')).toBeInTheDocument();
+    expect(screen.getByText(/Warmup \(\d+\/2 exercises done\)/)).toBeInTheDocument();
     expect(screen.getByText('Superset')).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /Post-Workout Supplemental \(10-20 min\)/i }),
@@ -97,8 +97,8 @@ describe('ActiveWorkoutPage', () => {
       vi.advanceTimersByTime(90_100);
     });
 
-    const nextExerciseCard = getExerciseCard('Seated Dumbbell Shoulder Press');
-    expect(within(nextExerciseCard).getByLabelText('Reps for set 1')).toHaveFocus();
+    const nextExerciseCard = getExerciseCard('Row Erg');
+    expect(within(nextExerciseCard).getByLabelText('Seconds for set 1')).toHaveFocus();
     expect(screen.queryByText('After Incline Dumbbell Press set 3')).not.toBeInTheDocument();
 
     const optionalCard = getExerciseCard('Rope Triceps Pushdown');
@@ -135,6 +135,11 @@ describe('ActiveWorkoutPage', () => {
       within(inclineCard).getByDisplayValue('Lower the bench by one notch before the top set.'),
     ).toBeVisible();
 
+    completeSet('Row Erg', 1);
+    completeSet('Banded Shoulder External Rotation', 1);
+    completeSet('Banded Shoulder External Rotation', 2);
+    completeSet('Incline Dumbbell Press', 1);
+    completeSet('Incline Dumbbell Press', 2);
     completeSet('Incline Dumbbell Press', 3);
     completeSet('Seated Dumbbell Shoulder Press', 1);
     completeSet('Seated Dumbbell Shoulder Press', 2);
@@ -153,6 +158,9 @@ describe('ActiveWorkoutPage', () => {
     fireEvent.change(within(getExerciseCard('Couch Stretch')).getByLabelText('Seconds for set 2'), {
       target: { value: '65' },
     });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Finish Workout' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }));
 
     expect(
       screen.getByRole('heading', { level: 2, name: 'How did this session feel?' }),
@@ -231,9 +239,22 @@ describe('ActiveWorkoutPage', () => {
   });
 
   it('starts fallback elapsed time from now for unsaved sessions', () => {
-    renderActiveWorkoutPage('/workouts/active');
+    renderActiveWorkoutPage('/workouts/active?template=upper-push');
 
     expect(screen.getByText('00:00')).toBeInTheDocument();
+  });
+
+  it('renders an empty state when there is no active session and no selected template', () => {
+    renderActiveWorkoutPage('/workouts/active');
+
+    expect(screen.getByRole('heading', { level: 1, name: 'No active workout' })).toBeInTheDocument();
+    expect(
+      screen.getByText('Start a session from one of your existing templates to begin logging sets.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Browse templates' })).toHaveAttribute(
+      'href',
+      '/workouts?view=templates',
+    );
   });
 
   it('supports manually finishing an active workout with confirmation and set summary ratio', async () => {
@@ -564,7 +585,7 @@ describe('ActiveWorkoutPage', () => {
   });
 });
 
-function renderActiveWorkoutPage(initialEntry = '/workouts/active') {
+function renderActiveWorkoutPage(initialEntry = '/workouts/active?template=upper-push') {
   return renderWithQueryClient(
     <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
@@ -594,6 +615,13 @@ function getExerciseCard(name: string) {
 
   if (!card) {
     throw new Error(`Expected exercise card for ${name}.`);
+  }
+
+  const exerciseToggle = within(card as HTMLElement)
+    .queryAllByRole('button')
+    .find((button) => button.getAttribute('aria-controls')?.startsWith('exercise-panel-'));
+  if (exerciseToggle?.getAttribute('aria-expanded') === 'false') {
+    fireEvent.click(exerciseToggle);
   }
 
   return card as HTMLElement;

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router';
+import { Link, useNavigate, useSearchParams } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
 
@@ -67,6 +67,7 @@ import {
   WORKOUT_SESSION_NOTICE_QUERY_KEY,
   clearStoredActiveWorkoutDraft,
   clearStoredActiveWorkoutSessionId,
+  getStoredActiveWorkoutSessionId,
   getStoredActiveWorkoutDraft,
   setStoredActiveWorkoutSessionId,
   setStoredActiveWorkoutDraft,
@@ -123,8 +124,10 @@ export function ActiveWorkoutPage() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const sessionId = searchParams.get('sessionId');
+  const requestedSessionId = searchParams.get('sessionId');
+  const sessionId = requestedSessionId ?? getStoredActiveWorkoutSessionId();
   const requestedTemplateId = searchParams.get('template');
+  const shouldRenderEmptyState = !sessionId && !requestedTemplateId;
   const sessionQuery = useWorkoutSession(sessionId);
   const { weightUnit } = useWeightUnit();
   const logSetMutation = useLogSet(sessionId);
@@ -339,6 +342,20 @@ export function ActiveWorkoutPage() {
       <section className="space-y-3 pb-8">
         <h1 className="text-2xl font-semibold text-foreground">Unable to load template</h1>
         <p className="text-sm text-muted">Refresh and try again.</p>
+      </section>
+    );
+  }
+
+  if (shouldRenderEmptyState) {
+    return (
+      <section className="space-y-4 pb-8">
+        <h1 className="text-2xl font-semibold text-foreground">No active workout</h1>
+        <p className="text-sm text-muted">
+          Start a session from one of your existing templates to begin logging sets.
+        </p>
+        <Button asChild type="button">
+          <Link to="/workouts?view=templates">Browse templates</Link>
+        </Button>
       </section>
     );
   }

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -26,7 +26,6 @@ import {
   countCompletedReps,
   createInitialWorkoutSetDrafts,
   createWorkoutSetDraft,
-  createWorkoutSetId,
   workoutFeedbackFields,
   workoutSessionContext,
   workoutSupplementalExercises,
@@ -103,14 +102,6 @@ const categoryBadgeByExerciseId = new Map(
 );
 const mockExerciseById = new Map(mockExercises.map((exercise) => [exercise.id, exercise]));
 
-const completedSetIds = [
-  createWorkoutSetId('row-erg', 1),
-  createWorkoutSetId('banded-shoulder-external-rotation', 1),
-  createWorkoutSetId('banded-shoulder-external-rotation', 2),
-  createWorkoutSetId('incline-dumbbell-press', 1),
-  createWorkoutSetId('incline-dumbbell-press', 2),
-];
-
 type RestTimerState = {
   duration: number;
   exerciseId: string;
@@ -148,10 +139,7 @@ export function ActiveWorkoutPage() {
   const [fallbackStartTime] = useState(() => new Date().toISOString());
   const [startTimeOverride, setStartTimeOverride] = useState<string | null>(null);
   const [setDrafts, setSetDrafts] = useState<ActiveWorkoutSetDrafts>(() =>
-    createInitialWorkoutSetDrafts(
-      template,
-      requestedTemplateId || sessionId ? new Set<string>() : new Set(completedSetIds),
-    ),
+    createInitialWorkoutSetDrafts(template, new Set<string>()),
   );
   const [exerciseNotes, setExerciseNotes] = useState<Record<string, string>>({});
   const [stage, setStage] = useState<'active' | 'feedback' | 'summary'>('active');
@@ -244,10 +232,7 @@ export function ActiveWorkoutPage() {
       return;
     }
 
-    const initialSetDrafts = createInitialWorkoutSetDrafts(
-      template,
-      requestedTemplateId || sessionId ? new Set<string>() : new Set(completedSetIds),
-    );
+    const initialSetDrafts = createInitialWorkoutSetDrafts(template, new Set<string>());
     const autosavedDraft = getStoredActiveWorkoutDraft(activeWorkoutDraftId);
 
     setSetDrafts(autosavedDraft?.setDrafts ?? initialSetDrafts);

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -453,8 +453,8 @@ describe('DashboardPage', () => {
     expect(screen.getByRole('heading', { name: 'Weight Trend' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Recent Workouts' })).toBeInTheDocument();
     expect(screen.getByText('Upper Push A (Completed)')).toBeInTheDocument();
-    expect(screen.getByText('1,900 / 2,300')).toBeInTheDocument();
-    expect(screen.getByText('170 g / 190 g')).toBeInTheDocument();
+    expect(screen.getByText('1900 / 2300')).toBeInTheDocument();
+    expect(screen.getByText('170g / 190g')).toBeInTheDocument();
     expect(screen.getByText('1/1')).toBeInTheDocument();
     expect(screen.getByLabelText('Weight (lbs)')).toHaveAttribute('id', 'dashboard-weight-input');
     expect(screen.getByLabelText('Weight (lbs)')).toHaveAttribute('name', 'weight');

--- a/apps/web/src/pages/workouts.test.tsx
+++ b/apps/web/src/pages/workouts.test.tsx
@@ -481,7 +481,7 @@ describe('WorkoutsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Templates' }));
 
     expect(await screen.findByRole('heading', { name: 'No workouts yet' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Browse Templates' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Browse Templates' })).not.toBeInTheDocument();
     expect(
       screen.getByText('Ask your agent to build a template, then start a session from it.'),
     ).toBeInTheDocument();

--- a/apps/web/src/pages/workouts.test.tsx
+++ b/apps/web/src/pages/workouts.test.tsx
@@ -274,7 +274,7 @@ describe('WorkoutsPage', () => {
     expect(screen.getByTestId('location-search')).toHaveTextContent('?view=exercises');
   });
 
-  it('includes the current view in session detail links', async () => {
+  it('includes the current view in session links and routes in-progress sessions to active workout', async () => {
     renderWithQueryClient(
       <MemoryRouter initialEntries={['/workouts?view=list']}>
         <Routes>
@@ -294,6 +294,17 @@ describe('WorkoutsPage', () => {
       throw new Error('Expected session detail link with view=list query param');
     }
     expect(detailsLink).toHaveAttribute('href', '/workouts/session/session-1?view=list');
+
+    const activeSessionLink = (await screen.findAllByRole('link')).find(
+      (link) => link.getAttribute('href') === '/workouts/active?view=list&sessionId=session-2',
+    );
+    if (!activeSessionLink) {
+      throw new Error('Expected in-progress session link to the active workout route');
+    }
+    expect(activeSessionLink).toHaveAttribute(
+      'href',
+      '/workouts/active?view=list&sessionId=session-2',
+    );
   });
 
   it('opens template detail when selecting a template card from the templates view', async () => {
@@ -408,7 +419,7 @@ describe('WorkoutsPage', () => {
     expect(await screen.findByRole('heading', { level: 2, name: 'Templates' })).toBeInTheDocument();
   });
 
-  it('renders the templates empty state and navigates to workout creation flow', async () => {
+  it('renders the templates empty state with browse templates messaging', async () => {
     vi.restoreAllMocks();
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
       const url = new URL(String(input), 'https://pulse.test');
@@ -463,7 +474,6 @@ describe('WorkoutsPage', () => {
       <MemoryRouter initialEntries={['/workouts']}>
         <Routes>
           <Route element={<WorkoutsPage />} path="/workouts" />
-          <Route element={<ActiveWorkoutRouteProbe />} path="/workouts/active" />
         </Routes>
       </MemoryRouter>,
     );
@@ -471,9 +481,10 @@ describe('WorkoutsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Templates' }));
 
     expect(await screen.findByRole('heading', { name: 'No workouts yet' })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Create Template' }));
-
-    expect(await screen.findByRole('heading', { name: 'Active workout page' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Browse Templates' })).toBeInTheDocument();
+    expect(
+      screen.getByText('Ask your agent to build a template, then start a session from it.'),
+    ).toBeInTheDocument();
   });
 
   it('shows a completion notice when redirected from an already-completed active session', () => {
@@ -565,7 +576,7 @@ describe('WorkoutsPage', () => {
     expect(screen.queryByText('How workouts flow in Pulse')).not.toBeInTheDocument();
   });
 
-  it('navigates to active workout flow from onboarding create CTA', async () => {
+  it('does not render onboarding create-template CTA', async () => {
     vi.restoreAllMocks();
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
       const url = new URL(String(input), 'https://pulse.test');
@@ -613,15 +624,12 @@ describe('WorkoutsPage', () => {
       <MemoryRouter initialEntries={['/workouts']}>
         <Routes>
           <Route element={<WorkoutsPage />} path="/workouts" />
-          <Route element={<ActiveWorkoutRouteProbe />} path="/workouts/active" />
         </Routes>
       </MemoryRouter>,
     );
 
     expect(await screen.findByText('How workouts flow in Pulse')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Create a template' }));
-
-    expect(await screen.findByRole('heading', { name: 'Active workout page' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Create a template' })).not.toBeInTheDocument();
   });
 
   it('prefetches top template details when the list view is active', async () => {
@@ -656,10 +664,6 @@ function TemplateRouteProbe() {
   const { templateId } = useParams();
 
   return <h1>{`Template ${templateId}`}</h1>;
-}
-
-function ActiveWorkoutRouteProbe() {
-  return <h1>Active workout page</h1>;
 }
 
 function LocationProbe() {

--- a/apps/web/src/pages/workouts.tsx
+++ b/apps/web/src/pages/workouts.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { Dumbbell, X } from 'lucide-react';
-import { useNavigate, useSearchParams } from 'react-router';
+import { useSearchParams } from 'react-router';
 
 import { WorkoutCardSkeleton } from '@/components/skeletons';
 import { Button } from '@/components/ui/button';
@@ -32,7 +32,6 @@ function isWorkoutView(value: string | null): value is WorkoutView {
 
 export function WorkoutsPage() {
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [onboardingDismissed, setOnboardingDismissed] = useState(() => {
     if (typeof window === 'undefined') {
@@ -88,9 +87,15 @@ export function WorkoutsPage() {
     setSearchParams(nextSearchParams);
   }
 
-  function buildSessionHref(sessionId: string) {
+  function buildSessionHref(sessionId: string, status?: 'scheduled' | 'in-progress' | 'completed') {
     const sessionSearchParams = new URLSearchParams();
     sessionSearchParams.set('view', activeView);
+
+    if (status === 'in-progress') {
+      sessionSearchParams.set('sessionId', sessionId);
+      return `/workouts/active?${sessionSearchParams.toString()}`;
+    }
+
     return `/workouts/session/${sessionId}?${sessionSearchParams.toString()}`;
   }
 
@@ -119,7 +124,7 @@ export function WorkoutsPage() {
             <div className="space-y-1">
               <h2 className="text-lg font-semibold text-foreground">How workouts flow in Pulse</h2>
               <p className="text-sm text-muted">
-                Create a template, start a session from it, then log sets as you go.
+                Ask your agent to create a template, then start a session and log sets as you go.
               </p>
             </div>
             <Button
@@ -134,9 +139,6 @@ export function WorkoutsPage() {
             </Button>
           </div>
           <div className="mt-4 flex flex-wrap gap-2">
-            <Button onClick={() => navigate('/workouts/active')} size="sm" type="button">
-              Create a template
-            </Button>
             <Button onClick={() => setActiveView('templates')} size="sm" type="button" variant="secondary">
               Browse templates
             </Button>
@@ -214,10 +216,10 @@ export function WorkoutsPage() {
         ) : shouldShowTemplatesEmptyState ? (
           <EmptyState
             action={{
-              label: 'Create Template',
-              onClick: () => navigate('/workouts/active'),
+              label: 'Browse Templates',
+              onClick: () => setActiveView('templates'),
             }}
-            description="Create a template or ask your agent to build one."
+            description="Ask your agent to build a template, then start a session from it."
             icon={Dumbbell}
             title="No workouts yet"
           />

--- a/apps/web/src/pages/workouts.tsx
+++ b/apps/web/src/pages/workouts.tsx
@@ -215,10 +215,6 @@ export function WorkoutsPage() {
           </div>
         ) : shouldShowTemplatesEmptyState ? (
           <EmptyState
-            action={{
-              label: 'Browse Templates',
-              onClick: () => setActiveView('templates'),
-            }}
             description="Ask your agent to build a template, then start a session from it."
             icon={Dumbbell}
             title="No workouts yet"


### PR DESCRIPTION
## Summary
This PR closes a set of QA round-2 defects by tightening workout routing behavior, fixing mobile nutrition layout issues, correcting exercise seed data, and standardizing number display logic across the UI. The workouts flow now correctly routes in-progress sessions to the active workout page, removes dead/demo-only template actions, and shows a proper empty state when no active session or template is selected. Nutrition macro rings were updated to use a responsive grid that renders as `2x2` on mobile and a single row on larger screens, with ring label sizing adjusted to scale reliably. On the backend, a new idempotent migration fixes six miscategorized exercises without affecting already-correct rows.

## Key Changes
- Added `apps/api/drizzle/0017_fix_exercise_categories.sql` to reclassify six exercises with category-guarded `UPDATE` statements.
- Added migration coverage that runs the SQL twice to verify idempotency and confirms non-target rows remain unchanged.
- Fixed workouts navigation so in-progress sessions link to `/workouts/active?...&sessionId=...` instead of session detail routes.
- Updated active workout page session resolution to use `sessionId` from URL or stored active session ID, and added a true “No active workout” empty state.
- Removed no-op/dead “Create template” workout actions and aligned empty-state copy with agent-driven template creation.
- Introduced shared `format-utils` (`formatCalories`, `formatGrams`, `formatWeight`, `formatPercent`, `formatTrendChange`, `formatServing`) and applied it across dashboard, habits, nutrition, and workouts components.
- Fixed macro rings mobile layout (`grid-cols-2` mobile, expanded layout at larger breakpoints) and improved progress-ring label width behavior to scale with component size.

## Technical Notes
- Number formatting is now centralized and deterministic; this intentionally removes mixed ad-hoc formatting patterns (including prior thousands-separator behavior in some views) to eliminate rounding/display inconsistencies.
- The exercise category migration is safe to re-run because each update includes both `name` and expected prior `category` in the `WHERE` clause.
- Workout route behavior is now status-aware at link construction time, reducing invalid navigation paths and preventing accidental entry into the active flow from template/onboarding CTAs.
- Existing TODOs around inferred tracking metadata in workout comparison/session detail remain; this PR keeps current inference behavior but improves output formatting consistency.

## Commits

- `099f333 fix(api): add idempotent exercise category correction migration`
- `dcb43d5 fix(workouts): remove no-op templates action and dead active init code`
- `3580a01 fix(workouts): clean active route flow and session navigation`
- `35320fd fix(web): resolve commit-2 review follow-ups`
- `1512636 fix(nutrition): fix macro rings mobile grid layout`
- `3256f20 fix(web): centralize number display formatting`

## Tasks

- **Centralize number display formatting and fix all components**: Fix floating-point display bugs by centralizing rounding rules into shared utils
- **Fix macro rings mobile layout**: Change macro rings from vertical stack to 2x2 grid on mobile, single row on desktop
- **Fix workout page routing and navigation bugs**: Fix routing bugs, remove demo data, remove create template button, fix in-progress session links
- **Fix miscategorized exercises via data migration**: Migration to correct 6 exercises with wrong category assignments

## Diff Stats

```
apps/api/drizzle/0017_fix_exercise_categories.sql  |  34 ++++
 apps/api/drizzle/meta/_journal.json                |   7 +
 apps/api/src/db/migrations.test.ts                 | 172 +++++++++++++++++++++
 apps/web/src/App.test.tsx                          |   2 +-
 apps/web/src/components/ui/progress-ring.test.tsx  |   7 +
 apps/web/src/components/ui/progress-ring.tsx       |   4 +-
 .../dashboard/components/snapshot-cards.test.tsx   |  10 +-
 .../dashboard/components/snapshot-cards.tsx        |  23 ++-
 .../dashboard/components/trend-sparkline.test.tsx  |  70 ++++-----
 .../dashboard/components/trend-sparkline.tsx       |  39 +++--
 .../dashboard/components/weight-trend-chart.tsx    |  82 +++++++---
 .../features/habits/components/daily-habits.tsx    |   5 +-
 .../features/habits/components/habit-history.tsx   |  37 ++++-
 .../nutrition/components/macro-rings.test.tsx      |  20 +++
 .../features/nutrition/components/macro-rings.tsx  |  11 +-
 .../components/nutrition-macro-rings.test.tsx      |  18 +++
 .../nutrition/components/nutrition-macro-rings.tsx |  36 ++++-
 .../src/features/nutrition/lib/nutrition-utils.ts  |  22 ++-
 .../components/session-comparison.test.tsx         |  16 +-
 .../workouts/components/session-comparison.tsx     |  75 ++++++---
 .../workouts/components/session-detail.tsx         |  59 +++++--
 .../components/session-exercise-list.test.tsx      |  24 +--
 .../workouts/components/session-exercise-list.tsx  |   3 +-
 .../workouts/components/workout-calendar.tsx       |   2 +
 .../workouts/components/workout-list.test.tsx      |   4 +
 .../features/workouts/components/workout-list.tsx  |   9 +-
 apps/web/src/lib/format-utils.test.ts              |  38 +++++
 apps/web/src/lib/format-utils.ts                   |  46 ++++++
 apps/web/src/pages/active-workout.test.tsx         |  40 ++++-
 apps/web/src/pages/active-workout.tsx              |  40 ++---
 apps/web/src/pages/dashboard.test.tsx              |   4 +-
 apps/web/src/pages/workouts.test.tsx               |  34 ++--
 apps/web/src/pages/workouts.tsx                    |  22 ++-
 33 files changed, 768 insertions(+), 247 deletions(-)
```