### PR TITLE
feat: global soft delete with trash management (QA #1)

### DIFF
--- a/.agents/skills/pulse-app-usage/SKILL.md
+++ b/.agents/skills/pulse-app-usage/SKILL.md
@@ -21,6 +21,8 @@ Use this flow when an agent creates exercises/templates and then logs workout se
 
 ## Notes
 
+- User-facing records in habits, workout templates, exercises, foods, and workout sessions are soft-deleted via `deletedAt`; deleted records are hidden from normal list/search/get endpoints.
+- Use `GET /api/v1/trash` to inspect deleted items, `POST /api/v1/trash/:type/:id/restore` to restore, and `DELETE /api/v1/trash/:type/:id` to permanently purge.
 - New exercises auto-created during template creation intentionally use placeholder metadata (`muscleGroups: []`, `equipment: ""`, `instructions: null`) until enriched.
 - Template creation is non-blocking: possible duplicate hints are returned in `newExercises[*].possibleDuplicates`.
 - Workout session status transitions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ pnpm --filter shared build  # Build shared package
 - **Workouts**: The most complex UI domain. Templates → Sessions → Sets. Active session state persists in localStorage.
 - **Habits**: User-configurable with boolean/numeric/time tracking types. Feed into dashboard "don't break the chain" widgets.
 - **Foods**: Per-user database. `lastUsedAt` tracks recency for agent quick-matching.
+- **Trash & Soft Delete**: User-facing habits, workout templates, exercises, foods, and workout sessions use `deletedAt` soft delete; restore/purge flows are handled via `/api/v1/trash`.
 
 ## PRD & Build Plan
 

--- a/apps/api/drizzle/0021_soft_delete_columns.sql
+++ b/apps/api/drizzle/0021_soft_delete_columns.sql
@@ -7,3 +7,13 @@ ALTER TABLE exercises ADD COLUMN deleted_at text;
 ALTER TABLE foods ADD COLUMN deleted_at text;
 --> statement-breakpoint
 ALTER TABLE workout_sessions ADD COLUMN deleted_at text;
+--> statement-breakpoint
+CREATE INDEX idx_habits_user_id_deleted_at ON habits(user_id, deleted_at);
+--> statement-breakpoint
+CREATE INDEX idx_workout_templates_user_id_deleted_at ON workout_templates(user_id, deleted_at);
+--> statement-breakpoint
+CREATE INDEX idx_exercises_user_id_deleted_at ON exercises(user_id, deleted_at);
+--> statement-breakpoint
+CREATE INDEX idx_foods_user_id_deleted_at ON foods(user_id, deleted_at);
+--> statement-breakpoint
+CREATE INDEX idx_workout_sessions_user_id_deleted_at ON workout_sessions(user_id, deleted_at);

--- a/apps/api/drizzle/0021_soft_delete_columns.sql
+++ b/apps/api/drizzle/0021_soft_delete_columns.sql
@@ -1,0 +1,9 @@
+ALTER TABLE habits ADD COLUMN deleted_at text;
+--> statement-breakpoint
+ALTER TABLE workout_templates ADD COLUMN deleted_at text;
+--> statement-breakpoint
+ALTER TABLE exercises ADD COLUMN deleted_at text;
+--> statement-breakpoint
+ALTER TABLE foods ADD COLUMN deleted_at text;
+--> statement-breakpoint
+ALTER TABLE workout_sessions ADD COLUMN deleted_at text;

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1773303265036,
       "tag": "0020_session_set_order_index",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1773306865036,
+      "tag": "0021_soft_delete_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/__tests__/workouts.test.ts
+++ b/apps/api/src/__tests__/workouts.test.ts
@@ -338,12 +338,24 @@ describe('workouts integration', () => {
     });
 
     const remainingTemplateExercises = context.db
-      .select({ id: templateExercises.id })
+      .select({ id: templateExercises.id, templateId: templateExercises.templateId })
       .from(templateExercises)
       .where(eq(templateExercises.templateId, createdTemplate.id))
       .all();
 
-    expect(remainingTemplateExercises).toEqual([]);
+    expect(remainingTemplateExercises).toHaveLength(2);
+    expect(remainingTemplateExercises.every((row) => row.templateId === createdTemplate.id)).toBe(
+      true,
+    );
+
+    const deletedTemplate = context.db
+      .select({ deletedAt: workoutTemplates.deletedAt })
+      .from(workoutTemplates)
+      .where(eq(workoutTemplates.id, createdTemplate.id))
+      .get();
+    expect(deletedTemplate).toEqual({
+      deletedAt: expect.any(String),
+    });
   });
 
   it('handles session lifecycle with template-derived planned sets and live set logging', async () => {
@@ -376,19 +388,21 @@ describe('workouts integration', () => {
     });
 
     expect(startResponse.statusCode).toBe(201);
-    const startedSession = (startResponse.json() as {
-      data: {
-        id: string;
-        templateId: string | null;
-        status: 'scheduled' | 'in-progress' | 'completed';
-        sets: Array<{
-          exerciseId: string;
-          setNumber: number;
-          section: TemplateSectionType | null;
-          completed: boolean;
-        }>;
-      };
-    }).data;
+    const startedSession = (
+      startResponse.json() as {
+        data: {
+          id: string;
+          templateId: string | null;
+          status: 'scheduled' | 'in-progress' | 'completed';
+          sets: Array<{
+            exerciseId: string;
+            setNumber: number;
+            section: TemplateSectionType | null;
+            completed: boolean;
+          }>;
+        };
+      }
+    ).data;
 
     expect(startedSession.templateId).toBe(template.id);
     expect(startedSession.status).toBe('in-progress');
@@ -441,12 +455,14 @@ describe('workouts integration', () => {
 
     expect(groupedSetResponse.statusCode).toBe(200);
 
-    const groupedSets = (groupedSetResponse.json() as {
-      data: Array<{
-        exerciseId: string;
-        sets: Array<{ setNumber: number }>;
-      }>;
-    }).data;
+    const groupedSets = (
+      groupedSetResponse.json() as {
+        data: Array<{
+          exerciseId: string;
+          sets: Array<{ setNumber: number }>;
+        }>;
+      }
+    ).data;
 
     const benchGroup = groupedSets.find((group) => group.exerciseId === 'global-bench-press');
     expect(benchGroup?.sets.map((set) => set.setNumber)).toEqual([1, 2, 3, 4]);
@@ -536,13 +552,15 @@ describe('workouts integration', () => {
 
     expect(rangeResponse.statusCode).toBe(200);
 
-    const rangeItems = (rangeResponse.json() as {
-      data: Array<{
-        id: string;
-        templateName: string | null;
-        date: string;
-      }>;
-    }).data;
+    const rangeItems = (
+      rangeResponse.json() as {
+        data: Array<{
+          id: string;
+          templateName: string | null;
+          date: string;
+        }>;
+      }
+    ).data;
 
     expect(rangeItems.map((item) => item.id)).toEqual([firstScheduleId, secondScheduleId]);
     expect(rangeItems.map((item) => item.templateName)).toEqual(['Template A', 'Template B']);
@@ -626,13 +644,15 @@ describe('workouts integration', () => {
     });
 
     expect(createResponse.statusCode).toBe(201);
-    const createdExercise = (createResponse.json() as {
-      data: {
-        id: string;
-        userId: string | null;
-        name: string;
-      };
-    }).data;
+    const createdExercise = (
+      createResponse.json() as {
+        data: {
+          id: string;
+          userId: string | null;
+          name: string;
+        };
+      }
+    ).data;
 
     expect(createdExercise.userId).toBe('user-1');
     expect(createdExercise.name).toBe('Single Arm Cable Row');

--- a/apps/api/src/db/schema.test.ts
+++ b/apps/api/src/db/schema.test.ts
@@ -129,6 +129,7 @@ describe('foods schema', () => {
       'source',
       'notes',
       'lastUsedAt',
+      'deletedAt',
       'createdAt',
       'updatedAt',
     ]);
@@ -773,6 +774,7 @@ describe('habits schema', () => {
       'frequencyTarget',
       'scheduledDays',
       'pausedUntil',
+      'deletedAt',
       'sortOrder',
       'active',
       'createdAt',
@@ -818,6 +820,7 @@ describe('exercises schema', () => {
       'tags',
       'formCues',
       'instructions',
+      'deletedAt',
       'createdAt',
       'updatedAt',
     ]);
@@ -855,6 +858,7 @@ describe('workoutTemplates schema', () => {
       'name',
       'description',
       'tags',
+      'deletedAt',
       'createdAt',
       'updatedAt',
     ]);
@@ -949,6 +953,7 @@ describe('workoutSessions schema', () => {
       'timeSegments',
       'feedback',
       'notes',
+      'deletedAt',
       'createdAt',
       'updatedAt',
     ]);

--- a/apps/api/src/db/schema/exercises.ts
+++ b/apps/api/src/db/schema/exercises.ts
@@ -35,6 +35,7 @@ export const exercises = sqliteTable(
     tags: text('tags', { mode: 'json' }).$type<string[]>().notNull().default([]),
     formCues: text('form_cues', { mode: 'json' }).$type<string[]>().notNull().default([]),
     instructions: text('instructions'),
+    deletedAt: text('deleted_at'),
     createdAt: integer('created_at', { mode: 'number' })
       .notNull()
       .default(sql`(unixepoch() * 1000)`)

--- a/apps/api/src/db/schema/foods.ts
+++ b/apps/api/src/db/schema/foods.ts
@@ -8,7 +8,9 @@ import { users } from './users.js';
 export const foods = sqliteTable(
   'foods',
   {
-    id: text('id').primaryKey().$defaultFn(() => randomUUID()),
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => randomUUID()),
     userId: text('user_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
@@ -26,6 +28,7 @@ export const foods = sqliteTable(
     source: text('source'),
     notes: text('notes'),
     lastUsedAt: integer('last_used_at', { mode: 'number' }),
+    deletedAt: text('deleted_at'),
     createdAt: integer('created_at', { mode: 'number' })
       .notNull()
       .default(sql`(unixepoch() * 1000)`)
@@ -38,7 +41,10 @@ export const foods = sqliteTable(
   },
   (table) => [
     index('foods_user_last_used_at_idx').on(table.userId, table.lastUsedAt),
-    check('foods_serving_grams_check', sql`${table.servingGrams} is null or ${table.servingGrams} > 0`),
+    check(
+      'foods_serving_grams_check',
+      sql`${table.servingGrams} is null or ${table.servingGrams} > 0`,
+    ),
     check(
       'foods_macros_nonnegative_check',
       sql`${table.calories} >= 0 and ${table.protein} >= 0 and ${table.carbs} >= 0 and ${table.fat} >= 0`,

--- a/apps/api/src/db/schema/habits.ts
+++ b/apps/api/src/db/schema/habits.ts
@@ -27,6 +27,7 @@ export const habits = sqliteTable(
     frequencyTarget: integer('frequency_target'),
     scheduledDays: text('scheduled_days'),
     pausedUntil: text('paused_until'),
+    deletedAt: text('deleted_at'),
     sortOrder: integer('sort_order').notNull().default(0),
     active: integer('active', { mode: 'boolean' }).notNull().default(true),
     createdAt: integer('created_at', { mode: 'number' })

--- a/apps/api/src/db/schema/workout-sessions.ts
+++ b/apps/api/src/db/schema/workout-sessions.ts
@@ -87,6 +87,7 @@ export const workoutSessions = sqliteTable(
     // JSON-encoded WorkoutSessionFeedback; use the serializer helpers when reading or writing.
     feedback: text('feedback'),
     notes: text('notes'),
+    deletedAt: text('deleted_at'),
     createdAt: integer('created_at', { mode: 'number' })
       .notNull()
       .default(sql`(unixepoch() * 1000)`)

--- a/apps/api/src/db/schema/workout-templates.ts
+++ b/apps/api/src/db/schema/workout-templates.ts
@@ -20,6 +20,7 @@ export const workoutTemplates = sqliteTable(
     name: text('name').notNull(),
     description: text('description'),
     tags: text('tags', { mode: 'json' }).$type<string[]>().notNull(),
+    deletedAt: text('deleted_at'),
     createdAt: integer('created_at', { mode: 'number' })
       .notNull()
       .default(sql`(unixepoch() * 1000)`)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -12,6 +12,7 @@ import { habitRoutes } from './routes/habits/index.js';
 import { nutritionRoutes } from './routes/nutrition/index.js';
 import { nutritionTargetRoutes } from './routes/nutrition-targets/index.js';
 import { scheduledWorkoutRoutes } from './routes/scheduled-workouts/index.js';
+import { trashRoutes } from './routes/trash/index.js';
 import { v1Routes } from './routes/v1/index.js';
 import { weightRoutes } from './routes/weight/index.js';
 import { workoutSessionRoutes } from './routes/workout-sessions/index.js';
@@ -49,6 +50,7 @@ export const buildServer = () => {
   app.register(nutritionRoutes, { prefix: '/api/v1/nutrition' });
   app.register(nutritionTargetRoutes, { prefix: '/api/v1/nutrition-targets' });
   app.register(scheduledWorkoutRoutes, { prefix: '/api/v1/scheduled-workouts' });
+  app.register(trashRoutes, { prefix: '/api/v1/trash' });
   app.register(v1Routes, { prefix: '/api/v1' });
   app.register(weightRoutes, { prefix: '/api/v1/weight' });
   app.register(workoutSessionRoutes, { prefix: '/api/v1/workout-sessions' });

--- a/apps/api/src/routes/agent/context-store.ts
+++ b/apps/api/src/routes/agent/context-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gte, inArray, lte, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, inArray, isNull, lte, or, sql } from 'drizzle-orm';
 import type { AgentContextResponse } from '@pulse/shared';
 
 import {
@@ -61,7 +61,13 @@ export const listAgentContextRecentWorkouts = async (
       createdAt: workoutSessions.createdAt,
     })
     .from(workoutSessions)
-    .where(and(eq(workoutSessions.userId, userId), eq(workoutSessions.status, 'completed')))
+    .where(
+      and(
+        eq(workoutSessions.userId, userId),
+        isNull(workoutSessions.deletedAt),
+        eq(workoutSessions.status, 'completed'),
+      ),
+    )
     .orderBy(
       desc(workoutSessions.date),
       desc(workoutSessions.completedAt),
@@ -87,7 +93,15 @@ export const listAgentContextRecentWorkouts = async (
     })
     .from(sessionSets)
     .innerJoin(exercises, eq(exercises.id, sessionSets.exerciseId))
-    .where(inArray(sessionSets.sessionId, sessionIds))
+    .where(
+      and(
+        inArray(sessionSets.sessionId, sessionIds),
+        or(
+          isNull(exercises.userId),
+          and(eq(exercises.userId, userId), isNull(exercises.deletedAt)),
+        ),
+      ),
+    )
     .orderBy(asc(sessionSets.createdAt), asc(sessionSets.setNumber))
     .all();
 
@@ -149,24 +163,23 @@ export const getAgentContextTodayNutrition = async (
 ): Promise<AgentContextResponse['todayNutrition']> => {
   const { db } = await import('../../db/index.js');
 
-  const actual =
-    db
-      .select({
-        calories: sql<number>`coalesce(sum(${mealItems.calories}), 0)`,
-        protein: sql<number>`coalesce(sum(${mealItems.protein}), 0)`,
-        carbs: sql<number>`coalesce(sum(${mealItems.carbs}), 0)`,
-        fat: sql<number>`coalesce(sum(${mealItems.fat}), 0)`,
-      })
-      .from(nutritionLogs)
-      .leftJoin(meals, eq(meals.nutritionLogId, nutritionLogs.id))
-      .leftJoin(mealItems, eq(mealItems.mealId, meals.id))
-      .where(and(eq(nutritionLogs.userId, userId), eq(nutritionLogs.date, date)))
-      .get() ?? {
-      calories: 0,
-      protein: 0,
-      carbs: 0,
-      fat: 0,
-    };
+  const actual = db
+    .select({
+      calories: sql<number>`coalesce(sum(${mealItems.calories}), 0)`,
+      protein: sql<number>`coalesce(sum(${mealItems.protein}), 0)`,
+      carbs: sql<number>`coalesce(sum(${mealItems.carbs}), 0)`,
+      fat: sql<number>`coalesce(sum(${mealItems.fat}), 0)`,
+    })
+    .from(nutritionLogs)
+    .leftJoin(meals, eq(meals.nutritionLogId, nutritionLogs.id))
+    .leftJoin(mealItems, eq(mealItems.mealId, meals.id))
+    .where(and(eq(nutritionLogs.userId, userId), eq(nutritionLogs.date, date)))
+    .get() ?? {
+    calories: 0,
+    protein: 0,
+    carbs: 0,
+    fat: 0,
+  };
 
   const target =
     db
@@ -327,7 +340,7 @@ export const listAgentContextHabits = async (
       createdAt: habits.createdAt,
     })
     .from(habits)
-    .where(and(eq(habits.userId, userId), eq(habits.active, true)))
+    .where(and(eq(habits.userId, userId), eq(habits.active, true), isNull(habits.deletedAt)))
     .orderBy(asc(habits.sortOrder), asc(habits.createdAt))
     .all();
 
@@ -397,7 +410,13 @@ export const listAgentContextScheduledWorkouts = async ({
       createdAt: scheduledWorkouts.createdAt,
     })
     .from(scheduledWorkouts)
-    .leftJoin(workoutTemplates, eq(workoutTemplates.id, scheduledWorkouts.templateId))
+    .leftJoin(
+      workoutTemplates,
+      and(
+        eq(workoutTemplates.id, scheduledWorkouts.templateId),
+        isNull(workoutTemplates.deletedAt),
+      ),
+    )
     .where(
       and(
         eq(scheduledWorkouts.userId, userId),

--- a/apps/api/src/routes/agent/exercises.ts
+++ b/apps/api/src/routes/agent/exercises.ts
@@ -97,7 +97,7 @@ export const agentExerciseRoutes: FastifyPluginAsync = async (app) => {
       return reply.send({ data: updated });
     }
 
-    const ownership = await findExerciseOwnership(request.params.id);
+    const ownership = await findExerciseOwnership(request.params.id, request.userId);
     if (!ownership) {
       return sendError(
         reply,

--- a/apps/api/src/routes/agent/store.ts
+++ b/apps/api/src/routes/agent/store.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm';
 
 import { foods } from '../../db/schema/index.js';
 
@@ -35,7 +35,7 @@ export const searchFoodsByName = async (
 ): Promise<AgentFoodRecord[]> => {
   const { db } = await import('../../db/index.js');
 
-  const conditions = [eq(foods.userId, userId)];
+  const conditions = [eq(foods.userId, userId), isNull(foods.deletedAt)];
   if (query) {
     const pattern = `%${escapeLikePattern(query)}%`;
     conditions.push(
@@ -45,7 +45,13 @@ export const searchFoodsByName = async (
 
   const where = conditions.length === 1 ? conditions[0] : and(...conditions);
 
-  return db.select(agentFoodSelection).from(foods).where(where).orderBy(recentSortExpr).limit(limit).all();
+  return db
+    .select(agentFoodSelection)
+    .from(foods)
+    .where(where)
+    .orderBy(recentSortExpr)
+    .limit(limit)
+    .all();
 };
 
 export const findFoodByName = async (
@@ -59,7 +65,13 @@ export const findFoodByName = async (
   const exact = db
     .select(agentFoodSelection)
     .from(foods)
-    .where(and(eq(foods.userId, userId), sql`lower(${foods.name}) = ${nameLower}`))
+    .where(
+      and(
+        eq(foods.userId, userId),
+        isNull(foods.deletedAt),
+        sql`lower(${foods.name}) = ${nameLower}`,
+      ),
+    )
     .orderBy(recentSortExpr)
     .limit(1)
     .get();
@@ -73,7 +85,11 @@ export const findFoodByName = async (
     .select(agentFoodSelection)
     .from(foods)
     .where(
-      and(eq(foods.userId, userId), sql`lower(${foods.name}) like ${pattern} escape '\\'`),
+      and(
+        eq(foods.userId, userId),
+        isNull(foods.deletedAt),
+        sql`lower(${foods.name}) like ${pattern} escape '\\'`,
+      ),
     )
     .orderBy(recentSortExpr)
     .limit(1)

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -679,8 +679,15 @@ describe('exercise routes', () => {
       },
     });
 
-    const remainingExerciseIds = context.db.select({ id: exercises.id }).from(exercises).all();
-    expect(remainingExerciseIds).toEqual([{ id: 'global-exercise' }]);
+    const remainingExercises = context.db
+      .select({ id: exercises.id, deletedAt: exercises.deletedAt })
+      .from(exercises)
+      .orderBy(exercises.id)
+      .all();
+    expect(remainingExercises).toEqual([
+      { id: 'global-exercise', deletedAt: null },
+      { id: 'user-exercise', deletedAt: expect.any(String) },
+    ]);
 
     const globalResponse = await context.app.inject({
       method: 'DELETE',
@@ -962,6 +969,56 @@ describe('exercise routes', () => {
         formCues: ['slight elbow bend'],
         tags: ['hypertrophy'],
       }),
+    });
+  });
+
+  it('agent exercise search excludes soft-deleted user exercises', async () => {
+    context.db
+      .insert(exercises)
+      .values({
+        id: 'active-owned',
+        userId: 'user-1',
+        name: 'Cable Curl',
+        muscleGroups: ['biceps'],
+        equipment: 'cable',
+        category: 'isolation',
+        tags: [],
+        formCues: [],
+        instructions: null,
+      })
+      .run();
+    context.db
+      .insert(exercises)
+      .values({
+        id: 'deleted-owned',
+        userId: 'user-1',
+        name: 'Cable Curl Old',
+        muscleGroups: ['biceps'],
+        equipment: 'cable',
+        category: 'isolation',
+        tags: [],
+        formCues: [],
+        instructions: null,
+        deletedAt: new Date().toISOString(),
+      })
+      .run();
+
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    const response = await context.app.inject({
+      method: 'GET',
+      url: '/api/agent/exercises/search?q=cable%20curl&limit=10',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: [
+        expect.objectContaining({
+          id: 'active-owned',
+          name: 'Cable Curl',
+        }),
+      ],
     });
   });
 });

--- a/apps/api/src/routes/exercises/index.ts
+++ b/apps/api/src/routes/exercises/index.ts
@@ -40,7 +40,7 @@ const ensureOwnedMutableExercise = async ({
   reply: FastifyReply;
   userId: string;
 }) => {
-  const exerciseOwnership = await findExerciseOwnership(exerciseId);
+  const exerciseOwnership = await findExerciseOwnership(exerciseId, userId);
   if (!exerciseOwnership) {
     sendError(reply, 404, EXERCISE_NOT_FOUND_RESPONSE.code, EXERCISE_NOT_FOUND_RESPONSE.message);
     return false;

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -192,6 +192,7 @@ export const findExerciseById = async (id: string): Promise<Exercise | undefined
 
 export const findExerciseOwnership = async (
   id: string,
+  userId: string,
 ): Promise<ExerciseOwnershipRecord | undefined> => {
   const { db } = await import('../../db/index.js');
 
@@ -201,7 +202,15 @@ export const findExerciseOwnership = async (
       userId: exercises.userId,
     })
     .from(exercises)
-    .where(and(eq(exercises.id, id), or(isNull(exercises.userId), isNull(exercises.deletedAt))))
+    .where(
+      and(
+        eq(exercises.id, id),
+        or(
+          and(isNull(exercises.userId), isNull(exercises.deletedAt)),
+          and(eq(exercises.userId, userId), isNull(exercises.deletedAt)),
+        ),
+      ),
+    )
     .limit(1)
     .get();
 };

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -58,7 +58,7 @@ const buildListWhereClause = ({
   category,
 }: Omit<ListExercisesInput, 'page' | 'limit'>) =>
   and(
-    or(isNull(exercises.userId), eq(exercises.userId, userId)),
+    or(isNull(exercises.userId), and(eq(exercises.userId, userId), isNull(exercises.deletedAt))),
     q ? sql`lower(${exercises.name}) like ${`%${q.toLowerCase()}%`}` : undefined,
     muscleGroup
       ? sql`exists (
@@ -166,7 +166,9 @@ export const listExerciseFilters = async (userId: string): Promise<ExerciseFilte
       equipment: exercises.equipment,
     })
     .from(exercises)
-    .where(or(isNull(exercises.userId), eq(exercises.userId, userId)))
+    .where(
+      or(isNull(exercises.userId), and(eq(exercises.userId, userId), isNull(exercises.deletedAt))),
+    )
     .all();
 
   return {
@@ -180,7 +182,12 @@ export const listExerciseFilters = async (userId: string): Promise<ExerciseFilte
 export const findExerciseById = async (id: string): Promise<Exercise | undefined> => {
   const { db } = await import('../../db/index.js');
 
-  return db.select(exerciseSelection).from(exercises).where(eq(exercises.id, id)).limit(1).get();
+  return db
+    .select(exerciseSelection)
+    .from(exercises)
+    .where(and(eq(exercises.id, id), isNull(exercises.deletedAt)))
+    .limit(1)
+    .get();
 };
 
 export const findExerciseOwnership = async (
@@ -194,7 +201,7 @@ export const findExerciseOwnership = async (
       userId: exercises.userId,
     })
     .from(exercises)
-    .where(eq(exercises.id, id))
+    .where(and(eq(exercises.id, id), or(isNull(exercises.userId), isNull(exercises.deletedAt))))
     .limit(1)
     .get();
 };
@@ -213,7 +220,7 @@ export const updateOwnedExercise = async ({
   const [updatedExercise] = await db
     .update(exercises)
     .set(changes)
-    .where(and(eq(exercises.id, id), eq(exercises.userId, userId)))
+    .where(and(eq(exercises.id, id), eq(exercises.userId, userId), isNull(exercises.deletedAt)))
     .returning(exerciseSelection);
 
   return updatedExercise;
@@ -223,8 +230,11 @@ export const deleteOwnedExercise = async (id: string, userId: string): Promise<b
   const { db } = await import('../../db/index.js');
 
   const result = db
-    .delete(exercises)
-    .where(and(eq(exercises.id, id), eq(exercises.userId, userId)))
+    .update(exercises)
+    .set({
+      deletedAt: new Date().toISOString(),
+    })
+    .where(and(eq(exercises.id, id), eq(exercises.userId, userId), isNull(exercises.deletedAt)))
     .run();
 
   return result.changes === 1;
@@ -245,7 +255,15 @@ export const findVisibleExerciseById = async ({
       userId: exercises.userId,
     })
     .from(exercises)
-    .where(and(eq(exercises.id, id), or(isNull(exercises.userId), eq(exercises.userId, userId))))
+    .where(
+      and(
+        eq(exercises.id, id),
+        or(
+          isNull(exercises.userId),
+          and(eq(exercises.userId, userId), isNull(exercises.deletedAt)),
+        ),
+      ),
+    )
     .limit(1)
     .get();
 };
@@ -266,7 +284,10 @@ export const findVisibleExerciseByName = async ({
     .where(
       and(
         sql`lower(${exercises.name}) = ${normalizedName}`,
-        or(isNull(exercises.userId), eq(exercises.userId, userId)),
+        or(
+          isNull(exercises.userId),
+          and(eq(exercises.userId, userId), isNull(exercises.deletedAt)),
+        ),
       ),
     )
     .orderBy(sql`case when ${exercises.userId} is null then 1 else 0 end asc`, asc(exercises.name))
@@ -290,7 +311,9 @@ const normalizeExerciseName = (name: string): string => {
   }
 
   const parts = normalized.split(' ');
-  const filtered = parts.filter((part, index) => !(index === 0 && EXERCISE_PREFIXES.includes(part)));
+  const filtered = parts.filter(
+    (part, index) => !(index === 0 && EXERCISE_PREFIXES.includes(part)),
+  );
 
   return filtered.join(' ').trim();
 };
@@ -354,7 +377,11 @@ const calculateExerciseSimilarity = (input: string, candidate: string): number =
   }
 
   if (input.includes(candidate) || candidate.includes(input)) {
-    return Number((Math.min(input.length, candidate.length) / Math.max(input.length, candidate.length)).toFixed(2));
+    return Number(
+      (Math.min(input.length, candidate.length) / Math.max(input.length, candidate.length)).toFixed(
+        2,
+      ),
+    );
   }
 
   return calculateLevenshteinSimilarity(input, candidate);
@@ -373,10 +400,11 @@ export const findExerciseDedupCandidates = async ({
   const inputNormalized = normalizeExerciseName(name);
   const inputLower = name.trim().toLowerCase();
   const firstToken = (inputNormalized || inputLower).split(' ').find((token) => token.length > 0);
-  const tokenMatch = firstToken
-    ? firstToken.slice(0, Math.min(firstToken.length, 5))
-    : undefined;
-  const visibilityWhereClause = or(isNull(exercises.userId), eq(exercises.userId, userId));
+  const tokenMatch = firstToken ? firstToken.slice(0, Math.min(firstToken.length, 5)) : undefined;
+  const visibilityWhereClause = or(
+    isNull(exercises.userId),
+    and(eq(exercises.userId, userId), isNull(exercises.deletedAt)),
+  );
   const candidateFilter =
     tokenMatch && tokenMatch.length > 0
       ? sql`lower(${exercises.name}) like ${`%${escapeSqlLikePattern(tokenMatch)}%`} escape '\\'`
@@ -449,6 +477,7 @@ export const findExerciseLastPerformance = async ({
     .where(
       and(
         eq(workoutSessions.userId, userId),
+        isNull(workoutSessions.deletedAt),
         eq(workoutSessions.status, 'completed'),
         sql`exists (
           select 1

--- a/apps/api/src/routes/foods/store.test.ts
+++ b/apps/api/src/routes/foods/store.test.ts
@@ -373,14 +373,17 @@ describe('foods store', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('deletes foods by scope and scopes lastUsedAt updates to the user', async () => {
+  it('soft-deletes foods by scope and scopes lastUsedAt updates to the user', async () => {
     const { deleteFood, updateFoodLastUsedAt } = await import('./store.js');
 
     await expect(deleteFood('food-1', 'user-1')).resolves.toBe(true);
-    expect(dbState.deleteWhereCalls).toHaveLength(1);
+    expect(dbState.updateSets[0]).toEqual({
+      deletedAt: expect.any(String),
+    });
 
-    dbState.deleteRunResult = { changes: 0 };
+    dbState.updateRunResult = { changes: 0 };
     await expect(deleteFood('food-1', 'user-2')).resolves.toBe(false);
+    dbState.updateRunResult = { changes: 1 };
 
     await updateFoodLastUsedAt('food-1', 'user-1', 1_700_000_300_000);
 

--- a/apps/api/src/routes/foods/store.ts
+++ b/apps/api/src/routes/foods/store.ts
@@ -1,4 +1,4 @@
-import { and, count, eq, sql, type SQL } from 'drizzle-orm';
+import { and, count, eq, isNull, sql, type SQL } from 'drizzle-orm';
 import type {
   CreateFoodInput,
   Food,
@@ -46,7 +46,7 @@ const toNullable = <T>(value: T | undefined): T | null => value ?? null;
 const escapeLikePattern = (value: string) => value.toLowerCase().replace(/[%_\\]/g, '\\$&');
 
 const buildFoodFilters = (userId: string, query?: string) => {
-  const filters: SQL<unknown>[] = [eq(foods.userId, userId)];
+  const filters: SQL<unknown>[] = [eq(foods.userId, userId), isNull(foods.deletedAt)];
 
   if (query) {
     const pattern = `%${escapeLikePattern(query)}%`;
@@ -80,7 +80,7 @@ const getFoodById = async (id: string, userId: string): Promise<FoodRecord | und
   return db
     .select(foodSelection)
     .from(foods)
-    .where(and(eq(foods.id, id), eq(foods.userId, userId)))
+    .where(and(eq(foods.id, id), eq(foods.userId, userId), isNull(foods.deletedAt)))
     .limit(1)
     .get();
 };
@@ -234,7 +234,7 @@ export const updateFood = async (
   const result = db
     .update(foods)
     .set(nextValues)
-    .where(and(eq(foods.id, id), eq(foods.userId, userId)))
+    .where(and(eq(foods.id, id), eq(foods.userId, userId), isNull(foods.deletedAt)))
     .run();
 
   if (result.changes !== 1) {
@@ -248,8 +248,11 @@ export const deleteFood = async (id: string, userId: string): Promise<boolean> =
   const { db } = await import('../../db/index.js');
 
   const result = db
-    .delete(foods)
-    .where(and(eq(foods.id, id), eq(foods.userId, userId)))
+    .update(foods)
+    .set({
+      deletedAt: new Date().toISOString(),
+    })
+    .where(and(eq(foods.id, id), eq(foods.userId, userId), isNull(foods.deletedAt)))
     .run();
 
   return result.changes === 1;
@@ -267,7 +270,7 @@ export const updateFoodLastUsedAt = async (
     .set({
       lastUsedAt,
     })
-    .where(and(eq(foods.id, foodId), eq(foods.userId, userId)))
+    .where(and(eq(foods.id, foodId), eq(foods.userId, userId), isNull(foods.deletedAt)))
     .run();
 
   if (result.changes !== 1) {

--- a/apps/api/src/routes/habits/store.ts
+++ b/apps/api/src/routes/habits/store.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray, sql } from 'drizzle-orm';
+import { and, asc, eq, inArray, isNull, sql } from 'drizzle-orm';
 import type { CreateHabitInput, Habit, UpdateHabitInput } from '@pulse/shared';
 
 import { habits } from '../../db/schema/index.js';
@@ -86,7 +86,7 @@ export const getNextHabitSortOrder = async (userId: string): Promise<number> => 
       maxSortOrder: sql<number>`coalesce(max(${habits.sortOrder}), -1)`,
     })
     .from(habits)
-    .where(eq(habits.userId, userId))
+    .where(and(eq(habits.userId, userId), isNull(habits.deletedAt)))
     .get();
 
   return (result?.maxSortOrder ?? -1) + 1;
@@ -147,7 +147,7 @@ export const listActiveHabits = async (userId: string): Promise<HabitRecord[]> =
   const records = db
     .select(habitSelection)
     .from(habits)
-    .where(and(eq(habits.userId, userId), eq(habits.active, true)))
+    .where(and(eq(habits.userId, userId), eq(habits.active, true), isNull(habits.deletedAt)))
     .orderBy(asc(habits.sortOrder), asc(habits.createdAt))
     .all();
 
@@ -163,7 +163,7 @@ export const findHabitById = async (
   const record = db
     .select(habitSelection)
     .from(habits)
-    .where(and(eq(habits.id, id), eq(habits.userId, userId)))
+    .where(and(eq(habits.id, id), eq(habits.userId, userId), isNull(habits.deletedAt)))
     .limit(1)
     .get();
 
@@ -192,7 +192,7 @@ export const updateHabit = async (
       pausedUntil: updates.pausedUntil ?? null,
       ...(updates.active === undefined ? {} : { active: updates.active }),
     })
-    .where(and(eq(habits.id, id), eq(habits.userId, userId)))
+    .where(and(eq(habits.id, id), eq(habits.userId, userId), isNull(habits.deletedAt)))
     .run();
 
   if (result.changes !== 1) {
@@ -207,8 +207,8 @@ export const softDeleteHabit = async (id: string, userId: string): Promise<boole
 
   const result = db
     .update(habits)
-    .set({ active: false })
-    .where(and(eq(habits.id, id), eq(habits.userId, userId)))
+    .set({ active: false, deletedAt: new Date().toISOString() })
+    .where(and(eq(habits.id, id), eq(habits.userId, userId), isNull(habits.deletedAt)))
     .run();
 
   return result.changes === 1;
@@ -224,7 +224,14 @@ export const reorderHabits = async (
   const existingHabits = db
     .select({ id: habits.id })
     .from(habits)
-    .where(and(eq(habits.userId, userId), eq(habits.active, true), inArray(habits.id, ids)))
+    .where(
+      and(
+        eq(habits.userId, userId),
+        eq(habits.active, true),
+        isNull(habits.deletedAt),
+        inArray(habits.id, ids),
+      ),
+    )
     .all();
 
   if (existingHabits.length !== ids.length) {
@@ -240,7 +247,14 @@ export const reorderHabits = async (
     .set({
       sortOrder: sql<number>`case ${sortOrderCases} else ${habits.sortOrder} end`,
     })
-    .where(and(eq(habits.userId, userId), eq(habits.active, true), inArray(habits.id, ids)))
+    .where(
+      and(
+        eq(habits.userId, userId),
+        eq(habits.active, true),
+        isNull(habits.deletedAt),
+        inArray(habits.id, ids),
+      ),
+    )
     .run();
 
   return true;

--- a/apps/api/src/routes/trash/index.test.ts
+++ b/apps/api/src/routes/trash/index.test.ts
@@ -1,0 +1,361 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { eq } from 'drizzle-orm';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import type { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  exercises,
+  foods,
+  habitEntries,
+  habits,
+  mealItems,
+  meals,
+  nutritionLogs,
+  sessionSets,
+  users,
+  workoutSessions,
+  workoutTemplates,
+} from '../../db/schema/index.js';
+
+type DatabaseModule = typeof import('../../db/index.js');
+
+type TestContext = {
+  app: FastifyInstance;
+  db: DatabaseModule['db'];
+  sqlite: DatabaseModule['sqlite'];
+  tempDir: string;
+};
+
+let context: TestContext;
+
+const createAuthorizationHeader = (token: string) => ({
+  authorization: `Bearer ${token}`,
+});
+
+describe('trash routes', () => {
+  beforeAll(async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'pulse-trash-routes-'));
+
+    process.env.JWT_SECRET = 'test-trash-secret';
+    process.env.DATABASE_URL = join(tempDir, 'test.db');
+    vi.resetModules();
+
+    const [{ buildServer }, dbModule] = await Promise.all([
+      import('../../index.js'),
+      import('../../db/index.js'),
+    ]);
+
+    migrate(dbModule.db, {
+      migrationsFolder: fileURLToPath(new URL('../../../drizzle', import.meta.url)),
+    });
+
+    const app = buildServer();
+    await app.ready();
+
+    context = {
+      app,
+      db: dbModule.db,
+      sqlite: dbModule.sqlite,
+      tempDir,
+    };
+  });
+
+  afterAll(async () => {
+    if (context) {
+      await context.app.close();
+      context.sqlite.close();
+      rmSync(context.tempDir, { recursive: true, force: true });
+    }
+
+    delete process.env.JWT_SECRET;
+    delete process.env.DATABASE_URL;
+    vi.resetModules();
+  });
+
+  beforeEach(() => {
+    context.db.delete(mealItems).run();
+    context.db.delete(meals).run();
+    context.db.delete(nutritionLogs).run();
+    context.db.delete(sessionSets).run();
+    context.db.delete(workoutSessions).run();
+    context.db.delete(workoutTemplates).run();
+    context.db.delete(exercises).run();
+    context.db.delete(habitEntries).run();
+    context.db.delete(habits).run();
+    context.db.delete(foods).run();
+    context.db.delete(users).run();
+
+    context.db
+      .insert(users)
+      .values({
+        id: 'user-1',
+        username: 'derek',
+        name: 'Derek',
+        passwordHash: 'not-used',
+      })
+      .run();
+    context.db
+      .insert(users)
+      .values({
+        id: 'user-2',
+        username: 'alex',
+        name: 'Alex',
+        passwordHash: 'not-used',
+      })
+      .run();
+  });
+
+  it('lists soft-deleted items grouped by type', async () => {
+    context.db
+      .insert(habits)
+      .values({
+        id: 'habit-1',
+        userId: 'user-1',
+        name: 'Hydrate',
+        trackingType: 'boolean',
+        active: false,
+        deletedAt: '2026-03-10T00:00:00.000Z',
+      })
+      .run();
+    context.db
+      .insert(workoutTemplates)
+      .values({
+        id: 'template-1',
+        userId: 'user-1',
+        name: 'Upper A',
+        tags: [],
+        deletedAt: '2026-03-10T00:00:00.000Z',
+      })
+      .run();
+    context.db
+      .insert(foods)
+      .values({
+        id: 'food-1',
+        userId: 'user-1',
+        name: 'Greek Yogurt',
+        calories: 90,
+        protein: 18,
+        carbs: 5,
+        fat: 0,
+        deletedAt: '2026-03-10T00:00:00.000Z',
+      })
+      .run();
+    context.db
+      .insert(exercises)
+      .values({
+        id: 'exercise-1',
+        userId: 'user-1',
+        name: 'Bench Press',
+        muscleGroups: ['chest'],
+        equipment: 'barbell',
+        category: 'compound',
+        tags: [],
+        formCues: [],
+        instructions: null,
+      })
+      .run();
+
+    context.db
+      .insert(workoutSessions)
+      .values({
+        id: 'session-1',
+        userId: 'user-1',
+        templateId: null,
+        name: 'Push Day',
+        date: '2026-03-10',
+        startedAt: Date.now(),
+        deletedAt: '2026-03-10T00:00:00.000Z',
+      })
+      .run();
+
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+    const response = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/trash',
+      headers: createAuthorizationHeader(authToken),
+    });
+    const payload = response.json() as {
+      data: {
+        habits: Array<{ id: string }>;
+        'workout-templates': Array<{ id: string }>;
+        exercises: Array<{ id: string }>;
+        foods: Array<{ id: string }>;
+        'workout-sessions': Array<{ id: string }>;
+      };
+    };
+
+    expect(response.statusCode).toBe(200);
+    expect(payload.data.habits.map((item) => item.id)).toEqual(['habit-1']);
+    expect(payload.data['workout-templates'].map((item) => item.id)).toEqual(['template-1']);
+    expect(payload.data.exercises).toEqual([]);
+    expect(payload.data.foods.map((item) => item.id)).toEqual(['food-1']);
+    expect(payload.data['workout-sessions'].map((item) => item.id)).toEqual(['session-1']);
+  });
+
+  it('restores a soft-deleted habit', async () => {
+    context.db
+      .insert(habits)
+      .values({
+        id: 'habit-1',
+        userId: 'user-1',
+        name: 'Hydrate',
+        trackingType: 'boolean',
+        active: false,
+        deletedAt: '2026-03-10T00:00:00.000Z',
+      })
+      .run();
+
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/trash/habits/habit-1/restore',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: { success: true },
+    });
+
+    const restored = context.db
+      .select({ active: habits.active, deletedAt: habits.deletedAt })
+      .from(habits)
+      .where(eq(habits.id, 'habit-1'))
+      .get();
+
+    expect(restored).toEqual({
+      active: true,
+      deletedAt: null,
+    });
+  });
+
+  it('purges soft-deleted items and cascades linked records', async () => {
+    context.db
+      .insert(exercises)
+      .values({
+        id: 'exercise-1',
+        userId: 'user-1',
+        name: 'Bench Press',
+        muscleGroups: ['chest'],
+        equipment: 'barbell',
+        category: 'compound',
+        tags: [],
+        formCues: [],
+        instructions: null,
+      })
+      .run();
+
+    context.db
+      .insert(foods)
+      .values({
+        id: 'food-1',
+        userId: 'user-1',
+        name: 'Greek Yogurt',
+        calories: 90,
+        protein: 18,
+        carbs: 5,
+        fat: 0,
+        deletedAt: '2026-03-10T00:00:00.000Z',
+      })
+      .run();
+    context.db
+      .insert(nutritionLogs)
+      .values({
+        id: 'log-1',
+        userId: 'user-1',
+        date: '2026-03-10',
+      })
+      .run();
+    context.db
+      .insert(meals)
+      .values({
+        id: 'meal-1',
+        nutritionLogId: 'log-1',
+        name: 'Breakfast',
+      })
+      .run();
+    context.db
+      .insert(mealItems)
+      .values({
+        id: 'meal-item-1',
+        mealId: 'meal-1',
+        foodId: 'food-1',
+        name: 'Greek Yogurt',
+        amount: 1,
+        unit: 'cup',
+        calories: 90,
+        protein: 18,
+        carbs: 5,
+        fat: 0,
+      })
+      .run();
+
+    context.db
+      .insert(workoutSessions)
+      .values({
+        id: 'session-1',
+        userId: 'user-1',
+        templateId: null,
+        name: 'Push Day',
+        date: '2026-03-10',
+        startedAt: Date.now(),
+        deletedAt: '2026-03-10T00:00:00.000Z',
+      })
+      .run();
+    context.db
+      .insert(sessionSets)
+      .values({
+        id: 'set-1',
+        sessionId: 'session-1',
+        exerciseId: 'exercise-1',
+        setNumber: 1,
+      })
+      .run();
+
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    const purgeFoodResponse = await context.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/trash/foods/food-1',
+      headers: createAuthorizationHeader(authToken),
+    });
+    expect(purgeFoodResponse.statusCode).toBe(200);
+
+    const purgeSessionResponse = await context.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/trash/workout-sessions/session-1',
+      headers: createAuthorizationHeader(authToken),
+    });
+    expect(purgeSessionResponse.statusCode).toBe(200);
+
+    expect(
+      context.db.select({ id: foods.id }).from(foods).where(eq(foods.id, 'food-1')).get(),
+    ).toBeUndefined();
+    expect(
+      context.db
+        .select({ id: mealItems.id })
+        .from(mealItems)
+        .where(eq(mealItems.id, 'meal-item-1'))
+        .get(),
+    ).toBeUndefined();
+    expect(
+      context.db
+        .select({ id: workoutSessions.id })
+        .from(workoutSessions)
+        .where(eq(workoutSessions.id, 'session-1'))
+        .get(),
+    ).toBeUndefined();
+    expect(
+      context.db
+        .select({ id: sessionSets.id })
+        .from(sessionSets)
+        .where(eq(sessionSets.id, 'set-1'))
+        .get(),
+    ).toBeUndefined();
+  });
+});

--- a/apps/api/src/routes/trash/index.ts
+++ b/apps/api/src/routes/trash/index.ts
@@ -30,6 +30,14 @@ const TRASH_INVALID_TYPE_RESPONSE = {
 const parseId = (value: unknown) =>
   typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
 
+const requireDeletedAt = (value: string | null): string => {
+  if (value === null) {
+    throw new Error('deletedAt unexpectedly null in trash list');
+  }
+
+  return value;
+};
+
 const listTrash = async (userId: string): Promise<TrashListResponse> => {
   const { db } = await import('../../db/index.js');
 
@@ -79,31 +87,31 @@ const listTrash = async (userId: string): Promise<TrashListResponse> => {
       id: row.id,
       type: 'habits',
       name: row.name,
-      deletedAt: row.deletedAt ?? '',
+      deletedAt: requireDeletedAt(row.deletedAt),
     })),
     'workout-templates': templateRows.map((row) => ({
       id: row.id,
       type: 'workout-templates',
       name: row.name,
-      deletedAt: row.deletedAt ?? '',
+      deletedAt: requireDeletedAt(row.deletedAt),
     })),
     exercises: exerciseRows.map((row) => ({
       id: row.id,
       type: 'exercises',
       name: row.name,
-      deletedAt: row.deletedAt ?? '',
+      deletedAt: requireDeletedAt(row.deletedAt),
     })),
     foods: foodRows.map((row) => ({
       id: row.id,
       type: 'foods',
       name: row.name,
-      deletedAt: row.deletedAt ?? '',
+      deletedAt: requireDeletedAt(row.deletedAt),
     })),
     'workout-sessions': sessionRows.map((row) => ({
       id: row.id,
       type: 'workout-sessions',
       name: row.name,
-      deletedAt: row.deletedAt ?? '',
+      deletedAt: requireDeletedAt(row.deletedAt),
     })),
   };
 };
@@ -235,6 +243,17 @@ const purgeTrashItem = async ({
 
     case 'exercises':
       return db.transaction((tx) => {
+        const target = tx
+          .select({ id: exercises.id })
+          .from(exercises)
+          .where(and(eq(exercises.id, id), eq(exercises.userId, userId), isNotNull(exercises.deletedAt)))
+          .limit(1)
+          .get();
+
+        if (!target) {
+          return false;
+        }
+
         tx.delete(templateExercises)
           .where(
             and(
@@ -263,14 +282,13 @@ const purgeTrashItem = async ({
           )
           .run();
 
-        const deletedExercise = tx
-          .delete(exercises)
+        tx.delete(exercises)
           .where(
             and(eq(exercises.id, id), eq(exercises.userId, userId), isNotNull(exercises.deletedAt)),
           )
           .run();
 
-        return deletedExercise.changes === 1;
+        return true;
       });
 
     case 'foods':
@@ -306,20 +324,39 @@ const purgeTrashItem = async ({
         return deletedFood.changes === 1;
       });
 
-    case 'workout-sessions': {
-      const result = db
-        .delete(workoutSessions)
-        .where(
-          and(
-            eq(workoutSessions.id, id),
-            eq(workoutSessions.userId, userId),
-            isNotNull(workoutSessions.deletedAt),
-          ),
-        )
-        .run();
+    case 'workout-sessions':
+      return db.transaction((tx) => {
+        const target = tx
+          .select({ id: workoutSessions.id })
+          .from(workoutSessions)
+          .where(
+            and(
+              eq(workoutSessions.id, id),
+              eq(workoutSessions.userId, userId),
+              isNotNull(workoutSessions.deletedAt),
+            ),
+          )
+          .limit(1)
+          .get();
 
-      return result.changes === 1;
-    }
+        if (!target) {
+          return false;
+        }
+
+        tx.delete(sessionSets).where(eq(sessionSets.sessionId, id)).run();
+
+        tx.delete(workoutSessions)
+          .where(
+            and(
+              eq(workoutSessions.id, id),
+              eq(workoutSessions.userId, userId),
+              isNotNull(workoutSessions.deletedAt),
+            ),
+          )
+          .run();
+
+        return true;
+      });
   }
 };
 

--- a/apps/api/src/routes/trash/index.ts
+++ b/apps/api/src/routes/trash/index.ts
@@ -1,0 +1,402 @@
+import { trashTypeSchema, type TrashListResponse, type TrashType } from '@pulse/shared';
+import { and, eq, inArray, isNotNull, sql } from 'drizzle-orm';
+import type { FastifyPluginAsync } from 'fastify';
+
+import {
+  exercises,
+  foods,
+  habits,
+  mealItems,
+  meals,
+  nutritionLogs,
+  sessionSets,
+  templateExercises,
+  workoutSessions,
+  workoutTemplates,
+} from '../../db/schema/index.js';
+import { sendError } from '../../lib/reply.js';
+import { requireUserAuth } from '../../middleware/auth.js';
+
+const TRASH_ITEM_NOT_FOUND_RESPONSE = {
+  code: 'TRASH_ITEM_NOT_FOUND',
+  message: 'Trash item not found',
+} as const;
+
+const TRASH_INVALID_TYPE_RESPONSE = {
+  code: 'VALIDATION_ERROR',
+  message: 'Invalid trash type',
+} as const;
+
+const parseId = (value: unknown) =>
+  typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+
+const listTrash = async (userId: string): Promise<TrashListResponse> => {
+  const { db } = await import('../../db/index.js');
+
+  const [habitRows, templateRows, exerciseRows, foodRows, sessionRows] = await Promise.all([
+    db
+      .select({ id: habits.id, name: habits.name, deletedAt: habits.deletedAt })
+      .from(habits)
+      .where(and(eq(habits.userId, userId), isNotNull(habits.deletedAt)))
+      .orderBy(sql`${habits.deletedAt} desc`)
+      .all(),
+    db
+      .select({
+        id: workoutTemplates.id,
+        name: workoutTemplates.name,
+        deletedAt: workoutTemplates.deletedAt,
+      })
+      .from(workoutTemplates)
+      .where(and(eq(workoutTemplates.userId, userId), isNotNull(workoutTemplates.deletedAt)))
+      .orderBy(sql`${workoutTemplates.deletedAt} desc`)
+      .all(),
+    db
+      .select({ id: exercises.id, name: exercises.name, deletedAt: exercises.deletedAt })
+      .from(exercises)
+      .where(and(eq(exercises.userId, userId), isNotNull(exercises.deletedAt)))
+      .orderBy(sql`${exercises.deletedAt} desc`)
+      .all(),
+    db
+      .select({ id: foods.id, name: foods.name, deletedAt: foods.deletedAt })
+      .from(foods)
+      .where(and(eq(foods.userId, userId), isNotNull(foods.deletedAt)))
+      .orderBy(sql`${foods.deletedAt} desc`)
+      .all(),
+    db
+      .select({
+        id: workoutSessions.id,
+        name: workoutSessions.name,
+        deletedAt: workoutSessions.deletedAt,
+      })
+      .from(workoutSessions)
+      .where(and(eq(workoutSessions.userId, userId), isNotNull(workoutSessions.deletedAt)))
+      .orderBy(sql`${workoutSessions.deletedAt} desc`)
+      .all(),
+  ]);
+
+  return {
+    habits: habitRows.map((row) => ({
+      id: row.id,
+      type: 'habits',
+      name: row.name,
+      deletedAt: row.deletedAt ?? '',
+    })),
+    'workout-templates': templateRows.map((row) => ({
+      id: row.id,
+      type: 'workout-templates',
+      name: row.name,
+      deletedAt: row.deletedAt ?? '',
+    })),
+    exercises: exerciseRows.map((row) => ({
+      id: row.id,
+      type: 'exercises',
+      name: row.name,
+      deletedAt: row.deletedAt ?? '',
+    })),
+    foods: foodRows.map((row) => ({
+      id: row.id,
+      type: 'foods',
+      name: row.name,
+      deletedAt: row.deletedAt ?? '',
+    })),
+    'workout-sessions': sessionRows.map((row) => ({
+      id: row.id,
+      type: 'workout-sessions',
+      name: row.name,
+      deletedAt: row.deletedAt ?? '',
+    })),
+  };
+};
+
+const restoreTrashItem = async ({
+  id,
+  type,
+  userId,
+}: {
+  id: string;
+  type: TrashType;
+  userId: string;
+}): Promise<boolean> => {
+  const { db } = await import('../../db/index.js');
+
+  switch (type) {
+    case 'habits': {
+      const result = db
+        .update(habits)
+        .set({
+          deletedAt: null,
+          active: true,
+        })
+        .where(and(eq(habits.id, id), eq(habits.userId, userId), isNotNull(habits.deletedAt)))
+        .run();
+
+      return result.changes === 1;
+    }
+
+    case 'workout-templates': {
+      const result = db
+        .update(workoutTemplates)
+        .set({
+          deletedAt: null,
+        })
+        .where(
+          and(
+            eq(workoutTemplates.id, id),
+            eq(workoutTemplates.userId, userId),
+            isNotNull(workoutTemplates.deletedAt),
+          ),
+        )
+        .run();
+
+      return result.changes === 1;
+    }
+
+    case 'exercises': {
+      const result = db
+        .update(exercises)
+        .set({
+          deletedAt: null,
+        })
+        .where(
+          and(eq(exercises.id, id), eq(exercises.userId, userId), isNotNull(exercises.deletedAt)),
+        )
+        .run();
+
+      return result.changes === 1;
+    }
+
+    case 'foods': {
+      const result = db
+        .update(foods)
+        .set({
+          deletedAt: null,
+        })
+        .where(and(eq(foods.id, id), eq(foods.userId, userId), isNotNull(foods.deletedAt)))
+        .run();
+
+      return result.changes === 1;
+    }
+
+    case 'workout-sessions': {
+      const result = db
+        .update(workoutSessions)
+        .set({
+          deletedAt: null,
+        })
+        .where(
+          and(
+            eq(workoutSessions.id, id),
+            eq(workoutSessions.userId, userId),
+            isNotNull(workoutSessions.deletedAt),
+          ),
+        )
+        .run();
+
+      return result.changes === 1;
+    }
+  }
+};
+
+const purgeTrashItem = async ({
+  id,
+  type,
+  userId,
+}: {
+  id: string;
+  type: TrashType;
+  userId: string;
+}): Promise<boolean> => {
+  const { db } = await import('../../db/index.js');
+
+  switch (type) {
+    case 'habits': {
+      const result = db
+        .delete(habits)
+        .where(and(eq(habits.id, id), eq(habits.userId, userId), isNotNull(habits.deletedAt)))
+        .run();
+
+      return result.changes === 1;
+    }
+
+    case 'workout-templates': {
+      const result = db
+        .delete(workoutTemplates)
+        .where(
+          and(
+            eq(workoutTemplates.id, id),
+            eq(workoutTemplates.userId, userId),
+            isNotNull(workoutTemplates.deletedAt),
+          ),
+        )
+        .run();
+
+      return result.changes === 1;
+    }
+
+    case 'exercises':
+      return db.transaction((tx) => {
+        tx.delete(templateExercises)
+          .where(
+            and(
+              eq(templateExercises.exerciseId, id),
+              sql`exists (
+                select 1
+                from ${workoutTemplates}
+                where ${workoutTemplates.id} = ${templateExercises.templateId}
+                  and ${workoutTemplates.userId} = ${userId}
+              )`,
+            ),
+          )
+          .run();
+
+        tx.delete(sessionSets)
+          .where(
+            and(
+              eq(sessionSets.exerciseId, id),
+              sql`exists (
+                select 1
+                from ${workoutSessions}
+                where ${workoutSessions.id} = ${sessionSets.sessionId}
+                  and ${workoutSessions.userId} = ${userId}
+              )`,
+            ),
+          )
+          .run();
+
+        const deletedExercise = tx
+          .delete(exercises)
+          .where(
+            and(eq(exercises.id, id), eq(exercises.userId, userId), isNotNull(exercises.deletedAt)),
+          )
+          .run();
+
+        return deletedExercise.changes === 1;
+      });
+
+    case 'foods':
+      return db.transaction((tx) => {
+        const linkedMealIds = tx
+          .select({ mealId: mealItems.mealId })
+          .from(mealItems)
+          .where(eq(mealItems.foodId, id))
+          .all();
+
+        if (linkedMealIds.length > 0) {
+          const mealIds = [...new Set(linkedMealIds.map((row) => row.mealId))];
+          const ownedMealIds = tx
+            .select({ id: meals.id })
+            .from(meals)
+            .innerJoin(nutritionLogs, eq(nutritionLogs.id, meals.nutritionLogId))
+            .where(and(inArray(meals.id, mealIds), eq(nutritionLogs.userId, userId)))
+            .all()
+            .map((row) => row.id);
+
+          if (ownedMealIds.length > 0) {
+            tx.delete(mealItems)
+              .where(and(eq(mealItems.foodId, id), inArray(mealItems.mealId, ownedMealIds)))
+              .run();
+          }
+        }
+
+        const deletedFood = tx
+          .delete(foods)
+          .where(and(eq(foods.id, id), eq(foods.userId, userId), isNotNull(foods.deletedAt)))
+          .run();
+
+        return deletedFood.changes === 1;
+      });
+
+    case 'workout-sessions': {
+      const result = db
+        .delete(workoutSessions)
+        .where(
+          and(
+            eq(workoutSessions.id, id),
+            eq(workoutSessions.userId, userId),
+            isNotNull(workoutSessions.deletedAt),
+          ),
+        )
+        .run();
+
+      return result.changes === 1;
+    }
+  }
+};
+
+export const trashRoutes: FastifyPluginAsync = async (app) => {
+  app.addHook('onRequest', requireUserAuth);
+
+  app.get('/', async (request, reply) => {
+    const trash = await listTrash(request.userId);
+    return reply.send({ data: trash });
+  });
+
+  app.post<{ Params: { id: string; type: string } }>(
+    '/:type/:id/restore',
+    async (request, reply) => {
+      const typeParse = trashTypeSchema.safeParse(request.params.type);
+      if (!typeParse.success) {
+        return sendError(
+          reply,
+          400,
+          TRASH_INVALID_TYPE_RESPONSE.code,
+          TRASH_INVALID_TYPE_RESPONSE.message,
+        );
+      }
+
+      const id = parseId(request.params.id);
+      if (!id) {
+        return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid trash item id');
+      }
+
+      const restored = await restoreTrashItem({
+        id,
+        type: typeParse.data,
+        userId: request.userId,
+      });
+      if (!restored) {
+        return sendError(
+          reply,
+          404,
+          TRASH_ITEM_NOT_FOUND_RESPONSE.code,
+          TRASH_ITEM_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      return reply.send({ data: { success: true } });
+    },
+  );
+
+  app.delete<{ Params: { id: string; type: string } }>('/:type/:id', async (request, reply) => {
+    const typeParse = trashTypeSchema.safeParse(request.params.type);
+    if (!typeParse.success) {
+      return sendError(
+        reply,
+        400,
+        TRASH_INVALID_TYPE_RESPONSE.code,
+        TRASH_INVALID_TYPE_RESPONSE.message,
+      );
+    }
+
+    const id = parseId(request.params.id);
+    if (!id) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid trash item id');
+    }
+
+    const purged = await purgeTrashItem({
+      id,
+      type: typeParse.data,
+      userId: request.userId,
+    });
+    if (!purged) {
+      return sendError(
+        reply,
+        404,
+        TRASH_ITEM_NOT_FOUND_RESPONSE.code,
+        TRASH_ITEM_NOT_FOUND_RESPONSE.message,
+      );
+    }
+
+    return reply.send({ data: { success: true } });
+  });
+};

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -2225,7 +2225,7 @@ describe('workout session routes', () => {
     });
   });
 
-  it('deletes owned workout sessions, cascades set rows, and unlinks scheduled workouts', async () => {
+  it('soft-deletes owned workout sessions', async () => {
     const authToken = context.app.jwt.sign({ userId: 'user-1' });
 
     seedWorkoutSession({
@@ -2274,16 +2274,37 @@ describe('workout session routes', () => {
     });
 
     expect(context.db.select().from(workoutSessions).all()).toEqual([
-      expect.objectContaining({ id: 'session-2' }),
+      expect.objectContaining({ id: 'session-1', deletedAt: expect.any(String) }),
+      expect.objectContaining({ id: 'session-2', deletedAt: null }),
     ]);
-    expect(context.db.select().from(sessionSets).all()).toEqual([]);
+    expect(context.db.select().from(sessionSets).all()).toEqual([
+      expect.objectContaining({ id: 'set-1', sessionId: 'session-1' }),
+    ]);
     expect(
       context.db
         .select({ sessionId: scheduledWorkouts.sessionId })
         .from(scheduledWorkouts)
         .where(eq(scheduledWorkouts.id, 'schedule-1'))
         .get(),
-    ).toEqual({ sessionId: null });
+    ).toEqual({ sessionId: 'session-1' });
+
+    const getDeletedResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/workout-sessions/session-1',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(getDeletedResponse.statusCode).toBe(404);
+
+    const listResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/workout-sessions',
+      headers: createAuthorizationHeader(authToken),
+    });
+    const listPayload = listResponse.json() as { data: Array<{ id: string }> };
+
+    expect(listResponse.statusCode).toBe(200);
+    expect(listPayload.data.map((session) => session.id)).toEqual([]);
 
     const otherUserResponse = await context.app.inject({
       method: 'DELETE',

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -249,7 +249,10 @@ export const allSessionExercisesAccessible = async ({
     .where(
       and(
         inArray(exercises.id, uniqueIds),
-        or(isNull(exercises.userId), eq(exercises.userId, userId)),
+        or(
+          isNull(exercises.userId),
+          and(eq(exercises.userId, userId), isNull(exercises.deletedAt)),
+        ),
       ),
     )
     .all()
@@ -277,7 +280,13 @@ export const findWorkoutSessionAccess = async (
   return db
     .select(workoutSessionAccessSelection)
     .from(workoutSessions)
-    .where(and(eq(workoutSessions.id, id), eq(workoutSessions.userId, userId)))
+    .where(
+      and(
+        eq(workoutSessions.id, id),
+        eq(workoutSessions.userId, userId),
+        isNull(workoutSessions.deletedAt),
+      ),
+    )
     .limit(1)
     .get();
 };
@@ -548,7 +557,7 @@ export const listWorkoutSessions = async ({
   limit?: number;
 }): Promise<WorkoutSessionListItem[]> => {
   const { db } = await import('../../db/index.js');
-  const whereClauses = [eq(workoutSessions.userId, userId)];
+  const whereClauses = [eq(workoutSessions.userId, userId), isNull(workoutSessions.deletedAt)];
 
   if (from) {
     whereClauses.push(gte(workoutSessions.date, from));
@@ -565,7 +574,10 @@ export const listWorkoutSessions = async ({
   const query = db
     .select(workoutSessionListSelection)
     .from(workoutSessions)
-    .leftJoin(workoutTemplates, eq(workoutTemplates.id, workoutSessions.templateId))
+    .leftJoin(
+      workoutTemplates,
+      and(eq(workoutTemplates.id, workoutSessions.templateId), isNull(workoutTemplates.deletedAt)),
+    )
     .where(and(...whereClauses))
     .orderBy(
       desc(workoutSessions.date),
@@ -589,7 +601,13 @@ export const findWorkoutSessionById = async (
   const session = db
     .select(workoutSessionSelection)
     .from(workoutSessions)
-    .where(and(eq(workoutSessions.id, id), eq(workoutSessions.userId, userId)))
+    .where(
+      and(
+        eq(workoutSessions.id, id),
+        eq(workoutSessions.userId, userId),
+        isNull(workoutSessions.deletedAt),
+      ),
+    )
     .limit(1)
     .get();
 
@@ -633,7 +651,13 @@ export const updateWorkoutSession = async ({
         feedback: serializeWorkoutSessionFeedback(input.feedback),
         notes: input.notes,
       })
-      .where(and(eq(workoutSessions.id, id), eq(workoutSessions.userId, userId)))
+      .where(
+        and(
+          eq(workoutSessions.id, id),
+          eq(workoutSessions.userId, userId),
+          isNull(workoutSessions.deletedAt),
+        ),
+      )
       .run();
 
     if (updateResult.changes !== 1) {
@@ -660,8 +684,17 @@ export const deleteWorkoutSession = async (id: string, userId: string): Promise<
   const { db } = await import('../../db/index.js');
 
   const result = db
-    .delete(workoutSessions)
-    .where(and(eq(workoutSessions.id, id), eq(workoutSessions.userId, userId)))
+    .update(workoutSessions)
+    .set({
+      deletedAt: new Date().toISOString(),
+    })
+    .where(
+      and(
+        eq(workoutSessions.id, id),
+        eq(workoutSessions.userId, userId),
+        isNull(workoutSessions.deletedAt),
+      ),
+    )
     .run();
 
   return result.changes === 1;
@@ -684,7 +717,13 @@ export const reorderWorkoutSessionExercises = async ({
     const session = tx
       .select(workoutSessionAccessSelection)
       .from(workoutSessions)
-      .where(and(eq(workoutSessions.id, sessionId), eq(workoutSessions.userId, userId)))
+      .where(
+        and(
+          eq(workoutSessions.id, sessionId),
+          eq(workoutSessions.userId, userId),
+          isNull(workoutSessions.deletedAt),
+        ),
+      )
       .limit(1)
       .get();
 
@@ -707,7 +746,13 @@ export const reorderWorkoutSessionExercises = async ({
 
     tx.update(workoutSessions)
       .set({ updatedAt: Date.now() })
-      .where(and(eq(workoutSessions.id, sessionId), eq(workoutSessions.userId, userId)))
+      .where(
+        and(
+          eq(workoutSessions.id, sessionId),
+          eq(workoutSessions.userId, userId),
+          isNull(workoutSessions.deletedAt),
+        ),
+      )
       .run();
 
     return true;

--- a/apps/api/src/routes/workout-templates/index.test.ts
+++ b/apps/api/src/routes/workout-templates/index.test.ts
@@ -642,7 +642,7 @@ describe('workout template routes', () => {
     ]);
   });
 
-  it('deletes only owned templates and cascades template exercise rows', async () => {
+  it('soft-deletes only owned templates', async () => {
     seedTemplate({
       id: 'template-1',
       userId: 'user-1',
@@ -679,9 +679,30 @@ describe('workout template routes', () => {
     });
 
     expect(context.db.select().from(workoutTemplates).all()).toEqual([
-      expect.objectContaining({ id: 'template-2' }),
+      expect.objectContaining({ id: 'template-1', deletedAt: expect.any(String) }),
+      expect.objectContaining({ id: 'template-2', deletedAt: null }),
     ]);
-    expect(context.db.select().from(templateExercises).all()).toEqual([]);
+    expect(context.db.select().from(templateExercises).all()).toEqual([
+      expect.objectContaining({ id: 'template-exercise-1', templateId: 'template-1' }),
+    ]);
+
+    const getDeletedResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/workout-templates/template-1',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(getDeletedResponse.statusCode).toBe(404);
+
+    const listResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/workout-templates',
+      headers: createAuthorizationHeader(authToken),
+    });
+    const listPayload = listResponse.json() as { data: Array<{ id: string }> };
+
+    expect(listResponse.statusCode).toBe(200);
+    expect(listPayload.data.map((template) => template.id)).toEqual([]);
 
     const otherUserResponse = await context.app.inject({
       method: 'DELETE',

--- a/apps/api/src/routes/workout-templates/store.ts
+++ b/apps/api/src/routes/workout-templates/store.ts
@@ -137,12 +137,13 @@ const findTemplateRows = async (userId: string): Promise<TemplateRecord[]> => {
   return db
     .select(templateSelection)
     .from(workoutTemplates)
-    .where(eq(workoutTemplates.userId, userId))
+    .where(and(eq(workoutTemplates.userId, userId), isNull(workoutTemplates.deletedAt)))
     .orderBy(asc(workoutTemplates.name), asc(workoutTemplates.createdAt))
     .all();
 };
 
 const findTemplateExerciseRows = async (
+  userId: string,
   templateIds: string[],
 ): Promise<TemplateExerciseRecord[]> => {
   if (templateIds.length === 0) {
@@ -155,7 +156,15 @@ const findTemplateExerciseRows = async (
     .select(templateExerciseSelection)
     .from(templateExercises)
     .innerJoin(exercises, eq(exercises.id, templateExercises.exerciseId))
-    .where(inArray(templateExercises.templateId, templateIds))
+    .where(
+      and(
+        inArray(templateExercises.templateId, templateIds),
+        or(
+          isNull(exercises.userId),
+          and(eq(exercises.userId, userId), isNull(exercises.deletedAt)),
+        ),
+      ),
+    )
     .all();
 };
 
@@ -165,7 +174,10 @@ export const listWorkoutTemplates = async (userId: string): Promise<WorkoutTempl
     return [];
   }
 
-  const exerciseRows = await findTemplateExerciseRows(templates.map((template) => template.id));
+  const exerciseRows = await findTemplateExerciseRows(
+    userId,
+    templates.map((template) => template.id),
+  );
 
   return templates.map((template) =>
     buildTemplate(
@@ -184,7 +196,13 @@ export const findWorkoutTemplateById = async (
   const template = db
     .select(templateSelection)
     .from(workoutTemplates)
-    .where(and(eq(workoutTemplates.id, id), eq(workoutTemplates.userId, userId)))
+    .where(
+      and(
+        eq(workoutTemplates.id, id),
+        eq(workoutTemplates.userId, userId),
+        isNull(workoutTemplates.deletedAt),
+      ),
+    )
     .limit(1)
     .get();
 
@@ -196,7 +214,15 @@ export const findWorkoutTemplateById = async (
     .select(templateExerciseSelection)
     .from(templateExercises)
     .innerJoin(exercises, eq(exercises.id, templateExercises.exerciseId))
-    .where(eq(templateExercises.templateId, id))
+    .where(
+      and(
+        eq(templateExercises.templateId, id),
+        or(
+          isNull(exercises.userId),
+          and(eq(exercises.userId, userId), isNull(exercises.deletedAt)),
+        ),
+      ),
+    )
     .all();
 
   return buildTemplate(template, rows);
@@ -222,7 +248,10 @@ export const allTemplateExercisesAccessible = async ({
     .where(
       and(
         inArray(exercises.id, uniqueIds),
-        or(isNull(exercises.userId), eq(exercises.userId, userId)),
+        or(
+          isNull(exercises.userId),
+          and(eq(exercises.userId, userId), isNull(exercises.deletedAt)),
+        ),
       ),
     )
     .all()
@@ -287,7 +316,13 @@ export const updateWorkoutTemplate = async ({
         description: input.description,
         tags: input.tags,
       })
-      .where(and(eq(workoutTemplates.id, id), eq(workoutTemplates.userId, userId)))
+      .where(
+        and(
+          eq(workoutTemplates.id, id),
+          eq(workoutTemplates.userId, userId),
+          isNull(workoutTemplates.deletedAt),
+        ),
+      )
       .run();
 
     if (updateResult.changes !== 1) {
@@ -327,7 +362,13 @@ export const reorderWorkoutTemplateExercises = async ({
     const templateExists = tx
       .select({ id: workoutTemplates.id })
       .from(workoutTemplates)
-      .where(and(eq(workoutTemplates.id, templateId), eq(workoutTemplates.userId, userId)))
+      .where(
+        and(
+          eq(workoutTemplates.id, templateId),
+          eq(workoutTemplates.userId, userId),
+          isNull(workoutTemplates.deletedAt),
+        ),
+      )
       .limit(1)
       .get();
 
@@ -376,7 +417,13 @@ export const reorderWorkoutTemplateExercises = async ({
       .set({
         updatedAt: Date.now(),
       })
-      .where(and(eq(workoutTemplates.id, templateId), eq(workoutTemplates.userId, userId)))
+      .where(
+        and(
+          eq(workoutTemplates.id, templateId),
+          eq(workoutTemplates.userId, userId),
+          isNull(workoutTemplates.deletedAt),
+        ),
+      )
       .run();
 
     return true;
@@ -387,8 +434,17 @@ export const deleteWorkoutTemplate = async (id: string, userId: string): Promise
   const { db } = await import('../../db/index.js');
 
   const result = db
-    .delete(workoutTemplates)
-    .where(and(eq(workoutTemplates.id, id), eq(workoutTemplates.userId, userId)))
+    .update(workoutTemplates)
+    .set({
+      deletedAt: new Date().toISOString(),
+    })
+    .where(
+      and(
+        eq(workoutTemplates.id, id),
+        eq(workoutTemplates.userId, userId),
+        isNull(workoutTemplates.deletedAt),
+      ),
+    )
     .run();
 
   return result.changes === 1;

--- a/apps/api/src/routes/workout-templates/template-access.ts
+++ b/apps/api/src/routes/workout-templates/template-access.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 
 import { workoutTemplates } from '../../db/schema/index.js';
 
@@ -12,7 +12,13 @@ export const templateBelongsToUser = async (
   const template = db
     .select({ id: workoutTemplates.id })
     .from(workoutTemplates)
-    .where(and(eq(workoutTemplates.id, templateId), eq(workoutTemplates.userId, userId)))
+    .where(
+      and(
+        eq(workoutTemplates.id, templateId),
+        eq(workoutTemplates.userId, userId),
+        isNull(workoutTemplates.deletedAt),
+      ),
+    )
     .limit(1)
     .get();
 

--- a/apps/web/src/features/settings/api/trash.test.tsx
+++ b/apps/web/src/features/settings/api/trash.test.tsx
@@ -1,0 +1,96 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { trashKeys, usePurgeItem, useRestoreItem, useTrashItems } from './trash';
+
+const mockFetch = vi.fn();
+
+const createJsonResponse = (data: unknown) =>
+  new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status: 200,
+  });
+
+describe('trash api hooks', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  it('loads grouped trash items', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        habits: [
+          {
+            id: 'habit-1',
+            type: 'habits',
+            name: 'Hydrate',
+            deletedAt: '2026-03-11T15:00:00.000Z',
+          },
+        ],
+        'workout-templates': [],
+        exercises: [],
+        foods: [],
+        'workout-sessions': [],
+      }),
+    );
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useTrashItems(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.habits).toHaveLength(1);
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/trash', expect.any(Object));
+  });
+
+  it('restores an item and invalidates related queries', async () => {
+    mockFetch.mockResolvedValueOnce(createJsonResponse({ success: true }));
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useRestoreItem(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: 'habit-1',
+        type: 'habits',
+      });
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/trash/habits/habit-1/restore',
+      expect.objectContaining({ method: 'POST' }));
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: trashKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['habits'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['foods'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['workouts'] });
+  });
+
+  it('purges an item and invalidates related queries', async () => {
+    mockFetch.mockResolvedValueOnce(createJsonResponse({ success: true }));
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => usePurgeItem(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: 'food-1',
+        type: 'foods',
+      });
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/trash/foods/food-1',
+      expect.objectContaining({ method: 'DELETE' }));
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: trashKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['habits'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['foods'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['workouts'] });
+  });
+});

--- a/apps/web/src/features/settings/api/trash.ts
+++ b/apps/web/src/features/settings/api/trash.ts
@@ -1,0 +1,87 @@
+import { type QueryClient, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { trashListResponseSchema, trashTypeSchema, type TrashListResponse, type TrashType } from '@pulse/shared';
+import { z } from 'zod';
+
+import { foodKeys } from '@/features/foods/api/keys';
+import { habitKeys } from '@/features/habits/api/keys';
+import { workoutQueryKeys } from '@/features/workouts/api/workouts';
+import { apiRequest } from '@/lib/api-client';
+
+const mutationResultSchema = z.object({
+  success: z.boolean(),
+});
+
+export const trashKeys = {
+  all: ['trash'] as const,
+  list: () => [...trashKeys.all, 'list'] as const,
+};
+
+type TrashMutationInput = {
+  id: string;
+  type: TrashType;
+};
+
+async function fetchTrashItems(signal?: AbortSignal): Promise<TrashListResponse> {
+  const payload = await apiRequest<TrashListResponse>('/api/v1/trash', {
+    method: 'GET',
+    signal,
+  });
+
+  return trashListResponseSchema.parse(payload);
+}
+
+async function restoreTrashItem(input: TrashMutationInput) {
+  const type = trashTypeSchema.parse(input.type);
+  const payload = await apiRequest<{ success: boolean }>(`/api/v1/trash/${type}/${input.id}/restore`, {
+    method: 'POST',
+  });
+
+  return mutationResultSchema.parse(payload);
+}
+
+async function purgeTrashItem(input: TrashMutationInput) {
+  const type = trashTypeSchema.parse(input.type);
+  const payload = await apiRequest<{ success: boolean }>(`/api/v1/trash/${type}/${input.id}`, {
+    method: 'DELETE',
+  });
+
+  return mutationResultSchema.parse(payload);
+}
+
+async function invalidateRelatedQueries(queryClient: QueryClient) {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: trashKeys.all }),
+    queryClient.invalidateQueries({ queryKey: habitKeys.all }),
+    queryClient.invalidateQueries({ queryKey: foodKeys.all }),
+    queryClient.invalidateQueries({ queryKey: workoutQueryKeys.all }),
+  ]);
+}
+
+export function useTrashItems() {
+  return useQuery({
+    queryFn: ({ signal }) => fetchTrashItems(signal),
+    queryKey: trashKeys.list(),
+  });
+}
+
+export function useRestoreItem() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: restoreTrashItem,
+    onSuccess: async () => {
+      await invalidateRelatedQueries(queryClient);
+    },
+  });
+}
+
+export function usePurgeItem() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: purgeTrashItem,
+    onSuccess: async () => {
+      await invalidateRelatedQueries(queryClient);
+    },
+  });
+}

--- a/apps/web/src/features/settings/components/trash-manager.test.tsx
+++ b/apps/web/src/features/settings/components/trash-manager.test.tsx
@@ -1,0 +1,152 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { TrashManager } from './trash-manager';
+
+const trashWithItems = {
+  habits: [
+    {
+      id: 'habit-1',
+      type: 'habits',
+      name: 'Hydrate',
+      deletedAt: '2026-03-11T15:00:00.000Z',
+    },
+  ],
+  'workout-templates': [
+    {
+      id: 'template-1',
+      type: 'workout-templates',
+      name: 'Upper Body',
+      deletedAt: '2026-03-11T14:00:00.000Z',
+    },
+  ],
+  exercises: [],
+  foods: [],
+  'workout-sessions': [],
+} as const;
+
+function createJsonResponse(data: unknown) {
+  return new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status: 200,
+  });
+}
+
+function renderTrashManager() {
+  const { wrapper } = createQueryClientWrapper();
+
+  return render(<TrashManager />, { wrapper });
+}
+
+describe('TrashManager', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: string | URL | Request, init?: RequestInit) => {
+        const rawUrl =
+          typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+        const url = new URL(rawUrl, 'http://localhost');
+        const method = init?.method?.toUpperCase() ?? 'GET';
+
+        if (url.pathname === '/api/v1/trash' && method === 'GET') {
+          return Promise.resolve(createJsonResponse(trashWithItems));
+        }
+
+        if (url.pathname === '/api/v1/trash/habits/habit-1/restore' && method === 'POST') {
+          return Promise.resolve(createJsonResponse({ success: true }));
+        }
+
+        if (url.pathname === '/api/v1/trash/habits/habit-1' && method === 'DELETE') {
+          return Promise.resolve(createJsonResponse({ success: true }));
+        }
+
+        return Promise.resolve(createJsonResponse(null));
+      }),
+    );
+  });
+
+  it('groups trash items and allows restoring them', async () => {
+    renderTrashManager();
+
+    await waitFor(() => {
+      expect(screen.getByText('Habits (1)')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Templates (1)')).toBeInTheDocument();
+    const hydrateRow = screen.getByText('Hydrate').closest('li');
+
+    expect(hydrateRow).not.toBeNull();
+
+    fireEvent.click(within(hydrateRow as HTMLElement).getByRole('button', { name: 'Restore' }));
+
+    await waitFor(() => {
+      expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+        '/api/v1/trash/habits/habit-1/restore',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+
+  it('shows confirm dialog before permanently deleting an item', async () => {
+    renderTrashManager();
+
+    await waitFor(() => {
+      expect(screen.getByText('Hydrate')).toBeInTheDocument();
+    });
+
+    const hydrateRow = screen.getByText('Hydrate').closest('li');
+    expect(hydrateRow).not.toBeNull();
+
+    fireEvent.click(
+      within(hydrateRow as HTMLElement).getByRole('button', { name: 'Delete permanently' }),
+    );
+
+    const dialog = await screen.findByRole('alertdialog');
+    expect(within(dialog).getByText(/Delete "Hydrate" permanently\?/i)).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete permanently' }));
+
+    await waitFor(() => {
+      expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+        '/api/v1/trash/habits/habit-1',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+  });
+
+  it('renders empty state when there are no deleted items', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: string | URL | Request, init?: RequestInit) => {
+        const rawUrl =
+          typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+        const url = new URL(rawUrl, 'http://localhost');
+        const method = init?.method?.toUpperCase() ?? 'GET';
+
+        if (url.pathname === '/api/v1/trash' && method === 'GET') {
+          return Promise.resolve(
+            createJsonResponse({
+              habits: [],
+              'workout-templates': [],
+              exercises: [],
+              foods: [],
+              'workout-sessions': [],
+            }),
+          );
+        }
+
+        return Promise.resolve(createJsonResponse(null));
+      }),
+    );
+
+    renderTrashManager();
+
+    await waitFor(() => {
+      expect(screen.getByText('Trash is empty')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/features/settings/components/trash-manager.tsx
+++ b/apps/web/src/features/settings/components/trash-manager.tsx
@@ -1,0 +1,214 @@
+import { useMemo, useState } from 'react';
+
+import type { TrashItem, TrashType } from '@pulse/shared';
+import { ChevronDownIcon, RotateCcwIcon, Trash2Icon } from 'lucide-react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { usePurgeItem, useRestoreItem, useTrashItems } from '@/features/settings/api/trash';
+
+const TRASH_GROUPS: Array<{ label: string; type: TrashType }> = [
+  { label: 'Habits', type: 'habits' },
+  { label: 'Templates', type: 'workout-templates' },
+  { label: 'Exercises', type: 'exercises' },
+  { label: 'Foods', type: 'foods' },
+  { label: 'Workouts', type: 'workout-sessions' },
+];
+
+function formatDeletedAt(value: string): string {
+  const parsedDate = new Date(value);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(parsedDate);
+}
+
+export function TrashManager() {
+  const { data, isPending } = useTrashItems();
+  const restoreItemMutation = useRestoreItem();
+  const purgeItemMutation = usePurgeItem();
+  const [restoreTargetId, setRestoreTargetId] = useState<string | null>(null);
+  const [purgeTarget, setPurgeTarget] = useState<TrashItem | null>(null);
+
+  const itemGroups = useMemo(() => {
+    if (!data) {
+      return [];
+    }
+
+    return TRASH_GROUPS.map((group) => ({
+      ...group,
+      items: data[group.type],
+    })).filter((group) => group.items.length > 0);
+  }, [data]);
+
+  const totalItems = useMemo(
+    () => itemGroups.reduce((count, group) => count + group.items.length, 0),
+    [itemGroups],
+  );
+
+  const isPurgePending = purgeItemMutation.isPending;
+
+  async function handleRestoreItem(item: TrashItem) {
+    setRestoreTargetId(item.id);
+
+    try {
+      await restoreItemMutation.mutateAsync({
+        id: item.id,
+        type: item.type,
+      });
+    } finally {
+      setRestoreTargetId(null);
+    }
+  }
+
+  async function handlePurgeItem() {
+    if (!purgeTarget) {
+      return;
+    }
+
+    try {
+      await purgeItemMutation.mutateAsync({
+        id: purgeTarget.id,
+        type: purgeTarget.type,
+      });
+      setPurgeTarget(null);
+    } catch {
+      // Keep dialog open to allow user retry if request fails.
+    }
+  }
+
+  return (
+    <Card className="gap-4 border-border/70 shadow-sm">
+      <CardHeader className="space-y-2">
+        <CardTitle>
+          <h2 className="text-xl font-semibold text-foreground">Trash</h2>
+        </CardTitle>
+        <CardDescription>
+          Restore recently deleted items or permanently remove them from your account.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-3">
+        {isPending ? (
+          <p className="text-sm text-muted-foreground">Loading trash...</p>
+        ) : totalItems === 0 ? (
+          <p className="rounded-xl border border-dashed border-border/70 bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
+            Trash is empty
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {itemGroups.map((group) => (
+              <details
+                key={group.type}
+                className="group rounded-xl border border-border/70 bg-muted/10"
+                open
+              >
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-foreground">
+                  <span>
+                    {group.label} ({group.items.length})
+                  </span>
+                  <ChevronDownIcon className="size-4 text-muted-foreground transition-transform duration-200 group-open:rotate-180" />
+                </summary>
+
+                <ul className="space-y-2 border-t border-border/60 p-3">
+                  {group.items.map((item) => {
+                    const isRestoring =
+                      restoreItemMutation.isPending && restoreTargetId !== null && restoreTargetId === item.id;
+
+                    return (
+                      <li
+                        key={item.id}
+                        className="flex flex-col gap-3 rounded-lg border border-border/60 bg-background/80 p-3 sm:flex-row sm:items-center sm:justify-between"
+                      >
+                        <div className="space-y-1">
+                          <p className="text-sm font-medium text-foreground">{item.name}</p>
+                          <p className="text-xs text-muted-foreground">
+                            Deleted {formatDeletedAt(item.deletedAt)}
+                          </p>
+                        </div>
+
+                        <div className="flex flex-wrap gap-2 sm:justify-end">
+                          <Button
+                            className="min-w-24"
+                            disabled={isRestoring || isPurgePending}
+                            onClick={() => {
+                              void handleRestoreItem(item);
+                            }}
+                            size="sm"
+                            type="button"
+                            variant="outline"
+                          >
+                            <RotateCcwIcon className="size-3.5" />
+                            {isRestoring ? 'Restoring...' : 'Restore'}
+                          </Button>
+                          <Button
+                            className="min-w-36"
+                            disabled={isRestoring || isPurgePending}
+                            onClick={() => {
+                              setPurgeTarget(item);
+                            }}
+                            size="sm"
+                            type="button"
+                            variant="destructive"
+                          >
+                            <Trash2Icon className="size-3.5" />
+                            Delete permanently
+                          </Button>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </details>
+            ))}
+          </div>
+        )}
+      </CardContent>
+
+      <AlertDialog
+        onOpenChange={(open) => {
+          if (!open) {
+            setPurgeTarget(null);
+          }
+        }}
+        open={purgeTarget !== null}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete "{purgeTarget?.name}" permanently?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This item will be removed forever and cannot be restored.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPurgePending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-white hover:bg-destructive/90"
+              disabled={isPurgePending}
+              onClick={() => {
+                void handlePurgeItem();
+              }}
+            >
+              {isPurgePending ? 'Deleting...' : 'Delete permanently'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}

--- a/apps/web/src/features/settings/components/trash-manager.tsx
+++ b/apps/web/src/features/settings/components/trash-manager.tsx
@@ -182,7 +182,7 @@ export function TrashManager() {
 
       <AlertDialog
         onOpenChange={(open) => {
-          if (!open) {
+          if (!open && !isPurgePending) {
             setPurgeTarget(null);
           }
         }}

--- a/apps/web/src/pages/settings.test.tsx
+++ b/apps/web/src/pages/settings.test.tsx
@@ -236,6 +236,26 @@ describe('SettingsPage', () => {
           );
         }
 
+        if (url.pathname === '/api/v1/trash' && (!init?.method || init.method === 'GET')) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: {
+                  habits: [],
+                  'workout-templates': [],
+                  exercises: [],
+                  foods: [],
+                  'workout-sessions': [],
+                },
+              }),
+              {
+                headers: { 'Content-Type': 'application/json' },
+                status: 200,
+              },
+            ),
+          );
+        }
+
         if (url.pathname === '/api/v1/users/me' && (!init?.method || init.method === 'GET')) {
           return Promise.resolve(
             new Response(JSON.stringify({ data: state.user }), {
@@ -294,6 +314,7 @@ describe('SettingsPage', () => {
 
     expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Theme' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Trash' })).toBeInTheDocument();
     expect(screen.getByLabelText('Daily calories')).toHaveValue(
       DEFAULT_SETTINGS.nutritionTargets.calories,
     );

--- a/apps/web/src/pages/settings.tsx
+++ b/apps/web/src/pages/settings.tsx
@@ -15,6 +15,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { AgentTokensCard } from '@/features/settings/components/agent-tokens-card';
+import { TrashManager } from '@/features/settings/components/trash-manager';
 import { useHabits } from '@/features/habits/api/habits';
 import { useNutritionTargets, useUpdateTargets } from '@/features/nutrition/api/targets';
 import { useDashboardConfig, useSaveDashboardConfig } from '@/hooks/use-dashboard-config';
@@ -820,6 +821,8 @@ export function SettingsPage() {
           </div>
         </CardContent>
       </Card>
+
+      <TrashManager />
     </section>
   );
 }

--- a/docs/conventions/data-models.md
+++ b/docs/conventions/data-models.md
@@ -12,7 +12,7 @@ Pulse stores application data in SQLite through Drizzle ORM. This document is th
 - Booleans: SQLite booleans are stored as `integer` `0`/`1`, usually through Drizzle `integer(..., { mode: 'boolean' })`.
 - Numeric measurements: weights, macros, and habit values use `real` or `integer` depending on whether fractional values are needed.
 - JSON-backed fields: prefer `text('col', { mode: 'json' }).$type<T>()` when the value should serialize and deserialize automatically. If a field stays as plain `text().$type<T>()`, pair it with explicit parse/serialize helpers.
-- Soft delete: use an `active` flag instead of deleting when historical visibility matters. `habits.active` is the current example.
+- Soft delete: user-facing entities use nullable `deletedAt` (`text` ISO timestamp). API reads must exclude rows where `deletedAt` is not `null`; restore clears `deletedAt`, and purge performs hard delete. `habits.active` remains for habit visibility state, but deletion semantics are tracked by `deletedAt`.
 - SQLite bootstrap: enable `journal_mode = WAL`, `busy_timeout = 5000`, `synchronous = NORMAL`, and `foreign_keys = ON`.
 
 ## User Scope Rules
@@ -88,6 +88,7 @@ Inherited ownership comes from foreign-key chains:
 - `unit`: nullable `text`
 - `sortOrder`: `integer`, required, default `0`
 - `active`: boolean-backed `integer`, required, default `true`
+- `deletedAt`: nullable `text` ISO timestamp for soft delete
 - `createdAt`: `integer` Unix ms, required, default now
 - `updatedAt`: `integer` Unix ms, required, default now, auto-updates
 
@@ -124,6 +125,7 @@ Constraints:
 - `tags`: JSON text array for exercise classification labels, default `[]`
 - `formCues`: JSON text array for durable technique guidance, default `[]`
 - `instructions`: nullable `text`
+- `deletedAt`: nullable `text` ISO timestamp for soft delete (applies to user-owned rows)
 - `createdAt`: `integer` Unix ms, required, default now
 - `updatedAt`: `integer` Unix ms, required, default now, auto-updates
 
@@ -139,6 +141,7 @@ Constraints:
 - `name`: `text`, required
 - `description`: nullable `text`
 - `tags`: JSON text array for template labels
+- `deletedAt`: nullable `text` ISO timestamp for soft delete
 - `createdAt`: `integer` Unix ms, required, default now
 - `updatedAt`: `integer` Unix ms, required, default now, auto-updates
 
@@ -178,6 +181,7 @@ Constraints:
 - `timeSegments`: required JSON text array of `{ start: string, end: string | null }`, default `'[]'`
 - `feedback`: nullable JSON text object for post-session ratings and notes
 - `notes`: nullable `text`
+- `deletedAt`: nullable `text` ISO timestamp for soft delete
 - `createdAt`: `integer` Unix ms, required, default now
 - `updatedAt`: `integer` Unix ms, required, default now, auto-updates
 
@@ -245,6 +249,7 @@ Indexes and constraints:
 - `source`: nullable `text`
 - `notes`: nullable `text`
 - `lastUsedAt`: nullable `integer` Unix ms
+- `deletedAt`: nullable `text` ISO timestamp for soft delete
 - `createdAt`: `integer` Unix ms, required, default now
 - `updatedAt`: `integer` Unix ms, required, default now, auto-updates
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -19,6 +19,7 @@ export * from './schemas/nutrition-targets.js';
 export * from './schemas/resources.js';
 export * from './schemas/scheduled-workouts.js';
 export * from './schemas/session-set.js';
+export * from './schemas/trash.js';
 export * from './schemas/weight.js';
 export * from './schemas/workout-sessions.js';
 export * from './schemas/users.js';

--- a/packages/shared/src/schemas/trash.ts
+++ b/packages/shared/src/schemas/trash.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export const trashTypeSchema = z.enum([
+  'habits',
+  'workout-templates',
+  'exercises',
+  'foods',
+  'workout-sessions',
+]);
+
+export const trashItemSchema = z.object({
+  id: z.string(),
+  type: trashTypeSchema,
+  name: z.string(),
+  deletedAt: z.string(),
+});
+
+export const trashListResponseSchema = z.object({
+  habits: z.array(trashItemSchema),
+  'workout-templates': z.array(trashItemSchema),
+  exercises: z.array(trashItemSchema),
+  foods: z.array(trashItemSchema),
+  'workout-sessions': z.array(trashItemSchema),
+});
+
+export type TrashType = z.infer<typeof trashTypeSchema>;
+export type TrashItem = z.infer<typeof trashItemSchema>;
+export type TrashListResponse = z.infer<typeof trashListResponseSchema>;


### PR DESCRIPTION
## Summary
This PR introduces a consistent soft-delete model across user-facing entities and adds a Trash management flow to restore or permanently remove deleted data. Habits, workout templates, exercises, foods, and workout sessions now store deletion state in `deletedAt`, and existing API reads/mutations were updated to treat soft-deleted rows as non-visible. A new authenticated `/api/v1/trash` API exposes grouped deleted items plus restore and purge actions. On the frontend, Settings now includes a Trash section where users can review deleted items by type, restore them, or permanently delete them with confirmation. The goal is safer deletion UX while preserving a path for irreversible cleanup when needed.

## Key Changes
- Added migration `0021_soft_delete_columns.sql` to add nullable `deleted_at` to habits, workout templates, exercises, foods, and workout sessions.
- Converted delete operations in affected stores from hard delete to soft delete (`deletedAt = ISO timestamp`) and updated read/update/access paths to exclude soft-deleted rows.
- Added new Trash API routes:
  - `GET /api/v1/trash` to list deleted items grouped by type
  - `POST /api/v1/trash/:type/:id/restore` to clear `deletedAt` (and reactivate habits)
  - `DELETE /api/v1/trash/:type/:id` to permanently purge soft-deleted items
- Added shared Zod schema/types for trash payloads in `@pulse/shared` and reused them across API and web.
- Implemented `TrashManager` in Settings with grouped sections, restore action, and destructive confirm dialog for permanent delete.
- Added React Query hooks for trash list/restore/purge and invalidation of related caches (`trash`, habits, foods, workouts) after mutations.
- Expanded backend and frontend tests to cover soft-delete filtering, restore/purge behavior, and settings page integration.

## Technical Notes
- Soft-delete filtering was propagated beyond standard CRUD into agent-facing context/search flows, so deleted user data is excluded from agent lookups as well.
- Purge behavior intentionally performs targeted cleanup in transactions for linked data:
  - Exercise purge removes related `template_exercises` and `session_sets` for that user context.
  - Food purge removes linked `meal_items` only for meals owned by the authenticated user.
- Restore/purge endpoints require valid trash type via shared `trashTypeSchema`, validate non-empty IDs, and return `404 TRASH_ITEM_NOT_FOUND` when the item is not owned, not soft-deleted, or absent.
- Habit restore explicitly sets `active: true` in addition to clearing `deletedAt`; this is a deliberate domain behavior reviewers should confirm matches product expectations.
- This change establishes `deletedAt` as the canonical deletion semantic for these entities; future queries touching them should include explicit `deletedAt` null checks to avoid regressions.

## Commits

- `7d70ac0 feat(settings): add trash management section in settings`
- `860b568 feat(api): implement soft-delete filtering and trash endpoints`

## Tasks

- **Soft delete — schema migration and API changes**: Add deletedAt columns, filter list and mutation lookups, soft-delete DELETE routes, and add trash restore/purge endpoints
- **Trash management UI in Settings**: Add Settings trash section with grouped entities plus restore and permanent delete actions

## Diff Stats

```
.agents/skills/pulse-app-usage/SKILL.md            |   2 +
 AGENTS.md                                          |   1 +
 apps/api/drizzle/0021_soft_delete_columns.sql      |   9 +
 apps/api/drizzle/meta/_journal.json                |   7 +
 apps/api/src/__tests__/workouts.test.ts            |  90 +++--
 apps/api/src/db/schema.test.ts                     |   5 +
 apps/api/src/db/schema/exercises.ts                |   1 +
 apps/api/src/db/schema/foods.ts                    |  10 +-
 apps/api/src/db/schema/habits.ts                   |   1 +
 apps/api/src/db/schema/workout-sessions.ts         |   1 +
 apps/api/src/db/schema/workout-templates.ts        |   1 +
 apps/api/src/index.ts                              |   2 +
 apps/api/src/routes/agent/context-store.ts         |  65 ++--
 apps/api/src/routes/agent/store.ts                 |  26 +-
 apps/api/src/routes/exercises/index.test.ts        |  61 +++-
 apps/api/src/routes/exercises/store.ts             |  59 ++-
 apps/api/src/routes/foods/store.test.ts            |   9 +-
 apps/api/src/routes/foods/store.ts                 |  17 +-
 apps/api/src/routes/habits/store.ts                |  32 +-
 apps/api/src/routes/trash/index.test.ts            | 361 ++++++++++++++++++
 apps/api/src/routes/trash/index.ts                 | 402 +++++++++++++++++++++
 apps/api/src/routes/workout-sessions/index.test.ts |  29 +-
 apps/api/src/routes/workout-sessions/store.ts      |  65 +++-
 .../api/src/routes/workout-templates/index.test.ts |  27 +-
 apps/api/src/routes/workout-templates/store.ts     |  78 +++-
 .../routes/workout-templates/template-access.ts    |  10 +-
 apps/web/src/features/settings/api/trash.test.tsx  |  96 +++++
 apps/web/src/features/settings/api/trash.ts        |  87 +++++
 .../settings/components/trash-manager.test.tsx     | 152 ++++++++
 .../features/settings/components/trash-manager.tsx | 214 +++++++++++
 apps/web/src/pages/settings.test.tsx               |  21 ++
 apps/web/src/pages/settings.tsx                    |   3 +
 docs/conventions/data-models.md                    |   7 +-
 packages/shared/src/index.ts                       |   1 +
 packages/shared/src/schemas/trash.ts               |  28 ++
 35 files changed, 1848 insertions(+), 132 deletions(-)
```