### PR TITLE
feat: workout scheduling and calendar integration (QA #12, #11, #21)

### DIFF
--- a/.agents/skills/pulse-app-usage/SKILL.md
+++ b/.agents/skills/pulse-app-usage/SKILL.md
@@ -8,8 +8,10 @@ Use this flow when an agent creates exercises/templates and then logs workout se
 2. Create with dedup guard: call `POST /api/agent/exercises`.
 3. If the response is `{ "data": { "created": false, "candidates": [...] } }`, inspect candidates and only retry with `force: true` when a true new exercise is required.
 4. Create template with `POST /api/agent/workout-templates`.
-5. Read `data.newExercises` from template creation response.
-6. For each new exercise id in `newExercises`, call `PATCH /api/agent/exercises/:id` to enrich:
+5. Schedule the template on calendar date(s) with `POST /api/agent/scheduled-workouts`.
+6. Review upcoming scheduled workouts via `GET /api/agent/scheduled-workouts?from=<YYYY-MM-DD>&to=<YYYY-MM-DD>`.
+7. Read `data.newExercises` from template creation response.
+8. For each new exercise id in `newExercises`, call `PATCH /api/agent/exercises/:id` to enrich:
    - `muscleGroups`
    - `equipment`
    - `category`
@@ -17,7 +19,7 @@ Use this flow when an agent creates exercises/templates and then logs workout se
    - `instructions`
    - `formCues`
    - `tags`
-7. Start session via `POST /api/agent/workout-sessions` and log progress via `PATCH /api/agent/workout-sessions/:id`.
+9. Start session via `POST /api/agent/workout-sessions` and log progress via `PATCH /api/agent/workout-sessions/:id`.
 
 ## Notes
 

--- a/apps/api/src/__tests__/workouts.test.ts
+++ b/apps/api/src/__tests__/workouts.test.ts
@@ -566,12 +566,11 @@ describe('workouts integration', () => {
     expect(rangeItems.map((item) => item.templateName)).toEqual(['Template A', 'Template B']);
 
     const updateResponse = await context.app.inject({
-      method: 'PUT',
+      method: 'PATCH',
       url: `/api/v1/scheduled-workouts/${firstScheduleId}`,
       headers: createAuthorizationHeader(authToken),
       payload: {
         date: '2026-04-20',
-        templateId: templateB.id,
       },
     });
 
@@ -580,7 +579,7 @@ describe('workouts integration', () => {
       data: expect.objectContaining({
         id: firstScheduleId,
         date: '2026-04-20',
-        templateId: templateB.id,
+        templateId: templateA.id,
       }),
     });
 
@@ -621,8 +620,8 @@ describe('workouts integration', () => {
       expect.objectContaining({
         id: firstScheduleId,
         date: '2026-04-20',
-        templateId: templateB.id,
-        templateName: 'Template B',
+        templateId: templateA.id,
+        templateName: 'Template A',
       }),
     ]);
   });

--- a/apps/api/src/routes/agent/workouts.test.ts
+++ b/apps/api/src/routes/agent/workouts.test.ts
@@ -7,6 +7,7 @@ import {
   findVisibleExerciseByName,
   updateOwnedExercise,
 } from '../exercises/store.js';
+import { createScheduledWorkout, listScheduledWorkouts } from '../scheduled-workouts/store.js';
 import {
   createWorkoutSession,
   findWorkoutSessionById,
@@ -17,6 +18,7 @@ import {
   findWorkoutTemplateById,
   updateWorkoutTemplate,
 } from '../workout-templates/store.js';
+import { templateBelongsToUser } from '../workout-templates/template-access.js';
 
 vi.mock('../exercises/store.js', () => ({
   createExercise: vi.fn(),
@@ -56,6 +58,15 @@ vi.mock('../workout-sessions/store.js', () => ({
   updateWorkoutSession: vi.fn(),
 }));
 
+vi.mock('../scheduled-workouts/store.js', () => ({
+  createScheduledWorkout: vi.fn(),
+  listScheduledWorkouts: vi.fn(),
+}));
+
+vi.mock('../workout-templates/template-access.js', () => ({
+  templateBelongsToUser: vi.fn(),
+}));
+
 const createAuthorizationHeader = (token: string) => ({
   authorization: `Bearer ${token}`,
 });
@@ -75,6 +86,9 @@ describe('agent workouts routes', () => {
     vi.mocked(createWorkoutSession).mockReset();
     vi.mocked(findWorkoutSessionById).mockReset();
     vi.mocked(updateWorkoutSession).mockReset();
+    vi.mocked(createScheduledWorkout).mockReset();
+    vi.mocked(listScheduledWorkouts).mockReset();
+    vi.mocked(templateBelongsToUser).mockReset();
     process.env.JWT_SECRET = 'test-agent-workouts-secret';
     dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(startedAt);
   });
@@ -82,6 +96,98 @@ describe('agent workouts routes', () => {
   afterEach(() => {
     delete process.env.JWT_SECRET;
     dateNowSpy.mockRestore();
+  });
+
+  describe('scheduled workout endpoints', () => {
+    it('creates a scheduled workout for an accessible template', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+        vi.mocked(templateBelongsToUser).mockResolvedValue(true);
+        vi.mocked(createScheduledWorkout).mockResolvedValue({
+          id: 'schedule-1',
+          userId: 'user-1',
+          templateId: 'template-1',
+          date: '2026-03-12',
+          sessionId: null,
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/scheduled-workouts',
+          headers: createAuthorizationHeader(token),
+          body: {
+            templateId: 'template-1',
+            date: '2026-03-12',
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+        expect(response.json()).toEqual({
+          data: {
+            id: 'schedule-1',
+            userId: 'user-1',
+            templateId: 'template-1',
+            date: '2026-03-12',
+            sessionId: null,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        });
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('lists scheduled workouts within a date range', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+        vi.mocked(listScheduledWorkouts).mockResolvedValue([
+          {
+            id: 'schedule-1',
+            date: '2026-03-12',
+            templateId: 'template-1',
+            templateName: 'Upper Push',
+            sessionId: null,
+            createdAt: 1,
+          },
+        ]);
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/scheduled-workouts?from=2026-03-10&to=2026-03-16',
+          headers: createAuthorizationHeader(token),
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.json()).toEqual({
+          data: [
+            {
+              id: 'schedule-1',
+              date: '2026-03-12',
+              templateId: 'template-1',
+              templateName: 'Upper Push',
+              sessionId: null,
+              createdAt: 1,
+            },
+          ],
+        });
+        expect(vi.mocked(listScheduledWorkouts)).toHaveBeenCalledWith({
+          userId: 'user-1',
+          from: '2026-03-10',
+          to: '2026-03-16',
+        });
+      } finally {
+        await app.close();
+      }
+    });
   });
 
   describe('POST /api/agent/workout-templates', () => {

--- a/apps/api/src/routes/agent/workouts.test.ts
+++ b/apps/api/src/routes/agent/workouts.test.ts
@@ -7,7 +7,11 @@ import {
   findVisibleExerciseByName,
   updateOwnedExercise,
 } from '../exercises/store.js';
-import { createScheduledWorkout, listScheduledWorkouts } from '../scheduled-workouts/store.js';
+import {
+  createScheduledWorkout,
+  linkTodayScheduledWorkoutToSession,
+  listScheduledWorkouts,
+} from '../scheduled-workouts/store.js';
 import {
   createWorkoutSession,
   findWorkoutSessionById,
@@ -60,6 +64,7 @@ vi.mock('../workout-sessions/store.js', () => ({
 
 vi.mock('../scheduled-workouts/store.js', () => ({
   createScheduledWorkout: vi.fn(),
+  linkTodayScheduledWorkoutToSession: vi.fn(),
   listScheduledWorkouts: vi.fn(),
 }));
 
@@ -87,6 +92,7 @@ describe('agent workouts routes', () => {
     vi.mocked(findWorkoutSessionById).mockReset();
     vi.mocked(updateWorkoutSession).mockReset();
     vi.mocked(createScheduledWorkout).mockReset();
+    vi.mocked(linkTodayScheduledWorkoutToSession).mockReset();
     vi.mocked(listScheduledWorkouts).mockReset();
     vi.mocked(templateBelongsToUser).mockReset();
     process.env.JWT_SECRET = 'test-agent-workouts-secret';
@@ -772,6 +778,7 @@ describe('agent workouts routes', () => {
           createdAt: 1,
           updatedAt: 1,
         });
+        vi.mocked(linkTodayScheduledWorkoutToSession).mockResolvedValue(true);
 
         const token = app.jwt.sign({ userId: 'user-1' });
         const response = await app.inject({
@@ -808,6 +815,12 @@ describe('agent workouts routes', () => {
             }),
           }),
         );
+        expect(vi.mocked(linkTodayScheduledWorkoutToSession)).toHaveBeenCalledWith({
+          userId: 'user-1',
+          templateId: 'template-1',
+          date: '2023-11-14',
+          sessionId: 'session-1',
+        });
       } finally {
         await app.close();
       }

--- a/apps/api/src/routes/agent/workouts.ts
+++ b/apps/api/src/routes/agent/workouts.ts
@@ -17,7 +17,11 @@ import {
 import type { FastifyPluginAsync } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
-import { createScheduledWorkout, listScheduledWorkouts } from '../scheduled-workouts/store.js';
+import {
+  createScheduledWorkout,
+  linkTodayScheduledWorkoutToSession,
+  listScheduledWorkouts,
+} from '../scheduled-workouts/store.js';
 import {
   createExercise,
   findExerciseDedupCandidates,
@@ -467,6 +471,15 @@ export const agentWorkoutRoutes: FastifyPluginAsync = async (app) => {
       userId: request.userId,
       input: payload.data,
     });
+
+    if (payload.data.templateId !== null) {
+      await linkTodayScheduledWorkoutToSession({
+        userId: request.userId,
+        templateId: payload.data.templateId,
+        date: payload.data.date,
+        sessionId: session.id,
+      });
+    }
 
     return reply.code(201).send({ data: session });
   });

--- a/apps/api/src/routes/agent/workouts.ts
+++ b/apps/api/src/routes/agent/workouts.ts
@@ -6,21 +6,25 @@ import {
   agentCreateWorkoutTemplateInputSchema,
   agentUpdateWorkoutSessionInputSchema,
   agentUpdateWorkoutTemplateInputSchema,
+  createScheduledWorkoutInputSchema,
   createWorkoutSessionInputSchema,
   type CreateWorkoutTemplateInput,
   type CreateWorkoutSessionInput,
+  scheduledWorkoutQueryParamsSchema,
   type WorkoutSession,
   type WorkoutTemplateSectionType,
 } from '@pulse/shared';
 import type { FastifyPluginAsync } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
+import { createScheduledWorkout, listScheduledWorkouts } from '../scheduled-workouts/store.js';
 import {
   createExercise,
   findExerciseDedupCandidates,
   findVisibleExerciseByName,
   updateOwnedExercise,
 } from '../exercises/store.js';
+import { templateBelongsToUser } from '../workout-templates/template-access.js';
 import {
   createWorkoutSession,
   findWorkoutSessionById,
@@ -288,6 +292,52 @@ const buildInitialSessionSets = (
 };
 
 export const agentWorkoutRoutes: FastifyPluginAsync = async (app) => {
+  app.post('/scheduled-workouts', async (request, reply) => {
+    const parsedBody = createScheduledWorkoutInputSchema.safeParse(request.body);
+    if (!parsedBody.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid scheduled workout payload');
+    }
+
+    const templateAccessible = await templateBelongsToUser(
+      parsedBody.data.templateId,
+      request.userId,
+    );
+    if (!templateAccessible) {
+      return sendError(
+        reply,
+        404,
+        WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE.code,
+        WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE.message,
+      );
+    }
+
+    const scheduledWorkout = await createScheduledWorkout({
+      id: randomUUID(),
+      userId: request.userId,
+      input: parsedBody.data,
+    });
+
+    return reply.code(201).send({
+      data: scheduledWorkout,
+    });
+  });
+
+  app.get('/scheduled-workouts', async (request, reply) => {
+    const parsedQuery = scheduledWorkoutQueryParamsSchema.safeParse(request.query);
+    if (!parsedQuery.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid scheduled workout query');
+    }
+
+    const scheduledWorkoutItems = await listScheduledWorkouts({
+      userId: request.userId,
+      ...parsedQuery.data,
+    });
+
+    return reply.send({
+      data: scheduledWorkoutItems,
+    });
+  });
+
   app.post('/workout-templates', async (request, reply) => {
     const parsed = agentCreateWorkoutTemplateInputSchema.safeParse(request.body);
     if (!parsed.success) {

--- a/apps/api/src/routes/scheduled-workouts/index.test.ts
+++ b/apps/api/src/routes/scheduled-workouts/index.test.ts
@@ -42,6 +42,7 @@ const seedTemplate = (values: {
   name: string;
   description?: string | null;
   tags?: string[];
+  deletedAt?: string | null;
 }) =>
   context.db
     .insert(workoutTemplates)
@@ -49,6 +50,7 @@ const seedTemplate = (values: {
       ...values,
       description: values.description ?? null,
       tags: values.tags ?? [],
+      deletedAt: values.deletedAt ?? null,
     })
     .run();
 
@@ -147,7 +149,7 @@ describe('scheduled workout routes', () => {
         url: '/api/v1/scheduled-workouts?from=2026-03-10&to=2026-03-16',
       }),
       context.app.inject({
-        method: 'PUT',
+        method: 'PATCH',
         url: '/api/v1/scheduled-workouts/schedule-1',
         payload: {
           date: '2026-03-11',
@@ -254,7 +256,7 @@ describe('scheduled workout routes', () => {
     });
   });
 
-  it('updates the scheduled date or template within the user scope', async () => {
+  it('reschedules a workout date within the user scope', async () => {
     const authToken = context.app.jwt.sign({ userId: 'user-1' });
 
     seedScheduledWorkout({
@@ -265,11 +267,10 @@ describe('scheduled workout routes', () => {
     });
 
     const response = await context.app.inject({
-      method: 'PUT',
+      method: 'PATCH',
       url: '/api/v1/scheduled-workouts/schedule-1',
       headers: createAuthorizationHeader(authToken),
       payload: {
-        templateId: 'template-2',
         date: '2026-03-13',
       },
     });
@@ -279,7 +280,7 @@ describe('scheduled workout routes', () => {
       data: {
         id: 'schedule-1',
         userId: 'user-1',
-        templateId: 'template-2',
+        templateId: 'template-1',
         date: '2026-03-13',
         sessionId: null,
         createdAt: expect.any(Number),
@@ -298,7 +299,7 @@ describe('scheduled workout routes', () => {
       .get();
 
     expect(updatedRow).toEqual({
-      templateId: 'template-2',
+      templateId: 'template-1',
       date: '2026-03-13',
     });
   });
@@ -336,37 +337,89 @@ describe('scheduled workout routes', () => {
     expect(deletedRow).toBeUndefined();
   });
 
-  it('rejects creation or updates that reference missing or inaccessible templates', async () => {
+  it('does not expose soft-deleted template metadata in list responses', async () => {
     const authToken = context.app.jwt.sign({ userId: 'user-1' });
 
-    seedScheduledWorkout({
-      id: 'schedule-1',
+    seedTemplate({
+      id: 'template-soft-deleted-list',
       userId: 'user-1',
-      templateId: 'template-1',
+      name: 'Old Plan',
+      deletedAt: '2026-03-01T00:00:00.000Z',
+    });
+    seedScheduledWorkout({
+      id: 'schedule-soft-deleted',
+      userId: 'user-1',
+      templateId: 'template-soft-deleted-list',
       date: '2026-03-12',
     });
 
-    const [createResponse, updateResponse] = await Promise.all([
-      context.app.inject({
-        method: 'POST',
-        url: '/api/v1/scheduled-workouts',
-        headers: createAuthorizationHeader(authToken),
-        payload: {
-          templateId: 'template-3',
-          date: '2026-03-14',
-        },
-      }),
-      context.app.inject({
-        method: 'PUT',
-        url: '/api/v1/scheduled-workouts/schedule-1',
-        headers: createAuthorizationHeader(authToken),
-        payload: {
-          templateId: 'missing-template',
-        },
-      }),
-    ]);
+    const response = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/scheduled-workouts?from=2026-03-10&to=2026-03-16',
+      headers: createAuthorizationHeader(authToken),
+    });
 
-    for (const response of [createResponse, updateResponse]) {
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: [
+        {
+          id: 'schedule-soft-deleted',
+          date: '2026-03-12',
+          templateId: 'template-soft-deleted-list',
+          templateName: null,
+          sessionId: null,
+          createdAt: expect.any(Number),
+        },
+      ],
+    });
+  });
+
+  it('rejects creation against missing, inaccessible, or soft-deleted templates', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    seedTemplate({
+      id: 'template-soft-deleted',
+      userId: 'user-1',
+      name: 'Archived Plan',
+      deletedAt: '2026-03-01T00:00:00.000Z',
+    });
+
+    const [createOtherUserResponse, createMissingResponse, createSoftDeletedResponse] =
+      await Promise.all([
+        context.app.inject({
+          method: 'POST',
+          url: '/api/v1/scheduled-workouts',
+          headers: createAuthorizationHeader(authToken),
+          payload: {
+            templateId: 'template-3',
+            date: '2026-03-14',
+          },
+        }),
+        context.app.inject({
+          method: 'POST',
+          url: '/api/v1/scheduled-workouts',
+          headers: createAuthorizationHeader(authToken),
+          payload: {
+            templateId: 'missing-template',
+            date: '2026-03-15',
+          },
+        }),
+        context.app.inject({
+          method: 'POST',
+          url: '/api/v1/scheduled-workouts',
+          headers: createAuthorizationHeader(authToken),
+          payload: {
+            templateId: 'template-soft-deleted',
+            date: '2026-03-16',
+          },
+        }),
+      ]);
+
+    for (const response of [
+      createOtherUserResponse,
+      createMissingResponse,
+      createSoftDeletedResponse,
+    ]) {
       expect(response.statusCode).toBe(404);
       expect(response.json()).toEqual({
         error: {
@@ -380,7 +433,7 @@ describe('scheduled workout routes', () => {
   it('returns validation errors for invalid schedule payloads and queries', async () => {
     const authToken = context.app.jwt.sign({ userId: 'user-1' });
 
-    const [postResponse, getResponse, putResponse] = await Promise.all([
+    const [postResponse, getResponse, patchResponse] = await Promise.all([
       context.app.inject({
         method: 'POST',
         url: '/api/v1/scheduled-workouts',
@@ -396,7 +449,7 @@ describe('scheduled workout routes', () => {
         headers: createAuthorizationHeader(authToken),
       }),
       context.app.inject({
-        method: 'PUT',
+        method: 'PATCH',
         url: '/api/v1/scheduled-workouts/schedule-1',
         headers: createAuthorizationHeader(authToken),
         payload: {},
@@ -419,8 +472,8 @@ describe('scheduled workout routes', () => {
       },
     });
 
-    expect(putResponse.statusCode).toBe(400);
-    expect(putResponse.json()).toEqual({
+    expect(patchResponse.statusCode).toBe(400);
+    expect(patchResponse.json()).toEqual({
       error: {
         code: 'VALIDATION_ERROR',
         message: 'Invalid scheduled workout payload',
@@ -440,7 +493,7 @@ describe('scheduled workout routes', () => {
 
     const [updateResponse, deleteResponse] = await Promise.all([
       context.app.inject({
-        method: 'PUT',
+        method: 'PATCH',
         url: '/api/v1/scheduled-workouts/other-user-schedule',
         headers: createAuthorizationHeader(authToken),
         payload: {

--- a/apps/api/src/routes/scheduled-workouts/index.test.ts
+++ b/apps/api/src/routes/scheduled-workouts/index.test.ts
@@ -8,7 +8,7 @@ import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import type { FastifyInstance } from 'fastify';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { scheduledWorkouts, users, workoutTemplates } from '../../db/schema/index.js';
+import { scheduledWorkouts, users, workoutSessions, workoutTemplates } from '../../db/schema/index.js';
 
 type DatabaseModule = typeof import('../../db/index.js');
 
@@ -66,6 +66,35 @@ const seedScheduledWorkout = (values: {
     .values({
       ...values,
       sessionId: values.sessionId ?? null,
+    })
+    .run();
+
+const seedWorkoutSession = (values: {
+  id: string;
+  userId: string;
+  templateId?: string | null;
+  name: string;
+  date: string;
+  status?: 'scheduled' | 'in-progress' | 'paused' | 'cancelled' | 'completed';
+  startedAt?: number;
+  timeSegments?: string;
+}) =>
+  context.db
+    .insert(workoutSessions)
+    .values({
+      id: values.id,
+      userId: values.userId,
+      templateId: values.templateId ?? null,
+      name: values.name,
+      date: values.date,
+      status: values.status ?? 'completed',
+      startedAt: values.startedAt ?? Date.UTC(2026, 2, 12, 10, 0, 0),
+      completedAt: Date.UTC(2026, 2, 12, 10, 45, 0),
+      duration: 45,
+      timeSegments: values.timeSegments ?? '[]',
+      feedback: null,
+      notes: null,
+      deletedAt: null,
     })
     .run();
 
@@ -259,11 +288,19 @@ describe('scheduled workout routes', () => {
   it('reschedules a workout date within the user scope', async () => {
     const authToken = context.app.jwt.sign({ userId: 'user-1' });
 
+    seedWorkoutSession({
+      id: 'session-1',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Upper Push',
+      date: '2026-03-12',
+    });
     seedScheduledWorkout({
       id: 'schedule-1',
       userId: 'user-1',
       templateId: 'template-1',
       date: '2026-03-12',
+      sessionId: 'session-1',
     });
 
     const response = await context.app.inject({
@@ -292,6 +329,7 @@ describe('scheduled workout routes', () => {
       .select({
         templateId: scheduledWorkouts.templateId,
         date: scheduledWorkouts.date,
+        sessionId: scheduledWorkouts.sessionId,
       })
       .from(scheduledWorkouts)
       .where(eq(scheduledWorkouts.id, 'schedule-1'))
@@ -301,6 +339,7 @@ describe('scheduled workout routes', () => {
     expect(updatedRow).toEqual({
       templateId: 'template-1',
       date: '2026-03-13',
+      sessionId: null,
     });
   });
 

--- a/apps/api/src/routes/scheduled-workouts/index.ts
+++ b/apps/api/src/routes/scheduled-workouts/index.ts
@@ -78,7 +78,7 @@ export const scheduledWorkoutRoutes: FastifyPluginAsync = async (app) => {
     });
   });
 
-  app.put<{ Params: { id: string } }>('/:id', async (request, reply) => {
+  app.patch<{ Params: { id: string } }>('/:id', async (request, reply) => {
     const parsedBody = updateScheduledWorkoutInputSchema.safeParse(request.body);
     if (!parsedBody.success) {
       return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid scheduled workout payload');
@@ -95,21 +95,6 @@ export const scheduledWorkoutRoutes: FastifyPluginAsync = async (app) => {
         SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.code,
         SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.message,
       );
-    }
-
-    if (parsedBody.data.templateId !== undefined) {
-      const templateAccessible = await templateBelongsToUser(
-        parsedBody.data.templateId,
-        request.userId,
-      );
-      if (!templateAccessible) {
-        return sendError(
-          reply,
-          404,
-          WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE.code,
-          WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE.message,
-        );
-      }
     }
 
     const scheduledWorkout = await updateScheduledWorkout({

--- a/apps/api/src/routes/scheduled-workouts/store.ts
+++ b/apps/api/src/routes/scheduled-workouts/store.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gte, lte } from 'drizzle-orm';
+import { and, asc, eq, gte, isNull, lte } from 'drizzle-orm';
 import type {
   CreateScheduledWorkoutInput,
   ScheduledWorkout,
@@ -74,7 +74,13 @@ export const listScheduledWorkouts = async ({
   return db
     .select(scheduledWorkoutListSelection)
     .from(scheduledWorkouts)
-    .leftJoin(workoutTemplates, eq(workoutTemplates.id, scheduledWorkouts.templateId))
+    .leftJoin(
+      workoutTemplates,
+      and(
+        eq(workoutTemplates.id, scheduledWorkouts.templateId),
+        isNull(workoutTemplates.deletedAt),
+      ),
+    )
     .where(
       and(
         eq(scheduledWorkouts.userId, userId),
@@ -126,6 +132,49 @@ export const deleteScheduledWorkout = async (id: string, userId: string): Promis
   const result = db
     .delete(scheduledWorkouts)
     .where(and(eq(scheduledWorkouts.id, id), eq(scheduledWorkouts.userId, userId)))
+    .run();
+
+  return result.changes === 1;
+};
+
+export const linkTodayScheduledWorkoutToSession = async ({
+  userId,
+  templateId,
+  date,
+  sessionId,
+}: {
+  userId: string;
+  templateId: string;
+  date: string;
+  sessionId: string;
+}): Promise<boolean> => {
+  const { db } = await import('../../db/index.js');
+
+  const scheduledWorkout = db
+    .select({
+      id: scheduledWorkouts.id,
+    })
+    .from(scheduledWorkouts)
+    .where(
+      and(
+        eq(scheduledWorkouts.userId, userId),
+        eq(scheduledWorkouts.templateId, templateId),
+        eq(scheduledWorkouts.date, date),
+        isNull(scheduledWorkouts.sessionId),
+      ),
+    )
+    .orderBy(asc(scheduledWorkouts.createdAt))
+    .limit(1)
+    .get();
+
+  if (!scheduledWorkout) {
+    return false;
+  }
+
+  const result = db
+    .update(scheduledWorkouts)
+    .set({ sessionId })
+    .where(and(eq(scheduledWorkouts.id, scheduledWorkout.id), eq(scheduledWorkouts.userId, userId)))
     .run();
 
   return result.changes === 1;

--- a/apps/api/src/routes/scheduled-workouts/store.ts
+++ b/apps/api/src/routes/scheduled-workouts/store.ts
@@ -117,9 +117,17 @@ export const updateScheduledWorkout = async ({
 }): Promise<ScheduledWorkout | undefined> => {
   const { db } = await import('../../db/index.js');
 
+  const existingWorkout = await findScheduledWorkoutById(id, userId);
+  if (!existingWorkout) {
+    return undefined;
+  }
+
+  const shouldClearSessionLink = existingWorkout.date !== changes.date;
+  const updatePayload = shouldClearSessionLink ? { ...changes, sessionId: null } : changes;
+
   const [updatedWorkout] = await db
     .update(scheduledWorkouts)
-    .set(changes)
+    .set(updatePayload)
     .where(and(eq(scheduledWorkouts.id, id), eq(scheduledWorkouts.userId, userId)))
     .returning(scheduledWorkoutSelection);
 

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -1364,6 +1364,50 @@ describe('workout session routes', () => {
     });
   });
 
+  it('links a newly started session to an unclaimed scheduled workout for today', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+    const today = new Date().toISOString().slice(0, 10);
+
+    seedScheduledWorkout({
+      id: 'schedule-1',
+      userId: 'user-1',
+      templateId: 'template-1',
+      date: today,
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        name: 'Upper Push',
+        date: today,
+        status: 'in-progress',
+        startedAt: 1_700_000_100_000,
+        completedAt: null,
+        duration: null,
+        feedback: null,
+        notes: null,
+        sets: [],
+      },
+    });
+
+    expect(createResponse.statusCode).toBe(201);
+    const sessionId = (createResponse.json() as { data: { id: string } }).data.id;
+
+    const linkedSchedule = context.db
+      .select({ sessionId: scheduledWorkouts.sessionId })
+      .from(scheduledWorkouts)
+      .where(eq(scheduledWorkouts.id, 'schedule-1'))
+      .limit(1)
+      .get();
+
+    expect(linkedSchedule).toEqual({
+      sessionId,
+    });
+  });
+
   it('backfills empty time segments for in-progress sessions at read time', async () => {
     const authToken = context.app.jwt.sign({ userId: 'user-1' });
     const startedAt = Date.UTC(2026, 2, 12, 14, 30, 0);

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -18,6 +18,7 @@ import type { FastifyPluginAsync, FastifyReply } from 'fastify';
 import { sendError } from '../../lib/reply.js';
 import { requireUserAuth } from '../../middleware/auth.js';
 import { templateBelongsToUser } from '../workout-templates/template-access.js';
+import { linkTodayScheduledWorkoutToSession } from '../scheduled-workouts/store.js';
 
 import {
   allSessionExercisesAccessible,
@@ -259,6 +260,16 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       userId: request.userId,
       input: inputWithInitialSegment,
     });
+
+    const today = new Date().toISOString().slice(0, 10);
+    if (inputWithInitialSegment.templateId !== null && inputWithInitialSegment.date === today) {
+      await linkTodayScheduledWorkoutToSession({
+        userId: request.userId,
+        templateId: inputWithInitialSegment.templateId,
+        date: today,
+        sessionId: session.id,
+      });
+    }
 
     return reply.code(201).send({
       data: session,

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -261,12 +261,11 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       input: inputWithInitialSegment,
     });
 
-    const today = new Date().toISOString().slice(0, 10);
-    if (inputWithInitialSegment.templateId !== null && inputWithInitialSegment.date === today) {
+    if (inputWithInitialSegment.templateId !== null) {
       await linkTodayScheduledWorkoutToSession({
         userId: request.userId,
         templateId: inputWithInitialSegment.templateId,
-        date: today,
+        date: inputWithInitialSegment.date,
         sessionId: session.id,
       });
     }

--- a/apps/web/e2e/workout-scheduling.spec.ts
+++ b/apps/web/e2e/workout-scheduling.spec.ts
@@ -38,6 +38,14 @@ function addDays(date: Date, days: number) {
   return next;
 }
 
+function getDateRange() {
+  const today = new Date();
+  return {
+    from: toDateKey(addDays(today, -7)),
+    to: toDateKey(addDays(today, 14)),
+  };
+}
+
 async function createAuthorizedApiContext() {
   return request.newContext({
     baseURL: apiBaseURL,
@@ -65,6 +73,22 @@ async function fetchScheduledWorkouts(apiContext: APIRequestContext, from: strin
 
 async function pickDayInDialog(page: Page, dateKey: string) {
   await page.locator(`[role="dialog"] [data-day="${dateKey}"]`).first().click();
+}
+
+async function openTemplatesAndSchedule(page: Page, dateKey?: string) {
+  await page.getByRole('button', { exact: true, name: 'Templates' }).click();
+  await page.getByRole('button', { name: `Template actions for ${seededTemplate.name}` }).click();
+  await page.getByRole('menuitem', { name: 'Schedule workout' }).click();
+
+  if (dateKey) {
+    await pickDayInDialog(page, dateKey);
+  }
+
+  await page.getByRole('dialog').getByRole('button', { name: 'Schedule' }).click();
+}
+
+function getScheduledCard(page: Page) {
+  return page.locator('[data-slot="card"]').filter({ hasText: seededTemplate.name }).first();
 }
 
 test.describe.serial('workout scheduling flow', () => {
@@ -153,78 +177,100 @@ test.describe.serial('workout scheduling flow', () => {
     }
   });
 
-  test('schedules, reschedules, removes, and starts from scheduled workouts', async ({ page }) => {
+  test('schedules a workout from template actions and renders in calendar/list', async ({ page }) => {
     test.setTimeout(90_000);
-
-    const today = new Date();
-    const secondDate = toDateKey(addDays(today, 4));
-    const thirdDate = toDateKey(today);
-    const rangeFrom = toDateKey(addDays(today, -7));
-    const rangeTo = toDateKey(addDays(today, 14));
 
     await authenticatePage(page);
     await page.goto('/workouts');
 
-    await page.getByRole('button', { exact: true, name: 'Templates' }).click();
-    await page.getByRole('button', { name: `Template actions for ${seededTemplate.name}` }).click();
-    await page.getByRole('menuitem', { name: 'Schedule workout' }).click();
-    await page.getByRole('dialog').getByRole('button', { name: 'Schedule' }).click();
+    await openTemplatesAndSchedule(page);
 
     await page.getByRole('button', { exact: true, name: 'Calendar' }).click();
     await expect(page.getByText(seededTemplate.name).first()).toBeVisible();
 
     await page.getByRole('button', { exact: true, name: 'List' }).click();
-    const scheduledCard = page
-      .locator('[data-slot="card"]')
-      .filter({ hasText: seededTemplate.name })
-      .first();
-    await expect(scheduledCard).toBeVisible();
+    await expect(getScheduledCard(page)).toBeVisible();
+  });
 
+  test('reschedules a scheduled workout', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    const secondDate = toDateKey(addDays(new Date(), 4));
+    const range = getDateRange();
+
+    await authenticatePage(page);
+    await page.goto('/workouts');
+    await page.getByRole('button', { exact: true, name: 'List' }).click();
+
+    const scheduledCard = getScheduledCard(page);
+    await expect(scheduledCard).toBeVisible();
     await scheduledCard.getByRole('button', { name: 'Reschedule' }).click();
     await pickDayInDialog(page, secondDate);
     await page.getByRole('dialog').getByRole('button', { name: 'Save' }).click();
 
     const apiContext = await createAuthorizedApiContext();
     try {
-      let scheduledRows = await fetchScheduledWorkouts(apiContext, rangeFrom, rangeTo);
-      let targetSchedule = scheduledRows.find(
+      const scheduledRows = await fetchScheduledWorkouts(apiContext, range.from, range.to);
+      const targetSchedule = scheduledRows.find(
         (row) => row.templateId === seededTemplateId && row.date === secondDate,
       );
       expect(targetSchedule).toBeTruthy();
+    } finally {
+      await apiContext.dispose();
+    }
+  });
 
-      await scheduledCard.getByRole('button', { name: 'Remove from schedule' }).click();
-      await page.getByRole('button', { name: 'Remove' }).click();
-      await expect(
-        page.locator('[data-slot="card"]').filter({ hasText: seededTemplate.name }),
-      ).toHaveCount(0);
+  test('removes a scheduled workout', async ({ page }) => {
+    test.setTimeout(90_000);
 
-      scheduledRows = await fetchScheduledWorkouts(apiContext, rangeFrom, rangeTo);
-      targetSchedule = scheduledRows.find((row) => row.templateId === seededTemplateId);
+    const range = getDateRange();
+
+    await authenticatePage(page);
+    await page.goto('/workouts');
+    await page.getByRole('button', { exact: true, name: 'List' }).click();
+
+    const scheduledCard = getScheduledCard(page);
+    await expect(scheduledCard).toBeVisible();
+
+    await scheduledCard.getByRole('button', { name: 'Remove from schedule' }).click();
+    await page.getByRole('button', { name: 'Remove' }).click();
+    await expect(getScheduledCard(page)).toHaveCount(0);
+
+    const apiContext = await createAuthorizedApiContext();
+    try {
+      const scheduledRows = await fetchScheduledWorkouts(apiContext, range.from, range.to);
+      const targetSchedule = scheduledRows.find((row) => row.templateId === seededTemplateId);
       expect(targetSchedule).toBeUndefined();
+    } finally {
+      await apiContext.dispose();
+    }
+  });
 
-      await page.getByRole('button', { exact: true, name: 'Templates' }).click();
-      await page
-        .getByRole('button', { name: `Template actions for ${seededTemplate.name}` })
-        .click();
-      await page.getByRole('menuitem', { name: 'Schedule workout' }).click();
-      await pickDayInDialog(page, thirdDate);
-      await page.getByRole('dialog').getByRole('button', { name: 'Schedule' }).click();
+  test('starts now from a scheduled workout and links schedule to session', async ({ page }) => {
+    test.setTimeout(90_000);
 
-      await page.getByRole('button', { exact: true, name: 'List' }).click();
-      const startCard = page
-        .locator('[data-slot="card"]')
-        .filter({ hasText: seededTemplate.name })
-        .first();
-      await expect(startCard).toBeVisible();
-      await startCard.getByRole('button', { name: 'Start now' }).click();
-      await expect(page).toHaveURL(/\/workouts\/active\?/);
+    const today = toDateKey(new Date());
+    const range = getDateRange();
 
-      const sessionId = new URL(page.url()).searchParams.get('sessionId');
-      expect(sessionId).toBeTruthy();
+    await authenticatePage(page);
+    await page.goto('/workouts');
 
-      const postStartRows = await fetchScheduledWorkouts(apiContext, rangeFrom, rangeTo);
+    await openTemplatesAndSchedule(page, today);
+
+    await page.getByRole('button', { exact: true, name: 'List' }).click();
+    const startCard = getScheduledCard(page);
+    await expect(startCard).toBeVisible();
+    await startCard.getByRole('button', { name: 'Start now' }).click();
+    await expect(page).toHaveURL(/\/workouts\/active\?/);
+
+    const sessionId = new URL(page.url()).searchParams.get('sessionId');
+    expect(sessionId).toBeTruthy();
+
+    const apiContext = await createAuthorizedApiContext();
+    try {
+      const postStartRows = await fetchScheduledWorkouts(apiContext, range.from, range.to);
       const linkedRow = postStartRows.find(
-        (row) => row.templateId === seededTemplateId && row.date === thirdDate,
+        (row) => row.templateId === seededTemplateId && row.date === today,
       );
       expect(linkedRow?.sessionId).toBe(sessionId);
     } finally {

--- a/apps/web/e2e/workout-scheduling.spec.ts
+++ b/apps/web/e2e/workout-scheduling.spec.ts
@@ -1,0 +1,234 @@
+import { expect, request, test, type APIRequestContext, type Page } from '@playwright/test';
+
+const authTokenStorageKey = 'pulse-auth-token';
+const apiBaseURL = process.env.API_BASE_URL ?? 'http://127.0.0.1:3001';
+const seedSuffix = Date.now();
+
+const testUser = {
+  username: `wsched-e2e-${seedSuffix}`,
+  password: 'super-secret-password',
+};
+
+const seededTemplate = {
+  name: `E2E Workout Scheduling ${seedSuffix}`,
+};
+
+let authToken = '';
+let seededTemplateId = '';
+
+async function authenticatePage(page: Page) {
+  await page.addInitScript(
+    ([storageKey, token]) => {
+      window.localStorage.setItem(storageKey, token);
+    },
+    [authTokenStorageKey, authToken] as const,
+  );
+}
+
+function toDateKey(date: Date) {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function addDays(date: Date, days: number) {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+async function createAuthorizedApiContext() {
+  return request.newContext({
+    baseURL: apiBaseURL,
+    extraHTTPHeaders: {
+      Authorization: `Bearer ${authToken}`,
+    },
+  });
+}
+
+async function fetchScheduledWorkouts(apiContext: APIRequestContext, from: string, to: string) {
+  const response = await apiContext.get(`/api/v1/scheduled-workouts?from=${from}&to=${to}`);
+  expect(response.ok()).toBeTruthy();
+  const payload = (await response.json()) as {
+    data: Array<{
+      id: string;
+      date: string;
+      templateId: string | null;
+      templateName: string | null;
+      sessionId: string | null;
+    }>;
+  };
+
+  return payload.data;
+}
+
+async function pickDayInDialog(page: Page, dateKey: string) {
+  await page.locator(`[role="dialog"] [data-day="${dateKey}"]`).first().click();
+}
+
+test.describe.serial('workout scheduling flow', () => {
+  test.beforeAll(async () => {
+    const apiContext = await request.newContext({ baseURL: apiBaseURL });
+
+    try {
+      const registerResponse = await apiContext.post('/api/v1/auth/register', {
+        data: testUser,
+      });
+      if (registerResponse.ok()) {
+        const registerPayload = (await registerResponse.json()) as {
+          data: {
+            token: string;
+          };
+        };
+        authToken = registerPayload.data.token;
+      } else if (registerResponse.status() === 409) {
+        const loginResponse = await apiContext.post('/api/v1/auth/login', {
+          data: testUser,
+        });
+        expect(loginResponse.ok()).toBeTruthy();
+
+        const loginPayload = (await loginResponse.json()) as {
+          data: {
+            token: string;
+          };
+        };
+        authToken = loginPayload.data.token;
+      } else {
+        throw new Error(
+          `Unable to create e2e auth token. register status=${registerResponse.status()}`,
+        );
+      }
+
+      const authorizedContext = await createAuthorizedApiContext();
+      try {
+        const exerciseResponse = await authorizedContext.post('/api/v1/exercises', {
+          data: {
+            category: 'compound',
+            equipment: 'barbell',
+            muscleGroups: ['chest', 'triceps'],
+            name: `E2E Scheduling Bench ${seedSuffix}`,
+          },
+        });
+        expect(exerciseResponse.ok()).toBeTruthy();
+        const exercisePayload = (await exerciseResponse.json()) as {
+          data: { id: string };
+        };
+
+        const templateResponse = await authorizedContext.post('/api/v1/workout-templates', {
+          data: {
+            description: 'Playwright seeded template for workout scheduling lifecycle coverage.',
+            name: seededTemplate.name,
+            sections: [
+              {
+                type: 'main',
+                exercises: [
+                  {
+                    exerciseId: exercisePayload.data.id,
+                    sets: 3,
+                    repsMin: 6,
+                    repsMax: 10,
+                    restSeconds: 120,
+                    cues: [],
+                  },
+                ],
+              },
+            ],
+            tags: ['e2e', 'workout-scheduling'],
+          },
+        });
+        expect(templateResponse.ok()).toBeTruthy();
+
+        const templatePayload = (await templateResponse.json()) as {
+          data: {
+            id: string;
+          };
+        };
+        seededTemplateId = templatePayload.data.id;
+      } finally {
+        await authorizedContext.dispose();
+      }
+    } finally {
+      await apiContext.dispose();
+    }
+  });
+
+  test('schedules, reschedules, removes, and starts from scheduled workouts', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    const today = new Date();
+    const secondDate = toDateKey(addDays(today, 4));
+    const thirdDate = toDateKey(today);
+    const rangeFrom = toDateKey(addDays(today, -7));
+    const rangeTo = toDateKey(addDays(today, 14));
+
+    await authenticatePage(page);
+    await page.goto('/workouts');
+
+    await page.getByRole('button', { exact: true, name: 'Templates' }).click();
+    await page.getByRole('button', { name: `Template actions for ${seededTemplate.name}` }).click();
+    await page.getByRole('menuitem', { name: 'Schedule workout' }).click();
+    await page.getByRole('dialog').getByRole('button', { name: 'Schedule' }).click();
+
+    await page.getByRole('button', { exact: true, name: 'Calendar' }).click();
+    await expect(page.getByText(seededTemplate.name).first()).toBeVisible();
+
+    await page.getByRole('button', { exact: true, name: 'List' }).click();
+    const scheduledCard = page
+      .locator('[data-slot="card"]')
+      .filter({ hasText: seededTemplate.name })
+      .first();
+    await expect(scheduledCard).toBeVisible();
+
+    await scheduledCard.getByRole('button', { name: 'Reschedule' }).click();
+    await pickDayInDialog(page, secondDate);
+    await page.getByRole('dialog').getByRole('button', { name: 'Save' }).click();
+
+    const apiContext = await createAuthorizedApiContext();
+    try {
+      let scheduledRows = await fetchScheduledWorkouts(apiContext, rangeFrom, rangeTo);
+      let targetSchedule = scheduledRows.find(
+        (row) => row.templateId === seededTemplateId && row.date === secondDate,
+      );
+      expect(targetSchedule).toBeTruthy();
+
+      await scheduledCard.getByRole('button', { name: 'Remove from schedule' }).click();
+      await page.getByRole('button', { name: 'Remove' }).click();
+      await expect(
+        page.locator('[data-slot="card"]').filter({ hasText: seededTemplate.name }),
+      ).toHaveCount(0);
+
+      scheduledRows = await fetchScheduledWorkouts(apiContext, rangeFrom, rangeTo);
+      targetSchedule = scheduledRows.find((row) => row.templateId === seededTemplateId);
+      expect(targetSchedule).toBeUndefined();
+
+      await page.getByRole('button', { exact: true, name: 'Templates' }).click();
+      await page
+        .getByRole('button', { name: `Template actions for ${seededTemplate.name}` })
+        .click();
+      await page.getByRole('menuitem', { name: 'Schedule workout' }).click();
+      await pickDayInDialog(page, thirdDate);
+      await page.getByRole('dialog').getByRole('button', { name: 'Schedule' }).click();
+
+      await page.getByRole('button', { exact: true, name: 'List' }).click();
+      const startCard = page
+        .locator('[data-slot="card"]')
+        .filter({ hasText: seededTemplate.name })
+        .first();
+      await expect(startCard).toBeVisible();
+      await startCard.getByRole('button', { name: 'Start now' }).click();
+      await expect(page).toHaveURL(/\/workouts\/active\?/);
+
+      const sessionId = new URL(page.url()).searchParams.get('sessionId');
+      expect(sessionId).toBeTruthy();
+
+      const postStartRows = await fetchScheduledWorkouts(apiContext, rangeFrom, rangeTo);
+      const linkedRow = postStartRows.find(
+        (row) => row.templateId === seededTemplateId && row.date === thirdDate,
+      );
+      expect(linkedRow?.sessionId).toBe(sessionId);
+    } finally {
+      await apiContext.dispose();
+    }
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "lucide-react": "^0.577.0",
     "radix-ui": "^1.4.3",
     "react": "^19.0.0",
+    "react-day-picker": "^9.14.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.71.2",
     "react-router": "^7.13.1",

--- a/apps/web/src/components/ui/calendar.tsx
+++ b/apps/web/src/components/ui/calendar.tsx
@@ -1,0 +1,54 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import * as React from 'react';
+import { DayPicker } from 'react-day-picker';
+
+import { cn } from '@/lib/utils';
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  ...props
+}: React.ComponentProps<typeof DayPicker>) {
+  return (
+    <DayPicker
+      className={cn('p-3', className)}
+      classNames={{
+        button_next:
+          'inline-flex h-7 w-7 items-center justify-center rounded-md border border-border bg-background p-0 text-foreground hover:bg-accent hover:text-accent-foreground',
+        button_previous:
+          'inline-flex h-7 w-7 items-center justify-center rounded-md border border-border bg-background p-0 text-foreground hover:bg-accent hover:text-accent-foreground',
+        caption_label: 'text-sm font-medium',
+        day: 'h-9 w-9 p-0 text-center text-sm [&:has([aria-selected])]:bg-accent/50',
+        day_button:
+          'h-9 w-9 rounded-md p-0 text-sm font-normal hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none',
+        disabled: 'text-muted opacity-50',
+        hidden: 'invisible',
+        month: 'space-y-4',
+        month_caption: 'flex items-center justify-center gap-1.5',
+        months: 'flex flex-col sm:flex-row gap-4',
+        nav: 'flex items-center gap-1',
+        outside: 'text-muted opacity-50 aria-selected:bg-accent/40',
+        selected:
+          'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',
+        today: 'bg-secondary text-secondary-foreground',
+        weekday: 'w-9 text-xs font-medium text-muted',
+        weekdays: 'flex',
+        week: 'mt-2 flex w-full',
+        ...classNames,
+      }}
+      components={{
+        Chevron: ({ orientation, className: iconClassName, ...iconProps }) =>
+          orientation === 'left' ? (
+            <ChevronLeft className={cn('h-4 w-4', iconClassName)} {...iconProps} />
+          ) : (
+            <ChevronRight className={cn('h-4 w-4', iconClassName)} {...iconProps} />
+          ),
+      }}
+      showOutsideDays={showOutsideDays}
+      {...props}
+    />
+  );
+}
+
+export { Calendar };

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -1,5 +1,6 @@
 import { type QueryClient, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
+  createScheduledWorkoutInputSchema,
   createWorkoutSessionInputSchema,
   exerciseQueryParamsSchema,
   exerciseSchema,
@@ -12,6 +13,7 @@ import {
   updateWorkoutTemplateInputSchema,
   type Exercise,
   type ExerciseQueryParams,
+  type CreateScheduledWorkoutInput,
   type ScheduledWorkout,
   type ScheduledWorkoutListItem,
   type ScheduledWorkoutQueryParams,
@@ -67,6 +69,7 @@ type ReorderTemplateExercisesRequest = {
   section: 'warmup' | 'main' | 'cooldown';
   exerciseIds: string[];
 };
+type CreateScheduledWorkoutRequest = CreateScheduledWorkoutInput;
 type UpdateScheduledWorkoutRequest = {
   id: string;
   date: string;
@@ -315,6 +318,17 @@ async function reorderTemplateExercises(input: ReorderTemplateExercisesRequest) 
   return payload.data;
 }
 
+async function createScheduledWorkout(input: CreateScheduledWorkoutRequest) {
+  const parsedInput = createScheduledWorkoutInputSchema.parse(input);
+  const data = await apiRequest<unknown>('/api/v1/scheduled-workouts', {
+    body: JSON.stringify(parsedInput),
+    method: 'POST',
+  });
+  const payload = z.object({ data: scheduledWorkoutSchema }).parse({ data });
+
+  return payload.data;
+}
+
 async function updateScheduledWorkout(input: UpdateScheduledWorkoutRequest) {
   const parsedInput = updateScheduledWorkoutInputSchema.parse({
     date: input.date,
@@ -430,7 +444,31 @@ export function useStartWorkoutSession() {
   });
 }
 
-export function useUpdateScheduledWorkout() {
+export function useScheduleWorkout() {
+  const queryClient = useQueryClient();
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  return useMutation<ScheduledWorkout, Error, CreateScheduledWorkoutRequest>({
+    mutationFn: createScheduledWorkout,
+    onSuccess: async (_, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.all,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.sessions(),
+        }),
+      ]);
+      toast.success(`Scheduled for ${formatter.format(new Date(`${variables.date}T12:00:00`))}`);
+    },
+  });
+}
+
+export function useRescheduleWorkout() {
   const queryClient = useQueryClient();
 
   return useMutation<ScheduledWorkout, Error, UpdateScheduledWorkoutRequest>({
@@ -449,7 +487,7 @@ export function useUpdateScheduledWorkout() {
   });
 }
 
-export function useDeleteScheduledWorkout() {
+export function useUnscheduleWorkout() {
   const queryClient = useQueryClient();
 
   return useMutation<DeleteScheduledWorkoutResponse, Error, DeleteScheduledWorkoutRequest>({
@@ -467,6 +505,9 @@ export function useDeleteScheduledWorkout() {
     },
   });
 }
+
+export const useUpdateScheduledWorkout = useRescheduleWorkout;
+export const useDeleteScheduledWorkout = useUnscheduleWorkout;
 
 export function useRenameExercise() {
   const queryClient = useQueryClient();

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -118,6 +118,7 @@ export const workoutQueryKeys = {
   completedSessions: () => ['workouts', 'completed-sessions'] as const,
   exercises: (params: ExerciseQueryParams) => ['workouts', 'exercises', params] as const,
   exerciseFilters: () => ['workouts', 'exercise-filters'] as const,
+  scheduledWorkoutsAll: () => ['workouts', 'scheduled-workouts'] as const,
   scheduledWorkouts: (params: ScheduledWorkoutQueryParams) =>
     ['workouts', 'scheduled-workouts', params] as const,
   session: (id: string) => ['workouts', 'session', id] as const,
@@ -457,7 +458,7 @@ export function useScheduleWorkout() {
     onSuccess: async (_, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.all,
+          queryKey: workoutQueryKeys.scheduledWorkoutsAll(),
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.sessions(),
@@ -476,7 +477,7 @@ export function useRescheduleWorkout() {
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.all,
+          queryKey: workoutQueryKeys.scheduledWorkoutsAll(),
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.sessions(),
@@ -495,7 +496,7 @@ export function useUnscheduleWorkout() {
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.all,
+          queryKey: workoutQueryKeys.scheduledWorkoutsAll(),
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.sessions(),
@@ -505,9 +506,6 @@ export function useUnscheduleWorkout() {
     },
   });
 }
-
-export const useUpdateScheduledWorkout = useRescheduleWorkout;
-export const useDeleteScheduledWorkout = useUnscheduleWorkout;
 
 export function useRenameExercise() {
   const queryClient = useQueryClient();

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -3,11 +3,18 @@ import {
   createWorkoutSessionInputSchema,
   exerciseQueryParamsSchema,
   exerciseSchema,
+  scheduledWorkoutListItemSchema,
+  scheduledWorkoutQueryParamsSchema,
+  scheduledWorkoutSchema,
   reorderWorkoutTemplateExercisesInputSchema,
+  updateScheduledWorkoutInputSchema,
   updateExerciseInputSchema,
   updateWorkoutTemplateInputSchema,
   type Exercise,
   type ExerciseQueryParams,
+  type ScheduledWorkout,
+  type ScheduledWorkoutListItem,
+  type ScheduledWorkoutQueryParams,
   type WorkoutSession,
   type WorkoutSessionListItem,
   type WorkoutSessionQueryParams,
@@ -60,6 +67,18 @@ type ReorderTemplateExercisesRequest = {
   section: 'warmup' | 'main' | 'cooldown';
   exerciseIds: string[];
 };
+type UpdateScheduledWorkoutRequest = {
+  id: string;
+  date: string;
+};
+type DeleteScheduledWorkoutRequest = {
+  id: string;
+};
+type DeleteScheduledWorkoutResponse = {
+  data: {
+    success: boolean;
+  };
+};
 
 // Preprocess in shared schemas widens inference here, so we pin the parsed response shape explicitly.
 const workoutTemplateResponseSchema = z.object({
@@ -96,6 +115,8 @@ export const workoutQueryKeys = {
   completedSessions: () => ['workouts', 'completed-sessions'] as const,
   exercises: (params: ExerciseQueryParams) => ['workouts', 'exercises', params] as const,
   exerciseFilters: () => ['workouts', 'exercise-filters'] as const,
+  scheduledWorkouts: (params: ScheduledWorkoutQueryParams) =>
+    ['workouts', 'scheduled-workouts', params] as const,
   session: (id: string) => ['workouts', 'session', id] as const,
   sessions: () => ['workouts', 'sessions'] as const,
   sessionsList: (params: WorkoutSessionQueryParams = {}) =>
@@ -121,6 +142,25 @@ async function getCompletedSessions(signal?: AbortSignal) {
     signal,
   });
   const payload = sessionListResponseSchema.parse({ data });
+
+  return payload.data;
+}
+
+const scheduledWorkoutListResponseSchema = z.object({
+  data: z.array(scheduledWorkoutListItemSchema),
+}) as unknown as z.ZodType<{ data: ScheduledWorkoutListItem[] }>;
+
+async function getScheduledWorkouts(params: ScheduledWorkoutQueryParams, signal?: AbortSignal) {
+  const parsedParams = scheduledWorkoutQueryParamsSchema.parse(params);
+  const searchParams = new URLSearchParams({
+    from: parsedParams.from,
+    to: parsedParams.to,
+  });
+  const data = await apiRequest<unknown>(`/api/v1/scheduled-workouts?${searchParams.toString()}`, {
+    method: 'GET',
+    signal,
+  });
+  const payload = scheduledWorkoutListResponseSchema.parse({ data });
 
   return payload.data;
 }
@@ -275,6 +315,32 @@ async function reorderTemplateExercises(input: ReorderTemplateExercisesRequest) 
   return payload.data;
 }
 
+async function updateScheduledWorkout(input: UpdateScheduledWorkoutRequest) {
+  const parsedInput = updateScheduledWorkoutInputSchema.parse({
+    date: input.date,
+  });
+  const data = await apiRequest<unknown>(`/api/v1/scheduled-workouts/${input.id}`, {
+    body: JSON.stringify(parsedInput),
+    method: 'PATCH',
+  });
+  const payload = z.object({ data: scheduledWorkoutSchema }).parse({ data });
+
+  return payload.data;
+}
+
+async function deleteScheduledWorkout(input: DeleteScheduledWorkoutRequest) {
+  const data = await apiRequest<unknown>(`/api/v1/scheduled-workouts/${input.id}`, {
+    method: 'DELETE',
+  });
+  return z
+    .object({
+      data: z.object({
+        success: z.boolean(),
+      }),
+    })
+    .parse({ data }) as DeleteScheduledWorkoutResponse;
+}
+
 export function useWorkoutTemplates() {
   return useQuery<WorkoutTemplate[]>({
     queryFn: getWorkoutTemplates,
@@ -286,6 +352,17 @@ export function useCompletedSessions() {
   return useQuery<WorkoutSessionListItem[]>({
     queryFn: ({ signal }) => getCompletedSessions(signal),
     queryKey: workoutQueryKeys.completedSessions(),
+  });
+}
+
+export function useScheduledWorkouts(
+  params: ScheduledWorkoutQueryParams,
+  options?: { enabled?: boolean },
+) {
+  return useQuery<ScheduledWorkoutListItem[]>({
+    enabled: options?.enabled,
+    queryFn: ({ signal }) => getScheduledWorkouts(params, signal),
+    queryKey: workoutQueryKeys.scheduledWorkouts(params),
   });
 }
 
@@ -349,6 +426,44 @@ export function useStartWorkoutSession() {
         queryKey: workoutQueryKeys.sessions(),
       });
       toast.success('Workout started');
+    },
+  });
+}
+
+export function useUpdateScheduledWorkout() {
+  const queryClient = useQueryClient();
+
+  return useMutation<ScheduledWorkout, Error, UpdateScheduledWorkoutRequest>({
+    mutationFn: updateScheduledWorkout,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.all,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.sessions(),
+        }),
+      ]);
+      toast.success('Workout rescheduled');
+    },
+  });
+}
+
+export function useDeleteScheduledWorkout() {
+  const queryClient = useQueryClient();
+
+  return useMutation<DeleteScheduledWorkoutResponse, Error, DeleteScheduledWorkoutRequest>({
+    mutationFn: deleteScheduledWorkout,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.all,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.sessions(),
+        }),
+      ]);
+      toast.success('Scheduled workout removed');
     },
   });
 }

--- a/apps/web/src/features/workouts/components/schedule-workout-dialog.tsx
+++ b/apps/web/src/features/workouts/components/schedule-workout-dialog.tsx
@@ -42,7 +42,7 @@ export function ScheduleWorkoutDialog({
   const selectedDateKey = useMemo(() => toDateKey(selectedDate), [selectedDate]);
 
   function handleOpenChange(nextOpen: boolean) {
-    if (nextOpen) {
+    if (!nextOpen) {
       setSelectedDate(parseDateKey(initialDate));
       setErrorMessage(null);
     }

--- a/apps/web/src/features/workouts/components/schedule-workout-dialog.tsx
+++ b/apps/web/src/features/workouts/components/schedule-workout-dialog.tsx
@@ -14,6 +14,8 @@ import { parseDateKey, toDateKey } from '@/lib/date-utils';
 
 type ScheduleWorkoutDialogProps = {
   description: string;
+  disallowDateKey?: string;
+  disallowDateMessage?: string;
   initialDate: string;
   isPending: boolean;
   onOpenChange: (open: boolean) => void;
@@ -25,6 +27,8 @@ type ScheduleWorkoutDialogProps = {
 
 export function ScheduleWorkoutDialog({
   description,
+  disallowDateKey,
+  disallowDateMessage = 'Pick a different date.',
   initialDate,
   isPending,
   onOpenChange,
@@ -47,6 +51,12 @@ export function ScheduleWorkoutDialog({
 
   async function handleSubmit() {
     setErrorMessage(null);
+
+    if (disallowDateKey != null && selectedDateKey === disallowDateKey) {
+      setErrorMessage(disallowDateMessage);
+      return;
+    }
+
     try {
       await onSubmitDate(selectedDateKey);
       handleOpenChange(false);

--- a/apps/web/src/features/workouts/components/schedule-workout-dialog.tsx
+++ b/apps/web/src/features/workouts/components/schedule-workout-dialog.tsx
@@ -37,13 +37,14 @@ export function ScheduleWorkoutDialog({
   submitLabel,
   title,
 }: ScheduleWorkoutDialogProps) {
-  const [selectedDate, setSelectedDate] = useState<Date>(() => parseDateKey(initialDate));
+  const [pendingSelectedDate, setPendingSelectedDate] = useState<Date | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const selectedDate = pendingSelectedDate ?? parseDateKey(initialDate);
   const selectedDateKey = useMemo(() => toDateKey(selectedDate), [selectedDate]);
 
   function handleOpenChange(nextOpen: boolean) {
     if (!nextOpen) {
-      setSelectedDate(parseDateKey(initialDate));
+      setPendingSelectedDate(null);
       setErrorMessage(null);
     }
     onOpenChange(nextOpen);
@@ -77,7 +78,7 @@ export function ScheduleWorkoutDialog({
             mode="single"
             onSelect={(date) => {
               if (date) {
-                setSelectedDate(date);
+                setPendingSelectedDate(date);
               }
             }}
             selected={selectedDate}

--- a/apps/web/src/features/workouts/components/schedule-workout-dialog.tsx
+++ b/apps/web/src/features/workouts/components/schedule-workout-dialog.tsx
@@ -1,0 +1,88 @@
+import { useMemo, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { parseDateKey, toDateKey } from '@/lib/date-utils';
+
+type ScheduleWorkoutDialogProps = {
+  description: string;
+  initialDate: string;
+  isPending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmitDate: (dateKey: string) => Promise<unknown>;
+  open: boolean;
+  submitLabel: string;
+  title: string;
+};
+
+export function ScheduleWorkoutDialog({
+  description,
+  initialDate,
+  isPending,
+  onOpenChange,
+  onSubmitDate,
+  open,
+  submitLabel,
+  title,
+}: ScheduleWorkoutDialogProps) {
+  const [selectedDate, setSelectedDate] = useState<Date>(() => parseDateKey(initialDate));
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const selectedDateKey = useMemo(() => toDateKey(selectedDate), [selectedDate]);
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (nextOpen) {
+      setSelectedDate(parseDateKey(initialDate));
+      setErrorMessage(null);
+    }
+    onOpenChange(nextOpen);
+  }
+
+  async function handleSubmit() {
+    setErrorMessage(null);
+    try {
+      await onSubmitDate(selectedDateKey);
+      handleOpenChange(false);
+    } catch {
+      setErrorMessage('Unable to save right now. Try again.');
+    }
+  }
+
+  return (
+    <Dialog onOpenChange={handleOpenChange} open={open}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className="flex justify-center">
+          <Calendar
+            mode="single"
+            onSelect={(date) => {
+              if (date) {
+                setSelectedDate(date);
+              }
+            }}
+            selected={selectedDate}
+          />
+        </div>
+        {errorMessage ? <p className="text-xs text-destructive">{errorMessage}</p> : null}
+        <DialogFooter>
+          <Button onClick={() => handleOpenChange(false)} type="button" variant="outline">
+            Cancel
+          </Button>
+          <Button disabled={isPending} onClick={handleSubmit} type="button">
+            {submitLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/workouts/components/template-browser.test.tsx
+++ b/apps/web/src/features/workouts/components/template-browser.test.tsx
@@ -7,6 +7,7 @@ import { TemplateBrowser } from './template-browser';
 
 const renameMutateMock = vi.fn();
 const deleteMutateMock = vi.fn();
+const scheduleMutateAsyncMock = vi.fn();
 
 vi.mock('@/features/workouts/api/workouts', () => ({
   useRenameTemplate: () => ({
@@ -16,6 +17,10 @@ vi.mock('@/features/workouts/api/workouts', () => ({
   useDeleteTemplate: () => ({
     isPending: false,
     mutate: deleteMutateMock,
+  }),
+  useScheduleWorkout: () => ({
+    isPending: false,
+    mutateAsync: scheduleMutateAsyncMock,
   }),
 }));
 
@@ -40,6 +45,7 @@ describe('TemplateBrowser', () => {
   beforeEach(() => {
     renameMutateMock.mockReset();
     deleteMutateMock.mockReset();
+    scheduleMutateAsyncMock.mockReset();
   });
 
   it('renders updated copy and empty state for users without templates', () => {
@@ -164,6 +170,37 @@ describe('TemplateBrowser', () => {
       expect.objectContaining({
         onError: expect.any(Function),
         onSuccess: expect.any(Function),
+      }),
+    );
+  });
+
+  it('opens schedule dialog from template actions and submits selected date', async () => {
+    scheduleMutateAsyncMock.mockResolvedValue({});
+
+    render(
+      <MemoryRouter>
+        <TemplateBrowser
+          buildTemplateHref={(templateId) => `/workouts/template/${templateId}`}
+          templates={[
+            {
+              id: 'template-1',
+              name: 'Upper Push',
+              description: 'Chest and shoulders',
+              tags: ['push'],
+              sections: [{ exercises: [] }],
+            },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Template actions for Upper Push' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Schedule workout' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Schedule' }));
+
+    expect(scheduleMutateAsyncMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateId: 'template-1',
       }),
     );
   });

--- a/apps/web/src/features/workouts/components/template-browser.tsx
+++ b/apps/web/src/features/workouts/components/template-browser.tsx
@@ -31,9 +31,15 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
-import { useDeleteTemplate, useRenameTemplate } from '@/features/workouts/api/workouts';
+import {
+  useDeleteTemplate,
+  useRenameTemplate,
+  useScheduleWorkout,
+} from '@/features/workouts/api/workouts';
+import { toDateKey } from '@/lib/date-utils';
 import { ApiError } from '@/lib/api-client';
 import { cn } from '@/lib/utils';
+import { ScheduleWorkoutDialog } from '@/features/workouts/components/schedule-workout-dialog';
 
 // Minimal structural interface — satisfied by both mock and API WorkoutTemplate shapes.
 interface TemplateSummary {
@@ -58,9 +64,11 @@ export function TemplateBrowser({
   const [searchQuery, setSearchQuery] = useState('');
   const [renameTarget, setRenameTarget] = useState<{ id: string; name: string } | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
+  const [scheduleTarget, setScheduleTarget] = useState<{ id: string; name: string } | null>(null);
   const [renameValue, setRenameValue] = useState('');
   const renameTemplateMutation = useRenameTemplate();
   const deleteTemplateMutation = useDeleteTemplate();
+  const scheduleWorkoutMutation = useScheduleWorkout();
   const normalizedQuery = searchQuery.trim().toLowerCase();
 
   const filteredTemplates = useMemo(
@@ -149,6 +157,16 @@ export function TemplateBrowser({
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
                     <DropdownMenuItem
+                      onSelect={() =>
+                        setScheduleTarget({
+                          id: template.id,
+                          name: template.name,
+                        })
+                      }
+                    >
+                      Schedule workout
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
                       onSelect={() => {
                         setRenameTarget({
                           id: template.id,
@@ -179,34 +197,38 @@ export function TemplateBrowser({
                   to={buildTemplateHref(template.id)}
                 >
                   <div className="flex flex-col gap-4">
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between gap-3">
-                      <h3 className="text-xl font-semibold text-foreground">{template.name}</h3>
-                      <ArrowRight aria-hidden="true" className="size-4 text-muted" />
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between gap-3">
+                        <h3 className="text-xl font-semibold text-foreground">{template.name}</h3>
+                        <ArrowRight aria-hidden="true" className="size-4 text-muted" />
+                      </div>
+                      {template.description ? (
+                        <p className="text-sm text-muted">{template.description}</p>
+                      ) : null}
                     </div>
-                    {template.description ? (
-                      <p className="text-sm text-muted">{template.description}</p>
-                    ) : null}
-                  </div>
 
-                  <div className="flex flex-wrap gap-2">
-                    {template.tags.map((tag) => (
-                      <Badge className="border-border bg-secondary/70" key={tag} variant="outline">
-                        {formatLabel(tag)}
-                      </Badge>
-                    ))}
-                  </div>
+                    <div className="flex flex-wrap gap-2">
+                      {template.tags.map((tag) => (
+                        <Badge
+                          className="border-border bg-secondary/70"
+                          key={tag}
+                          variant="outline"
+                        >
+                          {formatLabel(tag)}
+                        </Badge>
+                      ))}
+                    </div>
 
-                  <div className="flex flex-wrap gap-3 text-sm text-muted">
-                    <div className="inline-flex items-center gap-2">
-                      <ListChecks aria-hidden="true" className="size-4" />
-                      <span>{`${exerciseCount} exercises`}</span>
+                    <div className="flex flex-wrap gap-3 text-sm text-muted">
+                      <div className="inline-flex items-center gap-2">
+                        <ListChecks aria-hidden="true" className="size-4" />
+                        <span>{`${exerciseCount} exercises`}</span>
+                      </div>
+                      <div className="inline-flex items-center gap-2">
+                        <Tag aria-hidden="true" className="size-4" />
+                        <span>{`${template.tags.length} tags`}</span>
+                      </div>
                     </div>
-                    <div className="inline-flex items-center gap-2">
-                      <Tag aria-hidden="true" className="size-4" />
-                      <span>{`${template.tags.length} tags`}</span>
-                    </div>
-                  </div>
                   </div>
                 </Link>
               </div>
@@ -283,12 +305,12 @@ export function TemplateBrowser({
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Delete this template?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This cannot be undone.
-            </AlertDialogDescription>
+            <AlertDialogDescription>This cannot be undone.</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleteTemplateMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogCancel disabled={deleteTemplateMutation.isPending}>
+              Cancel
+            </AlertDialogCancel>
             <AlertDialogAction
               disabled={deleteTemplateMutation.isPending}
               onClick={(event) => {
@@ -320,6 +342,29 @@ export function TemplateBrowser({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+      <ScheduleWorkoutDialog
+        description={`Pick a date for ${scheduleTarget?.name ?? 'this workout'}.`}
+        initialDate={toDateKey(new Date())}
+        isPending={scheduleWorkoutMutation.isPending}
+        onOpenChange={(open) => {
+          if (!open) {
+            setScheduleTarget(null);
+          }
+        }}
+        onSubmitDate={async (date) => {
+          if (!scheduleTarget) {
+            return;
+          }
+
+          await scheduleWorkoutMutation.mutateAsync({
+            date,
+            templateId: scheduleTarget.id,
+          });
+        }}
+        open={scheduleTarget != null}
+        submitLabel="Schedule"
+        title="Schedule workout"
+      />
     </section>
   );
 }

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -266,6 +266,55 @@ describe('WorkoutTemplateDetail', () => {
     expect(window.localStorage.getItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY)).toBe('session-1');
   });
 
+  it('schedules a workout from the template detail view', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = String(input);
+
+      if (url.endsWith('/api/v1/workout-templates/upper-push')) {
+        return Promise.resolve(jsonResponse(templatePayload));
+      }
+
+      if (url.endsWith('/api/v1/scheduled-workouts') && init?.method === 'POST') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: 'scheduled-1',
+              userId: 'user-1',
+              templateId: 'upper-push',
+              date: '2026-03-20',
+              sessionId: null,
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutTemplateDetail templateId="upper-push" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Schedule' }));
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Schedule' }));
+
+    await waitFor(() => {
+      const scheduleCall = fetchSpy.mock.calls.find(([input, init]) => {
+        const requestMethod = input instanceof Request ? input.method : (init?.method ?? 'GET');
+        const requestUrl = input instanceof Request ? input.url : String(input);
+
+        return requestUrl.endsWith('/api/v1/scheduled-workouts') && requestMethod === 'POST';
+      });
+
+      expect(scheduleCall).toBeDefined();
+    });
+  });
+
   it('renames an exercise from the template exercise menu', async () => {
     const mutableTemplate = structuredClone(templatePayload);
     vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -35,12 +35,14 @@ import { ApiError } from '@/lib/api-client';
 import { toDateKey } from '@/lib/date-utils';
 
 import {
+  useScheduleWorkout,
   useRenameExercise,
   useReorderTemplateExercises,
   useWorkoutTemplate,
 } from '../api/workouts';
 import { FormCueChips } from './form-cue-chips';
 import { RenameExerciseDialog } from './rename-exercise-dialog';
+import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
 
 type WorkoutTemplateDetailProps = {
   templateId: string;
@@ -57,12 +59,14 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
   const navigate = useNavigate();
   const templateQuery = useWorkoutTemplate(templateId);
   const startWorkoutMutation = useStartSession();
+  const scheduleWorkoutMutation = useScheduleWorkout();
   const renameExerciseMutation = useRenameExercise();
   const reorderExercisesMutation = useReorderTemplateExercises();
   const [renameTarget, setRenameTarget] = useState<{
     exerciseId: string;
     exerciseName: string;
   } | null>(null);
+  const [isScheduleDialogOpen, setIsScheduleDialogOpen] = useState(false);
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
@@ -288,37 +292,63 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
       />
 
       <div className="space-y-2">
-        <Button
-          className="w-full sm:w-auto"
-          disabled={startWorkoutMutation.isPending}
-          onClick={() => {
-            const startedAt = Date.now();
+        <div className="flex flex-wrap gap-2">
+          <Button
+            className="w-full sm:w-auto"
+            disabled={startWorkoutMutation.isPending}
+            onClick={() => {
+              const startedAt = Date.now();
 
-            startWorkoutMutation.mutate(
-              {
-                date: toDateKey(new Date(startedAt)),
-                name: template.name,
-                sets: buildInitialSessionSets(template),
-                startedAt,
-                templateId: template.id,
-              },
-              {
-                onSuccess: (session) => {
-                  navigate(`/workouts/active?template=${template.id}&sessionId=${session.id}`);
+              startWorkoutMutation.mutate(
+                {
+                  date: toDateKey(new Date(startedAt)),
+                  name: template.name,
+                  sets: buildInitialSessionSets(template),
+                  startedAt,
+                  templateId: template.id,
                 },
-              },
-            );
-          }}
-          size="lg"
-          type="button"
-        >
-          {startWorkoutMutation.isPending ? 'Starting workout...' : 'Start Workout'}
-        </Button>
+                {
+                  onSuccess: (session) => {
+                    navigate(`/workouts/active?template=${template.id}&sessionId=${session.id}`);
+                  },
+                },
+              );
+            }}
+            size="lg"
+            type="button"
+          >
+            {startWorkoutMutation.isPending ? 'Starting workout...' : 'Start Workout'}
+          </Button>
+          <Button
+            className="w-full sm:w-auto"
+            onClick={() => setIsScheduleDialogOpen(true)}
+            size="lg"
+            type="button"
+            variant="outline"
+          >
+            Schedule
+          </Button>
+        </div>
 
         {startWorkoutMutation.isError ? (
           <p className="text-sm text-destructive">Unable to start the workout. Try again.</p>
         ) : null}
       </div>
+      <ScheduleWorkoutDialog
+        description={`Pick a date for ${template.name}.`}
+        initialDate={toDateKey(new Date())}
+        isPending={scheduleWorkoutMutation.isPending}
+        onOpenChange={setIsScheduleDialogOpen}
+        onSubmitDate={(date) =>
+          scheduleWorkoutMutation.mutateAsync({
+            date,
+            templateId: template.id,
+          })
+        }
+        open={isScheduleDialogOpen}
+        submitLabel="Schedule"
+        title="Schedule workout"
+      />
     </section>
   );
 }

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -18,7 +18,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { ArrowDown, ArrowUp, GripVertical, MoreVertical } from 'lucide-react';
 
-import type { WorkoutTemplate, WorkoutTemplateExercise } from '@pulse/shared';
+import type { WorkoutTemplateExercise } from '@pulse/shared';
 import { toast } from 'sonner';
 
 import { Badge } from '@/components/ui/badge';
@@ -40,6 +40,7 @@ import {
   useReorderTemplateExercises,
   useWorkoutTemplate,
 } from '../api/workouts';
+import { buildInitialSessionSets } from '../lib/workout-session-sets';
 import { FormCueChips } from './form-cue-chips';
 import { RenameExerciseDialog } from './rename-exercise-dialog';
 import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
@@ -530,23 +531,4 @@ function formatRepTarget(repsMin: number | null, repsMax: number | null) {
 
 function formatTempo(tempo: string) {
   return tempo.split('').join('-');
-}
-
-function buildInitialSessionSets(template: WorkoutTemplate) {
-  return template.sections.flatMap((section) =>
-    section.exercises.flatMap((exercise, exerciseIndex) => {
-      if (exercise.sets === null || exercise.sets < 1) {
-        return [];
-      }
-
-      return Array.from({ length: exercise.sets }, (_, index) => ({
-        exerciseId: exercise.exerciseId,
-        orderIndex: exerciseIndex,
-        reps: null,
-        section: section.type,
-        setNumber: index + 1,
-        weight: null,
-      }));
-    }),
-  );
 }

--- a/apps/web/src/features/workouts/components/workout-calendar.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.test.tsx
@@ -65,6 +65,14 @@ describe('WorkoutCalendar', () => {
                 sessionId: null,
                 createdAt: 1,
               },
+              {
+                id: 'schedule-2',
+                date: sessionDateKey,
+                templateId: 'template-2',
+                templateName: 'Accessory',
+                sessionId: null,
+                createdAt: 2,
+              },
             ],
           }),
         );
@@ -82,10 +90,12 @@ describe('WorkoutCalendar', () => {
     expect(await screen.findByText('Workout Calendar')).toBeInTheDocument();
     expect((await screen.findAllByLabelText('Completed workout')).length).toBeGreaterThan(0);
     expect((await screen.findAllByLabelText('Scheduled workout')).length).toBeGreaterThan(0);
+    expect(screen.getByText('+1')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Done' })).toHaveAttribute(
       'href',
       '/workouts/session/session-1',
     );
+    expect(screen.getByRole('button', { name: /selected/i })).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('shows empty calendar details when no workouts exist', async () => {

--- a/apps/web/src/features/workouts/components/workout-calendar.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.test.tsx
@@ -19,7 +19,7 @@ afterEach(() => {
 });
 
 describe('WorkoutCalendar', () => {
-  it('renders completed sessions from the API and links to session details', async () => {
+  it('renders completed and scheduled workouts with session links', async () => {
     const sessionDate = new Date();
     sessionDate.setDate(Math.min(sessionDate.getDate(), 10));
     const sessionDateKey = toDateKey(sessionDate);
@@ -38,36 +38,39 @@ describe('WorkoutCalendar', () => {
     };
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
-      const url = String(input);
+      const url = new URL(String(input), 'https://pulse.test');
 
-      if (url.includes('/api/v1/workout-sessions?status=completed')) {
-        return Promise.resolve(jsonResponse({ data: [completedSession] }));
+      if (url.pathname === '/api/v1/workout-sessions') {
+        const statuses = url.searchParams.getAll('status');
+        if (statuses.includes('completed')) {
+          return Promise.resolve(jsonResponse({ data: [completedSession] }));
+        }
+
+        if (statuses.includes('in-progress') || statuses.includes('paused')) {
+          return Promise.resolve(jsonResponse({ data: [] }));
+        }
+
+        return Promise.resolve(jsonResponse({ data: [] }));
       }
 
-      if (url.includes('/api/v1/workout-templates')) {
+      if (url.pathname === '/api/v1/scheduled-workouts') {
         return Promise.resolve(
           jsonResponse({
             data: [
               {
-                id: 'template-1',
-                userId: 'user-1',
-                name: 'Upper Push',
-                description: null,
-                tags: ['push'],
-                sections: [
-                  { type: 'warmup', exercises: [] },
-                  { type: 'main', exercises: [] },
-                  { type: 'cooldown', exercises: [] },
-                ],
+                id: 'schedule-1',
+                date: sessionDateKey,
+                templateId: 'template-1',
+                templateName: 'Upper Push',
+                sessionId: null,
                 createdAt: 1,
-                updatedAt: 1,
               },
             ],
           }),
         );
       }
 
-      throw new Error(`Unhandled request: ${url}`);
+      throw new Error(`Unhandled request: ${url.pathname}`);
     });
 
     renderWithQueryClient(
@@ -78,34 +81,26 @@ describe('WorkoutCalendar', () => {
 
     expect(await screen.findByText('Workout Calendar')).toBeInTheDocument();
     expect((await screen.findAllByLabelText('Completed workout')).length).toBeGreaterThan(0);
-
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: formatFullDate(new Date(`${sessionDateKey}T12:00:00`)),
-      }),
-    );
-
-    expect(screen.getByRole('heading', { name: 'Upper Push' })).toBeInTheDocument();
-    expect(screen.getByText('Completed')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'View Session' })).toHaveAttribute(
+    expect((await screen.findAllByLabelText('Scheduled workout')).length).toBeGreaterThan(0);
+    expect(screen.getByRole('link', { name: 'Done' })).toHaveAttribute(
       'href',
       '/workouts/session/session-1',
     );
   });
 
-  it('shows empty calendar details when no completed sessions exist', async () => {
+  it('shows empty calendar details when no workouts exist', async () => {
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
-      const url = String(input);
+      const url = new URL(String(input), 'https://pulse.test');
 
-      if (url.includes('/api/v1/workout-sessions?status=completed')) {
+      if (url.pathname === '/api/v1/workout-sessions') {
         return Promise.resolve(jsonResponse({ data: [] }));
       }
 
-      if (url.includes('/api/v1/workout-templates')) {
+      if (url.pathname === '/api/v1/scheduled-workouts') {
         return Promise.resolve(jsonResponse({ data: [] }));
       }
 
-      throw new Error(`Unhandled request: ${url}`);
+      throw new Error(`Unhandled request: ${url.pathname}`);
     });
 
     renderWithQueryClient(
@@ -117,22 +112,21 @@ describe('WorkoutCalendar', () => {
     expect(await screen.findByText('Workout Calendar')).toBeInTheDocument();
     expect(screen.queryByLabelText('Completed workout')).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'No workout planned' })).toBeInTheDocument();
-    expect(document.getElementById('workout-day-details')).toHaveClass('order-first');
   });
 
   it('navigates between months', async () => {
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
-      const url = String(input);
+      const url = new URL(String(input), 'https://pulse.test');
 
-      if (url.includes('/api/v1/workout-sessions?status=completed')) {
+      if (url.pathname === '/api/v1/workout-sessions') {
         return Promise.resolve(jsonResponse({ data: [] }));
       }
 
-      if (url.includes('/api/v1/workout-templates')) {
+      if (url.pathname === '/api/v1/scheduled-workouts') {
         return Promise.resolve(jsonResponse({ data: [] }));
       }
 
-      throw new Error(`Unhandled request: ${url}`);
+      throw new Error(`Unhandled request: ${url.pathname}`);
     });
 
     renderWithQueryClient(
@@ -150,15 +144,6 @@ describe('WorkoutCalendar', () => {
     expect(screen.getByText(formatMonth(nextMonth))).toBeInTheDocument();
   });
 });
-
-function formatFullDate(date: Date) {
-  return new Intl.DateTimeFormat('en-US', {
-    weekday: 'long',
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  }).format(date);
-}
 
 function formatMonth(date: Date) {
   return new Intl.DateTimeFormat('en-US', {

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { ChevronLeft, ChevronRight, EllipsisVertical } from 'lucide-react';
 import type { WorkoutSessionListItem } from '@pulse/shared';
 import { Link } from 'react-router';
@@ -6,20 +6,11 @@ import { Link } from 'react-router';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Input } from '@/components/ui/input';
 import {
   addDays,
   differenceInDays,
@@ -30,9 +21,9 @@ import {
 import { accentCardStyles } from '@/lib/accent-card-styles';
 import { cn } from '@/lib/utils';
 import {
-  useDeleteScheduledWorkout,
+  useRescheduleWorkout,
   useScheduledWorkouts,
-  useUpdateScheduledWorkout,
+  useUnscheduleWorkout,
   useWorkoutSessions,
 } from '../api/workouts';
 import {
@@ -40,6 +31,7 @@ import {
   isActiveScheduledWorkout,
   isActiveSessionListItem,
 } from '../lib/workout-filters';
+import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
 
 const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
 const TODAY_KEY = toDateKey(new Date());
@@ -118,7 +110,9 @@ export function WorkoutCalendar({
     () =>
       activeSessions.filter(
         (session) =>
-          session.status === 'completed' && session.date >= dateRange.from && session.date <= dateRange.to,
+          session.status === 'completed' &&
+          session.date >= dateRange.from &&
+          session.date <= dateRange.to,
       ),
     [activeSessions, dateRange.from, dateRange.to],
   );
@@ -172,7 +166,9 @@ export function WorkoutCalendar({
   function handleMonthChange(offset: number) {
     const nextMonth = addMonths(visibleMonth, offset);
     setVisibleMonth(nextMonth);
-    setSelectedDateKey(getDefaultSelectedDateKey(nextMonth, completedSessionByDate, scheduledByDate));
+    setSelectedDateKey(
+      getDefaultSelectedDateKey(nextMonth, completedSessionByDate, scheduledByDate),
+    );
   }
 
   return (
@@ -215,7 +211,9 @@ export function WorkoutCalendar({
           <LegendDot className="bg-emerald-500" label="Completed" />
           <LegendDot className="border border-slate-500 bg-transparent" label="Scheduled" />
           <LegendDot className="bg-orange-500" label="In progress" />
-          <span className="rounded-full border border-primary/30 px-2 py-1 text-foreground">Today</span>
+          <span className="rounded-full border border-primary/30 px-2 py-1 text-foreground">
+            Today
+          </span>
         </div>
       </CardHeader>
 
@@ -312,7 +310,9 @@ export function WorkoutCalendar({
                     >
                       {details.templateName ?? 'No workout'}
                     </p>
-                    <p className="truncate text-[10px] leading-snug text-muted">{details.notes ?? ''}</p>
+                    <p className="truncate text-[10px] leading-snug text-muted">
+                      {details.notes ?? ''}
+                    </p>
                   </div>
 
                   <div className="mt-auto flex items-center gap-1 pt-1 sm:gap-1.5 sm:pt-3">
@@ -335,7 +335,9 @@ export function WorkoutCalendar({
                       />
                     ) : null}
                     {isToday ? (
-                      <span className="hidden text-[11px] font-medium text-primary sm:inline">Today</span>
+                      <span className="hidden text-[11px] font-medium text-primary sm:inline">
+                        Today
+                      </span>
                     ) : null}
                   </div>
                 </div>
@@ -360,7 +362,9 @@ export function WorkoutCalendar({
             >
               Day details
             </p>
-            <h3 className="text-2xl font-semibold">{selectedDay.templateName ?? 'No workout planned'}</h3>
+            <h3 className="text-2xl font-semibold">
+              {selectedDay.templateName ?? 'No workout planned'}
+            </h3>
             <p
               className={cn(
                 'text-sm',
@@ -425,7 +429,9 @@ export function WorkoutCalendar({
 
           {selectedDay.scheduledWorkouts.length > 0 ? (
             <div className="space-y-2">
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted">Scheduled</p>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted">
+                Scheduled
+              </p>
               <div className="space-y-2">
                 {selectedDay.scheduledWorkouts.map((scheduledWorkout) => (
                   <div
@@ -433,7 +439,9 @@ export function WorkoutCalendar({
                     key={scheduledWorkout.id}
                   >
                     <div>
-                      <p className="text-sm font-medium text-foreground">{scheduledWorkout.templateName}</p>
+                      <p className="text-sm font-medium text-foreground">
+                        {scheduledWorkout.templateName}
+                      </p>
                       <p className="text-xs text-muted">Scheduled</p>
                     </div>
                     <ScheduledWorkoutActions
@@ -466,12 +474,12 @@ function ScheduledWorkoutActions({
   compact?: boolean;
   scheduledWorkout: ActiveScheduledWorkoutListItem;
 }) {
-  const updateScheduledWorkoutMutation = useUpdateScheduledWorkout();
-  const deleteScheduledWorkoutMutation = useDeleteScheduledWorkout();
+  const rescheduleWorkoutMutation = useRescheduleWorkout();
+  const unscheduleWorkoutMutation = useUnscheduleWorkout();
   const [isRescheduleDialogOpen, setIsRescheduleDialogOpen] = useState(false);
 
   async function handleReschedule(requestedDate: string) {
-    await updateScheduledWorkoutMutation.mutateAsync({
+    await rescheduleWorkoutMutation.mutateAsync({
       date: requestedDate,
       id: scheduledWorkout.id,
     });
@@ -486,7 +494,7 @@ function ScheduledWorkoutActions({
       return;
     }
 
-    void deleteScheduledWorkoutMutation.mutateAsync({ id: scheduledWorkout.id });
+    void unscheduleWorkoutMutation.mutateAsync({ id: scheduledWorkout.id });
   }
 
   return (
@@ -494,7 +502,9 @@ function ScheduledWorkoutActions({
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button
-            aria-label={compact ? 'Scheduled workout actions' : `Actions for ${scheduledWorkout.templateName}`}
+            aria-label={
+              compact ? 'Scheduled workout actions' : `Actions for ${scheduledWorkout.templateName}`
+            }
             className={cn(
               'inline-flex items-center justify-center rounded-full border border-slate-500 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-foreground hover:bg-secondary',
               compact && 'size-5 border-slate-500/70 px-0 py-0',
@@ -505,106 +515,33 @@ function ScheduledWorkoutActions({
             {compact ? <EllipsisVertical aria-hidden="true" className="size-3" /> : 'Scheduled'}
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-44" onClick={(event) => event.stopPropagation()}>
+        <DropdownMenuContent
+          align="end"
+          className="w-44"
+          onClick={(event) => event.stopPropagation()}
+        >
           <DropdownMenuItem asChild>
             <Link to={buildStartWorkoutHref(scheduledWorkout.templateId)}>Start workout</Link>
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setIsRescheduleDialogOpen(true)}>Reschedule</DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setIsRescheduleDialogOpen(true)}>
+            Reschedule
+          </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleRemove} variant="destructive">
             Remove
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      <RescheduleScheduledWorkoutDialog
-        currentDate={scheduledWorkout.date}
-        isPending={updateScheduledWorkoutMutation.isPending}
+      <ScheduleWorkoutDialog
+        description={`Move ${scheduledWorkout.templateName ?? 'this workout'} to a new date.`}
+        initialDate={scheduledWorkout.date}
+        isPending={rescheduleWorkoutMutation.isPending}
         onOpenChange={setIsRescheduleDialogOpen}
-        onReschedule={handleReschedule}
+        onSubmitDate={handleReschedule}
         open={isRescheduleDialogOpen}
-        templateName={scheduledWorkout.templateName}
+        submitLabel="Save"
+        title="Reschedule workout"
       />
     </>
-  );
-}
-
-function RescheduleScheduledWorkoutDialog({
-  currentDate,
-  isPending,
-  onOpenChange,
-  onReschedule,
-  open,
-  templateName,
-}: {
-  currentDate: string;
-  isPending: boolean;
-  onOpenChange: (open: boolean) => void;
-  onReschedule: (date: string) => Promise<unknown>;
-  open: boolean;
-  templateName: string | null;
-}) {
-  const [requestedDate, setRequestedDate] = useState(currentDate);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
-  function handleOpenChange(nextOpen: boolean) {
-    if (nextOpen) {
-      setRequestedDate(currentDate);
-      setErrorMessage(null);
-    }
-    onOpenChange(nextOpen);
-  }
-
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    const normalized = requestedDate.trim();
-    const isIsoDate = /^\d{4}-\d{2}-\d{2}$/.test(normalized);
-    if (!isIsoDate) {
-      setErrorMessage('Enter a valid date in YYYY-MM-DD format.');
-      return;
-    }
-
-    if (normalized === currentDate) {
-      setErrorMessage('Pick a different date to reschedule.');
-      return;
-    }
-
-    setErrorMessage(null);
-    try {
-      await onReschedule(normalized);
-      handleOpenChange(false);
-    } catch {
-      setErrorMessage('Unable to reschedule right now. Try again.');
-    }
-  }
-
-  return (
-    <Dialog onOpenChange={handleOpenChange} open={open}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Reschedule workout</DialogTitle>
-          <DialogDescription>
-            Move {templateName ?? 'this workout'} to a new date.
-          </DialogDescription>
-        </DialogHeader>
-        <form className="space-y-3" onSubmit={handleSubmit}>
-          <Input
-            aria-invalid={errorMessage != null}
-            min="1900-01-01"
-            onChange={(event) => setRequestedDate(event.target.value)}
-            type="date"
-            value={requestedDate}
-          />
-          {errorMessage ? <p className="text-xs text-destructive">{errorMessage}</p> : null}
-          <DialogFooter>
-            <Button onClick={() => handleOpenChange(false)} type="button" variant="outline">
-              Cancel
-            </Button>
-            <Button disabled={isPending} type="submit">
-              Save
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
   );
 }
 
@@ -639,7 +576,10 @@ function getDayDetails(dateKey: string, context: DayLookupContext): DayDetails {
   }
 
   const templateName =
-    completedSession?.templateName ?? scheduledWorkouts[0]?.templateName ?? inProgressSession?.templateName ?? null;
+    completedSession?.templateName ??
+    scheduledWorkouts[0]?.templateName ??
+    inProgressSession?.templateName ??
+    null;
   const notes = hasCompleted
     ? `${completedSession.exerciseCount} exercise${completedSession.exerciseCount === 1 ? '' : 's'} logged`
     : hasScheduled
@@ -687,7 +627,10 @@ function getDetailStats(selectedDay: DayDetails) {
       { label: 'Status', value: 'In progress' },
       { label: 'Duration', value: 'Timer running' },
       { label: 'Exercises', value: `${selectedDay.inProgressSession.exerciseCount}` },
-      { label: 'Started', value: timeFormatter.format(new Date(selectedDay.inProgressSession.startedAt)) },
+      {
+        label: 'Started',
+        value: timeFormatter.format(new Date(selectedDay.inProgressSession.startedAt)),
+      },
     ];
   }
 
@@ -695,7 +638,10 @@ function getDetailStats(selectedDay: DayDetails) {
     return [
       { label: 'Status', value: 'Scheduled' },
       { label: 'Planned', value: `${selectedDay.scheduledWorkouts.length} workouts` },
-      { label: 'Focus', value: selectedDay.scheduledWorkouts[0]?.templateName ?? 'Workout planned' },
+      {
+        label: 'Focus',
+        value: selectedDay.scheduledWorkouts[0]?.templateName ?? 'Workout planned',
+      },
       { label: 'Readiness', value: 'Ready to start' },
     ];
   }

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
-import { ChevronLeft, ChevronRight, EllipsisVertical } from 'lucide-react';
-import type { WorkoutSessionListItem } from '@pulse/shared';
+import { ChevronLeft, ChevronRight, EllipsisVertical, TriangleAlert } from 'lucide-react';
+import type { ScheduledWorkoutListItem, WorkoutSessionListItem } from '@pulse/shared';
 import { Link } from 'react-router';
 
 import { Button } from '@/components/ui/button';
@@ -27,8 +27,6 @@ import {
   useWorkoutSessions,
 } from '../api/workouts';
 import {
-  ActiveScheduledWorkoutListItem,
-  isActiveScheduledWorkout,
   isActiveSessionListItem,
 } from '../lib/workout-filters';
 import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
@@ -63,7 +61,7 @@ type DayDetails = {
   dateKey: string;
   completedSession: WorkoutSessionListItem | null;
   inProgressSession: WorkoutSessionListItem | null;
-  scheduledWorkouts: ActiveScheduledWorkoutListItem[];
+  scheduledWorkouts: ScheduledWorkoutListItem[];
   status: DayStatus;
   templateName: string | null;
   notes: string | null;
@@ -71,7 +69,7 @@ type DayDetails = {
 
 type DayLookupContext = {
   completedSessionByDate: Map<string, WorkoutSessionListItem>;
-  scheduledByDate: Map<string, ActiveScheduledWorkoutListItem[]>;
+  scheduledByDate: Map<string, ScheduledWorkoutListItem[]>;
   inProgressTodaySession: WorkoutSessionListItem | null;
 };
 
@@ -127,8 +125,8 @@ export function WorkoutCalendar({
     [activeCompletedSessions],
   );
   const scheduledByDate = useMemo(() => {
-    const grouped = new Map<string, ActiveScheduledWorkoutListItem[]>();
-    for (const scheduledWorkout of (scheduledQuery.data ?? []).filter(isActiveScheduledWorkout)) {
+    const grouped = new Map<string, ScheduledWorkoutListItem[]>();
+    for (const scheduledWorkout of scheduledQuery.data ?? []) {
       const scheduledOnDate = grouped.get(scheduledWorkout.date) ?? [];
       scheduledOnDate.push(scheduledWorkout);
       grouped.set(scheduledWorkout.date, scheduledOnDate);
@@ -287,11 +285,21 @@ export function WorkoutCalendar({
                         </Link>
                       ) : null}
                       {details.scheduledWorkouts[0] ? (
-                        <ScheduledWorkoutActions
-                          buildStartWorkoutHref={buildStartWorkoutHref}
-                          compact
-                          scheduledWorkout={details.scheduledWorkouts[0]}
-                        />
+                        details.scheduledWorkouts[0].templateId != null &&
+                        details.scheduledWorkouts[0].templateName != null ? (
+                          <ScheduledWorkoutActions
+                            buildStartWorkoutHref={buildStartWorkoutHref}
+                            compact
+                            scheduledWorkout={details.scheduledWorkouts[0]}
+                          />
+                        ) : (
+                          <span
+                            aria-label="Unavailable scheduled workout"
+                            className="inline-flex items-center rounded-full border border-destructive/50 bg-destructive/10 p-1 text-destructive"
+                          >
+                            <TriangleAlert aria-hidden="true" className="size-3" />
+                          </span>
+                        )
                       ) : null}
                       {details.scheduledWorkouts.length > 1 ? (
                         <span className="rounded-full border border-slate-500/70 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground">
@@ -326,6 +334,15 @@ export function WorkoutCalendar({
                       <span
                         aria-label="Scheduled workout"
                         className="size-2 rounded-full border border-slate-500 bg-transparent sm:size-2.5"
+                      />
+                    ) : null}
+                    {details.scheduledWorkouts.some(
+                      (scheduledWorkout) =>
+                        scheduledWorkout.templateId == null || scheduledWorkout.templateName == null,
+                    ) ? (
+                      <span
+                        aria-label="Unavailable scheduled workout"
+                        className="size-2 rounded-full bg-destructive/80 sm:size-2.5"
                       />
                     ) : null}
                     {details.inProgressSession ? (
@@ -440,9 +457,13 @@ export function WorkoutCalendar({
                   >
                     <div>
                       <p className="text-sm font-medium text-foreground">
-                        {scheduledWorkout.templateName}
+                        {scheduledWorkout.templateName ?? 'Workout unavailable'}
                       </p>
-                      <p className="text-xs text-muted">Scheduled</p>
+                      <p className="text-xs text-muted">
+                        {scheduledWorkout.templateName == null || scheduledWorkout.templateId == null
+                          ? 'Unavailable'
+                          : 'Scheduled'}
+                      </p>
                     </div>
                     <ScheduledWorkoutActions
                       buildStartWorkoutHref={buildStartWorkoutHref}
@@ -472,13 +493,20 @@ function ScheduledWorkoutActions({
 }: {
   buildStartWorkoutHref: (templateId: string) => string;
   compact?: boolean;
-  scheduledWorkout: ActiveScheduledWorkoutListItem;
+  scheduledWorkout: ScheduledWorkoutListItem;
 }) {
   const rescheduleWorkoutMutation = useRescheduleWorkout();
   const unscheduleWorkoutMutation = useUnscheduleWorkout();
   const [isRescheduleDialogOpen, setIsRescheduleDialogOpen] = useState(false);
+  const isUnavailable =
+    scheduledWorkout.templateId == null || scheduledWorkout.templateName == null;
+  const templateId = scheduledWorkout.templateId;
 
   async function handleReschedule(requestedDate: string) {
+    if (isUnavailable) {
+      return;
+    }
+
     await rescheduleWorkoutMutation.mutateAsync({
       date: requestedDate,
       id: scheduledWorkout.id,
@@ -503,16 +531,30 @@ function ScheduledWorkoutActions({
         <DropdownMenuTrigger asChild>
           <button
             aria-label={
-              compact ? 'Scheduled workout actions' : `Actions for ${scheduledWorkout.templateName}`
+              compact
+                ? 'Scheduled workout actions'
+                : `Actions for ${scheduledWorkout.templateName ?? 'scheduled workout'}`
             }
             className={cn(
               'inline-flex items-center justify-center rounded-full border border-slate-500 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-foreground hover:bg-secondary',
+              isUnavailable &&
+                'border-destructive/55 bg-destructive/10 text-destructive hover:bg-destructive/20',
               compact && 'size-5 border-slate-500/70 px-0 py-0',
             )}
             onClick={(event) => event.stopPropagation()}
             type="button"
           >
-            {compact ? <EllipsisVertical aria-hidden="true" className="size-3" /> : 'Scheduled'}
+            {compact ? (
+              isUnavailable ? (
+                <TriangleAlert aria-hidden="true" className="size-3" />
+              ) : (
+                <EllipsisVertical aria-hidden="true" className="size-3" />
+              )
+            ) : isUnavailable ? (
+              'Unavailable'
+            ) : (
+              'Scheduled'
+            )}
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
@@ -520,27 +562,35 @@ function ScheduledWorkoutActions({
           className="w-44"
           onClick={(event) => event.stopPropagation()}
         >
-          <DropdownMenuItem asChild>
-            <Link to={buildStartWorkoutHref(scheduledWorkout.templateId)}>Start workout</Link>
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setIsRescheduleDialogOpen(true)}>
-            Reschedule
-          </DropdownMenuItem>
+          {!isUnavailable && templateId ? (
+            <DropdownMenuItem asChild>
+              <Link to={buildStartWorkoutHref(templateId)}>Start workout</Link>
+            </DropdownMenuItem>
+          ) : null}
+          {!isUnavailable ? (
+            <DropdownMenuItem onSelect={() => setIsRescheduleDialogOpen(true)}>
+              Reschedule
+            </DropdownMenuItem>
+          ) : null}
           <DropdownMenuItem onSelect={handleRemove} variant="destructive">
             Remove
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      <ScheduleWorkoutDialog
-        description={`Move ${scheduledWorkout.templateName ?? 'this workout'} to a new date.`}
-        initialDate={scheduledWorkout.date}
-        isPending={rescheduleWorkoutMutation.isPending}
-        onOpenChange={setIsRescheduleDialogOpen}
-        onSubmitDate={handleReschedule}
-        open={isRescheduleDialogOpen}
-        submitLabel="Save"
-        title="Reschedule workout"
-      />
+      {!isUnavailable ? (
+        <ScheduleWorkoutDialog
+          description={`Move ${scheduledWorkout.templateName ?? 'this workout'} to a new date.`}
+          disallowDateKey={scheduledWorkout.date}
+          disallowDateMessage="Pick a different date to reschedule."
+          initialDate={scheduledWorkout.date}
+          isPending={rescheduleWorkoutMutation.isPending}
+          onOpenChange={setIsRescheduleDialogOpen}
+          onSubmitDate={handleReschedule}
+          open={isRescheduleDialogOpen}
+          submitLabel="Save"
+          title="Reschedule workout"
+        />
+      ) : null}
     </>
   );
 }
@@ -577,7 +627,9 @@ function getDayDetails(dateKey: string, context: DayLookupContext): DayDetails {
 
   const templateName =
     completedSession?.templateName ??
-    scheduledWorkouts[0]?.templateName ??
+    (scheduledWorkouts[0]
+      ? (scheduledWorkouts[0].templateName ?? 'Workout unavailable')
+      : null) ??
     inProgressSession?.templateName ??
     null;
   const notes = hasCompleted
@@ -657,7 +709,7 @@ function getDetailStats(selectedDay: DayDetails) {
 function getDefaultSelectedDateKey(
   month: Date,
   completedByDate: Map<string, WorkoutSessionListItem>,
-  scheduledByDate: Map<string, ActiveScheduledWorkoutListItem[]>,
+  scheduledByDate: Map<string, ScheduledWorkoutListItem[]>,
 ): string {
   if (
     isSameMonth(parseDateKey(TODAY_KEY), month) &&

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -1,16 +1,25 @@
-import { useMemo, useState } from 'react';
+import { FormEvent, useMemo, useState } from 'react';
 import { ChevronLeft, ChevronRight, EllipsisVertical } from 'lucide-react';
-import type { ScheduledWorkoutListItem, WorkoutSessionListItem } from '@pulse/shared';
+import type { WorkoutSessionListItem } from '@pulse/shared';
 import { Link } from 'react-router';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
 import {
   addDays,
   differenceInDays,
@@ -26,6 +35,11 @@ import {
   useUpdateScheduledWorkout,
   useWorkoutSessions,
 } from '../api/workouts';
+import {
+  ActiveScheduledWorkoutListItem,
+  isActiveScheduledWorkout,
+  isActiveSessionListItem,
+} from '../lib/workout-filters';
 
 const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
 const TODAY_KEY = toDateKey(new Date());
@@ -57,7 +71,7 @@ type DayDetails = {
   dateKey: string;
   completedSession: WorkoutSessionListItem | null;
   inProgressSession: WorkoutSessionListItem | null;
-  scheduledWorkouts: ScheduledWorkoutListItem[];
+  scheduledWorkouts: ActiveScheduledWorkoutListItem[];
   status: DayStatus;
   templateName: string | null;
   notes: string | null;
@@ -65,7 +79,7 @@ type DayDetails = {
 
 type DayLookupContext = {
   completedSessionByDate: Map<string, WorkoutSessionListItem>;
-  scheduledByDate: Map<string, ScheduledWorkoutListItem[]>;
+  scheduledByDate: Map<string, ActiveScheduledWorkoutListItem[]>;
   inProgressTodaySession: WorkoutSessionListItem | null;
 };
 
@@ -88,22 +102,25 @@ export function WorkoutCalendar({
     };
   }, [calendarDays, visibleMonth]);
 
-  const completedQuery = useWorkoutSessions({
-    from: dateRange.from,
-    status: ['completed'],
-    to: dateRange.to,
+  const sessionsQuery = useWorkoutSessions({
+    status: ['completed', 'in-progress', 'paused'],
   });
   const scheduledQuery = useScheduledWorkouts({
     from: dateRange.from,
     to: dateRange.to,
   });
-  const inProgressQuery = useWorkoutSessions({
-    status: ['in-progress', 'paused'],
-  });
 
+  const activeSessions = useMemo(
+    () => (sessionsQuery.data ?? []).filter(isActiveSessionListItem),
+    [sessionsQuery.data],
+  );
   const activeCompletedSessions = useMemo(
-    () => (completedQuery.data ?? []).filter(isActiveSessionListItem),
-    [completedQuery.data],
+    () =>
+      activeSessions.filter(
+        (session) =>
+          session.status === 'completed' && session.date >= dateRange.from && session.date <= dateRange.to,
+      ),
+    [activeSessions, dateRange.from, dateRange.to],
   );
   const completedSessionByDate = useMemo(
     () =>
@@ -116,7 +133,7 @@ export function WorkoutCalendar({
     [activeCompletedSessions],
   );
   const scheduledByDate = useMemo(() => {
-    const grouped = new Map<string, ScheduledWorkoutListItem[]>();
+    const grouped = new Map<string, ActiveScheduledWorkoutListItem[]>();
     for (const scheduledWorkout of (scheduledQuery.data ?? []).filter(isActiveScheduledWorkout)) {
       const scheduledOnDate = grouped.get(scheduledWorkout.date) ?? [];
       scheduledOnDate.push(scheduledWorkout);
@@ -127,10 +144,10 @@ export function WorkoutCalendar({
   }, [scheduledQuery.data]);
   const inProgressTodaySession = useMemo(
     () =>
-      (inProgressQuery.data ?? [])
-        .filter(isActiveSessionListItem)
+      activeSessions
+        .filter((session) => session.status === 'in-progress' || session.status === 'paused')
         .find((session) => spansToday(session, TODAY_KEY)) ?? null,
-    [inProgressQuery.data],
+    [activeSessions],
   );
 
   const lookupContext = useMemo(
@@ -226,7 +243,8 @@ export function WorkoutCalendar({
               return (
                 <div
                   aria-current={isToday ? 'date' : undefined}
-                  aria-label={fullDateFormatter.format(day)}
+                  aria-label={`${fullDateFormatter.format(day)}${isSelected ? ', selected' : ''}`}
+                  aria-pressed={isSelected}
                   className={cn(
                     'flex min-h-14 cursor-pointer flex-col rounded-xl border px-1.5 py-1.5 text-left transition-all duration-200 sm:min-h-28 sm:rounded-2xl sm:px-3 sm:py-3',
                     isInMonth
@@ -276,6 +294,11 @@ export function WorkoutCalendar({
                           compact
                           scheduledWorkout={details.scheduledWorkouts[0]}
                         />
+                      ) : null}
+                      {details.scheduledWorkouts.length > 1 ? (
+                        <span className="rounded-full border border-slate-500/70 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground">
+                          +{details.scheduledWorkouts.length - 1}
+                        </span>
                       ) : null}
                     </div>
                   </div>
@@ -441,22 +464,14 @@ function ScheduledWorkoutActions({
 }: {
   buildStartWorkoutHref: (templateId: string) => string;
   compact?: boolean;
-  scheduledWorkout: ScheduledWorkoutListItem;
+  scheduledWorkout: ActiveScheduledWorkoutListItem;
 }) {
   const updateScheduledWorkoutMutation = useUpdateScheduledWorkout();
   const deleteScheduledWorkoutMutation = useDeleteScheduledWorkout();
+  const [isRescheduleDialogOpen, setIsRescheduleDialogOpen] = useState(false);
 
-  function handleReschedule() {
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    const requestedDate = window.prompt('Reschedule to date (YYYY-MM-DD)', scheduledWorkout.date);
-    if (!requestedDate || requestedDate === scheduledWorkout.date) {
-      return;
-    }
-
-    void updateScheduledWorkoutMutation.mutateAsync({
+  async function handleReschedule(requestedDate: string) {
+    await updateScheduledWorkoutMutation.mutateAsync({
       date: requestedDate,
       id: scheduledWorkout.id,
     });
@@ -475,30 +490,121 @@ function ScheduledWorkoutActions({
   }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          aria-label={compact ? 'Scheduled workout actions' : `Actions for ${scheduledWorkout.templateName}`}
-          className={cn(
-            'inline-flex items-center justify-center rounded-full border border-slate-500 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-foreground hover:bg-secondary',
-            compact && 'size-5 border-slate-500/70 px-0 py-0',
-          )}
-          onClick={(event) => event.stopPropagation()}
-          type="button"
-        >
-          {compact ? <EllipsisVertical aria-hidden="true" className="size-3" /> : 'Scheduled'}
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-44" onClick={(event) => event.stopPropagation()}>
-        <DropdownMenuItem asChild>
-          <Link to={buildStartWorkoutHref(scheduledWorkout.templateId ?? '')}>Start workout</Link>
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={handleReschedule}>Reschedule</DropdownMenuItem>
-        <DropdownMenuItem onSelect={handleRemove} variant="destructive">
-          Remove
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            aria-label={compact ? 'Scheduled workout actions' : `Actions for ${scheduledWorkout.templateName}`}
+            className={cn(
+              'inline-flex items-center justify-center rounded-full border border-slate-500 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-foreground hover:bg-secondary',
+              compact && 'size-5 border-slate-500/70 px-0 py-0',
+            )}
+            onClick={(event) => event.stopPropagation()}
+            type="button"
+          >
+            {compact ? <EllipsisVertical aria-hidden="true" className="size-3" /> : 'Scheduled'}
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-44" onClick={(event) => event.stopPropagation()}>
+          <DropdownMenuItem asChild>
+            <Link to={buildStartWorkoutHref(scheduledWorkout.templateId)}>Start workout</Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setIsRescheduleDialogOpen(true)}>Reschedule</DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleRemove} variant="destructive">
+            Remove
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <RescheduleScheduledWorkoutDialog
+        currentDate={scheduledWorkout.date}
+        isPending={updateScheduledWorkoutMutation.isPending}
+        onOpenChange={setIsRescheduleDialogOpen}
+        onReschedule={handleReschedule}
+        open={isRescheduleDialogOpen}
+        templateName={scheduledWorkout.templateName}
+      />
+    </>
+  );
+}
+
+function RescheduleScheduledWorkoutDialog({
+  currentDate,
+  isPending,
+  onOpenChange,
+  onReschedule,
+  open,
+  templateName,
+}: {
+  currentDate: string;
+  isPending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onReschedule: (date: string) => Promise<unknown>;
+  open: boolean;
+  templateName: string | null;
+}) {
+  const [requestedDate, setRequestedDate] = useState(currentDate);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (nextOpen) {
+      setRequestedDate(currentDate);
+      setErrorMessage(null);
+    }
+    onOpenChange(nextOpen);
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const normalized = requestedDate.trim();
+    const isIsoDate = /^\d{4}-\d{2}-\d{2}$/.test(normalized);
+    if (!isIsoDate) {
+      setErrorMessage('Enter a valid date in YYYY-MM-DD format.');
+      return;
+    }
+
+    if (normalized === currentDate) {
+      setErrorMessage('Pick a different date to reschedule.');
+      return;
+    }
+
+    setErrorMessage(null);
+    try {
+      await onReschedule(normalized);
+      handleOpenChange(false);
+    } catch {
+      setErrorMessage('Unable to reschedule right now. Try again.');
+    }
+  }
+
+  return (
+    <Dialog onOpenChange={handleOpenChange} open={open}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Reschedule workout</DialogTitle>
+          <DialogDescription>
+            Move {templateName ?? 'this workout'} to a new date.
+          </DialogDescription>
+        </DialogHeader>
+        <form className="space-y-3" onSubmit={handleSubmit}>
+          <Input
+            aria-invalid={errorMessage != null}
+            min="1900-01-01"
+            onChange={(event) => setRequestedDate(event.target.value)}
+            type="date"
+            value={requestedDate}
+          />
+          {errorMessage ? <p className="text-xs text-destructive">{errorMessage}</p> : null}
+          <DialogFooter>
+            <Button onClick={() => handleOpenChange(false)} type="button" variant="outline">
+              Cancel
+            </Button>
+            <Button disabled={isPending} type="submit">
+              Save
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -605,7 +711,7 @@ function getDetailStats(selectedDay: DayDetails) {
 function getDefaultSelectedDateKey(
   month: Date,
   completedByDate: Map<string, WorkoutSessionListItem>,
-  scheduledByDate: Map<string, ScheduledWorkoutListItem[]>,
+  scheduledByDate: Map<string, ActiveScheduledWorkoutListItem[]>,
 ): string {
   if (
     isSameMonth(parseDateKey(TODAY_KEY), month) &&
@@ -659,14 +765,6 @@ function addMonths(date: Date, months: number) {
 
 function isSameMonth(left: Date, right: Date) {
   return left.getFullYear() === right.getFullYear() && left.getMonth() === right.getMonth();
-}
-
-function isActiveSessionListItem(session: WorkoutSessionListItem) {
-  return session.templateId == null || session.templateName != null;
-}
-
-function isActiveScheduledWorkout(scheduledWorkout: ScheduledWorkoutListItem) {
-  return scheduledWorkout.templateId != null && scheduledWorkout.templateName != null;
 }
 
 function spansToday(session: WorkoutSessionListItem, todayKey: string) {

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -6,6 +6,16 @@ import { Link } from 'react-router';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -26,13 +36,11 @@ import {
   useUnscheduleWorkout,
   useWorkoutSessions,
 } from '../api/workouts';
-import {
-  isActiveSessionListItem,
-} from '../lib/workout-filters';
+import { useTodayKey } from '../hooks/use-today-key';
+import { hasAvailableTemplate } from '../lib/workout-filters';
 import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
 
 const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
-const TODAY_KEY = toDateKey(new Date());
 const monthFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'long',
   year: 'numeric',
@@ -78,7 +86,8 @@ export function WorkoutCalendar({
   buildSessionHref,
   buildStartWorkoutHref = (templateId) => `/workouts/active?template=${templateId}`,
 }: WorkoutCalendarProps) {
-  const initialMonth = startOfMonth(parseDateKey(TODAY_KEY));
+  const todayKey = useTodayKey();
+  const initialMonth = startOfMonth(parseDateKey(todayKey));
   const [visibleMonth, setVisibleMonth] = useState(initialMonth);
 
   const calendarDays = buildCalendarDays(visibleMonth);
@@ -101,7 +110,7 @@ export function WorkoutCalendar({
   });
 
   const activeSessions = useMemo(
-    () => (sessionsQuery.data ?? []).filter(isActiveSessionListItem),
+    () => (sessionsQuery.data ?? []).filter(hasAvailableTemplate),
     [sessionsQuery.data],
   );
   const activeCompletedSessions = useMemo(
@@ -138,8 +147,8 @@ export function WorkoutCalendar({
     () =>
       activeSessions
         .filter((session) => session.status === 'in-progress' || session.status === 'paused')
-        .find((session) => spansToday(session, TODAY_KEY)) ?? null,
-    [activeSessions],
+        .find((session) => spansToday(session, todayKey)) ?? null,
+    [activeSessions, todayKey],
   );
 
   const lookupContext = useMemo(
@@ -152,10 +161,10 @@ export function WorkoutCalendar({
   );
 
   const [selectedDateKey, setSelectedDateKey] = useState(
-    getDefaultSelectedDateKey(initialMonth, completedSessionByDate, scheduledByDate),
+    getDefaultSelectedDateKey(initialMonth, completedSessionByDate, scheduledByDate, todayKey),
   );
 
-  const selectedDay = getDayDetails(selectedDateKey, lookupContext);
+  const selectedDay = getDayDetails(selectedDateKey, lookupContext, todayKey);
   const openDayHref = buildDayHref?.(selectedDateKey) ?? `?date=${selectedDateKey}`;
   const detailStats = getDetailStats(selectedDay);
   const hasWorkout = selectedDay.status !== 'none';
@@ -165,7 +174,7 @@ export function WorkoutCalendar({
     const nextMonth = addMonths(visibleMonth, offset);
     setVisibleMonth(nextMonth);
     setSelectedDateKey(
-      getDefaultSelectedDateKey(nextMonth, completedSessionByDate, scheduledByDate),
+      getDefaultSelectedDateKey(nextMonth, completedSessionByDate, scheduledByDate, todayKey),
     );
   }
 
@@ -231,9 +240,9 @@ export function WorkoutCalendar({
           <div className="grid grid-cols-7 gap-2">
             {calendarDays.map((day) => {
               const dateKey = toDateKey(day);
-              const details = getDayDetails(dateKey, lookupContext);
+              const details = getDayDetails(dateKey, lookupContext, todayKey);
               const isSelected = selectedDateKey === dateKey;
-              const isToday = dateKey === TODAY_KEY;
+              const isToday = dateKey === todayKey;
               const isInMonth = day.getMonth() === visibleMonth.getMonth();
 
               return (
@@ -498,6 +507,7 @@ function ScheduledWorkoutActions({
   const rescheduleWorkoutMutation = useRescheduleWorkout();
   const unscheduleWorkoutMutation = useUnscheduleWorkout();
   const [isRescheduleDialogOpen, setIsRescheduleDialogOpen] = useState(false);
+  const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false);
   const isUnavailable =
     scheduledWorkout.templateId == null || scheduledWorkout.templateName == null;
   const templateId = scheduledWorkout.templateId;
@@ -514,15 +524,8 @@ function ScheduledWorkoutActions({
   }
 
   function handleRemove() {
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    if (!window.confirm('Remove this scheduled workout?')) {
-      return;
-    }
-
     void unscheduleWorkoutMutation.mutateAsync({ id: scheduledWorkout.id });
+    setIsRemoveDialogOpen(false);
   }
 
   return (
@@ -572,7 +575,7 @@ function ScheduledWorkoutActions({
               Reschedule
             </DropdownMenuItem>
           ) : null}
-          <DropdownMenuItem onSelect={handleRemove} variant="destructive">
+          <DropdownMenuItem onSelect={() => setIsRemoveDialogOpen(true)} variant="destructive">
             Remove
           </DropdownMenuItem>
         </DropdownMenuContent>
@@ -591,6 +594,23 @@ function ScheduledWorkoutActions({
           title="Reschedule workout"
         />
       ) : null}
+      <AlertDialog onOpenChange={setIsRemoveDialogOpen} open={isRemoveDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove this scheduled workout?</AlertDialogTitle>
+            <AlertDialogDescription>This will remove it from your calendar.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={unscheduleWorkoutMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={unscheduleWorkoutMutation.isPending}
+              onClick={handleRemove}
+            >
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }
@@ -604,11 +624,11 @@ function LegendDot({ className, label }: { className: string; label: string }) {
   );
 }
 
-function getDayDetails(dateKey: string, context: DayLookupContext): DayDetails {
+function getDayDetails(dateKey: string, context: DayLookupContext, todayKey: string): DayDetails {
   const date = parseDateKey(dateKey);
   const completedSession = context.completedSessionByDate.get(dateKey) ?? null;
   const scheduledWorkouts = context.scheduledByDate.get(dateKey) ?? [];
-  const inProgressSession = dateKey === TODAY_KEY ? context.inProgressTodaySession : null;
+  const inProgressSession = dateKey === todayKey ? context.inProgressTodaySession : null;
 
   const hasCompleted = completedSession != null;
   const hasScheduled = scheduledWorkouts.length > 0;
@@ -710,12 +730,13 @@ function getDefaultSelectedDateKey(
   month: Date,
   completedByDate: Map<string, WorkoutSessionListItem>,
   scheduledByDate: Map<string, ScheduledWorkoutListItem[]>,
+  todayKey: string,
 ): string {
   if (
-    isSameMonth(parseDateKey(TODAY_KEY), month) &&
-    (completedByDate.has(TODAY_KEY) || (scheduledByDate.get(TODAY_KEY)?.length ?? 0) > 0)
+    isSameMonth(parseDateKey(todayKey), month) &&
+    (completedByDate.has(todayKey) || (scheduledByDate.get(todayKey)?.length ?? 0) > 0)
   ) {
-    return TODAY_KEY;
+    return todayKey;
   }
 
   const monthActivity = [...completedByDate.keys(), ...scheduledByDate.keys()]
@@ -727,7 +748,7 @@ function getDefaultSelectedDateKey(
     return toDateKey(monthActivity[0]);
   }
 
-  return isSameMonth(parseDateKey(TODAY_KEY), month) ? TODAY_KEY : toDateKey(month);
+  return isSameMonth(parseDateKey(todayKey), month) ? todayKey : toDateKey(month);
 }
 
 function buildCalendarDays(month: Date): Date[] {

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -1,10 +1,16 @@
 import { useMemo, useState } from 'react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
-import type { WorkoutSessionListItem } from '@pulse/shared';
+import { ChevronLeft, ChevronRight, EllipsisVertical } from 'lucide-react';
+import type { ScheduledWorkoutListItem, WorkoutSessionListItem } from '@pulse/shared';
 import { Link } from 'react-router';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import {
   addDays,
   differenceInDays,
@@ -14,7 +20,12 @@ import {
 } from '@/lib/date-utils';
 import { accentCardStyles } from '@/lib/accent-card-styles';
 import { cn } from '@/lib/utils';
-import { useCompletedSessions, useWorkoutTemplates } from '../api/workouts';
+import {
+  useDeleteScheduledWorkout,
+  useScheduledWorkouts,
+  useUpdateScheduledWorkout,
+  useWorkoutSessions,
+} from '../api/workouts';
 
 const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
 const TODAY_KEY = toDateKey(new Date());
@@ -35,66 +46,116 @@ const timeFormatter = new Intl.DateTimeFormat('en-US', {
 
 type WorkoutCalendarProps = {
   buildDayHref?: (date: string) => string;
-  // Calendar only renders completed sessions from `useCompletedSessions`,
-  // so the session link does not need status-aware routing.
   buildSessionHref?: (sessionId: string) => string;
+  buildStartWorkoutHref?: (templateId: string) => string;
 };
 
-type DayStatus = 'completed' | 'none';
+type DayStatus = 'completed' | 'scheduled' | 'in-progress' | 'mixed' | 'none';
 
 type DayDetails = {
   date: Date;
   dateKey: string;
-  session?: WorkoutSessionListItem;
+  completedSession: WorkoutSessionListItem | null;
+  inProgressSession: WorkoutSessionListItem | null;
+  scheduledWorkouts: ScheduledWorkoutListItem[];
   status: DayStatus;
   templateName: string | null;
   notes: string | null;
 };
 
 type DayLookupContext = {
-  sessionByDate: Map<string, WorkoutSessionListItem>;
-  templateNameById: Map<string, string>;
+  completedSessionByDate: Map<string, WorkoutSessionListItem>;
+  scheduledByDate: Map<string, ScheduledWorkoutListItem[]>;
+  inProgressTodaySession: WorkoutSessionListItem | null;
 };
 
-export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalendarProps) {
-  const completedQuery = useCompletedSessions();
-  const templatesQuery = useWorkoutTemplates();
+export function WorkoutCalendar({
+  buildDayHref,
+  buildSessionHref,
+  buildStartWorkoutHref = (templateId) => `/workouts/active?template=${templateId}`,
+}: WorkoutCalendarProps) {
   const initialMonth = startOfMonth(parseDateKey(TODAY_KEY));
   const [visibleMonth, setVisibleMonth] = useState(initialMonth);
 
-  const templateNameById = useMemo(
-    () => new Map((templatesQuery.data ?? []).map((template) => [template.id, template.name])),
-    [templatesQuery.data],
-  );
-  const sessionByDate = useMemo(
-    // Calendar displays one completed session per day; if multiple exist, the latest item in the array wins.
-    () => new Map((completedQuery.data ?? []).map((session) => [session.date, session])),
+  const calendarDays = buildCalendarDays(visibleMonth);
+  const dateRange = useMemo(() => {
+    const firstDay = calendarDays[0] ?? visibleMonth;
+    const lastDay = calendarDays[calendarDays.length - 1] ?? visibleMonth;
+
+    return {
+      from: toDateKey(firstDay),
+      to: toDateKey(lastDay),
+    };
+  }, [calendarDays, visibleMonth]);
+
+  const completedQuery = useWorkoutSessions({
+    from: dateRange.from,
+    status: ['completed'],
+    to: dateRange.to,
+  });
+  const scheduledQuery = useScheduledWorkouts({
+    from: dateRange.from,
+    to: dateRange.to,
+  });
+  const inProgressQuery = useWorkoutSessions({
+    status: ['in-progress', 'paused'],
+  });
+
+  const activeCompletedSessions = useMemo(
+    () => (completedQuery.data ?? []).filter(isActiveSessionListItem),
     [completedQuery.data],
   );
-  const lookupContext = useMemo(
-    () => ({
-      sessionByDate,
-      templateNameById,
-    }),
-    [sessionByDate, templateNameById],
+  const completedSessionByDate = useMemo(
+    () =>
+      new Map(
+        activeCompletedSessions
+          .slice()
+          .sort((left, right) => right.startedAt - left.startedAt)
+          .map((session) => [session.date, session]),
+      ),
+    [activeCompletedSessions],
+  );
+  const scheduledByDate = useMemo(() => {
+    const grouped = new Map<string, ScheduledWorkoutListItem[]>();
+    for (const scheduledWorkout of (scheduledQuery.data ?? []).filter(isActiveScheduledWorkout)) {
+      const scheduledOnDate = grouped.get(scheduledWorkout.date) ?? [];
+      scheduledOnDate.push(scheduledWorkout);
+      grouped.set(scheduledWorkout.date, scheduledOnDate);
+    }
+
+    return grouped;
+  }, [scheduledQuery.data]);
+  const inProgressTodaySession = useMemo(
+    () =>
+      (inProgressQuery.data ?? [])
+        .filter(isActiveSessionListItem)
+        .find((session) => spansToday(session, TODAY_KEY)) ?? null,
+    [inProgressQuery.data],
   );
 
-  const [selectedDateKey, setSelectedDateKey] = useState(getDefaultSelectedDateKey(initialMonth, sessionByDate));
+  const lookupContext = useMemo(
+    () => ({
+      completedSessionByDate,
+      inProgressTodaySession,
+      scheduledByDate,
+    }),
+    [completedSessionByDate, inProgressTodaySession, scheduledByDate],
+  );
 
-  const calendarDays = buildCalendarDays(visibleMonth);
+  const [selectedDateKey, setSelectedDateKey] = useState(
+    getDefaultSelectedDateKey(initialMonth, completedSessionByDate, scheduledByDate),
+  );
+
   const selectedDay = getDayDetails(selectedDateKey, lookupContext);
-  const detailHref = selectedDay.session
-    ? (buildSessionHref?.(selectedDay.session.id) ?? `/workouts/session/${selectedDay.session.id}`)
-    : (buildDayHref?.(selectedDateKey) ?? `?date=${selectedDateKey}`);
+  const openDayHref = buildDayHref?.(selectedDateKey) ?? `?date=${selectedDateKey}`;
   const detailStats = getDetailStats(selectedDay);
-  const hasWorkout = selectedDay.status === 'completed';
-
+  const hasWorkout = selectedDay.status !== 'none';
   const accentPanel = hasWorkout ? accentCardStyles.mint : 'bg-card text-foreground';
 
   function handleMonthChange(offset: number) {
     const nextMonth = addMonths(visibleMonth, offset);
     setVisibleMonth(nextMonth);
-    setSelectedDateKey(getDefaultSelectedDateKey(nextMonth, sessionByDate));
+    setSelectedDateKey(getDefaultSelectedDateKey(nextMonth, completedSessionByDate, scheduledByDate));
   }
 
   return (
@@ -104,7 +165,7 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
           <div className="space-y-1">
             <CardTitle>Workout Calendar</CardTitle>
             <p className="text-sm text-muted">
-              Track completed sessions and review workout activity in one monthly view.
+              Track completed sessions and scheduled workouts in one monthly view.
             </p>
           </div>
 
@@ -134,10 +195,10 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
         </div>
 
         <div className="flex flex-wrap items-center gap-3 text-xs text-muted">
-          <LegendDot className="bg-emerald-500" label="Completed workout" />
-          <span className="rounded-full border border-primary/30 px-2 py-1 text-foreground">
-            Today
-          </span>
+          <LegendDot className="bg-emerald-500" label="Completed" />
+          <LegendDot className="border border-slate-500 bg-transparent" label="Scheduled" />
+          <LegendDot className="bg-orange-500" label="In progress" />
+          <span className="rounded-full border border-primary/30 px-2 py-1 text-foreground">Today</span>
         </div>
       </CardHeader>
 
@@ -161,14 +222,11 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
               const isSelected = selectedDateKey === dateKey;
               const isToday = dateKey === TODAY_KEY;
               const isInMonth = day.getMonth() === visibleMonth.getMonth();
-              const isWorkoutDay = details.status === 'completed';
 
               return (
-                <button
-                  key={dateKey}
+                <div
                   aria-current={isToday ? 'date' : undefined}
                   aria-label={fullDateFormatter.format(day)}
-                  aria-pressed={isSelected}
                   className={cn(
                     'flex min-h-14 cursor-pointer flex-col rounded-xl border px-1.5 py-1.5 text-left transition-all duration-200 sm:min-h-28 sm:rounded-2xl sm:px-3 sm:py-3',
                     isInMonth
@@ -178,8 +236,16 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
                     isToday && 'ring-2 ring-primary/30',
                   )}
                   data-outside-month={!isInMonth}
+                  key={dateKey}
                   onClick={() => setSelectedDateKey(dateKey)}
-                  type="button"
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      setSelectedDateKey(dateKey);
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
                 >
                   <div className="flex items-start justify-between gap-0.5">
                     <span
@@ -191,11 +257,27 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
                     >
                       {day.getDate()}
                     </span>
-                    {isWorkoutDay ? (
-                      <span className="hidden shrink-0 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[9px] font-bold uppercase leading-none tracking-wide text-emerald-700 dark:text-emerald-400 sm:inline">
-                        Done
-                      </span>
-                    ) : null}
+                    <div className="flex items-center gap-1">
+                      {details.completedSession ? (
+                        <Link
+                          className="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[9px] font-bold uppercase leading-none tracking-wide text-emerald-700 hover:bg-emerald-500/25 dark:text-emerald-400"
+                          onClick={(event) => event.stopPropagation()}
+                          to={
+                            buildSessionHref?.(details.completedSession.id) ??
+                            `/workouts/session/${details.completedSession.id}`
+                          }
+                        >
+                          Done
+                        </Link>
+                      ) : null}
+                      {details.scheduledWorkouts[0] ? (
+                        <ScheduledWorkoutActions
+                          buildStartWorkoutHref={buildStartWorkoutHref}
+                          compact
+                          scheduledWorkout={details.scheduledWorkouts[0]}
+                        />
+                      ) : null}
+                    </div>
                   </div>
 
                   <div className="mt-1 hidden min-w-0 space-y-0.5 sm:block">
@@ -207,25 +289,33 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
                     >
                       {details.templateName ?? 'No workout'}
                     </p>
-                    <p className="truncate text-[10px] leading-snug text-muted">
-                      {details.notes ?? (isWorkoutDay ? 'Tap for details' : '')}
-                    </p>
+                    <p className="truncate text-[10px] leading-snug text-muted">{details.notes ?? ''}</p>
                   </div>
 
                   <div className="mt-auto flex items-center gap-1 pt-1 sm:gap-1.5 sm:pt-3">
-                    {details.status === 'completed' ? (
+                    {details.completedSession ? (
                       <span
                         aria-label="Completed workout"
                         className="size-2 rounded-full bg-emerald-500 sm:size-2.5"
                       />
                     ) : null}
+                    {details.scheduledWorkouts.length > 0 ? (
+                      <span
+                        aria-label="Scheduled workout"
+                        className="size-2 rounded-full border border-slate-500 bg-transparent sm:size-2.5"
+                      />
+                    ) : null}
+                    {details.inProgressSession ? (
+                      <span
+                        aria-label="In-progress workout"
+                        className="size-2 rounded-full bg-orange-500 animate-pulse sm:size-2.5"
+                      />
+                    ) : null}
                     {isToday ? (
-                      <span className="hidden text-[11px] font-medium text-primary sm:inline">
-                        Today
-                      </span>
+                      <span className="hidden text-[11px] font-medium text-primary sm:inline">Today</span>
                     ) : null}
                   </div>
-                </button>
+                </div>
               );
             })}
           </div>
@@ -247,9 +337,7 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
             >
               Day details
             </p>
-            <h3 className="text-2xl font-semibold">
-              {selectedDay.templateName ?? 'No workout planned'}
-            </h3>
+            <h3 className="text-2xl font-semibold">{selectedDay.templateName ?? 'No workout planned'}</h3>
             <p
               className={cn(
                 'text-sm',
@@ -263,13 +351,13 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
           <div className="grid gap-3 sm:grid-cols-2">
             {detailStats.map((stat) => (
               <div
-                key={stat.label}
                 className={cn(
                   'rounded-2xl border p-3',
                   hasWorkout
                     ? 'border-white/35 bg-white/45 dark:border-border dark:bg-secondary/60'
                     : 'border-border bg-secondary/40 text-foreground',
                 )}
+                key={stat.label}
               >
                 <p
                   className={cn(
@@ -291,22 +379,126 @@ export function WorkoutCalendar({ buildDayHref, buildSessionHref }: WorkoutCalen
             )}
           >
             {selectedDay.notes ??
-              'No workout is attached to this day yet. Complete a session to see it on the calendar.'}
+              'No workout is attached to this day yet. Complete or schedule a workout to see it here.'}
           </p>
 
-          {hasWorkout ? (
+          {selectedDay.completedSession ? (
             <Button
               asChild
               className="mt-auto self-start bg-white/60 hover:bg-white/75 dark:bg-primary dark:text-primary-foreground dark:hover:bg-primary/90"
               size="sm"
               variant="secondary"
             >
-              <Link to={detailHref}>View Session</Link>
+              <Link
+                to={
+                  buildSessionHref?.(selectedDay.completedSession.id) ??
+                  `/workouts/session/${selectedDay.completedSession.id}`
+                }
+              >
+                View Session
+              </Link>
+            </Button>
+          ) : null}
+
+          {selectedDay.scheduledWorkouts.length > 0 ? (
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted">Scheduled</p>
+              <div className="space-y-2">
+                {selectedDay.scheduledWorkouts.map((scheduledWorkout) => (
+                  <div
+                    className="flex items-center justify-between gap-2 rounded-2xl border border-border/70 bg-secondary/40 px-3 py-2"
+                    key={scheduledWorkout.id}
+                  >
+                    <div>
+                      <p className="text-sm font-medium text-foreground">{scheduledWorkout.templateName}</p>
+                      <p className="text-xs text-muted">Scheduled</p>
+                    </div>
+                    <ScheduledWorkoutActions
+                      buildStartWorkoutHref={buildStartWorkoutHref}
+                      scheduledWorkout={scheduledWorkout}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {!selectedDay.completedSession && selectedDay.scheduledWorkouts.length === 0 ? (
+            <Button asChild className="mt-auto self-start" size="sm" variant="outline">
+              <Link to={openDayHref}>Open Day</Link>
             </Button>
           ) : null}
         </aside>
       </CardContent>
     </Card>
+  );
+}
+
+function ScheduledWorkoutActions({
+  buildStartWorkoutHref,
+  compact = false,
+  scheduledWorkout,
+}: {
+  buildStartWorkoutHref: (templateId: string) => string;
+  compact?: boolean;
+  scheduledWorkout: ScheduledWorkoutListItem;
+}) {
+  const updateScheduledWorkoutMutation = useUpdateScheduledWorkout();
+  const deleteScheduledWorkoutMutation = useDeleteScheduledWorkout();
+
+  function handleReschedule() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const requestedDate = window.prompt('Reschedule to date (YYYY-MM-DD)', scheduledWorkout.date);
+    if (!requestedDate || requestedDate === scheduledWorkout.date) {
+      return;
+    }
+
+    void updateScheduledWorkoutMutation.mutateAsync({
+      date: requestedDate,
+      id: scheduledWorkout.id,
+    });
+  }
+
+  function handleRemove() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (!window.confirm('Remove this scheduled workout?')) {
+      return;
+    }
+
+    void deleteScheduledWorkoutMutation.mutateAsync({ id: scheduledWorkout.id });
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          aria-label={compact ? 'Scheduled workout actions' : `Actions for ${scheduledWorkout.templateName}`}
+          className={cn(
+            'inline-flex items-center justify-center rounded-full border border-slate-500 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-foreground hover:bg-secondary',
+            compact && 'size-5 border-slate-500/70 px-0 py-0',
+          )}
+          onClick={(event) => event.stopPropagation()}
+          type="button"
+        >
+          {compact ? <EllipsisVertical aria-hidden="true" className="size-3" /> : 'Scheduled'}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-44" onClick={(event) => event.stopPropagation()}>
+        <DropdownMenuItem asChild>
+          <Link to={buildStartWorkoutHref(scheduledWorkout.templateId ?? '')}>Start workout</Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={handleReschedule}>Reschedule</DropdownMenuItem>
+        <DropdownMenuItem onSelect={handleRemove} variant="destructive">
+          Remove
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -321,43 +513,84 @@ function LegendDot({ className, label }: { className: string; label: string }) {
 
 function getDayDetails(dateKey: string, context: DayLookupContext): DayDetails {
   const date = parseDateKey(dateKey);
-  const session = context.sessionByDate.get(dateKey);
+  const completedSession = context.completedSessionByDate.get(dateKey) ?? null;
+  const scheduledWorkouts = context.scheduledByDate.get(dateKey) ?? [];
+  const inProgressSession = dateKey === TODAY_KEY ? context.inProgressTodaySession : null;
+
+  const hasCompleted = completedSession != null;
+  const hasScheduled = scheduledWorkouts.length > 0;
+  const hasInProgress = inProgressSession != null;
+
+  let status: DayStatus = 'none';
+  if (hasCompleted && (hasScheduled || hasInProgress)) {
+    status = 'mixed';
+  } else if (hasCompleted) {
+    status = 'completed';
+  } else if (hasScheduled) {
+    status = 'scheduled';
+  } else if (hasInProgress) {
+    status = 'in-progress';
+  }
+
   const templateName =
-    session?.templateName ??
-    (session?.templateId ? (context.templateNameById.get(session.templateId) ?? null) : null);
-  const status: DayStatus = session ? 'completed' : 'none';
-  const notes =
-    session != null
-      ? `${session.exerciseCount} exercise${session.exerciseCount === 1 ? '' : 's'} logged`
-      : null;
+    completedSession?.templateName ?? scheduledWorkouts[0]?.templateName ?? inProgressSession?.templateName ?? null;
+  const notes = hasCompleted
+    ? `${completedSession.exerciseCount} exercise${completedSession.exerciseCount === 1 ? '' : 's'} logged`
+    : hasScheduled
+      ? `${scheduledWorkouts.length} scheduled workout${scheduledWorkouts.length === 1 ? '' : 's'}`
+      : hasInProgress
+        ? 'Workout currently in progress'
+        : null;
 
   return {
+    completedSession,
     date,
     dateKey,
-    session,
+    inProgressSession,
+    notes,
+    scheduledWorkouts,
     status,
     templateName,
-    notes,
   };
 }
 
 function getDetailStats(selectedDay: DayDetails) {
-  if (selectedDay.session) {
+  if (selectedDay.completedSession) {
     return [
       { label: 'Status', value: 'Completed' },
       {
         label: 'Duration',
         value:
-          selectedDay.session.duration != null ? `${selectedDay.session.duration} min` : 'Not tracked',
+          selectedDay.completedSession.duration != null
+            ? `${selectedDay.completedSession.duration} min`
+            : 'Not tracked',
       },
       {
         label: 'Exercises',
-        value: `${selectedDay.session.exerciseCount}`,
+        value: `${selectedDay.completedSession.exerciseCount}`,
       },
       {
         label: 'Started',
-        value: timeFormatter.format(new Date(selectedDay.session.startedAt)),
+        value: timeFormatter.format(new Date(selectedDay.completedSession.startedAt)),
       },
+    ];
+  }
+
+  if (selectedDay.inProgressSession) {
+    return [
+      { label: 'Status', value: 'In progress' },
+      { label: 'Duration', value: 'Timer running' },
+      { label: 'Exercises', value: `${selectedDay.inProgressSession.exerciseCount}` },
+      { label: 'Started', value: timeFormatter.format(new Date(selectedDay.inProgressSession.startedAt)) },
+    ];
+  }
+
+  if (selectedDay.scheduledWorkouts.length > 0) {
+    return [
+      { label: 'Status', value: 'Scheduled' },
+      { label: 'Planned', value: `${selectedDay.scheduledWorkouts.length} workouts` },
+      { label: 'Focus', value: selectedDay.scheduledWorkouts[0]?.templateName ?? 'Workout planned' },
+      { label: 'Readiness', value: 'Ready to start' },
     ];
   }
 
@@ -369,25 +602,28 @@ function getDetailStats(selectedDay: DayDetails) {
   ];
 }
 
-function getDefaultSelectedDateKey(month: Date, sessionByDate: Map<string, WorkoutSessionListItem>): string {
-  const monthActivity = [...sessionByDate.keys()]
+function getDefaultSelectedDateKey(
+  month: Date,
+  completedByDate: Map<string, WorkoutSessionListItem>,
+  scheduledByDate: Map<string, ScheduledWorkoutListItem[]>,
+): string {
+  if (
+    isSameMonth(parseDateKey(TODAY_KEY), month) &&
+    (completedByDate.has(TODAY_KEY) || (scheduledByDate.get(TODAY_KEY)?.length ?? 0) > 0)
+  ) {
+    return TODAY_KEY;
+  }
+
+  const monthActivity = [...completedByDate.keys(), ...scheduledByDate.keys()]
     .map((dateKey) => parseDateKey(dateKey))
     .filter((date) => isSameMonth(date, month))
     .sort((left, right) => left.getTime() - right.getTime());
-
-  if (isSameMonth(parseDateKey(TODAY_KEY), month) && hasWorkoutEntry(TODAY_KEY, sessionByDate)) {
-    return TODAY_KEY;
-  }
 
   if (monthActivity[0]) {
     return toDateKey(monthActivity[0]);
   }
 
   return isSameMonth(parseDateKey(TODAY_KEY), month) ? TODAY_KEY : toDateKey(month);
-}
-
-function hasWorkoutEntry(dateKey: string, sessionByDate: Map<string, WorkoutSessionListItem>) {
-  return sessionByDate.has(dateKey);
 }
 
 function buildCalendarDays(month: Date): Date[] {
@@ -423,4 +659,20 @@ function addMonths(date: Date, months: number) {
 
 function isSameMonth(left: Date, right: Date) {
   return left.getFullYear() === right.getFullYear() && left.getMonth() === right.getMonth();
+}
+
+function isActiveSessionListItem(session: WorkoutSessionListItem) {
+  return session.templateId == null || session.templateName != null;
+}
+
+function isActiveScheduledWorkout(scheduledWorkout: ScheduledWorkoutListItem) {
+  return scheduledWorkout.templateId != null && scheduledWorkout.templateName != null;
+}
+
+function spansToday(session: WorkoutSessionListItem, todayKey: string) {
+  const dayStart = new Date(`${todayKey}T00:00:00`).getTime();
+  const dayEnd = new Date(`${todayKey}T23:59:59.999`).getTime();
+  const sessionEnd = session.completedAt ?? Number.POSITIVE_INFINITY;
+
+  return session.startedAt <= dayEnd && sessionEnd >= dayStart;
 }

--- a/apps/web/src/features/workouts/components/workout-list.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react';
-import type { WorkoutSessionListItem } from '@pulse/shared';
+import type { ScheduledWorkoutListItem, WorkoutSessionListItem } from '@pulse/shared';
 import { MemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
@@ -8,15 +8,8 @@ import { renderWithQueryClient } from '@/test/render-with-query-client';
 import { WorkoutList } from './workout-list';
 
 describe('WorkoutList', () => {
-  it('groups sessions into upcoming and completed sections with status-specific indicators', async () => {
+  it('renders scheduled workouts above upcoming/completed with missed indicator', async () => {
     const sessions = [
-      createSession({
-        id: 'session-upcoming',
-        date: '2026-03-14',
-        status: 'scheduled',
-        templateId: 'template-push',
-        templateName: 'Upper Push',
-      }),
       createSession({
         id: 'session-in-progress',
         date: '2026-03-12',
@@ -41,57 +34,81 @@ describe('WorkoutList', () => {
       }),
     ];
 
-    renderWorkoutList(sessions);
-
-    expect(await screen.findByRole('heading', { level: 2, name: 'Upcoming' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 2, name: 'Completed' })).toBeInTheDocument();
-    expect(screen.getByText('Planned')).toBeInTheDocument();
-    expect(screen.getAllByText('In Progress').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Paused').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Completed').length).toBeGreaterThan(0);
-    expect(screen.getByText(/Scheduled /)).toBeInTheDocument();
-    expect(screen.getByText('49 min')).toBeInTheDocument();
-    const inProgressLink = screen
-      .getAllByRole('link', { name: /upper push/i })
-      .find((link) => link.getAttribute('href') === '/workouts/active?sessionId=session-in-progress');
-    expect(inProgressLink).toBeDefined();
-    const pausedLink = screen
-      .getAllByRole('link', { name: /upper pull/i })
-      .find((link) => link.getAttribute('href') === '/workouts/active?sessionId=session-paused');
-    expect(pausedLink).toBeDefined();
-  });
-
-  it('renders a workout card with summary stats and session detail link', async () => {
-    const sessions = [
-      createSession({
-        id: 'session-10',
-        date: '2026-03-10',
-        status: 'completed',
+    const scheduledWorkouts = [
+      createScheduledWorkout({
+        id: 'schedule-upcoming',
+        date: '2026-03-15',
         templateId: 'template-push',
         templateName: 'Upper Push',
-        exerciseCount: 7,
-        duration: 53,
+        sessionId: null,
+      }),
+      createScheduledWorkout({
+        id: 'schedule-missed',
+        date: '2026-03-01',
+        templateId: 'template-pull',
+        templateName: 'Upper Pull',
+        sessionId: 'session-soft-deleted',
       }),
     ];
 
-    renderWorkoutList(sessions);
+    renderWorkoutList(sessions, scheduledWorkouts);
 
-    expect(await screen.findByRole('link', { name: /upper push/i })).toHaveAttribute(
-      'href',
-      '/workouts/session/session-10',
-    );
-    expect(screen.getByText('53 min')).toBeInTheDocument();
-    expect(screen.getByText('7 exercises')).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: 'Scheduled' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Upcoming' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Completed' })).toBeInTheDocument();
+    expect(screen.getByText('Missed')).toBeInTheDocument();
+    const startLinks = screen.getAllByRole('link', { name: 'Start' });
+    expect(
+      startLinks.some((link) => link.getAttribute('href') === '/workouts/active?template=template-push'),
+    ).toBe(true);
+    expect(screen.getAllByText('In Progress').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Paused').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Completed').length).toBeGreaterThan(0);
   });
 
-  it('shows planned-workout onboarding when no scheduled sessions exist', async () => {
-    renderWorkoutList([
+  it('filters soft-deleted template rows from scheduled and session lists', async () => {
+    const sessions = [
       createSession({
-        id: 'session-11',
-        status: 'completed',
-        date: '2026-03-01',
+        id: 'session-hidden',
+        templateId: 'template-deleted',
+        templateName: null,
       }),
-    ]);
+      createSession({
+        id: 'session-visible',
+        templateId: 'template-kept',
+        templateName: 'Visible Workout',
+      }),
+    ];
+    const scheduledWorkouts = [
+      createScheduledWorkout({
+        id: 'schedule-hidden',
+        templateId: 'template-deleted',
+        templateName: null,
+      }),
+      createScheduledWorkout({
+        id: 'schedule-visible',
+        templateId: 'template-kept',
+        templateName: 'Visible Workout',
+      }),
+    ];
+
+    renderWorkoutList(sessions, scheduledWorkouts);
+
+    expect(await screen.findByRole('link', { name: /visible workout/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: 'Start' })).toHaveLength(1);
+  });
+
+  it('shows planned-workout onboarding when no scheduled or active workouts exist', async () => {
+    renderWorkoutList(
+      [
+        createSession({
+          id: 'session-11',
+          status: 'completed',
+          date: '2026-03-01',
+        }),
+      ],
+      [],
+    );
 
     expect(await screen.findByText('No workouts planned')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Plan a workout' })).toHaveAttribute(
@@ -104,30 +121,20 @@ describe('WorkoutList', () => {
     );
   });
 
-  it('does not show planned-workout onboarding when an in-progress session exists', async () => {
-    renderWorkoutList([
-      createSession({
-        id: 'session-12',
-        status: 'in-progress',
-        date: '2026-03-11',
-      }),
-    ]);
-
-    expect(screen.getAllByText('In Progress').length).toBeGreaterThan(0);
-    expect(screen.queryByText('No workouts planned')).not.toBeInTheDocument();
-  });
-
-  it('shows an empty state when no workout sessions are returned', async () => {
-    renderWorkoutList([]);
+  it('shows an empty state when no workout sessions or schedules are returned', async () => {
+    renderWorkoutList([], []);
 
     expect(await screen.findByText('No workouts yet. Plan one to get started.')).toBeInTheDocument();
   });
 });
 
-function renderWorkoutList(sessions: WorkoutSessionListItem[]) {
+function renderWorkoutList(
+  sessions: WorkoutSessionListItem[],
+  scheduledWorkouts: ScheduledWorkoutListItem[],
+) {
   return renderWithQueryClient(
     <MemoryRouter>
-      <WorkoutList sessions={sessions} />
+      <WorkoutList scheduledWorkouts={scheduledWorkouts} sessions={sessions} />
     </MemoryRouter>,
   );
 }
@@ -144,6 +151,20 @@ function createSession(overrides: Partial<WorkoutSessionListItem>): WorkoutSessi
     completedAt: Date.parse('2026-03-10T19:00:00Z'),
     duration: 60,
     exerciseCount: 5,
+    createdAt: 1,
+    ...overrides,
+  };
+}
+
+function createScheduledWorkout(
+  overrides: Partial<ScheduledWorkoutListItem>,
+): ScheduledWorkoutListItem {
+  return {
+    id: 'schedule-default',
+    date: '2026-03-15',
+    templateId: 'template-default',
+    templateName: 'Scheduled Workout',
+    sessionId: null,
     createdAt: 1,
     ...overrides,
   };

--- a/apps/web/src/features/workouts/components/workout-list.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import type { ScheduledWorkoutListItem, WorkoutSessionListItem } from '@pulse/shared';
 import { MemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
@@ -125,6 +125,32 @@ describe('WorkoutList', () => {
     renderWorkoutList([], []);
 
     expect(await screen.findByText('No workouts yet. Plan one to get started.')).toBeInTheDocument();
+  });
+
+  it('opens a date-input dialog for rescheduling', async () => {
+    const sessions = [
+      createSession({
+        id: 'session-completed',
+        status: 'completed',
+        date: '2026-03-10',
+      }),
+    ];
+    const scheduledWorkouts = [
+      createScheduledWorkout({
+        id: 'schedule-upcoming',
+        date: '2026-03-15',
+        templateId: 'template-push',
+        templateName: 'Upper Push',
+        sessionId: null,
+      }),
+    ];
+
+    renderWorkoutList(sessions, scheduledWorkouts);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Reschedule' }));
+
+    expect(await screen.findByRole('heading', { name: 'Reschedule workout' })).toBeInTheDocument();
+    expect(screen.getByDisplayValue('2026-03-15')).toHaveAttribute('type', 'date');
   });
 });
 

--- a/apps/web/src/features/workouts/components/workout-list.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import type { ScheduledWorkoutListItem, WorkoutSessionListItem } from '@pulse/shared';
 import { MemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
@@ -57,16 +57,13 @@ describe('WorkoutList', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Upcoming' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 2, name: 'Completed' })).toBeInTheDocument();
     expect(screen.getByText('Missed')).toBeInTheDocument();
-    const startLinks = screen.getAllByRole('link', { name: 'Start' });
-    expect(
-      startLinks.some((link) => link.getAttribute('href') === '/workouts/active?template=template-push'),
-    ).toBe(true);
+    expect(screen.getAllByRole('button', { name: 'Start now' }).length).toBeGreaterThan(0);
     expect(screen.getAllByText('In Progress').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Paused').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Completed').length).toBeGreaterThan(0);
   });
 
-  it('filters soft-deleted template rows from scheduled and session lists', async () => {
+  it('shows unavailable state for soft-deleted scheduled templates and hides stale start actions', async () => {
     const sessions = [
       createSession({
         id: 'session-hidden',
@@ -95,7 +92,12 @@ describe('WorkoutList', () => {
     renderWorkoutList(sessions, scheduledWorkouts);
 
     expect(await screen.findByRole('link', { name: /visible workout/i })).toBeInTheDocument();
-    expect(screen.getAllByRole('link', { name: 'Start' })).toHaveLength(1);
+    expect(screen.getByText('Workout unavailable')).toBeInTheDocument();
+    const unavailableCard = screen.getByText('Workout unavailable').closest('[data-slot="card"]');
+    expect(unavailableCard).not.toBeNull();
+    expect(
+      within(unavailableCard as HTMLElement).getByRole('button', { name: 'Start now' }),
+    ).toBeDisabled();
   });
 
   it('shows planned-workout onboarding when no scheduled or active workouts exist', async () => {
@@ -124,10 +126,12 @@ describe('WorkoutList', () => {
   it('shows an empty state when no workout sessions or schedules are returned', async () => {
     renderWorkoutList([], []);
 
-    expect(await screen.findByText('No workouts yet. Plan one to get started.')).toBeInTheDocument();
+    expect(
+      await screen.findByText('No workouts yet. Plan one to get started.'),
+    ).toBeInTheDocument();
   });
 
-  it('opens a date-input dialog for rescheduling', async () => {
+  it('opens a calendar dialog for rescheduling', async () => {
     const sessions = [
       createSession({
         id: 'session-completed',
@@ -150,7 +154,7 @@ describe('WorkoutList', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Reschedule' }));
 
     expect(await screen.findByRole('heading', { name: 'Reschedule workout' })).toBeInTheDocument();
-    expect(screen.getByDisplayValue('2026-03-15')).toHaveAttribute('type', 'date');
+    expect(screen.getByText('Move Upper Push to a new date.')).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/features/workouts/components/workout-list.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   Activity,
   CalendarCheck2,
@@ -15,33 +15,35 @@ import type {
   ScheduledWorkoutListItem,
   WorkoutSessionListItem,
   WorkoutSessionStatus,
+  WorkoutTemplate,
 } from '@pulse/shared';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { useNavigate } from 'react-router';
 import { toDateKey } from '@/lib/date-utils';
 import { cn } from '@/lib/utils';
 
 import {
-  useDeleteScheduledWorkout,
+  useRescheduleWorkout,
   useScheduledWorkouts,
-  useUpdateScheduledWorkout,
+  useUnscheduleWorkout,
+  useWorkoutTemplate,
   useWorkoutSessions,
 } from '../api/workouts';
-import {
-  ActiveScheduledWorkoutListItem,
-  isActiveScheduledWorkout,
-  isActiveSessionListItem,
-} from '../lib/workout-filters';
+import { isActiveSessionListItem } from '../lib/workout-filters';
+import { useStartSession } from '@/hooks/use-workout-session';
+import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
 
 const sessionDateFormatter = new Intl.DateTimeFormat('en-US', {
   weekday: 'short',
@@ -93,9 +95,7 @@ export function WorkoutList({
   const resolvedSessions = sessions ?? sessionsQuery.data ?? [];
   const activeSessions = resolvedSessions.filter(isActiveSessionListItem);
   const linkedSessionIds = new Set(activeSessions.map((session) => session.id));
-  const resolvedScheduledWorkouts = (scheduledWorkouts ?? scheduledQuery.data ?? []).filter(
-    isActiveScheduledWorkout,
-  );
+  const resolvedScheduledWorkouts = scheduledWorkouts ?? scheduledQuery.data ?? [];
 
   const scheduledItems = resolvedScheduledWorkouts
     .map((scheduledWorkout) => ({
@@ -103,6 +103,7 @@ export function WorkoutList({
       isMissed:
         scheduledWorkout.date < TODAY_KEY &&
         (scheduledWorkout.sessionId == null || !linkedSessionIds.has(scheduledWorkout.sessionId)),
+      isUnavailable: scheduledWorkout.templateId == null || scheduledWorkout.templateName == null,
     }))
     .sort((left, right) => left.date.localeCompare(right.date));
 
@@ -216,64 +217,98 @@ function ScheduledWorkoutCard({
   scheduledWorkout,
 }: {
   buildStartWorkoutHref: (templateId: string) => string;
-  scheduledWorkout: ActiveScheduledWorkoutListItem & { isMissed: boolean };
+  scheduledWorkout: ScheduledWorkoutListItem & { isMissed: boolean; isUnavailable: boolean };
 }) {
-  const updateScheduledWorkoutMutation = useUpdateScheduledWorkout();
-  const deleteScheduledWorkoutMutation = useDeleteScheduledWorkout();
+  const navigate = useNavigate();
+  const rescheduleWorkoutMutation = useRescheduleWorkout();
+  const unscheduleWorkoutMutation = useUnscheduleWorkout();
+  const startSessionMutation = useStartSession();
+  const templateId = scheduledWorkout.templateId ?? '';
+  const templateQuery = useWorkoutTemplate(templateId);
 
   const isMutating =
-    updateScheduledWorkoutMutation.isPending || deleteScheduledWorkoutMutation.isPending;
+    rescheduleWorkoutMutation.isPending ||
+    unscheduleWorkoutMutation.isPending ||
+    startSessionMutation.isPending;
   const [isRescheduleDialogOpen, setIsRescheduleDialogOpen] = useState(false);
+  const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false);
+  const isTemplateAvailable = !scheduledWorkout.isUnavailable && !templateQuery.isError;
+  const isStartDisabled = isMutating || !isTemplateAvailable || templateQuery.isPending;
 
   async function handleReschedule(requestedDate: string) {
-    await updateScheduledWorkoutMutation.mutateAsync({
+    await rescheduleWorkoutMutation.mutateAsync({
       date: requestedDate,
       id: scheduledWorkout.id,
     });
   }
 
-  function handleRemove() {
-    if (typeof window === 'undefined') {
+  async function handleStartNow() {
+    if (!templateQuery.data || !scheduledWorkout.templateId || !scheduledWorkout.templateName) {
       return;
     }
 
-    if (!window.confirm('Remove this scheduled workout?')) {
+    const startedAt = Date.now();
+    const session = await startSessionMutation.mutateAsync({
+      date: toDateKey(new Date(startedAt)),
+      name: scheduledWorkout.templateName,
+      sets: buildInitialSessionSets(templateQuery.data),
+      startedAt,
+      templateId: scheduledWorkout.templateId,
+    });
+    navigate(`/workouts/active?template=${scheduledWorkout.templateId}&sessionId=${session.id}`);
+  }
+
+  async function handleRemove() {
+    if (!scheduledWorkout.id) {
       return;
     }
 
-    void deleteScheduledWorkoutMutation.mutateAsync({ id: scheduledWorkout.id });
+    await unscheduleWorkoutMutation.mutateAsync({ id: scheduledWorkout.id });
+    setIsRemoveDialogOpen(false);
   }
 
   return (
     <Card
       className={cn(
         'gap-4 border-l-4 py-0',
-        scheduledWorkout.isMissed
-          ? 'border-amber-500/55 bg-amber-500/6'
-          : 'border-slate-300/70 dark:border-slate-700/70',
+        scheduledWorkout.isUnavailable
+          ? 'border-destructive/45 bg-destructive/5'
+          : scheduledWorkout.isMissed
+            ? 'border-amber-500/55 bg-amber-500/6'
+            : 'border-slate-300/70 dark:border-slate-700/70',
       )}
     >
       <CardHeader className="gap-3 py-5">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-1">
-            <CardTitle>{scheduledWorkout.templateName}</CardTitle>
-            <p className="text-sm text-muted">{sessionDateFormatter.format(parseDateForDisplay(scheduledWorkout.date))}</p>
+            <CardTitle>{scheduledWorkout.templateName ?? 'Workout unavailable'}</CardTitle>
+            <p className="text-sm text-muted">
+              {sessionDateFormatter.format(parseDateForDisplay(scheduledWorkout.date))}
+            </p>
           </div>
 
           <span
             className={cn(
               'inline-flex w-fit items-center gap-1 rounded-full px-3 py-1 text-[11px] font-semibold tracking-[0.18em] uppercase',
-              scheduledWorkout.isMissed
-                ? 'bg-amber-500/15 text-amber-700 dark:bg-amber-500/20 dark:text-amber-300'
-                : 'bg-secondary text-muted-foreground',
+              scheduledWorkout.isUnavailable
+                ? 'bg-destructive/10 text-destructive'
+                : scheduledWorkout.isMissed
+                  ? 'bg-amber-500/15 text-amber-700 dark:bg-amber-500/20 dark:text-amber-300'
+                  : 'bg-secondary text-muted-foreground',
             )}
           >
-            {scheduledWorkout.isMissed ? (
+            {scheduledWorkout.isUnavailable ? (
+              <TriangleAlert aria-hidden="true" className="size-3.5" />
+            ) : scheduledWorkout.isMissed ? (
               <TriangleAlert aria-hidden="true" className="size-3.5" />
             ) : (
               <CalendarClock aria-hidden="true" className="size-3.5" />
             )}
-            {scheduledWorkout.isMissed ? 'Missed' : 'Scheduled'}
+            {scheduledWorkout.isUnavailable
+              ? 'Unavailable'
+              : scheduledWorkout.isMissed
+                ? 'Missed'
+                : 'Scheduled'}
           </span>
         </div>
       </CardHeader>
@@ -284,15 +319,27 @@ function ScheduledWorkoutCard({
             icon={CalendarPlus2}
             label={`Scheduled ${sessionDateFormatter.format(parseDateForDisplay(scheduledWorkout.date))}`}
           />
-          {scheduledWorkout.isMissed ? <WorkoutStat icon={TriangleAlert} label="No active linked session" /> : null}
+          {scheduledWorkout.isUnavailable ? (
+            <WorkoutStat icon={TriangleAlert} label="Template was deleted from trash/soft delete" />
+          ) : null}
+          {scheduledWorkout.isMissed ? (
+            <WorkoutStat icon={TriangleAlert} label="No active linked session" />
+          ) : null}
         </ul>
 
         <div className="flex flex-wrap gap-2">
-          <Button asChild disabled={isMutating} size="sm">
-            <Link to={buildStartWorkoutHref(scheduledWorkout.templateId)}>Start</Link>
+          <Button
+            disabled={isStartDisabled}
+            onClick={() => {
+              void handleStartNow();
+            }}
+            size="sm"
+            type="button"
+          >
+            Start now
           </Button>
           <Button
-            disabled={isMutating}
+            disabled={isMutating || !isTemplateAvailable}
             onClick={() => setIsRescheduleDialogOpen(true)}
             size="sm"
             type="button"
@@ -300,101 +347,49 @@ function ScheduledWorkoutCard({
           >
             Reschedule
           </Button>
-          <Button disabled={isMutating} onClick={handleRemove} size="sm" type="button" variant="ghost">
-            Remove
+          <Button
+            disabled={isMutating}
+            onClick={() => setIsRemoveDialogOpen(true)}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            Remove from schedule
           </Button>
+          {!isTemplateAvailable && scheduledWorkout.templateId ? (
+            <Button asChild size="sm" variant="secondary">
+              <Link to={buildStartWorkoutHref(scheduledWorkout.templateId)}>
+                Open template view
+              </Link>
+            </Button>
+          ) : null}
         </div>
       </CardContent>
-      <RescheduleScheduledWorkoutDialog
-        currentDate={scheduledWorkout.date}
-        isPending={updateScheduledWorkoutMutation.isPending}
+      <ScheduleWorkoutDialog
+        description={`Move ${scheduledWorkout.templateName ?? 'this workout'} to a new date.`}
+        initialDate={scheduledWorkout.date}
+        isPending={rescheduleWorkoutMutation.isPending}
         onOpenChange={setIsRescheduleDialogOpen}
-        onReschedule={handleReschedule}
+        onSubmitDate={handleReschedule}
         open={isRescheduleDialogOpen}
-        templateName={scheduledWorkout.templateName}
+        submitLabel="Save"
+        title="Reschedule workout"
       />
+      <AlertDialog onOpenChange={setIsRemoveDialogOpen} open={isRemoveDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove this scheduled workout?</AlertDialogTitle>
+            <AlertDialogDescription>This will remove it from your calendar.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isMutating}>Cancel</AlertDialogCancel>
+            <AlertDialogAction disabled={isMutating} onClick={() => void handleRemove()}>
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Card>
-  );
-}
-
-function RescheduleScheduledWorkoutDialog({
-  currentDate,
-  isPending,
-  onOpenChange,
-  onReschedule,
-  open,
-  templateName,
-}: {
-  currentDate: string;
-  isPending: boolean;
-  onOpenChange: (open: boolean) => void;
-  onReschedule: (date: string) => Promise<unknown>;
-  open: boolean;
-  templateName: string | null;
-}) {
-  const [requestedDate, setRequestedDate] = useState(currentDate);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
-  function handleOpenChange(nextOpen: boolean) {
-    if (nextOpen) {
-      setRequestedDate(currentDate);
-      setErrorMessage(null);
-    }
-    onOpenChange(nextOpen);
-  }
-
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    const normalized = requestedDate.trim();
-    const isIsoDate = /^\d{4}-\d{2}-\d{2}$/.test(normalized);
-    if (!isIsoDate) {
-      setErrorMessage('Enter a valid date in YYYY-MM-DD format.');
-      return;
-    }
-
-    if (normalized === currentDate) {
-      setErrorMessage('Pick a different date to reschedule.');
-      return;
-    }
-
-    setErrorMessage(null);
-    try {
-      await onReschedule(normalized);
-      handleOpenChange(false);
-    } catch {
-      setErrorMessage('Unable to reschedule right now. Try again.');
-    }
-  }
-
-  return (
-    <Dialog onOpenChange={handleOpenChange} open={open}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Reschedule workout</DialogTitle>
-          <DialogDescription>
-            Move {templateName ?? 'this workout'} to a new date.
-          </DialogDescription>
-        </DialogHeader>
-        <form className="space-y-3" onSubmit={handleSubmit}>
-          <Input
-            aria-invalid={errorMessage != null}
-            min="1900-01-01"
-            onChange={(event) => setRequestedDate(event.target.value)}
-            type="date"
-            value={requestedDate}
-          />
-          {errorMessage ? <p className="text-xs text-destructive">{errorMessage}</p> : null}
-          <DialogFooter>
-            <Button onClick={() => handleOpenChange(false)} type="button" variant="outline">
-              Cancel
-            </Button>
-            <Button disabled={isPending} type="submit">
-              Save
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
   );
 }
 
@@ -450,7 +445,11 @@ function WorkoutListCard({
         <CardContent className="pb-5">
           <ul className="flex flex-wrap gap-3 text-sm text-muted">
             {buildStatusStats(session).map((stat) => (
-              <WorkoutStat icon={stat.icon} key={`${session.id}-${stat.label}`} label={stat.label} />
+              <WorkoutStat
+                icon={stat.icon}
+                key={`${session.id}-${stat.label}`}
+                label={stat.label}
+              />
             ))}
           </ul>
         </CardContent>
@@ -586,4 +585,23 @@ function getScheduledRange(today: string) {
     from: toDateKey(from),
     to: toDateKey(to),
   };
+}
+
+function buildInitialSessionSets(template: WorkoutTemplate) {
+  return template.sections.flatMap((section) =>
+    section.exercises.flatMap((exercise, exerciseIndex) => {
+      if (exercise.sets === null || exercise.sets < 1) {
+        return [];
+      }
+
+      return Array.from({ length: exercise.sets }, (_, index) => ({
+        exerciseId: exercise.exerciseId,
+        orderIndex: exerciseIndex,
+        reps: null,
+        section: section.type,
+        setNumber: index + 1,
+        weight: null,
+      }));
+    }),
+  );
 }

--- a/apps/web/src/features/workouts/components/workout-list.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.tsx
@@ -40,7 +40,8 @@ import {
   useWorkoutTemplate,
   useWorkoutSessions,
 } from '../api/workouts';
-import { isActiveSessionListItem } from '../lib/workout-filters';
+import { useTodayKey } from '../hooks/use-today-key';
+import { hasAvailableTemplate } from '../lib/workout-filters';
 import { buildInitialSessionSets } from '../lib/workout-session-sets';
 import { useStartSession } from '@/hooks/use-workout-session';
 import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
@@ -50,8 +51,6 @@ const sessionDateFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'short',
   day: 'numeric',
 });
-
-const TODAY_KEY = toDateKey(new Date());
 
 type WorkoutListProps = {
   buildSessionHref?: (sessionId: string, status: WorkoutSessionStatus) => string;
@@ -86,14 +85,15 @@ export function WorkoutList({
   sessions,
   scheduledWorkouts,
 }: WorkoutListProps) {
+  const todayKey = useTodayKey();
   const sessionsQuery = useWorkoutSessions({}, { enabled: sessions === undefined });
-  const scheduledRange = useMemo(() => getScheduledRange(TODAY_KEY), []);
+  const scheduledRange = useMemo(() => getScheduledRange(todayKey), [todayKey]);
   const scheduledQuery = useScheduledWorkouts(scheduledRange, {
     enabled: scheduledWorkouts === undefined,
   });
 
   const resolvedSessions = sessions ?? sessionsQuery.data ?? [];
-  const activeSessions = resolvedSessions.filter(isActiveSessionListItem);
+  const activeSessions = resolvedSessions.filter(hasAvailableTemplate);
   const linkedSessionIds = new Set(activeSessions.map((session) => session.id));
   const resolvedScheduledWorkouts = scheduledWorkouts ?? scheduledQuery.data ?? [];
 
@@ -101,7 +101,7 @@ export function WorkoutList({
     .map((scheduledWorkout) => ({
       ...scheduledWorkout,
       isMissed:
-        scheduledWorkout.date < TODAY_KEY &&
+        scheduledWorkout.date < todayKey &&
         (scheduledWorkout.sessionId == null || !linkedSessionIds.has(scheduledWorkout.sessionId)),
       isUnavailable: scheduledWorkout.templateId == null || scheduledWorkout.templateName == null,
     }))

--- a/apps/web/src/features/workouts/components/workout-list.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.tsx
@@ -15,7 +15,6 @@ import type {
   ScheduledWorkoutListItem,
   WorkoutSessionListItem,
   WorkoutSessionStatus,
-  WorkoutTemplate,
 } from '@pulse/shared';
 
 import { Button } from '@/components/ui/button';
@@ -42,6 +41,7 @@ import {
   useWorkoutSessions,
 } from '../api/workouts';
 import { isActiveSessionListItem } from '../lib/workout-filters';
+import { buildInitialSessionSets } from '../lib/workout-session-sets';
 import { useStartSession } from '@/hooks/use-workout-session';
 import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
 
@@ -259,10 +259,6 @@ function ScheduledWorkoutCard({
   }
 
   async function handleRemove() {
-    if (!scheduledWorkout.id) {
-      return;
-    }
-
     await unscheduleWorkoutMutation.mutateAsync({ id: scheduledWorkout.id });
     setIsRemoveDialogOpen(false);
   }
@@ -372,6 +368,8 @@ function ScheduledWorkoutCard({
         onOpenChange={setIsRescheduleDialogOpen}
         onSubmitDate={handleReschedule}
         open={isRescheduleDialogOpen}
+        disallowDateKey={scheduledWorkout.date}
+        disallowDateMessage="Pick a different date to reschedule."
         submitLabel="Save"
         title="Reschedule workout"
       />
@@ -585,23 +583,4 @@ function getScheduledRange(today: string) {
     from: toDateKey(from),
     to: toDateKey(to),
   };
-}
-
-function buildInitialSessionSets(template: WorkoutTemplate) {
-  return template.sections.flatMap((section) =>
-    section.exercises.flatMap((exercise, exerciseIndex) => {
-      if (exercise.sets === null || exercise.sets < 1) {
-        return [];
-      }
-
-      return Array.from({ length: exercise.sets }, (_, index) => ({
-        exerciseId: exercise.exerciseId,
-        orderIndex: exerciseIndex,
-        reps: null,
-        section: section.type,
-        setNumber: index + 1,
-        weight: null,
-      }));
-    }),
-  );
 }

--- a/apps/web/src/features/workouts/components/workout-list.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { FormEvent, useMemo, useState } from 'react';
 import {
   Activity,
   CalendarCheck2,
@@ -19,6 +19,15 @@ import type {
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
 import { toDateKey } from '@/lib/date-utils';
 import { cn } from '@/lib/utils';
 
@@ -28,6 +37,11 @@ import {
   useUpdateScheduledWorkout,
   useWorkoutSessions,
 } from '../api/workouts';
+import {
+  ActiveScheduledWorkoutListItem,
+  isActiveScheduledWorkout,
+  isActiveSessionListItem,
+} from '../lib/workout-filters';
 
 const sessionDateFormatter = new Intl.DateTimeFormat('en-US', {
   weekday: 'short',
@@ -202,25 +216,17 @@ function ScheduledWorkoutCard({
   scheduledWorkout,
 }: {
   buildStartWorkoutHref: (templateId: string) => string;
-  scheduledWorkout: ScheduledWorkoutListItem & { isMissed: boolean };
+  scheduledWorkout: ActiveScheduledWorkoutListItem & { isMissed: boolean };
 }) {
   const updateScheduledWorkoutMutation = useUpdateScheduledWorkout();
   const deleteScheduledWorkoutMutation = useDeleteScheduledWorkout();
 
   const isMutating =
     updateScheduledWorkoutMutation.isPending || deleteScheduledWorkoutMutation.isPending;
+  const [isRescheduleDialogOpen, setIsRescheduleDialogOpen] = useState(false);
 
-  function handleReschedule() {
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    const requestedDate = window.prompt('Reschedule to date (YYYY-MM-DD)', scheduledWorkout.date);
-    if (!requestedDate || requestedDate === scheduledWorkout.date) {
-      return;
-    }
-
-    void updateScheduledWorkoutMutation.mutateAsync({
+  async function handleReschedule(requestedDate: string) {
+    await updateScheduledWorkoutMutation.mutateAsync({
       date: requestedDate,
       id: scheduledWorkout.id,
     });
@@ -283,9 +289,15 @@ function ScheduledWorkoutCard({
 
         <div className="flex flex-wrap gap-2">
           <Button asChild disabled={isMutating} size="sm">
-            <Link to={buildStartWorkoutHref(scheduledWorkout.templateId ?? '')}>Start</Link>
+            <Link to={buildStartWorkoutHref(scheduledWorkout.templateId)}>Start</Link>
           </Button>
-          <Button disabled={isMutating} onClick={handleReschedule} size="sm" type="button" variant="outline">
+          <Button
+            disabled={isMutating}
+            onClick={() => setIsRescheduleDialogOpen(true)}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
             Reschedule
           </Button>
           <Button disabled={isMutating} onClick={handleRemove} size="sm" type="button" variant="ghost">
@@ -293,7 +305,96 @@ function ScheduledWorkoutCard({
           </Button>
         </div>
       </CardContent>
+      <RescheduleScheduledWorkoutDialog
+        currentDate={scheduledWorkout.date}
+        isPending={updateScheduledWorkoutMutation.isPending}
+        onOpenChange={setIsRescheduleDialogOpen}
+        onReschedule={handleReschedule}
+        open={isRescheduleDialogOpen}
+        templateName={scheduledWorkout.templateName}
+      />
     </Card>
+  );
+}
+
+function RescheduleScheduledWorkoutDialog({
+  currentDate,
+  isPending,
+  onOpenChange,
+  onReschedule,
+  open,
+  templateName,
+}: {
+  currentDate: string;
+  isPending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onReschedule: (date: string) => Promise<unknown>;
+  open: boolean;
+  templateName: string | null;
+}) {
+  const [requestedDate, setRequestedDate] = useState(currentDate);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (nextOpen) {
+      setRequestedDate(currentDate);
+      setErrorMessage(null);
+    }
+    onOpenChange(nextOpen);
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const normalized = requestedDate.trim();
+    const isIsoDate = /^\d{4}-\d{2}-\d{2}$/.test(normalized);
+    if (!isIsoDate) {
+      setErrorMessage('Enter a valid date in YYYY-MM-DD format.');
+      return;
+    }
+
+    if (normalized === currentDate) {
+      setErrorMessage('Pick a different date to reschedule.');
+      return;
+    }
+
+    setErrorMessage(null);
+    try {
+      await onReschedule(normalized);
+      handleOpenChange(false);
+    } catch {
+      setErrorMessage('Unable to reschedule right now. Try again.');
+    }
+  }
+
+  return (
+    <Dialog onOpenChange={handleOpenChange} open={open}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Reschedule workout</DialogTitle>
+          <DialogDescription>
+            Move {templateName ?? 'this workout'} to a new date.
+          </DialogDescription>
+        </DialogHeader>
+        <form className="space-y-3" onSubmit={handleSubmit}>
+          <Input
+            aria-invalid={errorMessage != null}
+            min="1900-01-01"
+            onChange={(event) => setRequestedDate(event.target.value)}
+            type="date"
+            value={requestedDate}
+          />
+          {errorMessage ? <p className="text-xs text-destructive">{errorMessage}</p> : null}
+          <DialogFooter>
+            <Button onClick={() => handleOpenChange(false)} type="button" variant="outline">
+              Cancel
+            </Button>
+            <Button disabled={isPending} type="submit">
+              Save
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -472,14 +573,6 @@ function getStatusBadgeIcon(status: WorkoutSessionStatus) {
 
 function parseDateForDisplay(dateKey: string) {
   return new Date(`${dateKey}T12:00:00`);
-}
-
-function isActiveSessionListItem(session: WorkoutSessionListItem) {
-  return session.templateId == null || session.templateName != null;
-}
-
-function isActiveScheduledWorkout(scheduledWorkout: ScheduledWorkoutListItem) {
-  return scheduledWorkout.templateId != null && scheduledWorkout.templateName != null;
 }
 
 function getScheduledRange(today: string) {

--- a/apps/web/src/features/workouts/components/workout-list.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.tsx
@@ -1,12 +1,33 @@
-import { Activity, CalendarCheck2, CalendarDays, CalendarPlus2, CheckCircle2, Dumbbell, Timer } from 'lucide-react';
+import { useMemo } from 'react';
+import {
+  Activity,
+  CalendarCheck2,
+  CalendarClock,
+  CalendarDays,
+  CalendarPlus2,
+  CheckCircle2,
+  Dumbbell,
+  Timer,
+  TriangleAlert,
+} from 'lucide-react';
 import { Link } from 'react-router';
-import type { WorkoutSessionListItem, WorkoutSessionStatus } from '@pulse/shared';
+import type {
+  ScheduledWorkoutListItem,
+  WorkoutSessionListItem,
+  WorkoutSessionStatus,
+} from '@pulse/shared';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { toDateKey } from '@/lib/date-utils';
 import { cn } from '@/lib/utils';
 
-import { useWorkoutSessions } from '../api/workouts';
+import {
+  useDeleteScheduledWorkout,
+  useScheduledWorkouts,
+  useUpdateScheduledWorkout,
+  useWorkoutSessions,
+} from '../api/workouts';
 
 const sessionDateFormatter = new Intl.DateTimeFormat('en-US', {
   weekday: 'short',
@@ -14,11 +35,15 @@ const sessionDateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
 });
 
+const TODAY_KEY = toDateKey(new Date());
+
 type WorkoutListProps = {
   buildSessionHref?: (sessionId: string, status: WorkoutSessionStatus) => string;
   buildTemplatesHref?: () => string;
   buildPlanWorkoutHref?: () => string;
+  buildStartWorkoutHref?: (templateId: string) => string;
   sessions?: WorkoutSessionListItem[];
+  scheduledWorkouts?: ScheduledWorkoutListItem[];
 };
 
 type WorkoutListViewItem = {
@@ -41,26 +66,42 @@ export function WorkoutList({
       : `/workouts/session/${sessionId}`,
   buildTemplatesHref = () => '/workouts?view=templates',
   buildPlanWorkoutHref = () => '/workouts?view=templates',
+  buildStartWorkoutHref = (templateId) => `/workouts/active?template=${templateId}`,
   sessions,
+  scheduledWorkouts,
 }: WorkoutListProps) {
   const sessionsQuery = useWorkoutSessions({}, { enabled: sessions === undefined });
+  const scheduledRange = useMemo(() => getScheduledRange(TODAY_KEY), []);
+  const scheduledQuery = useScheduledWorkouts(scheduledRange, {
+    enabled: scheduledWorkouts === undefined,
+  });
 
   const resolvedSessions = sessions ?? sessionsQuery.data ?? [];
-  const listItems = resolvedSessions.map((session) => buildWorkoutListItem(session));
+  const activeSessions = resolvedSessions.filter(isActiveSessionListItem);
+  const linkedSessionIds = new Set(activeSessions.map((session) => session.id));
+  const resolvedScheduledWorkouts = (scheduledWorkouts ?? scheduledQuery.data ?? []).filter(
+    isActiveScheduledWorkout,
+  );
+
+  const scheduledItems = resolvedScheduledWorkouts
+    .map((scheduledWorkout) => ({
+      ...scheduledWorkout,
+      isMissed:
+        scheduledWorkout.date < TODAY_KEY &&
+        (scheduledWorkout.sessionId == null || !linkedSessionIds.has(scheduledWorkout.sessionId)),
+    }))
+    .sort((left, right) => left.date.localeCompare(right.date));
+
+  const listItems = activeSessions.map((session) => buildWorkoutListItem(session));
   const upcomingSessions = listItems
-    .filter((session) => session.status !== 'completed')
+    .filter((session) => session.status !== 'completed' && session.status !== 'scheduled')
     .sort((left, right) => left.date.getTime() - right.date.getTime());
   const completedSessions = listItems
     .filter((session) => session.status === 'completed')
     .sort((left, right) => right.date.getTime() - left.date.getTime());
-  const hasPlannedWorkouts = listItems.some(
-    (session) =>
-      session.status === 'scheduled' ||
-      session.status === 'in-progress' ||
-      session.status === 'paused',
-  );
+  const hasPlannedWorkouts = scheduledItems.length > 0 || upcomingSessions.length > 0;
 
-  if (sessionsQuery.isLoading && !sessions) {
+  if ((sessionsQuery.isLoading && !sessions) || (scheduledQuery.isLoading && !scheduledWorkouts)) {
     return (
       <Card>
         <CardContent className="py-6">
@@ -70,7 +111,7 @@ export function WorkoutList({
     );
   }
 
-  if (listItems.length === 0) {
+  if (listItems.length === 0 && scheduledItems.length === 0) {
     return (
       <Card>
         <CardContent className="py-6">
@@ -82,6 +123,23 @@ export function WorkoutList({
 
   return (
     <div className="space-y-6">
+      <section className="space-y-3">
+        <SectionHeading count={scheduledItems.length} title="Scheduled" />
+        {scheduledItems.length > 0 ? (
+          <div className="grid gap-3">
+            {scheduledItems.map((scheduledWorkout) => (
+              <ScheduledWorkoutCard
+                buildStartWorkoutHref={buildStartWorkoutHref}
+                key={scheduledWorkout.id}
+                scheduledWorkout={scheduledWorkout}
+              />
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-muted">No scheduled workouts right now.</p>
+        )}
+      </section>
+
       <section className="space-y-3">
         <SectionHeading count={upcomingSessions.length} title="Upcoming" />
         {!hasPlannedWorkouts ? (
@@ -136,6 +194,106 @@ export function WorkoutList({
         )}
       </section>
     </div>
+  );
+}
+
+function ScheduledWorkoutCard({
+  buildStartWorkoutHref,
+  scheduledWorkout,
+}: {
+  buildStartWorkoutHref: (templateId: string) => string;
+  scheduledWorkout: ScheduledWorkoutListItem & { isMissed: boolean };
+}) {
+  const updateScheduledWorkoutMutation = useUpdateScheduledWorkout();
+  const deleteScheduledWorkoutMutation = useDeleteScheduledWorkout();
+
+  const isMutating =
+    updateScheduledWorkoutMutation.isPending || deleteScheduledWorkoutMutation.isPending;
+
+  function handleReschedule() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const requestedDate = window.prompt('Reschedule to date (YYYY-MM-DD)', scheduledWorkout.date);
+    if (!requestedDate || requestedDate === scheduledWorkout.date) {
+      return;
+    }
+
+    void updateScheduledWorkoutMutation.mutateAsync({
+      date: requestedDate,
+      id: scheduledWorkout.id,
+    });
+  }
+
+  function handleRemove() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (!window.confirm('Remove this scheduled workout?')) {
+      return;
+    }
+
+    void deleteScheduledWorkoutMutation.mutateAsync({ id: scheduledWorkout.id });
+  }
+
+  return (
+    <Card
+      className={cn(
+        'gap-4 border-l-4 py-0',
+        scheduledWorkout.isMissed
+          ? 'border-amber-500/55 bg-amber-500/6'
+          : 'border-slate-300/70 dark:border-slate-700/70',
+      )}
+    >
+      <CardHeader className="gap-3 py-5">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <CardTitle>{scheduledWorkout.templateName}</CardTitle>
+            <p className="text-sm text-muted">{sessionDateFormatter.format(parseDateForDisplay(scheduledWorkout.date))}</p>
+          </div>
+
+          <span
+            className={cn(
+              'inline-flex w-fit items-center gap-1 rounded-full px-3 py-1 text-[11px] font-semibold tracking-[0.18em] uppercase',
+              scheduledWorkout.isMissed
+                ? 'bg-amber-500/15 text-amber-700 dark:bg-amber-500/20 dark:text-amber-300'
+                : 'bg-secondary text-muted-foreground',
+            )}
+          >
+            {scheduledWorkout.isMissed ? (
+              <TriangleAlert aria-hidden="true" className="size-3.5" />
+            ) : (
+              <CalendarClock aria-hidden="true" className="size-3.5" />
+            )}
+            {scheduledWorkout.isMissed ? 'Missed' : 'Scheduled'}
+          </span>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-4 pb-5">
+        <ul className="flex flex-wrap gap-3 text-sm text-muted">
+          <WorkoutStat
+            icon={CalendarPlus2}
+            label={`Scheduled ${sessionDateFormatter.format(parseDateForDisplay(scheduledWorkout.date))}`}
+          />
+          {scheduledWorkout.isMissed ? <WorkoutStat icon={TriangleAlert} label="No active linked session" /> : null}
+        </ul>
+
+        <div className="flex flex-wrap gap-2">
+          <Button asChild disabled={isMutating} size="sm">
+            <Link to={buildStartWorkoutHref(scheduledWorkout.templateId ?? '')}>Start</Link>
+          </Button>
+          <Button disabled={isMutating} onClick={handleReschedule} size="sm" type="button" variant="outline">
+            Reschedule
+          </Button>
+          <Button disabled={isMutating} onClick={handleRemove} size="sm" type="button" variant="ghost">
+            Remove
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -210,7 +368,7 @@ function WorkoutStat({ icon: Icon, label }: { icon: typeof CalendarDays; label: 
 }
 
 function buildWorkoutListItem(session: WorkoutSessionListItem): WorkoutListViewItem {
-  const date = new Date(`${session.date}T12:00:00`);
+  const date = parseDateForDisplay(session.date);
   const presentation = getWorkoutPresentation(session.status);
 
   return {
@@ -310,4 +468,29 @@ function getStatusBadgeIcon(status: WorkoutSessionStatus) {
   }
 
   return <CalendarDays aria-hidden="true" className="size-3.5" />;
+}
+
+function parseDateForDisplay(dateKey: string) {
+  return new Date(`${dateKey}T12:00:00`);
+}
+
+function isActiveSessionListItem(session: WorkoutSessionListItem) {
+  return session.templateId == null || session.templateName != null;
+}
+
+function isActiveScheduledWorkout(scheduledWorkout: ScheduledWorkoutListItem) {
+  return scheduledWorkout.templateId != null && scheduledWorkout.templateName != null;
+}
+
+function getScheduledRange(today: string) {
+  const pivot = new Date(`${today}T12:00:00`);
+  const from = new Date(pivot);
+  const to = new Date(pivot);
+  from.setDate(from.getDate() - 30);
+  to.setDate(to.getDate() + 90);
+
+  return {
+    from: toDateKey(from),
+    to: toDateKey(to),
+  };
 }

--- a/apps/web/src/features/workouts/hooks/use-today-key.ts
+++ b/apps/web/src/features/workouts/hooks/use-today-key.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+import { toDateKey } from '@/lib/date-utils';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function msUntilNextLocalMidnight(now: Date) {
+  const next = new Date(now);
+  next.setHours(24, 0, 0, 0);
+  return Math.max(next.getTime() - now.getTime(), 0);
+}
+
+export function useTodayKey() {
+  const [todayKey, setTodayKey] = useState(() => toDateKey(new Date()));
+
+  useEffect(() => {
+    const syncToday = () => setTodayKey(toDateKey(new Date()));
+
+    syncToday();
+    const initialTimeout = window.setTimeout(() => {
+      syncToday();
+      const intervalId = window.setInterval(syncToday, DAY_MS);
+      cleanup = () => window.clearInterval(intervalId);
+    }, msUntilNextLocalMidnight(new Date()));
+
+    let cleanup = () => {};
+
+    return () => {
+      window.clearTimeout(initialTimeout);
+      cleanup();
+    };
+  }, []);
+
+  return todayKey;
+}

--- a/apps/web/src/features/workouts/hooks/use-today-key.ts
+++ b/apps/web/src/features/workouts/hooks/use-today-key.ts
@@ -15,6 +15,7 @@ export function useTodayKey() {
 
   useEffect(() => {
     const syncToday = () => setTodayKey(toDateKey(new Date()));
+    let cleanup = () => {};
 
     syncToday();
     const initialTimeout = window.setTimeout(() => {
@@ -22,8 +23,6 @@ export function useTodayKey() {
       const intervalId = window.setInterval(syncToday, DAY_MS);
       cleanup = () => window.clearInterval(intervalId);
     }, msUntilNextLocalMidnight(new Date()));
-
-    let cleanup = () => {};
 
     return () => {
       window.clearTimeout(initialTimeout);

--- a/apps/web/src/features/workouts/lib/workout-filters.ts
+++ b/apps/web/src/features/workouts/lib/workout-filters.ts
@@ -5,7 +5,7 @@ export type ActiveScheduledWorkoutListItem = ScheduledWorkoutListItem & {
   templateName: string;
 };
 
-export function isActiveSessionListItem(session: WorkoutSessionListItem) {
+export function hasAvailableTemplate(session: WorkoutSessionListItem) {
   return session.templateId == null || session.templateName != null;
 }
 

--- a/apps/web/src/features/workouts/lib/workout-filters.ts
+++ b/apps/web/src/features/workouts/lib/workout-filters.ts
@@ -1,0 +1,16 @@
+import type { ScheduledWorkoutListItem, WorkoutSessionListItem } from '@pulse/shared';
+
+export type ActiveScheduledWorkoutListItem = ScheduledWorkoutListItem & {
+  templateId: string;
+  templateName: string;
+};
+
+export function isActiveSessionListItem(session: WorkoutSessionListItem) {
+  return session.templateId == null || session.templateName != null;
+}
+
+export function isActiveScheduledWorkout(
+  scheduledWorkout: ScheduledWorkoutListItem,
+): scheduledWorkout is ActiveScheduledWorkoutListItem {
+  return scheduledWorkout.templateId != null && scheduledWorkout.templateName != null;
+}

--- a/apps/web/src/features/workouts/lib/workout-session-sets.ts
+++ b/apps/web/src/features/workouts/lib/workout-session-sets.ts
@@ -1,0 +1,20 @@
+import type { WorkoutTemplate } from '@pulse/shared';
+
+export function buildInitialSessionSets(template: WorkoutTemplate) {
+  return template.sections.flatMap((section) =>
+    section.exercises.flatMap((exercise, exerciseIndex) => {
+      if (exercise.sets === null || exercise.sets < 1) {
+        return [];
+      }
+
+      return Array.from({ length: exercise.sets }, (_, index) => ({
+        exerciseId: exercise.exerciseId,
+        orderIndex: exerciseIndex,
+        reps: null,
+        section: section.type,
+        setNumber: index + 1,
+        weight: null,
+      }));
+    }),
+  );
+}

--- a/apps/web/src/pages/workouts.test.tsx
+++ b/apps/web/src/pages/workouts.test.tsx
@@ -162,6 +162,16 @@ const allSessionsResponse = [
     createdAt: 3,
   },
 ];
+const scheduledWorkoutsResponse = [
+  {
+    id: 'schedule-1',
+    date: '2026-03-14',
+    templateId: 'upper-push',
+    templateName: 'Upper Push',
+    sessionId: null,
+    createdAt: 1,
+  },
+];
 
 describe('WorkoutsPage', () => {
   beforeEach(() => {
@@ -210,6 +220,14 @@ describe('WorkoutsPage', () => {
               url.searchParams.get('status') === 'completed'
                 ? completedSessionsResponse
                 : allSessionsResponse,
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/scheduled-workouts') {
+        return Promise.resolve(
+          jsonResponse({
+            data: scheduledWorkoutsResponse,
           }),
         );
       }
@@ -398,6 +416,14 @@ describe('WorkoutsPage', () => {
         );
       }
 
+      if (url.pathname === '/api/v1/scheduled-workouts') {
+        return Promise.resolve(
+          jsonResponse({
+            data: scheduledWorkoutsResponse,
+          }),
+        );
+      }
+
       if (url.pathname === '/api/v1/exercises') {
         return Promise.resolve(
           jsonResponse({
@@ -463,6 +489,14 @@ describe('WorkoutsPage', () => {
               url.searchParams.get('status') === 'completed'
                 ? completedSessionsResponse
                 : allSessionsResponse,
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/scheduled-workouts') {
+        return Promise.resolve(
+          jsonResponse({
+            data: scheduledWorkoutsResponse,
           }),
         );
       }

--- a/docs/conventions/agent-integration.md
+++ b/docs/conventions/agent-integration.md
@@ -451,6 +451,62 @@ Response (`200`):
 
 - `404 WORKOUT_TEMPLATE_NOT_FOUND` if template is missing or not user-owned.
 
+#### `POST /api/agent/scheduled-workouts`
+
+Schedules a template for a specific date.
+
+Request:
+
+```json
+{
+  "templateId": "template-1",
+  "date": "2026-03-12"
+}
+```
+
+Response (`201`):
+
+```json
+{
+  "data": {
+    "id": "schedule-1",
+    "userId": "user-1",
+    "templateId": "template-1",
+    "date": "2026-03-12",
+    "sessionId": null,
+    "createdAt": 1700000000000,
+    "updatedAt": 1700000000000
+  }
+}
+```
+
+- `404 WORKOUT_TEMPLATE_NOT_FOUND` if template is missing, not user-owned, or soft-deleted.
+
+#### `GET /api/agent/scheduled-workouts?from=<YYYY-MM-DD>&to=<YYYY-MM-DD>`
+
+Lists scheduled workouts in the requested date window.
+
+Response (`200`):
+
+```json
+{
+  "data": [
+    {
+      "id": "schedule-1",
+      "date": "2026-03-12",
+      "templateId": "template-1",
+      "templateName": "Upper Push",
+      "sessionId": null,
+      "createdAt": 1700000000000
+    }
+  ]
+}
+```
+
+Notes:
+
+- If a referenced template has been soft-deleted, `templateName` is `null`.
+
 #### `POST /api/agent/workout-sessions`
 
 Starts an in-progress session.
@@ -738,9 +794,10 @@ Response:
 1. Search/create exercises (`GET /api/agent/exercises/search`, `POST /api/agent/exercises`).
 2. If `POST /api/agent/exercises` returns `created: false`, review `candidates` and retry with `force: true` only when intentional.
 3. Create/update template (`POST/PUT /api/agent/workout-templates`).
-4. Read `newExercises` from template create response and enrich each via `PATCH /api/agent/exercises/:id`.
-5. Start session (`POST /api/agent/workout-sessions`).
-6. Log sets and status (`PATCH /api/agent/workout-sessions/:id`).
+4. Schedule template (`POST /api/agent/scheduled-workouts`) and review upcoming plan (`GET /api/agent/scheduled-workouts`).
+5. Read `newExercises` from template create response and enrich each via `PATCH /api/agent/exercises/:id`.
+6. Start session (`POST /api/agent/workout-sessions`).
+7. Log sets and status (`PATCH /api/agent/workout-sessions/:id`).
 
 ## Error Handling Conventions
 

--- a/docs/conventions/data-models.md
+++ b/docs/conventions/data-models.md
@@ -222,6 +222,10 @@ Constraints:
 - `createdAt`: `integer` Unix ms, required, default now
 - `updatedAt`: `integer` Unix ms, required, default now, auto-updates
 
+Behavior:
+
+- When a workout session is started from a template on the current date, the first matching `scheduled_workouts` row with `sessionId = null` is linked by setting `sessionId` to the created session id.
+
 Indexes and constraints:
 
 - `scheduled_workouts_user_date_idx`

--- a/packages/shared/src/schemas/scheduled-workouts.test.ts
+++ b/packages/shared/src/schemas/scheduled-workouts.test.ts
@@ -80,7 +80,7 @@ describe('createScheduledWorkoutInputSchema', () => {
 });
 
 describe('updateScheduledWorkoutInputSchema', () => {
-  it('accepts partial updates for date or template changes', () => {
+  it('accepts partial updates for date changes', () => {
     const payload: UpdateScheduledWorkoutInput = updateScheduledWorkoutInputSchema.parse({
       date: '2026-03-13',
     });

--- a/packages/shared/src/schemas/scheduled-workouts.ts
+++ b/packages/shared/src/schemas/scheduled-workouts.ts
@@ -30,7 +30,6 @@ export const createScheduledWorkoutInputSchema = z.object({
 
 export const updateScheduledWorkoutInputSchema = z
   .object({
-    templateId: requiredStringSchema.optional(),
     date: dateSchema.optional(),
   })
   .refine((value) => Object.values(value).some((field) => field !== undefined), {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       react:
         specifier: ^19.0.0
         version: 19.2.4
+      react-day-picker:
+        specifier: ^9.14.0
+        version: 9.14.0(react@19.2.4)
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
@@ -382,6 +385,9 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@date-fns/tz@1.4.1':
+    resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -1937,6 +1943,10 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
+  '@tabby_ai/hijri-converter@1.0.5':
+    resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
+    engines: {node: '>=16.0.0'}
+
   '@tailwindcss/node@4.2.1':
     resolution: {integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==}
 
@@ -2574,6 +2584,12 @@ packages:
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
+
+  date-fns-jalali@4.1.0-0:
+    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -3887,6 +3903,12 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-day-picker@9.14.0:
+    resolution: {integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8.0'
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
@@ -4939,6 +4961,8 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@date-fns/tz@1.4.1': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
     dependencies:
@@ -6276,6 +6300,8 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
+  '@tabby_ai/hijri-converter@1.0.5': {}
+
   '@tailwindcss/node@4.2.1':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -6909,6 +6935,10 @@ snapshots:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
+
+  date-fns-jalali@4.1.0-0: {}
+
+  date-fns@4.1.0: {}
 
   debug@4.4.3:
     dependencies:
@@ -8218,6 +8248,14 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+
+  react-day-picker@9.14.0(react@19.2.4):
+    dependencies:
+      '@date-fns/tz': 1.4.1
+      '@tabby_ai/hijri-converter': 1.0.5
+      date-fns: 4.1.0
+      date-fns-jalali: 4.1.0-0
+      react: 19.2.4
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:


### PR DESCRIPTION
## Summary
This PR adds end-to-end workout scheduling so users and agents can plan workouts by date and see that plan reflected consistently across templates, calendar, and list views. The API now supports scheduled workout creation/listing for both app and agent routes, with stricter soft-delete handling so archived templates cannot be newly scheduled and render as unavailable when already referenced. On the frontend, scheduling flows were added to template browser/detail, plus reschedule/remove/start actions in calendar and list surfaces. Starting a session from today’s scheduled template now auto-links the first unclaimed scheduled row to the new session, so schedule state and active logging stay in sync. The work also expands unit/integration/E2E coverage around scheduling lifecycle behavior and review regressions.

## Key Changes
- Added agent endpoints for scheduling:
  - `POST /api/agent/scheduled-workouts`
  - `GET /api/agent/scheduled-workouts?from&to`
- Updated scheduled workout update semantics from `PUT` to `PATCH` and narrowed updates to date-only rescheduling (no template reassignment in update payload).
- Hardened soft-delete behavior:
  - schedule creation rejects missing/inaccessible/soft-deleted templates
  - list queries left-join only non-deleted templates so deleted-template entries return `templateName: null`
- Added `linkTodayScheduledWorkoutToSession` and wired it into session creation to claim today’s first matching unlinked schedule entry.
- Added frontend scheduled-workout API hooks and mutations (`useScheduledWorkouts`, `useScheduleWorkout`, `useRescheduleWorkout`, `useUnscheduleWorkout`).
- Introduced reusable `ScheduleWorkoutDialog` backed by new `Calendar` UI component (`react-day-picker`).
- Integrated scheduling UI into:
  - template browser dropdown actions
  - template detail primary actions
  - workout calendar (badges, day details, per-item actions)
  - workout list (scheduled section, missed/unavailable states, start-now flow)
- Added helper filters/builders to keep soft-deleted templates out of active session rendering and reuse session set initialization logic.

## Technical Notes
- Reviewers should verify the intentional contract change: scheduled workout updates are now `PATCH` with `date` only; `templateId` was removed from `updateScheduledWorkoutInputSchema`.
- The schedule-to-session linking is intentionally scoped to sessions started **today** with a non-null `templateId`; it links only one row (oldest unclaimed match) to avoid claiming multiple scheduled instances.
- Soft-deleted templates are treated as historical references in schedule lists (kept visible but marked unavailable) while new scheduling against them is blocked.
- Calendar/list now merge multiple data sources (completed, in-progress/paused, scheduled); tests were expanded to cover mixed-day rendering, unavailable states, and schedule lifecycle flows.
- New Playwright coverage (`workout-scheduling.spec.ts`) validates the full userflow: schedule, reschedule, remove, and start-now linkage.

## Commits

- `8d8e2d4 fix(workouts): resolve commit-19 review feedback`
- `91b787b feat(workouts): add template scheduling actions and userflow coverage`
- `ca26013 fix(workouts): address calendar/list review feedback`
- `9a2f358 feat(workouts): integrate scheduled and completed items in calendar/list`
- `a328d94 feat(workouts): implement scheduled workout schema and APIs`

## Tasks

- **Workout scheduling — schema and API**: Scheduled workouts table, CRUD + agent endpoints, and soft-delete-aware template access
- **Calendar integration — completed and scheduled workouts**: Show completed sessions and scheduled workouts on calendar/list with soft-delete-safe rendering
- **Schedule UI and userflow tests**: Schedule/reschedule/remove UI actions, date picker flows, and soft-delete-safe scheduling UX

## Diff Stats

```
.agents/skills/pulse-app-usage/SKILL.md            |   8 +-
 apps/api/src/__tests__/workouts.test.ts            |   9 +-
 apps/api/src/routes/agent/workouts.test.ts         | 106 +++++
 apps/api/src/routes/agent/workouts.ts              |  50 +++
 .../src/routes/scheduled-workouts/index.test.ts    | 119 +++--
 apps/api/src/routes/scheduled-workouts/index.ts    |  17 +-
 apps/api/src/routes/scheduled-workouts/store.ts    |  53 ++-
 apps/api/src/routes/workout-sessions/index.test.ts |  44 ++
 apps/api/src/routes/workout-sessions/index.ts      |  11 +
 apps/web/e2e/workout-scheduling.spec.ts            | 280 ++++++++++++
 apps/web/package.json                              |   1 +
 apps/web/src/components/ui/calendar.tsx            |  54 +++
 apps/web/src/features/workouts/api/workouts.ts     | 156 +++++++
 .../components/schedule-workout-dialog.tsx         |  98 ++++
 .../workouts/components/template-browser.test.tsx  |  37 ++
 .../workouts/components/template-browser.tsx       | 103 +++--
 .../workouts/components/template-detail.test.tsx   |  49 ++
 .../workouts/components/template-detail.tsx        | 102 +++--
 .../workouts/components/workout-calendar.test.tsx  |  87 ++--
 .../workouts/components/workout-calendar.tsx       | 494 ++++++++++++++++++---
 .../workouts/components/workout-list.test.tsx      | 171 ++++---
 .../features/workouts/components/workout-list.tsx  | 303 ++++++++++++-
 .../src/features/workouts/lib/workout-filters.ts   |  16 +
 .../features/workouts/lib/workout-session-sets.ts  |  20 +
 apps/web/src/pages/workouts.test.tsx               |  34 ++
 docs/conventions/agent-integration.md              |  63 ++-
 docs/conventions/data-models.md                    |   4 +
 .../shared/src/schemas/scheduled-workouts.test.ts  |   2 +-
 packages/shared/src/schemas/scheduled-workouts.ts  |   1 -
 pnpm-lock.yaml                                     |  38 ++
 30 files changed, 2198 insertions(+), 332 deletions(-)
```