### PR TITLE
feat: referential habits and agent-modifiable sessions (QA #2, #14)

### DIFF
--- a/.agents/skills/pulse-app-usage/SKILL.md
+++ b/.agents/skills/pulse-app-usage/SKILL.md
@@ -21,6 +21,21 @@ Use this flow when an agent creates exercises/templates and then logs workout se
    - `tags`
 9. Start session via `POST /api/agent/workout-sessions` and log progress via `PATCH /api/agent/workout-sessions/:id`.
 
+## Habits
+
+Use referential habits when completion should be inferred from other tracked data.
+
+1. Create a habit with `POST /api/agent/habits`.
+2. For referential habits, include:
+   - `referenceSource`: `weight | nutrition_daily | nutrition_meal | workout`
+   - `referenceConfig`:
+     - `weight`: `{ "condition": "exists_today" }`
+     - `nutrition_daily`: `{ "field": "protein|calories|carbs|fat", "op": "gte|lte|eq", "value": number }`
+     - `nutrition_meal`: `{ "mealType": string, "field": string, "op": string, "value": number }`
+     - `workout`: `{ "condition": "session_completed_today" }`
+3. Read habits with `GET /api/v1/habits`; referential habits auto-resolve completion for today.
+4. Manually override a referential habit with `PATCH /api/agent/habits/:id/entries`; override entries are marked with `isOverride: true` and take precedence over resolver output.
+
 ## Notes
 
 - User-facing records in habits, workout templates, exercises, foods, and workout sessions are soft-deleted via `deletedAt`; deleted records are hidden from normal list/search/get endpoints.

--- a/.agents/skills/pulse-app-usage/SKILL.md
+++ b/.agents/skills/pulse-app-usage/SKILL.md
@@ -37,7 +37,7 @@ Use referential habits when completion should be inferred from other tracked dat
    - `referenceConfig`:
      - `weight`: `{ "condition": "exists_today" }`
      - `nutrition_daily`: `{ "field": "protein|calories|carbs|fat", "op": "gte|lte|eq", "value": number }`
-     - `nutrition_meal`: `{ "mealType": string, "field": string, "op": string, "value": number }`
+     - `nutrition_meal`: `{ "mealType": string, "field": "protein|calories|carbs|fat", "op": "gte|lte|eq", "value": number }`
      - `workout`: `{ "condition": "session_completed_today" }`
 3. Read habits with `GET /api/v1/habits`; referential habits auto-resolve completion for today.
 4. Manually override a referential habit with `PATCH /api/agent/habits/:id/entries`; override entries are marked with `isOverride: true` and take precedence over resolver output.

--- a/.agents/skills/pulse-app-usage/SKILL.md
+++ b/.agents/skills/pulse-app-usage/SKILL.md
@@ -19,7 +19,13 @@ Use this flow when an agent creates exercises/templates and then logs workout se
    - `instructions`
    - `formCues`
    - `tags`
-9. Start session via `POST /api/agent/workout-sessions` and log progress via `PATCH /api/agent/workout-sessions/:id`.
+9. Start session via `POST /api/agent/workout-sessions`.
+10. During the session, use `PATCH /api/agent/workout-sessions/:id` for:
+   - set logs: `sets: [{ exerciseName, setNumber, weight, reps }]`
+   - add exercises: `addExercises: [{ name, sets, reps, section }]`
+   - remove unstarted exercises: `removeExercises: [exerciseId]`
+   - reorder exercises: `reorderExercises: [exerciseId, ...]`
+11. Do not remove exercises that already have completed sets (`409 WORKOUT_SESSION_EXERCISE_HAS_LOGGED_SETS`).
 
 ## Habits
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ pnpm --filter shared build  # Build shared package
 
 - **Nutrition**: Meals are entered by AI agents only — no manual entry UI. The frontend is read-only for meal data.
 - **Workouts**: The most complex UI domain. Templates → Sessions → Sets. Active session state persists in localStorage.
-- **Habits**: User-configurable with boolean/numeric/time tracking types. Feed into dashboard "don't break the chain" widgets.
+- **Habits**: User-configurable with boolean/numeric/time tracking types, plus referential habits (`weight`, `nutrition_daily`, `nutrition_meal`, `workout`) that auto-resolve completion from linked data unless manually overridden. Feed into dashboard "don't break the chain" widgets.
 - **Foods**: Per-user database. `lastUsedAt` tracks recency for agent quick-matching.
 - **Trash & Soft Delete**: User-facing habits, workout templates, exercises, foods, and workout sessions use `deletedAt` soft delete; restore/purge flows are handled via `/api/v1/trash`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ pnpm --filter shared build  # Build shared package
 ## Key Domain Notes
 
 - **Nutrition**: Meals are entered by AI agents only — no manual entry UI. The frontend is read-only for meal data.
-- **Workouts**: The most complex UI domain. Templates → Sessions → Sets. Active session state persists in localStorage.
+- **Workouts**: The most complex UI domain. Templates → Sessions → Sets. Active session state is server-side.
 - **Habits**: User-configurable with boolean/numeric/time tracking types, plus referential habits (`weight`, `nutrition_daily`, `nutrition_meal`, `workout`) that auto-resolve completion from linked data unless manually overridden. Feed into dashboard "don't break the chain" widgets.
 - **Foods**: Per-user database. `lastUsedAt` tracks recency for agent quick-matching.
 - **Trash & Soft Delete**: User-facing habits, workout templates, exercises, foods, and workout sessions use `deletedAt` soft delete; restore/purge flows are handled via `/api/v1/trash`.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@ A personal health and fitness tracking app. Most data entry happens via AI agent
 ## Features
 
 - **Dashboard** — Configurable widgets with habit chains, trend sparklines, macro progress rings, and calendar navigation
-- **Workouts** — Interactive session logging with reusable templates, set tracking, rest timers, and session feedback
+- **Workouts** — Interactive session logging with reusable templates, set tracking, rest timers, pause/resume, cancel flows, and session feedback
+- **Active Workout Sessions** — Multiple concurrent active sessions, server-side session state, and agent-driven mid-session exercise add/remove/reorder updates
+- **Workout Planning** — Calendar scheduling plus reschedule/remove workflows linked to templates and sessions
+- **Exercise Management** — Taxonomy improvements (category/form cues/tags), dedup-aware creation, and metadata enrichment workflows
 - **Nutrition** — Daily meal cards with macro progress visualization (meals entered via agent API)
-- **Foods** — Per-user food database with search, management, and recency tracking
-- **Habits** — Configurable daily habits with don't-break-the-chain visualization
+- **Foods** — Per-user food database with search, management, soft delete support, and recency tracking (`lastUsedAt`)
+- **Habits** — Configurable daily habits, referential auto-complete (weight/nutrition/workout), and manual override/reset behavior
+- **Trash & Restore** — Soft delete for user content (habits, templates, exercises, foods, workout sessions) with restore/purge tools in Settings
 - **Trends** — Charts for weight, macros, workout consistency, and exercise progress
 - **Multi-user** — Fully isolated data per user with separate agent API tokens
 - **Themes** — Dark/light mode with switchable accent themes

--- a/apps/api/drizzle/0022_referential_habits.sql
+++ b/apps/api/drizzle/0022_referential_habits.sql
@@ -1,0 +1,5 @@
+ALTER TABLE habits ADD COLUMN reference_source text;
+--> statement-breakpoint
+ALTER TABLE habits ADD COLUMN reference_config text;
+--> statement-breakpoint
+ALTER TABLE habit_entries ADD COLUMN is_override integer DEFAULT false NOT NULL;

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1773306865036,
       "tag": "0021_soft_delete_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1773328000000,
+      "tag": "0022_referential_habits",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.test.ts
+++ b/apps/api/src/db/schema.test.ts
@@ -773,6 +773,8 @@ describe('habits schema', () => {
       'frequency',
       'frequencyTarget',
       'scheduledDays',
+      'referenceSource',
+      'referenceConfig',
       'pausedUntil',
       'deletedAt',
       'sortOrder',
@@ -1007,11 +1009,13 @@ describe('habitEntries schema', () => {
       'date',
       'completed',
       'value',
+      'isOverride',
       'createdAt',
     ]);
 
     expect(columns.id.defaultFn).toBeTypeOf('function');
     expect(columns.completed.default).toBe(false);
+    expect(columns.isOverride.default).toBe(false);
     expect(columns.createdAt.default).toBeDefined();
     expect(columns.createdAt.defaultFn).toBeTypeOf('function');
 

--- a/apps/api/src/db/schema/habits.ts
+++ b/apps/api/src/db/schema/habits.ts
@@ -7,6 +7,7 @@ import { users } from './users.js';
 
 export type HabitTrackingType = 'boolean' | 'numeric' | 'time';
 export type HabitFrequency = 'daily' | 'weekly' | 'specific_days';
+export type HabitReferenceSource = 'weight' | 'nutrition_daily' | 'nutrition_meal' | 'workout';
 
 export const habits = sqliteTable(
   'habits',
@@ -26,6 +27,8 @@ export const habits = sqliteTable(
     frequency: text('frequency').$type<HabitFrequency>().notNull().default('daily'),
     frequencyTarget: integer('frequency_target'),
     scheduledDays: text('scheduled_days'),
+    referenceSource: text('reference_source').$type<HabitReferenceSource | null>(),
+    referenceConfig: text('reference_config'),
     pausedUntil: text('paused_until'),
     deletedAt: text('deleted_at'),
     sortOrder: integer('sort_order').notNull().default(0),
@@ -68,6 +71,7 @@ export const habitEntries = sqliteTable(
     date: text('date').notNull(),
     completed: integer('completed', { mode: 'boolean' }).notNull().default(false),
     value: real('value'),
+    isOverride: integer('is_override', { mode: 'boolean' }).notNull().default(false),
     createdAt: integer('created_at', { mode: 'number' })
       .notNull()
       .default(sql`(unixepoch() * 1000)`)

--- a/apps/api/src/lib/habit-resolvers.test.ts
+++ b/apps/api/src/lib/habit-resolvers.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Habit } from '@pulse/shared';
+
+const testState = vi.hoisted(() => {
+  const getQueue: unknown[] = [];
+
+  const db = {
+    select: vi.fn(() => {
+      const query = {
+        from: vi.fn(() => query),
+        leftJoin: vi.fn(() => query),
+        innerJoin: vi.fn(() => query),
+        where: vi.fn(() => query),
+        limit: vi.fn(() => query),
+        get: vi.fn(() => getQueue.shift()),
+      };
+
+      return query;
+    }),
+  };
+
+  return {
+    db,
+    getQueue,
+    reset() {
+      getQueue.length = 0;
+      db.select.mockClear();
+    },
+  };
+});
+
+vi.mock('../db/index.js', () => ({
+  db: testState.db,
+}));
+
+const createHabit = (overrides: Partial<Habit> = {}): Habit => ({
+  id: 'habit-1',
+  userId: 'user-1',
+  name: 'Habit',
+  description: null,
+  emoji: null,
+  trackingType: 'boolean',
+  target: null,
+  unit: null,
+  frequency: 'daily',
+  frequencyTarget: null,
+  scheduledDays: null,
+  pausedUntil: null,
+  sortOrder: 0,
+  active: true,
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides,
+});
+
+describe('habit resolvers', () => {
+  beforeEach(() => {
+    testState.reset();
+  });
+
+  it('returns completed for weight resolver when a body weight row exists for the date', async () => {
+    const { resolveHabitCompletion } = await import('./habit-resolvers.js');
+
+    testState.getQueue.push({ id: 'weight-1' });
+
+    const result = await resolveHabitCompletion(
+      createHabit({
+        referenceSource: 'weight',
+        referenceConfig: { condition: 'exists_today' },
+      }),
+      'user-1',
+      '2026-03-09',
+    );
+
+    expect(result).toEqual({ completed: true });
+  });
+
+  it('evaluates nutrition_daily protein >= 150 correctly', async () => {
+    const { resolveHabitCompletion } = await import('./habit-resolvers.js');
+
+    testState.getQueue.push({
+      calories: 2_100,
+      protein: 160,
+      carbs: 200,
+      fat: 70,
+    });
+
+    const result = await resolveHabitCompletion(
+      createHabit({
+        referenceSource: 'nutrition_daily',
+        referenceConfig: {
+          field: 'protein',
+          op: 'gte',
+          value: 150,
+        },
+      }),
+      'user-1',
+      '2026-03-09',
+    );
+
+    expect(result).toEqual({ completed: true, value: 160 });
+  });
+
+  it('returns completed for workout resolver when a completed session exists for the date', async () => {
+    const { resolveHabitCompletion } = await import('./habit-resolvers.js');
+
+    testState.getQueue.push({ id: 'session-1' });
+
+    const result = await resolveHabitCompletion(
+      createHabit({
+        referenceSource: 'workout',
+        referenceConfig: { condition: 'session_completed_today' },
+      }),
+      'user-1',
+      '2026-03-09',
+    );
+
+    expect(result).toEqual({ completed: true });
+  });
+
+  it('handles missing source rows gracefully by resolving as not completed', async () => {
+    const { resolveHabitCompletion } = await import('./habit-resolvers.js');
+
+    testState.getQueue.push(undefined);
+
+    const result = await resolveHabitCompletion(
+      createHabit({
+        referenceSource: 'weight',
+        referenceConfig: { condition: 'exists_today' },
+      }),
+      'user-1',
+      '2026-03-09',
+    );
+
+    expect(result).toEqual({ completed: false });
+  });
+});

--- a/apps/api/src/lib/habit-resolvers.ts
+++ b/apps/api/src/lib/habit-resolvers.ts
@@ -1,5 +1,11 @@
 import { and, eq, isNull, sql } from 'drizzle-orm';
-import type { Habit } from '@pulse/shared';
+import {
+  nutritionDailyReferenceConfigSchema,
+  nutritionMealReferenceConfigSchema,
+  type Habit,
+  weightReferenceConfigSchema,
+  workoutReferenceConfigSchema,
+} from '@pulse/shared';
 
 import {
   bodyWeight,
@@ -23,9 +29,6 @@ const compareNumber = (actual: number, op: NumericOp, target: number): boolean =
 
   return actual === target;
 };
-
-const isNumericOp = (value: string): value is NumericOp =>
-  value === 'gte' || value === 'lte' || value === 'eq';
 
 const getDailyMacroFieldValue = (
   row: { calories: number; protein: number; carbs: number; fat: number },
@@ -159,58 +162,32 @@ export const resolveHabitCompletion = async (
     return { completed: false };
   }
 
-  if (
-    referenceSource === 'weight' &&
-    'condition' in referenceConfig &&
-    referenceConfig.condition === 'exists_today'
-  ) {
-    return resolveWeightCompletion(userId, date);
+  if (referenceSource === 'weight') {
+    const parsedConfig = weightReferenceConfigSchema.safeParse(referenceConfig);
+    if (parsedConfig.success) {
+      return resolveWeightCompletion(userId, date);
+    }
   }
 
-  if (
-    referenceSource === 'nutrition_daily' &&
-    'field' in referenceConfig &&
-    'op' in referenceConfig &&
-    'value' in referenceConfig &&
-    (referenceConfig.field === 'protein' ||
-      referenceConfig.field === 'calories' ||
-      referenceConfig.field === 'carbs' ||
-      referenceConfig.field === 'fat') &&
-    (referenceConfig.op === 'gte' || referenceConfig.op === 'lte' || referenceConfig.op === 'eq')
-  ) {
-    return resolveNutritionDailyCompletion(userId, date, {
-      field: referenceConfig.field,
-      op: referenceConfig.op,
-      value: referenceConfig.value,
-    });
+  if (referenceSource === 'nutrition_daily') {
+    const parsedConfig = nutritionDailyReferenceConfigSchema.safeParse(referenceConfig);
+    if (parsedConfig.success) {
+      return resolveNutritionDailyCompletion(userId, date, parsedConfig.data);
+    }
   }
 
-  if (
-    referenceSource === 'nutrition_meal' &&
-    'mealType' in referenceConfig &&
-    'field' in referenceConfig &&
-    'op' in referenceConfig &&
-    'value' in referenceConfig &&
-    (referenceConfig.field === 'protein' ||
-      referenceConfig.field === 'calories' ||
-      referenceConfig.field === 'carbs' ||
-      referenceConfig.field === 'fat') &&
-    isNumericOp(referenceConfig.op)
-  ) {
-    return resolveNutritionMealCompletion(userId, date, {
-      mealType: referenceConfig.mealType,
-      field: referenceConfig.field,
-      op: referenceConfig.op,
-      value: referenceConfig.value,
-    });
+  if (referenceSource === 'nutrition_meal') {
+    const parsedConfig = nutritionMealReferenceConfigSchema.safeParse(referenceConfig);
+    if (parsedConfig.success) {
+      return resolveNutritionMealCompletion(userId, date, parsedConfig.data);
+    }
   }
 
-  if (
-    referenceSource === 'workout' &&
-    'condition' in referenceConfig &&
-    referenceConfig.condition === 'session_completed_today'
-  ) {
-    return resolveWorkoutCompletion(userId, date);
+  if (referenceSource === 'workout') {
+    const parsedConfig = workoutReferenceConfigSchema.safeParse(referenceConfig);
+    if (parsedConfig.success) {
+      return resolveWorkoutCompletion(userId, date);
+    }
   }
 
   return { completed: false };

--- a/apps/api/src/lib/habit-resolvers.ts
+++ b/apps/api/src/lib/habit-resolvers.ts
@@ -34,14 +34,8 @@ const getDailyMacroFieldValue = (
 
 const getMealFieldValue = (
   row: { calories: number; protein: number; carbs: number; fat: number },
-  field: string,
-): number | null => {
-  if (field === 'calories' || field === 'protein' || field === 'carbs' || field === 'fat') {
-    return row[field];
-  }
-
-  return null;
-};
+  field: 'protein' | 'calories' | 'carbs' | 'fat',
+): number => row[field];
 
 export const resolveWeightCompletion = async (
   userId: string,
@@ -96,16 +90,12 @@ export const resolveNutritionMealCompletion = async (
   date: string,
   config: {
     mealType: string;
-    field: string;
-    op: string;
+    field: 'protein' | 'calories' | 'carbs' | 'fat';
+    op: NumericOp;
     value: number;
   },
 ): Promise<HabitResolution> => {
   const { db } = await import('../db/index.js');
-
-  if (!isNumericOp(config.op)) {
-    return { completed: false };
-  }
 
   const totals = db
     .select({
@@ -128,10 +118,6 @@ export const resolveNutritionMealCompletion = async (
     .get() ?? { calories: 0, protein: 0, carbs: 0, fat: 0 };
 
   const actual = getMealFieldValue(totals, config.field);
-  if (actual === null) {
-    return { completed: false };
-  }
-
   return {
     completed: compareNumber(actual, config.op, config.value),
     value: actual,
@@ -204,9 +190,19 @@ export const resolveHabitCompletion = async (
     'mealType' in referenceConfig &&
     'field' in referenceConfig &&
     'op' in referenceConfig &&
-    'value' in referenceConfig
+    'value' in referenceConfig &&
+    (referenceConfig.field === 'protein' ||
+      referenceConfig.field === 'calories' ||
+      referenceConfig.field === 'carbs' ||
+      referenceConfig.field === 'fat') &&
+    isNumericOp(referenceConfig.op)
   ) {
-    return resolveNutritionMealCompletion(userId, date, referenceConfig);
+    return resolveNutritionMealCompletion(userId, date, {
+      mealType: referenceConfig.mealType,
+      field: referenceConfig.field,
+      op: referenceConfig.op,
+      value: referenceConfig.value,
+    });
   }
 
   if (

--- a/apps/api/src/lib/habit-resolvers.ts
+++ b/apps/api/src/lib/habit-resolvers.ts
@@ -1,0 +1,223 @@
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import type { Habit } from '@pulse/shared';
+
+import {
+  bodyWeight,
+  mealItems,
+  meals,
+  nutritionLogs,
+  workoutSessions,
+} from '../db/schema/index.js';
+
+type HabitResolution = { completed: boolean; value?: number };
+type NumericOp = 'gte' | 'lte' | 'eq';
+
+const compareNumber = (actual: number, op: NumericOp, target: number): boolean => {
+  if (op === 'gte') {
+    return actual >= target;
+  }
+
+  if (op === 'lte') {
+    return actual <= target;
+  }
+
+  return actual === target;
+};
+
+const isNumericOp = (value: string): value is NumericOp =>
+  value === 'gte' || value === 'lte' || value === 'eq';
+
+const getDailyMacroFieldValue = (
+  row: { calories: number; protein: number; carbs: number; fat: number },
+  field: 'protein' | 'calories' | 'carbs' | 'fat',
+): number => row[field];
+
+const getMealFieldValue = (
+  row: { calories: number; protein: number; carbs: number; fat: number },
+  field: string,
+): number | null => {
+  if (field === 'calories' || field === 'protein' || field === 'carbs' || field === 'fat') {
+    return row[field];
+  }
+
+  return null;
+};
+
+export const resolveWeightCompletion = async (
+  userId: string,
+  date: string,
+): Promise<HabitResolution> => {
+  const { db } = await import('../db/index.js');
+
+  const row = db
+    .select({ id: bodyWeight.id })
+    .from(bodyWeight)
+    .where(and(eq(bodyWeight.userId, userId), eq(bodyWeight.date, date)))
+    .limit(1)
+    .get();
+
+  return { completed: row !== undefined };
+};
+
+export const resolveNutritionDailyCompletion = async (
+  userId: string,
+  date: string,
+  config: {
+    field: 'protein' | 'calories' | 'carbs' | 'fat';
+    op: NumericOp;
+    value: number;
+  },
+): Promise<HabitResolution> => {
+  const { db } = await import('../db/index.js');
+
+  const totals = db
+    .select({
+      calories: sql<number>`coalesce(sum(${mealItems.calories}), 0)`,
+      protein: sql<number>`coalesce(sum(${mealItems.protein}), 0)`,
+      carbs: sql<number>`coalesce(sum(${mealItems.carbs}), 0)`,
+      fat: sql<number>`coalesce(sum(${mealItems.fat}), 0)`,
+    })
+    .from(nutritionLogs)
+    .leftJoin(meals, eq(meals.nutritionLogId, nutritionLogs.id))
+    .leftJoin(mealItems, eq(mealItems.mealId, meals.id))
+    .where(and(eq(nutritionLogs.userId, userId), eq(nutritionLogs.date, date)))
+    .limit(1)
+    .get() ?? { calories: 0, protein: 0, carbs: 0, fat: 0 };
+
+  const actual = getDailyMacroFieldValue(totals, config.field);
+  return {
+    completed: compareNumber(actual, config.op, config.value),
+    value: actual,
+  };
+};
+
+export const resolveNutritionMealCompletion = async (
+  userId: string,
+  date: string,
+  config: {
+    mealType: string;
+    field: string;
+    op: string;
+    value: number;
+  },
+): Promise<HabitResolution> => {
+  const { db } = await import('../db/index.js');
+
+  if (!isNumericOp(config.op)) {
+    return { completed: false };
+  }
+
+  const totals = db
+    .select({
+      calories: sql<number>`coalesce(sum(${mealItems.calories}), 0)`,
+      protein: sql<number>`coalesce(sum(${mealItems.protein}), 0)`,
+      carbs: sql<number>`coalesce(sum(${mealItems.carbs}), 0)`,
+      fat: sql<number>`coalesce(sum(${mealItems.fat}), 0)`,
+    })
+    .from(nutritionLogs)
+    .innerJoin(meals, eq(meals.nutritionLogId, nutritionLogs.id))
+    .leftJoin(mealItems, eq(mealItems.mealId, meals.id))
+    .where(
+      and(
+        eq(nutritionLogs.userId, userId),
+        eq(nutritionLogs.date, date),
+        sql`lower(${meals.name}) = lower(${config.mealType})`,
+      ),
+    )
+    .limit(1)
+    .get() ?? { calories: 0, protein: 0, carbs: 0, fat: 0 };
+
+  const actual = getMealFieldValue(totals, config.field);
+  if (actual === null) {
+    return { completed: false };
+  }
+
+  return {
+    completed: compareNumber(actual, config.op, config.value),
+    value: actual,
+  };
+};
+
+export const resolveWorkoutCompletion = async (
+  userId: string,
+  date: string,
+): Promise<HabitResolution> => {
+  const { db } = await import('../db/index.js');
+
+  const row = db
+    .select({ id: workoutSessions.id })
+    .from(workoutSessions)
+    .where(
+      and(
+        eq(workoutSessions.userId, userId),
+        eq(workoutSessions.date, date),
+        eq(workoutSessions.status, 'completed'),
+        isNull(workoutSessions.deletedAt),
+      ),
+    )
+    .limit(1)
+    .get();
+
+  return { completed: row !== undefined };
+};
+
+export const resolveHabitCompletion = async (
+  habit: Habit,
+  userId: string,
+  date: string,
+): Promise<HabitResolution> => {
+  const referenceSource = habit.referenceSource;
+  const referenceConfig = habit.referenceConfig;
+
+  if (referenceSource == null || referenceConfig == null) {
+    return { completed: false };
+  }
+
+  if (
+    referenceSource === 'weight' &&
+    'condition' in referenceConfig &&
+    referenceConfig.condition === 'exists_today'
+  ) {
+    return resolveWeightCompletion(userId, date);
+  }
+
+  if (
+    referenceSource === 'nutrition_daily' &&
+    'field' in referenceConfig &&
+    'op' in referenceConfig &&
+    'value' in referenceConfig &&
+    (referenceConfig.field === 'protein' ||
+      referenceConfig.field === 'calories' ||
+      referenceConfig.field === 'carbs' ||
+      referenceConfig.field === 'fat') &&
+    (referenceConfig.op === 'gte' || referenceConfig.op === 'lte' || referenceConfig.op === 'eq')
+  ) {
+    return resolveNutritionDailyCompletion(userId, date, {
+      field: referenceConfig.field,
+      op: referenceConfig.op,
+      value: referenceConfig.value,
+    });
+  }
+
+  if (
+    referenceSource === 'nutrition_meal' &&
+    'mealType' in referenceConfig &&
+    'field' in referenceConfig &&
+    'op' in referenceConfig &&
+    'value' in referenceConfig
+  ) {
+    return resolveNutritionMealCompletion(userId, date, referenceConfig);
+  }
+
+  if (
+    referenceSource === 'workout' &&
+    'condition' in referenceConfig &&
+    referenceConfig.condition === 'session_completed_today'
+  ) {
+    return resolveWorkoutCompletion(userId, date);
+  }
+
+  return { completed: false };
+};
+
+export type { HabitResolution };

--- a/apps/api/src/routes/agent/daily.test.ts
+++ b/apps/api/src/routes/agent/daily.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildServer } from '../../index.js';
+import { resolveHabitCompletion } from '../../lib/habit-resolvers.js';
 import {
   findHabitEntryByHabitAndDate,
   listHabitEntriesByDateRange,
@@ -47,6 +48,9 @@ vi.mock('../nutrition/store.js', () => ({
   getDailyNutritionSummaryForDate: vi.fn(),
   deleteMealForDate: vi.fn(),
 }));
+vi.mock('../../lib/habit-resolvers.js', () => ({
+  resolveHabitCompletion: vi.fn(),
+}));
 
 const createAuthorizationHeader = (token: string) => ({
   authorization: `Bearer ${token}`,
@@ -65,6 +69,7 @@ describe('agent daily routes', () => {
     vi.mocked(listHabitEntriesByDateRange).mockReset();
     vi.mocked(getDailyNutritionSummaryForDate).mockReset();
     vi.mocked(getDailyNutritionForDate).mockReset();
+    vi.mocked(resolveHabitCompletion).mockReset();
     process.env.JWT_SECRET = 'test-agent-daily-secret';
   });
 
@@ -318,6 +323,8 @@ describe('agent daily routes', () => {
             frequency: 'daily',
             frequencyTarget: null,
             scheduledDays: null,
+            referenceSource: null,
+            referenceConfig: null,
             pausedUntil: null,
             sortOrder: 0,
             active: true,
@@ -336,6 +343,8 @@ describe('agent daily routes', () => {
             frequency: 'daily',
             frequencyTarget: null,
             scheduledDays: null,
+            referenceSource: null,
+            referenceConfig: null,
             pausedUntil: null,
             sortOrder: 1,
             active: true,
@@ -379,6 +388,7 @@ describe('agent daily routes', () => {
               todayEntry: {
                 value: 8,
                 completed: true,
+                isOverride: false,
               },
             },
           ],
@@ -386,6 +396,73 @@ describe('agent daily routes', () => {
         expect(vi.mocked(listHabitEntriesByDateRange)).toHaveBeenCalledWith(
           'user-1',
           '2026-03-09',
+          '2026-03-09',
+        );
+        expect(vi.mocked(resolveHabitCompletion)).not.toHaveBeenCalled();
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('resolves referential habits when no override entry exists', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-09T12:00:00'));
+
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(listActiveHabits).mockResolvedValue([
+          {
+            id: 'habit-1',
+            userId: 'user-1',
+            name: 'Protein',
+            description: null,
+            emoji: null,
+            trackingType: 'boolean',
+            target: null,
+            unit: null,
+            frequency: 'daily',
+            frequencyTarget: null,
+            scheduledDays: null,
+            referenceSource: 'nutrition_daily',
+            referenceConfig: { field: 'protein', op: 'gte', value: 150 },
+            pausedUntil: null,
+            sortOrder: 0,
+            active: true,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ]);
+        vi.mocked(listHabitEntriesByDateRange).mockResolvedValue([]);
+        vi.mocked(resolveHabitCompletion).mockResolvedValue({ completed: true, value: 160 });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'GET',
+          url: '/api/agent/habits',
+          headers: createAuthorizationHeader(token),
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.json()).toEqual({
+          data: [
+            {
+              id: 'habit-1',
+              name: 'Protein',
+              trackingType: 'boolean',
+              todayEntry: {
+                value: 160,
+                completed: true,
+                isOverride: false,
+              },
+            },
+          ],
+        });
+        expect(vi.mocked(resolveHabitCompletion)).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'habit-1' }),
+          'user-1',
           '2026-03-09',
         );
       } finally {

--- a/apps/api/src/routes/agent/daily.test.ts
+++ b/apps/api/src/routes/agent/daily.test.ts
@@ -6,7 +6,12 @@ import {
   listHabitEntriesByDateRange,
   upsertHabitEntry,
 } from '../habit-entries/store.js';
-import { findHabitById, listActiveHabits } from '../habits/store.js';
+import {
+  createHabit,
+  findHabitById,
+  getNextHabitSortOrder,
+  listActiveHabits,
+} from '../habits/store.js';
 import { getDailyNutritionForDate, getDailyNutritionSummaryForDate } from '../nutrition/store.js';
 import { findBodyWeightEntryByDate, upsertBodyWeightEntry } from '../weight/store.js';
 
@@ -51,6 +56,8 @@ describe('agent daily routes', () => {
   beforeEach(() => {
     vi.mocked(findBodyWeightEntryByDate).mockReset();
     vi.mocked(upsertBodyWeightEntry).mockReset();
+    vi.mocked(getNextHabitSortOrder).mockReset();
+    vi.mocked(createHabit).mockReset();
     vi.mocked(listActiveHabits).mockReset();
     vi.mocked(findHabitById).mockReset();
     vi.mocked(findHabitEntryByHabitAndDate).mockReset();
@@ -64,6 +71,76 @@ describe('agent daily routes', () => {
   afterEach(() => {
     delete process.env.JWT_SECRET;
     vi.useRealTimers();
+  });
+
+  describe('POST /api/agent/habits', () => {
+    it('creates a referential habit and returns 201', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(getNextHabitSortOrder).mockResolvedValue(2);
+        vi.mocked(createHabit).mockResolvedValue({
+          id: 'habit-1',
+          userId: 'user-1',
+          name: 'Protein',
+          description: null,
+          emoji: null,
+          trackingType: 'boolean',
+          target: null,
+          unit: null,
+          frequency: 'daily',
+          frequencyTarget: null,
+          scheduledDays: null,
+          pausedUntil: null,
+          referenceSource: 'nutrition_daily',
+          referenceConfig: {
+            field: 'protein',
+            op: 'gte',
+            value: 150,
+          },
+          sortOrder: 2,
+          active: true,
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/habits',
+          headers: createAuthorizationHeader(token),
+          body: {
+            name: 'Protein',
+            trackingType: 'boolean',
+            referenceSource: 'nutrition_daily',
+            referenceConfig: {
+              field: 'protein',
+              op: 'gte',
+              value: 150,
+            },
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+        expect(vi.mocked(getNextHabitSortOrder)).toHaveBeenCalledWith('user-1');
+        expect(vi.mocked(createHabit)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            userId: 'user-1',
+            sortOrder: 2,
+            referenceSource: 'nutrition_daily',
+            referenceConfig: {
+              field: 'protein',
+              op: 'gte',
+              value: 150,
+            },
+          }),
+        );
+      } finally {
+        await app.close();
+      }
+    });
   });
 
   describe('POST /api/agent/weight', () => {
@@ -274,6 +351,7 @@ describe('agent daily routes', () => {
             date: '2026-03-09',
             completed: true,
             value: 8,
+            isOverride: false,
             createdAt: 2,
           },
         ]);
@@ -370,6 +448,7 @@ describe('agent daily routes', () => {
           date: '2026-03-09',
           completed: true,
           value: 8,
+          isOverride: false,
           createdAt: 1,
         });
 
@@ -393,6 +472,7 @@ describe('agent daily routes', () => {
             date: '2026-03-09',
             completed: true,
             value: 8,
+            isOverride: false,
           }),
         );
       } finally {
@@ -431,6 +511,7 @@ describe('agent daily routes', () => {
           date: '2026-03-09',
           completed: true,
           value: 7,
+          isOverride: false,
           createdAt: 1,
         });
         vi.mocked(upsertHabitEntry).mockResolvedValue({
@@ -440,6 +521,7 @@ describe('agent daily routes', () => {
           date: '2026-03-09',
           completed: true,
           value: 8,
+          isOverride: false,
           createdAt: 1,
         });
 
@@ -462,6 +544,72 @@ describe('agent daily routes', () => {
             date: '2026-03-09',
             completed: true,
             value: 8,
+            isOverride: false,
+          }),
+        );
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('marks manual entries as overrides for referential habits', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findHabitById).mockResolvedValue({
+          id: 'habit-1',
+          userId: 'user-1',
+          name: 'Protein',
+          description: null,
+          emoji: null,
+          trackingType: 'boolean',
+          target: null,
+          unit: null,
+          frequency: 'daily',
+          frequencyTarget: null,
+          scheduledDays: null,
+          pausedUntil: null,
+          referenceSource: 'nutrition_daily',
+          referenceConfig: {
+            field: 'protein',
+            op: 'gte',
+            value: 150,
+          },
+          sortOrder: 0,
+          active: true,
+          createdAt: 1,
+          updatedAt: 1,
+        });
+        vi.mocked(findHabitEntryByHabitAndDate).mockResolvedValue(undefined);
+        vi.mocked(upsertHabitEntry).mockResolvedValue({
+          id: 'entry-1',
+          habitId: 'habit-1',
+          userId: 'user-1',
+          date: '2026-03-09',
+          completed: true,
+          value: null,
+          isOverride: true,
+          createdAt: 1,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/habits/habit-1/entries',
+          headers: createAuthorizationHeader(token),
+          body: {
+            date: '2026-03-09',
+            completed: true,
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+        expect(vi.mocked(upsertHabitEntry)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            habitId: 'habit-1',
+            isOverride: true,
           }),
         );
       } finally {

--- a/apps/api/src/routes/agent/daily.ts
+++ b/apps/api/src/routes/agent/daily.ts
@@ -8,6 +8,7 @@ import {
 } from '@pulse/shared';
 import type { FastifyPluginAsync } from 'fastify';
 
+import { resolveHabitCompletion } from '../../lib/habit-resolvers.js';
 import { sendError } from '../../lib/reply.js';
 import {
   findHabitEntryByHabitAndDate,
@@ -27,6 +28,8 @@ import { getTodayDate, isValidDate } from './date-utils.js';
 
 const parseId = (value: unknown) =>
   typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+const buildResolutionCacheKey = (source: string, config: unknown) =>
+  `${source}:${JSON.stringify(config)}`;
 
 export const agentDailyRoutes: FastifyPluginAsync = async (app) => {
   app.post('/habits', async (request, reply) => {
@@ -67,10 +70,36 @@ export const agentDailyRoutes: FastifyPluginAsync = async (app) => {
     const today = getTodayDate();
     const entries = await listHabitEntriesByDateRange(request.userId, today, today);
     const entriesByHabitId = new Map(entries.map((entry) => [entry.habitId, entry]));
+    const resolutionByKey = new Map<ReturnType<typeof buildResolutionCacheKey>, Promise<{
+      completed: boolean;
+      value?: number;
+    }>>();
 
     return reply.send({
-      data: habits.map((habit) => {
+      data: await Promise.all(habits.map(async (habit) => {
         const entry = entriesByHabitId.get(habit.id);
+
+        if (habit.referenceSource != null && !entry?.isOverride) {
+          const resolutionKey = buildResolutionCacheKey(habit.referenceSource, habit.referenceConfig);
+          const existingResolution = resolutionByKey.get(resolutionKey);
+          const resolutionPromise =
+            existingResolution ?? resolveHabitCompletion(habit, request.userId, today);
+          if (!existingResolution) {
+            resolutionByKey.set(resolutionKey, resolutionPromise);
+          }
+
+          const resolved = await resolutionPromise;
+          return {
+            id: habit.id,
+            name: habit.name,
+            trackingType: habit.trackingType,
+            todayEntry: {
+              value: resolved.value ?? null,
+              completed: resolved.completed,
+              isOverride: false,
+            },
+          };
+        }
 
         return {
           id: habit.id,
@@ -80,10 +109,11 @@ export const agentDailyRoutes: FastifyPluginAsync = async (app) => {
             ? {
                 value: entry.value,
                 completed: entry.completed,
+                isOverride: entry.isOverride,
               }
             : null,
         };
-      }),
+      })),
     });
   });
 

--- a/apps/api/src/routes/agent/daily.ts
+++ b/apps/api/src/routes/agent/daily.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import {
+  createHabitInputSchema,
   agentCreateWeightInputSchema,
   agentNutritionSummaryParamsSchema,
   agentUpdateHabitEntryInputSchema,
@@ -8,8 +9,17 @@ import {
 import type { FastifyPluginAsync } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
-import { findHabitEntryByHabitAndDate, listHabitEntriesByDateRange, upsertHabitEntry } from '../habit-entries/store.js';
-import { findHabitById, listActiveHabits } from '../habits/store.js';
+import {
+  findHabitEntryByHabitAndDate,
+  listHabitEntriesByDateRange,
+  upsertHabitEntry,
+} from '../habit-entries/store.js';
+import {
+  createHabit,
+  findHabitById,
+  getNextHabitSortOrder,
+  listActiveHabits,
+} from '../habits/store.js';
 import { getDailyNutritionForDate, getDailyNutritionSummaryForDate } from '../nutrition/store.js';
 import { findBodyWeightEntryByDate, upsertBodyWeightEntry } from '../weight/store.js';
 
@@ -19,6 +29,23 @@ const parseId = (value: unknown) =>
   typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
 
 export const agentDailyRoutes: FastifyPluginAsync = async (app) => {
+  app.post('/habits', async (request, reply) => {
+    const parsed = createHabitInputSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid habit payload');
+    }
+
+    const sortOrder = await getNextHabitSortOrder(request.userId);
+    const habit = await createHabit({
+      id: randomUUID(),
+      userId: request.userId,
+      sortOrder,
+      ...parsed.data,
+    });
+
+    return reply.code(201).send({ data: habit });
+  });
+
   app.post('/weight', async (request, reply) => {
     const parsed = agentCreateWeightInputSchema.safeParse(request.body);
     if (!parsed.success || !isValidDate(parsed.data.date)) {
@@ -84,6 +111,7 @@ export const agentDailyRoutes: FastifyPluginAsync = async (app) => {
       date: parsed.data.date,
       completed: parsed.data.completed ?? existing?.completed ?? false,
       value: parsed.data.value ?? existing?.value ?? undefined,
+      isOverride: habit.referenceSource != null,
     });
 
     return reply.code(existing ? 200 : 201).send({ data: entry });

--- a/apps/api/src/routes/agent/workouts.test.ts
+++ b/apps/api/src/routes/agent/workouts.test.ts
@@ -828,6 +828,368 @@ describe('agent workouts routes', () => {
   });
 
   describe('PATCH /api/agent/workout-sessions/:id', () => {
+    it('adds exercises to an active session', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findWorkoutSessionById).mockResolvedValue({
+          id: 'session-1',
+          userId: 'user-1',
+          templateId: null,
+          name: 'Upper Session',
+          date: '2023-11-14',
+          status: 'in-progress',
+          startedAt,
+          completedAt: null,
+          duration: null,
+          timeSegments: [],
+          feedback: null,
+          notes: null,
+          sets: [
+            {
+              id: 'set-1',
+              exerciseId: 'exercise-bench',
+              setNumber: 1,
+              weight: 100,
+              reps: 8,
+              completed: true,
+              skipped: false,
+              section: 'main',
+              notes: null,
+              createdAt: 1,
+            },
+          ],
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        vi.mocked(findVisibleExerciseByName).mockResolvedValue(undefined);
+        vi.mocked(findExerciseDedupCandidates).mockResolvedValue([]);
+        vi.mocked(createExercise).mockResolvedValue({
+          id: 'exercise-goblet-squat',
+          userId: 'user-1',
+          name: 'Goblet Squat',
+          category: 'compound',
+          trackingType: 'weight_reps',
+          tags: [],
+          formCues: [],
+          muscleGroups: [],
+          equipment: '',
+          instructions: null,
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        vi.mocked(updateWorkoutSession).mockResolvedValue({
+          id: 'session-1',
+          userId: 'user-1',
+          templateId: null,
+          name: 'Upper Session',
+          date: '2023-11-14',
+          status: 'in-progress',
+          startedAt,
+          completedAt: null,
+          duration: null,
+          timeSegments: [],
+          feedback: null,
+          notes: null,
+          sets: [],
+          createdAt: 1,
+          updatedAt: 2,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/workout-sessions/session-1',
+          headers: createAuthorizationHeader(token),
+          body: {
+            addExercises: [{ name: 'Goblet Squat', sets: 2, reps: 10, section: 'main' }],
+          },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(vi.mocked(updateWorkoutSession)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            input: expect.objectContaining({
+              sets: expect.arrayContaining([
+                expect.objectContaining({
+                  exerciseId: 'exercise-bench',
+                  setNumber: 1,
+                  completed: true,
+                }),
+                expect.objectContaining({
+                  exerciseId: 'exercise-goblet-squat',
+                  setNumber: 1,
+                  reps: 10,
+                  completed: false,
+                  section: 'main',
+                }),
+                expect.objectContaining({
+                  exerciseId: 'exercise-goblet-squat',
+                  setNumber: 2,
+                  reps: 10,
+                  completed: false,
+                  section: 'main',
+                }),
+              ]),
+            }),
+          }),
+        );
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('blocks removing exercises that have logged sets', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findWorkoutSessionById).mockResolvedValue({
+          id: 'session-1',
+          userId: 'user-1',
+          templateId: null,
+          name: 'Upper Session',
+          date: '2023-11-14',
+          status: 'in-progress',
+          startedAt,
+          completedAt: null,
+          duration: null,
+          timeSegments: [],
+          feedback: null,
+          notes: null,
+          sets: [
+            {
+              id: 'set-1',
+              exerciseId: 'exercise-bench',
+              setNumber: 1,
+              weight: 100,
+              reps: 8,
+              completed: true,
+              skipped: false,
+              section: 'main',
+              notes: null,
+              createdAt: 1,
+            },
+          ],
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/workout-sessions/session-1',
+          headers: createAuthorizationHeader(token),
+          body: {
+            removeExercises: ['exercise-bench'],
+          },
+        });
+
+        expect(response.statusCode).toBe(409);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'WORKOUT_SESSION_EXERCISE_HAS_LOGGED_SETS',
+            message: 'Cannot remove an exercise with logged sets',
+          },
+        });
+        expect(vi.mocked(updateWorkoutSession)).not.toHaveBeenCalled();
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('removes exercises that have no logged sets', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findWorkoutSessionById).mockResolvedValue({
+          id: 'session-1',
+          userId: 'user-1',
+          templateId: null,
+          name: 'Upper Session',
+          date: '2023-11-14',
+          status: 'in-progress',
+          startedAt,
+          completedAt: null,
+          duration: null,
+          timeSegments: [],
+          feedback: null,
+          notes: null,
+          sets: [
+            {
+              id: 'set-1',
+              exerciseId: 'exercise-bench',
+              setNumber: 1,
+              weight: null,
+              reps: null,
+              completed: false,
+              skipped: false,
+              section: 'main',
+              notes: null,
+              createdAt: 1,
+            },
+            {
+              id: 'set-2',
+              exerciseId: 'exercise-row',
+              setNumber: 1,
+              weight: null,
+              reps: null,
+              completed: false,
+              skipped: false,
+              section: 'main',
+              notes: null,
+              createdAt: 2,
+            },
+          ],
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        vi.mocked(updateWorkoutSession).mockResolvedValue({
+          id: 'session-1',
+          userId: 'user-1',
+          templateId: null,
+          name: 'Upper Session',
+          date: '2023-11-14',
+          status: 'in-progress',
+          startedAt,
+          completedAt: null,
+          duration: null,
+          timeSegments: [],
+          feedback: null,
+          notes: null,
+          sets: [],
+          createdAt: 1,
+          updatedAt: 2,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/workout-sessions/session-1',
+          headers: createAuthorizationHeader(token),
+          body: {
+            removeExercises: ['exercise-bench'],
+          },
+        });
+
+        expect(response.statusCode).toBe(200);
+        const updateCall = vi.mocked(updateWorkoutSession).mock.calls.at(0);
+        expect(updateCall?.[0].input.sets.map((set) => set.exerciseId)).toEqual(['exercise-row']);
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('reorders exercises while preserving logged set data', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findWorkoutSessionById).mockResolvedValue({
+          id: 'session-1',
+          userId: 'user-1',
+          templateId: null,
+          name: 'Upper Session',
+          date: '2023-11-14',
+          status: 'in-progress',
+          startedAt,
+          completedAt: null,
+          duration: null,
+          timeSegments: [],
+          feedback: null,
+          notes: null,
+          sets: [
+            {
+              id: 'set-1',
+              exerciseId: 'exercise-bench',
+              setNumber: 1,
+              weight: 105,
+              reps: 7,
+              completed: true,
+              skipped: false,
+              section: 'main',
+              notes: null,
+              createdAt: 1,
+            },
+            {
+              id: 'set-2',
+              exerciseId: 'exercise-row',
+              setNumber: 1,
+              weight: 85,
+              reps: 10,
+              completed: true,
+              skipped: false,
+              section: 'main',
+              notes: null,
+              createdAt: 2,
+            },
+          ],
+          createdAt: 1,
+          updatedAt: 1,
+        });
+
+        vi.mocked(updateWorkoutSession).mockResolvedValue({
+          id: 'session-1',
+          userId: 'user-1',
+          templateId: null,
+          name: 'Upper Session',
+          date: '2023-11-14',
+          status: 'in-progress',
+          startedAt,
+          completedAt: null,
+          duration: null,
+          timeSegments: [],
+          feedback: null,
+          notes: null,
+          sets: [],
+          createdAt: 1,
+          updatedAt: 2,
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/workout-sessions/session-1',
+          headers: createAuthorizationHeader(token),
+          body: {
+            reorderExercises: ['exercise-row', 'exercise-bench'],
+          },
+        });
+
+        expect(response.statusCode).toBe(200);
+        const updateCall = vi.mocked(updateWorkoutSession).mock.calls.at(0);
+        expect(updateCall?.[0].input.sets).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              exerciseId: 'exercise-row',
+              orderIndex: 0,
+              completed: true,
+              weight: 85,
+              reps: 10,
+            }),
+            expect.objectContaining({
+              exerciseId: 'exercise-bench',
+              orderIndex: 1,
+              completed: true,
+              weight: 105,
+              reps: 7,
+            }),
+          ]),
+        );
+      } finally {
+        await app.close();
+      }
+    });
+
     it('resolves exercise names and upserts sets', async () => {
       const app = buildServer();
 

--- a/apps/api/src/routes/agent/workouts.ts
+++ b/apps/api/src/routes/agent/workouts.ts
@@ -52,6 +52,11 @@ const WORKOUT_SESSION_NOT_FOUND_RESPONSE = {
   message: 'Workout session not found',
 } as const;
 
+const WORKOUT_SESSION_EXERCISE_HAS_LOGGED_SETS_RESPONSE = {
+  code: 'WORKOUT_SESSION_EXERCISE_HAS_LOGGED_SETS',
+  message: 'Cannot remove an exercise with logged sets',
+} as const;
+
 const DEFAULT_EXERCISE_CATEGORY = 'compound' as const;
 const DEFAULT_EXERCISE_TRACKING_TYPE = 'weight_reps' as const;
 const SITUATIONAL_CUE_PATTERN =
@@ -293,6 +298,83 @@ const buildInitialSessionSets = (
   }
 
   return sets;
+};
+
+const buildExerciseSectionOrder = (
+  sets: CreateWorkoutSessionInput['sets'],
+): Map<string, { section: WorkoutTemplateSectionType | null; orderIndex: number }> => {
+  const byExerciseId = new Map<string, { section: WorkoutTemplateSectionType | null; orderIndex: number }>();
+
+  for (const set of sets) {
+    const existing = byExerciseId.get(set.exerciseId);
+    const setOrderIndex = set.orderIndex ?? 0;
+    if (!existing || setOrderIndex < existing.orderIndex) {
+      byExerciseId.set(set.exerciseId, {
+        section: set.section,
+        orderIndex: setOrderIndex,
+      });
+    }
+  }
+
+  return byExerciseId;
+};
+
+const reorderSessionSetsByExercise = (
+  sets: CreateWorkoutSessionInput['sets'],
+  reorderExerciseIds: string[],
+) => {
+  const exerciseOrder = buildExerciseSectionOrder(sets);
+  const existingBySection = new Map<WorkoutTemplateSectionType | null, string[]>();
+
+  for (const [exerciseId, metadata] of exerciseOrder.entries()) {
+    const current = existingBySection.get(metadata.section) ?? [];
+    current.push(exerciseId);
+    existingBySection.set(metadata.section, current);
+  }
+
+  for (const [section, exerciseIds] of existingBySection.entries()) {
+    exerciseIds.sort((left, right) => {
+      const leftOrder = exerciseOrder.get(left)?.orderIndex ?? Number.MAX_SAFE_INTEGER;
+      const rightOrder = exerciseOrder.get(right)?.orderIndex ?? Number.MAX_SAFE_INTEGER;
+      if (leftOrder !== rightOrder) {
+        return leftOrder - rightOrder;
+      }
+      return left.localeCompare(right);
+    });
+    existingBySection.set(section, exerciseIds);
+  }
+
+  const reorderedBySection = new Map<WorkoutTemplateSectionType | null, string[]>();
+
+  for (const exerciseId of reorderExerciseIds) {
+    const metadata = exerciseOrder.get(exerciseId);
+    if (!metadata) {
+      continue;
+    }
+    const sectionExerciseIds = reorderedBySection.get(metadata.section) ?? [];
+    if (!sectionExerciseIds.includes(exerciseId)) {
+      sectionExerciseIds.push(exerciseId);
+      reorderedBySection.set(metadata.section, sectionExerciseIds);
+    }
+  }
+
+  for (const [section, currentIds] of existingBySection.entries()) {
+    const preferred = reorderedBySection.get(section) ?? [];
+    const merged = [...preferred, ...currentIds.filter((exerciseId) => !preferred.includes(exerciseId))];
+    reorderedBySection.set(section, merged);
+  }
+
+  const nextOrderIndexByExerciseId = new Map<string, number>();
+  for (const exerciseIds of reorderedBySection.values()) {
+    exerciseIds.forEach((exerciseId, index) => {
+      nextOrderIndexByExerciseId.set(exerciseId, index);
+    });
+  }
+
+  return sets.map((set) => ({
+    ...set,
+    orderIndex: nextOrderIndexByExerciseId.get(set.exerciseId) ?? set.orderIndex ?? 0,
+  }));
 };
 
 export const agentWorkoutRoutes: FastifyPluginAsync = async (app) => {
@@ -558,6 +640,86 @@ export const agentWorkoutRoutes: FastifyPluginAsync = async (app) => {
         }
         return left.setNumber - right.setNumber;
       });
+    }
+
+    if (parsed.data.addExercises) {
+      const exerciseSectionOrder = buildExerciseSectionOrder(merged.sets);
+      const nextOrderIndexBySection = new Map<WorkoutTemplateSectionType | null, number>();
+
+      for (const metadata of exerciseSectionOrder.values()) {
+        const current = nextOrderIndexBySection.get(metadata.section) ?? 0;
+        nextOrderIndexBySection.set(metadata.section, Math.max(current, metadata.orderIndex + 1));
+      }
+
+      for (const exercise of parsed.data.addExercises) {
+        const resolvedExercise = await resolveExerciseIdByName({
+          name: exercise.name,
+          userId: request.userId,
+        });
+        const existingMetadata = exerciseSectionOrder.get(resolvedExercise.exerciseId);
+        const targetSection = existingMetadata?.section ?? exercise.section;
+        const orderIndex =
+          existingMetadata?.orderIndex ?? nextOrderIndexBySection.get(targetSection) ?? 0;
+        const maxSetNumber = merged.sets
+          .filter((set) => set.exerciseId === resolvedExercise.exerciseId)
+          .reduce((maxValue, set) => Math.max(maxValue, set.setNumber), 0);
+
+        for (let setOffset = 1; setOffset <= exercise.sets; setOffset += 1) {
+          merged.sets.push({
+            exerciseId: resolvedExercise.exerciseId,
+            orderIndex,
+            setNumber: maxSetNumber + setOffset,
+            weight: exercise.weight ?? null,
+            reps: exercise.reps ?? null,
+            completed: false,
+            skipped: false,
+            section: targetSection,
+            notes: null,
+          });
+        }
+
+        if (!existingMetadata) {
+          exerciseSectionOrder.set(resolvedExercise.exerciseId, {
+            section: targetSection,
+            orderIndex,
+          });
+          nextOrderIndexBySection.set(targetSection, orderIndex + 1);
+        }
+      }
+    }
+
+    if (parsed.data.removeExercises) {
+      const removeExerciseIds = new Set(parsed.data.removeExercises);
+      const hasLoggedSets = merged.sets.some(
+        (set) => removeExerciseIds.has(set.exerciseId) && set.completed,
+      );
+      if (hasLoggedSets) {
+        return sendError(
+          reply,
+          409,
+          WORKOUT_SESSION_EXERCISE_HAS_LOGGED_SETS_RESPONSE.code,
+          WORKOUT_SESSION_EXERCISE_HAS_LOGGED_SETS_RESPONSE.message,
+        );
+      }
+
+      merged.sets = merged.sets.filter((set) => !removeExerciseIds.has(set.exerciseId));
+    }
+
+    if (parsed.data.reorderExercises) {
+      const currentExerciseIds = new Set(merged.sets.map((set) => set.exerciseId));
+      const hasUnknownExercise = parsed.data.reorderExercises.some(
+        (exerciseId) => !currentExerciseIds.has(exerciseId),
+      );
+      if (hasUnknownExercise) {
+        return sendError(
+          reply,
+          400,
+          'VALIDATION_ERROR',
+          'reorderExercises contains unknown exercise ids',
+        );
+      }
+
+      merged.sets = reorderSessionSetsByExercise(merged.sets, parsed.data.reorderExercises);
     }
 
     if (parsed.data.status !== undefined) {

--- a/apps/api/src/routes/habit-entries/index.test.ts
+++ b/apps/api/src/routes/habit-entries/index.test.ts
@@ -65,6 +65,7 @@ describe('habit entry routes', () => {
       date,
       completed: true,
       value: 8,
+      isOverride: false,
       createdAt: 1_700_000_100_000,
     }));
 
@@ -94,6 +95,7 @@ describe('habit entry routes', () => {
           date: string;
           completed: boolean;
           value: number | null;
+          isOverride: boolean;
           createdAt: number;
         };
       };
@@ -104,6 +106,7 @@ describe('habit entry routes', () => {
         date: '2026-03-07',
         completed: true,
         value: 8,
+        isOverride: false,
         createdAt: 1_700_000_100_000,
       });
       expect(payload.data.id).toBeTruthy();
@@ -130,6 +133,7 @@ describe('habit entry routes', () => {
         date: '2026-03-06',
         completed: true,
         value: null,
+        isOverride: false,
         createdAt: 1_700_000_000_000,
       },
       {
@@ -139,6 +143,7 @@ describe('habit entry routes', () => {
         date: '2026-03-07',
         completed: true,
         value: 8,
+        isOverride: false,
         createdAt: 1_700_000_100_000,
       },
     ]);
@@ -164,6 +169,7 @@ describe('habit entry routes', () => {
             date: '2026-03-06',
             completed: true,
             value: null,
+            isOverride: false,
             createdAt: 1_700_000_000_000,
           },
           {
@@ -173,6 +179,7 @@ describe('habit entry routes', () => {
             date: '2026-03-07',
             completed: true,
             value: 8,
+            isOverride: false,
             createdAt: 1_700_000_100_000,
           },
         ],
@@ -214,6 +221,7 @@ describe('habit entry routes', () => {
         date: '2026-03-05',
         completed: true,
         value: null,
+        isOverride: false,
         createdAt: 1_700_000_000_000,
       },
     ]);
@@ -239,6 +247,7 @@ describe('habit entry routes', () => {
             date: '2026-03-05',
             completed: true,
             value: null,
+            isOverride: false,
             createdAt: 1_700_000_000_000,
           },
         ],
@@ -262,6 +271,7 @@ describe('habit entry routes', () => {
       date: '2026-03-07',
       completed: false,
       value: 6,
+      isOverride: false,
       createdAt: 1_700_000_000_000,
     });
 
@@ -289,6 +299,7 @@ describe('habit entry routes', () => {
           date: '2026-03-07',
           completed: false,
           value: 6,
+          isOverride: false,
           createdAt: 1_700_000_000_000,
         },
       });

--- a/apps/api/src/routes/habit-entries/index.ts
+++ b/apps/api/src/routes/habit-entries/index.ts
@@ -49,6 +49,7 @@ export const habitEntryNestedRoutes: FastifyPluginAsync = async (app) => {
       habitId,
       userId: request.userId,
       ...parsedBody.data,
+      isOverride: parsedBody.data.isOverride,
     });
 
     return reply.code(201).send({

--- a/apps/api/src/routes/habit-entries/store.test.ts
+++ b/apps/api/src/routes/habit-entries/store.test.ts
@@ -95,6 +95,7 @@ describe('habit entry store', () => {
       date: '2026-03-07',
       completed: true,
       value: 8,
+      isOverride: false,
       createdAt: 1_700_000_000_000,
     });
 
@@ -114,6 +115,7 @@ describe('habit entry store', () => {
       date: '2026-03-07',
       completed: true,
       value: 8,
+      isOverride: false,
       createdAt: 1_700_000_000_000,
     });
     expect(testState.db.insert).toHaveBeenCalledOnce();
@@ -126,6 +128,7 @@ describe('habit entry store', () => {
         date: '2026-03-07',
         completed: true,
         value: 8,
+        isOverride: false,
       },
     ]);
     expect(testState.upsertConfigs).toEqual([
@@ -133,6 +136,7 @@ describe('habit entry store', () => {
         set: {
           completed: true,
           value: 8,
+          isOverride: false,
         },
       }),
     ]);
@@ -148,6 +152,7 @@ describe('habit entry store', () => {
       date: '2026-03-07',
       completed: false,
       value: null,
+      isOverride: false,
       createdAt: 1_700_000_000_000,
     });
 
@@ -166,6 +171,7 @@ describe('habit entry store', () => {
       date: '2026-03-07',
       completed: false,
       value: null,
+      isOverride: false,
       createdAt: 1_700_000_000_000,
     });
     expect(testState.db.insert).toHaveBeenCalledOnce();
@@ -178,6 +184,7 @@ describe('habit entry store', () => {
         date: '2026-03-07',
         completed: false,
         value: null,
+        isOverride: false,
       },
     ]);
     expect(testState.upsertConfigs).toEqual([
@@ -185,6 +192,7 @@ describe('habit entry store', () => {
         set: {
           completed: false,
           value: null,
+          isOverride: false,
         },
       }),
     ]);
@@ -200,6 +208,7 @@ describe('habit entry store', () => {
       date: '2026-03-07',
       completed: false,
       value: 6,
+      isOverride: false,
       createdAt: 1_700_000_000_000,
     });
 
@@ -215,6 +224,7 @@ describe('habit entry store', () => {
       date: '2026-03-07',
       completed: false,
       value: 6,
+      isOverride: false,
       createdAt: 1_700_000_000_000,
     });
     expect(testState.updateSets).toEqual([

--- a/apps/api/src/routes/habit-entries/store.ts
+++ b/apps/api/src/routes/habit-entries/store.ts
@@ -12,6 +12,7 @@ type UpsertHabitEntryInput = {
   date: string;
   completed: boolean;
   value?: number;
+  isOverride?: boolean;
 };
 
 const habitEntrySelection = {
@@ -21,6 +22,7 @@ const habitEntrySelection = {
   date: habitEntries.date,
   completed: habitEntries.completed,
   value: habitEntries.value,
+  isOverride: habitEntries.isOverride,
   createdAt: habitEntries.createdAt,
 };
 
@@ -66,6 +68,7 @@ export const upsertHabitEntry = async ({
   date,
   completed,
   value,
+  isOverride,
 }: UpsertHabitEntryInput): Promise<HabitEntryRecord> => {
   const { db } = await import('../../db/index.js');
 
@@ -77,12 +80,14 @@ export const upsertHabitEntry = async ({
       date,
       completed,
       value: value ?? null,
+      isOverride: isOverride ?? false,
     })
     .onConflictDoUpdate({
       target: [habitEntries.habitId, habitEntries.date],
       set: {
         completed,
         value: value ?? null,
+        isOverride: isOverride ?? false,
       },
     })
     .run();

--- a/apps/api/src/routes/habit-entries/store.ts
+++ b/apps/api/src/routes/habit-entries/store.ts
@@ -147,6 +147,7 @@ export const updateHabitEntry = async (
   const values = {
     ...(updates.completed !== undefined ? { completed: updates.completed } : {}),
     ...(updates.value !== undefined ? { value: updates.value } : {}),
+    ...(updates.isOverride !== undefined ? { isOverride: updates.isOverride } : {}),
   };
 
   const result = db

--- a/apps/api/src/routes/habits/index.test.ts
+++ b/apps/api/src/routes/habits/index.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildServer } from '../../index.js';
+import { resolveHabitCompletion } from '../../lib/habit-resolvers.js';
 import { findUserAuthById } from '../../middleware/store.js';
+import { listHabitEntriesByDateRange } from '../habit-entries/store.js';
 import {
   createHabit,
   findHabitById,
@@ -28,6 +30,17 @@ vi.mock('../../middleware/store.js', () => ({
 vi.mock('../auth/store.js', () => ({
   ensureStarterHabitsForUser: vi.fn(),
 }));
+vi.mock('../habit-entries/store.js', () => ({
+  findHabitEntryById: vi.fn(),
+  findHabitEntryByHabitAndDate: vi.fn(),
+  upsertHabitEntry: vi.fn(),
+  listHabitEntriesByDateRange: vi.fn(),
+  listHabitEntriesForHabitByDateRange: vi.fn(),
+  updateHabitEntry: vi.fn(),
+}));
+vi.mock('../../lib/habit-resolvers.js', () => ({
+  resolveHabitCompletion: vi.fn(),
+}));
 
 const createAuthorizationHeader = (token: string) => ({
   authorization: `Bearer ${token}`,
@@ -43,6 +56,8 @@ describe('habit routes', () => {
     vi.mocked(softDeleteHabit).mockReset();
     vi.mocked(updateHabit).mockReset();
     vi.mocked(findUserAuthById).mockReset();
+    vi.mocked(listHabitEntriesByDateRange).mockReset();
+    vi.mocked(resolveHabitCompletion).mockReset();
     vi.mocked(findUserAuthById).mockResolvedValue({ id: 'user-1' });
     vi.mocked(ensureStarterHabitsForUser).mockReset();
     vi.mocked(ensureStarterHabitsForUser).mockResolvedValue(undefined);
@@ -132,6 +147,7 @@ describe('habit routes', () => {
   });
 
   it('lists the authenticated users active habits sorted by sort order', async () => {
+    vi.mocked(listHabitEntriesByDateRange).mockResolvedValue([]);
     vi.mocked(listActiveHabits).mockResolvedValue([
       {
         id: 'habit-2',
@@ -202,6 +218,7 @@ describe('habit routes', () => {
             active: true,
             createdAt: 1_700_000_000_000,
             updatedAt: 1_700_000_000_000,
+            todayEntry: null,
           },
           {
             id: 'habit-1',
@@ -220,12 +237,216 @@ describe('habit routes', () => {
             active: true,
             createdAt: 1_700_000_100_000,
             updatedAt: 1_700_000_100_000,
+            todayEntry: null,
           },
         ],
       });
       expect(vi.mocked(listActiveHabits)).toHaveBeenCalledWith('user-1');
+      expect(vi.mocked(resolveHabitCompletion)).not.toHaveBeenCalled();
     } finally {
       await app.close();
+    }
+  });
+
+  it('uses manual override entries before referential resolver results', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-09T12:00:00.000Z'));
+    vi.mocked(listActiveHabits).mockResolvedValue([
+      {
+        id: 'habit-1',
+        userId: 'user-1',
+        name: 'Protein',
+        description: null,
+        emoji: null,
+        trackingType: 'boolean',
+        target: null,
+        unit: null,
+        frequency: 'daily',
+        frequencyTarget: null,
+        scheduledDays: null,
+        pausedUntil: null,
+        referenceSource: 'nutrition_daily',
+        referenceConfig: { field: 'protein', op: 'gte', value: 150 },
+        sortOrder: 0,
+        active: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ]);
+    vi.mocked(listHabitEntriesByDateRange).mockResolvedValue([
+      {
+        id: 'entry-1',
+        habitId: 'habit-1',
+        userId: 'user-1',
+        date: '2026-03-09',
+        completed: false,
+        value: 120,
+        isOverride: true,
+        createdAt: 2,
+      },
+    ]);
+    vi.mocked(resolveHabitCompletion).mockResolvedValue({ completed: true, value: 160 });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/habits',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: [
+          expect.objectContaining({
+            id: 'habit-1',
+            todayEntry: {
+              completed: false,
+              value: 120,
+              isOverride: true,
+            },
+          }),
+        ],
+      });
+      expect(vi.mocked(resolveHabitCompletion)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it('resolves referential habits when no override entry exists', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-09T12:00:00.000Z'));
+    vi.mocked(listActiveHabits).mockResolvedValue([
+      {
+        id: 'habit-1',
+        userId: 'user-1',
+        name: 'Weigh in',
+        description: null,
+        emoji: null,
+        trackingType: 'boolean',
+        target: null,
+        unit: null,
+        frequency: 'daily',
+        frequencyTarget: null,
+        scheduledDays: null,
+        pausedUntil: null,
+        referenceSource: 'weight',
+        referenceConfig: { condition: 'exists_today' },
+        sortOrder: 0,
+        active: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ]);
+    vi.mocked(listHabitEntriesByDateRange).mockResolvedValue([]);
+    vi.mocked(resolveHabitCompletion).mockResolvedValue({ completed: true });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/habits',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: [
+          expect.objectContaining({
+            id: 'habit-1',
+            todayEntry: {
+              completed: true,
+              value: null,
+              isOverride: false,
+            },
+          }),
+        ],
+      });
+      expect(vi.mocked(resolveHabitCompletion)).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'habit-1' }),
+        'user-1',
+        '2026-03-09',
+      );
+    } finally {
+      await app.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps non-referential habits driven by manual entries', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-09T12:00:00.000Z'));
+    vi.mocked(listActiveHabits).mockResolvedValue([
+      {
+        id: 'habit-1',
+        userId: 'user-1',
+        name: 'Supplements',
+        description: null,
+        emoji: null,
+        trackingType: 'boolean',
+        target: null,
+        unit: null,
+        frequency: 'daily',
+        frequencyTarget: null,
+        scheduledDays: null,
+        pausedUntil: null,
+        referenceSource: null,
+        referenceConfig: null,
+        sortOrder: 0,
+        active: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ]);
+    vi.mocked(listHabitEntriesByDateRange).mockResolvedValue([
+      {
+        id: 'entry-1',
+        habitId: 'habit-1',
+        userId: 'user-1',
+        date: '2026-03-09',
+        completed: true,
+        value: null,
+        isOverride: false,
+        createdAt: 2,
+      },
+    ]);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/habits',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: [
+          expect.objectContaining({
+            id: 'habit-1',
+            todayEntry: {
+              completed: true,
+              value: null,
+              isOverride: false,
+            },
+          }),
+        ],
+      });
+      expect(vi.mocked(resolveHabitCompletion)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+      vi.useRealTimers();
     }
   });
 

--- a/apps/api/src/routes/habits/index.ts
+++ b/apps/api/src/routes/habits/index.ts
@@ -33,6 +33,8 @@ const habitParamsSchema = {
 const sendNotFound = (reply: Parameters<typeof sendError>[0]) =>
   sendError(reply, 404, 'HABIT_NOT_FOUND', 'Habit not found');
 const shouldEnsureStarterHabits = () => process.env.NODE_ENV !== 'test';
+const buildResolutionCacheKey = (source: string, config: unknown) =>
+  `${source}:${JSON.stringify(config)}`;
 
 export const habitRoutes: FastifyPluginAsync = async (app) => {
   app.addHook('onRequest', requireAuth);
@@ -70,6 +72,10 @@ export const habitRoutes: FastifyPluginAsync = async (app) => {
     const today = getTodayDate();
     const todayEntries = await listHabitEntriesByDateRange(request.userId, today, today);
     const todayEntriesByHabitId = new Map(todayEntries.map((entry) => [entry.habitId, entry]));
+    const resolutionByKey = new Map<ReturnType<typeof buildResolutionCacheKey>, Promise<{
+      completed: boolean;
+      value?: number;
+    }>>();
 
     const habitsWithResolvedEntries = await Promise.all(
       habits.map(async (habit) => {
@@ -98,7 +104,15 @@ export const habitRoutes: FastifyPluginAsync = async (app) => {
           };
         }
 
-        const resolved = await resolveHabitCompletion(habit, request.userId, today);
+        const resolutionKey = buildResolutionCacheKey(habit.referenceSource, habit.referenceConfig);
+        const existingResolution = resolutionByKey.get(resolutionKey);
+        const resolutionPromise =
+          existingResolution ?? resolveHabitCompletion(habit, request.userId, today);
+        if (!existingResolution) {
+          resolutionByKey.set(resolutionKey, resolutionPromise);
+        }
+
+        const resolved = await resolutionPromise;
         return {
           ...habit,
           todayEntry: {

--- a/apps/api/src/routes/habits/index.ts
+++ b/apps/api/src/routes/habits/index.ts
@@ -7,8 +7,11 @@ import {
 } from '@pulse/shared';
 import type { FastifyPluginAsync } from 'fastify';
 
+import { getTodayDate } from '../../lib/date.js';
+import { resolveHabitCompletion } from '../../lib/habit-resolvers.js';
 import { sendError } from '../../lib/reply.js';
 import { requireAuth } from '../../middleware/auth.js';
+import { listHabitEntriesByDateRange } from '../habit-entries/store.js';
 import { habitEntryNestedRoutes } from '../habit-entries/index.js';
 import { ensureStarterHabitsForUser } from '../auth/store.js';
 
@@ -60,9 +63,55 @@ export const habitRoutes: FastifyPluginAsync = async (app) => {
     }
 
     const habits = await listActiveHabits(request.userId);
+    if (habits.length === 0) {
+      return reply.send({ data: [] });
+    }
+
+    const today = getTodayDate();
+    const todayEntries = await listHabitEntriesByDateRange(request.userId, today, today);
+    const todayEntriesByHabitId = new Map(todayEntries.map((entry) => [entry.habitId, entry]));
+
+    const habitsWithResolvedEntries = await Promise.all(
+      habits.map(async (habit) => {
+        const todayEntry = todayEntriesByHabitId.get(habit.id);
+        if (habit.referenceSource == null) {
+          return {
+            ...habit,
+            todayEntry: todayEntry
+              ? {
+                  completed: todayEntry.completed,
+                  value: todayEntry.value,
+                  isOverride: todayEntry.isOverride,
+                }
+              : null,
+          };
+        }
+
+        if (todayEntry?.isOverride) {
+          return {
+            ...habit,
+            todayEntry: {
+              completed: todayEntry.completed,
+              value: todayEntry.value,
+              isOverride: true,
+            },
+          };
+        }
+
+        const resolved = await resolveHabitCompletion(habit, request.userId, today);
+        return {
+          ...habit,
+          todayEntry: {
+            completed: resolved.completed,
+            value: resolved.value ?? null,
+            isOverride: false,
+          },
+        };
+      }),
+    );
 
     return reply.send({
-      data: habits,
+      data: habitsWithResolvedEntries,
     });
   });
 
@@ -111,6 +160,14 @@ export const habitRoutes: FastifyPluginAsync = async (app) => {
         parsedBody.data.pausedUntil === undefined
           ? existingHabit.pausedUntil
           : parsedBody.data.pausedUntil,
+      referenceSource:
+        parsedBody.data.referenceSource === undefined
+          ? existingHabit.referenceSource
+          : parsedBody.data.referenceSource,
+      referenceConfig:
+        parsedBody.data.referenceConfig === undefined
+          ? existingHabit.referenceConfig
+          : parsedBody.data.referenceConfig,
     });
 
     if (!mergedHabitInput.success) {

--- a/apps/api/src/routes/habits/store.ts
+++ b/apps/api/src/routes/habits/store.ts
@@ -1,4 +1,5 @@
 import { and, asc, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { referenceConfigSchema } from '@pulse/shared';
 import type { CreateHabitInput, Habit, ReferenceConfig, UpdateHabitInput } from '@pulse/shared';
 
 import { habits } from '../../db/schema/index.js';
@@ -44,7 +45,9 @@ const parseReferenceConfig = (referenceConfig: string | null): ReferenceConfig =
   }
 
   try {
-    return JSON.parse(referenceConfig) as ReferenceConfig;
+    const parsed = JSON.parse(referenceConfig) as unknown;
+    const result = referenceConfigSchema.safeParse(parsed);
+    return result.success ? result.data : null;
   } catch {
     return null;
   }
@@ -217,8 +220,12 @@ export const updateHabit = async (
       frequency: updates.frequency,
       frequencyTarget: updates.frequencyTarget ?? null,
       scheduledDays: serializeScheduledDays(updates.scheduledDays),
-      referenceSource: updates.referenceSource ?? null,
-      referenceConfig: serializeReferenceConfig(updates.referenceConfig),
+      ...(updates.referenceSource === undefined
+        ? {}
+        : { referenceSource: updates.referenceSource ?? null }),
+      ...(updates.referenceConfig === undefined
+        ? {}
+        : { referenceConfig: serializeReferenceConfig(updates.referenceConfig) }),
       pausedUntil: updates.pausedUntil ?? null,
       ...(updates.active === undefined ? {} : { active: updates.active }),
     })

--- a/apps/api/src/routes/habits/store.ts
+++ b/apps/api/src/routes/habits/store.ts
@@ -1,5 +1,5 @@
 import { and, asc, eq, inArray, isNull, sql } from 'drizzle-orm';
-import type { CreateHabitInput, Habit, UpdateHabitInput } from '@pulse/shared';
+import type { CreateHabitInput, Habit, ReferenceConfig, UpdateHabitInput } from '@pulse/shared';
 
 import { habits } from '../../db/schema/index.js';
 
@@ -7,6 +7,13 @@ type HabitRecord = Habit;
 
 const serializeScheduledDays = (scheduledDays: number[] | null | undefined): string | null =>
   scheduledDays === undefined || scheduledDays === null ? null : JSON.stringify(scheduledDays);
+
+const serializeReferenceConfig = (
+  referenceConfig: ReferenceConfig | null | undefined,
+): string | null =>
+  referenceConfig === undefined || referenceConfig === null
+    ? null
+    : JSON.stringify(referenceConfig);
 
 const parseScheduledDays = (scheduledDays: string | null): number[] | null => {
   if (scheduledDays === null) {
@@ -31,6 +38,18 @@ const parseScheduledDays = (scheduledDays: string | null): number[] | null => {
   return parsed as number[];
 };
 
+const parseReferenceConfig = (referenceConfig: string | null): ReferenceConfig => {
+  if (referenceConfig === null) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(referenceConfig) as ReferenceConfig;
+  } catch {
+    return null;
+  }
+};
+
 type CreateHabitRecordInput = CreateHabitInput & {
   id: string;
   userId: string;
@@ -49,6 +68,8 @@ const habitSelection = {
   frequency: habits.frequency,
   frequencyTarget: habits.frequencyTarget,
   scheduledDays: habits.scheduledDays,
+  referenceSource: habits.referenceSource,
+  referenceConfig: habits.referenceConfig,
   pausedUntil: habits.pausedUntil,
   sortOrder: habits.sortOrder,
   active: habits.active,
@@ -68,6 +89,8 @@ const mapHabitRecord = (record: {
   frequency: Habit['frequency'];
   frequencyTarget: number | null;
   scheduledDays: string | null;
+  referenceSource: Habit['referenceSource'];
+  referenceConfig: string | null;
   pausedUntil: string | null;
   sortOrder: number;
   active: boolean;
@@ -76,6 +99,7 @@ const mapHabitRecord = (record: {
 }): HabitRecord => ({
   ...record,
   scheduledDays: parseScheduledDays(record.scheduledDays),
+  referenceConfig: parseReferenceConfig(record.referenceConfig),
 });
 
 export const getNextHabitSortOrder = async (userId: string): Promise<number> => {
@@ -104,6 +128,8 @@ export const createHabit = async ({
   frequency,
   frequencyTarget,
   scheduledDays,
+  referenceSource,
+  referenceConfig,
   pausedUntil,
   sortOrder,
 }: CreateHabitRecordInput): Promise<HabitRecord> => {
@@ -123,6 +149,8 @@ export const createHabit = async ({
       frequency: frequency ?? 'daily',
       frequencyTarget: frequencyTarget ?? null,
       scheduledDays: serializeScheduledDays(scheduledDays),
+      referenceSource: referenceSource ?? null,
+      referenceConfig: serializeReferenceConfig(referenceConfig),
       pausedUntil: pausedUntil ?? null,
       sortOrder,
       active: true,
@@ -189,6 +217,8 @@ export const updateHabit = async (
       frequency: updates.frequency,
       frequencyTarget: updates.frequencyTarget ?? null,
       scheduledDays: serializeScheduledDays(updates.scheduledDays),
+      referenceSource: updates.referenceSource ?? null,
+      referenceConfig: serializeReferenceConfig(updates.referenceConfig),
       pausedUntil: updates.pausedUntil ?? null,
       ...(updates.active === undefined ? {} : { active: updates.active }),
     })

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -9,6 +9,7 @@ import type {
   SessionSet,
   UpdateSetInput,
   WorkoutSession,
+  WorkoutSessionExercise,
   WorkoutSessionListItem,
   WorkoutTemplateSectionType,
 } from '@pulse/shared';
@@ -188,6 +189,7 @@ const buildSessionSetGroups = (sets: SessionSetRecord[]): SessionSetGroup[] => {
 const buildWorkoutSession = (
   session: WorkoutSessionRecord,
   sets: SessionSetRecord[],
+  exerciseNamesById: Map<string, string>,
 ): WorkoutSession => {
   const parsedTimeSegments = parseWorkoutSessionTimeSegments(session.timeSegments);
   const timeSegments =
@@ -208,10 +210,64 @@ const buildWorkoutSession = (
     timeSegments,
     feedback: parseWorkoutSessionFeedback(session.feedback),
     notes: session.notes,
+    exercises: buildWorkoutSessionExercises(sets, exerciseNamesById),
     sets: sets.sort(sortSessionSets).map<SessionSet>(buildSessionSet),
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
   };
+};
+
+const buildWorkoutSessionExercises = (
+  sets: SessionSetRecord[],
+  exerciseNamesById: Map<string, string>,
+): WorkoutSessionExercise[] => {
+  const groupedByExercise = new Map<
+    string,
+    {
+      exerciseId: string;
+      exerciseName: string;
+      orderIndex: number;
+      section: WorkoutTemplateSectionType | null;
+      sets: SessionSet[];
+    }
+  >();
+
+  for (const set of sets.sort(sortSessionSets)) {
+    const existing = groupedByExercise.get(set.exerciseId);
+    const parsedSet = buildSessionSet(set);
+    const exerciseName = exerciseNamesById.get(set.exerciseId) ?? 'Unknown Exercise';
+
+    if (existing) {
+      existing.orderIndex = Math.min(existing.orderIndex, set.orderIndex);
+      existing.sets.push(parsedSet);
+      continue;
+    }
+
+    groupedByExercise.set(set.exerciseId, {
+      exerciseId: set.exerciseId,
+      exerciseName,
+      orderIndex: set.orderIndex,
+      section: set.section,
+      sets: [parsedSet],
+    });
+  }
+
+  return Array.from(groupedByExercise.values()).sort((left, right) => {
+    const leftSectionIndex =
+      left.section === null ? SECTION_ORDER.length : SECTION_ORDER.indexOf(left.section);
+    const rightSectionIndex =
+      right.section === null ? SECTION_ORDER.length : SECTION_ORDER.indexOf(right.section);
+
+    if (leftSectionIndex !== rightSectionIndex) {
+      return leftSectionIndex - rightSectionIndex;
+    }
+
+    if (left.orderIndex !== right.orderIndex) {
+      return left.orderIndex - right.orderIndex;
+    }
+
+    return left.exerciseName.localeCompare(right.exerciseName);
+  });
 };
 
 const buildSessionSetRows = (sessionId: string, sets: CreateWorkoutSessionInput['sets']) =>
@@ -621,7 +677,18 @@ export const findWorkoutSessionById = async (
     .where(eq(sessionSets.sessionId, id))
     .all();
 
-  return buildWorkoutSession(session, sets);
+  const uniqueExerciseIds = [...new Set(sets.map((set) => set.exerciseId))];
+  const exerciseNameRows =
+    uniqueExerciseIds.length === 0
+      ? []
+      : db
+          .select({ id: exercises.id, name: exercises.name })
+          .from(exercises)
+          .where(inArray(exercises.id, uniqueExerciseIds))
+          .all();
+  const exerciseNamesById = new Map(exerciseNameRows.map((row) => [row.id, row.name]));
+
+  return buildWorkoutSession(session, sets, exerciseNamesById);
 };
 
 export const updateWorkoutSession = async ({

--- a/apps/web/src/features/habits/api/habits.test.tsx
+++ b/apps/web/src/features/habits/api/habits.test.tsx
@@ -76,6 +76,11 @@ describe('habit api hooks', () => {
         active: true,
         createdAt: 1,
         updatedAt: 1,
+        todayEntry: {
+          completed: true,
+          isOverride: false,
+          value: 8,
+        },
       },
       {
         id: 'habit-archived',
@@ -94,8 +99,9 @@ describe('habit api hooks', () => {
         active: false,
         createdAt: 2,
         updatedAt: 2,
+        todayEntry: null,
       },
-    ];
+    ] as unknown as Habit[];
 
     mockedApiRequest.mockResolvedValueOnce(habits);
 
@@ -164,6 +170,47 @@ describe('habit api hooks', () => {
 
     await waitFor(() => {
       expect(queryClient.getQueryData<HabitEntry[]>(queryKey)).toEqual(initialEntries);
+    });
+  });
+
+  it('passes isOverride when toggling referential entries', async () => {
+    const queryClient = createAppQueryClient();
+    const wrapper = createWrapper(queryClient);
+    const serverEntry: HabitEntry = {
+      id: 'entry-3',
+      habitId: 'habit-3',
+      userId: 'user-1',
+      date: '2026-03-07',
+      completed: true,
+      value: null,
+      isOverride: true,
+      createdAt: 3,
+    };
+    mockedApiRequest.mockResolvedValueOnce(serverEntry);
+
+    const { result } = renderHook(() => useToggleHabit(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate({
+        habitId: 'habit-3',
+        date: '2026-03-07',
+        completed: true,
+        isOverride: true,
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockedApiRequest).toHaveBeenCalledWith(
+        '/api/v1/habits/habit-3/entries',
+        expect.objectContaining({
+          body: expect.objectContaining({
+            completed: true,
+            date: '2026-03-07',
+            isOverride: true,
+          }),
+          method: 'POST',
+        }),
+      );
     });
   });
 

--- a/apps/web/src/features/habits/api/habits.ts
+++ b/apps/web/src/features/habits/api/habits.ts
@@ -18,7 +18,15 @@ import { apiRequest } from '@/lib/api-client';
 
 import { habitKeys } from './keys';
 
-const habitsSchema = z.array(habitSchema);
+const resolvedTodayEntrySchema = z.object({
+  completed: z.boolean(),
+  value: z.number().nullable(),
+  isOverride: z.boolean(),
+});
+const habitWithTodayEntrySchema = habitSchema.extend({
+  todayEntry: resolvedTodayEntrySchema.nullable().optional(),
+});
+const habitsWithTodayEntrySchema = z.array(habitWithTodayEntrySchema);
 const habitEntriesSchema = z.array(habitEntrySchema);
 const habitEntriesKeyPrefix = [...habitKeys.all, 'entries'] as const;
 const successSchema = z.object({
@@ -36,6 +44,7 @@ type ToggleHabitVariables = {
   completed: boolean;
   entryId?: string | null;
   value?: number;
+  isOverride?: boolean;
 };
 
 type UpdateHabitEntryVariables = {
@@ -44,6 +53,7 @@ type UpdateHabitEntryVariables = {
   date: string;
   completed?: boolean;
   value?: number;
+  isOverride?: boolean;
 };
 
 type HabitEntryQuerySnapshot = Array<readonly [QueryKey, HabitEntry[] | undefined]>;
@@ -179,7 +189,7 @@ export function useHabits() {
         signal,
       });
 
-      return habitsSchema.parse(habits).filter((habit) => habit.active);
+      return habitsWithTodayEntrySchema.parse(habits).filter((habit) => habit.active);
     },
     queryKey: habitKeys.list(),
   });
@@ -323,11 +333,12 @@ export function useToggleHabit() {
   const queryClient = useQueryClient();
 
   return useMutation<HabitEntry, Error, ToggleHabitVariables, MutationContext>({
-    mutationFn: async ({ habitId, date, completed, value }) => {
+    mutationFn: async ({ habitId, date, completed, value, isOverride }) => {
       const entry = await apiRequest<HabitEntry>(`/api/v1/habits/${habitId}/entries`, {
         body: {
           completed,
           ...(value === undefined ? {} : { value }),
+          ...(isOverride === undefined ? {} : { isOverride }),
           date,
         },
         method: 'POST',
@@ -346,6 +357,7 @@ export function useToggleHabit() {
         date: variables.date,
         completed: variables.completed,
         value: variables.value ?? null,
+        isOverride: variables.isOverride ?? false,
         createdAt: Date.now(),
       };
 
@@ -376,11 +388,12 @@ export function useUpdateHabitEntry() {
   const queryClient = useQueryClient();
 
   return useMutation<HabitEntry, Error, UpdateHabitEntryVariables, MutationContext>({
-    mutationFn: async ({ id, completed, value }) => {
+    mutationFn: async ({ id, completed, value, isOverride }) => {
       const entry = await apiRequest<HabitEntry>(`/api/v1/habit-entries/${id}`, {
         body: {
           ...(completed === undefined ? {} : { completed }),
           ...(value === undefined ? {} : { value }),
+          ...(isOverride === undefined ? {} : { isOverride }),
         },
         method: 'PATCH',
       });
@@ -399,6 +412,7 @@ export function useUpdateHabitEntry() {
         date: variables.date,
         completed: variables.completed ?? existingEntry?.completed ?? false,
         value: variables.value ?? existingEntry?.value ?? null,
+        isOverride: variables.isOverride ?? existingEntry?.isOverride ?? false,
         createdAt: existingEntry?.createdAt ?? Date.now(),
       };
 

--- a/apps/web/src/features/habits/components/daily-habits.test.tsx
+++ b/apps/web/src/features/habits/components/daily-habits.test.tsx
@@ -1,5 +1,6 @@
 import type { Habit, HabitEntry } from '@pulse/shared';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { toast } from 'sonner';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -24,6 +25,9 @@ vi.mock('@/features/habits/api/habits', () => ({
   useUpdateHabit: vi.fn(),
   useUpdateHabitEntry: vi.fn(),
 }));
+vi.mock('sonner', () => ({
+  toast: vi.fn(),
+}));
 
 const mockedUseCreateHabit = vi.mocked(useCreateHabit);
 const mockedUseDeleteHabit = vi.mocked(useDeleteHabit);
@@ -33,6 +37,7 @@ const mockedUseReorderHabits = vi.mocked(useReorderHabits);
 const mockedUseToggleHabit = vi.mocked(useToggleHabit);
 const mockedUseUpdateHabit = vi.mocked(useUpdateHabit);
 const mockedUseUpdateHabitEntry = vi.mocked(useUpdateHabitEntry);
+const mockedToast = vi.mocked(toast);
 
 function createMutationMock() {
   return {
@@ -221,6 +226,107 @@ describe('DailyHabits', () => {
       habitId: 'hydrate',
       id: 'entry-hydrate',
       value: 9,
+    });
+  });
+
+  it('shows referential auto-managed state and creates manual override on toggle', () => {
+    const toggleMutation = createMutationMock();
+    mockedUseToggleHabit.mockReturnValue(toggleMutation as unknown as ReturnType<typeof useToggleHabit>);
+    mockedUseHabits.mockReturnValue({
+      data: [
+        {
+          ...habits[0],
+          id: 'weight-link',
+          name: 'Weight linked',
+          trackingType: 'boolean',
+          target: null,
+          unit: null,
+          referenceSource: 'weight',
+          referenceConfig: { condition: 'exists_today' },
+          todayEntry: { completed: true, value: null, isOverride: false },
+        },
+      ],
+      error: null,
+      isError: false,
+      isLoading: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useHabits>);
+    mockedUseHabitEntries.mockReturnValue({
+      data: [],
+      error: null,
+      isError: false,
+      isLoading: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useHabitEntries>);
+
+    render(<DailyHabits selectedDate={new Date('2026-03-10T00:00:00')} />);
+
+    expect(screen.getByText('Auto: weight logged today')).toBeInTheDocument();
+    const checkbox = screen.getByRole('checkbox', { name: 'Weight linked' });
+    expect(checkbox).toHaveClass('opacity-45');
+
+    fireEvent.click(checkbox);
+
+    expect(mockedToast).toHaveBeenCalledWith(
+      'Manual override - this will override auto-tracking for today',
+    );
+    expect(toggleMutation.mutate).toHaveBeenCalledWith({
+      completed: true,
+      date: '2026-03-10',
+      entryId: null,
+      habitId: 'weight-link',
+      isOverride: true,
+    });
+  });
+
+  it('shows reset action for referential override entries', () => {
+    const updateMutation = createMutationMock();
+    mockedUseUpdateHabitEntry.mockReturnValue(
+      updateMutation as unknown as ReturnType<typeof useUpdateHabitEntry>,
+    );
+    mockedUseHabits.mockReturnValue({
+      data: [
+        {
+          ...habits[0],
+          id: 'protein-link',
+          name: 'Protein auto',
+          referenceSource: 'nutrition_daily',
+          referenceConfig: { field: 'protein', op: 'gte', value: 150 },
+          todayEntry: { completed: true, value: 160, isOverride: true },
+        },
+      ],
+      error: null,
+      isError: false,
+      isLoading: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useHabits>);
+    mockedUseHabitEntries.mockReturnValue({
+      data: [
+        {
+          completed: true,
+          createdAt: 1,
+          date: '2026-03-10',
+          habitId: 'protein-link',
+          id: 'entry-protein-link',
+          isOverride: true,
+          userId: 'user-1',
+          value: 160,
+        },
+      ],
+      error: null,
+      isError: false,
+      isLoading: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useHabitEntries>);
+
+    render(<DailyHabits selectedDate={new Date('2026-03-10T00:00:00')} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Reset to auto' }));
+
+    expect(updateMutation.mutate).toHaveBeenCalledWith({
+      date: '2026-03-10',
+      habitId: 'protein-link',
+      id: 'entry-protein-link',
+      isOverride: false,
     });
   });
 });

--- a/apps/web/src/features/habits/components/daily-habits.tsx
+++ b/apps/web/src/features/habits/components/daily-habits.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
-import { CheckCheck, Plus } from 'lucide-react';
-import type { Habit, HabitEntry } from '@pulse/shared';
+import { CheckCheck, Link2, Plus } from 'lucide-react';
+import type { Habit, HabitEntry, ReferenceConfig, ReferenceSource } from '@pulse/shared';
+import { toast } from 'sonner';
 
 import { HabitRowSkeleton } from '@/components/skeletons';
 import { Button } from '@/components/ui/button';
@@ -29,6 +30,16 @@ import { HabitCardMenu } from './habit-card-menu';
 import { HabitFormDialog } from './habit-form-dialog';
 
 type HabitValue = boolean | number | null;
+type ResolvedTodayEntry = {
+  completed: boolean;
+  isOverride: boolean;
+  value: number | null;
+};
+
+type HabitWithTodayEntry = Habit & {
+  todayEntry?: ResolvedTodayEntry | null;
+};
+
 type DailyHabitsProps = {
   selectedDate?: Date;
 };
@@ -36,7 +47,10 @@ type DailyHabitsProps = {
 export type DailyHabit = HabitConfig & {
   sourceHabit: Habit;
   entryId: string | null;
+  isOverride: boolean;
+  isReferential: boolean;
   todayValue: HabitValue;
+  autoText: string | null;
 };
 
 const todayFormatter = new Intl.DateTimeFormat('en-US', {
@@ -173,13 +187,78 @@ function parseInputValue(rawValue: string) {
   return Number.isFinite(numericValue) ? numericValue : null;
 }
 
-function buildDailyHabits(habits: Habit[], entries: HabitEntry[]): DailyHabit[] {
+function getOperatorLabel(operator: string) {
+  if (operator === 'gte') {
+    return '>=';
+  }
+  if (operator === 'lte') {
+    return '<=';
+  }
+  if (operator === 'eq') {
+    return '=';
+  }
+
+  return operator;
+}
+
+function getReferentialAutoText(
+  source: Exclude<ReferenceSource, null>,
+  config: Exclude<ReferenceConfig, null>,
+): string {
+  if (source === 'weight') {
+    return 'Auto: weight logged today';
+  }
+
+  if (source === 'workout') {
+    return 'Auto: workout completed today';
+  }
+
+  if (
+    source === 'nutrition_daily' &&
+    config !== null &&
+    'field' in config &&
+    'op' in config &&
+    'value' in config
+  ) {
+    const fieldLabel = config.field === 'calories' ? 'calories' : `${config.field}g`;
+    return `Auto: ${fieldLabel} ${getOperatorLabel(config.op)} ${formatNumber(config.value)}`;
+  }
+
+  if (
+    source === 'nutrition_meal' &&
+    config !== null &&
+    'mealType' in config &&
+    'field' in config &&
+    'op' in config &&
+    'value' in config
+  ) {
+    return `Auto: ${config.mealType} ${config.field} ${getOperatorLabel(config.op)} ${formatNumber(config.value)}`;
+  }
+
+  return 'Auto: linked data source';
+}
+
+function buildDailyHabits(
+  habits: HabitWithTodayEntry[],
+  entries: HabitEntry[],
+  isSelectedDateToday: boolean,
+): DailyHabit[] {
   const entryByHabitId = new Map(entries.map((entry) => [entry.habitId, entry]));
 
   return habits.map((habit) => {
     const entry = entryByHabitId.get(habit.id);
+    const isReferential = habit.referenceSource !== null && habit.referenceSource !== undefined;
+    const useTodayEntry =
+      isSelectedDateToday &&
+      isReferential &&
+      habit.todayEntry !== undefined &&
+      habit.todayEntry !== null &&
+      (entry?.isOverride ?? false) !== true;
+    const effectiveBooleanValue =
+      useTodayEntry ? habit.todayEntry?.completed : (entry?.completed ?? false);
+    const effectiveNumericValue = useTodayEntry ? habit.todayEntry?.value : (entry?.value ?? null);
     const todayValue: HabitValue =
-      habit.trackingType === 'boolean' ? (entry?.completed ?? false) : (entry?.value ?? null);
+      habit.trackingType === 'boolean' ? (effectiveBooleanValue ?? false) : (effectiveNumericValue ?? null);
 
     return {
       id: habit.id,
@@ -190,7 +269,13 @@ function buildDailyHabits(habits: Habit[], entries: HabitEntry[]): DailyHabit[] 
       unit: habit.unit,
       sourceHabit: habit,
       entryId: entry?.id ?? null,
+      isOverride: entry?.isOverride === true || (useTodayEntry && habit.todayEntry?.isOverride === true),
+      isReferential,
       todayValue,
+      autoText:
+        habit.referenceSource != null && habit.referenceConfig != null
+          ? getReferentialAutoText(habit.referenceSource, habit.referenceConfig)
+          : null,
     };
   });
 }
@@ -281,9 +366,10 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
     ? activeHabits.find((habit) => habit.id === editingHabitId)
     : undefined;
 
-  const dailyHabits = useMemo(
-    () => buildDailyHabits(activeHabits, habitEntriesQuery.data ?? []),
-    [activeHabits, habitEntriesQuery.data],
+  const dailyHabits = buildDailyHabits(
+    activeHabits,
+    habitEntriesQuery.data ?? [],
+    isSelectedDateToday,
   );
 
   const completedCount = dailyHabits.filter((habit) =>
@@ -323,6 +409,11 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
     }
 
     const completed = getHabitCompletion(habit, nextValue);
+    const shouldCreateOverride = habit.isReferential && !habit.isOverride;
+
+    if (shouldCreateOverride) {
+      toast('Manual override - this will override auto-tracking for today');
+    }
 
     if (habit.entryId && nextValue !== null) {
       updateHabitEntryMutation.mutate({
@@ -331,6 +422,7 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
         date: activeDateKey,
         completed,
         value: nextValue,
+        ...(habit.isReferential ? { isOverride: true } : {}),
       });
       return;
     }
@@ -340,6 +432,7 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
       entryId: habit.entryId,
       date: activeDateKey,
       completed,
+      ...(habit.isReferential ? { isOverride: true } : {}),
       ...(nextValue === null ? {} : { value: nextValue }),
     });
   };
@@ -446,6 +539,9 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
               const isSavingToggle =
                 toggleHabitMutation.isPending &&
                 toggleHabitMutation.variables?.habitId === habit.id;
+              const isAutoManaged = habit.isReferential && !habit.isOverride;
+              const canResetToAuto =
+                habit.isReferential && habit.isOverride && habit.entryId !== null;
 
               return (
                 <Card
@@ -482,6 +578,14 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
                         >
                           {habit.name}
                         </CardTitle>
+                        {habit.isReferential ? (
+                          <span
+                            className="inline-flex items-center text-muted-foreground"
+                            title="Auto-managed from linked data"
+                          >
+                            <Link2 className="size-3.5" />
+                          </span>
+                        ) : null}
                         {frequencySummary ? (
                           <span className="hidden shrink-0 text-[11px] font-medium uppercase tracking-wider opacity-50 sm:inline">
                             {frequencySummary}
@@ -491,6 +595,11 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
                       {habit.sourceHabit.description ? (
                         <p className="mt-0.5 truncate text-xs italic opacity-55 dark:text-muted-foreground">
                           {habit.sourceHabit.description}
+                        </p>
+                      ) : null}
+                      {habit.autoText ? (
+                        <p className="mt-0.5 truncate text-xs text-muted-foreground/85">
+                          {habit.autoText}
                         </p>
                       ) : null}
                     </div>
@@ -535,21 +644,33 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
                           id={`habit-${habit.id}`}
                           aria-label={habit.name}
                           checked={value === true}
-                          className="size-5 border-border bg-white dark:bg-background"
+                          className={cn(
+                            'size-5 border-border bg-white dark:bg-background',
+                            isAutoManaged && 'opacity-45',
+                          )}
                           disabled={isSavingToggle}
                           onCheckedChange={(checked) => {
+                            const isManualOverride = habit.isReferential && !habit.isOverride;
+
+                            if (isManualOverride) {
+                              toast('Manual override - this will override auto-tracking for today');
+                            }
+
                             toggleHabitMutation.mutate({
                               habitId: habit.id,
                               entryId: habit.entryId,
                               date: activeDateKey,
                               completed: checked === true,
+                              ...(habit.isReferential ? { isOverride: true } : {}),
                             });
                           }}
                         />
                         <span className="text-sm text-foreground/70 dark:text-muted-foreground">
-                          {value === true
-                            ? 'Completed'
-                            : `Tap to complete${isSelectedDateToday ? '' : ' for this day'}`}
+                          {isAutoManaged
+                            ? 'Auto-tracked - tap to override'
+                            : value === true
+                              ? 'Completed'
+                              : `Tap to complete${isSelectedDateToday ? '' : ' for this day'}`}
                         </span>
                       </label>
                     ) : (
@@ -558,7 +679,10 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
                           <Input
                             id={`habit-${habit.id}`}
                             aria-label={habit.name}
-                            className="h-9 w-24 shrink-0 border-border bg-white/75 text-center text-base font-semibold text-foreground placeholder:text-muted focus-visible:border-ring focus-visible:ring-ring/20 dark:bg-background"
+                            className={cn(
+                              'h-9 w-24 shrink-0 border-border bg-white/75 text-center text-base font-semibold text-foreground placeholder:text-muted focus-visible:border-ring focus-visible:ring-ring/20 dark:bg-background',
+                              isAutoManaged && 'opacity-55',
+                            )}
                             disabled={isSavingValue || isSavingToggle}
                             inputMode="decimal"
                             min="0"
@@ -607,8 +731,39 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
                             />
                           </div>
                         ) : null}
+
+                        {isAutoManaged ? (
+                          <p className="text-xs text-muted-foreground">
+                            Auto-tracked from linked data. Enter a value to override.
+                          </p>
+                        ) : null}
                       </div>
                     )}
+
+                    {canResetToAuto ? (
+                      <div className="mt-2">
+                        <Button
+                          className="h-auto px-0 text-xs"
+                          disabled={isSavingValue || isSavingToggle}
+                          onClick={() => {
+                            if (!habit.entryId) {
+                              return;
+                            }
+
+                            updateHabitEntryMutation.mutate({
+                              id: habit.entryId,
+                              habitId: habit.id,
+                              date: activeDateKey,
+                              isOverride: false,
+                            });
+                          }}
+                          type="button"
+                          variant="link"
+                        >
+                          Reset to auto
+                        </Button>
+                      </div>
+                    ) : null}
                   </div>
                 </Card>
               );

--- a/apps/web/src/features/habits/components/habit-history.test.tsx
+++ b/apps/web/src/features/habits/components/habit-history.test.tsx
@@ -31,6 +31,8 @@ const habits: Habit[] = [
     frequencyTarget: null,
     scheduledDays: null,
     pausedUntil: null,
+    referenceSource: 'weight',
+    referenceConfig: { condition: 'exists_today' },
     updatedAt: 1,
     userId: 'user-1',
   },
@@ -49,6 +51,8 @@ const habits: Habit[] = [
     frequencyTarget: null,
     scheduledDays: [1],
     pausedUntil: null,
+    referenceSource: null,
+    referenceConfig: null,
     updatedAt: 2,
     userId: 'user-1',
   },
@@ -67,6 +71,8 @@ const habits: Habit[] = [
     frequencyTarget: null,
     scheduledDays: null,
     pausedUntil: null,
+    referenceSource: null,
+    referenceConfig: null,
     updatedAt: 3,
     userId: 'user-1',
   },
@@ -79,6 +85,7 @@ const entries: HabitEntry[] = [
     date: '2026-03-10',
     habitId: 'hydrate',
     id: 'entry-hydrate',
+    isOverride: true,
     userId: 'user-1',
     value: 5,
   },
@@ -88,6 +95,7 @@ const entries: HabitEntry[] = [
     date: '2026-03-10',
     habitId: 'mobility',
     id: 'entry-mobility',
+    isOverride: false,
     userId: 'user-1',
     value: null,
   },
@@ -143,10 +151,11 @@ describe('HabitHistory', () => {
     );
 
     const hydrateToday = screen.getByRole('button', {
-      name: 'Hydrate: Mar 10 - 5/10 glasses',
+      name: 'Hydrate: Mar 10 - 5/10 glasses (manual override)',
     });
 
     expect(hydrateToday).toHaveAttribute('data-percent', '50');
+    expect(hydrateToday).toHaveClass('ring-amber-500/70');
     expect(hydrateToday.getAttribute('style')).toContain(
       'background-color: color-mix(in srgb, #10b981 50%, var(--color-border));',
     );

--- a/apps/web/src/features/habits/components/habit-history.tsx
+++ b/apps/web/src/features/habits/components/habit-history.tsx
@@ -28,6 +28,7 @@ type HabitHistoryEntry = {
   date: Date;
   dateKey: string;
   isComplete: boolean;
+  isOverride: boolean;
   isScheduled: boolean;
   tooltipLabel: string;
 };
@@ -80,14 +81,17 @@ function getTooltipLabel(
   }
 
   if (habit.trackingType === 'boolean') {
-    return `${formattedDate} - ${entry?.completed === true ? 'Completed' : 'Not completed'}`;
+    const status = entry?.completed === true ? 'Completed' : 'Not completed';
+    const suffix = habit.referenceSource != null && entry?.isOverride ? ' (manual override)' : '';
+    return `${formattedDate} - ${status}${suffix}`;
   }
 
   if (typeof entry?.value !== 'number') {
     return `${formattedDate} - No entry`;
   }
 
-  return `${formattedDate} - ${formatNumber(entry.value)}/${formatNumber(habit.target ?? 0)} ${habit.unit}`;
+  const suffix = habit.referenceSource != null && entry.isOverride ? ' (manual override)' : '';
+  return `${formattedDate} - ${formatNumber(entry.value)}/${formatNumber(habit.target ?? 0)} ${habit.unit}${suffix}`;
 }
 
 function getCurrentStreakCount(history: HabitHistoryEntry[]) {
@@ -147,6 +151,7 @@ function buildHabitHistoryRows(habits: Habit[], entries: HabitEntry[], dates: Da
         date,
         dateKey,
         isComplete: isScheduled && matchingEntry?.completed === true,
+        isOverride: matchingEntry?.isOverride === true,
         isScheduled,
         tooltipLabel: getTooltipLabel(habit, date, matchingEntry, isScheduled),
       };
@@ -172,6 +177,8 @@ function getProgressCellColor(percent: number) {
 }
 
 function getCellPresentation(habit: Habit, entry: HabitHistoryEntry) {
+  const hasOverrideAccent = habit.referenceSource != null && entry.isOverride;
+
   if (!entry.isScheduled) {
     return {
       className:
@@ -182,15 +189,21 @@ function getCellPresentation(habit: Habit, entry: HabitHistoryEntry) {
 
   if (habit.trackingType === 'boolean') {
     return {
-      className: entry.isComplete
-        ? 'border-emerald-700/20 bg-emerald-500'
-        : 'border-slate-400/50 bg-slate-300/70 dark:border-slate-600/60 dark:bg-slate-600/45',
+      className: cn(
+        entry.isComplete
+          ? 'border-emerald-700/20 bg-emerald-500'
+          : 'border-slate-400/50 bg-slate-300/70 dark:border-slate-600/60 dark:bg-slate-600/45',
+        hasOverrideAccent && 'ring-1 ring-amber-500/70 ring-offset-0',
+      ),
       style: undefined,
     };
   }
 
   return {
-    className: 'border-black/5 dark:border-white/10',
+    className: cn(
+      'border-black/5 dark:border-white/10',
+      hasOverrideAccent && 'ring-1 ring-amber-500/70 ring-offset-0',
+    ),
     style: {
       backgroundColor: getProgressCellColor(entry.completionPercent),
     } satisfies CSSProperties,

--- a/apps/web/src/hooks/use-workout-session.ts
+++ b/apps/web/src/hooks/use-workout-session.ts
@@ -131,11 +131,20 @@ async function syncSessionMutationCache(
   ]);
 }
 
-export function useWorkoutSession(sessionId: string | null | undefined) {
+type UseWorkoutSessionOptions = {
+  refetchInterval?: number | false;
+};
+
+export function useWorkoutSession(
+  sessionId: string | null | undefined,
+  options?: UseWorkoutSessionOptions,
+) {
   const normalizedSessionId = sessionId?.trim() ?? '';
 
   return useQuery<WorkoutSession>({
     enabled: normalizedSessionId.length > 0,
+    refetchInterval: options?.refetchInterval,
+    refetchIntervalInBackground: options?.refetchInterval !== undefined,
     queryFn: () => getWorkoutSession(normalizedSessionId),
     queryKey: workoutSessionQueryKeys.detail(normalizedSessionId),
   });

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, screen, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast } from 'sonner';
 
 import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
 import { renderWithQueryClient } from '@/test/render-with-query-client';
@@ -10,8 +11,24 @@ import { ACTIVE_WORKOUT_SESSION_STORAGE_KEY } from '@/features/workouts/lib/sess
 
 import { ActiveWorkoutPage } from './active-workout';
 
+vi.mock('sonner', () => {
+  const toastMock = vi.fn() as ReturnType<typeof vi.fn> & {
+    success: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+  toastMock.success = vi.fn();
+  toastMock.error = vi.fn();
+
+  return {
+    toast: toastMock,
+  };
+});
+
 describe('ActiveWorkoutPage', () => {
   beforeEach(() => {
+    vi.mocked(toast).mockClear();
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.error).mockClear();
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-06T12:00:00.000Z'));
     vi.stubEnv('VITE_PULSE_DEV_USERNAME', 'dev-user');
@@ -242,6 +259,167 @@ describe('ActiveWorkoutPage', () => {
     renderActiveWorkoutPage('/workouts/active?template=upper-push');
 
     expect(screen.getByText('00:00')).toBeInTheDocument();
+  });
+
+  it('polls for agent session updates and preserves in-progress inputs', async () => {
+    const sessionId = 'session-polling-1';
+    const fetchMock = vi.fn();
+    const baseStartedAt = Date.parse('2026-03-06T12:00:00.000Z');
+    let currentSession = {
+      id: sessionId,
+      userId: 'user-1',
+      templateId: 'upper-push',
+      name: 'Upper Push',
+      date: '2026-03-06',
+      status: 'in-progress' as const,
+      startedAt: baseStartedAt,
+      completedAt: null,
+      duration: null,
+      timeSegments: [{ start: '2026-03-06T12:00:00.000Z', end: null }],
+      feedback: null,
+      notes: null,
+      sets: [
+        {
+          id: 'set-1',
+          exerciseId: 'incline-dumbbell-press',
+          orderIndex: 0,
+          setNumber: 1,
+          weight: null,
+          reps: null,
+          completed: false,
+          skipped: false,
+          section: 'main' as const,
+          notes: null,
+          createdAt: baseStartedAt,
+        },
+      ],
+      exercises: [
+        {
+          exerciseId: 'incline-dumbbell-press',
+          exerciseName: 'Incline Dumbbell Press',
+          orderIndex: 0,
+          section: 'main' as const,
+          sets: [
+            {
+              id: 'set-1',
+              exerciseId: 'incline-dumbbell-press',
+              orderIndex: 0,
+              setNumber: 1,
+              weight: null,
+              reps: null,
+              completed: false,
+              skipped: false,
+              section: 'main' as const,
+              notes: null,
+              createdAt: baseStartedAt,
+            },
+          ],
+        },
+      ],
+      createdAt: baseStartedAt,
+      updatedAt: baseStartedAt,
+    };
+
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.endsWith('/api/v1/auth/register')) {
+        return Promise.resolve(jsonResponse({ data: { token: 'dev-generated-token' } }));
+      }
+
+      if (url.includes('/api/v1/workout-sessions?status=in-progress&status=paused')) {
+        return Promise.resolve(
+          jsonResponse({
+            data: [buildWorkoutSessionListItem({ id: sessionId, exerciseCount: 1 })],
+          }),
+        );
+      }
+
+      if (
+        url.endsWith(`/api/v1/workout-sessions/${sessionId}`) &&
+        (!init?.method || init.method === 'GET')
+      ) {
+        return Promise.resolve(jsonResponse({ data: currentSession }));
+      }
+
+      if (url.includes('/api/v1/workout-sessions/') && init?.method === 'PATCH') {
+        return Promise.resolve(jsonResponse({ data: currentSession }));
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch request: ${url}`));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderActiveWorkoutPage(`/workouts/active?sessionId=${sessionId}`);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+
+    const firstExerciseCard = screen.getByRole('heading', {
+      level: 3,
+      name: 'Incline Dumbbell Press',
+    });
+    expect(firstExerciseCard).toBeInTheDocument();
+
+    const inclineCard = getExerciseCard('Incline Dumbbell Press');
+    fireEvent.change(within(inclineCard).getByLabelText('Reps for set 1'), {
+      target: { value: '9' },
+    });
+
+    currentSession = {
+      ...currentSession,
+      sets: [
+        ...currentSession.sets,
+        {
+          id: 'set-2',
+          exerciseId: 'seated-dumbbell-shoulder-press',
+          orderIndex: 1,
+          setNumber: 1,
+          weight: null,
+          reps: null,
+          completed: false,
+          skipped: false,
+          section: 'main',
+          notes: null,
+          createdAt: baseStartedAt + 1,
+        },
+      ],
+      exercises: [
+        ...currentSession.exercises,
+        {
+          exerciseId: 'seated-dumbbell-shoulder-press',
+          exerciseName: 'Seated Dumbbell Shoulder Press',
+          orderIndex: 1,
+          section: 'main',
+          sets: [
+            {
+              id: 'set-2',
+              exerciseId: 'seated-dumbbell-shoulder-press',
+              orderIndex: 1,
+              setNumber: 1,
+              weight: null,
+              reps: null,
+              completed: false,
+              skipped: false,
+              section: 'main',
+              notes: null,
+              createdAt: baseStartedAt + 1,
+            },
+          ],
+        },
+      ],
+      updatedAt: baseStartedAt + 10_000,
+    };
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_200);
+    });
+
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Seated Dumbbell Shoulder Press' }),
+    ).toBeInTheDocument();
+    expect(within(getExerciseCard('Incline Dumbbell Press')).getByLabelText('Reps for set 1')).toHaveValue(9);
+    expect(vi.mocked(toast)).toHaveBeenCalledWith('Workout updated by agent');
   });
 
   it('pauses and resumes an active session timer using segmented duration', async () => {

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -165,8 +165,10 @@ export function ActiveWorkoutPage() {
     activeSessionsQuery.isSuccess &&
     activeSessions.length > 1;
   const showBackToSessionList = Boolean(requestedSessionId) && activeSessions.length > 1;
+  const [stage, setStage] = useState<'active' | 'feedback' | 'summary'>('active');
   const sessionQuery = useWorkoutSession(sessionId, {
-    refetchInterval: ACTIVE_WORKOUT_POLL_INTERVAL_MS,
+    refetchInterval:
+      stage === 'active' && sessionId != null ? ACTIVE_WORKOUT_POLL_INTERVAL_MS : false,
   });
   const { weightUnit } = useWeightUnit();
   const logSetMutation = useLogSet(sessionId);
@@ -202,7 +204,6 @@ export function ActiveWorkoutPage() {
   );
   const [exerciseNotes, setExerciseNotes] = useState<Record<string, string>>({});
   const [sessionCuesByExercise, setSessionCuesByExercise] = useState<Record<string, string[]>>({});
-  const [stage, setStage] = useState<'active' | 'feedback' | 'summary'>('active');
   const [sessionCompletedAt, setSessionCompletedAt] = useState<string | null>(null);
   const [sessionFeedback, setSessionFeedback] = useState<ActiveWorkoutFeedbackDraft>([]);
   const [sessionNotes, setSessionNotes] = useState('');
@@ -1413,6 +1414,8 @@ function mergeServerSetDrafts(
       }
 
       if (currentDraft.completed || serverSetDraft.completed) {
+        // Completed sets are server-authoritative; this may replace uncommitted local input if
+        // an external actor completed the set between poll intervals.
         return serverSetDraft;
       }
 

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { MoreVertical, Pause, Play } from 'lucide-react';
+import { toast } from 'sonner';
 import { z } from 'zod';
 
 import {
@@ -9,6 +10,7 @@ import {
   updateWorkoutSessionTimeSegmentsInputSchema,
   updateWorkoutSessionInputSchema,
   type ExerciseTrackingType,
+  type WorkoutSession as ApiWorkoutSession,
   type SessionSet,
   type WorkoutSessionTimeSegment,
   workoutSessionSchema,
@@ -130,6 +132,8 @@ type RestTimerState = {
   token: number;
 };
 
+const ACTIVE_WORKOUT_POLL_INTERVAL_MS = 10_000;
+
 export function ActiveWorkoutPage() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -161,7 +165,9 @@ export function ActiveWorkoutPage() {
     activeSessionsQuery.isSuccess &&
     activeSessions.length > 1;
   const showBackToSessionList = Boolean(requestedSessionId) && activeSessions.length > 1;
-  const sessionQuery = useWorkoutSession(sessionId);
+  const sessionQuery = useWorkoutSession(sessionId, {
+    refetchInterval: ACTIVE_WORKOUT_POLL_INTERVAL_MS,
+  });
   const { weightUnit } = useWeightUnit();
   const logSetMutation = useLogSet(sessionId);
   const updateSetMutation = useUpdateSet(sessionId);
@@ -179,7 +185,12 @@ export function ActiveWorkoutPage() {
     () => (templateQuery.data ? toMockWorkoutTemplate(templateQuery.data) : null),
     [templateQuery.data],
   );
-  const template = apiTemplate ?? selectedMockTemplate ?? defaultTemplate;
+  const fallbackTemplate = apiTemplate ?? selectedMockTemplate ?? defaultTemplate;
+  const activeSession = sessionQuery.data;
+  const template = useMemo(
+    () => buildTemplateFromSession(activeSession, fallbackTemplate),
+    [activeSession, fallbackTemplate],
+  );
 
   const [fallbackStartTime] = useState(() => new Date().toISOString());
   const [startTimeOverride, setStartTimeOverride] = useState<string | null>(null);
@@ -210,9 +221,10 @@ export function ActiveWorkoutPage() {
   const restTimerTokenRef = useRef(0);
   const hydratedSessionIdRef = useRef<string | null>(null);
   const hydratedDraftKeyRef = useRef<string | null>(null);
+  const lastServerUpdateRef = useRef<number | null>(null);
+  const lastSessionStructureRef = useRef<string | null>(null);
   const supplementalExercises = workoutSupplementalExercises;
 
-  const activeSession = sessionQuery.data;
   const activeSessionId = activeSession?.id ?? null;
   const activeSessionStatus = activeSession?.status ?? null;
   const isPaused = activeSessionStatus === 'paused';
@@ -259,33 +271,70 @@ export function ActiveWorkoutPage() {
       return;
     }
 
-    if (hydratedSessionIdRef.current === activeSession.id) {
-      return;
-    }
-
     const serverSetDrafts = createSessionSetDrafts(
       template,
       activeSession.sets,
       templateExerciseById,
     );
     const serverExerciseNotes = extractExerciseNotes(activeSession.sets);
-    const autosavedDraft = getStoredActiveWorkoutDraft(activeSession.id);
+    const serverExerciseOrder = buildExerciseOrderFromSessionSets(template, activeSession.sets);
+    const sessionStructureSignature = buildSessionStructureSignature(activeSession);
+    const isSessionSwitch = hydratedSessionIdRef.current !== activeSession.id;
+
+    if (!isSessionSwitch && lastServerUpdateRef.current === activeSession.updatedAt) {
+      return;
+    }
+
     const previousDraftKey = hydratedDraftKeyRef.current;
 
-    setSetDrafts(autosavedDraft?.setDrafts ?? serverSetDrafts);
-    setExerciseNotes(autosavedDraft?.exerciseNotes ?? serverExerciseNotes);
-    setSessionCuesByExercise(autosavedDraft?.sessionCuesByExercise ?? {});
-    setExerciseOrderBySection(buildExerciseOrderFromSessionSets(template, activeSession.sets));
-    hydratedSessionIdRef.current = activeSession.id;
-    hydratedDraftKeyRef.current = activeSession.id;
+    if (isSessionSwitch) {
+      const autosavedDraft = getStoredActiveWorkoutDraft(activeSession.id);
+      setSetDrafts(autosavedDraft?.setDrafts ?? serverSetDrafts);
+      setExerciseNotes(autosavedDraft?.exerciseNotes ?? serverExerciseNotes);
+      setSessionCuesByExercise(autosavedDraft?.sessionCuesByExercise ?? {});
+      setExerciseOrderBySection(serverExerciseOrder);
+      hydratedSessionIdRef.current = activeSession.id;
+      hydratedDraftKeyRef.current = activeSession.id;
 
-    if (previousDraftKey && previousDraftKey !== activeSession.id) {
-      clearStoredActiveWorkoutDraft(previousDraftKey);
+      if (previousDraftKey && previousDraftKey !== activeSession.id) {
+        clearStoredActiveWorkoutDraft(previousDraftKey);
+      }
+
+      if (template.id !== activeSession.id) {
+        clearStoredActiveWorkoutDraft(template.id);
+      }
+    } else {
+      setSetDrafts((current) => mergeServerSetDrafts(current, serverSetDrafts));
+      setExerciseOrderBySection(serverExerciseOrder);
+      setExerciseNotes((current) => {
+        const nextNotes: Record<string, string> = {};
+        const activeExerciseIds = new Set(activeSession.sets.map((set) => set.exerciseId));
+
+        for (const exerciseId of activeExerciseIds) {
+          const currentNote = current[exerciseId];
+          if (currentNote !== undefined) {
+            nextNotes[exerciseId] = currentNote;
+            continue;
+          }
+          const serverNote = serverExerciseNotes[exerciseId];
+          if (serverNote !== undefined) {
+            nextNotes[exerciseId] = serverNote;
+          }
+        }
+
+        return nextNotes;
+      });
+
+      if (
+        lastSessionStructureRef.current &&
+        lastSessionStructureRef.current !== sessionStructureSignature
+      ) {
+        toast('Workout updated by agent');
+      }
     }
 
-    if (template.id !== activeSession.id) {
-      clearStoredActiveWorkoutDraft(template.id);
-    }
+    lastServerUpdateRef.current = activeSession.updatedAt;
+    lastSessionStructureRef.current = sessionStructureSignature;
   }, [activeSession, template, templateExerciseById]);
 
   useEffect(() => {
@@ -300,7 +349,10 @@ export function ActiveWorkoutPage() {
     setExerciseNotes(autosavedDraft?.exerciseNotes ?? {});
     setSessionCuesByExercise(autosavedDraft?.sessionCuesByExercise ?? {});
     setExerciseOrderBySection(buildExerciseOrderFromTemplate(template));
+    hydratedSessionIdRef.current = null;
     hydratedDraftKeyRef.current = activeWorkoutDraftId;
+    lastServerUpdateRef.current = null;
+    lastSessionStructureRef.current = null;
   }, [activeSession, activeWorkoutDraftId, requestedTemplateId, sessionId, template]);
 
   useEffect(() => {
@@ -387,7 +439,7 @@ export function ActiveWorkoutPage() {
     );
   }
 
-  if (shouldLoadApiTemplate && templateQuery.isPending) {
+  if (shouldLoadApiTemplate && templateQuery.isPending && !activeSession) {
     return (
       <section className="space-y-3 pb-8">
         <h1 className="text-2xl font-semibold text-foreground">Loading workout template</h1>
@@ -405,7 +457,7 @@ export function ActiveWorkoutPage() {
     );
   }
 
-  if (shouldLoadApiTemplate && templateQuery.isError) {
+  if (shouldLoadApiTemplate && templateQuery.isError && !activeSession) {
     return (
       <section className="space-y-3 pb-8">
         <h1 className="text-2xl font-semibold text-foreground">Unable to load template</h1>
@@ -1344,6 +1396,63 @@ function createSessionSetDrafts(
   return drafts;
 }
 
+function mergeServerSetDrafts(
+  currentSetDrafts: ActiveWorkoutSetDrafts,
+  serverSetDrafts: ActiveWorkoutSetDrafts,
+) {
+  const nextDrafts: ActiveWorkoutSetDrafts = {};
+
+  for (const [exerciseId, serverExerciseDrafts] of Object.entries(serverSetDrafts)) {
+    const currentExerciseDrafts = currentSetDrafts[exerciseId] ?? [];
+
+    nextDrafts[exerciseId] = serverExerciseDrafts.map((serverSetDraft) => {
+      const currentDraft = currentExerciseDrafts.find((set) => set.number === serverSetDraft.number);
+
+      if (!currentDraft) {
+        return serverSetDraft;
+      }
+
+      if (currentDraft.completed || serverSetDraft.completed) {
+        return serverSetDraft;
+      }
+
+      return {
+        ...serverSetDraft,
+        distance: currentDraft.distance,
+        reps: currentDraft.reps,
+        seconds: currentDraft.seconds,
+        weight: currentDraft.weight,
+      };
+    });
+  }
+
+  return nextDrafts;
+}
+
+function buildSessionStructureSignature(session: ApiWorkoutSession) {
+  const sortedSets = [...session.sets].sort((left, right) => {
+    const leftSection = left.section ?? 'main';
+    const rightSection = right.section ?? 'main';
+    if (leftSection !== rightSection) {
+      return leftSection.localeCompare(rightSection);
+    }
+
+    if ((left.orderIndex ?? 0) !== (right.orderIndex ?? 0)) {
+      return (left.orderIndex ?? 0) - (right.orderIndex ?? 0);
+    }
+
+    if (left.exerciseId !== right.exerciseId) {
+      return left.exerciseId.localeCompare(right.exerciseId);
+    }
+
+    return left.setNumber - right.setNumber;
+  });
+
+  return sortedSets
+    .map((set) => `${set.section ?? 'main'}:${set.exerciseId}:${set.orderIndex ?? 0}:${set.setNumber}`)
+    .join('|');
+}
+
 function buildExerciseOrderFromTemplate(template: MockWorkoutTemplate): ExerciseOrderBySection {
   return {
     warmup:
@@ -1812,4 +1921,139 @@ function formatTemplateExerciseReps(repsMin: number | null, repsMax: number | nu
 function getDefaultExerciseBadges(exerciseId: string): MockWorkoutBadgeType[] {
   const categoryBadge = categoryBadgeByExerciseId.get(exerciseId);
   return categoryBadge ? [categoryBadge] : [];
+}
+
+function buildTemplateFromSession(
+  activeSession: ApiWorkoutSession | undefined,
+  fallbackTemplate: MockWorkoutTemplate,
+): MockWorkoutTemplate {
+  if (!activeSession) {
+    return fallbackTemplate;
+  }
+
+  const sectionOrder: WorkoutTemplateSectionType[] = ['warmup', 'main', 'cooldown'];
+  const fallbackExerciseById = new Map(
+    fallbackTemplate.sections.flatMap((section) =>
+      section.exercises.map((exercise) => [exercise.exerciseId, { exercise, section: section.type }]),
+    ),
+  );
+  const fallbackExerciseNameById = new Map(
+    fallbackTemplate.sections.flatMap((section) =>
+      section.exercises.map((exercise) => [exercise.exerciseId, exercise.exerciseName]),
+    ),
+  );
+  const sessionExercises =
+    activeSession.exercises && activeSession.exercises.length > 0
+      ? activeSession.exercises
+      : buildSessionExercisesFromSets(activeSession);
+  const sectionsByType = new Map<WorkoutTemplateSectionType, MockWorkoutTemplate['sections'][number]>(
+    sectionOrder.map((type) => [type, { type, title: sectionTitleByType[type], exercises: [] }]),
+  );
+
+  for (const sessionExercise of sessionExercises) {
+    const sectionType = sessionExercise.section ?? 'main';
+    const targetSection = sectionsByType.get(sectionType);
+    if (!targetSection) {
+      continue;
+    }
+
+    const fallbackExercise = fallbackExerciseById.get(sessionExercise.exerciseId)?.exercise;
+    const defaultReps = fallbackExercise?.reps ?? inferExerciseRepsFromSets(sessionExercise.sets);
+
+    targetSection.exercises.push({
+      exerciseId: sessionExercise.exerciseId,
+      exerciseName:
+        sessionExercise.exerciseName ||
+        fallbackExerciseNameById.get(sessionExercise.exerciseId) ||
+        'Unknown Exercise',
+      sets: Math.max(
+        fallbackExercise?.sets ?? 0,
+        sessionExercise.sets.reduce((maxValue, set) => Math.max(maxValue, set.setNumber), 0),
+      ),
+      reps: defaultReps,
+      tempo: fallbackExercise?.tempo ?? '2111',
+      restSeconds: fallbackExercise?.restSeconds ?? 60,
+      formCues: fallbackExercise?.formCues ?? [],
+      templateCues: fallbackExercise?.templateCues ?? [],
+      badges: fallbackExercise?.badges ?? getDefaultExerciseBadges(sessionExercise.exerciseId),
+    });
+  }
+
+  for (const section of sectionsByType.values()) {
+    section.exercises.sort((left, right) => {
+      const leftOrder = sessionExercises.find((exercise) => exercise.exerciseId === left.exerciseId)?.orderIndex;
+      const rightOrder = sessionExercises.find((exercise) => exercise.exerciseId === right.exerciseId)?.orderIndex;
+      if ((leftOrder ?? 0) !== (rightOrder ?? 0)) {
+        return (leftOrder ?? 0) - (rightOrder ?? 0);
+      }
+      return (left.exerciseName ?? '').localeCompare(right.exerciseName ?? '');
+    });
+  }
+
+  return {
+    ...fallbackTemplate,
+    id: activeSession.templateId ?? fallbackTemplate.id,
+    name: activeSession.name,
+    sections: sectionOrder
+      .map((type) => sectionsByType.get(type))
+      .filter((section): section is MockWorkoutTemplate['sections'][number] =>
+        Boolean(section && section.exercises.length > 0),
+      ),
+  };
+}
+
+function buildSessionExercisesFromSets(session: ApiWorkoutSession) {
+  const namesById = new Map(
+    session.sets.map((set) => [set.exerciseId, mockExerciseById.get(set.exerciseId)?.name ?? 'Unknown Exercise']),
+  );
+  const grouped = new Map<
+    string,
+    {
+      exerciseId: string;
+      exerciseName: string;
+      orderIndex: number;
+      section: WorkoutTemplateSectionType | null;
+      sets: SessionSet[];
+    }
+  >();
+
+  for (const set of session.sets) {
+    const existing = grouped.get(set.exerciseId);
+    if (existing) {
+      existing.orderIndex = Math.min(existing.orderIndex, set.orderIndex ?? 0);
+      existing.sets.push(set);
+      continue;
+    }
+
+    grouped.set(set.exerciseId, {
+      exerciseId: set.exerciseId,
+      exerciseName: namesById.get(set.exerciseId) ?? 'Unknown Exercise',
+      orderIndex: set.orderIndex ?? 0,
+      section: set.section,
+      sets: [set],
+    });
+  }
+
+  return Array.from(grouped.values()).sort((left, right) => {
+    const leftSection = left.section ?? 'main';
+    const rightSection = right.section ?? 'main';
+    if (leftSection !== rightSection) {
+      return leftSection.localeCompare(rightSection);
+    }
+
+    if (left.orderIndex !== right.orderIndex) {
+      return left.orderIndex - right.orderIndex;
+    }
+
+    return left.exerciseName.localeCompare(right.exerciseName);
+  });
+}
+
+function inferExerciseRepsFromSets(sets: SessionSet[]) {
+  const defaultReps = sets.find((set) => !set.completed && set.reps !== null)?.reps;
+  if (defaultReps !== undefined && defaultReps !== null) {
+    return String(defaultReps);
+  }
+
+  return '';
 }

--- a/docs/conventions/agent-integration.md
+++ b/docs/conventions/agent-integration.md
@@ -559,18 +559,20 @@ Response (`201`):
 
 #### `PATCH /api/agent/workout-sessions/:id`
 
-Updates session status/notes and upserts set logs by `exerciseName + setNumber`.
+Updates session status/notes, upserts set logs by `exerciseName + setNumber`, and supports
+mid-session structural edits.
 
 Request:
 
 ```json
 {
-  "status": "completed",
-  "notes": "Solid session",
+  "notes": "Agent adjusted plan mid-session",
   "sets": [
-    { "exerciseName": "Bench Press", "setNumber": 1, "weight": 105, "reps": 7 },
-    { "exerciseName": "Squat", "setNumber": 1, "weight": 225, "reps": 5 }
-  ]
+    { "exerciseName": "Bench Press", "setNumber": 1, "weight": 105, "reps": 7 }
+  ],
+  "addExercises": [{ "name": "Goblet Squat", "sets": 2, "reps": 10, "section": "main" }],
+  "removeExercises": ["exercise-unstarted-isolation"],
+  "reorderExercises": ["exercise-bench-press", "exercise-goblet-squat"]
 }
 ```
 
@@ -590,6 +592,22 @@ Response (`200`):
     "duration": 62,
     "feedback": null,
     "notes": "Solid session",
+    "exercises": [
+      {
+        "exerciseId": "exercise-bench-press",
+        "exerciseName": "Bench Press",
+        "orderIndex": 0,
+        "section": "main",
+        "sets": [{ "id": "set-1", "exerciseId": "exercise-bench-press", "setNumber": 1 }]
+      },
+      {
+        "exerciseId": "exercise-goblet-squat",
+        "exerciseName": "Goblet Squat",
+        "orderIndex": 1,
+        "section": "main",
+        "sets": [{ "id": "set-2", "exerciseId": "exercise-goblet-squat", "setNumber": 1 }]
+      }
+    ],
     "sets": [
       {
         "id": "set-1",
@@ -626,8 +644,12 @@ Behavior notes:
 
 - Unknown exercise names are auto-created.
 - Upserted sets are marked `completed: true`, `skipped: false`.
+- `addExercises` appends planned sets for the exercise (`completed: false`).
+- `removeExercises` is allowed only when that exercise has no completed sets.
+- `reorderExercises` updates exercise order while preserving set data.
 - Completing a session sets `completedAt` and duration.
 - `404 WORKOUT_SESSION_NOT_FOUND` if missing.
+- `409 WORKOUT_SESSION_EXERCISE_HAS_LOGGED_SETS` when removing an exercise that has logged sets.
 
 ### Daily Tracking
 

--- a/docs/conventions/data-models.md
+++ b/docs/conventions/data-models.md
@@ -86,6 +86,12 @@ Inherited ownership comes from foreign-key chains:
 - `trackingType`: `text`, required, one of `boolean | numeric | time`
 - `target`: nullable `real`
 - `unit`: nullable `text`
+- `frequency`: `text`, required, one of `daily | weekly | specific_days`
+- `frequencyTarget`: nullable `integer`
+- `scheduledDays`: nullable JSON text array of weekday integers `0..6`
+- `referenceSource`: nullable `text`, one of `weight | nutrition_daily | nutrition_meal | workout`
+- `referenceConfig`: nullable JSON text object (source-specific resolver config)
+- `pausedUntil`: nullable `text` calendar date (`YYYY-MM-DD`)
 - `sortOrder`: `integer`, required, default `0`
 - `active`: boolean-backed `integer`, required, default `true`
 - `deletedAt`: nullable `text` ISO timestamp for soft delete
@@ -104,6 +110,7 @@ Constraints:
 - `date`: `text`, required, `YYYY-MM-DD`, indexed
 - `completed`: boolean-backed `integer`, required, default `false`
 - `value`: nullable `real`
+- `isOverride`: boolean-backed `integer`, required, default `false`
 - `createdAt`: `integer` Unix ms, required, default now
 
 Constraints:

--- a/packages/shared/src/schemas/agent.test.ts
+++ b/packages/shared/src/schemas/agent.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  agentUpdateWorkoutSessionInputSchema,
   agentPatchExerciseInputSchema,
   agentCreateWorkoutTemplateInputSchema,
   type AgentCreateWorkoutTemplateInput,
@@ -54,6 +55,22 @@ describe('agentPatchExerciseInputSchema', () => {
 
     expect(payload).toEqual({
       name: 'Incline Dumbbell Press',
+    });
+  });
+});
+
+describe('agentUpdateWorkoutSessionInputSchema', () => {
+  it('accepts mid-session exercise mutations', () => {
+    const payload = agentUpdateWorkoutSessionInputSchema.parse({
+      addExercises: [{ name: 'Goblet Squat', sets: 2, reps: 10 }],
+      removeExercises: ['exercise-1'],
+      reorderExercises: ['exercise-2', 'exercise-1'],
+    });
+
+    expect(payload).toEqual({
+      addExercises: [{ name: 'Goblet Squat', sets: 2, reps: 10, section: 'main' }],
+      removeExercises: ['exercise-1'],
+      reorderExercises: ['exercise-2', 'exercise-1'],
     });
   });
 });

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -4,6 +4,7 @@ import { dateSchema } from './common.js';
 import { exerciseCategorySchema, exerciseTrackingTypeSchema } from './exercises.js';
 import { habitTrackingTypeSchema } from './habits.js';
 import { workoutSessionStatusSchema } from './workout-sessions.js';
+import { workoutTemplateSectionTypeSchema } from './workout-templates.js';
 
 const requiredText = (maxLength = 255) => z.string().trim().min(1).max(maxLength);
 
@@ -107,14 +108,31 @@ export const agentWorkoutSetUpsertInputSchema = z.object({
   reps: z.number().int().min(0).nullable(),
 });
 
+export const agentWorkoutSessionExerciseMutationSchema = z.object({
+  name: requiredText(),
+  sets: z.number().int().min(1).max(100),
+  reps: z.number().int().min(0).max(1000).nullable().optional(),
+  weight: z.number().min(0).nullable().optional(),
+  section: workoutTemplateSectionTypeSchema.optional().default('main'),
+});
+
 export const agentUpdateWorkoutSessionInputSchema = z
   .object({
     sets: z.array(agentWorkoutSetUpsertInputSchema).min(1).max(500).optional(),
+    addExercises: z.array(agentWorkoutSessionExerciseMutationSchema).min(1).max(100).optional(),
+    removeExercises: z.array(z.string().trim().min(1)).min(1).max(100).optional(),
+    reorderExercises: z.array(z.string().trim().min(1)).min(1).max(200).optional(),
     status: workoutSessionStatusSchema.optional(),
     notes: optionalText(4000),
   })
   .refine(
-    (value) => value.sets !== undefined || value.status !== undefined || value.notes !== undefined,
+    (value) =>
+      value.sets !== undefined ||
+      value.addExercises !== undefined ||
+      value.removeExercises !== undefined ||
+      value.reorderExercises !== undefined ||
+      value.status !== undefined ||
+      value.notes !== undefined,
     {
       message: 'At least one workout session field must be provided',
     },

--- a/packages/shared/src/schemas/habit-entries.test.ts
+++ b/packages/shared/src/schemas/habit-entries.test.ts
@@ -16,12 +16,14 @@ describe('createHabitEntryInputSchema', () => {
       date: '2026-03-07',
       completed: true,
       value: 8,
+      isOverride: true,
     });
 
     expect(payload).toEqual({
       date: '2026-03-07',
       completed: true,
       value: 8,
+      isOverride: true,
     });
   });
 
@@ -48,10 +50,12 @@ describe('updateHabitEntryInputSchema', () => {
   it('accepts partial updates', () => {
     const payload = updateHabitEntryInputSchema.parse({
       value: 45,
+      isOverride: false,
     });
 
     expect(payload).toEqual({
       value: 45,
+      isOverride: false,
     });
   });
 

--- a/packages/shared/src/schemas/habit-entries.test.ts
+++ b/packages/shared/src/schemas/habit-entries.test.ts
@@ -118,6 +118,7 @@ describe('habitEntrySchema', () => {
       date: '2026-03-07',
       completed: true,
       value: null,
+      isOverride: false,
       createdAt: 1_700_000_000_000,
     });
 
@@ -132,6 +133,7 @@ describe('habitEntrySchema', () => {
       date: '2026-03-07',
       completed: false,
       value: 30,
+      isOverride: false,
       createdAt: 1_700_000_000_000,
     };
 

--- a/packages/shared/src/schemas/habit-entries.ts
+++ b/packages/shared/src/schemas/habit-entries.ts
@@ -54,6 +54,7 @@ export const habitEntrySchema = z.object({
   date: dateSchema,
   completed: z.boolean(),
   value: z.number().nullable(),
+  isOverride: z.boolean().optional(),
   createdAt: z.number().int(),
 });
 

--- a/packages/shared/src/schemas/habit-entries.ts
+++ b/packages/shared/src/schemas/habit-entries.ts
@@ -14,12 +14,14 @@ export const createHabitEntryInputSchema = z.object({
   date: dateSchema,
   completed: z.boolean(),
   value: habitEntryValueSchema.optional(),
+  isOverride: z.boolean().optional(),
 });
 
 export const updateHabitEntryInputSchema = z
   .object({
     completed: z.boolean().optional(),
     value: habitEntryValueSchema.optional(),
+    isOverride: z.boolean().optional(),
   })
   .refine((value) => Object.keys(value).length > 0, {
     message: 'At least one field is required',

--- a/packages/shared/src/schemas/habits.test.ts
+++ b/packages/shared/src/schemas/habits.test.ts
@@ -129,6 +129,22 @@ describe('createHabitInputSchema', () => {
       }),
     ).toThrow();
   });
+
+  it('rejects nutrition_meal configs with unsupported macro fields', () => {
+    expect(() =>
+      createHabitInputSchema.parse({
+        name: 'Lunch protein',
+        trackingType: 'boolean',
+        referenceSource: 'nutrition_meal',
+        referenceConfig: {
+          mealType: 'Lunch',
+          field: 'sodium',
+          op: 'gte',
+          value: 40,
+        },
+      }),
+    ).toThrow();
+  });
 });
 
 describe('updateHabitInputSchema', () => {

--- a/packages/shared/src/schemas/habits.test.ts
+++ b/packages/shared/src/schemas/habits.test.ts
@@ -103,6 +103,32 @@ describe('createHabitInputSchema', () => {
       }),
     ).toThrow();
   });
+
+  it('accepts a referential habit with matching source config', () => {
+    const payload = createHabitInputSchema.parse({
+      name: 'Weigh in',
+      trackingType: 'boolean',
+      referenceSource: 'weight',
+      referenceConfig: { condition: 'exists_today' },
+    });
+
+    expect(payload.referenceSource).toBe('weight');
+  });
+
+  it('rejects a referential habit with mismatched source config', () => {
+    expect(() =>
+      createHabitInputSchema.parse({
+        name: 'Protein',
+        trackingType: 'boolean',
+        referenceSource: 'weight',
+        referenceConfig: {
+          field: 'protein',
+          op: 'gte',
+          value: 150,
+        },
+      }),
+    ).toThrow();
+  });
 });
 
 describe('updateHabitInputSchema', () => {
@@ -197,6 +223,8 @@ describe('habitSchema', () => {
       frequencyTarget: 3,
       scheduledDays: null,
       pausedUntil: null,
+      referenceSource: null,
+      referenceConfig: null,
       sortOrder: 0,
       active: true,
       createdAt: 1_700_000_000_000,
@@ -220,6 +248,8 @@ describe('habitSchema', () => {
       frequencyTarget: null,
       scheduledDays: null,
       pausedUntil: null,
+      referenceSource: null,
+      referenceConfig: null,
       sortOrder: 1,
       active: true,
       createdAt: 1_700_000_000_000,

--- a/packages/shared/src/schemas/habits.ts
+++ b/packages/shared/src/schemas/habits.ts
@@ -2,6 +2,39 @@ import { z } from 'zod';
 
 export const habitTrackingTypeSchema = z.enum(['boolean', 'numeric', 'time']);
 export const habitFrequencySchema = z.enum(['daily', 'weekly', 'specific_days']);
+export const referenceSourceSchema = z
+  .enum(['weight', 'nutrition_daily', 'nutrition_meal', 'workout'])
+  .nullable();
+
+const weightReferenceConfigSchema = z.object({
+  condition: z.literal('exists_today'),
+});
+
+const nutritionDailyReferenceConfigSchema = z.object({
+  field: z.enum(['protein', 'calories', 'carbs', 'fat']),
+  op: z.enum(['gte', 'lte', 'eq']),
+  value: z.number().finite(),
+});
+
+const nutritionMealReferenceConfigSchema = z.object({
+  mealType: z.string().trim().min(1).max(120),
+  field: z.string().trim().min(1).max(120),
+  op: z.string().trim().min(1).max(16),
+  value: z.number().finite(),
+});
+
+const workoutReferenceConfigSchema = z.object({
+  condition: z.literal('session_completed_today'),
+});
+
+export const referenceConfigSchema = z
+  .union([
+    weightReferenceConfigSchema,
+    nutritionDailyReferenceConfigSchema,
+    nutritionMealReferenceConfigSchema,
+    workoutReferenceConfigSchema,
+  ])
+  .nullable();
 
 const nullableTrimmedString = (maxLength: number) =>
   z.string().trim().min(1).max(maxLength).nullable();
@@ -25,6 +58,8 @@ const habitDefinitionFieldsSchema = z.object({
     .regex(/^\d{4}-\d{2}-\d{2}$/)
     .nullable()
     .optional(),
+  referenceSource: referenceSourceSchema.optional(),
+  referenceConfig: referenceConfigSchema.optional(),
 });
 
 const validateHabitDefinition = (
@@ -37,6 +72,8 @@ const validateHabitDefinition = (
   const frequency = value.frequency ?? 'daily';
   const frequencyTarget = value.frequencyTarget ?? null;
   const scheduledDays = value.scheduledDays ?? null;
+  const referenceSource = value.referenceSource ?? null;
+  const referenceConfig = value.referenceConfig ?? null;
 
   if (requiresTarget) {
     if (target === null) {
@@ -89,6 +126,45 @@ const validateHabitDefinition = (
       });
     }
   }
+
+  if (referenceSource === null && referenceConfig !== null) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'referenceConfig requires referenceSource',
+      path: ['referenceConfig'],
+    });
+    return;
+  }
+
+  if (referenceSource !== null && referenceConfig === null) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'referenceConfig is required when referenceSource is set',
+      path: ['referenceConfig'],
+    });
+    return;
+  }
+
+  if (referenceSource === null || referenceConfig === null) {
+    return;
+  }
+
+  const referenceConfigBySourceValidators = {
+    weight: weightReferenceConfigSchema,
+    nutrition_daily: nutritionDailyReferenceConfigSchema,
+    nutrition_meal: nutritionMealReferenceConfigSchema,
+    workout: workoutReferenceConfigSchema,
+  } as const;
+
+  const parsedReferenceConfig =
+    referenceConfigBySourceValidators[referenceSource].safeParse(referenceConfig);
+  if (!parsedReferenceConfig.success) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Invalid referenceConfig for source ${referenceSource}`,
+      path: ['referenceConfig'],
+    });
+  }
 };
 
 const habitDefinitionSchema = habitDefinitionFieldsSchema.superRefine(validateHabitDefinition);
@@ -123,6 +199,42 @@ export const updateHabitInputSchema = habitDefinitionFieldsSchema
         message: 'Specific-day habits require scheduledDays',
         path: ['scheduledDays'],
       });
+    }
+
+    if (value.referenceSource === null && value.referenceConfig !== undefined) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'referenceConfig cannot be set when referenceSource is null',
+        path: ['referenceConfig'],
+      });
+    }
+
+    if (value.referenceSource !== undefined && value.referenceSource !== null) {
+      if (value.referenceConfig === undefined || value.referenceConfig === null) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'referenceConfig is required when referenceSource is set',
+          path: ['referenceConfig'],
+        });
+      } else {
+        const referenceConfigBySourceValidators = {
+          weight: weightReferenceConfigSchema,
+          nutrition_daily: nutritionDailyReferenceConfigSchema,
+          nutrition_meal: nutritionMealReferenceConfigSchema,
+          workout: workoutReferenceConfigSchema,
+        } as const;
+
+        const parsedReferenceConfig = referenceConfigBySourceValidators[
+          value.referenceSource
+        ].safeParse(value.referenceConfig);
+        if (!parsedReferenceConfig.success) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Invalid referenceConfig for source ${value.referenceSource}`,
+            path: ['referenceConfig'],
+          });
+        }
+      }
     }
   })
   .refine((value) => Object.keys(value).length > 0, {
@@ -159,6 +271,8 @@ export const habitSchema = z.object({
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/)
     .nullable(),
+  referenceSource: referenceSourceSchema.optional(),
+  referenceConfig: referenceConfigSchema.optional(),
   sortOrder: z.number().int().nonnegative(),
   active: z.boolean(),
   createdAt: z.number().int(),
@@ -167,6 +281,8 @@ export const habitSchema = z.object({
 
 export type HabitTrackingType = z.infer<typeof habitTrackingTypeSchema>;
 export type HabitFrequency = z.infer<typeof habitFrequencySchema>;
+export type ReferenceSource = z.infer<typeof referenceSourceSchema>;
+export type ReferenceConfig = z.infer<typeof referenceConfigSchema>;
 export type CreateHabitInput = z.infer<typeof createHabitInputSchema>;
 export type UpdateHabitInput = z.infer<typeof updateHabitInputSchema>;
 export type ReorderHabitsInput = z.infer<typeof reorderHabitsInputSchema>;

--- a/packages/shared/src/schemas/habits.ts
+++ b/packages/shared/src/schemas/habits.ts
@@ -6,24 +6,24 @@ export const referenceSourceSchema = z
   .enum(['weight', 'nutrition_daily', 'nutrition_meal', 'workout'])
   .nullable();
 
-const weightReferenceConfigSchema = z.object({
+export const weightReferenceConfigSchema = z.object({
   condition: z.literal('exists_today'),
 });
 
-const nutritionDailyReferenceConfigSchema = z.object({
+export const nutritionDailyReferenceConfigSchema = z.object({
   field: z.enum(['protein', 'calories', 'carbs', 'fat']),
   op: z.enum(['gte', 'lte', 'eq']),
   value: z.number().finite(),
 });
 
-const nutritionMealReferenceConfigSchema = z.object({
+export const nutritionMealReferenceConfigSchema = z.object({
   mealType: z.string().trim().min(1).max(120),
   field: z.enum(['protein', 'calories', 'carbs', 'fat']),
   op: z.enum(['gte', 'lte', 'eq']),
   value: z.number().finite(),
 });
 
-const workoutReferenceConfigSchema = z.object({
+export const workoutReferenceConfigSchema = z.object({
   condition: z.literal('session_completed_today'),
 });
 

--- a/packages/shared/src/schemas/habits.ts
+++ b/packages/shared/src/schemas/habits.ts
@@ -18,8 +18,8 @@ const nutritionDailyReferenceConfigSchema = z.object({
 
 const nutritionMealReferenceConfigSchema = z.object({
   mealType: z.string().trim().min(1).max(120),
-  field: z.string().trim().min(1).max(120),
-  op: z.string().trim().min(1).max(16),
+  field: z.enum(['protein', 'calories', 'carbs', 'fat']),
+  op: z.enum(['gte', 'lte', 'eq']),
   value: z.number().finite(),
 });
 

--- a/packages/shared/src/schemas/workout-sessions.ts
+++ b/packages/shared/src/schemas/workout-sessions.ts
@@ -250,6 +250,14 @@ export const sessionSetSchema = z
     path: ['skipped'],
   });
 
+export const workoutSessionExerciseSchema = z.object({
+  exerciseId: requiredStringSchema,
+  exerciseName: requiredStringSchema,
+  orderIndex: z.number().int().min(0),
+  section: workoutTemplateSectionTypeSchema.nullable(),
+  sets: z.array(sessionSetSchema).max(500),
+});
+
 export const workoutSessionSchema = z
   .object({
     id: z.string(),
@@ -264,6 +272,7 @@ export const workoutSessionSchema = z
     timeSegments: timeSegmentsSchema,
     feedback: workoutSessionFeedbackSchema.nullable(),
     notes: nullableLongStringSchema,
+    exercises: z.array(workoutSessionExerciseSchema).optional(),
     sets: z.array(sessionSetSchema).max(500),
     createdAt: z.number().int(),
     updatedAt: z.number().int(),
@@ -381,6 +390,7 @@ export type WorkoutSessionTimeSegment = z.infer<typeof timeSegmentsSchema>[numbe
 export type WorkoutSessionFeedback = z.infer<typeof workoutSessionFeedbackSchema>;
 export type WorkoutSessionFeedbackResponse = z.infer<typeof workoutSessionFeedbackResponseSchema>;
 export type SessionSet = z.infer<typeof sessionSetSchema>;
+export type WorkoutSessionExercise = z.infer<typeof workoutSessionExerciseSchema>;
 export type WorkoutSession = z.infer<typeof workoutSessionSchema>;
 export type WorkoutSessionListItem = z.infer<typeof workoutSessionListItemSchema>;
 export type SessionSetInput = z.infer<typeof sessionSetInputSchema>;


### PR DESCRIPTION
## Summary
This PR adds referential habits that can auto-complete from linked data sources (weight, nutrition totals, meal-level nutrition, and completed workouts) while preserving manual control through explicit overrides. It extends the habit model and API so referential rules are validated end-to-end, resolved server-side for today, and returned with `todayEntry` state that distinguishes auto-computed values from manual overrides. On the frontend, referential habits now have dedicated UI treatment, clear “auto-managed” messaging, override affordances, and a reset path back to automatic behavior. The PR also upgrades active workout sessions so agents can modify sessions mid-workout (add/remove/reorder exercises) and the UI stays synchronized via polling without clobbering in-progress user inputs.

## Key Changes
- Added referential habit fields in schema/storage: `referenceSource`, `referenceConfig`, plus `habit_entries.isOverride` (migration `0022_referential_habits.sql`).
- Added shared Zod support for referential sources/configs with source-specific validation rules and update/create constraints.
- Implemented backend habit resolvers (`weight`, `nutrition_daily`, `nutrition_meal`, `workout`) and wired `GET /api/v1/habits` to return resolved `todayEntry` for referential habits unless a manual override exists.
- Added `POST /api/agent/habits` to create habits (including referential ones) and updated agent habit-entry updates to mark entries as overrides for referential habits.
- Extended habit entry create/update payloads and API/store plumbing to persist and return `isOverride`.
- Updated daily habits UI with referential indicators (`Link2` icon), auto-rule helper text, dimmed auto-managed controls, override toasts, and “Reset to auto”.
- Updated habit history UI/tooltips to surface manual overrides visually and textually.
- Extended `PATCH /api/agent/workout-sessions/:id` with `addExercises`, `removeExercises`, and `reorderExercises`; enforced `409 WORKOUT_SESSION_EXERCISE_HAS_LOGGED_SETS` when removing exercises that already have completed sets.
- Extended workout session responses with grouped `exercises[]` metadata (name/order/section/sets) in addition to flat sets.
- Active workout page now polls session state every 10s, rebuilds the rendered template from server session structure, merges server changes into local drafts, and shows “Workout updated by agent” when structure changes.

## Technical Notes
- Referential config is stored as JSON text in SQLite and parsed/serialized in `habits/store`, with Zod guarding source/config compatibility.
- Auto-resolution is intentionally applied to “today” habit state returned by `GET /api/v1/habits`; manual override entries take precedence when present.
- Mid-session reorder logic preserves per-set logged data by reindexing exercise order rather than rewriting set payload content.
- Active workout synchronization uses `updatedAt` and a derived session-structure signature to avoid unnecessary hydration and to prevent overwriting unfinished user-entered values during polling.
- New tests cover resolver behavior, referential precedence vs overrides, agent workout mutation scenarios (add/remove/reorder and conflict path), and frontend polling/override UX flows.

## Commits

- `189d154 feat(workouts): enable agent mid-session session modifications`
- `0a0fa82 feat(habits): add referential override UI and history indicators`
- `add36a9 feat(habits): add referential resolver completion and overrides`

## Tasks

- **Referential habits — schema and API**: Add referenceSource/referenceConfig to habits, resolver functions per source type
- **Referential habits — frontend UI**: Distinct visual treatment for auto-managed habits, manual override support
- **Agent-modifiable active workouts**: Server-side session state, agent PATCH endpoint for mid-session modification, frontend polling

## Diff Stats

```
.agents/skills/pulse-app-usage/SKILL.md            |  23 +-
 AGENTS.md                                          |   4 +-
 README.md                                          |  10 +-
 apps/api/drizzle/0022_referential_habits.sql       |   5 +
 apps/api/drizzle/meta/_journal.json                |   7 +
 apps/api/src/db/schema.test.ts                     |   4 +
 apps/api/src/db/schema/habits.ts                   |   4 +
 apps/api/src/lib/habit-resolvers.test.ts           | 138 ++++++++
 apps/api/src/lib/habit-resolvers.ts                | 223 +++++++++++++
 apps/api/src/routes/agent/daily.test.ts            | 150 ++++++++-
 apps/api/src/routes/agent/daily.ts                 |  32 +-
 apps/api/src/routes/agent/workouts.test.ts         | 362 +++++++++++++++++++++
 apps/api/src/routes/agent/workouts.ts              | 162 +++++++++
 apps/api/src/routes/habit-entries/index.test.ts    |  11 +
 apps/api/src/routes/habit-entries/index.ts         |   1 +
 apps/api/src/routes/habit-entries/store.test.ts    |  10 +
 apps/api/src/routes/habit-entries/store.ts         |   6 +
 apps/api/src/routes/habits/index.test.ts           | 221 +++++++++++++
 apps/api/src/routes/habits/index.ts                |  59 +++-
 apps/api/src/routes/habits/store.ts                |  32 +-
 apps/api/src/routes/workout-sessions/store.ts      |  69 +++-
 apps/web/src/features/habits/api/habits.test.tsx   |  49 ++-
 apps/web/src/features/habits/api/habits.ts         |  22 +-
 .../habits/components/daily-habits.test.tsx        | 106 ++++++
 .../features/habits/components/daily-habits.tsx    | 179 +++++++++-
 .../habits/components/habit-history.test.tsx       |  11 +-
 .../features/habits/components/habit-history.tsx   |  25 +-
 apps/web/src/hooks/use-workout-session.ts          |  11 +-
 apps/web/src/pages/active-workout.test.tsx         | 178 ++++++++++
 apps/web/src/pages/active-workout.tsx              | 286 ++++++++++++++--
 docs/conventions/agent-integration.md              |  34 +-
 docs/conventions/data-models.md                    |   7 +
 packages/shared/src/schemas/agent.test.ts          |  17 +
 packages/shared/src/schemas/agent.ts               |  20 +-
 packages/shared/src/schemas/habit-entries.test.ts  |   6 +
 packages/shared/src/schemas/habit-entries.ts       |   3 +
 packages/shared/src/schemas/habits.test.ts         |  30 ++
 packages/shared/src/schemas/habits.ts              | 116 +++++++
 packages/shared/src/schemas/workout-sessions.ts    |  10 +
 39 files changed, 2578 insertions(+), 65 deletions(-)
```