### PR TITLE
fix(api): add missing PATCH endpoints for meals, meal-items, weight, and foods

### DIFF
--- a/apps/api/src/__tests__/agent.test.ts
+++ b/apps/api/src/__tests__/agent.test.ts
@@ -267,6 +267,12 @@ vi.mock('../routes/nutrition/store.js', () => ({
   deleteMealForDate: vi.fn(),
   getDailyNutritionForDate: vi.fn(async () => null),
   getDailyNutritionSummaryForDate: vi.fn(async () => ({ calories: 0, protein: 0, carbs: 0, fat: 0 })),
+  findMealForDate: vi.fn(),
+  findMealItemForDate: vi.fn(),
+  findMealById: vi.fn(),
+  findMealItemById: vi.fn(),
+  patchMealById: vi.fn(),
+  patchMealItemById: vi.fn(),
 }));
 
 vi.mock('../routes/exercises/store.js', () => ({

--- a/apps/api/src/__tests__/foods-nutrition.test.ts
+++ b/apps/api/src/__tests__/foods-nutrition.test.ts
@@ -392,6 +392,12 @@ vi.mock('../routes/nutrition/store.js', () => ({
 
     return true;
   }),
+  findMealForDate: vi.fn(),
+  findMealItemForDate: vi.fn(),
+  findMealById: vi.fn(),
+  findMealItemById: vi.fn(),
+  patchMealById: vi.fn(),
+  patchMealItemById: vi.fn(),
 }));
 
 const createAuthorizationHeader = (token: string) => ({

--- a/apps/api/src/routes/agent/daily.test.ts
+++ b/apps/api/src/routes/agent/daily.test.ts
@@ -54,6 +54,12 @@ vi.mock('../nutrition/store.js', () => ({
   getDailyNutritionForDate: vi.fn(),
   getDailyNutritionSummaryForDate: vi.fn(),
   deleteMealForDate: vi.fn(),
+  findMealForDate: vi.fn(),
+  findMealItemForDate: vi.fn(),
+  findMealById: vi.fn(),
+  findMealItemById: vi.fn(),
+  patchMealById: vi.fn(),
+  patchMealItemById: vi.fn(),
 }));
 vi.mock('../../lib/habit-resolvers.js', () => ({
   resolveHabitCompletion: vi.fn(),

--- a/apps/api/src/routes/agent/daily.test.ts
+++ b/apps/api/src/routes/agent/daily.test.ts
@@ -14,10 +14,17 @@ import {
   listActiveHabits,
 } from '../habits/store.js';
 import { getDailyNutritionForDate, getDailyNutritionSummaryForDate } from '../nutrition/store.js';
-import { findBodyWeightEntryByDate, upsertBodyWeightEntry } from '../weight/store.js';
+import {
+  findBodyWeightEntryByDate,
+  findBodyWeightEntryById,
+  patchBodyWeightEntryById,
+  upsertBodyWeightEntry,
+} from '../weight/store.js';
 
 vi.mock('../weight/store.js', () => ({
+  findBodyWeightEntryById: vi.fn(),
   findBodyWeightEntryByDate: vi.fn(),
+  patchBodyWeightEntryById: vi.fn(),
   upsertBodyWeightEntry: vi.fn(),
   listBodyWeightEntries: vi.fn(),
   getLatestBodyWeightEntry: vi.fn(),
@@ -59,6 +66,8 @@ const createAuthorizationHeader = (token: string) => ({
 describe('agent daily routes', () => {
   beforeEach(() => {
     vi.mocked(findBodyWeightEntryByDate).mockReset();
+    vi.mocked(findBodyWeightEntryById).mockReset();
+    vi.mocked(patchBodyWeightEntryById).mockReset();
     vi.mocked(upsertBodyWeightEntry).mockReset();
     vi.mocked(getNextHabitSortOrder).mockReset();
     vi.mocked(createHabit).mockReset();
@@ -277,6 +286,170 @@ describe('agent daily routes', () => {
         });
         expect(vi.mocked(findBodyWeightEntryByDate)).not.toHaveBeenCalled();
         expect(vi.mocked(upsertBodyWeightEntry)).not.toHaveBeenCalled();
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  describe('PATCH /api/agent/weight/:id', () => {
+    it('returns 401 without auth', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/weight/weight-1',
+          body: { weight: 182.4 },
+        });
+
+        expect(response.statusCode).toBe(401);
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('patches weight entries with partial payloads', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findBodyWeightEntryById).mockResolvedValue({
+          id: 'weight-1',
+          date: '2026-03-09',
+          weight: 183,
+          notes: null,
+          createdAt: 1,
+          updatedAt: 1,
+        });
+        vi.mocked(patchBodyWeightEntryById)
+          .mockResolvedValueOnce({
+            id: 'weight-1',
+            date: '2026-03-09',
+            weight: 182.4,
+            notes: null,
+            createdAt: 1,
+            updatedAt: 2,
+          })
+          .mockResolvedValueOnce({
+            id: 'weight-1',
+            date: '2026-03-09',
+            weight: 182.4,
+            notes: 'Fasted',
+            createdAt: 1,
+            updatedAt: 3,
+          })
+          .mockResolvedValueOnce({
+            id: 'weight-1',
+            date: '2026-03-09',
+            weight: 182.2,
+            notes: 'Post-workout',
+            createdAt: 1,
+            updatedAt: 4,
+          });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const weightOnlyResponse = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/weight/weight-1',
+          headers: createAuthorizationHeader(token),
+          body: { weight: 182.4 },
+        });
+        const notesOnlyResponse = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/weight/weight-1',
+          headers: createAuthorizationHeader(token),
+          body: { notes: '  Fasted  ' },
+        });
+        const bothResponse = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/weight/weight-1',
+          headers: createAuthorizationHeader(token),
+          body: { weight: 182.2, notes: 'Post-workout' },
+        });
+
+        expect(weightOnlyResponse.statusCode).toBe(200);
+        expect(notesOnlyResponse.statusCode).toBe(200);
+        expect(bothResponse.statusCode).toBe(200);
+        expect(vi.mocked(findBodyWeightEntryById)).toHaveBeenCalledTimes(3);
+        expect(vi.mocked(patchBodyWeightEntryById)).toHaveBeenNthCalledWith(
+          1,
+          'weight-1',
+          'user-1',
+          { weight: 182.4 },
+        );
+        expect(vi.mocked(patchBodyWeightEntryById)).toHaveBeenNthCalledWith(
+          2,
+          'weight-1',
+          'user-1',
+          { notes: 'Fasted' },
+        );
+        expect(vi.mocked(patchBodyWeightEntryById)).toHaveBeenNthCalledWith(
+          3,
+          'weight-1',
+          'user-1',
+          { weight: 182.2, notes: 'Post-workout' },
+        );
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 404 for a missing or unauthorized entry', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findBodyWeightEntryById).mockResolvedValue(null);
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/weight/missing',
+          headers: createAuthorizationHeader(token),
+          body: { weight: 182.4 },
+        });
+
+        expect(response.statusCode).toBe(404);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'WEIGHT_NOT_FOUND',
+            message: 'Weight entry not found',
+          },
+        });
+        expect(vi.mocked(patchBodyWeightEntryById)).not.toHaveBeenCalled();
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('rejects empty patch payloads', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/weight/weight-1',
+          headers: createAuthorizationHeader(token),
+          body: {},
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Invalid weight payload',
+          },
+        });
+        expect(vi.mocked(findBodyWeightEntryById)).not.toHaveBeenCalled();
+        expect(vi.mocked(patchBodyWeightEntryById)).not.toHaveBeenCalled();
       } finally {
         await app.close();
       }

--- a/apps/api/src/routes/agent/daily.ts
+++ b/apps/api/src/routes/agent/daily.ts
@@ -5,6 +5,7 @@ import {
   agentCreateWeightInputSchema,
   agentNutritionSummaryParamsSchema,
   agentUpdateHabitEntryInputSchema,
+  patchWeightInputSchema,
 } from '@pulse/shared';
 import type { FastifyPluginAsync } from 'fastify';
 
@@ -22,7 +23,12 @@ import {
   listActiveHabits,
 } from '../habits/store.js';
 import { getDailyNutritionForDate, getDailyNutritionSummaryForDate } from '../nutrition/store.js';
-import { findBodyWeightEntryByDate, upsertBodyWeightEntry } from '../weight/store.js';
+import {
+  findBodyWeightEntryByDate,
+  findBodyWeightEntryById,
+  patchBodyWeightEntryById,
+  upsertBodyWeightEntry,
+} from '../weight/store.js';
 
 import { getTodayDate, isValidDate } from './date-utils.js';
 
@@ -59,6 +65,25 @@ export const agentDailyRoutes: FastifyPluginAsync = async (app) => {
     const entry = await upsertBodyWeightEntry(request.userId, parsed.data);
 
     return reply.code(existing ? 200 : 201).send({ data: entry });
+  });
+
+  app.patch<{ Params: { id: string } }>('/weight/:id', async (request, reply) => {
+    const parsed = patchWeightInputSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid weight payload');
+    }
+
+    const existing = await findBodyWeightEntryById(request.params.id, request.userId);
+    if (!existing) {
+      return sendError(reply, 404, 'WEIGHT_NOT_FOUND', 'Weight entry not found');
+    }
+
+    const entry = await patchBodyWeightEntryById(request.params.id, request.userId, parsed.data);
+    if (!entry) {
+      return sendError(reply, 404, 'WEIGHT_NOT_FOUND', 'Weight entry not found');
+    }
+
+    return reply.send({ data: entry });
   });
 
   app.get('/habits', async (request, reply) => {

--- a/apps/api/src/routes/agent/foods.test.ts
+++ b/apps/api/src/routes/agent/foods.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildServer } from '../../index.js';
-import { createFood } from '../foods/store.js';
+import { createFood, findFoodById, updateFood } from '../foods/store.js';
 
 import { searchFoodsByName } from './store.js';
 
@@ -13,6 +13,7 @@ vi.mock('./store.js', () => ({
 vi.mock('../foods/store.js', () => ({
   createFood: vi.fn(),
   deleteFood: vi.fn(),
+  findFoodById: vi.fn(),
   listFoods: vi.fn(),
   updateFood: vi.fn(),
   updateFoodLastUsedAt: vi.fn(),
@@ -47,6 +48,8 @@ describe('agent foods routes', () => {
   beforeEach(() => {
     vi.mocked(searchFoodsByName).mockReset();
     vi.mocked(createFood).mockReset();
+    vi.mocked(findFoodById).mockReset();
+    vi.mocked(updateFood).mockReset();
     process.env.JWT_SECRET = 'test-agent-foods-secret';
   });
 
@@ -212,6 +215,150 @@ describe('agent foods routes', () => {
         expect(response.json()).toEqual({
           error: { code: 'VALIDATION_ERROR', message: 'Invalid food payload' },
         });
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  describe('PATCH /api/agent/foods/:id', () => {
+    it('returns 401 without auth', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/foods/food-1',
+          body: { name: 'Updated' },
+        });
+
+        expect(response.statusCode).toBe(401);
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('patches food fields with partial payloads', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findFoodById).mockResolvedValue(agentFood);
+        vi.mocked(updateFood)
+          .mockResolvedValueOnce({ ...agentFood, name: 'Lean Chicken Breast' })
+          .mockResolvedValueOnce({ ...agentFood, calories: 160, protein: 32, carbs: 0, fat: 3.2 })
+          .mockResolvedValueOnce({ ...agentFood, name: 'Turkey Breast', calories: 135, notes: 'sliced' });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const nameOnlyResponse = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/foods/food-1',
+          headers: createAuthorizationHeader(token),
+          body: {
+            name: ' Lean Chicken Breast ',
+          },
+        });
+        const macrosOnlyResponse = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/foods/food-1',
+          headers: createAuthorizationHeader(token),
+          body: {
+            calories: 160,
+            protein: 32,
+            carbs: 0,
+            fat: 3.2,
+          },
+        });
+        const multiFieldResponse = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/foods/food-1',
+          headers: createAuthorizationHeader(token),
+          body: {
+            name: 'Turkey Breast',
+            calories: 135,
+            notes: ' sliced ',
+          },
+        });
+
+        expect(nameOnlyResponse.statusCode).toBe(200);
+        expect(macrosOnlyResponse.statusCode).toBe(200);
+        expect(multiFieldResponse.statusCode).toBe(200);
+        expect(vi.mocked(findFoodById)).toHaveBeenCalledTimes(3);
+        expect(vi.mocked(updateFood)).toHaveBeenNthCalledWith(1, 'food-1', 'user-1', {
+          name: 'Lean Chicken Breast',
+        });
+        expect(vi.mocked(updateFood)).toHaveBeenNthCalledWith(2, 'food-1', 'user-1', {
+          calories: 160,
+          protein: 32,
+          carbs: 0,
+          fat: 3.2,
+        });
+        expect(vi.mocked(updateFood)).toHaveBeenNthCalledWith(3, 'food-1', 'user-1', {
+          name: 'Turkey Breast',
+          calories: 135,
+          notes: 'sliced',
+        });
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 404 for missing, unauthorized, or soft-deleted foods', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+        vi.mocked(findFoodById).mockResolvedValue(undefined);
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/foods/missing',
+          headers: createAuthorizationHeader(token),
+          body: {
+            notes: 'updated',
+          },
+        });
+
+        expect(response.statusCode).toBe(404);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'FOOD_NOT_FOUND',
+            message: 'Food not found',
+          },
+        });
+        expect(vi.mocked(updateFood)).not.toHaveBeenCalled();
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('rejects empty patch payloads', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/foods/food-1',
+          headers: createAuthorizationHeader(token),
+          body: {},
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Invalid food payload',
+          },
+        });
+        expect(vi.mocked(findFoodById)).not.toHaveBeenCalled();
+        expect(vi.mocked(updateFood)).not.toHaveBeenCalled();
       } finally {
         await app.close();
       }

--- a/apps/api/src/routes/agent/foods.ts
+++ b/apps/api/src/routes/agent/foods.ts
@@ -1,10 +1,14 @@
 import { randomUUID } from 'node:crypto';
 
-import { agentCreateFoodInputSchema, agentFoodSearchParamsSchema } from '@pulse/shared';
+import {
+  agentCreateFoodInputSchema,
+  agentFoodSearchParamsSchema,
+  patchFoodInputSchema,
+} from '@pulse/shared';
 import type { FastifyPluginAsync } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
-import { createFood } from '../foods/store.js';
+import { createFood, findFoodById, updateFood } from '../foods/store.js';
 
 import { searchFoodsByName } from './store.js';
 
@@ -59,5 +63,24 @@ export const agentFoodsRoutes: FastifyPluginAsync = async (app) => {
         fat: food.fat,
       },
     });
+  });
+
+  app.patch<{ Params: { id: string } }>('/:id', async (request, reply) => {
+    const parsed = patchFoodInputSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid food payload');
+    }
+
+    const existingFood = await findFoodById(request.params.id, request.userId);
+    if (!existingFood) {
+      return sendError(reply, 404, 'FOOD_NOT_FOUND', 'Food not found');
+    }
+
+    const food = await updateFood(request.params.id, request.userId, parsed.data);
+    if (!food) {
+      return sendError(reply, 404, 'FOOD_NOT_FOUND', 'Food not found');
+    }
+
+    return reply.send({ data: food });
   });
 };

--- a/apps/api/src/routes/agent/meals.test.ts
+++ b/apps/api/src/routes/agent/meals.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildServer } from '../../index.js';
 import { updateFoodLastUsedAt } from '../foods/store.js';
-import { createMealForDate } from '../nutrition/store.js';
+import { createMealForDate, findMealById, findMealItemById, patchMealById, patchMealItemById } from '../nutrition/store.js';
 
 import { findFoodByName } from './store.js';
 
@@ -21,6 +21,10 @@ vi.mock('../foods/store.js', () => ({
 
 vi.mock('../nutrition/store.js', () => ({
   createMealForDate: vi.fn(),
+  findMealById: vi.fn(),
+  findMealItemById: vi.fn(),
+  patchMealById: vi.fn(),
+  patchMealItemById: vi.fn(),
   deleteMealForDate: vi.fn(),
   getDailyNutritionForDate: vi.fn(),
   getDailyNutritionSummaryForDate: vi.fn(),
@@ -95,10 +99,33 @@ const createdItems = [
   },
 ];
 
+const patchedMeal = {
+  ...createdMeal,
+  name: 'Updated Lunch',
+  time: '13:00',
+  notes: 'changed by agent',
+  updatedAt: 1_700_000_000_100,
+};
+
+const patchedMealItem = {
+  ...createdItems[0],
+  amount: 2.5,
+  calories: 345,
+  protein: 63,
+  carbs: 2,
+  fat: 8,
+  fiber: 1,
+  sugar: 0,
+};
+
 describe('agent meals routes', () => {
   beforeEach(() => {
     vi.mocked(findFoodByName).mockReset();
     vi.mocked(createMealForDate).mockReset();
+    vi.mocked(findMealById).mockReset();
+    vi.mocked(findMealItemById).mockReset();
+    vi.mocked(patchMealById).mockReset();
+    vi.mocked(patchMealItemById).mockReset();
     vi.mocked(updateFoodLastUsedAt).mockReset();
     vi.mocked(updateFoodLastUsedAt).mockResolvedValue(undefined);
     process.env.JWT_SECRET = 'test-agent-meals-secret';
@@ -286,6 +313,237 @@ describe('agent meals routes', () => {
         expect(response.statusCode).toBe(400);
         expect(response.json()).toEqual({
           error: { code: 'VALIDATION_ERROR', message: 'Invalid meal payload' },
+        });
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  describe('PATCH /api/agent/meals/:id', () => {
+    it('patches meals with partial payloads', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+        vi.mocked(findMealById).mockResolvedValueOnce(createdMeal).mockResolvedValueOnce(createdMeal).mockResolvedValueOnce(createdMeal);
+        vi.mocked(patchMealById).mockResolvedValue(patchedMeal);
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const patchNameResponse = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/meals/meal-1',
+          headers: createAuthorizationHeader(token),
+          body: {
+            name: ' Updated Lunch ',
+          },
+        });
+        const patchTimeResponse = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/meals/meal-1',
+          headers: createAuthorizationHeader(token),
+          body: {
+            time: '13:00',
+          },
+        });
+        const patchMultipleResponse = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/meals/meal-1',
+          headers: createAuthorizationHeader(token),
+          body: {
+            name: 'Updated Lunch',
+            time: '13:00',
+            notes: 'changed by agent',
+          },
+        });
+
+        expect(patchNameResponse.statusCode).toBe(200);
+        expect(patchTimeResponse.statusCode).toBe(200);
+        expect(patchMultipleResponse.statusCode).toBe(200);
+        expect(patchNameResponse.json()).toEqual({
+          data: patchedMeal,
+        });
+        expect(vi.mocked(findMealById)).toHaveBeenNthCalledWith(1, 'user-1', 'meal-1');
+        expect(vi.mocked(findMealById)).toHaveBeenNthCalledWith(2, 'user-1', 'meal-1');
+        expect(vi.mocked(findMealById)).toHaveBeenNthCalledWith(3, 'user-1', 'meal-1');
+        expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(1, 'meal-1', {
+          name: 'Updated Lunch',
+        });
+        expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(2, 'meal-1', {
+          time: '13:00',
+        });
+        expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(3, 'meal-1', {
+          name: 'Updated Lunch',
+          time: '13:00',
+          notes: 'changed by agent',
+        });
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 404 when patching a meal not in user scope', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+        vi.mocked(findMealById).mockResolvedValue(undefined);
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const wrongUserResponse = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/meals/meal-404',
+          headers: createAuthorizationHeader(token),
+          body: {
+            notes: 'irrelevant',
+          },
+        });
+        const missingResponse = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/meals/missing-meal',
+          headers: createAuthorizationHeader(token),
+          body: {
+            notes: 'missing',
+          },
+        });
+
+        expect(wrongUserResponse.statusCode).toBe(404);
+        expect(wrongUserResponse.json()).toEqual({
+          error: {
+            code: 'MEAL_NOT_FOUND',
+            message: 'Meal not found',
+          },
+        });
+        expect(missingResponse.statusCode).toBe(404);
+        expect(missingResponse.json()).toEqual({
+          error: {
+            code: 'MEAL_NOT_FOUND',
+            message: 'Meal not found',
+          },
+        });
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  describe('PATCH /api/agent/meals/:id/items/:itemId', () => {
+    it('patches meal-item snapshots directly', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+        vi.mocked(findMealItemById)
+          .mockResolvedValueOnce(createdItems[0])
+          .mockResolvedValueOnce(createdItems[0])
+          .mockResolvedValueOnce(createdItems[0]);
+        vi.mocked(patchMealItemById).mockResolvedValue(patchedMealItem);
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const patchAmountResponse = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/meals/meal-1/items/item-1',
+          headers: createAuthorizationHeader(token),
+          body: {
+            amount: 2.5,
+          },
+        });
+        const patchMacrosResponse = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/meals/meal-1/items/item-1',
+          headers: createAuthorizationHeader(token),
+          body: {
+            calories: 345,
+            protein: 63,
+            carbs: 2,
+            fat: 8,
+          },
+        });
+        const patchMultipleResponse = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/meals/meal-1/items/item-1',
+          headers: createAuthorizationHeader(token),
+          body: {
+            amount: 2.5,
+            calories: 345,
+            protein: 63,
+            carbs: 2,
+            fat: 8,
+            fiber: 1,
+            sugar: 0,
+          },
+        });
+
+        expect(patchAmountResponse.statusCode).toBe(200);
+        expect(patchMacrosResponse.statusCode).toBe(200);
+        expect(patchMultipleResponse.statusCode).toBe(200);
+        expect(patchMacrosResponse.json()).toEqual({
+          data: patchedMealItem,
+        });
+        expect(vi.mocked(findMealItemById)).toHaveBeenNthCalledWith(1, 'user-1', 'meal-1', 'item-1');
+        expect(vi.mocked(findMealItemById)).toHaveBeenNthCalledWith(2, 'user-1', 'meal-1', 'item-1');
+        expect(vi.mocked(findMealItemById)).toHaveBeenNthCalledWith(3, 'user-1', 'meal-1', 'item-1');
+        expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(1, 'meal-1', 'item-1', {
+          amount: 2.5,
+        });
+        expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(2, 'meal-1', 'item-1', {
+          calories: 345,
+          protein: 63,
+          carbs: 2,
+          fat: 8,
+        });
+        expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(3, 'meal-1', 'item-1', {
+          amount: 2.5,
+          calories: 345,
+          protein: 63,
+          carbs: 2,
+          fat: 8,
+          fiber: 1,
+          sugar: 0,
+        });
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 404 when patching a meal item outside user scope', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+        vi.mocked(findMealItemById).mockResolvedValue(undefined);
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const wrongUserResponse = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/meals/meal-1/items/item-404',
+          headers: createAuthorizationHeader(token),
+          body: {
+            amount: 1.1,
+          },
+        });
+        const missingResponse = await app.inject({
+          method: 'PATCH',
+          url: '/api/agent/meals/meal-404/items/item-missing',
+          headers: createAuthorizationHeader(token),
+          body: {
+            amount: 1.2,
+          },
+        });
+
+        expect(wrongUserResponse.statusCode).toBe(404);
+        expect(wrongUserResponse.json()).toEqual({
+          error: {
+            code: 'MEAL_ITEM_NOT_FOUND',
+            message: 'Meal item not found',
+          },
+        });
+        expect(missingResponse.statusCode).toBe(404);
+        expect(missingResponse.json()).toEqual({
+          error: {
+            code: 'MEAL_ITEM_NOT_FOUND',
+            message: 'Meal item not found',
+          },
         });
       } finally {
         await app.close();

--- a/apps/api/src/routes/agent/meals.test.ts
+++ b/apps/api/src/routes/agent/meals.test.ts
@@ -366,13 +366,13 @@ describe('agent meals routes', () => {
         expect(vi.mocked(findMealById)).toHaveBeenNthCalledWith(1, 'user-1', 'meal-1');
         expect(vi.mocked(findMealById)).toHaveBeenNthCalledWith(2, 'user-1', 'meal-1');
         expect(vi.mocked(findMealById)).toHaveBeenNthCalledWith(3, 'user-1', 'meal-1');
-        expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(1, 'meal-1', {
+        expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(1, 'user-1', 'meal-1', {
           name: 'Updated Lunch',
         });
-        expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(2, 'meal-1', {
+        expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(2, 'user-1', 'meal-1', {
           time: '13:00',
         });
-        expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(3, 'meal-1', {
+        expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(3, 'user-1', 'meal-1', {
           name: 'Updated Lunch',
           time: '13:00',
           notes: 'changed by agent',
@@ -483,16 +483,16 @@ describe('agent meals routes', () => {
         expect(vi.mocked(findMealItemById)).toHaveBeenNthCalledWith(1, 'user-1', 'meal-1', 'item-1');
         expect(vi.mocked(findMealItemById)).toHaveBeenNthCalledWith(2, 'user-1', 'meal-1', 'item-1');
         expect(vi.mocked(findMealItemById)).toHaveBeenNthCalledWith(3, 'user-1', 'meal-1', 'item-1');
-        expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(1, 'meal-1', 'item-1', {
+        expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(1, 'user-1', 'meal-1', 'item-1', {
           amount: 2.5,
         });
-        expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(2, 'meal-1', 'item-1', {
+        expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(2, 'user-1', 'meal-1', 'item-1', {
           calories: 345,
           protein: 63,
           carbs: 2,
           fat: 8,
         });
-        expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(3, 'meal-1', 'item-1', {
+        expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(3, 'user-1', 'meal-1', 'item-1', {
           amount: 2.5,
           calories: 345,
           protein: 63,

--- a/apps/api/src/routes/agent/meals.ts
+++ b/apps/api/src/routes/agent/meals.ts
@@ -119,7 +119,7 @@ export const agentMealsRoutes: FastifyPluginAsync = async (app) => {
       return sendError(reply, 404, 'MEAL_NOT_FOUND', 'Meal not found');
     }
 
-    const updatedMeal = await patchMealById(request.params.id, parsed.data);
+    const updatedMeal = await patchMealById(request.userId, request.params.id, parsed.data);
     if (!updatedMeal) {
       return sendError(reply, 404, 'MEAL_NOT_FOUND', 'Meal not found');
     }
@@ -140,7 +140,12 @@ export const agentMealsRoutes: FastifyPluginAsync = async (app) => {
       return sendError(reply, 404, 'MEAL_ITEM_NOT_FOUND', 'Meal item not found');
     }
 
-    const updatedMealItem = await patchMealItemById(request.params.id, request.params.itemId, parsed.data);
+    const updatedMealItem = await patchMealItemById(
+      request.userId,
+      request.params.id,
+      request.params.itemId,
+      parsed.data,
+    );
     if (!updatedMealItem) {
       return sendError(reply, 404, 'MEAL_ITEM_NOT_FOUND', 'Meal item not found');
     }

--- a/apps/api/src/routes/agent/meals.ts
+++ b/apps/api/src/routes/agent/meals.ts
@@ -1,9 +1,15 @@
-import { agentCreateMealInputSchema } from '@pulse/shared';
+import { agentCreateMealInputSchema, patchMealInputSchema, patchMealItemInputSchema } from '@pulse/shared';
 import type { FastifyPluginAsync } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
 import { updateFoodLastUsedAt } from '../foods/store.js';
-import { createMealForDate } from '../nutrition/store.js';
+import {
+  createMealForDate,
+  findMealById,
+  findMealItemById,
+  patchMealById,
+  patchMealItemById,
+} from '../nutrition/store.js';
 
 import { isValidDate } from './date-utils.js';
 import { findFoodByName } from './store.js';
@@ -99,6 +105,48 @@ export const agentMealsRoutes: FastifyPluginAsync = async (app) => {
           fat: item.fat,
         })),
       },
+    });
+  });
+
+  app.patch<{ Params: { id: string } }>('/:id', async (request, reply) => {
+    const parsed = patchMealInputSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid meal payload');
+    }
+
+    const existingMeal = await findMealById(request.userId, request.params.id);
+    if (!existingMeal) {
+      return sendError(reply, 404, 'MEAL_NOT_FOUND', 'Meal not found');
+    }
+
+    const updatedMeal = await patchMealById(request.params.id, parsed.data);
+    if (!updatedMeal) {
+      return sendError(reply, 404, 'MEAL_NOT_FOUND', 'Meal not found');
+    }
+
+    return reply.send({
+      data: updatedMeal,
+    });
+  });
+
+  app.patch<{ Params: { id: string; itemId: string } }>('/:id/items/:itemId', async (request, reply) => {
+    const parsed = patchMealItemInputSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid meal item payload');
+    }
+
+    const existingMealItem = await findMealItemById(request.userId, request.params.id, request.params.itemId);
+    if (!existingMealItem) {
+      return sendError(reply, 404, 'MEAL_ITEM_NOT_FOUND', 'Meal item not found');
+    }
+
+    const updatedMealItem = await patchMealItemById(request.params.id, request.params.itemId, parsed.data);
+    if (!updatedMealItem) {
+      return sendError(reply, 404, 'MEAL_ITEM_NOT_FOUND', 'Meal item not found');
+    }
+
+    return reply.send({
+      data: updatedMealItem,
     });
   });
 };

--- a/apps/api/src/routes/foods/index.test.ts
+++ b/apps/api/src/routes/foods/index.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildServer } from '../../index.js';
-import { createFood, deleteFood, listFoods, updateFood } from './store.js';
+import { createFood, deleteFood, findFoodById, listFoods, updateFood } from './store.js';
 
 vi.mock('./store.js', () => ({
   createFood: vi.fn(),
   deleteFood: vi.fn(),
+  findFoodById: vi.fn(),
   listFoods: vi.fn(),
   updateFood: vi.fn(),
 }));
@@ -61,6 +62,7 @@ describe('foods routes', () => {
   beforeEach(() => {
     vi.mocked(createFood).mockReset();
     vi.mocked(deleteFood).mockReset();
+    vi.mocked(findFoodById).mockReset();
     vi.mocked(listFoods).mockReset();
     vi.mocked(updateFood).mockReset();
     process.env.JWT_SECRET = 'test-foods-secret';
@@ -233,6 +235,13 @@ describe('foods routes', () => {
           method: 'DELETE',
           url: '/api/v1/foods/food-1',
         }),
+        app.inject({
+          method: 'PATCH',
+          url: '/api/v1/foods/food-1',
+          payload: {
+            name: 'Updated',
+          },
+        }),
       ]);
 
       for (const response of requests) {
@@ -244,6 +253,132 @@ describe('foods routes', () => {
           },
         });
       }
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('patches foods with partial payloads', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      vi.mocked(findFoodById).mockResolvedValue(buildFood());
+      vi.mocked(updateFood)
+        .mockResolvedValueOnce(buildFood({ name: 'Lowfat Greek Yogurt' }))
+        .mockResolvedValueOnce(buildFood({ protein: 20, carbs: 4, fat: 0, calories: 100 }))
+        .mockResolvedValueOnce(buildFood({ name: 'Skyr', calories: 110, protein: 19, notes: 'new' }));
+
+      const nameOnlyResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/foods/food-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          name: ' Lowfat Greek Yogurt ',
+        },
+      });
+
+      const macrosOnlyResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/foods/food-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          calories: 100,
+          protein: 20,
+          carbs: 4,
+          fat: 0,
+        },
+      });
+
+      const multiFieldResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/foods/food-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          name: 'Skyr',
+          calories: 110,
+          protein: 19,
+          notes: ' new ',
+        },
+      });
+
+      expect(nameOnlyResponse.statusCode).toBe(200);
+      expect(macrosOnlyResponse.statusCode).toBe(200);
+      expect(multiFieldResponse.statusCode).toBe(200);
+      expect(vi.mocked(findFoodById)).toHaveBeenCalledTimes(3);
+      expect(vi.mocked(updateFood)).toHaveBeenNthCalledWith(1, 'food-1', 'user-1', {
+        name: 'Lowfat Greek Yogurt',
+      });
+      expect(vi.mocked(updateFood)).toHaveBeenNthCalledWith(2, 'food-1', 'user-1', {
+        calories: 100,
+        protein: 20,
+        carbs: 4,
+        fat: 0,
+      });
+      expect(vi.mocked(updateFood)).toHaveBeenNthCalledWith(3, 'food-1', 'user-1', {
+        name: 'Skyr',
+        calories: 110,
+        protein: 19,
+        notes: 'new',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns 404 when patching missing or soft-deleted foods', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      vi.mocked(findFoodById).mockResolvedValue(undefined);
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/foods/food-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          notes: 'Updated',
+        },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'FOOD_NOT_FOUND',
+          message: 'Food not found',
+        },
+      });
+      expect(vi.mocked(updateFood)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects empty patch payloads', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/foods/food-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid food payload',
+        },
+      });
+      expect(vi.mocked(findFoodById)).not.toHaveBeenCalled();
+      expect(vi.mocked(updateFood)).not.toHaveBeenCalled();
     } finally {
       await app.close();
     }

--- a/apps/api/src/routes/foods/index.ts
+++ b/apps/api/src/routes/foods/index.ts
@@ -1,12 +1,17 @@
 import { randomUUID } from 'node:crypto';
 
-import { createFoodInputSchema, foodQueryParamsSchema, updateFoodInputSchema } from '@pulse/shared';
+import {
+  createFoodInputSchema,
+  foodQueryParamsSchema,
+  patchFoodInputSchema,
+  updateFoodInputSchema,
+} from '@pulse/shared';
 import type { FastifyPluginAsync } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
 import { requireAuth } from '../../middleware/auth.js';
 
-import { createFood, deleteFood, listFoods, updateFood } from './store.js';
+import { createFood, deleteFood, findFoodById, listFoods, updateFood } from './store.js';
 
 export const foodsRoutes: FastifyPluginAsync = async (app) => {
   app.addHook('onRequest', requireAuth);
@@ -52,6 +57,27 @@ export const foodsRoutes: FastifyPluginAsync = async (app) => {
     const parsedBody = updateFoodInputSchema.safeParse(request.body);
     if (!parsedBody.success) {
       return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid food payload');
+    }
+
+    const food = await updateFood(request.params.id, request.userId, parsedBody.data);
+    if (!food) {
+      return sendError(reply, 404, 'FOOD_NOT_FOUND', 'Food not found');
+    }
+
+    return reply.send({
+      data: food,
+    });
+  });
+
+  app.patch<{ Params: { id: string } }>('/:id', async (request, reply) => {
+    const parsedBody = patchFoodInputSchema.safeParse(request.body);
+    if (!parsedBody.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid food payload');
+    }
+
+    const existingFood = await findFoodById(request.params.id, request.userId);
+    if (!existingFood) {
+      return sendError(reply, 404, 'FOOD_NOT_FOUND', 'Food not found');
     }
 
     const food = await updateFood(request.params.id, request.userId, parsedBody.data);

--- a/apps/api/src/routes/foods/store.ts
+++ b/apps/api/src/routes/foods/store.ts
@@ -2,6 +2,7 @@ import { and, count, eq, isNull, sql, type SQL } from 'drizzle-orm';
 import type {
   CreateFoodInput,
   Food,
+  PatchFoodInput,
   FoodQueryParams,
   FoodSort,
   UpdateFoodInput,
@@ -74,7 +75,7 @@ const buildFoodSort = (sort: FoodSort) => {
   }
 };
 
-const getFoodById = async (id: string, userId: string): Promise<FoodRecord | undefined> => {
+export const findFoodById = async (id: string, userId: string): Promise<FoodRecord | undefined> => {
   const { db } = await import('../../db/index.js');
 
   return db
@@ -129,7 +130,7 @@ export const createFood = async ({
     throw new Error('Failed to persist food');
   }
 
-  const food = await getFoodById(id, userId);
+  const food = await findFoodById(id, userId);
   if (!food) {
     throw new Error('Failed to load created food');
   }
@@ -172,7 +173,7 @@ export const listFoods = async (
 export const updateFood = async (
   id: string,
   userId: string,
-  updates: UpdateFoodInput,
+  updates: UpdateFoodInput | PatchFoodInput,
 ): Promise<FoodRecord | undefined> => {
   const { db } = await import('../../db/index.js');
   const nextValues: Partial<typeof foods.$inferInsert> & { updatedAt: number } = {
@@ -241,7 +242,7 @@ export const updateFood = async (
     return undefined;
   }
 
-  return getFoodById(id, userId);
+  return findFoodById(id, userId);
 };
 
 export const deleteFood = async (id: string, userId: string): Promise<boolean> => {

--- a/apps/api/src/routes/nutrition/index.test.ts
+++ b/apps/api/src/routes/nutrition/index.test.ts
@@ -468,13 +468,13 @@ describe('nutrition routes', () => {
       expect(vi.mocked(findMealForDate)).toHaveBeenNthCalledWith(5, 'user-2', '2026-03-09', 'meal-1');
       expect(vi.mocked(findMealForDate)).toHaveBeenNthCalledWith(6, 'user-1', '2026-03-09', 'meal-404');
 
-      expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(1, 'meal-1', {
+      expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(1, 'user-1', 'meal-1', {
         name: 'Updated Lunch',
       });
-      expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(2, 'meal-1', {
+      expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(2, 'user-1', 'meal-1', {
         time: '13:15',
       });
-      expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(3, 'meal-1', {
+      expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(3, 'user-1', 'meal-1', {
         notes: 'Updated note',
         name: 'Updated Lunch',
       });
@@ -613,16 +613,16 @@ describe('nutrition routes', () => {
         'item-404',
       );
 
-      expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(1, 'meal-1', 'item-1', {
+      expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(1, 'user-1', 'meal-1', 'item-1', {
         amount: 9,
       });
-      expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(2, 'meal-1', 'item-1', {
+      expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(2, 'user-1', 'meal-1', 'item-1', {
         calories: 400,
         protein: 78,
         carbs: 1,
         fat: 9,
       });
-      expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(3, 'meal-1', 'item-1', {
+      expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(3, 'user-1', 'meal-1', 'item-1', {
         amount: 9,
         calories: 420,
         protein: 78,

--- a/apps/api/src/routes/nutrition/index.test.ts
+++ b/apps/api/src/routes/nutrition/index.test.ts
@@ -6,15 +6,23 @@ import { updateFoodLastUsedAt } from '../foods/store.js';
 import {
   createMealForDate,
   deleteMealForDate,
+  findMealForDate,
+  findMealItemForDate,
   getDailyNutritionForDate,
   getDailyNutritionSummaryForDate,
+  patchMealById,
+  patchMealItemById,
 } from './store.js';
 
 vi.mock('./store.js', () => ({
   createMealForDate: vi.fn(),
   deleteMealForDate: vi.fn(),
+  findMealForDate: vi.fn(),
+  findMealItemForDate: vi.fn(),
   getDailyNutritionForDate: vi.fn(),
   getDailyNutritionSummaryForDate: vi.fn(),
+  patchMealById: vi.fn(),
+  patchMealItemById: vi.fn(),
 }));
 
 vi.mock('../foods/store.js', () => ({
@@ -68,6 +76,25 @@ const mealItems = [
   },
 ];
 
+const patchedMeal = {
+  ...meal,
+  name: 'Updated Lunch',
+  time: '13:15',
+  notes: 'Updated note',
+  updatedAt: 1_700_000_000_100,
+};
+
+const patchedMealItem = {
+  ...mealItems[0],
+  amount: 9,
+  calories: 420,
+  protein: 78,
+  carbs: 1,
+  fat: 9,
+  fiber: 1,
+  sugar: 0,
+};
+
 const nutritionSummary = {
   date: '2026-03-09',
   meals: 1,
@@ -89,8 +116,12 @@ describe('nutrition routes', () => {
   beforeEach(() => {
     vi.mocked(createMealForDate).mockReset();
     vi.mocked(deleteMealForDate).mockReset();
+    vi.mocked(findMealForDate).mockReset();
+    vi.mocked(findMealItemForDate).mockReset();
     vi.mocked(getDailyNutritionForDate).mockReset();
     vi.mocked(getDailyNutritionSummaryForDate).mockReset();
+    vi.mocked(patchMealById).mockReset();
+    vi.mocked(patchMealItemById).mockReset();
     vi.mocked(updateFoodLastUsedAt).mockReset();
     vi.mocked(updateFoodLastUsedAt).mockResolvedValue(undefined);
     process.env.JWT_SECRET = 'test-nutrition-routes-secret';
@@ -357,6 +388,258 @@ describe('nutrition routes', () => {
     }
   });
 
+  it('patches meals with partial payloads and returns 404 for out-of-scope meals', async () => {
+    vi.mocked(findMealForDate)
+      .mockResolvedValueOnce(meal)
+      .mockResolvedValueOnce(meal)
+      .mockResolvedValueOnce(meal)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+    vi.mocked(patchMealById).mockResolvedValue(patchedMeal);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+
+      const patchNameResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/nutrition/2026-03-09/meals/meal-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          name: ' Updated Lunch ',
+        },
+      });
+      const patchTimeResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/nutrition/2026-03-09/meals/meal-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          time: '13:15',
+        },
+      });
+      const patchMultipleResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/nutrition/2026-03-09/meals/meal-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          notes: 'Updated note',
+          name: 'Updated Lunch',
+        },
+      });
+
+      const wrongDateResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/nutrition/2026-03-10/meals/meal-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          notes: 'wrong date scope',
+        },
+      });
+      const wrongUserResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/nutrition/2026-03-09/meals/meal-1',
+        headers: createAuthorizationHeader(app.jwt.sign({ userId: 'user-2' })),
+        payload: {
+          notes: 'wrong user scope',
+        },
+      });
+      const missingResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/nutrition/2026-03-09/meals/meal-404',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          notes: 'missing meal id',
+        },
+      });
+
+      expect(patchNameResponse.statusCode).toBe(200);
+      expect(patchTimeResponse.statusCode).toBe(200);
+      expect(patchMultipleResponse.statusCode).toBe(200);
+      expect(patchNameResponse.json()).toEqual({
+        data: patchedMeal,
+      });
+      expect(vi.mocked(findMealForDate)).toHaveBeenNthCalledWith(1, 'user-1', '2026-03-09', 'meal-1');
+      expect(vi.mocked(findMealForDate)).toHaveBeenNthCalledWith(2, 'user-1', '2026-03-09', 'meal-1');
+      expect(vi.mocked(findMealForDate)).toHaveBeenNthCalledWith(3, 'user-1', '2026-03-09', 'meal-1');
+      expect(vi.mocked(findMealForDate)).toHaveBeenNthCalledWith(4, 'user-1', '2026-03-10', 'meal-1');
+      expect(vi.mocked(findMealForDate)).toHaveBeenNthCalledWith(5, 'user-2', '2026-03-09', 'meal-1');
+      expect(vi.mocked(findMealForDate)).toHaveBeenNthCalledWith(6, 'user-1', '2026-03-09', 'meal-404');
+
+      expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(1, 'meal-1', {
+        name: 'Updated Lunch',
+      });
+      expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(2, 'meal-1', {
+        time: '13:15',
+      });
+      expect(vi.mocked(patchMealById)).toHaveBeenNthCalledWith(3, 'meal-1', {
+        notes: 'Updated note',
+        name: 'Updated Lunch',
+      });
+
+      expect(wrongDateResponse.statusCode).toBe(404);
+      expect(wrongUserResponse.statusCode).toBe(404);
+      expect(missingResponse.statusCode).toBe(404);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('patches meal-item snapshots and returns 404 for out-of-scope items', async () => {
+    vi.mocked(findMealItemForDate)
+      .mockResolvedValueOnce(mealItems[0])
+      .mockResolvedValueOnce(mealItems[0])
+      .mockResolvedValueOnce(mealItems[0])
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+    vi.mocked(patchMealItemById).mockResolvedValue(patchedMealItem);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+
+      const patchAmountResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/nutrition/2026-03-09/meals/meal-1/items/item-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          amount: 9,
+        },
+      });
+
+      const patchMacrosResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/nutrition/2026-03-09/meals/meal-1/items/item-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          calories: 400,
+          protein: 78,
+          carbs: 1,
+          fat: 9,
+        },
+      });
+
+      const patchMultipleResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/nutrition/2026-03-09/meals/meal-1/items/item-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          amount: 9,
+          calories: 420,
+          protein: 78,
+          carbs: 1,
+          fat: 9,
+          fiber: 1,
+          sugar: 0,
+        },
+      });
+
+      const wrongMealResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/nutrition/2026-03-09/meals/meal-2/items/item-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          amount: 8.5,
+        },
+      });
+      const wrongUserResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/nutrition/2026-03-09/meals/meal-1/items/item-1',
+        headers: createAuthorizationHeader(app.jwt.sign({ userId: 'user-2' })),
+        payload: {
+          amount: 8.5,
+        },
+      });
+      const missingResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/nutrition/2026-03-09/meals/meal-1/items/item-404',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          amount: 8.5,
+        },
+      });
+
+      expect(patchAmountResponse.statusCode).toBe(200);
+      expect(patchMacrosResponse.statusCode).toBe(200);
+      expect(patchMultipleResponse.statusCode).toBe(200);
+      expect(patchMacrosResponse.json()).toEqual({
+        data: patchedMealItem,
+      });
+      expect(vi.mocked(findMealItemForDate)).toHaveBeenNthCalledWith(
+        1,
+        'user-1',
+        '2026-03-09',
+        'meal-1',
+        'item-1',
+      );
+      expect(vi.mocked(findMealItemForDate)).toHaveBeenNthCalledWith(
+        2,
+        'user-1',
+        '2026-03-09',
+        'meal-1',
+        'item-1',
+      );
+      expect(vi.mocked(findMealItemForDate)).toHaveBeenNthCalledWith(
+        3,
+        'user-1',
+        '2026-03-09',
+        'meal-1',
+        'item-1',
+      );
+      expect(vi.mocked(findMealItemForDate)).toHaveBeenNthCalledWith(
+        4,
+        'user-1',
+        '2026-03-09',
+        'meal-2',
+        'item-1',
+      );
+      expect(vi.mocked(findMealItemForDate)).toHaveBeenNthCalledWith(
+        5,
+        'user-2',
+        '2026-03-09',
+        'meal-1',
+        'item-1',
+      );
+      expect(vi.mocked(findMealItemForDate)).toHaveBeenNthCalledWith(
+        6,
+        'user-1',
+        '2026-03-09',
+        'meal-1',
+        'item-404',
+      );
+
+      expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(1, 'meal-1', 'item-1', {
+        amount: 9,
+      });
+      expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(2, 'meal-1', 'item-1', {
+        calories: 400,
+        protein: 78,
+        carbs: 1,
+        fat: 9,
+      });
+      expect(vi.mocked(patchMealItemById)).toHaveBeenNthCalledWith(3, 'meal-1', 'item-1', {
+        amount: 9,
+        calories: 420,
+        protein: 78,
+        carbs: 1,
+        fat: 9,
+        fiber: 1,
+        sugar: 0,
+      });
+
+      expect(wrongMealResponse.statusCode).toBe(404);
+      expect(wrongUserResponse.statusCode).toBe(404);
+      expect(missingResponse.statusCode).toBe(404);
+    } finally {
+      await app.close();
+    }
+  });
+
   it('gets a daily nutrition summary with actuals, target, and meal count', async () => {
     vi.mocked(getDailyNutritionSummaryForDate)
       .mockResolvedValueOnce(nutritionSummary)
@@ -436,39 +719,52 @@ describe('nutrition routes', () => {
         invalidSummaryDateResponse,
         invalidPayloadResponse,
         invalidDeleteParamsResponse,
-      ] =
-        await Promise.all([
-          app.inject({
-            method: 'GET',
-            url: '/api/v1/nutrition/03-09-2026',
-            headers: createAuthorizationHeader(authToken),
-          }),
-          app.inject({
-            method: 'GET',
-            url: '/api/v1/nutrition/2026-02-30',
-            headers: createAuthorizationHeader(authToken),
-          }),
-          app.inject({
-            method: 'GET',
-            url: '/api/v1/nutrition/03-09-2026/summary',
-            headers: createAuthorizationHeader(authToken),
-          }),
-          app.inject({
-            method: 'POST',
-            url: '/api/v1/nutrition/2026-03-09/meals',
-            headers: createAuthorizationHeader(authToken),
-            payload: {
-              name: 'Lunch',
-              time: '7:30',
-              items: [],
-            },
-          }),
-          app.inject({
-            method: 'DELETE',
-            url: '/api/v1/nutrition/2026-03-09/meals/%20%20',
-            headers: createAuthorizationHeader(authToken),
-          }),
-        ]);
+        invalidPatchMealPayloadResponse,
+        invalidPatchMealItemParamsResponse,
+      ] = await Promise.all([
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/nutrition/03-09-2026',
+          headers: createAuthorizationHeader(authToken),
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/nutrition/2026-02-30',
+          headers: createAuthorizationHeader(authToken),
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/nutrition/03-09-2026/summary',
+          headers: createAuthorizationHeader(authToken),
+        }),
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/nutrition/2026-03-09/meals',
+          headers: createAuthorizationHeader(authToken),
+          payload: {
+            name: 'Lunch',
+            time: '7:30',
+            items: [],
+          },
+        }),
+        app.inject({
+          method: 'DELETE',
+          url: '/api/v1/nutrition/2026-03-09/meals/%20%20',
+          headers: createAuthorizationHeader(authToken),
+        }),
+        app.inject({
+          method: 'PATCH',
+          url: '/api/v1/nutrition/2026-03-09/meals/meal-1',
+          headers: createAuthorizationHeader(authToken),
+          payload: {},
+        }),
+        app.inject({
+          method: 'PATCH',
+          url: '/api/v1/nutrition/2026-03-09/meals/meal-1/items/%20%20',
+          headers: createAuthorizationHeader(authToken),
+          payload: { amount: 1 },
+        }),
+      ]);
 
       expect(invalidDateResponse.statusCode).toBe(400);
       expect(invalidDateResponse.json()).toEqual({
@@ -505,6 +801,22 @@ describe('nutrition routes', () => {
         error: {
           code: 'VALIDATION_ERROR',
           message: 'Invalid meal parameters',
+        },
+      });
+
+      expect(invalidPatchMealPayloadResponse.statusCode).toBe(400);
+      expect(invalidPatchMealPayloadResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid meal payload',
+        },
+      });
+
+      expect(invalidPatchMealItemParamsResponse.statusCode).toBe(400);
+      expect(invalidPatchMealItemParamsResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid meal item parameters',
         },
       });
     } finally {
@@ -547,6 +859,16 @@ describe('nutrition routes', () => {
         app.inject({
           method: 'DELETE',
           url: '/api/v1/nutrition/2026-03-09/meals/meal-1',
+        }),
+        app.inject({
+          method: 'PATCH',
+          url: '/api/v1/nutrition/2026-03-09/meals/meal-1',
+          payload: { name: 'Lunch 2' },
+        }),
+        app.inject({
+          method: 'PATCH',
+          url: '/api/v1/nutrition/2026-03-09/meals/meal-1/items/item-1',
+          payload: { amount: 2 },
         }),
       ]);
 

--- a/apps/api/src/routes/nutrition/index.ts
+++ b/apps/api/src/routes/nutrition/index.ts
@@ -124,7 +124,7 @@ export const nutritionRoutes: FastifyPluginAsync = async (app) => {
         return sendError(reply, 404, 'MEAL_NOT_FOUND', 'Meal not found');
       }
 
-      const updatedMeal = await patchMealById(request.params.mealId, parsedBody.data);
+      const updatedMeal = await patchMealById(request.userId, request.params.mealId, parsedBody.data);
       if (!updatedMeal) {
         return sendError(reply, 404, 'MEAL_NOT_FOUND', 'Meal not found');
       }
@@ -162,6 +162,7 @@ export const nutritionRoutes: FastifyPluginAsync = async (app) => {
       }
 
       const updatedMealItem = await patchMealItemById(
+        request.userId,
         request.params.mealId,
         request.params.itemId,
         parsedBody.data,

--- a/apps/api/src/routes/nutrition/index.ts
+++ b/apps/api/src/routes/nutrition/index.ts
@@ -1,4 +1,4 @@
-import { createMealInputSchema } from '@pulse/shared';
+import { createMealInputSchema, patchMealInputSchema, patchMealItemInputSchema } from '@pulse/shared';
 import type { FastifyPluginAsync } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
@@ -8,8 +8,12 @@ import { updateFoodLastUsedAt } from '../foods/store.js';
 import {
   createMealForDate,
   deleteMealForDate,
+  findMealForDate,
+  findMealItemForDate,
   getDailyNutritionForDate,
   getDailyNutritionSummaryForDate,
+  patchMealById,
+  patchMealItemById,
 } from './store.js';
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
@@ -23,6 +27,7 @@ const isValidDateParam = (date: string) => {
   return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(date);
 };
 const isValidMealIdParam = (mealId: string) => mealId.trim().length > 0;
+const isValidItemIdParam = (itemId: string) => itemId.trim().length > 0;
 const isNonEmptyString = (value: string | null): value is string =>
   typeof value === 'string' && value.length > 0;
 
@@ -94,6 +99,79 @@ export const nutritionRoutes: FastifyPluginAsync = async (app) => {
         data: {
           success: true,
         },
+      });
+    },
+  );
+
+  app.patch<{ Params: { date: string; mealId: string } }>(
+    '/:date/meals/:mealId',
+    async (request, reply) => {
+      if (!isValidDateParam(request.params.date) || !isValidMealIdParam(request.params.mealId)) {
+        return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid meal parameters');
+      }
+
+      const parsedBody = patchMealInputSchema.safeParse(request.body);
+      if (!parsedBody.success) {
+        return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid meal payload');
+      }
+
+      const existingMeal = await findMealForDate(
+        request.userId,
+        request.params.date,
+        request.params.mealId,
+      );
+      if (!existingMeal) {
+        return sendError(reply, 404, 'MEAL_NOT_FOUND', 'Meal not found');
+      }
+
+      const updatedMeal = await patchMealById(request.params.mealId, parsedBody.data);
+      if (!updatedMeal) {
+        return sendError(reply, 404, 'MEAL_NOT_FOUND', 'Meal not found');
+      }
+
+      return reply.send({
+        data: updatedMeal,
+      });
+    },
+  );
+
+  app.patch<{ Params: { date: string; mealId: string; itemId: string } }>(
+    '/:date/meals/:mealId/items/:itemId',
+    async (request, reply) => {
+      if (
+        !isValidDateParam(request.params.date) ||
+        !isValidMealIdParam(request.params.mealId) ||
+        !isValidItemIdParam(request.params.itemId)
+      ) {
+        return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid meal item parameters');
+      }
+
+      const parsedBody = patchMealItemInputSchema.safeParse(request.body);
+      if (!parsedBody.success) {
+        return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid meal item payload');
+      }
+
+      const existingMealItem = await findMealItemForDate(
+        request.userId,
+        request.params.date,
+        request.params.mealId,
+        request.params.itemId,
+      );
+      if (!existingMealItem) {
+        return sendError(reply, 404, 'MEAL_ITEM_NOT_FOUND', 'Meal item not found');
+      }
+
+      const updatedMealItem = await patchMealItemById(
+        request.params.mealId,
+        request.params.itemId,
+        parsedBody.data,
+      );
+      if (!updatedMealItem) {
+        return sendError(reply, 404, 'MEAL_ITEM_NOT_FOUND', 'Meal item not found');
+      }
+
+      return reply.send({
+        data: updatedMealItem,
       });
     },
   );

--- a/apps/api/src/routes/nutrition/store.ts
+++ b/apps/api/src/routes/nutrition/store.ts
@@ -362,6 +362,7 @@ export const findMealById = async (userId: string, mealId: string): Promise<Meal
 };
 
 export const patchMealById = async (
+  userId: string,
   mealId: string,
   updates: PatchMealInput,
 ): Promise<MealRecord | undefined> => {
@@ -382,7 +383,17 @@ export const patchMealById = async (
     mealUpdate.notes = updates.notes;
   }
 
-  return db.update(meals).set(mealUpdate).where(eq(meals.id, mealId)).returning(mealSelection).get();
+  const scopedNutritionLogIds = db
+    .select({ id: nutritionLogs.id })
+    .from(nutritionLogs)
+    .where(eq(nutritionLogs.userId, userId));
+
+  return db
+    .update(meals)
+    .set(mealUpdate)
+    .where(and(eq(meals.id, mealId), inArray(meals.nutritionLogId, scopedNutritionLogIds)))
+    .returning(mealSelection)
+    .get();
 };
 
 export const findMealItemForDate = async (
@@ -430,6 +441,7 @@ export const findMealItemById = async (
 };
 
 export const patchMealItemById = async (
+  userId: string,
   mealId: string,
   itemId: string,
   updates: PatchMealItemInput,
@@ -465,10 +477,22 @@ export const patchMealItemById = async (
     itemUpdate.sugar = updates.sugar;
   }
 
+  const scopedMealIds = db
+    .select({ id: meals.id })
+    .from(meals)
+    .innerJoin(nutritionLogs, eq(nutritionLogs.id, meals.nutritionLogId))
+    .where(eq(nutritionLogs.userId, userId));
+
   return db
     .update(mealItems)
     .set(itemUpdate)
-    .where(and(eq(mealItems.id, itemId), eq(mealItems.mealId, mealId)))
+    .where(
+      and(
+        eq(mealItems.id, itemId),
+        eq(mealItems.mealId, mealId),
+        inArray(mealItems.mealId, scopedMealIds),
+      ),
+    )
     .returning(mealItemSelection)
     .get();
 };

--- a/apps/api/src/routes/nutrition/store.ts
+++ b/apps/api/src/routes/nutrition/store.ts
@@ -1,6 +1,6 @@
 import { and, asc, desc, eq, inArray, lte, sql } from 'drizzle-orm';
 
-import type { CreateMealInput } from '@pulse/shared';
+import type { CreateMealInput, PatchMealInput, PatchMealItemInput } from '@pulse/shared';
 
 import { foods, mealItems, meals, nutritionLogs, nutritionTargets } from '../../db/schema/index.js';
 
@@ -331,4 +331,144 @@ export const deleteMealForDate = async (
 
     return result.changes === 1;
   });
+};
+
+export const findMealForDate = async (
+  userId: string,
+  date: string,
+  mealId: string,
+): Promise<MealRecord | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  return db
+    .select(mealSelection)
+    .from(meals)
+    .innerJoin(nutritionLogs, eq(nutritionLogs.id, meals.nutritionLogId))
+    .where(and(eq(meals.id, mealId), eq(nutritionLogs.userId, userId), eq(nutritionLogs.date, date)))
+    .limit(1)
+    .get();
+};
+
+export const findMealById = async (userId: string, mealId: string): Promise<MealRecord | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  return db
+    .select(mealSelection)
+    .from(meals)
+    .innerJoin(nutritionLogs, eq(nutritionLogs.id, meals.nutritionLogId))
+    .where(and(eq(meals.id, mealId), eq(nutritionLogs.userId, userId)))
+    .limit(1)
+    .get();
+};
+
+export const patchMealById = async (
+  mealId: string,
+  updates: PatchMealInput,
+): Promise<MealRecord | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  const now = Date.now();
+  const mealUpdate: Partial<typeof meals.$inferInsert> = {
+    updatedAt: now,
+  };
+
+  if (updates.name !== undefined) {
+    mealUpdate.name = updates.name;
+  }
+  if (updates.time !== undefined) {
+    mealUpdate.time = updates.time;
+  }
+  if (updates.notes !== undefined) {
+    mealUpdate.notes = updates.notes;
+  }
+
+  return db.update(meals).set(mealUpdate).where(eq(meals.id, mealId)).returning(mealSelection).get();
+};
+
+export const findMealItemForDate = async (
+  userId: string,
+  date: string,
+  mealId: string,
+  itemId: string,
+): Promise<MealItemRecord | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  return db
+    .select(mealItemSelection)
+    .from(mealItems)
+    .innerJoin(meals, eq(meals.id, mealItems.mealId))
+    .innerJoin(nutritionLogs, eq(nutritionLogs.id, meals.nutritionLogId))
+    .where(
+      and(
+        eq(mealItems.id, itemId),
+        eq(mealItems.mealId, mealId),
+        eq(nutritionLogs.userId, userId),
+        eq(nutritionLogs.date, date),
+      ),
+    )
+    .limit(1)
+    .get();
+};
+
+export const findMealItemById = async (
+  userId: string,
+  mealId: string,
+  itemId: string,
+): Promise<MealItemRecord | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  return db
+    .select(mealItemSelection)
+    .from(mealItems)
+    .innerJoin(meals, eq(meals.id, mealItems.mealId))
+    .innerJoin(nutritionLogs, eq(nutritionLogs.id, meals.nutritionLogId))
+    .where(
+      and(eq(mealItems.id, itemId), eq(mealItems.mealId, mealId), eq(nutritionLogs.userId, userId)),
+    )
+    .limit(1)
+    .get();
+};
+
+export const patchMealItemById = async (
+  mealId: string,
+  itemId: string,
+  updates: PatchMealItemInput,
+): Promise<MealItemRecord | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  const itemUpdate: Partial<typeof mealItems.$inferInsert> = {};
+  if (updates.name !== undefined) {
+    itemUpdate.name = updates.name;
+  }
+  if (updates.amount !== undefined) {
+    itemUpdate.amount = updates.amount;
+  }
+  if (updates.unit !== undefined) {
+    itemUpdate.unit = updates.unit;
+  }
+  if (updates.calories !== undefined) {
+    itemUpdate.calories = updates.calories;
+  }
+  if (updates.protein !== undefined) {
+    itemUpdate.protein = updates.protein;
+  }
+  if (updates.carbs !== undefined) {
+    itemUpdate.carbs = updates.carbs;
+  }
+  if (updates.fat !== undefined) {
+    itemUpdate.fat = updates.fat;
+  }
+  if (updates.fiber !== undefined) {
+    itemUpdate.fiber = updates.fiber;
+  }
+  if (updates.sugar !== undefined) {
+    itemUpdate.sugar = updates.sugar;
+  }
+
+  return db
+    .update(mealItems)
+    .set(itemUpdate)
+    .where(and(eq(mealItems.id, itemId), eq(mealItems.mealId, mealId)))
+    .returning(mealItemSelection)
+    .get();
 };

--- a/apps/api/src/routes/weight/index.test.ts
+++ b/apps/api/src/routes/weight/index.test.ts
@@ -6,16 +6,20 @@ import { buildServer } from '../../index.js';
 import { findAgentTokenByHash, updateAgentTokenLastUsedAt } from '../../middleware/store.js';
 
 import {
+  findBodyWeightEntryById,
   findBodyWeightEntryByDate,
   getLatestBodyWeightEntry,
   listBodyWeightEntries,
+  patchBodyWeightEntryById,
   upsertBodyWeightEntry,
 } from './store.js';
 
 vi.mock('./store.js', () => ({
+  findBodyWeightEntryById: vi.fn(),
   findBodyWeightEntryByDate: vi.fn(),
   getLatestBodyWeightEntry: vi.fn(),
   listBodyWeightEntries: vi.fn(),
+  patchBodyWeightEntryById: vi.fn(),
   upsertBodyWeightEntry: vi.fn(),
 }));
 
@@ -30,9 +34,11 @@ const createAuthorizationHeader = (token: string) => ({
 
 describe('weight routes', () => {
   beforeEach(() => {
+    vi.mocked(findBodyWeightEntryById).mockReset();
     vi.mocked(findBodyWeightEntryByDate).mockReset();
     vi.mocked(getLatestBodyWeightEntry).mockReset();
     vi.mocked(listBodyWeightEntries).mockReset();
+    vi.mocked(patchBodyWeightEntryById).mockReset();
     vi.mocked(upsertBodyWeightEntry).mockReset();
     vi.mocked(findAgentTokenByHash).mockReset();
     vi.mocked(updateAgentTokenLastUsedAt).mockReset();
@@ -313,6 +319,148 @@ describe('weight routes', () => {
     }
   });
 
+  it('patches weight entries with partial payloads', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+
+      vi.mocked(findBodyWeightEntryById).mockResolvedValue({
+        id: 'entry-1',
+        date: '2026-03-07',
+        weight: 182,
+        notes: null,
+        createdAt: 1_700_000_000_000,
+        updatedAt: 1_700_000_000_000,
+      });
+      vi.mocked(patchBodyWeightEntryById)
+        .mockResolvedValueOnce({
+          id: 'entry-1',
+          date: '2026-03-07',
+          weight: 181.5,
+          notes: null,
+          createdAt: 1_700_000_000_000,
+          updatedAt: 1_700_000_001_000,
+        })
+        .mockResolvedValueOnce({
+          id: 'entry-1',
+          date: '2026-03-07',
+          weight: 181.5,
+          notes: 'Evening weigh-in',
+          createdAt: 1_700_000_000_000,
+          updatedAt: 1_700_000_002_000,
+        })
+        .mockResolvedValueOnce({
+          id: 'entry-1',
+          date: '2026-03-07',
+          weight: 181.2,
+          notes: 'Fasted',
+          createdAt: 1_700_000_000_000,
+          updatedAt: 1_700_000_003_000,
+        });
+
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const weightOnlyResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/weight/entry-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          weight: 181.5,
+        },
+      });
+      const notesOnlyResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/weight/entry-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          notes: '  Evening weigh-in  ',
+        },
+      });
+      const bothResponse = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/weight/entry-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          weight: 181.2,
+          notes: 'Fasted',
+        },
+      });
+
+      expect(weightOnlyResponse.statusCode).toBe(200);
+      expect(notesOnlyResponse.statusCode).toBe(200);
+      expect(bothResponse.statusCode).toBe(200);
+      expect(vi.mocked(findBodyWeightEntryById)).toHaveBeenCalledTimes(3);
+      expect(vi.mocked(patchBodyWeightEntryById)).toHaveBeenNthCalledWith(1, 'entry-1', 'user-1', {
+        weight: 181.5,
+      });
+      expect(vi.mocked(patchBodyWeightEntryById)).toHaveBeenNthCalledWith(2, 'entry-1', 'user-1', {
+        notes: 'Evening weigh-in',
+      });
+      expect(vi.mocked(patchBodyWeightEntryById)).toHaveBeenNthCalledWith(3, 'entry-1', 'user-1', {
+        weight: 181.2,
+        notes: 'Fasted',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns 404 when patching a missing scoped weight entry', async () => {
+    vi.mocked(findBodyWeightEntryById).mockResolvedValue(null);
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/weight/missing-entry',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          weight: 181.5,
+        },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'WEIGHT_NOT_FOUND',
+          message: 'Weight entry not found',
+        },
+      });
+      expect(vi.mocked(patchBodyWeightEntryById)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects empty patch payloads', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/weight/entry-1',
+        headers: createAuthorizationHeader(authToken),
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid weight payload',
+        },
+      });
+      expect(vi.mocked(findBodyWeightEntryById)).not.toHaveBeenCalled();
+      expect(vi.mocked(patchBodyWeightEntryById)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
   it('returns the latest body weight entry or null', async () => {
     vi.mocked(getLatestBodyWeightEntry)
       .mockResolvedValueOnce({
@@ -386,6 +534,13 @@ describe('weight routes', () => {
         app.inject({
           method: 'GET',
           url: '/api/v1/weight/latest',
+        }),
+        app.inject({
+          method: 'PATCH',
+          url: '/api/v1/weight/entry-1',
+          payload: {
+            weight: 181.5,
+          },
         }),
       ]);
 

--- a/apps/api/src/routes/weight/index.ts
+++ b/apps/api/src/routes/weight/index.ts
@@ -1,13 +1,19 @@
-import { createWeightInputSchema, weightQueryParamsSchema } from '@pulse/shared';
+import {
+  createWeightInputSchema,
+  patchWeightInputSchema,
+  weightQueryParamsSchema,
+} from '@pulse/shared';
 import type { FastifyPluginAsync } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
 import { requireAuth } from '../../middleware/auth.js';
 
 import {
+  findBodyWeightEntryById,
   findBodyWeightEntryByDate,
   getLatestBodyWeightEntry,
   listBodyWeightEntries,
+  patchBodyWeightEntryById,
   upsertBodyWeightEntry,
 } from './store.js';
 
@@ -46,6 +52,27 @@ export const weightRoutes: FastifyPluginAsync = async (app) => {
 
     return reply.send({
       data: entries,
+    });
+  });
+
+  app.patch<{ Params: { id: string } }>('/:id', async (request, reply) => {
+    const parsedBody = patchWeightInputSchema.safeParse(request.body);
+    if (!parsedBody.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid weight payload');
+    }
+
+    const existingEntry = await findBodyWeightEntryById(request.params.id, request.userId);
+    if (!existingEntry) {
+      return sendError(reply, 404, 'WEIGHT_NOT_FOUND', 'Weight entry not found');
+    }
+
+    const entry = await patchBodyWeightEntryById(request.params.id, request.userId, parsedBody.data);
+    if (!entry) {
+      return sendError(reply, 404, 'WEIGHT_NOT_FOUND', 'Weight entry not found');
+    }
+
+    return reply.send({
+      data: entry,
     });
   });
 };

--- a/apps/api/src/routes/weight/store.ts
+++ b/apps/api/src/routes/weight/store.ts
@@ -1,6 +1,11 @@
 import { and, asc, desc, eq, gte, lte } from 'drizzle-orm';
 
-import type { BodyWeightEntry, CreateWeightInput, WeightQueryParams } from '@pulse/shared';
+import type {
+  BodyWeightEntry,
+  CreateWeightInput,
+  PatchWeightInput,
+  WeightQueryParams,
+} from '@pulse/shared';
 
 import { bodyWeight } from '../../db/schema/index.js';
 import { addUtcDays, getTodayDate } from '../../lib/date.js';
@@ -25,6 +30,22 @@ export const findBodyWeightEntryByDate = async (
       .select(bodyWeightEntrySelection)
       .from(bodyWeight)
       .where(and(eq(bodyWeight.userId, userId), eq(bodyWeight.date, date)))
+      .limit(1)
+      .get() ?? null
+  );
+};
+
+export const findBodyWeightEntryById = async (
+  id: string,
+  userId: string,
+): Promise<BodyWeightEntry | null> => {
+  const { db } = await import('../../db/index.js');
+
+  return (
+    db
+      .select(bodyWeightEntrySelection)
+      .from(bodyWeight)
+      .where(and(eq(bodyWeight.id, id), eq(bodyWeight.userId, userId)))
       .limit(1)
       .get() ?? null
   );
@@ -106,4 +127,35 @@ export const getLatestBodyWeightEntry = async (userId: string): Promise<BodyWeig
       .limit(1)
       .get() ?? null
   );
+};
+
+export const patchBodyWeightEntryById = async (
+  id: string,
+  userId: string,
+  input: PatchWeightInput,
+): Promise<BodyWeightEntry | null> => {
+  const { db } = await import('../../db/index.js');
+  const updates: Partial<typeof bodyWeight.$inferInsert> & { updatedAt: number } = {
+    updatedAt: Date.now(),
+  };
+
+  if (input.weight !== undefined) {
+    updates.weight = input.weight;
+  }
+
+  if ('notes' in input) {
+    updates.notes = input.notes ?? null;
+  }
+
+  const result = db
+    .update(bodyWeight)
+    .set(updates)
+    .where(and(eq(bodyWeight.id, id), eq(bodyWeight.userId, userId)))
+    .run();
+
+  if (result.changes !== 1) {
+    return null;
+  }
+
+  return findBodyWeightEntryById(id, userId);
 };

--- a/packages/shared/src/schemas/foods.test.ts
+++ b/packages/shared/src/schemas/foods.test.ts
@@ -6,7 +6,9 @@ import {
   foodSchema,
   type Food,
   type FoodQueryParams,
+  type PatchFoodInput,
   type UpdateFoodInput,
+  patchFoodInputSchema,
   updateFoodInputSchema,
 } from './foods';
 
@@ -116,6 +118,44 @@ describe('updateFoodInputSchema', () => {
 
   it('rejects empty update payloads', () => {
     expect(() => updateFoodInputSchema.parse({})).toThrow();
+  });
+});
+
+describe('patchFoodInputSchema', () => {
+  it('accepts a valid single-field patch', () => {
+    const payload: PatchFoodInput = patchFoodInputSchema.parse({
+      notes: '  updated source  ',
+    });
+
+    expect(payload).toEqual({
+      notes: 'updated source',
+    });
+  });
+
+  it('accepts a valid multi-field patch', () => {
+    const payload = patchFoodInputSchema.parse({
+      name: ' Greek Yogurt ',
+      brand: ' Fage ',
+      verified: true,
+    });
+
+    expect(payload).toEqual({
+      name: 'Greek Yogurt',
+      brand: 'Fage',
+      verified: true,
+    });
+  });
+
+  it('rejects an empty patch payload', () => {
+    expect(() => patchFoodInputSchema.parse({})).toThrow();
+  });
+
+  it('enforces field constraints', () => {
+    expect(() =>
+      patchFoodInputSchema.parse({
+        name: 'x'.repeat(256),
+      }),
+    ).toThrow();
   });
 });
 

--- a/packages/shared/src/schemas/foods.ts
+++ b/packages/shared/src/schemas/foods.ts
@@ -62,9 +62,7 @@ export const updateFoodInputSchema = foodMutationFieldsSchema
   .partial()
   .refine((value) => Object.keys(value).length > 0, 'At least one field must be provided');
 
-export const patchFoodInputSchema = foodMutationFieldsSchema
-  .partial()
-  .refine((value) => Object.keys(value).length > 0, 'At least one field must be provided');
+export const patchFoodInputSchema = updateFoodInputSchema;
 
 export const foodQueryParamsSchema = z.object({
   q: optionalQueryText,

--- a/packages/shared/src/schemas/foods.ts
+++ b/packages/shared/src/schemas/foods.ts
@@ -62,6 +62,10 @@ export const updateFoodInputSchema = foodMutationFieldsSchema
   .partial()
   .refine((value) => Object.keys(value).length > 0, 'At least one field must be provided');
 
+export const patchFoodInputSchema = foodMutationFieldsSchema
+  .partial()
+  .refine((value) => Object.keys(value).length > 0, 'At least one field must be provided');
+
 export const foodQueryParamsSchema = z.object({
   q: optionalQueryText,
   sort: foodSortSchema.default('name'),
@@ -73,4 +77,5 @@ export type Food = z.infer<typeof foodSchema>;
 export type FoodSort = z.infer<typeof foodSortSchema>;
 export type CreateFoodInput = z.infer<typeof createFoodInputSchema>;
 export type UpdateFoodInput = z.infer<typeof updateFoodInputSchema>;
+export type PatchFoodInput = z.infer<typeof patchFoodInputSchema>;
 export type FoodQueryParams = z.infer<typeof foodQueryParamsSchema>;

--- a/packages/shared/src/schemas/nutrition.test.ts
+++ b/packages/shared/src/schemas/nutrition.test.ts
@@ -5,11 +5,15 @@ import {
   type DailyNutrition,
   type DeleteMealResult,
   type MealItemInput,
+  type PatchMealInput,
+  type PatchMealItemInput,
   type NutritionSummary,
   createMealInputSchema,
   dailyNutritionSchema,
   deleteMealResultSchema,
   mealItemInputSchema,
+  patchMealInputSchema,
+  patchMealItemInputSchema,
   nutritionSummarySchema,
 } from './nutrition';
 
@@ -138,6 +142,80 @@ describe('createMealInputSchema', () => {
     };
 
     expect(meal.name).toBe('Breakfast');
+  });
+});
+
+describe('patchMealInputSchema', () => {
+  it('accepts a valid single-field patch', () => {
+    const payload: PatchMealInput = patchMealInputSchema.parse({
+      name: ' Dinner ',
+    });
+
+    expect(payload).toEqual({
+      name: 'Dinner',
+    });
+  });
+
+  it('accepts a valid multi-field patch', () => {
+    const payload = patchMealInputSchema.parse({
+      time: null,
+      notes: '  lighter meal  ',
+    });
+
+    expect(payload).toEqual({
+      time: null,
+      notes: 'lighter meal',
+    });
+  });
+
+  it('rejects an empty patch payload', () => {
+    expect(() => patchMealInputSchema.parse({})).toThrow();
+  });
+
+  it('enforces field constraints', () => {
+    expect(() =>
+      patchMealInputSchema.parse({
+        name: 'x'.repeat(121),
+      }),
+    ).toThrow();
+  });
+});
+
+describe('patchMealItemInputSchema', () => {
+  it('accepts a valid single-field patch', () => {
+    const payload: PatchMealItemInput = patchMealItemInputSchema.parse({
+      amount: 2.5,
+    });
+
+    expect(payload).toEqual({
+      amount: 2.5,
+    });
+  });
+
+  it('accepts a valid multi-field patch', () => {
+    const payload = patchMealItemInputSchema.parse({
+      name: ' Grilled Chicken ',
+      calories: 220,
+      fiber: null,
+    });
+
+    expect(payload).toEqual({
+      name: 'Grilled Chicken',
+      calories: 220,
+      fiber: null,
+    });
+  });
+
+  it('rejects an empty patch payload', () => {
+    expect(() => patchMealItemInputSchema.parse({})).toThrow();
+  });
+
+  it('enforces field constraints', () => {
+    expect(() =>
+      patchMealItemInputSchema.parse({
+        amount: 0,
+      }),
+    ).toThrow();
   });
 });
 

--- a/packages/shared/src/schemas/nutrition.ts
+++ b/packages/shared/src/schemas/nutrition.ts
@@ -98,12 +98,9 @@ export const patchMealInputSchema = z
     time: mealTimeSchema.nullable().optional(),
     notes: z.string().trim().max(2_000).nullable().optional(),
   })
-  .refine(
-    (value) => value.name !== undefined || value.time !== undefined || value.notes !== undefined,
-    {
-      message: 'At least one field must be provided',
-    },
-  );
+  .refine((value) => Object.values(value).some((field) => field !== undefined), {
+    message: 'At least one field must be provided',
+  });
 
 export const patchMealItemInputSchema = z
   .object({
@@ -117,21 +114,9 @@ export const patchMealItemInputSchema = z
     fiber: nonnegativeNumber.nullable().optional(),
     sugar: nonnegativeNumber.nullable().optional(),
   })
-  .refine(
-    (value) =>
-      value.name !== undefined ||
-      value.amount !== undefined ||
-      value.unit !== undefined ||
-      value.calories !== undefined ||
-      value.protein !== undefined ||
-      value.carbs !== undefined ||
-      value.fat !== undefined ||
-      value.fiber !== undefined ||
-      value.sugar !== undefined,
-    {
-      message: 'At least one field must be provided',
-    },
-  );
+  .refine((value) => Object.values(value).some((field) => field !== undefined), {
+    message: 'At least one field must be provided',
+  });
 
 export type MealItemInput = z.infer<typeof mealItemInputSchema>;
 export type CreateMealInput = z.infer<typeof createMealInputSchema>;

--- a/packages/shared/src/schemas/nutrition.ts
+++ b/packages/shared/src/schemas/nutrition.ts
@@ -92,8 +92,51 @@ export const createMealInputSchema = z.object({
   items: z.array(mealItemInputSchema).min(1),
 });
 
+export const patchMealInputSchema = z
+  .object({
+    name: requiredText(120).optional(),
+    time: mealTimeSchema.nullable().optional(),
+    notes: z.string().trim().max(2_000).nullable().optional(),
+  })
+  .refine(
+    (value) => value.name !== undefined || value.time !== undefined || value.notes !== undefined,
+    {
+      message: 'At least one field must be provided',
+    },
+  );
+
+export const patchMealItemInputSchema = z
+  .object({
+    name: requiredText().optional(),
+    amount: z.number().positive().finite().optional(),
+    unit: requiredText(50).optional(),
+    calories: nonnegativeNumber.optional(),
+    protein: nonnegativeNumber.optional(),
+    carbs: nonnegativeNumber.optional(),
+    fat: nonnegativeNumber.optional(),
+    fiber: nonnegativeNumber.nullable().optional(),
+    sugar: nonnegativeNumber.nullable().optional(),
+  })
+  .refine(
+    (value) =>
+      value.name !== undefined ||
+      value.amount !== undefined ||
+      value.unit !== undefined ||
+      value.calories !== undefined ||
+      value.protein !== undefined ||
+      value.carbs !== undefined ||
+      value.fat !== undefined ||
+      value.fiber !== undefined ||
+      value.sugar !== undefined,
+    {
+      message: 'At least one field must be provided',
+    },
+  );
+
 export type MealItemInput = z.infer<typeof mealItemInputSchema>;
 export type CreateMealInput = z.infer<typeof createMealInputSchema>;
+export type PatchMealInput = z.infer<typeof patchMealInputSchema>;
+export type PatchMealItemInput = z.infer<typeof patchMealItemInputSchema>;
 export type NutritionMacroTotals = z.infer<typeof nutritionMacroTotalsSchema>;
 export type NutritionLog = z.infer<typeof nutritionLogSchema>;
 export type NutritionMeal = z.infer<typeof nutritionMealSchema>;

--- a/packages/shared/src/schemas/weight.test.ts
+++ b/packages/shared/src/schemas/weight.test.ts
@@ -113,6 +113,24 @@ describe('patchWeightInputSchema', () => {
     });
   });
 
+  it('allows null notes to explicitly clear an existing note', () => {
+    const payload = patchWeightInputSchema.parse({
+      notes: null,
+    });
+
+    expect(payload).toEqual({
+      notes: null,
+    });
+  });
+
+  it('rejects blank notes when no other patch fields are provided', () => {
+    expect(() =>
+      patchWeightInputSchema.parse({
+        notes: '   ',
+      }),
+    ).toThrow();
+  });
+
   it('rejects an empty patch payload', () => {
     expect(() => patchWeightInputSchema.parse({})).toThrow();
   });

--- a/packages/shared/src/schemas/weight.test.ts
+++ b/packages/shared/src/schemas/weight.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from 'vitest';
 import {
   type BodyWeightEntry,
   type CreateWeightInput,
+  type PatchWeightInput,
   type WeightQueryParams,
   bodyWeightEntrySchema,
   createWeightInputSchema,
+  patchWeightInputSchema,
   weightQueryParamsSchema,
 } from './weight';
 
@@ -85,6 +87,42 @@ describe('bodyWeightEntrySchema', () => {
     };
 
     expect(entry.notes).toBeNull();
+  });
+});
+
+describe('patchWeightInputSchema', () => {
+  it('accepts a valid single-field patch', () => {
+    const payload: PatchWeightInput = patchWeightInputSchema.parse({
+      weight: 180.5,
+    });
+
+    expect(payload).toEqual({
+      weight: 180.5,
+    });
+  });
+
+  it('accepts a valid multi-field patch', () => {
+    const payload = patchWeightInputSchema.parse({
+      weight: 179.9,
+      notes: '  feeling good  ',
+    });
+
+    expect(payload).toEqual({
+      weight: 179.9,
+      notes: 'feeling good',
+    });
+  });
+
+  it('rejects an empty patch payload', () => {
+    expect(() => patchWeightInputSchema.parse({})).toThrow();
+  });
+
+  it('rejects invalid field values', () => {
+    expect(() =>
+      patchWeightInputSchema.parse({
+        weight: -1,
+      }),
+    ).toThrow();
   });
 });
 

--- a/packages/shared/src/schemas/weight.ts
+++ b/packages/shared/src/schemas/weight.ts
@@ -18,6 +18,15 @@ export const createWeightInputSchema = z.object({
   notes: weightNotesSchema.optional(),
 });
 
+export const patchWeightInputSchema = z
+  .object({
+    weight: bodyWeightValueSchema.optional(),
+    notes: z.string().trim().max(2000).optional(),
+  })
+  .refine((value) => value.weight !== undefined || value.notes !== undefined, {
+    message: 'At least one field must be provided',
+  });
+
 export const bodyWeightEntrySchema = z.object({
   id: z.string(),
   date: dateSchema,
@@ -44,4 +53,5 @@ export const weightQueryParamsSchema = z
 
 export type BodyWeightEntry = z.infer<typeof bodyWeightEntrySchema>;
 export type CreateWeightInput = z.infer<typeof createWeightInputSchema>;
+export type PatchWeightInput = z.infer<typeof patchWeightInputSchema>;
 export type WeightQueryParams = z.infer<typeof weightQueryParamsSchema>;

--- a/packages/shared/src/schemas/weight.ts
+++ b/packages/shared/src/schemas/weight.ts
@@ -21,9 +21,9 @@ export const createWeightInputSchema = z.object({
 export const patchWeightInputSchema = z
   .object({
     weight: bodyWeightValueSchema.optional(),
-    notes: z.string().trim().max(2000).optional(),
+    notes: weightNotesSchema.nullable().optional(),
   })
-  .refine((value) => value.weight !== undefined || value.notes !== undefined, {
+  .refine((value) => Object.values(value).some((field) => field !== undefined), {
     message: 'At least one field must be provided',
   });
 


### PR DESCRIPTION
## Summary
This PR closes a gap in the API surface by adding missing `PATCH` endpoints for weight entries, foods, meals, and meal items across both `/api/v1` and `/api/agent`. The main goal is to support true partial updates without forcing clients to send full replacement payloads. It also aligns runtime validation with this behavior by introducing dedicated patch schemas in `@pulse/shared` that reject empty payloads and preserve existing field constraints. For nutrition resources, the patch flow explicitly verifies user ownership (and date scope for v1 routes) before applying updates, so out-of-scope records return consistent `404` responses instead of updating by raw ID.

## Key Changes
- Added new shared patch schemas and types:
  - `patchWeightInputSchema` / `PatchWeightInput`
  - `patchFoodInputSchema` / `PatchFoodInput`
  - `patchMealInputSchema` / `PatchMealInput`
  - `patchMealItemInputSchema` / `PatchMealItemInput`
- Added `PATCH /api/v1/weight/:id` and `PATCH /api/agent/weight/:id` with partial field support and `WEIGHT_NOT_FOUND` handling.
- Added `PATCH /api/v1/foods/:id` and `PATCH /api/agent/foods/:id`, including pre-checks for missing/unauthorized/soft-deleted foods.
- Added meal patch endpoints:
  - `PATCH /api/v1/nutrition/:date/meals/:mealId`
  - `PATCH /api/v1/nutrition/:date/meals/:mealId/items/:itemId`
  - `PATCH /api/agent/meals/:id`
  - `PATCH /api/agent/meals/:id/items/:itemId`
- Extended nutrition and weight stores with scoped lookup and patch helpers (`find*ById` / `find*ForDate`, `patch*ById`) used by both app and agent routes.
- Added broad test coverage for success paths, empty-payload validation failures, auth requirements, and not-found/out-of-scope behavior for every new patch endpoint.

## Technical Notes
- Nutrition patch authorization is enforced via joins to `nutritionLogs` (and `date` in v1), so a valid `mealId`/`itemId` outside user/date scope is treated as not found.
- Foods patch reuses `updateFood` with partial input while preserving the existing soft-delete guard (`deletedAt IS NULL`) in store queries.
- Patch schemas enforce “at least one field provided” at the shared validation layer, preventing no-op writes and keeping behavior consistent across v1 and agent routes.
- Route handlers use an existence pre-check plus patch operation to preserve explicit domain error codes/messages (`FOOD_NOT_FOUND`, `MEAL_NOT_FOUND`, `MEAL_ITEM_NOT_FOUND`, `WEIGHT_NOT_FOUND`) in race or scope-edge cases.

## Commits

- `4af36e0 feat(api): add meal and meal-item patch endpoints`
- `f63c754 feat(api): add patch routes for weight and foods`
- `e264554 feat(shared): add patch schemas for weight meals and foods`

## Tasks

- **Add shared PATCH Zod schemas for weight, meals, meal-items, and foods**: Create patchWeightInputSchema, patchMealInputSchema, patchMealItemInputSchema, and patchFoodInputSchema with at-least-one-field refines
- **Add PATCH routes for weight and foods (v1 + agent)**: Implement PATCH /:id for weight and foods on both v1 app routes and agent routes
- **Add PATCH routes for meals and meal-items (v1 + agent)**: Implement PATCH for meals and meal-items on both v1 and agent routes with ownership verification via nutritionLogs join

## Diff Stats

```
apps/api/src/__tests__/agent.test.ts           |   6 +
 apps/api/src/__tests__/foods-nutrition.test.ts |   6 +
 apps/api/src/routes/agent/daily.test.ts        | 181 +++++++++++-
 apps/api/src/routes/agent/daily.ts             |  27 +-
 apps/api/src/routes/agent/foods.test.ts        | 149 +++++++++-
 apps/api/src/routes/agent/foods.ts             |  27 +-
 apps/api/src/routes/agent/meals.test.ts        | 260 ++++++++++++++++-
 apps/api/src/routes/agent/meals.ts             |  52 +++-
 apps/api/src/routes/foods/index.test.ts        | 137 ++++++++-
 apps/api/src/routes/foods/index.ts             |  30 +-
 apps/api/src/routes/foods/store.ts             |   9 +-
 apps/api/src/routes/nutrition/index.test.ts    | 388 ++++++++++++++++++++++---
 apps/api/src/routes/nutrition/index.ts         |  80 ++++-
 apps/api/src/routes/nutrition/store.ts         | 142 ++++++++-
 apps/api/src/routes/weight/index.test.ts       | 155 ++++++++++
 apps/api/src/routes/weight/index.ts            |  29 +-
 apps/api/src/routes/weight/store.ts            |  54 +++-
 packages/shared/src/schemas/foods.test.ts      |  40 +++
 packages/shared/src/schemas/foods.ts           |   5 +
 packages/shared/src/schemas/nutrition.test.ts  |  78 +++++
 packages/shared/src/schemas/nutrition.ts       |  43 +++
 packages/shared/src/schemas/weight.test.ts     |  38 +++
 packages/shared/src/schemas/weight.ts          |  10 +
 23 files changed, 1894 insertions(+), 52 deletions(-)
```