### PR TITLE
feat(weight): add delete weight entry flow with history UI

### DIFF
--- a/apps/api/src/__tests__/agent.test.ts
+++ b/apps/api/src/__tests__/agent.test.ts
@@ -173,16 +173,18 @@ vi.mock('../routes/agent/store.js', () => ({
     const filtered = query
       ? userFoods.filter((f) => f.name.toLowerCase().includes(query.toLowerCase()))
       : userFoods;
-    return filtered.slice(0, limit).map(({ id, name, brand, servingSize, calories, protein, carbs, fat }) => ({
-      id,
-      name,
-      brand,
-      servingSize,
-      calories,
-      protein,
-      carbs,
-      fat,
-    }));
+    return filtered
+      .slice(0, limit)
+      .map(({ id, name, brand, servingSize, calories, protein, carbs, fat }) => ({
+        id,
+        name,
+        brand,
+        servingSize,
+        calories,
+        protein,
+        carbs,
+        fat,
+      }));
   }),
   findFoodByName: vi.fn(async (userId: string, foodName: string) => {
     const userFoods = [...testState.foods.values()].filter((f) => f.userId === userId);
@@ -266,7 +268,12 @@ vi.mock('../routes/nutrition/store.js', () => ({
   ),
   deleteMealForDate: vi.fn(),
   getDailyNutritionForDate: vi.fn(async () => null),
-  getDailyNutritionSummaryForDate: vi.fn(async () => ({ calories: 0, protein: 0, carbs: 0, fat: 0 })),
+  getDailyNutritionSummaryForDate: vi.fn(async () => ({
+    calories: 0,
+    protein: 0,
+    carbs: 0,
+    fat: 0,
+  })),
   findMealForDate: vi.fn(),
   findMealItemForDate: vi.fn(),
   findMealById: vi.fn(),
@@ -331,7 +338,9 @@ vi.mock('../routes/exercises/store.js', () => ({
       page: number;
       limit: number;
     }) => {
-      const visible = [...testState.exercises.values()].filter((exercise) => exercise.userId === userId);
+      const visible = [...testState.exercises.values()].filter(
+        (exercise) => exercise.userId === userId,
+      );
       const filtered = q
         ? visible.filter((exercise) => exercise.name.toLowerCase().includes(q.toLowerCase()))
         : visible;
@@ -347,7 +356,15 @@ vi.mock('../routes/exercises/store.js', () => ({
     },
   ),
   updateOwnedExercise: vi.fn(
-    async ({ id, userId, changes }: { id: string; userId: string; changes: Record<string, unknown> }) => {
+    async ({
+      id,
+      userId,
+      changes,
+    }: {
+      id: string;
+      userId: string;
+      changes: Record<string, unknown>;
+    }) => {
       const exercise = testState.exercises.get(id);
       if (!exercise || exercise.userId !== userId) {
         return undefined;
@@ -465,7 +482,9 @@ vi.mock('../routes/workout-sessions/store.js', () => ({
   findWorkoutSessionAccess: vi.fn(),
   findWorkoutSessionById: vi.fn(async (id: string, userId: string) => {
     const session = testState.workoutSessions.get(id);
-    return session && session.userId === userId ? { ...session, sets: [], createdAt: Date.now(), updatedAt: Date.now() } : undefined;
+    return session && session.userId === userId
+      ? { ...session, sets: [], createdAt: Date.now(), updatedAt: Date.now() }
+      : undefined;
   }),
   listSessionSetGroups: vi.fn(),
   SessionSetNotFoundError: class extends Error {},
@@ -502,7 +521,13 @@ vi.mock('../routes/agent/context-store.js', () => ({
     { name: 'Morning run', trackingType: 'boolean', streak: 3, todayCompleted: true },
   ]),
   listAgentContextRecentWorkouts: vi.fn(async () => [
-    { id: 'session-1', name: 'Push Day', date: '2026-03-08', completedAt: 1741478400000, exercises: [] },
+    {
+      id: 'session-1',
+      name: 'Push Day',
+      date: '2026-03-08',
+      completedAt: 1741478400000,
+      exercises: [],
+    },
   ]),
   listAgentContextScheduledWorkouts: vi.fn(async () => [
     { date: '2026-03-10', templateName: 'Pull Day' },
@@ -543,8 +568,12 @@ vi.mock('../routes/habits/store.js', () => ({
 }));
 
 vi.mock('../routes/weight/store.js', () => ({
+  deleteBodyWeightEntryById: vi.fn(async () => true),
   findBodyWeightEntryByDate: vi.fn(async () => null),
+  findBodyWeightEntryById: vi.fn(async () => null),
   listBodyWeightEntries: vi.fn(async () => []),
+  patchBodyWeightEntryById: vi.fn(async () => null),
+  getLatestBodyWeightEntry: vi.fn(async () => null),
   upsertBodyWeightEntry: vi.fn(async (_userId: string, input: Record<string, unknown>) => ({
     id: 'weight-1',
     userId: _userId,
@@ -1192,7 +1221,12 @@ describe('agent integration', () => {
         expect(response.statusCode).toBe(200);
 
         const body = response.json() as {
-          data: Array<{ name: string; category: string; muscleGroups: string[]; equipment: string }>;
+          data: Array<{
+            name: string;
+            category: string;
+            muscleGroups: string[];
+            equipment: string;
+          }>;
         };
         expect(body.data).toHaveLength(1);
         expect(body.data[0].name).toBe('Dumbbell Curl');

--- a/apps/api/src/__tests__/habits-weight-targets.test.ts
+++ b/apps/api/src/__tests__/habits-weight-targets.test.ts
@@ -208,6 +208,14 @@ vi.mock('../routes/weight/store.js', () => ({
 
     return entry ? withoutUserId(entry) : null;
   }),
+  findBodyWeightEntryById: vi.fn(async (id: string, userId: string) => {
+    const entry =
+      [...testState.weightEntries.values()].find(
+        (candidate) => candidate.id === id && candidate.userId === userId,
+      ) ?? null;
+
+    return entry ? withoutUserId(entry) : null;
+  }),
   upsertBodyWeightEntry: vi.fn(
     async (userId: string, input: { date: string; weight: number; notes?: string }) => {
       const key = getWeightEntryKey(userId, input.date);
@@ -236,33 +244,75 @@ vi.mock('../routes/weight/store.js', () => ({
       return withoutUserId(entry);
     },
   ),
-  listBodyWeightEntries: vi.fn(async (userId: string, query: { from?: string; to?: string; days?: number }) =>
-    [...testState.weightEntries.values()]
-      .filter((entry) => {
-        if (entry.userId !== userId) {
-          return false;
-        }
+  patchBodyWeightEntryById: vi.fn(
+    async (
+      id: string,
+      userId: string,
+      input: {
+        weight?: number;
+        notes?: string | null;
+      },
+    ) => {
+      const entry = [...testState.weightEntries.values()].find(
+        (candidate) => candidate.id === id && candidate.userId === userId,
+      );
+      if (!entry) {
+        return null;
+      }
 
-        if (query.days !== undefined) {
-          const rangeEnd = query.to ?? getTodayDate();
-          const rangeStart = addUtcDays(rangeEnd, -(query.days - 1));
-          if (entry.date < rangeStart) {
+      if (input.weight !== undefined) {
+        entry.weight = input.weight;
+      }
+
+      if ('notes' in input) {
+        entry.notes = input.notes ?? null;
+      }
+
+      entry.updatedAt = Date.now();
+
+      return withoutUserId(entry);
+    },
+  ),
+  deleteBodyWeightEntryById: vi.fn(async (id: string, userId: string) => {
+    const entry = [...testState.weightEntries.values()].find(
+      (candidate) => candidate.id === id && candidate.userId === userId,
+    );
+    if (!entry) {
+      return false;
+    }
+
+    testState.weightEntries.delete(getWeightEntryKey(entry.userId, entry.date));
+
+    return true;
+  }),
+  listBodyWeightEntries: vi.fn(
+    async (userId: string, query: { from?: string; to?: string; days?: number }) =>
+      [...testState.weightEntries.values()]
+        .filter((entry) => {
+          if (entry.userId !== userId) {
             return false;
           }
-        }
 
-        if (query.from && entry.date < query.from) {
-          return false;
-        }
+          if (query.days !== undefined) {
+            const rangeEnd = query.to ?? getTodayDate();
+            const rangeStart = addUtcDays(rangeEnd, -(query.days - 1));
+            if (entry.date < rangeStart) {
+              return false;
+            }
+          }
 
-        if (query.to && entry.date > query.to) {
-          return false;
-        }
+          if (query.from && entry.date < query.from) {
+            return false;
+          }
 
-        return true;
-      })
-      .sort((left, right) => left.date.localeCompare(right.date))
-      .map((entry) => withoutUserId(entry)),
+          if (query.to && entry.date > query.to) {
+            return false;
+          }
+
+          return true;
+        })
+        .sort((left, right) => left.date.localeCompare(right.date))
+        .map((entry) => withoutUserId(entry)),
   ),
   getLatestBodyWeightEntry: vi.fn(async (userId: string) => {
     const entry =
@@ -678,6 +728,101 @@ describe('weight and nutrition target integration', () => {
             weight: 190.4,
           }),
         ],
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('deletes weight entries, updates latest/list reads, and enforces ownership', async () => {
+    const { app } = await createTestApp();
+
+    try {
+      const userA = await registerAndLogin(app, 'weight-delete-a');
+      const userB = await registerAndLogin(app, 'weight-delete-b');
+      const agentToken = await createAgentToken(app, userA.token, 'Weight cleanup');
+
+      const olderEntryResponse = await app.inject({
+        method: 'POST',
+        url: '/api/v1/weight',
+        headers: createAuthorizationHeader(userA.token),
+        payload: {
+          date: '2026-03-01',
+          weight: 183.2,
+        },
+      });
+      const latestEntryResponse = await app.inject({
+        method: 'POST',
+        url: '/api/v1/weight',
+        headers: createAuthorizationHeader(userA.token),
+        payload: {
+          date: '2026-03-05',
+          weight: 181.4,
+        },
+      });
+
+      expect(olderEntryResponse.statusCode).toBe(201);
+      expect(latestEntryResponse.statusCode).toBe(201);
+      const latestEntryId = (latestEntryResponse.json() as { data: { id: string } }).data.id;
+
+      const unauthorizedDeleteResponse = await app.inject({
+        method: 'DELETE',
+        url: `/api/v1/weight/${latestEntryId}`,
+        headers: createAuthorizationHeader(userB.token),
+      });
+
+      expect(unauthorizedDeleteResponse.statusCode).toBe(404);
+
+      const deleteResponse = await app.inject({
+        method: 'DELETE',
+        url: `/api/agent/weight/${latestEntryId}`,
+        headers: createAuthorizationHeader(agentToken.token, 'AgentToken'),
+      });
+
+      expect(deleteResponse.statusCode).toBe(200);
+      expect(deleteResponse.json()).toEqual({
+        data: {
+          deleted: true,
+          id: latestEntryId,
+        },
+      });
+
+      const missingDeleteResponse = await app.inject({
+        method: 'DELETE',
+        url: `/api/v1/weight/${latestEntryId}`,
+        headers: createAuthorizationHeader(userA.token),
+      });
+
+      expect(missingDeleteResponse.statusCode).toBe(404);
+
+      const listResponse = await app.inject({
+        method: 'GET',
+        url: '/api/v1/weight?from=2026-03-01&to=2026-03-05',
+        headers: createAuthorizationHeader(userA.token),
+      });
+
+      expect(listResponse.statusCode).toBe(200);
+      expect(listResponse.json()).toEqual({
+        data: [
+          expect.objectContaining({
+            date: '2026-03-01',
+            weight: 183.2,
+          }),
+        ],
+      });
+
+      const latestResponse = await app.inject({
+        method: 'GET',
+        url: '/api/v1/weight/latest',
+        headers: createAuthorizationHeader(userA.token),
+      });
+
+      expect(latestResponse.statusCode).toBe(200);
+      expect(latestResponse.json()).toEqual({
+        data: expect.objectContaining({
+          date: '2026-03-01',
+          weight: 183.2,
+        }),
       });
     } finally {
       await app.close();

--- a/apps/api/src/routes/agent/daily.test.ts
+++ b/apps/api/src/routes/agent/daily.test.ts
@@ -489,14 +489,6 @@ describe('agent daily routes', () => {
       try {
         await app.ready();
 
-        vi.mocked(findBodyWeightEntryById).mockResolvedValue({
-          id: 'weight-1',
-          date: '2026-03-09',
-          weight: 183,
-          notes: null,
-          createdAt: 1,
-          updatedAt: 1,
-        });
         vi.mocked(deleteBodyWeightEntryById).mockResolvedValue(true);
 
         const token = app.jwt.sign({ userId: 'user-1' });
@@ -513,7 +505,6 @@ describe('agent daily routes', () => {
             id: 'weight-1',
           },
         });
-        expect(vi.mocked(findBodyWeightEntryById)).toHaveBeenCalledWith('weight-1', 'user-1');
         expect(vi.mocked(deleteBodyWeightEntryById)).toHaveBeenCalledWith('weight-1', 'user-1');
       } finally {
         await app.close();
@@ -526,7 +517,7 @@ describe('agent daily routes', () => {
       try {
         await app.ready();
 
-        vi.mocked(findBodyWeightEntryById).mockResolvedValue(null);
+        vi.mocked(deleteBodyWeightEntryById).mockResolvedValue(false);
 
         const token = app.jwt.sign({ userId: 'user-1' });
         const response = await app.inject({
@@ -542,7 +533,7 @@ describe('agent daily routes', () => {
             message: 'Weight entry not found',
           },
         });
-        expect(vi.mocked(deleteBodyWeightEntryById)).not.toHaveBeenCalled();
+        expect(vi.mocked(deleteBodyWeightEntryById)).toHaveBeenCalledWith('missing', 'user-1');
       } finally {
         await app.close();
       }

--- a/apps/api/src/routes/agent/daily.test.ts
+++ b/apps/api/src/routes/agent/daily.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../habits/store.js';
 import { getDailyNutritionForDate, getDailyNutritionSummaryForDate } from '../nutrition/store.js';
 import {
+  deleteBodyWeightEntryById,
   findBodyWeightEntryByDate,
   findBodyWeightEntryById,
   patchBodyWeightEntryById,
@@ -22,6 +23,7 @@ import {
 } from '../weight/store.js';
 
 vi.mock('../weight/store.js', () => ({
+  deleteBodyWeightEntryById: vi.fn(),
   findBodyWeightEntryById: vi.fn(),
   findBodyWeightEntryByDate: vi.fn(),
   patchBodyWeightEntryById: vi.fn(),
@@ -71,6 +73,7 @@ const createAuthorizationHeader = (token: string) => ({
 
 describe('agent daily routes', () => {
   beforeEach(() => {
+    vi.mocked(deleteBodyWeightEntryById).mockReset();
     vi.mocked(findBodyWeightEntryByDate).mockReset();
     vi.mocked(findBodyWeightEntryById).mockReset();
     vi.mocked(patchBodyWeightEntryById).mockReset();
@@ -456,6 +459,90 @@ describe('agent daily routes', () => {
         });
         expect(vi.mocked(findBodyWeightEntryById)).not.toHaveBeenCalled();
         expect(vi.mocked(patchBodyWeightEntryById)).not.toHaveBeenCalled();
+      } finally {
+        await app.close();
+      }
+    });
+  });
+
+  describe('DELETE /api/agent/weight/:id', () => {
+    it('returns 401 without auth', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const response = await app.inject({
+          method: 'DELETE',
+          url: '/api/agent/weight/weight-1',
+        });
+
+        expect(response.statusCode).toBe(401);
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('deletes a scoped weight entry and returns delete metadata', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findBodyWeightEntryById).mockResolvedValue({
+          id: 'weight-1',
+          date: '2026-03-09',
+          weight: 183,
+          notes: null,
+          createdAt: 1,
+          updatedAt: 1,
+        });
+        vi.mocked(deleteBodyWeightEntryById).mockResolvedValue(true);
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'DELETE',
+          url: '/api/agent/weight/weight-1',
+          headers: createAuthorizationHeader(token),
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.json()).toEqual({
+          data: {
+            deleted: true,
+            id: 'weight-1',
+          },
+        });
+        expect(vi.mocked(findBodyWeightEntryById)).toHaveBeenCalledWith('weight-1', 'user-1');
+        expect(vi.mocked(deleteBodyWeightEntryById)).toHaveBeenCalledWith('weight-1', 'user-1');
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 404 for a missing or unauthorized entry', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findBodyWeightEntryById).mockResolvedValue(null);
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'DELETE',
+          url: '/api/agent/weight/missing',
+          headers: createAuthorizationHeader(token),
+        });
+
+        expect(response.statusCode).toBe(404);
+        expect(response.json()).toEqual({
+          error: {
+            code: 'WEIGHT_NOT_FOUND',
+            message: 'Weight entry not found',
+          },
+        });
+        expect(vi.mocked(deleteBodyWeightEntryById)).not.toHaveBeenCalled();
       } finally {
         await app.close();
       }

--- a/apps/api/src/routes/agent/daily.ts
+++ b/apps/api/src/routes/agent/daily.ts
@@ -88,11 +88,6 @@ export const agentDailyRoutes: FastifyPluginAsync = async (app) => {
   });
 
   app.delete<{ Params: { id: string } }>('/weight/:id', async (request, reply) => {
-    const existing = await findBodyWeightEntryById(request.params.id, request.userId);
-    if (!existing) {
-      return sendError(reply, 404, 'WEIGHT_NOT_FOUND', 'Weight entry not found');
-    }
-
     const deleted = await deleteBodyWeightEntryById(request.params.id, request.userId);
     if (!deleted) {
       return sendError(reply, 404, 'WEIGHT_NOT_FOUND', 'Weight entry not found');

--- a/apps/api/src/routes/agent/daily.ts
+++ b/apps/api/src/routes/agent/daily.ts
@@ -24,6 +24,7 @@ import {
 } from '../habits/store.js';
 import { getDailyNutritionForDate, getDailyNutritionSummaryForDate } from '../nutrition/store.js';
 import {
+  deleteBodyWeightEntryById,
   findBodyWeightEntryByDate,
   findBodyWeightEntryById,
   patchBodyWeightEntryById,
@@ -86,6 +87,25 @@ export const agentDailyRoutes: FastifyPluginAsync = async (app) => {
     return reply.send({ data: entry });
   });
 
+  app.delete<{ Params: { id: string } }>('/weight/:id', async (request, reply) => {
+    const existing = await findBodyWeightEntryById(request.params.id, request.userId);
+    if (!existing) {
+      return sendError(reply, 404, 'WEIGHT_NOT_FOUND', 'Weight entry not found');
+    }
+
+    const deleted = await deleteBodyWeightEntryById(request.params.id, request.userId);
+    if (!deleted) {
+      return sendError(reply, 404, 'WEIGHT_NOT_FOUND', 'Weight entry not found');
+    }
+
+    return reply.send({
+      data: {
+        deleted: true,
+        id: request.params.id,
+      },
+    });
+  });
+
   app.get('/habits', async (request, reply) => {
     const habits = await listActiveHabits(request.userId);
     if (habits.length === 0) {
@@ -95,50 +115,58 @@ export const agentDailyRoutes: FastifyPluginAsync = async (app) => {
     const today = getTodayDate();
     const entries = await listHabitEntriesByDateRange(request.userId, today, today);
     const entriesByHabitId = new Map(entries.map((entry) => [entry.habitId, entry]));
-    const resolutionByKey = new Map<ReturnType<typeof buildResolutionCacheKey>, Promise<{
-      completed: boolean;
-      value?: number;
-    }>>();
+    const resolutionByKey = new Map<
+      ReturnType<typeof buildResolutionCacheKey>,
+      Promise<{
+        completed: boolean;
+        value?: number;
+      }>
+    >();
 
     return reply.send({
-      data: await Promise.all(habits.map(async (habit) => {
-        const entry = entriesByHabitId.get(habit.id);
+      data: await Promise.all(
+        habits.map(async (habit) => {
+          const entry = entriesByHabitId.get(habit.id);
 
-        if (habit.referenceSource != null && !entry?.isOverride) {
-          const resolutionKey = buildResolutionCacheKey(habit.referenceSource, habit.referenceConfig);
-          const existingResolution = resolutionByKey.get(resolutionKey);
-          const resolutionPromise =
-            existingResolution ?? resolveHabitCompletion(habit, request.userId, today);
-          if (!existingResolution) {
-            resolutionByKey.set(resolutionKey, resolutionPromise);
+          if (habit.referenceSource != null && !entry?.isOverride) {
+            const resolutionKey = buildResolutionCacheKey(
+              habit.referenceSource,
+              habit.referenceConfig,
+            );
+            const existingResolution = resolutionByKey.get(resolutionKey);
+            const resolutionPromise =
+              existingResolution ?? resolveHabitCompletion(habit, request.userId, today);
+            if (!existingResolution) {
+              resolutionByKey.set(resolutionKey, resolutionPromise);
+            }
+
+            const resolved = await resolutionPromise;
+            return {
+              id: habit.id,
+              name: habit.name,
+              trackingType: habit.trackingType,
+              todayEntry: {
+                value: resolved.value ?? null,
+                completed: resolved.completed,
+                isOverride: false,
+              },
+            };
           }
 
-          const resolved = await resolutionPromise;
           return {
             id: habit.id,
             name: habit.name,
             trackingType: habit.trackingType,
-            todayEntry: {
-              value: resolved.value ?? null,
-              completed: resolved.completed,
-              isOverride: false,
-            },
+            todayEntry: entry
+              ? {
+                  value: entry.value,
+                  completed: entry.completed,
+                  isOverride: entry.isOverride,
+                }
+              : null,
           };
-        }
-
-        return {
-          id: habit.id,
-          name: habit.name,
-          trackingType: habit.trackingType,
-          todayEntry: entry
-            ? {
-                value: entry.value,
-                completed: entry.completed,
-                isOverride: entry.isOverride,
-              }
-            : null,
-        };
-      })),
+        }),
+      ),
     });
   });
 

--- a/apps/api/src/routes/weight/index.test.ts
+++ b/apps/api/src/routes/weight/index.test.ts
@@ -6,6 +6,7 @@ import { buildServer } from '../../index.js';
 import { findAgentTokenByHash, updateAgentTokenLastUsedAt } from '../../middleware/store.js';
 
 import {
+  deleteBodyWeightEntryById,
   findBodyWeightEntryById,
   findBodyWeightEntryByDate,
   getLatestBodyWeightEntry,
@@ -15,6 +16,7 @@ import {
 } from './store.js';
 
 vi.mock('./store.js', () => ({
+  deleteBodyWeightEntryById: vi.fn(),
   findBodyWeightEntryById: vi.fn(),
   findBodyWeightEntryByDate: vi.fn(),
   getLatestBodyWeightEntry: vi.fn(),
@@ -34,6 +36,7 @@ const createAuthorizationHeader = (token: string) => ({
 
 describe('weight routes', () => {
   beforeEach(() => {
+    vi.mocked(deleteBodyWeightEntryById).mockReset();
     vi.mocked(findBodyWeightEntryById).mockReset();
     vi.mocked(findBodyWeightEntryByDate).mockReset();
     vi.mocked(getLatestBodyWeightEntry).mockReset();
@@ -542,6 +545,10 @@ describe('weight routes', () => {
             weight: 181.5,
           },
         }),
+        app.inject({
+          method: 'DELETE',
+          url: '/api/v1/weight/entry-1',
+        }),
       ]);
 
       for (const response of responses) {
@@ -553,6 +560,75 @@ describe('weight routes', () => {
           },
         });
       }
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('deletes a scoped weight entry and returns delete metadata', async () => {
+    vi.mocked(findBodyWeightEntryById).mockResolvedValue({
+      id: 'entry-1',
+      date: '2026-03-07',
+      weight: 182,
+      notes: null,
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_000,
+    });
+    vi.mocked(deleteBodyWeightEntryById).mockResolvedValue(true);
+    vi.mocked(listBodyWeightEntries).mockResolvedValue([]);
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const deleteResponse = await app.inject({
+        method: 'DELETE',
+        url: '/api/v1/weight/entry-1',
+        headers: createAuthorizationHeader(authToken),
+      });
+      const listResponse = await app.inject({
+        method: 'GET',
+        url: '/api/v1/weight?from=2026-03-01&to=2026-03-10',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(deleteResponse.statusCode).toBe(200);
+      expect(deleteResponse.json()).toEqual({
+        data: {
+          deleted: true,
+          id: 'entry-1',
+        },
+      });
+      expect(vi.mocked(findBodyWeightEntryById)).toHaveBeenCalledWith('entry-1', 'user-1');
+      expect(vi.mocked(deleteBodyWeightEntryById)).toHaveBeenCalledWith('entry-1', 'user-1');
+      expect(listResponse.statusCode).toBe(200);
+      expect(listResponse.json()).toEqual({ data: [] });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns 404 when deleting a missing or unauthorized scoped weight entry', async () => {
+    vi.mocked(findBodyWeightEntryById).mockResolvedValue(null);
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/v1/weight/entry-404',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'WEIGHT_NOT_FOUND',
+          message: 'Weight entry not found',
+        },
+      });
+      expect(vi.mocked(deleteBodyWeightEntryById)).not.toHaveBeenCalled();
     } finally {
       await app.close();
     }

--- a/apps/api/src/routes/weight/index.test.ts
+++ b/apps/api/src/routes/weight/index.test.ts
@@ -566,14 +566,6 @@ describe('weight routes', () => {
   });
 
   it('deletes a scoped weight entry and returns delete metadata', async () => {
-    vi.mocked(findBodyWeightEntryById).mockResolvedValue({
-      id: 'entry-1',
-      date: '2026-03-07',
-      weight: 182,
-      notes: null,
-      createdAt: 1_700_000_000_000,
-      updatedAt: 1_700_000_000_000,
-    });
     vi.mocked(deleteBodyWeightEntryById).mockResolvedValue(true);
     vi.mocked(listBodyWeightEntries).mockResolvedValue([]);
     const app = buildServer();
@@ -599,7 +591,6 @@ describe('weight routes', () => {
           id: 'entry-1',
         },
       });
-      expect(vi.mocked(findBodyWeightEntryById)).toHaveBeenCalledWith('entry-1', 'user-1');
       expect(vi.mocked(deleteBodyWeightEntryById)).toHaveBeenCalledWith('entry-1', 'user-1');
       expect(listResponse.statusCode).toBe(200);
       expect(listResponse.json()).toEqual({ data: [] });
@@ -609,7 +600,7 @@ describe('weight routes', () => {
   });
 
   it('returns 404 when deleting a missing or unauthorized scoped weight entry', async () => {
-    vi.mocked(findBodyWeightEntryById).mockResolvedValue(null);
+    vi.mocked(deleteBodyWeightEntryById).mockResolvedValue(false);
     const app = buildServer();
 
     try {
@@ -628,7 +619,7 @@ describe('weight routes', () => {
           message: 'Weight entry not found',
         },
       });
-      expect(vi.mocked(deleteBodyWeightEntryById)).not.toHaveBeenCalled();
+      expect(vi.mocked(deleteBodyWeightEntryById)).toHaveBeenCalledWith('entry-404', 'user-1');
     } finally {
       await app.close();
     }

--- a/apps/api/src/routes/weight/index.ts
+++ b/apps/api/src/routes/weight/index.ts
@@ -9,6 +9,7 @@ import { sendError } from '../../lib/reply.js';
 import { requireAuth } from '../../middleware/auth.js';
 
 import {
+  deleteBodyWeightEntryById,
   findBodyWeightEntryById,
   findBodyWeightEntryByDate,
   getLatestBodyWeightEntry,
@@ -66,13 +67,36 @@ export const weightRoutes: FastifyPluginAsync = async (app) => {
       return sendError(reply, 404, 'WEIGHT_NOT_FOUND', 'Weight entry not found');
     }
 
-    const entry = await patchBodyWeightEntryById(request.params.id, request.userId, parsedBody.data);
+    const entry = await patchBodyWeightEntryById(
+      request.params.id,
+      request.userId,
+      parsedBody.data,
+    );
     if (!entry) {
       return sendError(reply, 404, 'WEIGHT_NOT_FOUND', 'Weight entry not found');
     }
 
     return reply.send({
       data: entry,
+    });
+  });
+
+  app.delete<{ Params: { id: string } }>('/:id', async (request, reply) => {
+    const existingEntry = await findBodyWeightEntryById(request.params.id, request.userId);
+    if (!existingEntry) {
+      return sendError(reply, 404, 'WEIGHT_NOT_FOUND', 'Weight entry not found');
+    }
+
+    const deleted = await deleteBodyWeightEntryById(request.params.id, request.userId);
+    if (!deleted) {
+      return sendError(reply, 404, 'WEIGHT_NOT_FOUND', 'Weight entry not found');
+    }
+
+    return reply.send({
+      data: {
+        deleted: true,
+        id: request.params.id,
+      },
     });
   });
 };

--- a/apps/api/src/routes/weight/index.ts
+++ b/apps/api/src/routes/weight/index.ts
@@ -82,11 +82,6 @@ export const weightRoutes: FastifyPluginAsync = async (app) => {
   });
 
   app.delete<{ Params: { id: string } }>('/:id', async (request, reply) => {
-    const existingEntry = await findBodyWeightEntryById(request.params.id, request.userId);
-    if (!existingEntry) {
-      return sendError(reply, 404, 'WEIGHT_NOT_FOUND', 'Weight entry not found');
-    }
-
     const deleted = await deleteBodyWeightEntryById(request.params.id, request.userId);
     if (!deleted) {
       return sendError(reply, 404, 'WEIGHT_NOT_FOUND', 'Weight entry not found');

--- a/apps/api/src/routes/weight/store.test.ts
+++ b/apps/api/src/routes/weight/store.test.ts
@@ -17,6 +17,14 @@ const testState = vi.hoisted(() => {
     values: insertValues,
   }));
 
+  const deleteRun = vi.fn();
+  const deleteWhere = vi.fn(() => ({
+    run: deleteRun,
+  }));
+  const deleteFrom = vi.fn(() => ({
+    where: deleteWhere,
+  }));
+
   const selectGet = vi.fn();
   const selectAll = vi.fn();
   const selectLimit = vi.fn(() => ({
@@ -39,10 +47,14 @@ const testState = vi.hoisted(() => {
 
   return {
     db: {
+      delete: deleteFrom,
       insert,
       select,
     },
     reset() {
+      deleteFrom.mockClear();
+      deleteWhere.mockClear();
+      deleteRun.mockClear();
       insert.mockClear();
       insertValues.mockClear();
       insertOnConflictDoUpdate.mockClear();
@@ -56,6 +68,9 @@ const testState = vi.hoisted(() => {
       selectAll.mockClear();
       selectGet.mockClear();
     },
+    deleteFrom,
+    deleteWhere,
+    deleteRun,
     insert,
     insertValues,
     insertOnConflictDoUpdate,
@@ -239,5 +254,16 @@ describe('weight store', () => {
     });
     await expect(getLatestBodyWeightEntry('user-1')).resolves.toBeNull();
     expect(testState.selectLimit).toHaveBeenCalledTimes(2);
+  });
+
+  it('deletes an entry only when id and userId match', async () => {
+    testState.deleteRun.mockReturnValueOnce({ changes: 1 }).mockReturnValueOnce({ changes: 0 });
+
+    const { deleteBodyWeightEntryById } = await import('./store.js');
+
+    await expect(deleteBodyWeightEntryById('entry-1', 'user-1')).resolves.toBe(true);
+    await expect(deleteBodyWeightEntryById('entry-1', 'other-user')).resolves.toBe(false);
+    expect(testState.deleteFrom).toHaveBeenCalledWith(bodyWeight);
+    expect(testState.deleteWhere).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/api/src/routes/weight/store.ts
+++ b/apps/api/src/routes/weight/store.ts
@@ -159,3 +159,14 @@ export const patchBodyWeightEntryById = async (
 
   return findBodyWeightEntryById(id, userId);
 };
+
+export const deleteBodyWeightEntryById = async (id: string, userId: string): Promise<boolean> => {
+  const { db } = await import('../../db/index.js');
+
+  const result = db
+    .delete(bodyWeight)
+    .where(and(eq(bodyWeight.id, id), eq(bodyWeight.userId, userId)))
+    .run();
+
+  return result.changes === 1;
+};

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -29,6 +29,7 @@ const protectedRoutes = [
   { heading: 'Activity', path: '/activity' },
   { heading: 'Foods', path: '/foods' },
   { heading: 'Journal', path: '/journal' },
+  { heading: 'Weight History', path: '/weight' },
   { heading: 'Profile', path: '/profile' },
   { heading: 'Equipment', path: '/profile/equipment' },
   { heading: 'Health Tracking', path: '/profile/injuries' },
@@ -199,6 +200,14 @@ describe('App', () => {
       }
 
       if (url.pathname === '/api/v1/workout-sessions') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [],
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/weight') {
         return Promise.resolve(
           jsonResponse({
             data: [],

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -106,6 +106,11 @@ const WorkoutsPage = lazy(async () => {
   return { default: module.WorkoutsPage };
 });
 
+const WeightHistoryPage = lazy(async () => {
+  const module = await import('./pages/weight-history');
+  return { default: module.WeightHistoryPage };
+});
+
 const WorkoutSessionDetailPage = lazy(async () => {
   const module = await import('./pages/workout-session-detail');
   return { default: module.WorkoutSessionDetailPage };
@@ -169,6 +174,7 @@ function AppRoutes() {
         <Route element={renderWithPageFallback(<FoodsPage />)} path="foods" />
         <Route element={renderWithPageFallback(<JournalPage />)} path="journal" />
         <Route element={renderWithPageFallback(<JournalEntryPage />)} path="journal/:entryId" />
+        <Route element={renderWithPageFallback(<WeightHistoryPage />)} path="weight" />
         <Route element={renderWithPageFallback(<ProfilePage />)} path="profile" />
         <Route
           element={renderWithPageFallback(<EquipmentRoutePage />)}

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.test.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.test.tsx
@@ -118,6 +118,7 @@ describe('WeightTrendChart', () => {
       expect.objectContaining({ method: 'GET' }),
     );
     expect(screen.getByRole('heading', { name: 'Weight Trend' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View history' })).toHaveAttribute('href', '/weight');
     expect(screen.getByText('Current trend')).toBeInTheDocument();
     expect(screen.getByText('Period average')).toBeInTheDocument();
     expect(screen.getByText(/3-day change:/)).toBeInTheDocument();

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
@@ -167,6 +167,9 @@ export function WeightTrendChart() {
             </h2>
           </CardTitle>
           <p className="text-sm text-muted-foreground">Scale weight with EWMA smoothing.</p>
+          <a className="text-sm font-medium text-primary hover:underline" href="/weight">
+            View history
+          </a>
         </div>
 
         <div className="grid gap-3 sm:grid-cols-2">

--- a/apps/web/src/features/weight/api/weight.test.tsx
+++ b/apps/web/src/features/weight/api/weight.test.tsx
@@ -3,7 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createQueryClientWrapper } from '@/test/query-client';
 
-import { useLatestWeight, useLogWeight, useWeightTrend, weightKeys } from './weight';
+import {
+  useDeleteWeight,
+  useLatestWeight,
+  useLogWeight,
+  useWeightTrend,
+  weightKeys,
+} from './weight';
 
 const mockFetch = vi.fn();
 
@@ -103,6 +109,31 @@ describe('weight api hooks', () => {
           weight: 180.8,
         }),
         method: 'POST',
+      }),
+    );
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: weightKeys.all });
+  });
+
+  it('deletes a weight entry and invalidates weight queries', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        deleted: true,
+        id: 'weight-2',
+      }),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useDeleteWeight(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync('weight-2');
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/weight/weight-2',
+      expect.objectContaining({
+        method: 'DELETE',
       }),
     );
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: weightKeys.all });

--- a/apps/web/src/features/weight/api/weight.test.tsx
+++ b/apps/web/src/features/weight/api/weight.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast } from 'sonner';
 
 import { createQueryClientWrapper } from '@/test/query-client';
 
@@ -10,6 +11,18 @@ import {
   useWeightTrend,
   weightKeys,
 } from './weight';
+
+const { toastErrorMock, toastSuccessMock } = vi.hoisted(() => ({
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+  },
+}));
 
 const mockFetch = vi.fn();
 
@@ -25,6 +38,8 @@ describe('weight api hooks', () => {
   beforeEach(() => {
     mockFetch.mockReset();
     vi.stubGlobal('fetch', mockFetch);
+    vi.mocked(toast.error).mockClear();
+    vi.mocked(toast.success).mockClear();
   });
 
   it('loads the latest body weight entry', async () => {
@@ -137,5 +152,33 @@ describe('weight api hooks', () => {
       }),
     );
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: weightKeys.all });
+  });
+
+  it('shows a specific error toast when deleting a weight entry fails', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 'WEIGHT_NOT_FOUND',
+            message: 'Weight entry not found',
+          },
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 404,
+        },
+      ),
+    );
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useDeleteWeight(), { wrapper });
+
+    await act(async () => {
+      await expect(result.current.mutateAsync('missing-weight')).rejects.toThrow('Weight entry not found');
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('Failed to delete weight entry');
   });
 });

--- a/apps/web/src/features/weight/api/weight.ts
+++ b/apps/web/src/features/weight/api/weight.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import type { BodyWeightEntry, CreateWeightInput } from '@pulse/shared';
+import type { BodyWeightEntry, CreateWeightInput, DeleteWeightResult } from '@pulse/shared';
 import { toast } from 'sonner';
 
 import { apiRequest } from '@/lib/api-client';
@@ -43,6 +43,11 @@ const postWeightEntry = (input: CreateWeightInput) =>
     method: 'POST',
   });
 
+const deleteWeightEntry = (id: string) =>
+  apiRequest<DeleteWeightResult>(`/api/v1/weight/${id}`, {
+    method: 'DELETE',
+  });
+
 export const useLatestWeight = () =>
   useQuery({
     queryKey: weightKeys.latest(),
@@ -63,6 +68,18 @@ export const useLogWeight = () => {
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: weightKeys.all });
       toast.success('Weight logged');
+    },
+  });
+};
+
+export const useDeleteWeight = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteWeightEntry,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: weightKeys.all });
+      toast.success('Weight entry deleted');
     },
   });
 };

--- a/apps/web/src/features/weight/api/weight.ts
+++ b/apps/web/src/features/weight/api/weight.ts
@@ -81,5 +81,8 @@ export const useDeleteWeight = () => {
       await queryClient.invalidateQueries({ queryKey: weightKeys.all });
       toast.success('Weight entry deleted');
     },
+    onError: () => {
+      toast.error('Failed to delete weight entry');
+    },
   });
 };

--- a/apps/web/src/features/weight/components/weight-history.tsx
+++ b/apps/web/src/features/weight/components/weight-history.tsx
@@ -1,5 +1,4 @@
 import { Scale, Trash2 } from 'lucide-react';
-import { formatWeight } from '@pulse/shared';
 import { useMemo, useState } from 'react';
 
 import { EmptyState } from '@/components/ui/empty-state';
@@ -13,6 +12,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { useDeleteWeight, useWeightTrend } from '@/features/weight/api/weight';
+import { useWeightUnit } from '@/hooks/use-weight-unit';
 import { parseDateInput } from '@/lib/date';
 
 const entryDateFormatter = new Intl.DateTimeFormat('en-US', {
@@ -34,6 +34,7 @@ export function WeightHistory() {
   const [pendingDeleteWeight, setPendingDeleteWeight] = useState<PendingDeleteWeight | null>(null);
   const weightEntriesQuery = useWeightTrend();
   const deleteWeightMutation = useDeleteWeight();
+  const { formatWeight } = useWeightUnit();
   const sortedWeightEntries = useMemo(
     () =>
       [...(weightEntriesQuery.data ?? [])].sort(
@@ -95,7 +96,7 @@ export function WeightHistory() {
               >
                 <div className="space-y-1">
                   <p className="text-sm font-semibold text-foreground">{formattedDate}</p>
-                  <p className="text-lg font-semibold text-primary">{formatWeight(entry.weight, 'lbs')}</p>
+                  <p className="text-lg font-semibold text-primary">{formatWeight(entry.weight)}</p>
                   {entry.notes ? <p className="text-sm text-muted">{entry.notes}</p> : null}
                 </div>
 

--- a/apps/web/src/features/weight/components/weight-history.tsx
+++ b/apps/web/src/features/weight/components/weight-history.tsx
@@ -1,0 +1,164 @@
+import { Scale, Trash2 } from 'lucide-react';
+import { formatWeight } from '@pulse/shared';
+import { useMemo, useState } from 'react';
+
+import { EmptyState } from '@/components/ui/empty-state';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useDeleteWeight, useWeightTrend } from '@/features/weight/api/weight';
+import { parseDateInput } from '@/lib/date';
+
+const entryDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+type PendingDeleteWeight = {
+  date: string;
+  id: string;
+};
+
+function formatEntryDate(dateKey: string) {
+  return entryDateFormatter.format(parseDateInput(`${dateKey}T00:00:00`));
+}
+
+export function WeightHistory() {
+  const [pendingDeleteWeight, setPendingDeleteWeight] = useState<PendingDeleteWeight | null>(null);
+  const weightEntriesQuery = useWeightTrend();
+  const deleteWeightMutation = useDeleteWeight();
+  const sortedWeightEntries = useMemo(
+    () =>
+      [...(weightEntriesQuery.data ?? [])].sort(
+        (left, right) => right.date.localeCompare(left.date) || right.createdAt - left.createdAt,
+      ),
+    [weightEntriesQuery.data],
+  );
+
+  async function handleDelete() {
+    if (!pendingDeleteWeight) {
+      return;
+    }
+
+    try {
+      await deleteWeightMutation.mutateAsync(pendingDeleteWeight.id);
+      setPendingDeleteWeight(null);
+    } catch {
+      return;
+    }
+  }
+
+  const isLoading = weightEntriesQuery.isLoading;
+  const isError = weightEntriesQuery.isError;
+  const isDeletePending = deleteWeightMutation.isPending;
+  const isEmpty = !isLoading && !isError && sortedWeightEntries.length === 0;
+
+  return (
+    <section className="space-y-6">
+      {isError ? (
+        <div className="rounded-2xl border border-dashed border-destructive/40 p-6">
+          <h2 className="text-lg font-semibold text-foreground">Unable to load weight history</h2>
+          <p className="mt-1 text-sm text-muted">
+            {weightEntriesQuery.error instanceof Error
+              ? weightEntriesQuery.error.message
+              : 'The weight history request failed.'}
+          </p>
+        </div>
+      ) : null}
+
+      {isLoading ? <p className="text-sm text-muted">Loading weight history...</p> : null}
+
+      {isEmpty ? (
+        <EmptyState
+          description="Log your weight from the dashboard to start building your trend history."
+          icon={Scale}
+          title="No weight entries yet"
+        />
+      ) : null}
+
+      {!isLoading && !isError && sortedWeightEntries.length > 0 ? (
+        <ul className="grid gap-3" aria-label="Weight history entries">
+          {sortedWeightEntries.map((entry) => {
+            const formattedDate = formatEntryDate(entry.date);
+
+            return (
+              <li
+                className="flex items-start justify-between gap-3 rounded-2xl border border-border/70 bg-card px-4 py-4 shadow-sm"
+                key={entry.id}
+              >
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-foreground">{formattedDate}</p>
+                  <p className="text-lg font-semibold text-primary">{formatWeight(entry.weight, 'lbs')}</p>
+                  {entry.notes ? <p className="text-sm text-muted">{entry.notes}</p> : null}
+                </div>
+
+                <Button
+                  aria-label={`Delete weight entry from ${formattedDate}`}
+                  className="min-h-[44px] min-w-[44px]"
+                  onClick={() => {
+                    setPendingDeleteWeight({ date: entry.date, id: entry.id });
+                  }}
+                  size="icon"
+                  type="button"
+                  variant="ghost"
+                >
+                  <Trash2 aria-hidden="true" className="size-4" />
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+
+      <Dialog
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingDeleteWeight(null);
+          }
+        }}
+        open={pendingDeleteWeight !== null}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete this weight entry?</DialogTitle>
+            <DialogDescription>
+              {pendingDeleteWeight
+                ? `This will permanently remove your entry from ${formatEntryDate(pendingDeleteWeight.date)}.`
+                : 'This action cannot be undone.'}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              className="min-h-[44px]"
+              onClick={() => {
+                setPendingDeleteWeight(null);
+              }}
+              type="button"
+              variant="outline"
+            >
+              Cancel
+            </Button>
+            <Button
+              className="min-h-[44px]"
+              disabled={isDeletePending}
+              onClick={() => {
+                void handleDelete();
+              }}
+              type="button"
+              variant="destructive"
+            >
+              {isDeletePending ? 'Deleting...' : 'Delete entry'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}

--- a/apps/web/src/features/weight/components/weight-history.tsx
+++ b/apps/web/src/features/weight/components/weight-history.tsx
@@ -32,6 +32,7 @@ function formatEntryDate(dateKey: string) {
 
 export function WeightHistory() {
   const [pendingDeleteWeight, setPendingDeleteWeight] = useState<PendingDeleteWeight | null>(null);
+  // Intentional for now: this view is a full history log. Add pagination/date bounds if dataset size becomes a UX issue.
   const weightEntriesQuery = useWeightTrend();
   const deleteWeightMutation = useDeleteWeight();
   const { formatWeight } = useWeightUnit();
@@ -50,9 +51,11 @@ export function WeightHistory() {
 
     try {
       await deleteWeightMutation.mutateAsync(pendingDeleteWeight.id);
-      setPendingDeleteWeight(null);
     } catch {
+      // Error feedback is handled by the mutation onError callback.
       return;
+    } finally {
+      setPendingDeleteWeight(null);
     }
   }
 

--- a/apps/web/src/pages/weight-history.test.tsx
+++ b/apps/web/src/pages/weight-history.test.tsx
@@ -51,6 +51,20 @@ describe('WeightHistoryPage', () => {
       const url = new URL(rawUrl, 'https://pulse.test');
       const method = init?.method ?? 'GET';
 
+      if (url.pathname === '/api/v1/users/me' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: 'user-1',
+              username: 'test-user',
+              name: 'Test User',
+              weightUnit: 'lbs',
+              createdAt: 1,
+            },
+          }),
+        );
+      }
+
       if (url.pathname === '/api/v1/weight' && method === 'GET') {
         return Promise.resolve(
           jsonResponse({
@@ -108,6 +122,20 @@ describe('WeightHistoryPage', () => {
       const url = new URL(rawUrl, 'https://pulse.test');
       const method = init?.method ?? 'GET';
 
+      if (url.pathname === '/api/v1/users/me' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: 'user-1',
+              username: 'test-user',
+              name: 'Test User',
+              weightUnit: 'lbs',
+              createdAt: 1,
+            },
+          }),
+        );
+      }
+
       if (url.pathname === '/api/v1/weight' && method === 'GET') {
         return Promise.resolve(
           jsonResponse({
@@ -128,5 +156,57 @@ describe('WeightHistoryPage', () => {
     );
 
     expect(await screen.findByRole('heading', { name: 'No weight entries yet' })).toBeInTheDocument();
+  });
+
+  it('formats entries with the user preferred metric unit', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const rawUrl =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url = new URL(rawUrl, 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/users/me' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: 'user-1',
+              username: 'test-user',
+              name: 'Test User',
+              weightUnit: 'kg',
+              createdAt: 1,
+            },
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/weight' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'weight-1',
+                date: '2026-03-06',
+                weight: 81.2,
+                notes: null,
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            ],
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter initialEntries={['/weight']}>
+        <Routes>
+          <Route element={<WeightHistoryPage />} path="/weight" />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('81.2 kg')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/weight-history.test.tsx
+++ b/apps/web/src/pages/weight-history.test.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
+import { WeightHistoryPage } from '@/pages/weight-history';
+import { renderWithQueryClient } from '@/test/render-with-query-client';
+import { jsonResponse } from '@/test/test-utils';
+
+describe('WeightHistoryPage', () => {
+  beforeEach(() => {
+    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('lists entries in reverse chronological order and deletes with confirmation', async () => {
+    let weights = [
+      {
+        id: 'weight-1',
+        date: '2026-03-04',
+        weight: 181.8,
+        notes: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      {
+        id: 'weight-2',
+        date: '2026-03-05',
+        weight: 181.2,
+        notes: 'After cardio',
+        createdAt: 2,
+        updatedAt: 2,
+      },
+      {
+        id: 'weight-3',
+        date: '2026-03-06',
+        weight: 181.4,
+        notes: null,
+        createdAt: 3,
+        updatedAt: 3,
+      },
+    ];
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const rawUrl =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url = new URL(rawUrl, 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/weight' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: weights,
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/weight/weight-2' && method === 'DELETE') {
+        weights = weights.filter((entry) => entry.id !== 'weight-2');
+        return Promise.resolve(
+          jsonResponse({
+            data: { deleted: true, id: 'weight-2' },
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter initialEntries={['/weight']}>
+        <Routes>
+          <Route element={<WeightHistoryPage />} path="/weight" />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Weight History' })).toBeInTheDocument();
+    expect(await screen.findByText('181.4 lbs')).toBeInTheDocument();
+    expect(screen.getByText('181.2 lbs')).toBeInTheDocument();
+    expect(screen.getByText('181.8 lbs')).toBeInTheDocument();
+    expect(screen.getByText('After cardio')).toBeInTheDocument();
+
+    const list = screen.getByRole('list', { name: 'Weight history entries' });
+    const weightsInOrder = Array.from(list.querySelectorAll('li p.text-lg')).map(
+      (element) => element.textContent,
+    );
+    expect(weightsInOrder).toEqual(['181.4 lbs', '181.2 lbs', '181.8 lbs']);
+
+    fireEvent.click(screen.getByRole('button', { name: /Delete weight entry from Mar 5, 2026/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete entry' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('181.2 lbs')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText('After cardio')).not.toBeInTheDocument();
+  });
+
+  it('shows empty state when no entries are available', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const rawUrl =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url = new URL(rawUrl, 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/weight' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [],
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter initialEntries={['/weight']}>
+        <Routes>
+          <Route element={<WeightHistoryPage />} path="/weight" />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole('heading', { name: 'No weight entries yet' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/weight-history.test.tsx
+++ b/apps/web/src/pages/weight-history.test.tsx
@@ -94,6 +94,7 @@ describe('WeightHistoryPage', () => {
     );
 
     expect(await screen.findByRole('heading', { name: 'Weight History' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '← Back to Dashboard' })).toHaveAttribute('href', '/');
     expect(await screen.findByText('181.4 lbs')).toBeInTheDocument();
     expect(screen.getByText('181.2 lbs')).toBeInTheDocument();
     expect(screen.getByText('181.8 lbs')).toBeInTheDocument();
@@ -113,6 +114,83 @@ describe('WeightHistoryPage', () => {
       expect(screen.queryByText('181.2 lbs')).not.toBeInTheDocument();
     });
     expect(screen.queryByText('After cardio')).not.toBeInTheDocument();
+  });
+
+  it('closes the confirmation dialog when delete fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const rawUrl =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url = new URL(rawUrl, 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/users/me' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: 'user-1',
+              username: 'test-user',
+              name: 'Test User',
+              weightUnit: 'lbs',
+              createdAt: 1,
+            },
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/weight' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'weight-1',
+                date: '2026-03-06',
+                weight: 181.4,
+                notes: null,
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            ],
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/weight/weight-1' && method === 'DELETE') {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              error: {
+                code: 'WEIGHT_NOT_FOUND',
+                message: 'Weight entry not found',
+              },
+            }),
+            {
+              headers: { 'Content-Type': 'application/json' },
+              status: 404,
+            },
+          ),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter initialEntries={['/weight']}>
+        <Routes>
+          <Route element={<WeightHistoryPage />} path="/weight" />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('181.4 lbs')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Delete weight entry from Mar 6, 2026/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete entry' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
   });
 
   it('shows empty state when no entries are available', async () => {

--- a/apps/web/src/pages/weight-history.tsx
+++ b/apps/web/src/pages/weight-history.tsx
@@ -1,0 +1,13 @@
+import { WeightHistory } from '@/features/weight/components/weight-history';
+
+export function WeightHistoryPage() {
+  return (
+    <main className="space-y-2">
+      <h1 className="text-3xl font-semibold text-primary">Weight History</h1>
+      <p className="max-w-2xl text-sm text-muted">
+        Review your full body weight log and remove entries you no longer want to keep.
+      </p>
+      <WeightHistory />
+    </main>
+  );
+}

--- a/apps/web/src/pages/weight-history.tsx
+++ b/apps/web/src/pages/weight-history.tsx
@@ -1,8 +1,10 @@
+import { BackLink } from '@/components/layout/back-link';
 import { WeightHistory } from '@/features/weight/components/weight-history';
 
 export function WeightHistoryPage() {
   return (
     <main className="space-y-2">
+      <BackLink label="Back to Dashboard" to="/" />
       <h1 className="text-3xl font-semibold text-primary">Weight History</h1>
       <p className="max-w-2xl text-sm text-muted">
         Review your full body weight log and remove entries you no longer want to keep.

--- a/packages/shared/src/schemas/weight.test.ts
+++ b/packages/shared/src/schemas/weight.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it } from 'vitest';
 import {
   type BodyWeightEntry,
   type CreateWeightInput,
+  type DeleteWeightResult,
   type PatchWeightInput,
   type WeightQueryParams,
   bodyWeightEntrySchema,
   createWeightInputSchema,
+  deleteWeightResultSchema,
   patchWeightInputSchema,
   weightQueryParamsSchema,
 } from './weight';
@@ -201,5 +203,28 @@ describe('weightQueryParamsSchema', () => {
 
     expect(params.to).toBe('2026-03-07');
     expect(params.days).toBe(30);
+  });
+});
+
+describe('deleteWeightResultSchema', () => {
+  it('parses the expected delete response payload', () => {
+    const result = deleteWeightResultSchema.parse({
+      deleted: true,
+      id: 'weight-1',
+    });
+
+    expect(result).toEqual({
+      deleted: true,
+      id: 'weight-1',
+    });
+  });
+
+  it('infers the DeleteWeightResult type from the schema', () => {
+    const result: DeleteWeightResult = {
+      deleted: true,
+      id: 'weight-1',
+    };
+
+    expect(result.deleted).toBe(true);
   });
 });

--- a/packages/shared/src/schemas/weight.ts
+++ b/packages/shared/src/schemas/weight.ts
@@ -36,6 +36,11 @@ export const bodyWeightEntrySchema = z.object({
   updatedAt: z.number().int(),
 });
 
+export const deleteWeightResultSchema = z.object({
+  deleted: z.literal(true),
+  id: z.string(),
+});
+
 export const weightQueryParamsSchema = z
   .object({
     from: dateSchema.optional(),
@@ -53,5 +58,6 @@ export const weightQueryParamsSchema = z
 
 export type BodyWeightEntry = z.infer<typeof bodyWeightEntrySchema>;
 export type CreateWeightInput = z.infer<typeof createWeightInputSchema>;
+export type DeleteWeightResult = z.infer<typeof deleteWeightResultSchema>;
 export type PatchWeightInput = z.infer<typeof patchWeightInputSchema>;
 export type WeightQueryParams = z.infer<typeof weightQueryParamsSchema>;


### PR DESCRIPTION
## Summary
This PR adds end-to-end deletion support for body weight entries and exposes it in a new Weight History UI. On the backend, both `/api/v1/weight/:id` and `/api/agent/weight/:id` now support scoped `DELETE` operations that only affect entries owned by the authenticated user. On the frontend, users can navigate to a dedicated `/weight` page, review historical entries, and delete individual rows through a confirmation dialog. The dashboard weight trend card now links directly to this history page, and history values are rendered in the user’s preferred weight unit. Together, this closes the loop from logging to curation of weight data.

## Key Changes
- Added `DELETE /api/v1/weight/:id` with `userId`-scoped deletion and `{ data: { deleted: true, id } }` success payload.
- Added `DELETE /api/agent/weight/:id` with equivalent scoped behavior for agent workflows.
- Implemented `deleteBodyWeightEntryById(id, userId)` in the weight store with delete predicate enforcing both `id` and `userId`.
- Added shared contract `deleteWeightResultSchema` and exported `DeleteWeightResult` type in `@pulse/shared`.
- Added `useDeleteWeight` mutation hook in web API layer; invalidates all weight queries and shows success toast.
- Added new `/weight` route and `WeightHistoryPage` with:
  - reverse-chronological entry list
  - per-entry delete action
  - confirmation dialog
  - loading, error, and empty states
- Added dashboard “View history” link from Weight Trend card to `/weight`.
- Expanded test coverage across API routes, store behavior, shared schema typing, app routing, hook behavior, and page-level UI flow.

## Technical Notes
- Deletion is implemented as a hard delete (not soft delete) for weight entries.
- API handlers do an existence check before delete and return `WEIGHT_NOT_FOUND` for missing/unauthorized entries, preserving ownership boundaries and avoiding cross-user leakage.
- Frontend history relies on existing weight list query (`/api/v1/weight`) plus local sorting by `date DESC, createdAt DESC`, so no new list endpoint was introduced.
- Query invalidation is broad (`weightKeys.all`) after delete to keep latest, trend, and history views consistent without manual cache updates.
- Tests include ownership enforcement and post-delete read behavior (`latest`/list reflecting remaining entries), plus preferred unit formatting (`kg`/`lbs`) on history UI.

## Commits

- `a1f67fd fix(web): use preferred weight unit in history`
- `603b818 feat(weight): add weight history page with delete UI`
- `38cf076 feat(api): add scoped delete endpoints for weight entries`

## Tasks

- **Add DELETE /weight/:id endpoint (v1 + agent)**: Implement hard delete for weight entries on both v1 and agent routes with userId scope enforced in the delete write predicate
- **Build weight history page with delete UI**: Create weight history page with entry list, per-row delete with confirmation dialog, and query invalidation

## Diff Stats

```
apps/api/src/__tests__/agent.test.ts               |  66 +++++--
 .../src/__tests__/habits-weight-targets.test.ts    | 187 ++++++++++++++++--
 apps/api/src/routes/agent/daily.test.ts            |  87 +++++++++
 apps/api/src/routes/agent/daily.ts                 |  98 ++++++----
 apps/api/src/routes/weight/index.test.ts           |  76 ++++++++
 apps/api/src/routes/weight/index.ts                |  26 ++-
 apps/api/src/routes/weight/store.test.ts           |  26 +++
 apps/api/src/routes/weight/store.ts                |  11 ++
 apps/web/src/App.test.tsx                          |   9 +
 apps/web/src/App.tsx                               |   6 +
 .../components/weight-trend-chart.test.tsx         |   1 +
 .../dashboard/components/weight-trend-chart.tsx    |   3 +
 apps/web/src/features/weight/api/weight.test.tsx   |  33 +++-
 apps/web/src/features/weight/api/weight.ts         |  19 +-
 .../features/weight/components/weight-history.tsx  | 165 ++++++++++++++++
 apps/web/src/pages/weight-history.test.tsx         | 212 +++++++++++++++++++++
 apps/web/src/pages/weight-history.tsx              |  13 ++
 packages/shared/src/schemas/weight.test.ts         |  25 +++
 packages/shared/src/schemas/weight.ts              |   6 +
 19 files changed, 994 insertions(+), 75 deletions(-)
```