### PR TITLE
fix(web): mobile UX — remove redundant hamburger menu and add pull-to-refresh

### DIFF
--- a/apps/web/src/components/layout/app-layout.test.tsx
+++ b/apps/web/src/components/layout/app-layout.test.tsx
@@ -1,0 +1,49 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AppLayout } from '@/components/layout/app-layout';
+
+const mockInvalidateQueries = vi.fn().mockResolvedValue(undefined);
+const mockPullToRefresh = vi.fn();
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({
+    invalidateQueries: mockInvalidateQueries,
+  }),
+}));
+
+vi.mock('@/components/layout/sidebar', () => ({
+  Sidebar: () => <div data-testid="sidebar" />,
+}));
+
+vi.mock('@/components/layout/bottom-nav', () => ({
+  BottomNav: () => <div data-testid="bottom-nav" />,
+}));
+
+vi.mock('@/components/workouts/active-session-resume-gate', () => ({
+  ActiveSessionResumeGate: () => <div data-testid="session-gate" />,
+}));
+
+vi.mock('@/components/ui/pull-to-refresh', () => ({
+  PullToRefresh: ({ onRefresh }: { onRefresh: () => Promise<unknown> | unknown }) => {
+    mockPullToRefresh(onRefresh);
+    return <div data-testid="pull-to-refresh" />;
+  },
+}));
+
+describe('AppLayout', () => {
+  it('wires pull-to-refresh to query invalidation', async () => {
+    render(
+      <AppLayout>
+        <div>content</div>
+      </AppLayout>,
+    );
+
+    expect(mockPullToRefresh).toHaveBeenCalledTimes(1);
+
+    const onRefresh = mockPullToRefresh.mock.calls[0][0] as () => Promise<unknown>;
+    await onRefresh();
+
+    expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/layout/app-layout.tsx
+++ b/apps/web/src/components/layout/app-layout.tsx
@@ -1,14 +1,21 @@
 import type { PropsWithChildren } from 'react';
+import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { Outlet } from 'react-router';
 import { BottomNav } from '@/components/layout/bottom-nav';
 import { Sidebar } from '@/components/layout/sidebar';
+import { PullToRefresh } from '@/components/ui/pull-to-refresh';
 import { ActiveSessionResumeGate } from '@/components/workouts/active-session-resume-gate';
 
 export function AppLayout({ children }: PropsWithChildren) {
+  const queryClient = useQueryClient();
   const content = children ?? <Outlet />;
+
+  const handleRefresh = useCallback(() => queryClient.invalidateQueries(), [queryClient]);
 
   return (
     <div className="min-h-screen overflow-x-clip bg-background text-foreground">
+      <PullToRefresh onRefresh={handleRefresh} />
       <ActiveSessionResumeGate />
       <div className="mx-auto flex min-h-screen w-full max-w-screen-2xl">
         <Sidebar />

--- a/apps/web/src/components/layout/sidebar.test.tsx
+++ b/apps/web/src/components/layout/sidebar.test.tsx
@@ -130,28 +130,12 @@ describe('Sidebar', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
   });
 
-  it('opens and closes the mobile overlay menu from the hamburger trigger', () => {
+  it('does not render mobile sidebar controls', () => {
     renderSidebar();
 
-    const menuButton = screen.getByRole('button', { name: 'Open navigation menu' });
-    expect(menuButton).toHaveClass('min-h-[44px]', 'min-w-[44px]');
-    menuButton.focus();
-    expect(menuButton).toHaveFocus();
-
-    fireEvent.click(menuButton);
-
     expect(screen.queryByRole('button', { name: 'Open navigation menu' })).not.toBeInTheDocument();
-
-    const mobileNav = screen.getByRole('dialog', { name: 'Mobile navigation' });
-    expect(mobileNav).toBeInTheDocument();
-    expect(mobileNav).toHaveAttribute('aria-modal', 'true');
-    const closeButton = screen.getByRole('button', { name: 'Close sidebar panel' });
-    expect(closeButton).toBeInTheDocument();
-    expect(closeButton).toHaveFocus();
-
-    fireEvent.click(closeButton);
     expect(screen.queryByRole('dialog', { name: 'Mobile navigation' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Open navigation menu' })).toHaveFocus();
+    expect(screen.getByRole('navigation', { name: 'Desktop navigation' })).toBeInTheDocument();
   });
 
   it('renders the collapsed avatar without adding it to the tab order', () => {

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useId, useRef, useState } from 'react';
+import { useState } from 'react';
 import { Link, NavLink, useNavigate } from 'react-router';
-import { ChevronLeft, ChevronRight, LogOut, Menu, X } from 'lucide-react';
+import { ChevronLeft, ChevronRight, LogOut } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { sidebarNavItems } from '@/components/layout/nav-items';
@@ -18,11 +18,6 @@ function getInitialCollapsed() {
 
 export function Sidebar() {
   const [collapsed, setCollapsed] = useState(getInitialCollapsed);
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const mobilePanelId = useId();
-  const menuButtonRef = useRef<HTMLButtonElement>(null);
-  const closeButtonRef = useRef<HTMLButtonElement>(null);
-  const shouldRestoreFocusRef = useRef(false);
   const navigate = useNavigate();
   const { logout } = useAuthStore();
   const { data: user } = useUser();
@@ -44,129 +39,125 @@ export function Sidebar() {
     });
   }
 
-  function openMobileMenu() {
-    shouldRestoreFocusRef.current = true;
-    setMobileMenuOpen(true);
-  }
-
-  function closeMobileMenu() {
-    setMobileMenuOpen(false);
-  }
-
   function handleLogout() {
-    shouldRestoreFocusRef.current = false;
-    closeMobileMenu();
     logout();
     navigate('/login', { replace: true });
   }
 
-  useEffect(() => {
-    if (!mobileMenuOpen) {
-      if (shouldRestoreFocusRef.current) {
-        menuButtonRef.current?.focus();
-        shouldRestoreFocusRef.current = false;
-      }
-
-      return;
-    }
-
-    closeButtonRef.current?.focus();
-
-    const previousBodyOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setMobileMenuOpen(false);
-      }
-    };
-
-    window.addEventListener('keydown', onKeyDown);
-
-    return () => {
-      document.body.style.overflow = previousBodyOverflow;
-      window.removeEventListener('keydown', onKeyDown);
-    };
-  }, [mobileMenuOpen]);
-
   return (
-    <>
-      {!mobileMenuOpen ? (
-        <button
-          aria-controls={mobilePanelId}
-          aria-expanded={mobileMenuOpen}
-          aria-label="Open navigation menu"
-          className="fixed top-[calc(env(safe-area-inset-top)+0.75rem)] left-4 z-40 flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded-xl border border-border/70 bg-card/95 text-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-secondary md:hidden"
-          onClick={openMobileMenu}
-          ref={menuButtonRef}
-          type="button"
-        >
-          <Menu aria-hidden="true" className="size-5" />
-        </button>
-      ) : null}
-
-      {mobileMenuOpen ? (
-        <div className="fixed inset-0 z-50 md:hidden">
-          <button
-            aria-label="Close navigation overlay"
-            className="absolute inset-0 bg-black/40"
-            onClick={closeMobileMenu}
-            type="button"
-          />
-
-          <aside
-            aria-label="Mobile navigation"
-            aria-modal="true"
-            className="absolute inset-y-0 left-0 flex w-[min(20rem,calc(100vw-2rem))] max-w-full animate-in slide-in-from-left-4 fade-in-0 duration-200 flex-col border-r border-border/60 bg-card shadow-xl"
-            id={mobilePanelId}
-            role="dialog"
-          >
-            <div className="flex items-center justify-between border-b border-border/40 px-4 py-5">
-              <p className="px-2 text-2xl font-extrabold tracking-tight text-primary font-display">Pulse</p>
-              <button
-                aria-label="Close sidebar panel"
-                className="flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded-xl text-muted transition-colors hover:bg-secondary hover:text-foreground"
-                onClick={closeMobileMenu}
-                ref={closeButtonRef}
-                type="button"
-              >
-                <X className="size-4" aria-hidden="true" />
-              </button>
-            </div>
-
-            <nav
-              aria-label="Mobile navigation links"
-              className="flex flex-1 flex-col gap-1 overflow-y-auto px-3 py-4"
+    <aside
+      className={cn(
+        'sticky top-0 hidden h-screen shrink-0 flex-col border-r border-border/60 bg-card transition-[width] duration-200 md:flex',
+        collapsed ? 'w-[4.5rem]' : 'w-[17rem]',
+      )}
+    >
+      <TooltipProvider delayDuration={0}>
+        <div className="flex h-full flex-col">
+          <div className="flex items-center justify-between border-b border-border/40 px-4 py-6">
+            {collapsed ? (
+              <p className="w-full text-center text-2xl font-extrabold tracking-tight text-primary font-display">
+                P
+              </p>
+            ) : (
+              <p className="px-2 text-2xl font-extrabold tracking-tight text-primary font-display">
+                Pulse
+              </p>
+            )}
+            <button
+              aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+              className="flex min-h-[44px] min-w-[44px] shrink-0 cursor-pointer items-center justify-center rounded-lg text-muted transition-colors hover:bg-secondary hover:text-foreground"
+              onClick={toggleCollapsed}
+              type="button"
             >
-              {sidebarNavItems.map((item) => {
-                const Icon = item.icon;
+              {collapsed ? (
+                <ChevronRight className="size-4" aria-hidden="true" />
+              ) : (
+                <ChevronLeft className="size-4" aria-hidden="true" />
+              )}
+            </button>
+          </div>
 
+          <nav
+            className={cn(
+              'flex flex-1 flex-col gap-1 overflow-y-auto py-4',
+              collapsed ? 'items-center' : 'px-3',
+            )}
+            aria-label="Desktop navigation"
+          >
+            {sidebarNavItems.map((item) => {
+              const Icon = item.icon;
+
+              if (collapsed) {
                 return (
-                  <NavLink
-                    key={item.to}
-                    className={({ isActive }) =>
-                      cn(
-                        'flex min-h-[44px] cursor-pointer items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-all duration-200',
-                        isActive
-                          ? 'bg-primary text-primary-foreground shadow-sm shadow-primary/25'
-                          : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
-                      )
-                    }
-                    end={item.end}
-                    onClick={closeMobileMenu}
-                    to={item.to}
-                  >
-                    <Icon className="size-[18px]" aria-hidden="true" />
-                    <span>{item.label}</span>
-                  </NavLink>
+                  <Tooltip key={item.to}>
+                    <TooltipTrigger asChild>
+                      <NavLink className="block" end={item.end} to={item.to}>
+                        {({ isActive }) => (
+                          <span
+                            className={cn(
+                              'flex min-h-[44px] min-w-[44px] items-center justify-center rounded-xl transition-colors',
+                              isActive
+                                ? 'bg-primary text-primary-foreground shadow-sm shadow-primary/25'
+                                : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
+                            )}
+                          >
+                            <Icon className="size-[18px]" aria-hidden="true" />
+                          </span>
+                        )}
+                      </NavLink>
+                    </TooltipTrigger>
+                    <TooltipContent side="right" sideOffset={8}>
+                      {item.label}
+                    </TooltipContent>
+                  </Tooltip>
                 );
-              })}
-            </nav>
+              }
 
-            <div className="space-y-3 border-t border-border/40 px-3 py-4">
+              return (
+                <NavLink
+                  key={item.to}
+                  className={({ isActive }) =>
+                    cn(
+                      'flex min-h-[44px] cursor-pointer items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-all duration-200',
+                      isActive
+                        ? 'bg-primary text-primary-foreground shadow-sm shadow-primary/25'
+                        : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
+                    )
+                  }
+                  end={item.end}
+                  to={item.to}
+                >
+                  <Icon className="size-[18px]" aria-hidden="true" />
+                  <span>{item.label}</span>
+                </NavLink>
+              );
+            })}
+          </nav>
+
+          <div
+            className={cn(
+              'border-t border-border/40 py-4',
+              collapsed ? 'flex items-center justify-center px-2' : 'space-y-3 px-3',
+            )}
+          >
+            {collapsed ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Link
+                    aria-label={displayName}
+                    className="flex size-10 items-center justify-center rounded-full bg-primary/12 text-sm font-semibold text-primary transition-opacity hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                    to="/profile"
+                  >
+                    {avatarLabel}
+                  </Link>
+                </TooltipTrigger>
+                <TooltipContent side="right" sideOffset={8}>
+                  {displayName}
+                </TooltipContent>
+              </Tooltip>
+            ) : (
               <Link
                 className="flex items-center gap-3 rounded-xl border border-border/50 bg-background/70 px-3 py-2 transition-opacity hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-                onClick={closeMobileMenu}
                 to="/profile"
               >
                 <div className="flex size-10 items-center justify-center rounded-full bg-primary/12 text-sm font-semibold text-primary">
@@ -177,7 +168,25 @@ export function Sidebar() {
                   <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
                 </div>
               </Link>
+            )}
 
+            {collapsed ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    aria-label="Log out"
+                    className="flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+                    onClick={handleLogout}
+                    type="button"
+                  >
+                    <LogOut className="size-[18px]" aria-hidden="true" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="right" sideOffset={8}>
+                  Log out
+                </TooltipContent>
+              </Tooltip>
+            ) : (
               <button
                 className="flex min-h-[44px] w-full cursor-pointer items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium text-muted-foreground transition-all duration-200 hover:bg-secondary hover:text-foreground"
                 onClick={handleLogout}
@@ -186,166 +195,10 @@ export function Sidebar() {
                 <LogOut className="size-[18px]" aria-hidden="true" />
                 <span>Log out</span>
               </button>
-            </div>
-          </aside>
-        </div>
-      ) : null}
-
-      <aside
-        className={cn(
-          'sticky top-0 hidden h-screen shrink-0 flex-col border-r border-border/60 bg-card transition-[width] duration-200 md:flex',
-          collapsed ? 'w-[4.5rem]' : 'w-[17rem]',
-        )}
-      >
-        <TooltipProvider delayDuration={0}>
-          <div className="flex h-full flex-col">
-            <div className="flex items-center justify-between border-b border-border/40 px-4 py-6">
-              {collapsed ? (
-                <p className="w-full text-center text-2xl font-extrabold tracking-tight text-primary font-display">
-                  P
-                </p>
-              ) : (
-                <p className="px-2 text-2xl font-extrabold tracking-tight text-primary font-display">
-                  Pulse
-                </p>
-              )}
-              <button
-                aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-                className="flex min-h-[44px] min-w-[44px] shrink-0 cursor-pointer items-center justify-center rounded-lg text-muted transition-colors hover:bg-secondary hover:text-foreground"
-                onClick={toggleCollapsed}
-                type="button"
-              >
-                {collapsed ? (
-                  <ChevronRight className="size-4" aria-hidden="true" />
-                ) : (
-                  <ChevronLeft className="size-4" aria-hidden="true" />
-                )}
-              </button>
-            </div>
-
-            <nav
-              className={cn(
-                'flex flex-1 flex-col gap-1 overflow-y-auto py-4',
-                collapsed ? 'items-center' : 'px-3',
-              )}
-              aria-label="Desktop navigation"
-            >
-              {sidebarNavItems.map((item) => {
-                const Icon = item.icon;
-
-                if (collapsed) {
-                  return (
-                    <Tooltip key={item.to}>
-                      <TooltipTrigger asChild>
-                        <NavLink className="block" end={item.end} to={item.to}>
-                          {({ isActive }) => (
-                            <span
-                              className={cn(
-                                'flex min-h-[44px] min-w-[44px] items-center justify-center rounded-xl transition-colors',
-                                isActive
-                                  ? 'bg-primary text-primary-foreground shadow-sm shadow-primary/25'
-                                  : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
-                              )}
-                            >
-                              <Icon className="size-[18px]" aria-hidden="true" />
-                            </span>
-                          )}
-                        </NavLink>
-                      </TooltipTrigger>
-                      <TooltipContent side="right" sideOffset={8}>
-                        {item.label}
-                      </TooltipContent>
-                    </Tooltip>
-                  );
-                }
-
-                return (
-                  <NavLink
-                    key={item.to}
-                    className={({ isActive }) =>
-                      cn(
-                        'flex min-h-[44px] cursor-pointer items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-all duration-200',
-                        isActive
-                          ? 'bg-primary text-primary-foreground shadow-sm shadow-primary/25'
-                          : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
-                      )
-                    }
-                    end={item.end}
-                    to={item.to}
-                  >
-                    <Icon className="size-[18px]" aria-hidden="true" />
-                    <span>{item.label}</span>
-                  </NavLink>
-                );
-              })}
-            </nav>
-
-            <div
-              className={cn(
-                'border-t border-border/40 py-4',
-                collapsed ? 'flex items-center justify-center px-2' : 'space-y-3 px-3',
-              )}
-            >
-              {collapsed ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Link
-                      aria-label={displayName}
-                      className="flex size-10 items-center justify-center rounded-full bg-primary/12 text-sm font-semibold text-primary transition-opacity hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-                      to="/profile"
-                    >
-                      {avatarLabel}
-                    </Link>
-                  </TooltipTrigger>
-                  <TooltipContent side="right" sideOffset={8}>
-                    {displayName}
-                  </TooltipContent>
-                </Tooltip>
-              ) : (
-                <Link
-                  className="flex items-center gap-3 rounded-xl border border-border/50 bg-background/70 px-3 py-2 transition-opacity hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-                  to="/profile"
-                >
-                  <div className="flex size-10 items-center justify-center rounded-full bg-primary/12 text-sm font-semibold text-primary">
-                    {avatarLabel}
-                  </div>
-                  <div className="min-w-0">
-                    <p className="truncate text-sm font-medium text-foreground">{displayName}</p>
-                    <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
-                  </div>
-                </Link>
-              )}
-
-              {collapsed ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      aria-label="Log out"
-                      className="flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
-                      onClick={handleLogout}
-                      type="button"
-                    >
-                      <LogOut className="size-[18px]" aria-hidden="true" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="right" sideOffset={8}>
-                    Log out
-                  </TooltipContent>
-                </Tooltip>
-              ) : (
-                <button
-                  className="flex min-h-[44px] w-full cursor-pointer items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium text-muted-foreground transition-all duration-200 hover:bg-secondary hover:text-foreground"
-                  onClick={handleLogout}
-                  type="button"
-                >
-                  <LogOut className="size-[18px]" aria-hidden="true" />
-                  <span>Log out</span>
-                </button>
-              )}
-            </div>
+            )}
           </div>
-        </TooltipProvider>
-      </aside>
-    </>
+        </div>
+      </TooltipProvider>
+    </aside>
   );
 }

--- a/apps/web/src/components/ui/pull-to-refresh.test.tsx
+++ b/apps/web/src/components/ui/pull-to-refresh.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { usePullToRefresh } from '@/hooks/use-pull-to-refresh';
+
+import { PullToRefresh } from './pull-to-refresh';
+
+vi.mock('@/hooks/use-pull-to-refresh', () => ({
+  usePullToRefresh: vi.fn(),
+}));
+
+const mockedUsePullToRefresh = vi.mocked(usePullToRefresh);
+
+describe('PullToRefresh', () => {
+  it('does not render when app is not in standalone mode', () => {
+    mockedUsePullToRefresh.mockReturnValue({
+      isStandalone: false,
+      pullDistance: 0,
+      pulling: false,
+      refreshing: false,
+    });
+
+    const { container } = render(<PullToRefresh onRefresh={vi.fn()} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows release message when threshold is reached', () => {
+    mockedUsePullToRefresh.mockReturnValue({
+      isStandalone: true,
+      pullDistance: 100,
+      pulling: true,
+      refreshing: false,
+    });
+
+    render(<PullToRefresh onRefresh={vi.fn()} threshold={80} />);
+
+    expect(screen.getByText('Release to refresh')).toBeInTheDocument();
+  });
+
+  it('shows refreshing state', () => {
+    mockedUsePullToRefresh.mockReturnValue({
+      isStandalone: true,
+      pullDistance: 0,
+      pulling: false,
+      refreshing: true,
+    });
+
+    render(<PullToRefresh onRefresh={vi.fn()} />);
+
+    expect(screen.getByText('Refreshing...')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/pull-to-refresh.test.tsx
+++ b/apps/web/src/components/ui/pull-to-refresh.test.tsx
@@ -6,6 +6,7 @@ import { usePullToRefresh } from '@/hooks/use-pull-to-refresh';
 import { PullToRefresh } from './pull-to-refresh';
 
 vi.mock('@/hooks/use-pull-to-refresh', () => ({
+  DEFAULT_THRESHOLD: 80,
   usePullToRefresh: vi.fn(),
 }));
 

--- a/apps/web/src/components/ui/pull-to-refresh.tsx
+++ b/apps/web/src/components/ui/pull-to-refresh.tsx
@@ -1,6 +1,6 @@
 import { ArrowDown, Loader2 } from 'lucide-react';
 
-import { usePullToRefresh } from '@/hooks/use-pull-to-refresh';
+import { DEFAULT_THRESHOLD, usePullToRefresh } from '@/hooks/use-pull-to-refresh';
 import { cn } from '@/lib/utils';
 
 type PullToRefreshProps = {
@@ -8,7 +8,10 @@ type PullToRefreshProps = {
   threshold?: number;
 };
 
-export function PullToRefresh({ onRefresh, threshold = 80 }: PullToRefreshProps) {
+export function PullToRefresh({ onRefresh, threshold }: PullToRefreshProps) {
+  const effectiveThreshold = threshold ?? DEFAULT_THRESHOLD;
+  const PULL_INDICATOR_AREA_HEIGHT = 64;
+
   const { isStandalone, pulling, pullDistance, refreshing } = usePullToRefresh({
     onRefresh,
     threshold,
@@ -18,8 +21,8 @@ export function PullToRefresh({ onRefresh, threshold = 80 }: PullToRefreshProps)
     return null;
   }
 
-  const progress = Math.min(pullDistance / threshold, 1);
-  const offsetY = refreshing ? 0 : -64 + progress * 64;
+  const progress = Math.min(pullDistance / effectiveThreshold, 1);
+  const offsetY = refreshing ? 0 : -PULL_INDICATOR_AREA_HEIGHT + progress * PULL_INDICATOR_AREA_HEIGHT;
   const indicatorText = refreshing
     ? 'Refreshing...'
     : progress >= 1
@@ -29,6 +32,8 @@ export function PullToRefresh({ onRefresh, threshold = 80 }: PullToRefreshProps)
   return (
     <div
       aria-hidden={!refreshing && !pulling}
+      aria-live="polite"
+      role="status"
       className="pointer-events-none fixed inset-x-0 top-0 z-50 flex justify-center"
       style={{ transform: `translateY(${offsetY}px)`, transition: refreshing ? 'transform 180ms ease-out' : 'none' }}
     >

--- a/apps/web/src/components/ui/pull-to-refresh.tsx
+++ b/apps/web/src/components/ui/pull-to-refresh.tsx
@@ -1,0 +1,49 @@
+import { ArrowDown, Loader2 } from 'lucide-react';
+
+import { usePullToRefresh } from '@/hooks/use-pull-to-refresh';
+import { cn } from '@/lib/utils';
+
+type PullToRefreshProps = {
+  onRefresh: () => Promise<unknown> | unknown;
+  threshold?: number;
+};
+
+export function PullToRefresh({ onRefresh, threshold = 80 }: PullToRefreshProps) {
+  const { isStandalone, pulling, pullDistance, refreshing } = usePullToRefresh({
+    onRefresh,
+    threshold,
+  });
+
+  if (!isStandalone) {
+    return null;
+  }
+
+  const progress = Math.min(pullDistance / threshold, 1);
+  const offsetY = refreshing ? 0 : -64 + progress * 64;
+  const indicatorText = refreshing
+    ? 'Refreshing...'
+    : progress >= 1
+      ? 'Release to refresh'
+      : 'Pull to refresh';
+
+  return (
+    <div
+      aria-hidden={!refreshing && !pulling}
+      className="pointer-events-none fixed inset-x-0 top-0 z-50 flex justify-center"
+      style={{ transform: `translateY(${offsetY}px)`, transition: refreshing ? 'transform 180ms ease-out' : 'none' }}
+    >
+      <div className="mt-2 flex min-w-44 items-center gap-2 rounded-full border border-border/70 bg-card px-4 py-2 text-sm text-muted-foreground shadow-sm">
+        {refreshing ? (
+          <Loader2 aria-hidden="true" className="size-4 animate-spin text-primary" />
+        ) : (
+          <ArrowDown
+            aria-hidden="true"
+            className={cn('size-4 text-muted-foreground transition-transform duration-100')}
+            style={{ transform: `rotate(${Math.round(progress * 180)}deg)` }}
+          />
+        )}
+        <span>{indicatorText}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-pull-to-refresh.test.tsx
+++ b/apps/web/src/hooks/use-pull-to-refresh.test.tsx
@@ -1,0 +1,162 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { usePullToRefresh } from './use-pull-to-refresh';
+
+type MatchMediaMock = {
+  addEventListener: ReturnType<typeof vi.fn>;
+  addListener: ReturnType<typeof vi.fn>;
+  media: string;
+  matches: boolean;
+  onchange: ((event: MediaQueryListEvent) => void) | null;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  removeListener: ReturnType<typeof vi.fn>;
+};
+
+const createTouchEvent = (type: string, y?: number) => {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as Event & {
+    changedTouches: Array<{ clientY: number }>;
+    touches: Array<{ clientY: number }>;
+  };
+
+  Object.defineProperty(event, 'touches', {
+    configurable: true,
+    value: y === undefined ? [] : [{ clientY: y }],
+  });
+
+  Object.defineProperty(event, 'changedTouches', {
+    configurable: true,
+    value: y === undefined ? [] : [{ clientY: y }],
+  });
+
+  return event;
+};
+
+const dispatchTouch = (type: 'touchstart' | 'touchmove' | 'touchend', y?: number) => {
+  const event = createTouchEvent(type, y);
+  window.dispatchEvent(event);
+  return event;
+};
+
+const setupStandalone = (matches = true, iosStandalone = false) => {
+  const mediaQueryMock: MatchMediaMock = {
+    addEventListener: vi.fn(),
+    addListener: vi.fn(),
+    media: '(display-mode: standalone)',
+    matches,
+    onchange: null,
+    removeEventListener: vi.fn(),
+    removeListener: vi.fn(),
+  };
+
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mediaQueryMock));
+  Object.defineProperty(window.navigator, 'standalone', {
+    configurable: true,
+    value: iosStandalone,
+    writable: true,
+  });
+
+  return mediaQueryMock;
+};
+
+describe('usePullToRefresh', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 0,
+      writable: true,
+    });
+    document.documentElement.scrollTop = 0;
+    setupStandalone(true, false);
+  });
+
+  it('does not activate outside standalone mode', () => {
+    setupStandalone(false, false);
+    const onRefresh = vi.fn();
+
+    renderHook(() => usePullToRefresh({ onRefresh }));
+
+    act(() => {
+      dispatchTouch('touchstart', 0);
+      dispatchTouch('touchmove', 120);
+      dispatchTouch('touchend');
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('refreshes when released past threshold while at the top', async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh, threshold: 80 }));
+
+    act(() => {
+      dispatchTouch('touchstart', 10);
+      dispatchTouch('touchmove', 120);
+    });
+
+    expect(result.current.pulling).toBe(true);
+    expect(result.current.pullDistance).toBe(110);
+
+    act(() => {
+      dispatchTouch('touchend');
+    });
+
+    await waitFor(() => {
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(result.current.refreshing).toBe(false);
+      expect(result.current.pulling).toBe(false);
+      expect(result.current.pullDistance).toBe(0);
+    });
+  });
+
+  it('does not refresh if the page is not scrolled to top', () => {
+    const onRefresh = vi.fn();
+    window.scrollY = 20;
+    document.documentElement.scrollTop = 20;
+
+    renderHook(() => usePullToRefresh({ onRefresh, threshold: 80 }));
+
+    act(() => {
+      dispatchTouch('touchstart', 10);
+      dispatchTouch('touchmove', 120);
+      dispatchTouch('touchend');
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('keeps refreshing state true until async refresh completes', async () => {
+    let resolveRefresh: (() => void) | undefined;
+    const onRefresh = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh, threshold: 80 }));
+
+    act(() => {
+      dispatchTouch('touchstart', 0);
+      dispatchTouch('touchmove', 100);
+      dispatchTouch('touchend');
+    });
+
+    await waitFor(() => {
+      expect(result.current.refreshing).toBe(true);
+    });
+
+    act(() => {
+      resolveRefresh?.();
+    });
+
+    await waitFor(() => {
+      expect(result.current.refreshing).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/hooks/use-pull-to-refresh.ts
+++ b/apps/web/src/hooks/use-pull-to-refresh.ts
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type RefreshCallback = () => Promise<unknown> | unknown;
+
+type PullToRefreshState = {
+  isStandalone: boolean;
+  pulling: boolean;
+  pullDistance: number;
+  refreshing: boolean;
+};
+
+type UsePullToRefreshOptions = {
+  onRefresh: RefreshCallback;
+  threshold?: number;
+  maxPullDistance?: number;
+};
+
+const DISPLAY_MODE_STANDALONE_QUERY = '(display-mode: standalone)';
+const DEFAULT_THRESHOLD = 80;
+const DEFAULT_MAX_PULL_DISTANCE = 140;
+
+const hasWindow = () => typeof window !== 'undefined';
+
+const isStandalonePwa = (): boolean => {
+  if (!hasWindow()) {
+    return false;
+  }
+
+  const mediaMatches =
+    typeof window.matchMedia === 'function' && window.matchMedia(DISPLAY_MODE_STANDALONE_QUERY).matches;
+  const iOSStandalone = Boolean((window.navigator as Navigator & { standalone?: boolean }).standalone);
+
+  return mediaMatches || iOSStandalone;
+};
+
+const isAtTop = (): boolean => {
+  if (!hasWindow()) {
+    return false;
+  }
+
+  return window.scrollY <= 0 || document.documentElement.scrollTop <= 0;
+};
+
+export function usePullToRefresh({
+  onRefresh,
+  threshold = DEFAULT_THRESHOLD,
+  maxPullDistance = DEFAULT_MAX_PULL_DISTANCE,
+}: UsePullToRefreshOptions): PullToRefreshState {
+  const [isStandalone, setIsStandalone] = useState<boolean>(() => isStandalonePwa());
+  const [pulling, setPulling] = useState(false);
+  const [pullDistance, setPullDistance] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const touchStartYRef = useRef(0);
+  const isTouchActiveRef = useRef(false);
+  const canPullRef = useRef(false);
+  const pullDistanceRef = useRef(0);
+
+  const updatePullDistance = useCallback((nextDistance: number) => {
+    pullDistanceRef.current = nextDistance;
+    setPullDistance(nextDistance);
+  }, []);
+
+  useEffect(() => {
+    if (!hasWindow() || typeof window.matchMedia !== 'function') {
+      setIsStandalone(Boolean((globalThis.navigator as Navigator & { standalone?: boolean }).standalone));
+      return;
+    }
+
+    const mediaQueryList = window.matchMedia(DISPLAY_MODE_STANDALONE_QUERY);
+    const syncStandaloneState = () => {
+      setIsStandalone(mediaQueryList.matches || Boolean((window.navigator as Navigator & { standalone?: boolean }).standalone));
+    };
+
+    syncStandaloneState();
+
+    if (typeof mediaQueryList.addEventListener === 'function') {
+      mediaQueryList.addEventListener('change', syncStandaloneState);
+      return () => {
+        mediaQueryList.removeEventListener('change', syncStandaloneState);
+      };
+    }
+
+    mediaQueryList.addListener(syncStandaloneState);
+    return () => {
+      mediaQueryList.removeListener(syncStandaloneState);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!hasWindow() || !isStandalone) {
+      return;
+    }
+
+    const resetPullState = () => {
+      isTouchActiveRef.current = false;
+      canPullRef.current = false;
+      setPulling(false);
+      updatePullDistance(0);
+    };
+
+    const onTouchStart = (event: TouchEvent) => {
+      if (refreshing) {
+        return;
+      }
+
+      const touch = event.touches[0];
+      if (!touch) {
+        return;
+      }
+
+      isTouchActiveRef.current = true;
+      canPullRef.current = isAtTop();
+      touchStartYRef.current = touch.clientY;
+    };
+
+    const onTouchMove = (event: TouchEvent) => {
+      if (!isTouchActiveRef.current || refreshing) {
+        return;
+      }
+
+      const touch = event.touches[0];
+      if (!touch) {
+        return;
+      }
+
+      const deltaY = touch.clientY - touchStartYRef.current;
+
+      if (!canPullRef.current || deltaY <= 0 || !isAtTop()) {
+        setPulling(false);
+        updatePullDistance(0);
+        return;
+      }
+
+      const nextDistance = Math.min(deltaY, maxPullDistance);
+      setPulling(true);
+      updatePullDistance(nextDistance);
+      event.preventDefault();
+    };
+
+    const onTouchEnd = async () => {
+      if (!isTouchActiveRef.current) {
+        return;
+      }
+
+      const shouldRefresh = pullDistanceRef.current >= threshold;
+      resetPullState();
+
+      if (!shouldRefresh || refreshing) {
+        return;
+      }
+
+      setRefreshing(true);
+      try {
+        await onRefresh();
+      } finally {
+        setRefreshing(false);
+      }
+    };
+
+    window.addEventListener('touchstart', onTouchStart, { passive: true });
+    window.addEventListener('touchmove', onTouchMove, { passive: false });
+    window.addEventListener('touchend', onTouchEnd);
+    window.addEventListener('touchcancel', onTouchEnd);
+
+    return () => {
+      window.removeEventListener('touchstart', onTouchStart);
+      window.removeEventListener('touchmove', onTouchMove);
+      window.removeEventListener('touchend', onTouchEnd);
+      window.removeEventListener('touchcancel', onTouchEnd);
+    };
+  }, [isStandalone, maxPullDistance, onRefresh, refreshing, threshold, updatePullDistance]);
+
+  return {
+    isStandalone,
+    pulling,
+    pullDistance,
+    refreshing,
+  };
+}

--- a/apps/web/src/hooks/use-pull-to-refresh.ts
+++ b/apps/web/src/hooks/use-pull-to-refresh.ts
@@ -16,7 +16,7 @@ type UsePullToRefreshOptions = {
 };
 
 const DISPLAY_MODE_STANDALONE_QUERY = '(display-mode: standalone)';
-const DEFAULT_THRESHOLD = 80;
+export const DEFAULT_THRESHOLD = 80;
 const DEFAULT_MAX_PULL_DISTANCE = 140;
 
 const hasWindow = () => typeof window !== 'undefined';
@@ -38,7 +38,7 @@ const isAtTop = (): boolean => {
     return false;
   }
 
-  return window.scrollY <= 0 || document.documentElement.scrollTop <= 0;
+  return window.scrollY <= 0;
 };
 
 export function usePullToRefresh({
@@ -55,6 +55,7 @@ export function usePullToRefresh({
   const isTouchActiveRef = useRef(false);
   const canPullRef = useRef(false);
   const pullDistanceRef = useRef(0);
+  const refreshingRef = useRef(false);
 
   const updatePullDistance = useCallback((nextDistance: number) => {
     pullDistanceRef.current = nextDistance;
@@ -88,6 +89,10 @@ export function usePullToRefresh({
   }, []);
 
   useEffect(() => {
+    refreshingRef.current = refreshing;
+  }, [refreshing]);
+
+  useEffect(() => {
     if (!hasWindow() || !isStandalone) {
       return;
     }
@@ -100,7 +105,7 @@ export function usePullToRefresh({
     };
 
     const onTouchStart = (event: TouchEvent) => {
-      if (refreshing) {
+      if (refreshingRef.current) {
         return;
       }
 
@@ -115,7 +120,7 @@ export function usePullToRefresh({
     };
 
     const onTouchMove = (event: TouchEvent) => {
-      if (!isTouchActiveRef.current || refreshing) {
+      if (!isTouchActiveRef.current || refreshingRef.current) {
         return;
       }
 
@@ -146,14 +151,18 @@ export function usePullToRefresh({
       const shouldRefresh = pullDistanceRef.current >= threshold;
       resetPullState();
 
-      if (!shouldRefresh || refreshing) {
+      if (!shouldRefresh || refreshingRef.current) {
         return;
       }
 
+      refreshingRef.current = true;
       setRefreshing(true);
       try {
         await onRefresh();
+      } catch (error) {
+        console.error('Pull-to-refresh failed:', error);
       } finally {
+        refreshingRef.current = false;
         setRefreshing(false);
       }
     };
@@ -169,7 +178,7 @@ export function usePullToRefresh({
       window.removeEventListener('touchend', onTouchEnd);
       window.removeEventListener('touchcancel', onTouchEnd);
     };
-  }, [isStandalone, maxPullDistance, onRefresh, refreshing, threshold, updatePullDistance]);
+  }, [isStandalone, maxPullDistance, onRefresh, threshold, updatePullDistance]);
 
   return {
     isStandalone,


### PR DESCRIPTION
## Summary
This PR simplifies mobile navigation by removing the sidebar’s hamburger trigger and overlay panel, which were redundant with the existing bottom navigation. It also adds a standalone-only pull-to-refresh interaction so installed PWA users can refresh app data with a native-feeling gesture. The new refresh flow is wired at the layout level to invalidate TanStack Query caches, ensuring visible screens pick up fresh server state. Overall, this reduces mobile UI complexity while improving data refresh ergonomics in standalone mode.

## Key Changes
- Removed mobile sidebar menu state/UI (hamburger trigger, overlay backdrop, slide-in dialog, escape/restore-focus handling) from `Sidebar`.
- Kept sidebar as a desktop-only navigation surface (`md:flex`) and updated tests to assert mobile controls are absent.
- Added `PullToRefresh` UI component with threshold-based indicator states (`Pull to refresh`, `Release to refresh`, `Refreshing...`).
- Added `usePullToRefresh` hook to manage touch gesture lifecycle, pull distance, threshold checks, and async refresh state.
- Integrated pull-to-refresh in `AppLayout` and connected `onRefresh` to `queryClient.invalidateQueries()`.
- Added focused tests for layout wiring, standalone gating, indicator rendering, and hook behavior (top-of-page constraint, threshold crossing, async refresh lifecycle).

## Technical Notes
- Pull-to-refresh is explicitly gated to standalone/PWA contexts using both `matchMedia('(display-mode: standalone)')` and iOS `navigator.standalone`.
- Gesture handling uses `touchmove` with `{ passive: false }` to call `preventDefault()` only during active downward pull at scroll top, reducing interference with normal scrolling.
- Refresh currently invalidates all queries via `invalidateQueries()` for correctness/simplicity; reviewers may want to confirm this broad invalidation is acceptable for current cache volume.
- `Sidebar` refactor removes a large amount of mobile-specific accessibility/focus-trap logic by eliminating the overlay path entirely.

## Commits

- `0d0038c feat(web): add standalone pull-to-refresh interaction`
- `8d69f40 fix(web): remove mobile sidebar menu overlay`

## Tasks

- **Remove hamburger menu button and mobile sidebar overlay**: Remove redundant mobile hamburger menu and overlay from sidebar — bottom nav covers all mobile navigation
- **Add pull-to-refresh for standalone PWA mode**: Implement touch-based pull-to-refresh gesture that detects standalone mode and invalidates TanStack Query cache

## Diff Stats

```
apps/web/src/components/layout/app-layout.test.tsx |  49 +++
 apps/web/src/components/layout/app-layout.tsx      |   7 +
 apps/web/src/components/layout/sidebar.test.tsx    |  20 +-
 apps/web/src/components/layout/sidebar.tsx         | 409 +++++++--------------
 .../web/src/components/ui/pull-to-refresh.test.tsx |  53 +++
 apps/web/src/components/ui/pull-to-refresh.tsx     |  49 +++
 apps/web/src/hooks/use-pull-to-refresh.test.tsx    | 162 ++++++++
 apps/web/src/hooks/use-pull-to-refresh.ts          | 180 +++++++++
 8 files changed, 633 insertions(+), 296 deletions(-)
```