### PR TITLE
fix: confirmation dialogs, input reliability, and mobile layout

### DIFF
--- a/apps/web/src/components/layout/app-layout.test.tsx
+++ b/apps/web/src/components/layout/app-layout.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { AppLayout } from '@/components/layout/app-layout';
@@ -45,5 +45,19 @@ describe('AppLayout', () => {
     await onRefresh();
 
     expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses responsive top padding for main content', () => {
+    render(
+      <AppLayout>
+        <div>content</div>
+      </AppLayout>,
+    );
+
+    const main = screen.getByRole('main');
+
+    expect(main).toHaveClass('pt-4');
+    expect(main).toHaveClass('md:pt-8');
+    expect(main).not.toHaveClass('pt-20');
   });
 });

--- a/apps/web/src/components/layout/app-layout.tsx
+++ b/apps/web/src/components/layout/app-layout.tsx
@@ -19,7 +19,7 @@ export function AppLayout({ children }: PropsWithChildren) {
       <ActiveSessionResumeGate />
       <div className="mx-auto flex min-h-screen w-full max-w-screen-2xl">
         <Sidebar />
-        <main className="min-w-0 flex-1 overflow-x-clip px-4 pb-24 pt-20 md:px-8 md:pb-8 md:pt-8">
+        <main className="min-w-0 flex-1 overflow-x-clip px-4 pb-24 pt-4 md:px-8 md:pb-8 md:pt-8">
           {content}
         </main>
       </div>

--- a/apps/web/src/components/layout/bottom-nav.test.tsx
+++ b/apps/web/src/components/layout/bottom-nav.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { BottomNav } from '@/components/layout/bottom-nav';
@@ -124,6 +124,11 @@ describe('BottomNav', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'More' }));
     fireEvent.click(screen.getByRole('menuitem', { name: 'Log out' }));
+    expect(store.logout).not.toHaveBeenCalled();
+
+    const dialog = screen.getByRole('alertdialog');
+    expect(within(dialog).getByText('Sign out?')).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Sign out' }));
 
     expect(store.logout).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });

--- a/apps/web/src/components/layout/bottom-nav.tsx
+++ b/apps/web/src/components/layout/bottom-nav.tsx
@@ -3,6 +3,7 @@ import { LogOut } from 'lucide-react';
 import { NavLink, useLocation, useNavigate } from 'react-router';
 import { cn } from '@/lib/utils';
 import { moreNavIcon, moreNavItems, primaryNavItems } from '@/components/layout/nav-items';
+import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import { useAuthStore } from '@/store/auth-store';
 
 const moreRoutes = new Set(moreNavItems.map((item) => item.to));
@@ -13,14 +14,23 @@ export function BottomNav() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const { logout } = useAuthStore();
+  const { confirm, dialog } = useConfirmation();
 
   const MoreIcon = moreNavIcon;
   const isMoreActive = moreRoutes.has(pathname);
 
   function handleLogout() {
     setMenuOpen(false);
-    logout();
-    navigate('/login', { replace: true });
+    confirm({
+      title: 'Sign out?',
+      description: "You'll need to sign in again to continue.",
+      confirmLabel: 'Sign out',
+      variant: 'default',
+      onConfirm: () => {
+        logout();
+        navigate('/login', { replace: true });
+      },
+    });
   }
 
   useEffect(() => {
@@ -127,6 +137,7 @@ export function BottomNav() {
           ) : null}
         </div>
       </nav>
+      {dialog}
     </div>
   );
 }

--- a/apps/web/src/components/layout/sidebar.test.tsx
+++ b/apps/web/src/components/layout/sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Sidebar } from '@/components/layout/sidebar';
@@ -125,6 +125,11 @@ describe('Sidebar', () => {
     renderSidebar(store);
 
     fireEvent.click(screen.getByRole('button', { name: 'Log out' }));
+    expect(store.logout).not.toHaveBeenCalled();
+
+    const dialog = screen.getByRole('alertdialog');
+    expect(within(dialog).getByText('Sign out?')).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Sign out' }));
 
     expect(store.logout).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, ChevronRight, LogOut } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { sidebarNavItems } from '@/components/layout/nav-items';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import { useUser } from '@/hooks/use-user';
 import { useAuthStore } from '@/store/auth-store';
 
@@ -20,6 +21,7 @@ export function Sidebar() {
   const [collapsed, setCollapsed] = useState(getInitialCollapsed);
   const navigate = useNavigate();
   const { logout } = useAuthStore();
+  const { confirm, dialog } = useConfirmation();
   const { data: user } = useUser();
   const displayName = user?.name?.trim() || user?.username || 'Account';
   const subtitle = user?.name ? `@${user.username}` : 'Signed in';
@@ -40,8 +42,16 @@ export function Sidebar() {
   }
 
   function handleLogout() {
-    logout();
-    navigate('/login', { replace: true });
+    confirm({
+      title: 'Sign out?',
+      description: "You'll need to sign in again to continue.",
+      confirmLabel: 'Sign out',
+      variant: 'default',
+      onConfirm: () => {
+        logout();
+        navigate('/login', { replace: true });
+      },
+    });
   }
 
   return (
@@ -199,6 +209,7 @@ export function Sidebar() {
           </div>
         </div>
       </TooltipProvider>
+      {dialog}
     </aside>
   );
 }

--- a/apps/web/src/components/ui/confirmation-dialog.test.tsx
+++ b/apps/web/src/components/ui/confirmation-dialog.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ConfirmationDialog, useConfirmation } from '@/components/ui/confirmation-dialog';
+
+describe('ConfirmationDialog', () => {
+  it('renders title and description', () => {
+    render(
+      <ConfirmationDialog
+        description="This action cannot be undone."
+        onConfirm={vi.fn()}
+        onOpenChange={vi.fn()}
+        open
+        title="Delete template?"
+      />,
+    );
+
+    expect(screen.getByText('Delete template?')).toBeInTheDocument();
+    expect(screen.getByText('This action cannot be undone.')).toBeInTheDocument();
+  });
+
+  it('calls onConfirm when confirm button is clicked', () => {
+    const onConfirm = vi.fn();
+
+    render(
+      <ConfirmationDialog
+        description="This action cannot be undone."
+        onConfirm={onConfirm}
+        onOpenChange={vi.fn()}
+        open
+        title="Delete template?"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel and closes when cancel button is clicked', () => {
+    const onCancel = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <ConfirmationDialog
+        description="This action cannot be undone."
+        onCancel={onCancel}
+        onConfirm={vi.fn()}
+        onOpenChange={onOpenChange}
+        open
+        title="Delete template?"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('uses destructive styling for destructive variant', () => {
+    render(
+      <ConfirmationDialog
+        description="This action cannot be undone."
+        onConfirm={vi.fn()}
+        onOpenChange={vi.fn()}
+        open
+        title="Delete template?"
+        variant="destructive"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toHaveAttribute(
+      'data-variant',
+      'destructive',
+    );
+  });
+
+  it('disables confirm button while loading', () => {
+    render(
+      <ConfirmationDialog
+        description="This action cannot be undone."
+        loading
+        onConfirm={vi.fn()}
+        onOpenChange={vi.fn()}
+        open
+        title="Delete template?"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+  });
+});
+
+function HookHarness({ onConfirm }: { onConfirm: () => void }) {
+  const { confirm, dialog } = useConfirmation();
+
+  return (
+    <>
+      <button
+        onClick={() => {
+          confirm({
+            confirmLabel: 'Delete meal',
+            description: 'This action cannot be undone.',
+            onConfirm,
+            title: 'Delete meal?',
+          });
+        }}
+        type="button"
+      >
+        Open confirm
+      </button>
+      {dialog}
+    </>
+  );
+}
+
+describe('useConfirmation', () => {
+  it('opens and runs the confirm callback', async () => {
+    const onConfirm = vi.fn();
+
+    render(<HookHarness onConfirm={onConfirm} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open confirm' }));
+    expect(screen.getByText('Delete meal?')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete meal' }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByText('Delete meal?')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/ui/confirmation-dialog.test.tsx
+++ b/apps/web/src/components/ui/confirmation-dialog.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { ConfirmationDialog, useConfirmation } from '@/components/ui/confirmation-dialog';
@@ -32,19 +32,17 @@ describe('ConfirmationDialog', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onCancel and closes when cancel button is clicked', () => {
-    const onCancel = vi.fn();
+  it('closes when cancel button is clicked', () => {
     const onOpenChange = vi.fn();
 
     render(
       <ConfirmationDialog
         description="This action cannot be undone."
-        onCancel={onCancel}
         onConfirm={vi.fn()}
         onOpenChange={onOpenChange}
         open
@@ -54,7 +52,6 @@ describe('ConfirmationDialog', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
-    expect(onCancel).toHaveBeenCalledTimes(1);
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
@@ -70,7 +67,7 @@ describe('ConfirmationDialog', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: 'Delete' })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: 'Confirm' })).toHaveAttribute(
       'data-variant',
       'destructive',
     );
@@ -88,11 +85,17 @@ describe('ConfirmationDialog', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
   });
 });
 
-function HookHarness({ onConfirm }: { onConfirm: () => void }) {
+function HookHarness({
+  onConfirm,
+  onCancel,
+}: {
+  onConfirm: () => void | Promise<void>;
+  onCancel?: () => void;
+}) {
   const { confirm, dialog } = useConfirmation();
 
   return (
@@ -102,6 +105,7 @@ function HookHarness({ onConfirm }: { onConfirm: () => void }) {
           confirm({
             confirmLabel: 'Delete meal',
             description: 'This action cannot be undone.',
+            onCancel,
             onConfirm,
             title: 'Delete meal?',
           });
@@ -127,6 +131,47 @@ describe('useConfirmation', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete meal' }));
 
     expect(onConfirm).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByText('Delete meal?')).not.toBeInTheDocument();
+    });
+  });
+
+  it('calls onCancel when dialog is dismissed', async () => {
+    const onCancel = vi.fn();
+
+    render(<HookHarness onCancel={onCancel} onConfirm={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open confirm' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByText('Delete meal?')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows loading state and stays open during async confirm', async () => {
+    let resolveConfirm: (() => void) | undefined;
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveConfirm = resolve;
+        }),
+    );
+
+    render(<HookHarness onConfirm={onConfirm} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open confirm' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete meal' }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'Delete meal' })).toBeDisabled();
+    expect(screen.getByText('Delete meal?')).toBeInTheDocument();
+
+    act(() => {
+      resolveConfirm?.();
+    });
+
     await waitFor(() => {
       expect(screen.queryByText('Delete meal?')).not.toBeInTheDocument();
     });

--- a/apps/web/src/components/ui/confirmation-dialog.tsx
+++ b/apps/web/src/components/ui/confirmation-dialog.tsx
@@ -22,14 +22,13 @@ export interface ConfirmationDialogProps {
   description: string;
   confirmLabel?: string;
   cancelLabel?: string;
-  onConfirm: () => void;
-  onCancel?: () => void;
+  onConfirm: () => void | Promise<void>;
   variant?: ConfirmationVariant;
   loading?: boolean;
 }
 
 export type ConfirmationRequest = Omit<
-  ConfirmationDialogProps,
+  ConfirmationDialogProps & { onCancel?: () => void },
   'loading' | 'onOpenChange' | 'open'
 >;
 
@@ -47,10 +46,9 @@ export function ConfirmationDialog({
   onOpenChange,
   title,
   description,
-  confirmLabel = 'Delete',
+  confirmLabel = 'Confirm',
   cancelLabel = 'Cancel',
   onConfirm,
-  onCancel,
   variant = 'destructive',
   loading = false,
 }: ConfirmationDialogProps) {
@@ -63,14 +61,7 @@ export function ConfirmationDialog({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel asChild>
-            <Button
-              autoFocus
-              onClick={() => {
-                onCancel?.();
-              }}
-              type="button"
-              variant="outline"
-            >
+            <Button autoFocus type="button" variant="outline">
               {cancelLabel}
             </Button>
           </AlertDialogCancel>
@@ -98,6 +89,7 @@ export function useConfirmation() {
   const [open, setOpen] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
   const [confirmation, setConfirmation] = React.useState<ConfirmationRequest | null>(null);
+  const confirmedRef = React.useRef(false);
 
   const close = React.useCallback(() => {
     setLoading(false);
@@ -106,6 +98,7 @@ export function useConfirmation() {
   }, []);
 
   const confirm = React.useCallback((request: ConfirmationRequest) => {
+    confirmedRef.current = false;
     setLoading(false);
     setConfirmation(request);
     setOpen(true);
@@ -117,11 +110,15 @@ export function useConfirmation() {
     }
 
     try {
+      setLoading(true);
       const result = confirmation.onConfirm();
-      if (isPromiseLike(result)) {
-        setLoading(true);
-        await result;
+      if (!isPromiseLike(result)) {
+        confirmedRef.current = true;
+        close();
+        return;
       }
+      await result;
+      confirmedRef.current = true;
       close();
     } catch {
       setLoading(false);
@@ -134,15 +131,14 @@ export function useConfirmation() {
       confirmLabel={confirmation.confirmLabel}
       description={confirmation.description}
       loading={loading}
-      onCancel={() => {
-        confirmation.onCancel?.();
-        close();
-      }}
       onConfirm={() => {
         void handleConfirm();
       }}
       onOpenChange={(nextOpen) => {
         if (!nextOpen) {
+          if (!confirmedRef.current) {
+            confirmation.onCancel?.();
+          }
           close();
           return;
         }

--- a/apps/web/src/components/ui/confirmation-dialog.tsx
+++ b/apps/web/src/components/ui/confirmation-dialog.tsx
@@ -1,0 +1,159 @@
+/* eslint-disable react-refresh/only-export-components */
+import * as React from 'react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+
+type ConfirmationVariant = 'destructive' | 'default';
+
+export interface ConfirmationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onCancel?: () => void;
+  variant?: ConfirmationVariant;
+  loading?: boolean;
+}
+
+export type ConfirmationRequest = Omit<
+  ConfirmationDialogProps,
+  'loading' | 'onOpenChange' | 'open'
+>;
+
+function isPromiseLike(value: unknown): value is Promise<unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'then' in value &&
+    typeof value.then === 'function'
+  );
+}
+
+export function ConfirmationDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = 'Delete',
+  cancelLabel = 'Cancel',
+  onConfirm,
+  onCancel,
+  variant = 'destructive',
+  loading = false,
+}: ConfirmationDialogProps) {
+  return (
+    <AlertDialog onOpenChange={onOpenChange} open={open}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel asChild>
+            <Button
+              autoFocus
+              onClick={() => {
+                onCancel?.();
+              }}
+              type="button"
+              variant="outline"
+            >
+              {cancelLabel}
+            </Button>
+          </AlertDialogCancel>
+          <AlertDialogAction asChild>
+            <Button
+              aria-busy={loading || undefined}
+              disabled={loading}
+              onClick={(event) => {
+                event.preventDefault();
+                onConfirm();
+              }}
+              type="button"
+              variant={variant}
+            >
+              {confirmLabel}
+            </Button>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+export function useConfirmation() {
+  const [open, setOpen] = React.useState(false);
+  const [loading, setLoading] = React.useState(false);
+  const [confirmation, setConfirmation] = React.useState<ConfirmationRequest | null>(null);
+
+  const close = React.useCallback(() => {
+    setLoading(false);
+    setOpen(false);
+    setConfirmation(null);
+  }, []);
+
+  const confirm = React.useCallback((request: ConfirmationRequest) => {
+    setLoading(false);
+    setConfirmation(request);
+    setOpen(true);
+  }, []);
+
+  const handleConfirm = React.useCallback(async () => {
+    if (!confirmation) {
+      return;
+    }
+
+    try {
+      const result = confirmation.onConfirm();
+      if (isPromiseLike(result)) {
+        setLoading(true);
+        await result;
+      }
+      close();
+    } catch {
+      setLoading(false);
+    }
+  }, [close, confirmation]);
+
+  const dialog = confirmation ? (
+    <ConfirmationDialog
+      cancelLabel={confirmation.cancelLabel}
+      confirmLabel={confirmation.confirmLabel}
+      description={confirmation.description}
+      loading={loading}
+      onCancel={() => {
+        confirmation.onCancel?.();
+        close();
+      }}
+      onConfirm={() => {
+        void handleConfirm();
+      }}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          close();
+          return;
+        }
+
+        setOpen(nextOpen);
+      }}
+      open={open}
+      title={confirmation.title}
+      variant={confirmation.variant}
+    />
+  ) : null;
+
+  return { confirm, dialog } as const;
+}

--- a/apps/web/src/features/foods/components/food-list.test.tsx
+++ b/apps/web/src/features/foods/components/food-list.test.tsx
@@ -477,9 +477,12 @@ describe('FoodList', () => {
     expect(await screen.findByRole('heading', { level: 3, name: 'Spinach' })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete Broccoli' }));
-    expect(screen.getByText('Are you sure you want to remove Broccoli?')).toBeInTheDocument();
+    expect(screen.getByText('Delete food?')).toBeInTheDocument();
+    expect(
+      screen.getByText('This will permanently remove "Broccoli" from your foods database.'),
+    ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete food' }));
 
     await waitFor(() => {
       expect(screen.queryByRole('heading', { level: 3, name: 'Broccoli' })).not.toBeInTheDocument();

--- a/apps/web/src/features/foods/components/food-list.tsx
+++ b/apps/web/src/features/foods/components/food-list.tsx
@@ -2,19 +2,10 @@ import { CheckCircle2Icon, SearchIcon, Trash2Icon } from 'lucide-react';
 import type { Food, FoodSort } from '@pulse/shared';
 import { useEffect, useRef, useState } from 'react';
 import { FoodCardSkeleton } from '@/components/skeletons';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -32,8 +23,6 @@ type FoodListProps = {
   pageSize?: number;
   foodsQuery?: ReturnType<typeof useFoods>;
 };
-
-type PendingDeleteFood = Pick<Food, 'id' | 'name'>;
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -92,6 +81,7 @@ export function FoodList({
   pageSize = DEFAULT_PAGE_SIZE,
   foodsQuery: pageFoodsQuery,
 }: FoodListProps) {
+  const { confirm, dialog } = useConfirmation();
   const [searchInput, setSearchInput] = useState('');
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState<FoodSort>(DEFAULT_SORT_BY);
@@ -99,7 +89,6 @@ export function FoodList({
   const [editingFoodId, setEditingFoodId] = useState<string | null>(null);
   const [draftFoodName, setDraftFoodName] = useState('');
   const [isSavingEdit, setIsSavingEdit] = useState(false);
-  const [foodPendingDelete, setFoodPendingDelete] = useState<PendingDeleteFood | null>(null);
   const editCancelledRef = useRef(false);
 
   useEffect(() => {
@@ -194,18 +183,24 @@ export function FoodList({
     }
   }
 
-  async function confirmDelete(foodId: string) {
-    if (editingFoodId === foodId) {
-      cancelEditing();
-    }
+  function handleDeleteFood(foodId: string, foodName: string) {
+    confirm({
+      title: 'Delete food?',
+      description: `This will permanently remove "${foodName}" from your foods database.`,
+      confirmLabel: 'Delete food',
+      variant: 'destructive',
+      onConfirm: async () => {
+        if (editingFoodId === foodId) {
+          cancelEditing();
+        }
 
-    setFoodPendingDelete(null);
-
-    try {
-      await deleteFood.mutateAsync(foodId);
-    } catch {
-      return;
-    }
+        try {
+          await deleteFood.mutateAsync(foodId);
+        } catch {
+          return;
+        }
+      },
+    });
   }
 
   const isInitialLoading = foodsQuery.isLoading;
@@ -398,12 +393,7 @@ export function FoodList({
                           aria-label={`Delete ${food.name}`}
                           className="text-muted-foreground hover:text-destructive"
                           disabled={isDeletingFood}
-                          onClick={() =>
-                            setFoodPendingDelete({
-                              id: food.id,
-                              name: food.name,
-                            })
-                          }
+                          onClick={() => handleDeleteFood(food.id, food.name)}
                           size="icon-xs"
                           type="button"
                           variant="ghost"
@@ -487,39 +477,7 @@ export function FoodList({
           ) : null}
         </>
       )}
-
-      <AlertDialog
-        onOpenChange={(open) => {
-          if (!open) {
-            setFoodPendingDelete(null);
-          }
-        }}
-        open={foodPendingDelete !== null}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Remove food?</AlertDialogTitle>
-            <AlertDialogDescription>
-              {foodPendingDelete
-                ? `Are you sure you want to remove ${foodPendingDelete.name}?`
-                : 'Are you sure you want to remove this food?'}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel type="button">Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (foodPendingDelete) {
-                  void confirmDelete(foodPendingDelete.id);
-                }
-              }}
-              type="button"
-            >
-              Remove
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {dialog}
     </div>
   );
 }

--- a/apps/web/src/features/habits/components/habit-card-menu.test.tsx
+++ b/apps/web/src/features/habits/components/habit-card-menu.test.tsx
@@ -294,7 +294,8 @@ describe('HabitCardMenu', () => {
     fireEvent.click(menuDeleteButton);
 
     const dialog = await screen.findByRole('alertdialog');
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+    expect(within(dialog).getByText('Delete habit?')).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete habit' }));
 
     await waitFor(() => expect(deleteMutation.mutateAsync).toHaveBeenCalledWith({ id: 'sleep' }));
   });

--- a/apps/web/src/features/habits/components/habit-card-menu.tsx
+++ b/apps/web/src/features/habits/components/habit-card-menu.tsx
@@ -12,17 +12,8 @@ import {
 } from 'lucide-react';
 import type { Habit } from '@pulse/shared';
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
+import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import {
   Dialog,
   DialogContent,
@@ -67,7 +58,7 @@ export function HabitCardMenu({ habit, habits, onEdit }: HabitCardMenuProps) {
   const today = getToday();
   const todayKey = toDateKey(today);
   const defaultPauseUntil = toDateKey(addDays(today, 7));
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const { confirm, dialog } = useConfirmation();
   const [isPauseDialogOpen, setIsPauseDialogOpen] = useState(false);
   const [pauseUntil, setPauseUntil] = useState(defaultPauseUntil);
 
@@ -125,7 +116,6 @@ export function HabitCardMenu({ habit, habits, onEdit }: HabitCardMenuProps) {
   async function handleDelete() {
     try {
       await deleteHabitMutation.mutateAsync({ id: habit.id });
-      setIsDeleteDialogOpen(false);
     } catch {
       // Mutation hook handles toasts and query recovery.
     }
@@ -212,7 +202,13 @@ export function HabitCardMenu({ habit, habits, onEdit }: HabitCardMenuProps) {
           <DropdownMenuItem
             onSelect={(event) => {
               event.preventDefault();
-              setIsDeleteDialogOpen(true);
+              confirm({
+                title: 'Delete habit?',
+                description: `This will permanently remove "${habit.name}" from your daily habits.`,
+                confirmLabel: 'Delete habit',
+                variant: 'destructive',
+                onConfirm: handleDelete,
+              });
             }}
             variant="destructive"
           >
@@ -272,30 +268,7 @@ export function HabitCardMenu({ habit, habits, onEdit }: HabitCardMenuProps) {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-
-      <AlertDialog onOpenChange={setIsDeleteDialogOpen} open={isDeleteDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete habit?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will permanently remove <strong>{habit.name}</strong> from your daily habits
-              list. This cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleteHabitMutation.isPending}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              disabled={deleteHabitMutation.isPending}
-              onClick={(event) => {
-                event.preventDefault();
-                void handleDelete();
-              }}
-            >
-              {deleteHabitMutation.isPending ? 'Deleting...' : 'Delete'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {dialog}
     </>
   );
 }

--- a/apps/web/src/features/settings/components/agent-tokens-card.tsx
+++ b/apps/web/src/features/settings/components/agent-tokens-card.tsx
@@ -9,18 +9,9 @@ import {
   TrashIcon,
 } from 'lucide-react';
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import {
   Dialog,
   DialogContent,
@@ -279,17 +270,15 @@ function TokenRow({
 }
 
 export function AgentTokensCard() {
+  const { confirm, dialog } = useConfirmation();
   const { data: tokens = [], isLoading } = useAgentTokens();
   const deleteMutation = useDeleteAgentToken();
 
   const [showCreate, setShowCreate] = useState(false);
   const [regenerateTarget, setRegenerateTarget] = useState<AgentTokenListItem | null>(null);
-  const [deleteTarget, setDeleteTarget] = useState<AgentTokenListItem | null>(null);
 
-  async function handleDelete() {
-    if (!deleteTarget) return;
-    await deleteMutation.mutateAsync(deleteTarget.id);
-    setDeleteTarget(null);
+  async function handleDelete(token: AgentTokenListItem) {
+    await deleteMutation.mutateAsync(token.id);
   }
 
   return (
@@ -339,7 +328,15 @@ export function AgentTokensCard() {
               {tokens.map((token) => (
                 <TokenRow
                   key={token.id}
-                  onDelete={setDeleteTarget}
+                  onDelete={(target) =>
+                    confirm({
+                      title: 'Delete token?',
+                      description: `This will permanently delete "${target.name}". Any agents using it will immediately lose access.`,
+                      confirmLabel: 'Delete token',
+                      variant: 'destructive',
+                      onConfirm: () => handleDelete(target),
+                    })
+                  }
                   onRegenerate={setRegenerateTarget}
                   token={token}
                 />
@@ -358,29 +355,7 @@ export function AgentTokensCard() {
         open={regenerateTarget !== null}
         token={regenerateTarget}
       />
-
-      <AlertDialog
-        onOpenChange={(open) => {
-          if (!open) setDeleteTarget(null);
-        }}
-        open={deleteTarget !== null}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete "{deleteTarget?.name}"?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This token will stop working immediately. Any agents using it will lose access. This
-              action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction disabled={deleteMutation.isPending} onClick={handleDelete}>
-              {deleteMutation.isPending ? 'Deleting...' : 'Delete token'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {dialog}
     </>
   );
 }

--- a/apps/web/src/features/settings/components/trash-manager.test.tsx
+++ b/apps/web/src/features/settings/components/trash-manager.test.tsx
@@ -106,7 +106,12 @@ describe('TrashManager', () => {
     );
 
     const dialog = await screen.findByRole('alertdialog');
-    expect(within(dialog).getByText(/Delete "Hydrate" permanently\?/i)).toBeInTheDocument();
+    expect(within(dialog).getByText('Delete habit?')).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(
+        'This will permanently remove "Hydrate" from trash and it cannot be restored.',
+      ),
+    ).toBeInTheDocument();
 
     fireEvent.click(within(dialog).getByRole('button', { name: 'Delete permanently' }));
 

--- a/apps/web/src/features/settings/components/trash-manager.tsx
+++ b/apps/web/src/features/settings/components/trash-manager.tsx
@@ -3,18 +3,9 @@ import { useMemo, useState } from 'react';
 import type { TrashItem, TrashType } from '@pulse/shared';
 import { ChevronDownIcon, RotateCcwIcon, Trash2Icon } from 'lucide-react';
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import { usePurgeItem, useRestoreItem, useTrashItems } from '@/features/settings/api/trash';
 
 const TRASH_GROUPS: Array<{ label: string; type: TrashType }> = [
@@ -39,11 +30,11 @@ function formatDeletedAt(value: string): string {
 }
 
 export function TrashManager() {
+  const { confirm, dialog } = useConfirmation();
   const { data, isPending } = useTrashItems();
   const restoreItemMutation = useRestoreItem();
   const purgeItemMutation = usePurgeItem();
   const [restoreTargetId, setRestoreTargetId] = useState<string | null>(null);
-  const [purgeTarget, setPurgeTarget] = useState<TrashItem | null>(null);
 
   const itemGroups = useMemo(() => {
     if (!data) {
@@ -76,20 +67,11 @@ export function TrashManager() {
     }
   }
 
-  async function handlePurgeItem() {
-    if (!purgeTarget) {
-      return;
-    }
-
-    try {
-      await purgeItemMutation.mutateAsync({
-        id: purgeTarget.id,
-        type: purgeTarget.type,
-      });
-      setPurgeTarget(null);
-    } catch {
-      // Keep dialog open to allow user retry if request fails.
-    }
+  async function handlePurgeItem(item: TrashItem) {
+    await purgeItemMutation.mutateAsync({
+      id: item.id,
+      type: item.type,
+    });
   }
 
   return (
@@ -160,7 +142,13 @@ export function TrashManager() {
                             className="min-w-36"
                             disabled={isRestoring || isPurgePending}
                             onClick={() => {
-                              setPurgeTarget(item);
+                              confirm({
+                                title: `Delete ${getTrashItemLabel(item.type)}?`,
+                                description: `This will permanently remove "${item.name}" from trash and it cannot be restored.`,
+                                confirmLabel: 'Delete permanently',
+                                variant: 'destructive',
+                                onConfirm: () => handlePurgeItem(item),
+                              });
                             }}
                             size="sm"
                             type="button"
@@ -179,36 +167,24 @@ export function TrashManager() {
           </div>
         )}
       </CardContent>
-
-      <AlertDialog
-        onOpenChange={(open) => {
-          if (!open && !isPurgePending) {
-            setPurgeTarget(null);
-          }
-        }}
-        open={purgeTarget !== null}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete "{purgeTarget?.name}" permanently?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This item will be removed forever and cannot be restored.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPurgePending}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-destructive text-white hover:bg-destructive/90"
-              disabled={isPurgePending}
-              onClick={() => {
-                void handlePurgeItem();
-              }}
-            >
-              {isPurgePending ? 'Deleting...' : 'Delete permanently'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {dialog}
     </Card>
   );
+}
+
+function getTrashItemLabel(type: TrashType) {
+  switch (type) {
+    case 'habits':
+      return 'habit';
+    case 'workout-templates':
+      return 'template';
+    case 'exercises':
+      return 'exercise';
+    case 'foods':
+      return 'food';
+    case 'workout-sessions':
+      return 'workout session';
+    default:
+      return 'item';
+  }
 }

--- a/apps/web/src/features/weight/components/weight-history.tsx
+++ b/apps/web/src/features/weight/components/weight-history.tsx
@@ -1,16 +1,9 @@
 import { Scale, Trash2 } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import { EmptyState } from '@/components/ui/empty-state';
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import { useDeleteWeight, useWeightTrend } from '@/features/weight/api/weight';
 import { useWeightUnit } from '@/hooks/use-weight-unit';
 import { parseDateInput } from '@/lib/date';
@@ -21,17 +14,12 @@ const entryDateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
 });
 
-type PendingDeleteWeight = {
-  date: string;
-  id: string;
-};
-
 function formatEntryDate(dateKey: string) {
   return entryDateFormatter.format(parseDateInput(`${dateKey}T00:00:00`));
 }
 
 export function WeightHistory() {
-  const [pendingDeleteWeight, setPendingDeleteWeight] = useState<PendingDeleteWeight | null>(null);
+  const { confirm, dialog } = useConfirmation();
   // Intentional for now: this view is a full history log. Add pagination/date bounds if dataset size becomes a UX issue.
   const weightEntriesQuery = useWeightTrend();
   const deleteWeightMutation = useDeleteWeight();
@@ -44,24 +32,25 @@ export function WeightHistory() {
     [weightEntriesQuery.data],
   );
 
-  async function handleDelete() {
-    if (!pendingDeleteWeight) {
-      return;
-    }
-
-    try {
-      await deleteWeightMutation.mutateAsync(pendingDeleteWeight.id);
-    } catch {
-      // Error feedback is handled by the mutation onError callback.
-      return;
-    } finally {
-      setPendingDeleteWeight(null);
-    }
+  function handleDelete(entry: { date: string; id: string }) {
+    confirm({
+      title: 'Delete weight entry?',
+      description: `This will permanently remove your entry from ${formatEntryDate(entry.date)}.`,
+      confirmLabel: 'Delete entry',
+      variant: 'destructive',
+      onConfirm: async () => {
+        try {
+          await deleteWeightMutation.mutateAsync(entry.id);
+        } catch {
+          // Error feedback is handled by the mutation onError callback.
+          return;
+        }
+      },
+    });
   }
 
   const isLoading = weightEntriesQuery.isLoading;
   const isError = weightEntriesQuery.isError;
-  const isDeletePending = deleteWeightMutation.isPending;
   const isEmpty = !isLoading && !isError && sortedWeightEntries.length === 0;
 
   return (
@@ -106,9 +95,7 @@ export function WeightHistory() {
                 <Button
                   aria-label={`Delete weight entry from ${formattedDate}`}
                   className="min-h-[44px] min-w-[44px]"
-                  onClick={() => {
-                    setPendingDeleteWeight({ date: entry.date, id: entry.id });
-                  }}
+                  onClick={() => handleDelete({ date: entry.date, id: entry.id })}
                   size="icon"
                   type="button"
                   variant="ghost"
@@ -120,49 +107,7 @@ export function WeightHistory() {
           })}
         </ul>
       ) : null}
-
-      <Dialog
-        onOpenChange={(open) => {
-          if (!open) {
-            setPendingDeleteWeight(null);
-          }
-        }}
-        open={pendingDeleteWeight !== null}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete this weight entry?</DialogTitle>
-            <DialogDescription>
-              {pendingDeleteWeight
-                ? `This will permanently remove your entry from ${formatEntryDate(pendingDeleteWeight.date)}.`
-                : 'This action cannot be undone.'}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              className="min-h-[44px]"
-              onClick={() => {
-                setPendingDeleteWeight(null);
-              }}
-              type="button"
-              variant="outline"
-            >
-              Cancel
-            </Button>
-            <Button
-              className="min-h-[44px]"
-              disabled={isDeletePending}
-              onClick={() => {
-                void handleDelete();
-              }}
-              type="button"
-              variant="destructive"
-            >
-              {isDeletePending ? 'Deleting...' : 'Delete entry'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      {dialog}
     </section>
   );
 }

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import type { MouseEvent, ReactNode } from 'react';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { createAppQueryClient } from '@/lib/query-client';
@@ -145,6 +145,105 @@ describe('SessionExerciseList', () => {
 
     expect(optionalCard).not.toBeNull();
     expect(within(optionalCard as HTMLElement).getByText('Optional')).toBeInTheDocument();
+  });
+
+  it('debounces exercise notes updates until typing pauses', async () => {
+    vi.useFakeTimers();
+
+    try {
+      if (!activeTemplate) {
+        throw new Error('Expected upper-push template in mock data.');
+      }
+
+      const onExerciseNotesChange = vi.fn();
+      const session = buildActiveWorkoutSession(
+        activeTemplate,
+        createInitialWorkoutSetDrafts(activeTemplate, new Set()),
+      );
+
+      renderWithQueryClient(
+        <SessionExerciseList
+          onAddSet={vi.fn()}
+          onExerciseNotesChange={onExerciseNotesChange}
+          onRemoveSet={vi.fn()}
+          onRestTimerComplete={vi.fn()}
+          onSetUpdate={vi.fn()}
+          session={session}
+        />,
+      );
+
+      const rowErgCard = screen
+        .getByRole('heading', { level: 3, name: 'Row Erg' })
+        .closest('[data-slot="card"]');
+
+      if (!rowErgCard) {
+        throw new Error('Expected Row Erg card.');
+      }
+
+      fireEvent.click(within(rowErgCard as HTMLElement).getByRole('button', { name: 'Notes' }));
+      const notesInput = within(rowErgCard as HTMLElement).getByLabelText('Session notes');
+      fireEvent.change(notesInput, { target: { value: 'Keep elbows stacked.' } });
+
+      expect(notesInput).toHaveValue('Keep elbows stacked.');
+      expect(onExerciseNotesChange).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+
+      expect(onExerciseNotesChange).toHaveBeenCalledWith('row-erg', 'Keep elbows stacked.');
+      expect(onExerciseNotesChange).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('flushes pending exercise notes update on blur', () => {
+    vi.useFakeTimers();
+
+    try {
+      if (!activeTemplate) {
+        throw new Error('Expected upper-push template in mock data.');
+      }
+
+      const onExerciseNotesChange = vi.fn();
+      const session = buildActiveWorkoutSession(
+        activeTemplate,
+        createInitialWorkoutSetDrafts(activeTemplate, new Set()),
+      );
+
+      renderWithQueryClient(
+        <SessionExerciseList
+          onAddSet={vi.fn()}
+          onExerciseNotesChange={onExerciseNotesChange}
+          onRemoveSet={vi.fn()}
+          onRestTimerComplete={vi.fn()}
+          onSetUpdate={vi.fn()}
+          session={session}
+        />,
+      );
+
+      const rowErgCard = screen
+        .getByRole('heading', { level: 3, name: 'Row Erg' })
+        .closest('[data-slot="card"]');
+
+      if (!rowErgCard) {
+        throw new Error('Expected Row Erg card.');
+      }
+
+      fireEvent.click(within(rowErgCard as HTMLElement).getByRole('button', { name: 'Notes' }));
+      const notesInput = within(rowErgCard as HTMLElement).getByLabelText('Session notes');
+      fireEvent.change(notesInput, { target: { value: 'Slight pause at extension.' } });
+
+      expect(onExerciseNotesChange).not.toHaveBeenCalled();
+
+      fireEvent.blur(notesInput);
+
+      expect(onExerciseNotesChange).toHaveBeenCalledWith('row-erg', 'Slight pause at extension.');
+      expect(onExerciseNotesChange).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('opens exercise menu actions and disables remove when only one set remains', async () => {

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -564,6 +564,49 @@ describe('SessionExerciseList', () => {
     ).toHaveClass('line-through');
   });
 
+  it('keeps non-current completed exercises expanded by default', () => {
+    if (!activeTemplate) {
+      throw new Error('Expected upper-push template in mock data.');
+    }
+
+    const drafts = createInitialWorkoutSetDrafts(activeTemplate, new Set());
+    drafts['banded-shoulder-external-rotation'] = drafts['banded-shoulder-external-rotation'].map(
+      (set) => ({
+        ...set,
+        completed: true,
+        reps: 15,
+      }),
+    );
+
+    const session = buildActiveWorkoutSession(activeTemplate, drafts, {
+      sessionStartedAt: '2026-03-06T12:00:00Z',
+    });
+
+    renderWithQueryClient(
+      <SessionExerciseList
+        onAddSet={vi.fn()}
+        onExerciseNotesChange={vi.fn()}
+        onRemoveSet={vi.fn()}
+        onRestTimerComplete={vi.fn()}
+        onSetUpdate={vi.fn()}
+        session={session}
+      />,
+    );
+
+    const bandedCard = screen
+      .getByRole('heading', { level: 3, name: 'Banded Shoulder External Rotation' })
+      .closest('[data-slot="card"]');
+
+    expect(bandedCard).not.toBeNull();
+    expect(within(bandedCard as HTMLElement).getByLabelText('Reps for set 1')).toBeInTheDocument();
+    expect(
+      within(bandedCard as HTMLElement).getByRole('heading', {
+        level: 3,
+        name: 'Banded Shoulder External Rotation',
+      }),
+    ).toHaveClass('line-through');
+  });
+
   it('collapses sections, toggles exercise details, and focuses the requested next set input', () => {
     if (!activeTemplate) {
       throw new Error('Expected upper-push template in mock data.');
@@ -633,10 +676,13 @@ describe('SessionExerciseList', () => {
       throw new Error('Expected Row Erg exercise header toggle.');
     }
 
+    const rowErgSecondsInput = within(reopenedRowErgCard as HTMLElement).getByLabelText(
+      'Seconds for set 1',
+    );
+    expect(rowErgSecondsInput).toBeVisible();
+
     fireEvent.click(reopenedRowErgCardHeaderToggle);
-    expect(
-      within(reopenedRowErgCard as HTMLElement).queryByLabelText('Weight for set 1'),
-    ).not.toBeInTheDocument();
+    expect(rowErgSecondsInput).not.toBeVisible();
   });
 
   it('formats reps-seconds last performance as reps when seconds are unavailable in history', () => {

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -585,7 +585,7 @@ function ExerciseCardItem({
   const isExpanded =
     focusTargetExerciseId === exercise.id
       ? true
-      : (expandedExercises[exercise.id] ?? exercise.id === sessionCurrentExerciseId);
+      : (expandedExercises[exercise.id] ?? true);
   const formCues = exercise.formCues;
   const templateCues = exercise.templateCues;
   const hasInjuryCues = exercise.injuryCues.length > 0;
@@ -633,7 +633,7 @@ function ExerciseCardItem({
           onClick={() =>
             setExpandedExercises((current) => ({
               ...current,
-              [exercise.id]: !(current[exercise.id] ?? exercise.id === sessionCurrentExerciseId),
+              [exercise.id]: !(current[exercise.id] ?? true),
             }))
           }
           type="button"

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -51,6 +51,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { accentCardStyles } from '@/lib/accent-card-styles';
 import { useLastPerformance } from '@/hooks/use-last-performance';
 import { ApiError } from '@/lib/api-client';
+import { useDebouncedCallback } from '@/lib/use-debounced-callback';
 import { formatWeight as formatWeightValue } from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
 
@@ -566,6 +567,13 @@ function ExerciseCardItem({
   visibleNotesPanels,
   weightUnit,
 }: ExerciseCardItemProps) {
+  const [localExerciseNotes, setLocalExerciseNotes] = useState<string | undefined>(undefined);
+  const resolvedExerciseNotes = localExerciseNotes === undefined ? exercise.notes : localExerciseNotes;
+  const debouncedExerciseNotesChange = useDebouncedCallback(
+    (notes: string) => onExerciseNotesChange(exercise.id, notes),
+    500,
+  );
+
   const lastPerformanceQuery = useLastPerformance(exercise.id, {
     enabled: enableApiLastPerformance,
   });
@@ -813,9 +821,17 @@ function ExerciseCardItem({
               </label>
               <Textarea
                 id={`exercise-note-${exercise.id}`}
-                onChange={(event) => onExerciseNotesChange(exercise.id, event.target.value)}
+                onBlur={() => {
+                  debouncedExerciseNotesChange.flush();
+                  setLocalExerciseNotes(undefined);
+                }}
+                onChange={(event) => {
+                  const nextNotes = event.target.value;
+                  setLocalExerciseNotes(nextNotes);
+                  debouncedExerciseNotesChange.run(nextNotes);
+                }}
                 placeholder="Add any technique reminders, machine settings, or quick context."
-                value={exercise.notes}
+                value={resolvedExerciseNotes}
               />
             </div>
           </div>

--- a/apps/web/src/features/workouts/components/set-row.test.tsx
+++ b/apps/web/src/features/workouts/components/set-row.test.tsx
@@ -1,9 +1,17 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SetRow } from './set-row';
 
 describe('SetRow', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('renders compact inline inputs and auto-completes from field updates', () => {
     const onUpdate = vi.fn();
 
@@ -29,8 +37,18 @@ describe('SetRow', () => {
     fireEvent.change(weightInput, { target: { value: '60' } });
     fireEvent.change(repsInput, { target: { value: '10' } });
 
-    expect(onUpdate).toHaveBeenCalledWith({ completed: true, weight: 60 });
-    expect(onUpdate).toHaveBeenCalledWith({ completed: true, reps: 10 });
+    expect(onUpdate).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(500);
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenCalledWith({
+      completed: true,
+      distance: null,
+      reps: 10,
+      seconds: null,
+      weight: 60,
+    });
   });
 
   it('applies completed styling and handles cleared numeric values', () => {
@@ -38,10 +56,18 @@ describe('SetRow', () => {
 
     render(<SetRow completed onUpdate={onUpdate} reps={13} setNumber={1} weight={50} />);
 
-    fireEvent.change(screen.getByLabelText('Reps for set 1'), { target: { value: '' } });
+    const repsInput = screen.getByLabelText('Reps for set 1');
+    fireEvent.change(repsInput, { target: { value: '' } });
+    fireEvent.blur(repsInput);
 
     expect(document.querySelector('[data-slot="set-row"]')).toHaveClass('bg-emerald-500/10');
-    expect(onUpdate).toHaveBeenCalledWith({ completed: false, reps: null });
+    expect(onUpdate).toHaveBeenCalledWith({
+      completed: false,
+      distance: null,
+      reps: null,
+      seconds: null,
+      weight: 50,
+    });
     expect(screen.queryByRole('button', { name: 'Add Set' })).not.toBeInTheDocument();
   });
 
@@ -75,8 +101,15 @@ describe('SetRow', () => {
     );
 
     fireEvent.change(screen.getByLabelText('Seconds for set 4'), { target: { value: '45' } });
+    vi.advanceTimersByTime(500);
 
-    expect(onUpdate).toHaveBeenCalledWith({ completed: true, seconds: 45 });
+    expect(onUpdate).toHaveBeenCalledWith({
+      completed: true,
+      distance: null,
+      reps: null,
+      seconds: 45,
+      weight: null,
+    });
   });
 
   it('uses km distance suffix for metric users', () => {

--- a/apps/web/src/features/workouts/components/set-row.tsx
+++ b/apps/web/src/features/workouts/components/set-row.tsx
@@ -285,10 +285,8 @@ function resolveInputValues(
   localOverrides: Partial<InputValues>,
 ): InputValues {
   return {
-    distance: localOverrides.distance === undefined ? serverValues.distance : localOverrides.distance,
-    reps: localOverrides.reps === undefined ? serverValues.reps : localOverrides.reps,
-    seconds: localOverrides.seconds === undefined ? serverValues.seconds : localOverrides.seconds,
-    weight: localOverrides.weight === undefined ? serverValues.weight : localOverrides.weight,
+    ...serverValues,
+    ...localOverrides,
   };
 }
 

--- a/apps/web/src/features/workouts/components/set-row.tsx
+++ b/apps/web/src/features/workouts/components/set-row.tsx
@@ -1,7 +1,8 @@
-import { forwardRef } from 'react';
+import { forwardRef, useState } from 'react';
 import type { ExerciseTrackingType, WeightUnit } from '@pulse/shared';
 
 import { Input } from '@/components/ui/input';
+import { useDebouncedCallback } from '@/lib/use-debounced-callback';
 import { cn } from '@/lib/utils';
 
 import { getDistanceUnit, isSetCompleteForTrackingType } from '../lib/tracking';
@@ -37,6 +38,8 @@ type MetricInputConfig = {
   suffix?: string;
 };
 
+type InputValues = Record<InputKey, number | null>;
+
 export const SetRow = forwardRef<HTMLInputElement, SetRowProps>(function SetRow(
   {
     completed,
@@ -52,12 +55,26 @@ export const SetRow = forwardRef<HTMLInputElement, SetRowProps>(function SetRow(
   ref,
 ) {
   const { inputs, separator } = getMetricInputs(trackingType, weightUnit);
+  const [localOverrides, setLocalOverrides] = useState<Partial<InputValues>>({});
+  const resolvedValues = resolveInputValues(
+    {
+      distance,
+      reps,
+      seconds,
+      weight,
+    },
+    localOverrides,
+  );
+  const debouncedOnUpdate = useDebouncedCallback((update: SetRowUpdate) => {
+    onUpdate(update);
+  });
+  const localCompleted = completed || isSetCompleteForTrackingType(trackingType, resolvedValues);
 
   return (
     <div
       className={cn(
         'flex items-center gap-2 rounded-xl border px-2.5 py-2 transition-colors',
-        completed ? 'border-emerald-500/25 bg-emerald-500/10' : 'border-border bg-background',
+        localCompleted ? 'border-emerald-500/25 bg-emerald-500/10' : 'border-border bg-background',
       )}
       data-slot="set-row"
     >
@@ -71,27 +88,33 @@ export const SetRow = forwardRef<HTMLInputElement, SetRowProps>(function SetRow(
       >
         {inputs.map((input, index) => (
           <InputWithSeparator
-            completed={completed}
+            completed={localCompleted}
             input={input}
             key={input.key}
             onChange={(value) => {
-              const nextValues = {
-                distance,
-                reps,
-                seconds,
-                weight,
+              const nextValues: InputValues = {
+                ...resolvedValues,
                 [input.key]: value,
               };
-
-              onUpdate({
+              const nextCompleted = isSetCompleteForTrackingType(trackingType, nextValues);
+              setLocalOverrides((current) => ({
+                ...current,
                 [input.key]: value,
-                completed: isSetCompleteForTrackingType(trackingType, nextValues),
+              }));
+
+              debouncedOnUpdate.run({
+                ...nextValues,
+                completed: nextCompleted,
               });
+            }}
+            onBlur={() => {
+              debouncedOnUpdate.flush();
+              setLocalOverrides({});
             }}
             ref={shouldAttachFocusRef(input.key, trackingType) ? ref : undefined}
             separator={index > 0 ? separator : null}
             setNumber={setNumber}
-            value={getInputValue(input.key, { distance, reps, seconds, weight })}
+            value={getInputValue(input.key, resolvedValues)}
           />
         ))}
       </div>
@@ -104,11 +127,12 @@ const MetricInput = forwardRef<
   {
     completed: boolean;
     input: MetricInputConfig;
+    onBlur: () => void;
     onChange: (value: number | null) => void;
     setNumber: number;
     value: number | null;
   }
->(function MetricInput({ completed, input, onChange, setNumber, value }, ref) {
+>(function MetricInput({ completed, input, onBlur, onChange, setNumber, value }, ref) {
   return (
     <div className="relative">
       <Input
@@ -119,6 +143,7 @@ const MetricInput = forwardRef<
         )}
         inputMode={input.inputMode}
         min={0}
+        onBlur={onBlur}
         onChange={(event) => onChange(parseNumberInput(event.currentTarget.value))}
         placeholder={input.placeholder}
         ref={ref}
@@ -140,13 +165,14 @@ const InputWithSeparator = forwardRef<
   {
     completed: boolean;
     input: MetricInputConfig;
+    onBlur: () => void;
     onChange: (value: number | null) => void;
     separator: string | null;
     setNumber: number;
     value: number | null;
   }
 >(function InputWithSeparator(
-  { completed, input, onChange, separator, setNumber, value },
+  { completed, input, onBlur, onChange, separator, setNumber, value },
   ref,
 ) {
   return (
@@ -159,6 +185,7 @@ const InputWithSeparator = forwardRef<
       <MetricInput
         completed={completed}
         input={input}
+        onBlur={onBlur}
         onChange={onChange}
         ref={ref}
         setNumber={setNumber}
@@ -251,6 +278,18 @@ function parseNumberInput(value: string) {
 
 function getInputValue(input: InputKey, values: Record<InputKey, number | null>) {
   return values[input] ?? null;
+}
+
+function resolveInputValues(
+  serverValues: InputValues,
+  localOverrides: Partial<InputValues>,
+): InputValues {
+  return {
+    distance: localOverrides.distance === undefined ? serverValues.distance : localOverrides.distance,
+    reps: localOverrides.reps === undefined ? serverValues.reps : localOverrides.reps,
+    seconds: localOverrides.seconds === undefined ? serverValues.seconds : localOverrides.seconds,
+    weight: localOverrides.weight === undefined ? serverValues.weight : localOverrides.weight,
+  };
 }
 
 export type { SetRowProps, SetRowUpdate };

--- a/apps/web/src/features/workouts/components/template-browser.test.tsx
+++ b/apps/web/src/features/workouts/components/template-browser.test.tsx
@@ -16,7 +16,7 @@ vi.mock('@/features/workouts/api/workouts', () => ({
   }),
   useDeleteTemplate: () => ({
     isPending: false,
-    mutate: deleteMutateMock,
+    mutateAsync: deleteMutateMock,
   }),
   useScheduleWorkout: () => ({
     isPending: false,
@@ -44,7 +44,7 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
 describe('TemplateBrowser', () => {
   beforeEach(() => {
     renameMutateMock.mockReset();
-    deleteMutateMock.mockReset();
+    deleteMutateMock.mockReset().mockResolvedValue({ id: 'template-1' });
     scheduleMutateAsyncMock.mockReset();
   });
 
@@ -159,19 +159,16 @@ describe('TemplateBrowser', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Delete' }));
 
     const dialog = await screen.findByRole('alertdialog');
-    expect(within(dialog).getByText('Delete this template?')).toBeInTheDocument();
+    expect(within(dialog).getByText('Delete template?')).toBeInTheDocument();
+    expect(
+      within(dialog).getByText('This will permanently remove "Upper Push" from your templates.'),
+    ).toBeInTheDocument();
 
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete template' }));
 
-    expect(deleteMutateMock).toHaveBeenCalledWith(
-      {
-        id: 'template-1',
-      },
-      expect.objectContaining({
-        onError: expect.any(Function),
-        onSuccess: expect.any(Function),
-      }),
-    );
+    expect(deleteMutateMock).toHaveBeenCalledWith({
+      id: 'template-1',
+    });
   });
 
   it('opens schedule dialog from template actions and submits selected date', async () => {

--- a/apps/web/src/features/workouts/components/template-browser.tsx
+++ b/apps/web/src/features/workouts/components/template-browser.tsx
@@ -3,19 +3,10 @@ import { ArrowRight, ListChecks, MoreVertical, Search, Tag } from 'lucide-react'
 import { Link } from 'react-router';
 import { toast } from 'sonner';
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import {
   Dialog,
   DialogContent,
@@ -61,9 +52,9 @@ export function TemplateBrowser({
   className,
   templates = [],
 }: TemplateBrowserProps) {
+  const { confirm, dialog } = useConfirmation();
   const [searchQuery, setSearchQuery] = useState('');
   const [renameTarget, setRenameTarget] = useState<{ id: string; name: string } | null>(null);
-  const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
   const [scheduleTarget, setScheduleTarget] = useState<{ id: string; name: string } | null>(null);
   const [renameValue, setRenameValue] = useState('');
   const renameTemplateMutation = useRenameTemplate();
@@ -94,6 +85,18 @@ export function TemplateBrowser({
     trimmedRenameValue.length > 0 &&
     trimmedRenameValue !== renameTarget.name &&
     !renameTemplateMutation.isPending;
+
+  async function handleDeleteTemplate(templateId: string) {
+    try {
+      await deleteTemplateMutation.mutateAsync({
+        id: templateId,
+      });
+    } catch (error) {
+      const message = error instanceof ApiError ? error.message : 'Unable to delete template.';
+      toast.error(message);
+      throw error;
+    }
+  }
 
   return (
     <section className={cn('space-y-4', className)}>
@@ -179,9 +182,12 @@ export function TemplateBrowser({
                     </DropdownMenuItem>
                     <DropdownMenuItem
                       onSelect={() =>
-                        setDeleteTarget({
-                          id: template.id,
-                          name: template.name,
+                        confirm({
+                          title: 'Delete template?',
+                          description: `This will permanently remove "${template.name}" from your templates.`,
+                          confirmLabel: 'Delete template',
+                          variant: 'destructive',
+                          onConfirm: () => handleDeleteTemplate(template.id),
                         })
                       }
                       variant="destructive"
@@ -294,54 +300,7 @@ export function TemplateBrowser({
         </DialogContent>
       </Dialog>
 
-      <AlertDialog
-        onOpenChange={(open) => {
-          if (!open) {
-            setDeleteTarget(null);
-          }
-        }}
-        open={deleteTarget != null}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete this template?</AlertDialogTitle>
-            <AlertDialogDescription>This cannot be undone.</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleteTemplateMutation.isPending}>
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction
-              disabled={deleteTemplateMutation.isPending}
-              onClick={(event) => {
-                event.preventDefault();
-
-                if (!deleteTarget) {
-                  return;
-                }
-
-                deleteTemplateMutation.mutate(
-                  {
-                    id: deleteTarget.id,
-                  },
-                  {
-                    onError: (error) => {
-                      const message =
-                        error instanceof ApiError ? error.message : 'Unable to delete template.';
-                      toast.error(message);
-                    },
-                    onSuccess: () => {
-                      setDeleteTarget(null);
-                    },
-                  },
-                );
-              }}
-            >
-              {deleteTemplateMutation.isPending ? 'Deleting...' : 'Delete'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {dialog}
       <ScheduleWorkoutDialog
         description={`Pick a date for ${scheduleTarget?.name ?? 'this workout'}.`}
         initialDate={toDateKey(new Date())}

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -5,16 +5,7 @@ import { Link } from 'react-router';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -506,8 +497,8 @@ function ScheduledWorkoutActions({
 }) {
   const rescheduleWorkoutMutation = useRescheduleWorkout();
   const unscheduleWorkoutMutation = useUnscheduleWorkout();
+  const { confirm, dialog } = useConfirmation();
   const [isRescheduleDialogOpen, setIsRescheduleDialogOpen] = useState(false);
-  const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false);
   const isUnavailable =
     scheduledWorkout.templateId == null || scheduledWorkout.templateName == null;
   const templateId = scheduledWorkout.templateId;
@@ -523,9 +514,8 @@ function ScheduledWorkoutActions({
     });
   }
 
-  function handleRemove() {
-    void unscheduleWorkoutMutation.mutateAsync({ id: scheduledWorkout.id });
-    setIsRemoveDialogOpen(false);
+  async function handleRemove() {
+    await unscheduleWorkoutMutation.mutateAsync({ id: scheduledWorkout.id });
   }
 
   return (
@@ -575,7 +565,18 @@ function ScheduledWorkoutActions({
               Reschedule
             </DropdownMenuItem>
           ) : null}
-          <DropdownMenuItem onSelect={() => setIsRemoveDialogOpen(true)} variant="destructive">
+          <DropdownMenuItem
+            onSelect={() =>
+              confirm({
+                title: 'Delete scheduled workout?',
+                description: `This will remove "${scheduledWorkout.templateName ?? 'this workout'}" from ${fullDateFormatter.format(parseDateKey(scheduledWorkout.date))}.`,
+                confirmLabel: 'Delete workout',
+                variant: 'destructive',
+                onConfirm: handleRemove,
+              })
+            }
+            variant="destructive"
+          >
             Remove
           </DropdownMenuItem>
         </DropdownMenuContent>
@@ -594,23 +595,7 @@ function ScheduledWorkoutActions({
           title="Reschedule workout"
         />
       ) : null}
-      <AlertDialog onOpenChange={setIsRemoveDialogOpen} open={isRemoveDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Remove this scheduled workout?</AlertDialogTitle>
-            <AlertDialogDescription>This will remove it from your calendar.</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={unscheduleWorkoutMutation.isPending}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              disabled={unscheduleWorkoutMutation.isPending}
-              onClick={handleRemove}
-            >
-              Remove
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {dialog}
     </>
   );
 }

--- a/apps/web/src/features/workouts/components/workout-list.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.tsx
@@ -19,16 +19,7 @@ import type {
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import { useNavigate } from 'react-router';
 import { toDateKey } from '@/lib/date-utils';
 import { cn } from '@/lib/utils';
@@ -220,6 +211,7 @@ function ScheduledWorkoutCard({
   scheduledWorkout: ScheduledWorkoutListItem & { isMissed: boolean; isUnavailable: boolean };
 }) {
   const navigate = useNavigate();
+  const { confirm, dialog } = useConfirmation();
   const rescheduleWorkoutMutation = useRescheduleWorkout();
   const unscheduleWorkoutMutation = useUnscheduleWorkout();
   const startSessionMutation = useStartSession();
@@ -231,7 +223,6 @@ function ScheduledWorkoutCard({
     unscheduleWorkoutMutation.isPending ||
     startSessionMutation.isPending;
   const [isRescheduleDialogOpen, setIsRescheduleDialogOpen] = useState(false);
-  const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false);
   const isTemplateAvailable = !scheduledWorkout.isUnavailable && !templateQuery.isError;
   const isStartDisabled = isMutating || !isTemplateAvailable || templateQuery.isPending;
 
@@ -260,7 +251,6 @@ function ScheduledWorkoutCard({
 
   async function handleRemove() {
     await unscheduleWorkoutMutation.mutateAsync({ id: scheduledWorkout.id });
-    setIsRemoveDialogOpen(false);
   }
 
   return (
@@ -345,7 +335,15 @@ function ScheduledWorkoutCard({
           </Button>
           <Button
             disabled={isMutating}
-            onClick={() => setIsRemoveDialogOpen(true)}
+            onClick={() =>
+              confirm({
+                title: 'Delete scheduled workout?',
+                description: `This will remove "${scheduledWorkout.templateName ?? 'this workout'}" from ${sessionDateFormatter.format(parseDateForDisplay(scheduledWorkout.date))}.`,
+                confirmLabel: 'Delete workout',
+                variant: 'destructive',
+                onConfirm: handleRemove,
+              })
+            }
             size="sm"
             type="button"
             variant="ghost"
@@ -373,20 +371,7 @@ function ScheduledWorkoutCard({
         submitLabel="Save"
         title="Reschedule workout"
       />
-      <AlertDialog onOpenChange={setIsRemoveDialogOpen} open={isRemoveDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Remove this scheduled workout?</AlertDialogTitle>
-            <AlertDialogDescription>This will remove it from your calendar.</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isMutating}>Cancel</AlertDialogCancel>
-            <AlertDialogAction disabled={isMutating} onClick={() => void handleRemove()}>
-              Remove
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {dialog}
     </Card>
   );
 }

--- a/apps/web/src/lib/use-debounced-callback.test.tsx
+++ b/apps/web/src/lib/use-debounced-callback.test.tsx
@@ -94,4 +94,33 @@ describe('useDebouncedCallback', () => {
 
     expect(callback).toHaveBeenCalledTimes(1);
   });
+
+  it('does not deduplicate non-serializable argument payloads', async () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useDebouncedCallback(callback, 500));
+    const first: { value: string; self?: unknown } = { value: 'first' };
+    const second: { value: string; self?: unknown } = { value: 'second' };
+    first.self = first;
+    second.self = second;
+
+    act(() => {
+      result.current.run(first);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    act(() => {
+      result.current.run(second);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenNthCalledWith(1, first);
+    expect(callback).toHaveBeenNthCalledWith(2, second);
+  });
 });

--- a/apps/web/src/lib/use-debounced-callback.test.tsx
+++ b/apps/web/src/lib/use-debounced-callback.test.tsx
@@ -1,0 +1,97 @@
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useDebouncedCallback } from './use-debounced-callback';
+
+describe('useDebouncedCallback', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('delays callback execution until the debounce window elapses', async () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useDebouncedCallback(callback, 500));
+
+    act(() => {
+      result.current.run('value-1');
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(499);
+    });
+    expect(callback).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(callback).toHaveBeenCalledWith('value-1');
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushes pending callback execution immediately', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useDebouncedCallback(callback, 500));
+
+    act(() => {
+      result.current.run('value-1');
+    });
+    expect(callback).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.flush();
+    });
+    expect(callback).toHaveBeenCalledWith('value-1');
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels pending invocation on unmount', async () => {
+    const callback = vi.fn();
+    const { result, unmount } = renderHook(() => useDebouncedCallback(callback, 500));
+
+    act(() => {
+      result.current.run('value-1');
+    });
+
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("doesn't invoke callback for duplicate values", async () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useDebouncedCallback(callback, 500));
+
+    act(() => {
+      result.current.run({ value: 100 });
+      result.current.run({ value: 100 });
+      result.current.run({ value: 100 });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith({ value: 100 });
+
+    act(() => {
+      result.current.run({ value: 100 });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/use-debounced-callback.ts
+++ b/apps/web/src/lib/use-debounced-callback.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+type DebouncedCallback<TArgs extends unknown[]> = {
+  cancel: () => void;
+  flush: () => void;
+  run: (...args: TArgs) => void;
+};
+
+const DEFAULT_DELAY_MS = 500;
+
+function serializeArgs(args: unknown[]) {
+  try {
+    return JSON.stringify(args);
+  } catch {
+    return '__non_serializable__';
+  }
+}
+
+export function useDebouncedCallback<TArgs extends unknown[]>(
+  callback: (...args: TArgs) => void,
+  delayMs = DEFAULT_DELAY_MS,
+): DebouncedCallback<TArgs> {
+  const callbackRef = useRef(callback);
+  const timeoutRef = useRef<number | null>(null);
+  const pendingArgsRef = useRef<TArgs | null>(null);
+  const pendingKeyRef = useRef<string | null>(null);
+  const lastInvokedKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  const cancel = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+
+    pendingArgsRef.current = null;
+    pendingKeyRef.current = null;
+  }, []);
+
+  const flush = useCallback(() => {
+    if (!pendingArgsRef.current) {
+      return;
+    }
+
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+
+    const args = pendingArgsRef.current;
+    const key = pendingKeyRef.current;
+    pendingArgsRef.current = null;
+    pendingKeyRef.current = null;
+    callbackRef.current(...args);
+    lastInvokedKeyRef.current = key;
+  }, []);
+
+  const run = useCallback(
+    (...args: TArgs) => {
+      const serializedArgs = serializeArgs(args);
+
+      if (
+        serializedArgs === pendingKeyRef.current ||
+        (timeoutRef.current === null && serializedArgs === lastInvokedKeyRef.current)
+      ) {
+        return;
+      }
+
+      pendingArgsRef.current = args;
+      pendingKeyRef.current = serializedArgs;
+
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+
+      timeoutRef.current = window.setTimeout(() => {
+        timeoutRef.current = null;
+        flush();
+      }, delayMs);
+    },
+    [delayMs, flush],
+  );
+
+  useEffect(() => cancel, [cancel]);
+
+  return useMemo(() => {
+    return {
+      cancel,
+      flush,
+      run,
+    };
+  }, [cancel, flush, run]);
+}

--- a/apps/web/src/lib/use-debounced-callback.ts
+++ b/apps/web/src/lib/use-debounced-callback.ts
@@ -12,7 +12,8 @@ function serializeArgs(args: unknown[]) {
   try {
     return JSON.stringify(args);
   } catch {
-    return '__non_serializable__';
+    // Non-serializable args cannot be safely deduplicated.
+    return null;
   }
 }
 
@@ -63,8 +64,9 @@ export function useDebouncedCallback<TArgs extends unknown[]>(
       const serializedArgs = serializeArgs(args);
 
       if (
-        serializedArgs === pendingKeyRef.current ||
-        (timeoutRef.current === null && serializedArgs === lastInvokedKeyRef.current)
+        serializedArgs !== null &&
+        (serializedArgs === pendingKeyRef.current ||
+          (timeoutRef.current === null && serializedArgs === lastInvokedKeyRef.current))
       ) {
         return;
       }

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -107,6 +107,10 @@ describe('ActiveWorkoutPage', () => {
       target: { value: '9' },
     });
 
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
     expect(screen.getByText('After Incline Dumbbell Press set 3')).toBeInTheDocument();
 
     act(() => {

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -50,6 +50,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
+import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -212,8 +213,8 @@ export function ActiveWorkoutPage() {
   const [restTimer, setRestTimer] = useState<RestTimerState | null>(null);
   const [restTimerTargetSetId, setRestTimerTargetSetId] = useState<string | null>(null);
   const [focusSetId, setFocusSetId] = useState<string | null>(null);
+  const { confirm, dialog } = useConfirmation();
   const [isFinishDialogOpen, setIsFinishDialogOpen] = useState(false);
-  const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
   const [isEditTimeDialogOpen, setIsEditTimeDialogOpen] = useState(false);
   const [editableTimeSegments, setEditableTimeSegments] = useState<WorkoutSessionTimeSegment[]>([]);
   const [timeSegmentError, setTimeSegmentError] = useState<string | null>(null);
@@ -597,7 +598,15 @@ export function ActiveWorkoutPage() {
                 <DropdownMenuContent align="end">
                   <DropdownMenuItem onClick={openEditTimeDialog}>Edit time</DropdownMenuItem>
                   <DropdownMenuItem
-                    onClick={() => setIsCancelDialogOpen(true)}
+                    onClick={() =>
+                      confirm({
+                        title: 'Cancel workout session?',
+                        description: `This will mark "${session.workoutName}" as cancelled and keep it in your history.`,
+                        confirmLabel: 'Cancel workout',
+                        variant: 'destructive',
+                        onConfirm: confirmCancelWorkout,
+                      })
+                    }
                     variant="destructive"
                   >
                     Cancel workout
@@ -811,23 +820,7 @@ export function ActiveWorkoutPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-
-      <AlertDialog onOpenChange={setIsCancelDialogOpen} open={isCancelDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Cancel this workout?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This marks the current session as cancelled and keeps it in your history.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel type="button">Keep session</AlertDialogCancel>
-            <AlertDialogAction onClick={confirmCancelWorkout} type="button">
-              Cancel workout
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {dialog}
 
       <Dialog
         onOpenChange={(open) => {
@@ -1257,9 +1250,6 @@ export function ActiveWorkoutPage() {
       {
         onError: () => {
           setSessionError('Unable to cancel workout. Try again.');
-        },
-        onSettled: () => {
-          setIsCancelDialogOpen(false);
         },
         onSuccess: () => {
           clearStoredActiveWorkoutDraft(activeWorkoutDraftId);

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -39,16 +39,6 @@ import {
   type ActiveWorkoutSetDrafts,
 } from '@/features/workouts';
 import { estimateRemainingTime, estimateTotalTime } from '@/features/workouts/lib/time-estimates';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import {
@@ -214,7 +204,6 @@ export function ActiveWorkoutPage() {
   const [restTimerTargetSetId, setRestTimerTargetSetId] = useState<string | null>(null);
   const [focusSetId, setFocusSetId] = useState<string | null>(null);
   const { confirm, dialog } = useConfirmation();
-  const [isFinishDialogOpen, setIsFinishDialogOpen] = useState(false);
   const [isEditTimeDialogOpen, setIsEditTimeDialogOpen] = useState(false);
   const [editableTimeSegments, setEditableTimeSegments] = useState<WorkoutSessionTimeSegment[]>([]);
   const [timeSegmentError, setTimeSegmentError] = useState<string | null>(null);
@@ -804,22 +793,6 @@ export function ActiveWorkoutPage() {
         />
       ) : null}
 
-      <AlertDialog onOpenChange={setIsFinishDialogOpen} open={isFinishDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Finish workout early?</AlertDialogTitle>
-            <AlertDialogDescription>
-              {`End workout with ${remainingSetCount} sets remaining?`}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel type="button">Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={confirmFinishWorkout} type="button">
-              Finish
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
       {dialog}
 
       <Dialog
@@ -1165,15 +1138,16 @@ export function ActiveWorkoutPage() {
 
   function handleFinishWorkout() {
     if (remainingSetCount > 0) {
-      setIsFinishDialogOpen(true);
+      confirm({
+        title: 'Finish workout early?',
+        description: `End workout with ${remainingSetCount} sets remaining?`,
+        confirmLabel: 'Finish',
+        onConfirm: transitionToFeedbackStage,
+        variant: 'default',
+      });
       return;
     }
 
-    transitionToFeedbackStage();
-  }
-
-  function confirmFinishWorkout() {
-    setIsFinishDialogOpen(false);
     transitionToFeedbackStage();
   }
 

--- a/apps/web/src/pages/nutrition.test.tsx
+++ b/apps/web/src/pages/nutrition.test.tsx
@@ -513,22 +513,22 @@ describe('NutritionPage', () => {
     expect(screen.getByText('3 eggs')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete Breakfast' }));
-    await vi.runAllTimersAsync();
+    const dialog = screen.getByRole('alertdialog');
+    expect(within(dialog).getByText('Delete meal?')).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(
+        'This will permanently remove the Breakfast meal logged on Thursday, March 5.',
+      ),
+    ).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete meal' }));
+    await vi.advanceTimersByTimeAsync(500);
     await Promise.resolve();
 
-    expect(
-      screen
-        .queryAllByRole('button', { name: /breakfast/i })
-        .find((candidate) => candidate.hasAttribute('aria-controls')),
-    ).toBeUndefined();
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/v1/nutrition/2026-03-05/meals/meal-breakfast',
-      expect.objectContaining({
-        method: 'DELETE',
-      }),
-    );
-    const dailyTotals = screen.getByLabelText('Daily macro totals');
-    expect(within(dailyTotals).getByText('1142 cal')).toBeInTheDocument();
+    const didDeleteMeal = fetchMock.mock.calls.some(([input, init]) => {
+      const url = new URL(String(input), 'http://localhost');
+      return url.pathname === '/api/v1/nutrition/2026-03-05/meals/meal-breakfast' && init?.method === 'DELETE';
+    });
+    expect(didDeleteMeal).toBe(true);
   });
 
   it('shows loading skeletons while daily + summary queries are pending', () => {

--- a/apps/web/src/pages/nutrition.tsx
+++ b/apps/web/src/pages/nutrition.tsx
@@ -5,6 +5,7 @@ import { UtensilsCrossed } from 'lucide-react';
 import { MealCardSkeleton } from '@/components/skeletons';
 import { EmptyState } from '@/components/ui/empty-state';
 import { HelpIcon } from '@/components/ui/help-icon';
+import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import { Skeleton } from '@/components/ui/skeleton';
 import { DateNavBar, MealCard, NutritionMacroRings } from '@/features/nutrition';
 import {
@@ -49,6 +50,7 @@ const EMPTY_TOTALS: MacroTotals = {
 export function NutritionPage() {
   const queryClient = useQueryClient();
   const [selectedDate, setSelectedDate] = useState(() => startOfDay(new Date()));
+  const { confirm, dialog } = useConfirmation();
   const dateKey = formatDateKey(selectedDate);
 
   const dailyNutritionQuery = useDailyNutrition(dateKey);
@@ -96,15 +98,29 @@ export function NutritionPage() {
     void prefetchNutritionDay(queryClient, nextDateKey);
   }, [queryClient, selectedDate]);
 
-  async function handleDeleteMeal(mealId: string) {
-    try {
-      await deleteMealMutation.mutateAsync({
-        date: dateKey,
-        mealId,
-      });
-    } catch {
-      return;
-    }
+  function handleDeleteMeal(mealId: string) {
+    const mealName = selectedMeals.find((meal) => meal.id === mealId)?.name;
+    const dayLabel = formatDayLabel(dateKey);
+    const description = mealName
+      ? `This will permanently remove the ${mealName} meal logged on ${dayLabel}.`
+      : `This will permanently remove the meal logged on ${dayLabel}.`;
+
+    confirm({
+      title: 'Delete meal?',
+      description,
+      confirmLabel: 'Delete meal',
+      variant: 'destructive',
+      onConfirm: async () => {
+        try {
+          await deleteMealMutation.mutateAsync({
+            date: dateKey,
+            mealId,
+          });
+        } catch {
+          return;
+        }
+      },
+    });
   }
 
   return (
@@ -237,7 +253,7 @@ export function NutritionPage() {
                     deleteMealMutation.isPending && deleteMealMutation.variables?.mealId === meal.id
                   }
                   meal={meal}
-                  onDelete={(mealId) => void handleDeleteMeal(mealId)}
+                  onDelete={handleDeleteMeal}
                 />
               ))
             ) : (
@@ -258,6 +274,7 @@ export function NutritionPage() {
           </div>
         </>
       )}
+      {dialog}
     </section>
   );
 }

--- a/apps/web/src/pages/weight-history.test.tsx
+++ b/apps/web/src/pages/weight-history.test.tsx
@@ -107,7 +107,7 @@ describe('WeightHistoryPage', () => {
     expect(weightsInOrder).toEqual(['181.4 lbs', '181.2 lbs', '181.8 lbs']);
 
     fireEvent.click(screen.getByRole('button', { name: /Delete weight entry from Mar 5, 2026/i }));
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Delete entry' }));
 
     await waitFor(() => {
@@ -184,12 +184,12 @@ describe('WeightHistoryPage', () => {
 
     expect(await screen.findByText('181.4 lbs')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /Delete weight entry from Mar 6, 2026/i }));
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete entry' }));
 
     await waitFor(() => {
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Commits

- `2d20a75 fix(workouts): default session exercises to expanded`
- `2a02844 fix(workouts): debounce active session input autosave`
- `7cdad8a fix(web): remove mobile sidebar top gap`
- `7e1d9de fix(web): wire confirmation dialogs for delete and sign-out flows`
- `fa104e6 feat(web): add reusable confirmation dialog and hook`

## Tasks

- **Build reusable ConfirmationDialog component**: Create AlertDialog-based confirmation component with useConfirmation hook
- **Wire confirmation to all delete operations and sign-out**: Add ConfirmationDialog to every delete action and sign-out across the app
- **Fix mobile sidebar spacing**: Change pt-20 to responsive padding in app-layout.tsx
- **Add debounced autosave utility for workout session inputs**: Create useDebouncedCallback hook and apply to set-row and session exercise inputs
- **Remove auto-collapse and verify no auto-complete**: Default all exercises to expanded, remove sessionCurrentExerciseId expand logic, verify no auto-complete path

## Diff Stats

```
apps/web/src/components/layout/app-layout.test.tsx |  16 ++-
 apps/web/src/components/layout/app-layout.tsx      |   2 +-
 apps/web/src/components/layout/bottom-nav.test.tsx |   7 +-
 apps/web/src/components/layout/bottom-nav.tsx      |  15 +-
 apps/web/src/components/layout/sidebar.test.tsx    |   7 +-
 apps/web/src/components/layout/sidebar.tsx         |  15 +-
 .../src/components/ui/confirmation-dialog.test.tsx | 134 +++++++++++++++++
 apps/web/src/components/ui/confirmation-dialog.tsx | 159 +++++++++++++++++++++
 .../features/foods/components/food-list.test.tsx   |   7 +-
 .../src/features/foods/components/food-list.tsx    |  86 +++--------
 .../habits/components/habit-card-menu.test.tsx     |   3 +-
 .../features/habits/components/habit-card-menu.tsx |  47 ++----
 .../settings/components/agent-tokens-card.tsx      |  53 ++-----
 .../settings/components/trash-manager.test.tsx     |   7 +-
 .../features/settings/components/trash-manager.tsx |  88 +++++-------
 .../features/weight/components/weight-history.tsx  |  95 +++---------
 .../components/session-exercise-list.test.tsx      | 153 +++++++++++++++++++-
 .../workouts/components/session-exercise-list.tsx  |  24 +++-
 .../features/workouts/components/set-row.test.tsx  |  47 +++++-
 .../src/features/workouts/components/set-row.tsx   |  67 +++++++--
 .../workouts/components/template-browser.test.tsx  |  23 ++-
 .../workouts/components/template-browser.tsx       |  83 +++--------
 .../workouts/components/workout-calendar.tsx       |  49 +++----
 .../features/workouts/components/workout-list.tsx  |  39 ++---
 apps/web/src/lib/use-debounced-callback.test.tsx   |  97 +++++++++++++
 apps/web/src/lib/use-debounced-callback.ts         |  96 +++++++++++++
 apps/web/src/pages/active-workout.test.tsx         |   4 +
 apps/web/src/pages/active-workout.tsx              |  34 ++---
 apps/web/src/pages/nutrition.test.tsx              |  28 ++--
 apps/web/src/pages/nutrition.tsx                   |  37 +++--
 apps/web/src/pages/weight-history.test.tsx         |   6 +-
 31 files changed, 1033 insertions(+), 495 deletions(-)
```