### PR TITLE
fix: post-session feedback UX improvements

### DIFF
--- a/apps/web/src/features/workouts/components/session-feedback.test.tsx
+++ b/apps/web/src/features/workouts/components/session-feedback.test.tsx
@@ -337,7 +337,7 @@ describe('SessionFeedback', () => {
     expect(screen.getByText('Maximal, all-out effort')).toBeInTheDocument();
   });
 
-  it('applies stronger selected-state styling to option controls', () => {
+  it('marks selected option controls with pressed state', () => {
     render(<SessionFeedback fields={[]} onSubmit={() => {}} />);
 
     const rpeSeven = within(screen.getByRole('group', { name: 'Session RPE rating' })).getByRole(
@@ -347,7 +347,7 @@ describe('SessionFeedback', () => {
       },
     );
     fireEvent.click(rpeSeven);
-    expect(rpeSeven).toHaveClass('bg-[var(--color-accent-peach)]', 'text-on-peach');
+    expect(rpeSeven).toHaveAttribute('aria-pressed', 'true');
 
     const energyStrong = within(
       screen.getByRole('group', { name: 'Energy post workout options' }),
@@ -355,7 +355,7 @@ describe('SessionFeedback', () => {
       name: '💪',
     });
     fireEvent.click(energyStrong);
-    expect(energyStrong).toHaveClass('bg-[var(--color-accent-peach)]', 'text-on-peach');
+    expect(energyStrong).toHaveAttribute('aria-pressed', 'true');
 
     const yesButton = within(
       screen.getByRole('group', { name: 'Any pain or discomfort? response' }),
@@ -363,6 +363,6 @@ describe('SessionFeedback', () => {
       name: 'Yes',
     });
     fireEvent.click(yesButton);
-    expect(yesButton).toHaveClass('bg-[var(--color-accent-peach)]', 'text-on-peach');
+    expect(yesButton).toHaveAttribute('aria-pressed', 'true');
   });
 });

--- a/apps/web/src/features/workouts/components/session-feedback.test.tsx
+++ b/apps/web/src/features/workouts/components/session-feedback.test.tsx
@@ -280,6 +280,49 @@ describe('SessionFeedback', () => {
     ).toBeInTheDocument();
   });
 
+  it('clears incoming field values to avoid stale prefills and uses coach-note guidance copy', () => {
+    render(
+      <SessionFeedback
+        fields={[
+          {
+            id: 'shoulder-feel',
+            label: 'Shoulder feel',
+            max: 5,
+            min: 1,
+            notes: 'Previously felt fine.',
+            type: 'scale',
+            value: 4,
+          },
+          {
+            id: 'session-note',
+            label: 'Coach note',
+            notes: 'Carry this note forward.',
+            optional: true,
+            type: 'text',
+            value: 'Use a pause next session.',
+          },
+        ]}
+        onSubmit={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        'What should we remember next time? Add a carry-forward coaching or programming note.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(
+        'What should we remember next time? Add a carry-forward coaching or programming note.',
+      ),
+    ).toHaveValue('');
+    expect(
+      within(screen.getByRole('group', { name: 'Shoulder feel rating' })).getByRole('button', {
+        name: '4',
+      }),
+    ).toHaveAttribute('aria-pressed', 'false');
+  });
+
   it('shows session RPE guidance anchors in the help dialog', () => {
     render(<SessionFeedback fields={[]} onSubmit={() => {}} />);
 

--- a/apps/web/src/features/workouts/components/session-feedback.test.tsx
+++ b/apps/web/src/features/workouts/components/session-feedback.test.tsx
@@ -50,11 +50,12 @@ describe('SessionFeedback', () => {
       }),
     );
     fireEvent.click(
-      within(
-        screen.getByRole('group', { name: 'Energy post workout options' }),
-      ).getByRole('button', {
-        name: '🙂',
-      }),
+      within(screen.getByRole('group', { name: 'Energy post workout options' })).getByRole(
+        'button',
+        {
+          name: '🙂',
+        },
+      ),
     );
     fireEvent.click(
       within(screen.getByRole('group', { name: 'Any pain or discomfort? response' })).getByRole(
@@ -122,7 +123,9 @@ describe('SessionFeedback', () => {
         value: false,
       }),
     );
-    expect(submittedFeedback.find((field) => field.id === 'effort' && field.type === 'slider')).toEqual(
+    expect(
+      submittedFeedback.find((field) => field.id === 'effort' && field.type === 'slider'),
+    ).toEqual(
       expect.objectContaining({
         value: 8,
       }),
@@ -151,11 +154,12 @@ describe('SessionFeedback', () => {
       }),
     );
     fireEvent.click(
-      within(
-        screen.getByRole('group', { name: 'Energy post workout options' }),
-      ).getByRole('button', {
-        name: '😐',
-      }),
+      within(screen.getByRole('group', { name: 'Energy post workout options' })).getByRole(
+        'button',
+        {
+          name: '😐',
+        },
+      ),
     );
     fireEvent.click(
       within(screen.getByRole('group', { name: 'Any pain or discomfort? response' })).getByRole(
@@ -236,7 +240,9 @@ describe('SessionFeedback', () => {
       />,
     );
 
-    expect(screen.queryByRole('group', { name: 'Energy post workout rating' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('group', { name: 'Energy post workout rating' }),
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole('group', { name: 'Knee pain rating' })).not.toBeInTheDocument();
     expect(screen.getByRole('group', { name: 'Energy post workout options' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 3, name: 'Coach note' })).toBeInTheDocument();
@@ -266,9 +272,54 @@ describe('SessionFeedback', () => {
       />,
     );
 
-    expect(screen.getByRole('heading', { level: 3, name: 'Muscle pain scale' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Muscle pain scale' }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { level: 3, name: 'Joint discomfort check' }),
     ).toBeInTheDocument();
+  });
+
+  it('shows session RPE guidance anchors in the help dialog', () => {
+    render(<SessionFeedback fields={[]} onSubmit={() => {}} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Session RPE guide' }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Session RPE Guide' })).toBeInTheDocument();
+    expect(screen.getByText('Easy, plenty left in the tank')).toBeInTheDocument();
+    expect(screen.getByText('Moderate, solid work but comfortable')).toBeInTheDocument();
+    expect(screen.getByText('Hard, challenging but repeatable')).toBeInTheDocument();
+    expect(screen.getByText('Very hard, close to limit')).toBeInTheDocument();
+    expect(screen.getByText('Maximal, all-out effort')).toBeInTheDocument();
+  });
+
+  it('applies stronger selected-state styling to option controls', () => {
+    render(<SessionFeedback fields={[]} onSubmit={() => {}} />);
+
+    const rpeSeven = within(screen.getByRole('group', { name: 'Session RPE rating' })).getByRole(
+      'button',
+      {
+        name: '7',
+      },
+    );
+    fireEvent.click(rpeSeven);
+    expect(rpeSeven).toHaveClass('bg-[var(--color-accent-peach)]', 'text-on-peach');
+
+    const energyStrong = within(
+      screen.getByRole('group', { name: 'Energy post workout options' }),
+    ).getByRole('button', {
+      name: '💪',
+    });
+    fireEvent.click(energyStrong);
+    expect(energyStrong).toHaveClass('bg-[var(--color-accent-peach)]', 'text-on-peach');
+
+    const yesButton = within(
+      screen.getByRole('group', { name: 'Any pain or discomfort? response' }),
+    ).getByRole('button', {
+      name: 'Yes',
+    });
+    fireEvent.click(yesButton);
+    expect(yesButton).toHaveClass('bg-[var(--color-accent-peach)]', 'text-on-peach');
   });
 });

--- a/apps/web/src/features/workouts/components/session-feedback.tsx
+++ b/apps/web/src/features/workouts/components/session-feedback.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -516,7 +517,11 @@ function isCoachNoteField(field: ActiveWorkoutCustomFeedbackField) {
   const normalizedId = field.id.trim().toLowerCase();
   const normalizedLabel = field.label.trim().toLowerCase().replace(/\s+/g, ' ');
 
-  return normalizedId === 'coach-note' || normalizedId === 'session-note' || normalizedLabel === 'coach note';
+  return (
+    normalizedId === 'coach-note' ||
+    normalizedId === 'session-note' ||
+    normalizedLabel === 'coach note'
+  );
 }
 
 function getFeedbackOptionClassName(isSelected: boolean) {
@@ -545,7 +550,7 @@ function RpeScaleHelp() {
             </Button>
           </TooltipTrigger>
           <TooltipContent
-            className="hidden max-w-xs space-y-2 bg-card p-3 text-foreground shadow-xl ring-1 ring-border sm:block"
+            className="max-w-xs space-y-2 bg-card p-3 text-foreground shadow-xl ring-1 ring-border"
             side="top"
             sideOffset={8}
           >
@@ -569,12 +574,13 @@ function RpeScaleHelp() {
             <CircleHelp className="size-4" />
           </Button>
         </DialogTrigger>
-        <DialogContent
-          aria-describedby={undefined}
-          className="top-auto bottom-0 translate-y-0 rounded-t-2xl rounded-b-none border-b-0 p-5 sm:top-[50%] sm:bottom-auto sm:translate-y-[-50%] sm:rounded-lg sm:border-b sm:p-6"
-        >
+        <DialogContent className="top-auto bottom-0 translate-y-0 rounded-t-2xl rounded-b-none border-b-0 p-5 sm:top-[50%] sm:bottom-auto sm:translate-y-[-50%] sm:rounded-lg sm:border-b sm:p-6">
           <DialogHeader>
             <DialogTitle>Session RPE Guide</DialogTitle>
+            <DialogDescription className="sr-only">
+              This guide explains the Rate of Perceived Exertion scale so you can score your
+              session consistently.
+            </DialogDescription>
           </DialogHeader>
           <RpeScaleAnchorList />
         </DialogContent>
@@ -585,13 +591,16 @@ function RpeScaleHelp() {
 
 function RpeScaleAnchorList() {
   return (
-    <ul className="space-y-2 text-sm text-muted">
-      {RPE_SCALE_ANCHORS.map((anchor) => (
-        <li className="flex gap-2" key={anchor.rating}>
-          <span className="font-semibold text-foreground">{anchor.rating}</span>
-          <span>{anchor.description}</span>
-        </li>
-      ))}
-    </ul>
+    <div className="space-y-3">
+      <p className="text-xs text-muted">Below 6: Very light effort or warm-up pace.</p>
+      <ul className="space-y-2 text-sm text-muted">
+        {RPE_SCALE_ANCHORS.map((anchor) => (
+          <li className="flex gap-2" key={anchor.rating}>
+            <span className="font-semibold text-foreground">{anchor.rating}</span>
+            <span>{anchor.description}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }

--- a/apps/web/src/features/workouts/components/session-feedback.tsx
+++ b/apps/web/src/features/workouts/components/session-feedback.tsx
@@ -148,7 +148,7 @@ export function SessionFeedback({ className, fields, onSubmit }: SessionFeedback
                 field.id === 'pain-discomfort' &&
                 field.type === 'yes_no' &&
                 field.value === true
-              ) ? (
+              ) && field.type !== 'text' ? (
                 <div className="space-y-2">
                   <label
                     className="text-xs font-semibold tracking-[0.18em] text-muted uppercase"
@@ -247,39 +247,39 @@ function normalizeFeedbackField(
     case 'scale':
       return {
         ...field,
-        notes: field.notes ?? '',
-        value: field.value ?? null,
+        notes: '',
+        value: null,
       };
     case 'text':
       return {
         ...field,
-        notes: field.notes ?? '',
-        value: field.value ?? '',
+        notes: '',
+        value: '',
       };
     case 'yes_no':
       return {
         ...field,
-        notes: field.notes ?? '',
-        value: field.value ?? null,
+        notes: '',
+        value: null,
       };
     case 'emoji':
       return {
         ...field,
-        notes: field.notes ?? '',
-        value: field.value ?? null,
+        notes: '',
+        value: null,
       };
     case 'slider':
       return {
         ...field,
-        notes: field.notes ?? '',
+        notes: '',
         step: field.step ?? 1,
-        value: field.value ?? field.min,
+        value: null,
       };
     case 'multi_select':
       return {
         ...field,
-        notes: field.notes ?? '',
-        value: field.value ?? [],
+        notes: '',
+        value: [],
       };
     default:
       return field;
@@ -291,6 +291,10 @@ function getFeedbackDescription(field: ActiveWorkoutCustomFeedbackField) {
     case 'scale':
       return `Rate ${field.label.toLowerCase()} from ${field.min} to ${field.max}.`;
     case 'text':
+      if (isCoachNoteField(field)) {
+        return 'What should we remember next time? Add a carry-forward coaching or programming note.';
+      }
+
       return `Add a note for ${field.label.toLowerCase()}.`;
     case 'yes_no':
       return 'Select yes or no.';
@@ -355,7 +359,11 @@ function renderFeedbackInput(
               ),
             )
           }
-          placeholder={`Add your ${field.label.toLowerCase()} notes.`}
+          placeholder={
+            isCoachNoteField(field)
+              ? 'What should we remember next time? Add a carry-forward coaching or programming note.'
+              : `Add your ${field.label.toLowerCase()} notes.`
+          }
           value={field.value}
         />
       );
@@ -502,6 +510,13 @@ function renderFeedbackInput(
     default:
       return null;
   }
+}
+
+function isCoachNoteField(field: ActiveWorkoutCustomFeedbackField) {
+  const normalizedId = field.id.trim().toLowerCase();
+  const normalizedLabel = field.label.trim().toLowerCase().replace(/\s+/g, ' ');
+
+  return normalizedId === 'coach-note' || normalizedId === 'session-note' || normalizedLabel === 'coach note';
 }
 
 function getFeedbackOptionClassName(isSelected: boolean) {

--- a/apps/web/src/features/workouts/components/session-feedback.tsx
+++ b/apps/web/src/features/workouts/components/session-feedback.tsx
@@ -1,8 +1,17 @@
 import { useState, type Dispatch, type SetStateAction } from 'react';
+import { CircleHelp } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
 import type { ActiveWorkoutCustomFeedbackField, ActiveWorkoutFeedbackDraft } from '../types';
@@ -33,6 +42,14 @@ export const STANDARD_FEEDBACK_QUESTIONS: ActiveWorkoutCustomFeedbackField[] = [
     value: null,
   },
 ];
+
+const RPE_SCALE_ANCHORS = [
+  { rating: 6, description: 'Easy, plenty left in the tank' },
+  { rating: 7, description: 'Moderate, solid work but comfortable' },
+  { rating: 8, description: 'Hard, challenging but repeatable' },
+  { rating: 9, description: 'Very hard, close to limit' },
+  { rating: 10, description: 'Maximal, all-out effort' },
+] as const;
 
 type SessionFeedbackProps = {
   className?: string;
@@ -90,7 +107,10 @@ export function SessionFeedback({ className, fields, onSubmit }: SessionFeedback
           <section className="rounded-3xl border border-border bg-secondary/25 p-4" key={field.id}>
             <div className="space-y-3">
               <div className="space-y-1">
-                <h3 className="text-lg font-semibold text-foreground">{field.label}</h3>
+                <div className="flex items-center justify-between gap-2">
+                  <h3 className="text-lg font-semibold text-foreground">{field.label}</h3>
+                  {field.id === 'session-rpe' ? <RpeScaleHelp /> : null}
+                </div>
                 <p className="text-sm text-muted">{getFeedbackDescription(field)}</p>
               </div>
 
@@ -124,7 +144,11 @@ export function SessionFeedback({ className, fields, onSubmit }: SessionFeedback
                 </div>
               ) : null}
 
-              {!(field.id === 'pain-discomfort' && field.type === 'yes_no' && field.value === true) ? (
+              {!(
+                field.id === 'pain-discomfort' &&
+                field.type === 'yes_no' &&
+                field.value === true
+              ) ? (
                 <div className="space-y-2">
                   <label
                     className="text-xs font-semibold tracking-[0.18em] text-muted uppercase"
@@ -216,7 +240,9 @@ function getCanonicalStandardFieldId(field: ActiveWorkoutCustomFeedbackField) {
   return null;
 }
 
-function normalizeFeedbackField(field: ActiveWorkoutCustomFeedbackField): ActiveWorkoutCustomFeedbackField {
+function normalizeFeedbackField(
+  field: ActiveWorkoutCustomFeedbackField,
+): ActiveWorkoutCustomFeedbackField {
   switch (field.type) {
     case 'scale':
       return {
@@ -294,11 +320,7 @@ function renderFeedbackInput(
               return (
                 <Button
                   aria-pressed={isSelected}
-                  className={cn(
-                    'min-w-11',
-                    isSelected &&
-                      'border-transparent bg-[var(--color-accent-cream)] text-on-cream hover:bg-[var(--color-accent-cream)]/90 dark:bg-amber-500/20 dark:text-amber-400 dark:hover:bg-amber-500/30',
-                  )}
+                  className={cn('min-w-11', getFeedbackOptionClassName(isSelected))}
                   key={score}
                   onClick={() =>
                     setFeedback((current) =>
@@ -311,7 +333,7 @@ function renderFeedbackInput(
                   }
                   size="sm"
                   type="button"
-                  variant={isSelected ? 'secondary' : 'outline'}
+                  variant="outline"
                 >
                   {score}
                 </Button>
@@ -342,6 +364,7 @@ function renderFeedbackInput(
         <div aria-label={`${field.label} response`} className="flex gap-2" role="group">
           <Button
             aria-pressed={field.value === true}
+            className={getFeedbackOptionClassName(field.value === true)}
             onClick={() =>
               setFeedback((current) =>
                 current.map((entry) =>
@@ -352,12 +375,13 @@ function renderFeedbackInput(
               )
             }
             type="button"
-            variant={field.value === true ? 'secondary' : 'outline'}
+            variant="outline"
           >
             Yes
           </Button>
           <Button
             aria-pressed={field.value === false}
+            className={getFeedbackOptionClassName(field.value === false)}
             onClick={() =>
               setFeedback((current) =>
                 current.map((entry) =>
@@ -368,7 +392,7 @@ function renderFeedbackInput(
               )
             }
             type="button"
-            variant={field.value === false ? 'secondary' : 'outline'}
+            variant="outline"
           >
             No
           </Button>
@@ -383,7 +407,7 @@ function renderFeedbackInput(
             return (
               <Button
                 aria-pressed={isSelected}
-                className="min-w-11 px-3"
+                className={cn('min-w-11 px-3', getFeedbackOptionClassName(isSelected))}
                 key={option}
                 onClick={() =>
                   setFeedback((current) =>
@@ -396,7 +420,7 @@ function renderFeedbackInput(
                 }
                 size="sm"
                 type="button"
-                variant={isSelected ? 'secondary' : 'outline'}
+                variant="outline"
               >
                 <span aria-hidden="true" className="text-lg leading-none">
                   {option}
@@ -447,6 +471,7 @@ function renderFeedbackInput(
             return (
               <Button
                 aria-pressed={isSelected}
+                className={getFeedbackOptionClassName(isSelected)}
                 key={option}
                 onClick={() =>
                   setFeedback((current) =>
@@ -466,7 +491,7 @@ function renderFeedbackInput(
                 }
                 size="sm"
                 type="button"
-                variant={isSelected ? 'secondary' : 'outline'}
+                variant="outline"
               >
                 {option}
               </Button>
@@ -477,4 +502,81 @@ function renderFeedbackInput(
     default:
       return null;
   }
+}
+
+function getFeedbackOptionClassName(isSelected: boolean) {
+  return cn(
+    'border transition-all active:scale-[0.98]',
+    isSelected
+      ? 'border-[var(--color-accent-peach)] bg-[var(--color-accent-peach)] text-on-peach shadow-[0_0_0_1px_var(--color-accent-peach)] hover:bg-[var(--color-accent-peach)]/90 dark:border-[var(--color-accent-cream)] dark:bg-[var(--color-accent-cream)]/25 dark:text-[var(--color-accent-cream)] dark:shadow-[0_0_0_1px_var(--color-accent-cream)] dark:hover:bg-[var(--color-accent-cream)]/35'
+      : 'border-border bg-background text-foreground hover:bg-accent/70 hover:text-accent-foreground',
+  );
+}
+
+function RpeScaleHelp() {
+  return (
+    <div className="flex items-center">
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              aria-label="Session RPE scale anchors"
+              className="hidden h-9 w-9 p-0 text-muted sm:inline-flex"
+              size="icon-sm"
+              type="button"
+              variant="ghost"
+            >
+              <CircleHelp className="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent
+            className="hidden max-w-xs space-y-2 bg-card p-3 text-foreground shadow-xl ring-1 ring-border sm:block"
+            side="top"
+            sideOffset={8}
+          >
+            <p className="text-xs font-semibold tracking-[0.18em] uppercase text-muted">
+              Session RPE Guide
+            </p>
+            <RpeScaleAnchorList />
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+
+      <Dialog>
+        <DialogTrigger asChild>
+          <Button
+            aria-label="Open Session RPE guide"
+            className="h-9 w-9 p-0 text-muted sm:hidden"
+            size="icon-sm"
+            type="button"
+            variant="ghost"
+          >
+            <CircleHelp className="size-4" />
+          </Button>
+        </DialogTrigger>
+        <DialogContent
+          aria-describedby={undefined}
+          className="top-auto bottom-0 translate-y-0 rounded-t-2xl rounded-b-none border-b-0 p-5 sm:top-[50%] sm:bottom-auto sm:translate-y-[-50%] sm:rounded-lg sm:border-b sm:p-6"
+        >
+          <DialogHeader>
+            <DialogTitle>Session RPE Guide</DialogTitle>
+          </DialogHeader>
+          <RpeScaleAnchorList />
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function RpeScaleAnchorList() {
+  return (
+    <ul className="space-y-2 text-sm text-muted">
+      {RPE_SCALE_ANCHORS.map((anchor) => (
+        <li className="flex gap-2" key={anchor.rating}>
+          <span className="font-semibold text-foreground">{anchor.rating}</span>
+          <span>{anchor.description}</span>
+        </li>
+      ))}
+    </ul>
+  );
 }

--- a/apps/web/src/features/workouts/components/session-summary.test.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.test.tsx
@@ -86,16 +86,22 @@ describe('SessionSummary', () => {
       screen.getByText('Pause the first rep of each incline set next time.'),
     ).toBeInTheDocument();
     expect(
-      screen.getByPlaceholderText('How did it feel? What would you change?'),
+      screen.getByPlaceholderText('What happened today? Anything notable about this session?'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('What happened today? Anything notable about this session?'),
     ).toBeInTheDocument();
     expect(screen.getByTestId('session-summary-notes')).toHaveAttribute('id', 'session-summary-notes');
     expect(screen.getByTestId('session-summary-notes')).toHaveAttribute('name', 'session-summary-notes');
     expect(screen.getByLabelText('Session notes')).toHaveValue('');
     expect(screen.getByRole('textbox', { name: 'Session notes' })).toHaveValue('');
 
-    fireEvent.change(screen.getByPlaceholderText('How did it feel? What would you change?'), {
-      target: { value: 'Tempo was good but shoulders fatigued early.' },
-    });
+    fireEvent.change(
+      screen.getByPlaceholderText('What happened today? Anything notable about this session?'),
+      {
+        target: { value: 'Tempo was good but shoulders fatigued early.' },
+      },
+    );
     expect(notesChangeSpy).toHaveBeenCalledWith('Tempo was good but shoulders fatigued early.');
 
     fireEvent.click(screen.getByRole('button', { name: 'Save as Template' }));

--- a/apps/web/src/features/workouts/components/session-summary.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.tsx
@@ -100,6 +100,9 @@ export function SessionSummary({
             <h2 className="text-sm font-semibold tracking-[0.18em] uppercase opacity-70 dark:text-muted dark:opacity-100">
               Session notes
             </h2>
+            <p className="text-sm text-muted">
+              What happened today? Anything notable about this session?
+            </p>
             <Textarea
               aria-label="Session notes"
               data-testid="session-summary-notes"
@@ -109,7 +112,7 @@ export function SessionSummary({
               onChange={(event) => {
                 onNotesChange?.(event.target.value);
               }}
-              placeholder="How did it feel? What would you change?"
+              placeholder="What happened today? Anything notable about this session?"
               rows={4}
               value={initialSessionNotes}
             />

--- a/apps/web/src/features/workouts/lib/mock-data.ts
+++ b/apps/web/src/features/workouts/lib/mock-data.ts
@@ -149,15 +149,16 @@ export const workoutFeedbackFields: ActiveWorkoutCustomFeedbackField[] = [
     type: 'scale',
     min: 1,
     max: 5,
-    value: 4,
-    notes: 'Left shoulder stayed stable with neutral-grip pressing.',
+    value: null,
+    notes: '',
   },
   {
     id: 'session-note',
     label: 'Coach note',
     optional: true,
     type: 'text',
-    value: 'Keep incline press to a 2-count pause on the chest next week.',
+    value: '',
+    notes: '',
   },
 ];
 

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -218,12 +218,13 @@ describe('ActiveWorkoutPage', () => {
         name: '3',
       }),
     );
-    fireEvent.change(
-      screen.getByDisplayValue('Keep incline press to a 2-count pause on the chest next week.'),
-      {
-        target: { value: 'Shoulders stayed stable, keep the same setup.' },
-      },
+    const coachNoteInput = screen.getByPlaceholderText(
+      'What should we remember next time? Add a carry-forward coaching or programming note.',
     );
+    expect(coachNoteInput).toHaveValue('');
+    fireEvent.change(coachNoteInput, {
+      target: { value: 'Shoulders stayed stable, keep the same setup.' },
+    });
 
     fireEvent.click(screen.getByRole('button', { name: 'Finalize session' }));
 
@@ -755,6 +756,12 @@ describe('ActiveWorkoutPage', () => {
         },
       ),
     );
+    expect(
+      screen.getByPlaceholderText(
+        'What should we remember next time? Add a carry-forward coaching or programming note.',
+      ),
+    ).toHaveValue('');
+    expect(screen.getByRole('button', { name: 'Finalize session' })).toBeDisabled();
     fireEvent.click(
       within(screen.getByRole('group', { name: 'Shoulder feel rating' })).getByRole('button', {
         name: '3',


### PR DESCRIPTION
## Summary
This PR improves post-session feedback UX by making the inputs clearer, more consistent, and safer against stale state. It fixes a bug where incoming feedback values could prefill the form with old data, which could lead to accidental submission of outdated notes/ratings. It also adds Session RPE guidance so users can interpret effort scores consistently, with responsive behavior for desktop and mobile. Finally, it strengthens selected-state styling across feedback controls and updates helper copy for both Coach note and Session notes to better guide what should be written.

## Key Changes
- Added a Session RPE help affordance next to the RPE field label:
  - Desktop: tooltip with 6-10 anchor descriptions.
  - Mobile: dialog/bottom-sheet style guide with the same anchors.
- Introduced shared selected-state styling for feedback option controls (`scale`, `yes_no`, `emoji`, `multi_select`) to improve visual clarity.
- Fixed stale prefill behavior by normalizing incoming feedback fields to empty/default draft state (`value`/`notes` reset by field type) instead of reusing prior values.
- Added Coach note-specific guidance copy and placeholder:
  - “What should we remember next time? Add a carry-forward coaching or programming note.”
- Updated Session notes UI text and placeholder in summary to:
  - “What happened today? Anything notable about this session?”
- Expanded tests to cover:
  - stale prefill clearing,
  - RPE guide visibility/content,
  - stronger selected-state class application,
  - updated placeholder/helper copy expectations.

## Technical Notes
- The reset logic is centralized in `normalizeFeedbackField`, and now intentionally treats incoming field values as schema/config, not draft answers.
- `isCoachNoteField` uses normalized `id`/`label` matching (`coach-note`, `session-note`, and “coach note”) to apply note-specific guidance consistently across field variants.
- Option buttons now always use `variant="outline"` and apply selected/unselected appearance via `getFeedbackOptionClassName`, reducing style divergence between control types.
- The RPE guidance component uses tooltip + dialog split by breakpoint (`sm`) to preserve accessibility and usability across device sizes.

## Commits

- `b296111 fix(workouts): clear stale post-session feedback prefills`
- `11baa12 feat(workouts): add RPE guidance and stronger feedback selected states`

## Tasks

- **Add RPE guidance tooltip and improve selected state styling**: Help icon with scale anchors for RPE, stronger visual selected state on feedback controls
- **Fix stale feedback prefill and improve note field labels**: Investigate/fix stale prefill, update Coach note and Session notes helper text

## Diff Stats

```
.../workouts/components/session-feedback.test.tsx  | 120 +++++++++++++--
 .../workouts/components/session-feedback.tsx       | 171 +++++++++++++++++----
 .../workouts/components/session-summary.test.tsx   |  14 +-
 .../workouts/components/session-summary.tsx        |   5 +-
 apps/web/src/features/workouts/lib/mock-data.ts    |   7 +-
 apps/web/src/pages/active-workout.test.tsx         |  17 +-
 6 files changed, 281 insertions(+), 53 deletions(-)
```