### PR TITLE
fix: workout data integrity and same-day history

### DIFF
--- a/apps/api/src/__tests__/agent.test.ts
+++ b/apps/api/src/__tests__/agent.test.ts
@@ -451,7 +451,6 @@ vi.mock('../routes/workout-templates/store.js', () => ({
 }));
 
 vi.mock('../routes/workout-sessions/store.js', () => ({
-  allSessionExercisesAccessible: vi.fn(),
   batchUpsertSessionSets: vi.fn(),
   createSessionSet: vi.fn(),
   createWorkoutSession: vi.fn(

--- a/apps/api/src/routes/agent/workouts.test.ts
+++ b/apps/api/src/routes/agent/workouts.test.ts
@@ -47,7 +47,6 @@ vi.mock('../workout-templates/store.js', () => ({
 }));
 
 vi.mock('../workout-sessions/store.js', () => ({
-  allSessionExercisesAccessible: vi.fn(),
   batchUpsertSessionSets: vi.fn(),
   createSessionSet: vi.fn(),
   createWorkoutSession: vi.fn(),

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -726,6 +726,115 @@ describe('exercise routes', () => {
     });
   });
 
+  it('excludes soft-deleted exercises referenced only by deleted sessions or templates', async () => {
+    seedExercise({
+      id: 'deleted-session-only',
+      userId: 'user-1',
+      name: 'Deleted Session Only',
+      muscleGroups: ['hamstrings'],
+      equipment: 'machine',
+      category: 'isolation',
+    });
+    seedExercise({
+      id: 'deleted-template-only',
+      userId: 'user-1',
+      name: 'Deleted Template Only',
+      muscleGroups: ['glutes'],
+      equipment: 'cable',
+      category: 'isolation',
+    });
+
+    context.db
+      .update(exercises)
+      .set({ deletedAt: '2026-03-01T00:00:00.000Z' })
+      .where(eq(exercises.id, 'deleted-session-only'))
+      .run();
+    context.db
+      .update(exercises)
+      .set({ deletedAt: '2026-03-01T00:00:00.000Z' })
+      .where(eq(exercises.id, 'deleted-template-only'))
+      .run();
+
+    seedWorkoutSession({
+      id: 'deleted-history-session',
+      userId: 'user-1',
+      name: 'Deleted Session',
+      date: '2026-03-10',
+      status: 'completed',
+      startedAt: 1_700_000_100_000,
+      completedAt: 1_700_000_120_000,
+    });
+    seedSessionSet({
+      id: 'deleted-history-set',
+      sessionId: 'deleted-history-session',
+      exerciseId: 'deleted-session-only',
+      setNumber: 1,
+      weight: 100,
+      reps: 10,
+    });
+    context.db
+      .update(workoutSessions)
+      .set({ deletedAt: '2026-03-12T00:00:00.000Z' })
+      .where(eq(workoutSessions.id, 'deleted-history-session'))
+      .run();
+
+    context.db
+      .insert(workoutTemplates)
+      .values({
+        id: 'deleted-template',
+        userId: 'user-1',
+        name: 'Deleted Template',
+        description: null,
+        tags: [],
+      })
+      .run();
+    context.db
+      .insert(templateExercises)
+      .values({
+        id: 'deleted-template-exercise',
+        templateId: 'deleted-template',
+        exerciseId: 'deleted-template-only',
+        orderIndex: 0,
+        section: 'main',
+      })
+      .run();
+    context.db
+      .update(workoutTemplates)
+      .set({ deletedAt: '2026-03-12T00:00:00.000Z' })
+      .where(eq(workoutTemplates.id, 'deleted-template'))
+      .run();
+
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+    const response = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises?page=1&limit=20',
+      headers: createAuthorizationHeader(authToken),
+    });
+    const filtersResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises/filters',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: [],
+      meta: {
+        page: 1,
+        limit: 20,
+        total: 0,
+      },
+    });
+
+    expect(filtersResponse.statusCode).toBe(200);
+    expect(filtersResponse.json()).toEqual({
+      data: {
+        muscleGroups: [],
+        equipment: [],
+      },
+    });
+  });
+
   it('updates only user-specific exercises and rejects global rows', async () => {
     seedExercise({
       id: 'user-exercise',

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -637,6 +637,82 @@ describe('exercise routes', () => {
     });
   });
 
+  it('includes soft-deleted user exercises when they are referenced by workout history', async () => {
+    seedExercise({
+      id: 'active-owned',
+      userId: 'user-1',
+      name: 'Active Owned',
+      muscleGroups: ['quads'],
+      equipment: 'barbell',
+      category: 'compound',
+    });
+    seedExercise({
+      id: 'deleted-used',
+      userId: 'user-1',
+      name: 'Deleted But Used',
+      muscleGroups: ['hamstrings'],
+      equipment: 'machine',
+      category: 'isolation',
+    });
+    seedExercise({
+      id: 'deleted-unused',
+      userId: 'user-1',
+      name: 'Deleted Unused',
+      muscleGroups: ['calves'],
+      equipment: 'machine',
+      category: 'isolation',
+    });
+
+    context.db
+      .update(exercises)
+      .set({ deletedAt: '2026-03-01T00:00:00.000Z' })
+      .where(eq(exercises.id, 'deleted-used'))
+      .run();
+    context.db
+      .update(exercises)
+      .set({ deletedAt: '2026-03-01T00:00:00.000Z' })
+      .where(eq(exercises.id, 'deleted-unused'))
+      .run();
+
+    seedWorkoutSession({
+      id: 'history-session',
+      userId: 'user-1',
+      name: 'Lower',
+      date: '2026-03-10',
+      status: 'completed',
+      startedAt: 1_700_000_100_000,
+      completedAt: 1_700_000_120_000,
+    });
+    seedSessionSet({
+      id: 'history-set',
+      sessionId: 'history-session',
+      exerciseId: 'deleted-used',
+      setNumber: 1,
+      weight: 100,
+      reps: 10,
+    });
+
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+    const response = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises?page=1&limit=20',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: [
+        expect.objectContaining({ id: 'active-owned' }),
+        expect.objectContaining({ id: 'deleted-used' }),
+      ],
+      meta: {
+        page: 1,
+        limit: 20,
+        total: 2,
+      },
+    });
+  });
+
   it('updates only user-specific exercises and rejects global rows', async () => {
     seedExercise({
       id: 'user-exercise',

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -698,6 +698,11 @@ describe('exercise routes', () => {
       url: '/api/v1/exercises?page=1&limit=20',
       headers: createAuthorizationHeader(authToken),
     });
+    const filtersResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises/filters',
+      headers: createAuthorizationHeader(authToken),
+    });
 
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
@@ -709,6 +714,14 @@ describe('exercise routes', () => {
         page: 1,
         limit: 20,
         total: 2,
+      },
+    });
+
+    expect(filtersResponse.statusCode).toBe(200);
+    expect(filtersResponse.json()).toEqual({
+      data: {
+        muscleGroups: ['hamstrings', 'quads'],
+        equipment: ['barbell', 'machine'],
       },
     });
   });

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -360,6 +360,76 @@ describe('exercise routes', () => {
     });
   });
 
+  it('returns the newest same-day completed performance for history lookups', async () => {
+    seedExercise({
+      id: 'global-squat',
+      userId: null,
+      name: 'Back Squat',
+      muscleGroups: ['quads'],
+      equipment: 'barbell',
+      category: 'compound',
+    });
+
+    seedWorkoutSession({
+      id: 'session-early',
+      userId: 'user-1',
+      name: 'Lower Body',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: Date.parse('2026-03-12T09:00:00.000Z'),
+      completedAt: Date.parse('2026-03-12T09:35:00.000Z'),
+    });
+    seedWorkoutSession({
+      id: 'session-late',
+      userId: 'user-1',
+      name: 'Lower Body PM',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: Date.parse('2026-03-12T17:00:00.000Z'),
+      completedAt: Date.parse('2026-03-12T17:42:00.000Z'),
+    });
+
+    seedSessionSet({
+      id: 'set-early',
+      sessionId: 'session-early',
+      exerciseId: 'global-squat',
+      setNumber: 1,
+      weight: 225,
+      reps: 5,
+    });
+    seedSessionSet({
+      id: 'set-late',
+      sessionId: 'session-late',
+      exerciseId: 'global-squat',
+      setNumber: 1,
+      weight: 235,
+      reps: 4,
+    });
+
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    const response = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises/global-squat/last-performance',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: {
+        sessionId: 'session-late',
+        date: '2026-03-12',
+        sets: [
+          {
+            setNumber: 1,
+            weight: 235,
+            reps: 4,
+          },
+        ],
+      },
+    });
+  });
+
   it('creates a user-specific exercise for the authenticated user', async () => {
     const authToken = context.app.jwt.sign({ userId: 'user-1' });
 

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -194,6 +194,7 @@ export const listExercises = async ({
 
 export const listExerciseFilters = async (userId: string): Promise<ExerciseFilters> => {
   const { db } = await import('../../db/index.js');
+  const whereClause = buildListWhereClause({ userId });
 
   const visibleExercises = await db
     .select({
@@ -201,9 +202,7 @@ export const listExerciseFilters = async (userId: string): Promise<ExerciseFilte
       equipment: exercises.equipment,
     })
     .from(exercises)
-    .where(
-      or(isNull(exercises.userId), and(eq(exercises.userId, userId), isNull(exercises.deletedAt))),
-    )
+    .where(whereClause)
     .all();
 
   return {

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -80,6 +80,7 @@ const buildListWhereClause = ({
                   on ${workoutSessions.id} = ${sessionSets.sessionId}
                 where ${sessionSets.exerciseId} = ${exercises.id}
                   and ${workoutSessions.userId} = ${userId}
+                  and ${workoutSessions.deletedAt} is null
               )
               or exists (
                 select 1
@@ -88,6 +89,7 @@ const buildListWhereClause = ({
                   on ${workoutTemplates.id} = ${templateExercises.templateId}
                 where ${templateExercises.exerciseId} = ${exercises.id}
                   and ${workoutTemplates.userId} = ${userId}
+                  and ${workoutTemplates.deletedAt} is null
               )
             )`,
           ),

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, isNull, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, isNotNull, isNull, or, sql } from 'drizzle-orm';
 import type {
   CreateExerciseInput,
   Exercise,
@@ -7,7 +7,13 @@ import type {
   UpdateExerciseInput,
 } from '@pulse/shared';
 
-import { exercises, sessionSets, workoutSessions } from '../../db/schema/index.js';
+import {
+  exercises,
+  sessionSets,
+  templateExercises,
+  workoutSessions,
+  workoutTemplates,
+} from '../../db/schema/index.js';
 
 type ListExercisesInput = {
   userId: string;
@@ -58,7 +64,36 @@ const buildListWhereClause = ({
   category,
 }: Omit<ListExercisesInput, 'page' | 'limit'>) =>
   and(
-    or(isNull(exercises.userId), and(eq(exercises.userId, userId), isNull(exercises.deletedAt))),
+    or(
+      and(isNull(exercises.userId), isNull(exercises.deletedAt)),
+      and(
+        eq(exercises.userId, userId),
+        or(
+          isNull(exercises.deletedAt),
+          and(
+            isNotNull(exercises.deletedAt),
+            sql`(
+              exists (
+                select 1
+                from ${sessionSets}
+                inner join ${workoutSessions}
+                  on ${workoutSessions.id} = ${sessionSets.sessionId}
+                where ${sessionSets.exerciseId} = ${exercises.id}
+                  and ${workoutSessions.userId} = ${userId}
+              )
+              or exists (
+                select 1
+                from ${templateExercises}
+                inner join ${workoutTemplates}
+                  on ${workoutTemplates.id} = ${templateExercises.templateId}
+                where ${templateExercises.exerciseId} = ${exercises.id}
+                  and ${workoutTemplates.userId} = ${userId}
+              )
+            )`,
+          ),
+        ),
+      ),
+    ),
     q ? sql`lower(${exercises.name}) like ${`%${q.toLowerCase()}%`}` : undefined,
     muscleGroup
       ? sql`exists (

--- a/apps/api/src/routes/v1/dashboard-store.test.ts
+++ b/apps/api/src/routes/v1/dashboard-store.test.ts
@@ -1,4 +1,5 @@
 import { DASHBOARD_WIDGET_IDS } from '@pulse/shared';
+import { SQLiteSyncDialect } from 'drizzle-orm/sqlite-core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const DEFAULT_VISIBLE_WIDGETS = Object.keys(DASHBOARD_WIDGET_IDS);
@@ -7,12 +8,16 @@ const testState = vi.hoisted(() => {
   const selectGetResults: unknown[] = [];
   const selectAllResults: unknown[] = [];
   const insertRunResults: unknown[] = [];
+  const whereCalls: unknown[] = [];
 
   const select = vi.fn(() => {
     const chain = {
       from: vi.fn(() => chain),
       leftJoin: vi.fn(() => chain),
-      where: vi.fn(() => chain),
+      where: vi.fn((condition: unknown) => {
+        whereCalls.push(condition);
+        return chain;
+      }),
       groupBy: vi.fn(() => chain),
       orderBy: vi.fn(() => chain),
       limit: vi.fn(() => chain),
@@ -44,10 +49,12 @@ const testState = vi.hoisted(() => {
     selectGetResults,
     selectAllResults,
     insertRunResults,
+    whereCalls,
     reset() {
       selectGetResults.length = 0;
       selectAllResults.length = 0;
       insertRunResults.length = 0;
+      whereCalls.length = 0;
       select.mockClear();
       db.insert.mockClear();
     },
@@ -172,6 +179,20 @@ describe('dashboard store', () => {
       completed: 2,
       percentage: 66.7,
     });
+  });
+
+  it('scopes dashboard workout snapshot lookup by local workout date', async () => {
+    testState.selectGetResults.push(undefined, undefined, undefined, undefined, undefined);
+
+    const { getDashboardSnapshot } = await import('./dashboard-store.js');
+    await getDashboardSnapshot('user-1', '2026-03-11');
+
+    const workoutWhereClause = testState.whereCalls[3];
+    const dialect = new SQLiteSyncDialect();
+    const workoutWhereSql = dialect.sqlToQuery(workoutWhereClause as never).sql;
+
+    expect(workoutWhereSql).toContain('"workout_sessions"."date"');
+    expect(workoutWhereSql).not.toContain('"workout_sessions"."started_at"');
   });
 
   it('returns weight trend points in ascending date order', async () => {

--- a/apps/api/src/routes/v1/dashboard-store.ts
+++ b/apps/api/src/routes/v1/dashboard-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, between, desc, eq, gte, lt, lte, sql } from 'drizzle-orm';
+import { and, asc, between, desc, eq, isNull, lte, sql } from 'drizzle-orm';
 
 import type {
   DashboardConfig,
@@ -84,17 +84,6 @@ const dashboardConfigSelection = {
 
 const activeHabitIdsSelection = {
   id: habits.id,
-};
-
-const getDateRangeForUtcDay = (date: string) => {
-  const start = new Date(`${date}T00:00:00.000Z`);
-  const end = new Date(start);
-  end.setUTCDate(end.getUTCDate() + 1);
-
-  return {
-    start: start.getTime(),
-    end: end.getTime(),
-  };
 };
 
 // TODO: Source this from user preferences once kg/lb switching is introduced.
@@ -208,14 +197,12 @@ const toDashboardTrendMetrics = (metrics: string[] | null | undefined): Dashboar
   return validMetrics.length > 0 ? validMetrics : [];
 };
 
-const toDashboardConfig = (
-  value: {
-    habitChainIds: string[] | null;
-    trendMetrics: string[] | null;
-    visibleWidgets: string[] | null;
-    widgetOrder: string[] | null;
-  },
-): DashboardConfig => {
+const toDashboardConfig = (value: {
+  habitChainIds: string[] | null;
+  trendMetrics: string[] | null;
+  visibleWidgets: string[] | null;
+  widgetOrder: string[] | null;
+}): DashboardConfig => {
   const parsed = dashboardConfigSchema.parse({
     habitChainIds: value.habitChainIds ?? [],
     trendMetrics: toDashboardTrendMetrics(value.trendMetrics),
@@ -230,8 +217,6 @@ export const getDashboardSnapshot = async (
   userId: string,
   date: string,
 ): Promise<DashboardSnapshot> => {
-  const dayRange = getDateRangeForUtcDay(date);
-
   const weight =
     db
       .select(weightSelection)
@@ -265,11 +250,11 @@ export const getDashboardSnapshot = async (
     .where(
       and(
         eq(workoutSessions.userId, userId),
-        gte(workoutSessions.startedAt, dayRange.start),
-        lt(workoutSessions.startedAt, dayRange.end),
+        isNull(workoutSessions.deletedAt),
+        eq(workoutSessions.date, date),
       ),
     )
-    .orderBy(desc(workoutSessions.startedAt))
+    .orderBy(desc(workoutSessions.completedAt), desc(workoutSessions.startedAt))
     .limit(1)
     .get();
 
@@ -360,6 +345,7 @@ export const getDashboardConsistencyTrend = async (
       and(
         eq(workoutSessions.userId, userId),
         eq(workoutSessions.status, 'completed'),
+        isNull(workoutSessions.deletedAt),
         between(workoutSessions.date, from, to),
       ),
     )

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -949,7 +949,25 @@ describe('workout session routes', () => {
     expect(inaccessibleExerciseResponse.json()).toEqual({
       error: {
         code: 'INVALID_SESSION_EXERCISE',
-        message: 'Session references one or more unavailable exercises',
+        message: 'Session references one or more unavailable exercises: user-2-private-row',
+      },
+    });
+
+    const missingExerciseResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions/session-active/sets',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        exerciseId: 'missing-exercise-id',
+        setNumber: 1,
+      },
+    });
+
+    expect(missingExerciseResponse.statusCode).toBe(400);
+    expect(missingExerciseResponse.json()).toEqual({
+      error: {
+        code: 'INVALID_SESSION_EXERCISE',
+        message: 'Session references one or more unavailable exercises: missing-exercise-id',
       },
     });
 

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -2502,6 +2502,54 @@ describe('workout session routes', () => {
     });
   });
 
+  it('allows patch updates without sets when existing session sets reference now-deleted exercises', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    seedExercise({
+      id: 'user-1-soft-delete-lift',
+      userId: 'user-1',
+      name: 'Temporary Lift',
+    });
+    seedWorkoutSession({
+      id: 'session-with-deleted-exercise',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      startedAt: 1000,
+    });
+    seedSessionSet({
+      id: 'set-soft-delete-lift',
+      sessionId: 'session-with-deleted-exercise',
+      exerciseId: 'user-1-soft-delete-lift',
+      setNumber: 1,
+      reps: 8,
+      section: 'main',
+    });
+    context.db
+      .update(exercises)
+      .set({ deletedAt: '2026-03-13T00:00:00.000Z' })
+      .where(eq(exercises.id, 'user-1-soft-delete-lift'))
+      .run();
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-sessions/session-with-deleted-exercise',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        status: 'completed',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        id: 'session-with-deleted-exercise',
+        status: 'completed',
+      }),
+    });
+  });
+
   it('rejects invalid list queries and malformed payloads', async () => {
     const authToken = context.app.jwt.sign({ userId: 'user-1' });
 

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -1310,6 +1310,50 @@ describe('workout session routes', () => {
     });
   });
 
+  it('includes sessions completed on the same-day range boundary', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    seedWorkoutSession({
+      id: 'session-yesterday',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Yesterday Session',
+      date: '2026-03-11',
+      status: 'completed',
+      startedAt: Date.parse('2026-03-11T23:55:00.000Z'),
+      completedAt: Date.parse('2026-03-11T23:58:00.000Z'),
+      duration: 3,
+    });
+    seedWorkoutSession({
+      id: 'session-today',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Today Session',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: Date.parse('2026-03-12T00:05:00.000Z'),
+      completedAt: Date.parse('2026-03-12T00:25:00.000Z'),
+      duration: 20,
+    });
+
+    const response = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/workout-sessions?status=completed&from=2026-03-12&to=2026-03-12',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: [
+        expect.objectContaining({
+          id: 'session-today',
+          date: '2026-03-12',
+          status: 'completed',
+        }),
+      ],
+    });
+  });
+
   it('filters workout session listings by multiple statuses', async () => {
     const authToken = context.app.jwt.sign({ userId: 'user-1' });
 

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -2480,7 +2480,7 @@ describe('workout session routes', () => {
     expect(unavailableExerciseResponse.json()).toEqual({
       error: {
         code: 'INVALID_SESSION_EXERCISE',
-        message: 'Session references one or more unavailable exercises',
+        message: 'Session references one or more unavailable exercises: user-2-private-row',
       },
     });
 

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -700,17 +700,19 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       }
     }
 
-    const invalidExerciseIds = await findInvalidSessionExerciseIds({
-      userId: request.userId,
-      exerciseIds: getReferencedExerciseIds(input.sets),
-    });
-    if (invalidExerciseIds.length > 0) {
-      return sendError(
-        reply,
-        400,
-        INVALID_SESSION_EXERCISE_RESPONSE.code,
-        buildInvalidExerciseMessage(invalidExerciseIds),
-      );
+    if (parsedBody.data.sets !== undefined) {
+      const invalidExerciseIds = await findInvalidSessionExerciseIds({
+        userId: request.userId,
+        exerciseIds: getReferencedExerciseIds(input.sets),
+      });
+      if (invalidExerciseIds.length > 0) {
+        return sendError(
+          reply,
+          400,
+          INVALID_SESSION_EXERCISE_RESPONSE.code,
+          buildInvalidExerciseMessage(invalidExerciseIds),
+        );
+      }
     }
 
     const session = await updateWorkoutSession({

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -26,6 +26,7 @@ import {
   createSessionSet,
   createWorkoutSession,
   deleteWorkoutSession,
+  findInvalidSessionExerciseIds,
   findWorkoutSessionAccess,
   findWorkoutSessionById,
   listSessionSetGroups,
@@ -107,6 +108,13 @@ const toCreateWorkoutSessionInput = (
 
 const getReferencedExerciseIds = (sets: CreateWorkoutSessionInput['sets']) =>
   sets.map((set) => set.exerciseId);
+
+const buildInvalidExerciseMessage = (invalidExerciseIds: string[]) => {
+  const dedupedIds = [...new Set(invalidExerciseIds)];
+  const preview = dedupedIds.slice(0, 3).join(', ');
+  const suffix = dedupedIds.length > 3 ? ', ...' : '';
+  return `${INVALID_SESSION_EXERCISE_RESPONSE.message}: ${preview}${suffix}`;
+};
 
 const applyExerciseNotesToSets = ({
   sets,
@@ -306,16 +314,16 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       return reply;
     }
 
-    const exerciseAccessible = await allSessionExercisesAccessible({
+    const invalidExerciseIds = await findInvalidSessionExerciseIds({
       userId: request.userId,
       exerciseIds: [parsedBody.data.exerciseId],
     });
-    if (!exerciseAccessible) {
+    if (invalidExerciseIds.length > 0) {
       return sendError(
         reply,
         400,
         INVALID_SESSION_EXERCISE_RESPONSE.code,
-        INVALID_SESSION_EXERCISE_RESPONSE.message,
+        buildInvalidExerciseMessage(invalidExerciseIds),
       );
     }
 
@@ -399,16 +407,16 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       return reply;
     }
 
-    const exercisesAccessible = await allSessionExercisesAccessible({
+    const invalidExerciseIds = await findInvalidSessionExerciseIds({
       userId: request.userId,
       exerciseIds: parsedBody.data.sets.map((set) => set.exerciseId),
     });
-    if (!exercisesAccessible) {
+    if (invalidExerciseIds.length > 0) {
       return sendError(
         reply,
         400,
         INVALID_SESSION_EXERCISE_RESPONSE.code,
-        INVALID_SESSION_EXERCISE_RESPONSE.message,
+        buildInvalidExerciseMessage(invalidExerciseIds),
       );
     }
 
@@ -694,16 +702,16 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       }
     }
 
-    const exercisesAccessible = await allSessionExercisesAccessible({
+    const invalidExerciseIds = await findInvalidSessionExerciseIds({
       userId: request.userId,
       exerciseIds: getReferencedExerciseIds(input.sets),
     });
-    if (!exercisesAccessible) {
+    if (invalidExerciseIds.length > 0) {
       return sendError(
         reply,
         400,
         INVALID_SESSION_EXERCISE_RESPONSE.code,
-        INVALID_SESSION_EXERCISE_RESPONSE.message,
+        buildInvalidExerciseMessage(invalidExerciseIds),
       );
     }
 

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -21,7 +21,6 @@ import { templateBelongsToUser } from '../workout-templates/template-access.js';
 import { linkTodayScheduledWorkoutToSession } from '../scheduled-workouts/store.js';
 
 import {
-  allSessionExercisesAccessible,
   batchUpsertSessionSets,
   createSessionSet,
   createWorkoutSession,
@@ -110,9 +109,8 @@ const getReferencedExerciseIds = (sets: CreateWorkoutSessionInput['sets']) =>
   sets.map((set) => set.exerciseId);
 
 const buildInvalidExerciseMessage = (invalidExerciseIds: string[]) => {
-  const dedupedIds = [...new Set(invalidExerciseIds)];
-  const preview = dedupedIds.slice(0, 3).join(', ');
-  const suffix = dedupedIds.length > 3 ? ', ...' : '';
+  const preview = invalidExerciseIds.slice(0, 3).join(', ');
+  const suffix = invalidExerciseIds.length > 3 ? ', ...' : '';
   return `${INVALID_SESSION_EXERCISE_RESPONSE.message}: ${preview}${suffix}`;
 };
 
@@ -242,16 +240,16 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       }
     }
 
-    const exercisesAccessible = await allSessionExercisesAccessible({
+    const invalidExerciseIds = await findInvalidSessionExerciseIds({
       userId: request.userId,
       exerciseIds: getReferencedExerciseIds(parsedBody.data.sets),
     });
-    if (!exercisesAccessible) {
+    if (invalidExerciseIds.length > 0) {
       return sendError(
         reply,
         400,
         INVALID_SESSION_EXERCISE_RESPONSE.code,
-        INVALID_SESSION_EXERCISE_RESPONSE.message,
+        buildInvalidExerciseMessage(invalidExerciseIds),
       );
     }
 

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -296,8 +296,19 @@ export const allSessionExercisesAccessible = async ({
   userId: string;
   exerciseIds: string[];
 }): Promise<boolean> => {
+  const invalidExerciseIds = await findInvalidSessionExerciseIds({ userId, exerciseIds });
+  return invalidExerciseIds.length === 0;
+};
+
+export const findInvalidSessionExerciseIds = async ({
+  userId,
+  exerciseIds,
+}: {
+  userId: string;
+  exerciseIds: string[];
+}): Promise<string[]> => {
   if (exerciseIds.length === 0) {
-    return true;
+    return [];
   }
 
   const uniqueIds = [...new Set(exerciseIds)];
@@ -309,16 +320,18 @@ export const allSessionExercisesAccessible = async ({
     .where(
       and(
         inArray(exercises.id, uniqueIds),
+        isNull(exercises.deletedAt),
         or(
           isNull(exercises.userId),
-          and(eq(exercises.userId, userId), isNull(exercises.deletedAt)),
+          eq(exercises.userId, userId),
         ),
       ),
     )
     .all()
     .map((exercise) => exercise.id);
 
-  return visibleExerciseIds.length === uniqueIds.length;
+  const visibleExerciseIdSet = new Set(visibleExerciseIds);
+  return uniqueIds.filter((exerciseId) => !visibleExerciseIdSet.has(exerciseId));
 };
 
 export class SessionSetNotFoundError extends Error {

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -289,17 +289,6 @@ const buildSessionSetRows = (sessionId: string, sets: CreateWorkoutSessionInput[
     notes: set.notes,
   }));
 
-export const allSessionExercisesAccessible = async ({
-  userId,
-  exerciseIds,
-}: {
-  userId: string;
-  exerciseIds: string[];
-}): Promise<boolean> => {
-  const invalidExerciseIds = await findInvalidSessionExerciseIds({ userId, exerciseIds });
-  return invalidExerciseIds.length === 0;
-};
-
 export const findInvalidSessionExerciseIds = async ({
   userId,
   exerciseIds,

--- a/apps/api/src/scripts/repair-workout-exercise-links.test.ts
+++ b/apps/api/src/scripts/repair-workout-exercise-links.test.ts
@@ -253,6 +253,55 @@ describe('repair-workout-exercise-links script', () => {
     expect(persisted).toEqual({ exerciseId: 'dry-run-link' });
   });
 
+  it('cleans up placeholder exercises when relink fails after placeholder creation', async () => {
+    context.sqlite.pragma('foreign_keys = OFF');
+    context.sqlite
+      .prepare(
+        `
+        insert into session_sets (
+          id, session_id, exercise_id, order_index, set_number, weight, reps, completed, skipped, section, notes
+        ) values ('set-fail', 'session-1', 'broken-link', 0, 1, null, 5, 0, 0, 'main', null)
+        `,
+      )
+      .run();
+    context.sqlite.pragma('foreign_keys = ON');
+
+    context.sqlite
+      .prepare(
+        `
+        create trigger if not exists fail_relink_on_set_fail
+        before update of exercise_id on session_sets
+        when old.id = 'set-fail'
+        begin
+          select raise(fail, 'forced relink failure');
+        end
+        `,
+      )
+      .run();
+
+    try {
+      const result = await repairWorkoutExerciseLinks({
+        userId: 'user-1',
+        dryRun: false,
+      });
+
+      expect(result.orphanCount).toBe(1);
+      expect(result.repairedCount).toBe(0);
+      expect(result.manualReviewCount).toBe(1);
+      expect(result.results[0]?.action).toBe('manual-review');
+      expect(result.results[0]?.note).toContain('Placeholder relink failed');
+
+      const placeholderExercises = context.db
+        .select({ id: exercises.id })
+        .from(exercises)
+        .where(eq(exercises.name, 'Broken Link'))
+        .all();
+      expect(placeholderExercises).toHaveLength(0);
+    } finally {
+      context.sqlite.prepare('drop trigger if exists fail_relink_on_set_fail').run();
+    }
+  });
+
   it('annotates cross-user references when relinking by name', async () => {
     context.db
       .insert(exercises)

--- a/apps/api/src/scripts/repair-workout-exercise-links.test.ts
+++ b/apps/api/src/scripts/repair-workout-exercise-links.test.ts
@@ -1,0 +1,246 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { eq } from 'drizzle-orm';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  exercises,
+  sessionSets,
+  templateExercises,
+  users,
+  workoutSessions,
+  workoutTemplates,
+} from '../db/schema/index.js';
+
+type DatabaseModule = typeof import('../db/index.js');
+
+type TestContext = {
+  db: DatabaseModule['db'];
+  sqlite: DatabaseModule['sqlite'];
+  tempDir: string;
+};
+
+let context: TestContext;
+let repairWorkoutExerciseLinks: typeof import('./repair-workout-exercise-links.js').repairWorkoutExerciseLinks;
+
+describe('repair-workout-exercise-links script', () => {
+  beforeAll(async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'pulse-repair-workout-links-'));
+    process.env.DATABASE_URL = join(tempDir, 'test.db');
+    vi.resetModules();
+
+    const [dbModule, scriptModule] = await Promise.all([
+      import('../db/index.js'),
+      import('./repair-workout-exercise-links.js'),
+    ]);
+
+    migrate(dbModule.db, {
+      migrationsFolder: fileURLToPath(new URL('../../drizzle', import.meta.url)),
+    });
+
+    context = {
+      db: dbModule.db,
+      sqlite: dbModule.sqlite,
+      tempDir,
+    };
+    repairWorkoutExerciseLinks = scriptModule.repairWorkoutExerciseLinks;
+  });
+
+  afterAll(() => {
+    if (context) {
+      context.sqlite.close();
+      rmSync(context.tempDir, { recursive: true, force: true });
+    }
+
+    delete process.env.DATABASE_URL;
+    vi.resetModules();
+  });
+
+  beforeEach(() => {
+    context.db.delete(sessionSets).run();
+    context.db.delete(workoutSessions).run();
+    context.db.delete(templateExercises).run();
+    context.db.delete(workoutTemplates).run();
+    context.db.delete(exercises).run();
+    context.db.delete(users).run();
+
+    context.db
+      .insert(users)
+      .values({
+        id: 'user-1',
+        username: 'derek',
+        name: 'Derek',
+        passwordHash: 'test',
+      })
+      .run();
+
+    context.db
+      .insert(workoutSessions)
+      .values({
+        id: 'session-1',
+        userId: 'user-1',
+        templateId: null,
+        name: 'Upper',
+        date: '2026-03-13',
+        status: 'completed',
+        startedAt: 1_700_000_000_000,
+        completedAt: 1_700_000_005_000,
+        duration: 300,
+        feedback: null,
+        notes: null,
+      })
+      .run();
+
+    context.db
+      .insert(workoutTemplates)
+      .values({
+        id: 'template-1',
+        userId: 'user-1',
+        name: 'Template',
+        description: null,
+        tags: [],
+      })
+      .run();
+  });
+
+  it('detects orphan links and repairs by restoring, relinking, or creating placeholders', async () => {
+    context.db
+      .insert(exercises)
+      .values({
+        id: 'deleted-owned',
+        userId: 'user-1',
+        name: 'Old Bench',
+        muscleGroups: ['chest'],
+        equipment: 'barbell',
+        category: 'compound',
+        trackingType: 'weight_reps',
+        tags: [],
+        formCues: [],
+        instructions: null,
+        deletedAt: '2026-03-01T00:00:00.000Z',
+      })
+      .run();
+    context.db
+      .insert(exercises)
+      .values({
+        id: 'ghost-press-match',
+        userId: 'user-1',
+        name: 'Ghost Press',
+        muscleGroups: ['chest'],
+        equipment: 'machine',
+        category: 'compound',
+        trackingType: 'weight_reps',
+        tags: [],
+        formCues: [],
+        instructions: null,
+      })
+      .run();
+
+    context.sqlite.pragma('foreign_keys = OFF');
+    context.sqlite
+      .prepare(
+        `
+        insert into session_sets (
+          id, session_id, exercise_id, order_index, set_number, weight, reps, completed, skipped, section, notes
+        ) values
+          ('set-restore', 'session-1', 'deleted-owned', 0, 1, null, 8, 0, 0, 'main', null),
+          ('set-placeholder', 'session-1', 'unknown-link', 1, 1, null, 10, 0, 0, 'main', null)
+        `,
+      )
+      .run();
+    context.sqlite
+      .prepare(
+        `
+        insert into template_exercises (
+          id, template_id, exercise_id, order_index, sets, reps_min, reps_max, tempo, rest_seconds, superset_group, section, notes, cues
+        ) values (
+          'template-relink', 'template-1', 'ghost-press', 0, 3, null, null, null, null, null, 'main', null, null
+        )
+        `,
+      )
+      .run();
+    context.sqlite.pragma('foreign_keys = ON');
+
+    const result = await repairWorkoutExerciseLinks({
+      userId: 'user-1',
+      dryRun: false,
+    });
+
+    expect(result.orphanCount).toBe(3);
+    expect(result.manualReviewCount).toBe(0);
+    expect(result.repairedCount).toBe(3);
+    expect(result.results.map((entry) => entry.action).sort()).toEqual([
+      'created-placeholder',
+      'relinked-by-name',
+      'restored-soft-deleted',
+    ]);
+
+    const restoredExercise = context.db
+      .select({ deletedAt: exercises.deletedAt })
+      .from(exercises)
+      .where(eq(exercises.id, 'deleted-owned'))
+      .get();
+    expect(restoredExercise).toEqual({ deletedAt: null });
+
+    const relinkedTemplateExercise = context.db
+      .select({ exerciseId: templateExercises.exerciseId })
+      .from(templateExercises)
+      .where(eq(templateExercises.id, 'template-relink'))
+      .get();
+    expect(relinkedTemplateExercise).toEqual({ exerciseId: 'ghost-press-match' });
+
+    const placeholderSessionSet = context.db
+      .select({ exerciseId: sessionSets.exerciseId })
+      .from(sessionSets)
+      .where(eq(sessionSets.id, 'set-placeholder'))
+      .get();
+    expect(placeholderSessionSet?.exerciseId).not.toBe('unknown-link');
+    expect(placeholderSessionSet?.exerciseId).toBeTruthy();
+
+    const placeholderExercise = context.db
+      .select({
+        userId: exercises.userId,
+        name: exercises.name,
+      })
+      .from(exercises)
+      .where(eq(exercises.id, placeholderSessionSet?.exerciseId ?? ''))
+      .get();
+    expect(placeholderExercise).toEqual({
+      userId: 'user-1',
+      name: 'Unknown Link',
+    });
+  });
+
+  it('supports dry-run mode without persisting repairs', async () => {
+    context.sqlite.pragma('foreign_keys = OFF');
+    context.sqlite
+      .prepare(
+        `
+        insert into session_sets (
+          id, session_id, exercise_id, order_index, set_number, weight, reps, completed, skipped, section, notes
+        ) values ('set-dry', 'session-1', 'dry-run-link', 0, 1, null, 5, 0, 0, 'main', null)
+        `,
+      )
+      .run();
+    context.sqlite.pragma('foreign_keys = ON');
+
+    const dryRunResult = await repairWorkoutExerciseLinks({
+      userId: 'user-1',
+      dryRun: true,
+    });
+
+    expect(dryRunResult.orphanCount).toBe(1);
+    expect(dryRunResult.repairedCount).toBe(1);
+
+    const persisted = context.db
+      .select({ exerciseId: sessionSets.exerciseId })
+      .from(sessionSets)
+      .where(eq(sessionSets.id, 'set-dry'))
+      .get();
+    expect(persisted).toEqual({ exerciseId: 'dry-run-link' });
+  });
+});

--- a/apps/api/src/scripts/repair-workout-exercise-links.test.ts
+++ b/apps/api/src/scripts/repair-workout-exercise-links.test.ts
@@ -77,6 +77,15 @@ describe('repair-workout-exercise-links script', () => {
         passwordHash: 'test',
       })
       .run();
+    context.db
+      .insert(users)
+      .values({
+        id: 'user-2',
+        username: 'alex',
+        name: 'Alex',
+        passwordHash: 'test',
+      })
+      .run();
 
     context.db
       .insert(workoutSessions)
@@ -242,5 +251,78 @@ describe('repair-workout-exercise-links script', () => {
       .where(eq(sessionSets.id, 'set-dry'))
       .get();
     expect(persisted).toEqual({ exerciseId: 'dry-run-link' });
+  });
+
+  it('annotates cross-user references when relinking by name', async () => {
+    context.db
+      .insert(exercises)
+      .values({
+        id: 'cross-user-source',
+        userId: 'user-2',
+        name: 'Shared Name Curl',
+        muscleGroups: ['biceps'],
+        equipment: 'dumbbell',
+        category: 'isolation',
+        trackingType: 'weight_reps',
+        tags: [],
+        formCues: [],
+        instructions: null,
+      })
+      .run();
+    context.db
+      .insert(exercises)
+      .values({
+        id: 'owner-candidate',
+        userId: 'user-1',
+        name: 'Shared Name Curl',
+        muscleGroups: ['biceps'],
+        equipment: 'dumbbell',
+        category: 'isolation',
+        trackingType: 'weight_reps',
+        tags: [],
+        formCues: [],
+        instructions: null,
+      })
+      .run();
+
+    context.db
+      .insert(sessionSets)
+      .values({
+        id: 'set-cross-user',
+        sessionId: 'session-1',
+        exerciseId: 'cross-user-source',
+        orderIndex: 0,
+        setNumber: 1,
+        weight: 30,
+        reps: 10,
+        completed: false,
+        skipped: false,
+        section: 'main',
+        notes: null,
+      })
+      .run();
+
+    const result = await repairWorkoutExerciseLinks({
+      userId: 'user-1',
+      dryRun: false,
+    });
+
+    expect(result.orphanCount).toBe(1);
+    expect(result.repairedCount).toBe(1);
+    expect(result.results[0]).toMatchObject({
+      source: 'session_sets',
+      rowId: 'set-cross-user',
+      action: 'relinked-by-name',
+      previousExerciseId: 'cross-user-source',
+      nextExerciseId: 'owner-candidate',
+    });
+    expect(result.results[0]?.note).toContain('Cross-user reference detected');
+
+    const repaired = context.db
+      .select({ exerciseId: sessionSets.exerciseId })
+      .from(sessionSets)
+      .where(eq(sessionSets.id, 'set-cross-user'))
+      .get();
+    expect(repaired).toEqual({ exerciseId: 'owner-candidate' });
   });
 });

--- a/apps/api/src/scripts/repair-workout-exercise-links.ts
+++ b/apps/api/src/scripts/repair-workout-exercise-links.ts
@@ -144,6 +144,8 @@ const listOrphanRows = (userId: string | null): OrphanLinkRow[] => {
         )
       `,
     )
+    // Positional bindings:
+    // 1-2 => session_sets user filter, 3-4 => template_exercises user filter.
     .all(userId, userId, userId, userId) as Array<{
     source: LinkSource;
     row_id: string;
@@ -267,6 +269,7 @@ const createPlaceholderExercise = ({
       ) values (?, ?, ?, json('[]'), 'unknown', 'compound', 'weight_reps', json('[]'), json('[]'), null)
       `,
     )
+    // Use 'compound' as a neutral fallback for unknown legacy exercises.
     .run(id, ownerUserId, exerciseName);
 
   return id;
@@ -276,15 +279,18 @@ export const repairWorkoutExerciseLinks = async (
   options: RepairWorkoutExerciseLinksOptions,
   logger: Logger = console,
 ): Promise<RepairWorkoutExerciseLinksResult> => {
-  const orphanRows = listOrphanRows(options.userId);
-  const results: RepairResultRow[] = [];
-
   if (options.dryRun) {
     sqlite.exec('BEGIN');
   }
 
+  const results: RepairResultRow[] = [];
+
   try {
+    const orphanRows = listOrphanRows(options.userId);
+
     for (const row of orphanRows) {
+      const crossUserReference =
+        row.exerciseUserId !== null && row.exerciseUserId !== row.ownerUserId;
       const canRestoreOriginal =
         row.exerciseDeletedAt !== null &&
         (row.exerciseUserId === null || row.exerciseUserId === row.ownerUserId);
@@ -330,7 +336,9 @@ export const repairWorkoutExerciseLinks = async (
             previousExerciseId: row.exerciseId,
             nextExerciseId: candidate.id,
             action: 'relinked-by-name',
-            note: 'Relinked by exercise name match.',
+            note: crossUserReference
+              ? 'Cross-user reference detected; relinked by exercise name match for owner scope.'
+              : 'Relinked by exercise name match.',
           });
         } catch (error) {
           results.push({
@@ -364,7 +372,9 @@ export const repairWorkoutExerciseLinks = async (
           previousExerciseId: row.exerciseId,
           nextExerciseId: placeholderId,
           action: 'created-placeholder',
-          note: 'Created placeholder exercise and relinked orphan row.',
+          note: crossUserReference
+            ? 'Cross-user reference detected; created owner-scoped placeholder and relinked orphan row.'
+            : 'Created placeholder exercise and relinked orphan row.',
         });
       } catch (error) {
         results.push({

--- a/apps/api/src/scripts/repair-workout-exercise-links.ts
+++ b/apps/api/src/scripts/repair-workout-exercise-links.ts
@@ -1,7 +1,16 @@
 import { randomUUID } from 'node:crypto';
 import { pathToFileURL } from 'node:url';
 
-import { sqlite } from '../db/index.js';
+import { and, eq, isNotNull, isNull, ne, or, sql } from 'drizzle-orm';
+
+import { db, sqlite } from '../db/index.js';
+import {
+  exercises,
+  sessionSets,
+  templateExercises,
+  workoutSessions,
+  workoutTemplates,
+} from '../db/schema/index.js';
 
 type Logger = Pick<Console, 'info' | 'warn' | 'error'>;
 
@@ -102,60 +111,57 @@ const parseCliArgs = (args: string[]): RepairWorkoutExerciseLinksOptions => {
 };
 
 const listOrphanRows = (userId: string | null): OrphanLinkRow[] => {
-  const rows = sqlite
-    .prepare(
-      `
-      select
-        'session_sets' as source,
-        ss.id as row_id,
-        ss.session_id as owner_id,
-        ws.user_id as owner_user_id,
-        ss.exercise_id as exercise_id,
-        e.user_id as exercise_user_id,
-        e.deleted_at as exercise_deleted_at,
-        e.name as exercise_name
-      from session_sets ss
-      inner join workout_sessions ws on ws.id = ss.session_id
-      left join exercises e on e.id = ss.exercise_id
-      where (? is null or ws.user_id = ?)
-        and (
-          e.id is null
-          or e.deleted_at is not null
-          or (e.user_id is not null and e.user_id != ws.user_id)
-        )
-      union all
-      select
-        'template_exercises' as source,
-        te.id as row_id,
-        te.template_id as owner_id,
-        wt.user_id as owner_user_id,
-        te.exercise_id as exercise_id,
-        e.user_id as exercise_user_id,
-        e.deleted_at as exercise_deleted_at,
-        e.name as exercise_name
-      from template_exercises te
-      inner join workout_templates wt on wt.id = te.template_id
-      left join exercises e on e.id = te.exercise_id
-      where (? is null or wt.user_id = ?)
-        and (
-          e.id is null
-          or e.deleted_at is not null
-          or (e.user_id is not null and e.user_id != wt.user_id)
-        )
-      `,
-    )
-    // Positional bindings:
-    // 1-2 => session_sets user filter, 3-4 => template_exercises user filter.
-    .all(userId, userId, userId, userId) as Array<{
-    source: LinkSource;
-    row_id: string;
-    owner_id: string;
-    owner_user_id: string;
-    exercise_id: string;
-    exercise_user_id: string | null;
-    exercise_deleted_at: string | null;
-    exercise_name: string | null;
-  }>;
+  const sessionSetOrphans = db
+    .select({
+      source: sql<LinkSource>`'session_sets'`.as('source'),
+      row_id: sessionSets.id,
+      owner_id: sessionSets.sessionId,
+      owner_user_id: workoutSessions.userId,
+      exercise_id: sessionSets.exerciseId,
+      exercise_user_id: exercises.userId,
+      exercise_deleted_at: exercises.deletedAt,
+      exercise_name: exercises.name,
+    })
+    .from(sessionSets)
+    .innerJoin(workoutSessions, eq(workoutSessions.id, sessionSets.sessionId))
+    .leftJoin(exercises, eq(exercises.id, sessionSets.exerciseId))
+    .where(
+      and(
+        userId ? eq(workoutSessions.userId, userId) : undefined,
+        or(
+          isNull(exercises.id),
+          isNotNull(exercises.deletedAt),
+          and(isNotNull(exercises.userId), ne(exercises.userId, workoutSessions.userId)),
+        ),
+      ),
+    );
+
+  const templateExerciseOrphans = db
+    .select({
+      source: sql<LinkSource>`'template_exercises'`.as('source'),
+      row_id: templateExercises.id,
+      owner_id: templateExercises.templateId,
+      owner_user_id: workoutTemplates.userId,
+      exercise_id: templateExercises.exerciseId,
+      exercise_user_id: exercises.userId,
+      exercise_deleted_at: exercises.deletedAt,
+      exercise_name: exercises.name,
+    })
+    .from(templateExercises)
+    .innerJoin(workoutTemplates, eq(workoutTemplates.id, templateExercises.templateId))
+    .leftJoin(exercises, eq(exercises.id, templateExercises.exerciseId))
+    .where(
+      and(
+        userId ? eq(workoutTemplates.userId, userId) : undefined,
+        or(
+          isNull(exercises.id),
+          isNotNull(exercises.deletedAt),
+          and(isNotNull(exercises.userId), ne(exercises.userId, workoutTemplates.userId)),
+        ),
+      ),
+    );
+
+  const rows = sessionSetOrphans.unionAll(templateExerciseOrphans).all();
 
   return rows.map((row) => ({
     source: row.source,
@@ -377,6 +383,16 @@ export const repairWorkoutExerciseLinks = async (
             : 'Created placeholder exercise and relinked orphan row.',
         });
       } catch (error) {
+        // Best effort cleanup: don't leave a newly created placeholder orphaned
+        // when the follow-up relink fails.
+        sqlite
+          .prepare(
+            `
+            delete from exercises
+            where id = ?
+            `,
+          )
+          .run(placeholderId);
         results.push({
           source: row.source,
           rowId: row.rowId,

--- a/apps/api/src/scripts/repair-workout-exercise-links.ts
+++ b/apps/api/src/scripts/repair-workout-exercise-links.ts
@@ -1,0 +1,433 @@
+import { randomUUID } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
+
+import { sqlite } from '../db/index.js';
+
+type Logger = Pick<Console, 'info' | 'warn' | 'error'>;
+
+type LinkSource = 'session_sets' | 'template_exercises';
+
+type OrphanLinkRow = {
+  source: LinkSource;
+  rowId: string;
+  ownerId: string;
+  ownerUserId: string;
+  exerciseId: string;
+  exerciseUserId: string | null;
+  exerciseDeletedAt: string | null;
+  exerciseName: string | null;
+};
+
+type RepairAction = 'restored-soft-deleted' | 'relinked-by-name' | 'created-placeholder' | 'manual-review';
+
+type RepairResultRow = {
+  source: LinkSource;
+  rowId: string;
+  ownerUserId: string;
+  previousExerciseId: string;
+  nextExerciseId: string;
+  action: RepairAction;
+  note: string;
+};
+
+export type RepairWorkoutExerciseLinksOptions = {
+  userId: string | null;
+  dryRun: boolean;
+};
+
+export type RepairWorkoutExerciseLinksResult = {
+  dryRun: boolean;
+  orphanCount: number;
+  repairedCount: number;
+  manualReviewCount: number;
+  results: RepairResultRow[];
+};
+
+const usage =
+  'Usage: npx tsx src/scripts/repair-workout-exercise-links.ts [--user <userId>] [--dry-run]';
+
+const toTitleCase = (value: string): string =>
+  value
+    .split(' ')
+    .filter((part) => part.length > 0)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+const deriveExerciseNameFromId = (exerciseId: string): string => {
+  const normalized = exerciseId
+    .trim()
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (normalized.length === 0) {
+    return 'Recovered Exercise';
+  }
+
+  return toTitleCase(normalized);
+};
+
+const normalizedName = (name: string) => name.trim().toLowerCase();
+
+const parseCliArgs = (args: string[]): RepairWorkoutExerciseLinksOptions => {
+  let userId: string | null = null;
+  let dryRun = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const current = args[index];
+
+    if (current === '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+
+    if (current === '--user') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('--')) {
+        throw new Error(`Missing value for --user. ${usage}`);
+      }
+
+      userId = next;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${current}. ${usage}`);
+  }
+
+  return {
+    userId,
+    dryRun,
+  };
+};
+
+const listOrphanRows = (userId: string | null): OrphanLinkRow[] => {
+  const rows = sqlite
+    .prepare(
+      `
+      select
+        'session_sets' as source,
+        ss.id as row_id,
+        ss.session_id as owner_id,
+        ws.user_id as owner_user_id,
+        ss.exercise_id as exercise_id,
+        e.user_id as exercise_user_id,
+        e.deleted_at as exercise_deleted_at,
+        e.name as exercise_name
+      from session_sets ss
+      inner join workout_sessions ws on ws.id = ss.session_id
+      left join exercises e on e.id = ss.exercise_id
+      where (? is null or ws.user_id = ?)
+        and (
+          e.id is null
+          or e.deleted_at is not null
+          or (e.user_id is not null and e.user_id != ws.user_id)
+        )
+      union all
+      select
+        'template_exercises' as source,
+        te.id as row_id,
+        te.template_id as owner_id,
+        wt.user_id as owner_user_id,
+        te.exercise_id as exercise_id,
+        e.user_id as exercise_user_id,
+        e.deleted_at as exercise_deleted_at,
+        e.name as exercise_name
+      from template_exercises te
+      inner join workout_templates wt on wt.id = te.template_id
+      left join exercises e on e.id = te.exercise_id
+      where (? is null or wt.user_id = ?)
+        and (
+          e.id is null
+          or e.deleted_at is not null
+          or (e.user_id is not null and e.user_id != wt.user_id)
+        )
+      `,
+    )
+    .all(userId, userId, userId, userId) as Array<{
+    source: LinkSource;
+    row_id: string;
+    owner_id: string;
+    owner_user_id: string;
+    exercise_id: string;
+    exercise_user_id: string | null;
+    exercise_deleted_at: string | null;
+    exercise_name: string | null;
+  }>;
+
+  return rows.map((row) => ({
+    source: row.source,
+    rowId: row.row_id,
+    ownerId: row.owner_id,
+    ownerUserId: row.owner_user_id,
+    exerciseId: row.exercise_id,
+    exerciseUserId: row.exercise_user_id,
+    exerciseDeletedAt: row.exercise_deleted_at,
+    exerciseName: row.exercise_name,
+  }));
+};
+
+const restoreExercise = (exerciseId: string) => {
+  sqlite
+    .prepare(
+      `
+      update exercises
+      set deleted_at = null
+      where id = ?
+      `,
+    )
+    .run(exerciseId);
+};
+
+const relinkRow = ({ source, rowId, nextExerciseId }: { source: LinkSource; rowId: string; nextExerciseId: string }) => {
+  if (source === 'session_sets') {
+    sqlite
+      .prepare(
+        `
+        update session_sets
+        set exercise_id = ?
+        where id = ?
+        `,
+      )
+      .run(nextExerciseId, rowId);
+    return;
+  }
+
+  sqlite
+    .prepare(
+      `
+      update template_exercises
+      set exercise_id = ?
+      where id = ?
+      `,
+    )
+    .run(nextExerciseId, rowId);
+};
+
+const findCandidateByName = ({
+  name,
+  ownerUserId,
+}: {
+  name: string;
+  ownerUserId: string;
+}): { id: string; deletedAt: string | null } | undefined => {
+  const candidate = sqlite
+    .prepare(
+      `
+      select id, deleted_at
+      from exercises
+      where lower(trim(name)) = ?
+        and (user_id is null or user_id = ?)
+      order by
+        case when user_id = ? then 0 else 1 end,
+        case when deleted_at is null then 0 else 1 end
+      limit 1
+      `,
+    )
+    .get(normalizedName(name), ownerUserId, ownerUserId) as
+    | {
+        id: string;
+        deleted_at: string | null;
+      }
+    | undefined;
+
+  if (!candidate) {
+    return undefined;
+  }
+
+  return {
+    id: candidate.id,
+    deletedAt: candidate.deleted_at,
+  };
+};
+
+const createPlaceholderExercise = ({
+  ownerUserId,
+  exerciseName,
+}: {
+  ownerUserId: string;
+  exerciseName: string;
+}): string => {
+  const id = randomUUID();
+
+  sqlite
+    .prepare(
+      `
+      insert into exercises (
+        id,
+        user_id,
+        name,
+        muscle_groups,
+        equipment,
+        category,
+        tracking_type,
+        tags,
+        form_cues,
+        instructions
+      ) values (?, ?, ?, json('[]'), 'unknown', 'compound', 'weight_reps', json('[]'), json('[]'), null)
+      `,
+    )
+    .run(id, ownerUserId, exerciseName);
+
+  return id;
+};
+
+export const repairWorkoutExerciseLinks = async (
+  options: RepairWorkoutExerciseLinksOptions,
+  logger: Logger = console,
+): Promise<RepairWorkoutExerciseLinksResult> => {
+  const orphanRows = listOrphanRows(options.userId);
+  const results: RepairResultRow[] = [];
+
+  if (options.dryRun) {
+    sqlite.exec('BEGIN');
+  }
+
+  try {
+    for (const row of orphanRows) {
+      const canRestoreOriginal =
+        row.exerciseDeletedAt !== null &&
+        (row.exerciseUserId === null || row.exerciseUserId === row.ownerUserId);
+
+      if (canRestoreOriginal) {
+        restoreExercise(row.exerciseId);
+        results.push({
+          source: row.source,
+          rowId: row.rowId,
+          ownerUserId: row.ownerUserId,
+          previousExerciseId: row.exerciseId,
+          nextExerciseId: row.exerciseId,
+          action: 'restored-soft-deleted',
+          note: 'Restored soft-deleted exercise referenced by workout row.',
+        });
+        continue;
+      }
+
+      const nameHint =
+        row.exerciseName && row.exerciseName.trim().length > 0
+          ? row.exerciseName
+          : deriveExerciseNameFromId(row.exerciseId);
+      const candidate = findCandidateByName({
+        name: nameHint,
+        ownerUserId: row.ownerUserId,
+      });
+
+      if (candidate) {
+        if (candidate.deletedAt !== null) {
+          restoreExercise(candidate.id);
+        }
+
+        try {
+          relinkRow({
+            source: row.source,
+            rowId: row.rowId,
+            nextExerciseId: candidate.id,
+          });
+          results.push({
+            source: row.source,
+            rowId: row.rowId,
+            ownerUserId: row.ownerUserId,
+            previousExerciseId: row.exerciseId,
+            nextExerciseId: candidate.id,
+            action: 'relinked-by-name',
+            note: 'Relinked by exercise name match.',
+          });
+        } catch (error) {
+          results.push({
+            source: row.source,
+            rowId: row.rowId,
+            ownerUserId: row.ownerUserId,
+            previousExerciseId: row.exerciseId,
+            nextExerciseId: row.exerciseId,
+            action: 'manual-review',
+            note: `Relink failed and requires manual review: ${String(error)}`,
+          });
+        }
+        continue;
+      }
+
+      const placeholderId = createPlaceholderExercise({
+        ownerUserId: row.ownerUserId,
+        exerciseName: nameHint,
+      });
+
+      try {
+        relinkRow({
+          source: row.source,
+          rowId: row.rowId,
+          nextExerciseId: placeholderId,
+        });
+        results.push({
+          source: row.source,
+          rowId: row.rowId,
+          ownerUserId: row.ownerUserId,
+          previousExerciseId: row.exerciseId,
+          nextExerciseId: placeholderId,
+          action: 'created-placeholder',
+          note: 'Created placeholder exercise and relinked orphan row.',
+        });
+      } catch (error) {
+        results.push({
+          source: row.source,
+          rowId: row.rowId,
+          ownerUserId: row.ownerUserId,
+          previousExerciseId: row.exerciseId,
+          nextExerciseId: row.exerciseId,
+          action: 'manual-review',
+          note: `Placeholder relink failed and requires manual review: ${String(error)}`,
+        });
+      }
+    }
+
+    if (options.dryRun) {
+      sqlite.exec('ROLLBACK');
+    }
+
+    const summary = {
+      dryRun: options.dryRun,
+      orphanCount: orphanRows.length,
+      repairedCount: results.filter((result) => result.action !== 'manual-review').length,
+      manualReviewCount: results.filter((result) => result.action === 'manual-review').length,
+      results,
+    };
+
+    logger.info(
+      `Workout exercise link repair complete: ${summary.orphanCount} orphan rows, ${summary.repairedCount} repaired, ${summary.manualReviewCount} manual review.`,
+    );
+
+    return summary;
+  } catch (error) {
+    if (options.dryRun) {
+      sqlite.exec('ROLLBACK');
+    }
+    throw error;
+  }
+};
+
+const runCli = async () => {
+  const options = parseCliArgs(process.argv.slice(2));
+  const result = await repairWorkoutExerciseLinks(options, console);
+
+  if (result.results.length > 0) {
+    for (const row of result.results) {
+      console.info(
+        `[${row.source}] row=${row.rowId} user=${row.ownerUserId} ${row.previousExerciseId} -> ${row.nextExerciseId} (${row.action})`,
+      );
+    }
+  }
+};
+
+const isMainModule = () => {
+  if (!process.argv[1]) {
+    return false;
+  }
+
+  return import.meta.url === pathToFileURL(process.argv[1]).href;
+};
+
+if (isMainModule()) {
+  runCli().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
This PR fixes two data-integrity gaps in workout tracking: same-day completed sessions were being dropped in some history lookups, and session/template rows could reference invalid exercises. History queries were standardized to rely on `workout_sessions.date` (with soft-delete guards) so sessions completed on the selected day appear immediately and consistently. Exercise reference validation was tightened during session/set creation and updates, and API errors now report which exercise IDs are invalid. A new repair script was also added to detect and remediate legacy orphaned workout-to-exercise links so existing data can be brought back into a valid state.

## Key Changes
- Updated dashboard workout snapshot query to filter by local workout `date` (not UTC `startedAt` windows), and order by completion/start timestamps for deterministic “latest workout” selection.
- Updated workout history behavior/tests to include sessions completed on same-day range boundaries.
- Added `deletedAt` protections to workout aggregations (including consistency trend) so deleted sessions are excluded.
- Replaced boolean exercise-access checks with `findInvalidSessionExerciseIds`, and enforced this across session creation and set mutation routes.
- Improved `INVALID_SESSION_EXERCISE` responses to include a preview of offending exercise IDs.
- Expanded exercise visibility logic to include soft-deleted user exercises when they are still referenced by session history or template links, including filters endpoint parity.
- Added `repair-workout-exercise-links` script (+ tests) to scan `session_sets` and `template_exercises` for orphan/cross-user/deleted exercise links and repair via:
  - restore soft-deleted owned exercise,
  - relink by name to owner-visible candidate,
  - create owner-scoped placeholder exercise when no match exists,
  - optional `--dry-run` support.

## Technical Notes
- The key behavior change is date semantics: history/dashboard queries now anchor to `workout_sessions.date` rather than deriving UTC day ranges from timestamps, which avoids boundary misses for same-day completions.
- Validation now returns concrete invalid IDs, which improves debugging but intentionally surfaces identifier details in 400 responses for authenticated callers.
- Exercise listing/filter queries became more permissive for deleted user exercises only when they are still actively referenced; this preserves historical/template integrity without fully restoring deleted rows.
- The repair script is transactional for dry runs (`BEGIN`/`ROLLBACK`) and records per-row actions, making it suitable for safe audits before applying fixes.

## Commits

- `9433304 fix(api): address commit-24 review findings`
- `04c9601 fix(api): enforce workout exercise linkage integrity`
- `b4b4fdf fix(api): include same-day completed workouts across history queries`

## Tasks

- **Full history audit — fix same-day completed sessions**: Audit and fix all date-bounded history queries so same-day completed sessions appear immediately
- **Enforce exercise linkage integrity**: Add exerciseId validation on session set creation, migration to detect/repair orphan exercises

## Diff Stats

```
apps/api/src/__tests__/agent.test.ts               |   1 -
 apps/api/src/routes/agent/workouts.test.ts         |   1 -
 apps/api/src/routes/exercises/index.test.ts        | 159 ++++++++
 apps/api/src/routes/exercises/store.ts             |  46 ++-
 apps/api/src/routes/v1/dashboard-store.test.ts     |  23 +-
 apps/api/src/routes/v1/dashboard-store.ts          |  36 +-
 apps/api/src/routes/workout-sessions/index.test.ts |  66 ++-
 apps/api/src/routes/workout-sessions/index.ts      |  32 +-
 apps/api/src/routes/workout-sessions/store.ts      |  12 +-
 .../scripts/repair-workout-exercise-links.test.ts  | 328 +++++++++++++++
 .../src/scripts/repair-workout-exercise-links.ts   | 443 +++++++++++++++++++++
 11 files changed, 1093 insertions(+), 54 deletions(-)
```