### PR TITLE
feat: workout calendar and list redesign

### DIFF
--- a/.agents/skills/pulse-app-usage/SKILL.md
+++ b/.agents/skills/pulse-app-usage/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: pulse-app-usage
+description: Pulse app API usage patterns for workout, habit, and nutrition agent workflows
+---
+
 # Pulse App Usage Skill
 
 ## Workout Workflow

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -392,9 +392,9 @@ export function useWorkoutSessions(
   });
 }
 
-export function useWorkoutTemplate(id: string) {
+export function useWorkoutTemplate(id: string, options?: { enabled?: boolean }) {
   return useQuery<WorkoutTemplate>({
-    enabled: id.trim().length > 0,
+    enabled: (options?.enabled ?? true) && id.trim().length > 0,
     queryFn: ({ signal }) => getWorkoutTemplate(id, signal),
     queryKey: workoutQueryKeys.template(id),
   });

--- a/apps/web/src/features/workouts/components/template-browser.test.tsx
+++ b/apps/web/src/features/workouts/components/template-browser.test.tsx
@@ -1,8 +1,10 @@
 import type { MouseEvent, ReactNode } from 'react';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
+import { jsonResponse } from '@/test/test-utils';
 import { TemplateBrowser } from './template-browser';
 
 const renameMutateMock = vi.fn();
@@ -43,9 +45,28 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
 
 describe('TemplateBrowser', () => {
   beforeEach(() => {
+    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
     renameMutateMock.mockReset();
     deleteMutateMock.mockReset().mockResolvedValue({ id: 'template-1' });
     scheduleMutateAsyncMock.mockReset();
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/workout-sessions') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (url.pathname === '/api/v1/scheduled-workouts') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+  });
+
+  afterEach(() => {
+    window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
+    vi.restoreAllMocks();
   });
 
   it('renders updated copy and empty state for users without templates', () => {
@@ -195,10 +216,81 @@ describe('TemplateBrowser', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Schedule workout' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Schedule' }));
 
-    expect(scheduleMutateAsyncMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        templateId: 'template-1',
-      }),
+    await waitFor(() => {
+      expect(scheduleMutateAsyncMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          templateId: 'template-1',
+        }),
+      );
+    });
+  });
+
+  it('warns before scheduling another workout on an occupied day', async () => {
+    scheduleMutateAsyncMock.mockResolvedValue({});
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/workout-sessions') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'session-1',
+                name: 'Upper Push',
+                date: '2026-03-13',
+                status: 'completed',
+                templateId: 'template-1',
+                templateName: 'Upper Push',
+                startedAt: Date.parse('2026-03-13T10:00:00Z'),
+                completedAt: Date.parse('2026-03-13T11:00:00Z'),
+                duration: 60,
+                exerciseCount: 5,
+                createdAt: 1,
+              },
+            ],
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/scheduled-workouts') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/workouts?date=2026-03-13']}>
+        <TemplateBrowser
+          buildTemplateHref={(templateId) => `/workouts/template/${templateId}`}
+          templates={[
+            {
+              id: 'template-1',
+              name: 'Upper Push',
+              description: 'Chest and shoulders',
+              tags: ['push'],
+              sections: [{ exercises: [] }],
+            },
+          ]}
+        />
+      </MemoryRouter>,
     );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Template actions for Upper Push' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Schedule workout' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Schedule' }));
+
+    const dialog = await screen.findByRole('alertdialog');
+    expect(within(dialog).getByText('This day already has a workout')).toBeInTheDocument();
+    expect(within(dialog).getByText(/Upper Push \(completed\)/)).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Create another anyway' }));
+
+    await waitFor(() => {
+      expect(scheduleMutateAsyncMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          templateId: 'template-1',
+        }),
+      );
+    });
   });
 });

--- a/apps/web/src/features/workouts/components/template-browser.tsx
+++ b/apps/web/src/features/workouts/components/template-browser.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { ArrowRight, ListChecks, MoreVertical, Search, Tag } from 'lucide-react';
-import { Link } from 'react-router';
+import { Link, useSearchParams } from 'react-router';
 import { toast } from 'sonner';
 
 import { Badge } from '@/components/ui/badge';
@@ -31,6 +31,10 @@ import { toDateKey } from '@/lib/date-utils';
 import { ApiError } from '@/lib/api-client';
 import { cn } from '@/lib/utils';
 import { ScheduleWorkoutDialog } from '@/features/workouts/components/schedule-workout-dialog';
+import {
+  formatWorkoutConflictDescription,
+  getDayWorkoutConflicts,
+} from '@/features/workouts/lib/day-workout-conflicts';
 
 // Minimal structural interface — satisfied by both mock and API WorkoutTemplate shapes.
 interface TemplateSummary {
@@ -52,6 +56,7 @@ export function TemplateBrowser({
   className,
   templates = [],
 }: TemplateBrowserProps) {
+  const [searchParams] = useSearchParams();
   const { confirm, dialog } = useConfirmation();
   const [searchQuery, setSearchQuery] = useState('');
   const [renameTarget, setRenameTarget] = useState<{ id: string; name: string } | null>(null);
@@ -60,6 +65,11 @@ export function TemplateBrowser({
   const renameTemplateMutation = useRenameTemplate();
   const deleteTemplateMutation = useDeleteTemplate();
   const scheduleWorkoutMutation = useScheduleWorkout();
+  const requestedDate = searchParams.get('date');
+  const scheduleInitialDate =
+    requestedDate != null && /^\\d{4}-\\d{2}-\\d{2}$/.test(requestedDate)
+      ? requestedDate
+      : toDateKey(new Date());
   const normalizedQuery = searchQuery.trim().toLowerCase();
 
   const filteredTemplates = useMemo(
@@ -96,6 +106,26 @@ export function TemplateBrowser({
       toast.error(message);
       throw error;
     }
+  }
+
+  async function confirmDuplicateDayWorkouts(dateKey: string) {
+    const conflicts = await getDayWorkoutConflicts(dateKey);
+
+    if (conflicts.length === 0) {
+      return true;
+    }
+
+    return await new Promise<boolean>((resolve) => {
+      confirm({
+        title: 'This day already has a workout',
+        description: formatWorkoutConflictDescription(conflicts),
+        cancelLabel: 'Cancel',
+        confirmLabel: 'Create another anyway',
+        variant: 'default',
+        onConfirm: () => resolve(true),
+        onCancel: () => resolve(false),
+      });
+    });
   }
 
   return (
@@ -303,7 +333,7 @@ export function TemplateBrowser({
       {dialog}
       <ScheduleWorkoutDialog
         description={`Pick a date for ${scheduleTarget?.name ?? 'this workout'}.`}
-        initialDate={toDateKey(new Date())}
+        initialDate={scheduleInitialDate}
         isPending={scheduleWorkoutMutation.isPending}
         onOpenChange={(open) => {
           if (!open) {
@@ -312,6 +342,11 @@ export function TemplateBrowser({
         }}
         onSubmitDate={async (date) => {
           if (!scheduleTarget) {
+            return;
+          }
+
+          const shouldCreateAnother = await confirmDuplicateDayWorkouts(date);
+          if (!shouldCreateAnother) {
             return;
           }
 

--- a/apps/web/src/features/workouts/components/template-browser.tsx
+++ b/apps/web/src/features/workouts/components/template-browser.tsx
@@ -67,7 +67,7 @@ export function TemplateBrowser({
   const scheduleWorkoutMutation = useScheduleWorkout();
   const requestedDate = searchParams.get('date');
   const scheduleInitialDate =
-    requestedDate != null && /^\\d{4}-\\d{2}-\\d{2}$/.test(requestedDate)
+    requestedDate != null && /^\d{4}-\d{2}-\d{2}$/.test(requestedDate)
       ? requestedDate
       : toDateKey(new Date());
   const normalizedQuery = searchQuery.trim().toLowerCase();

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -188,6 +188,14 @@ describe('WorkoutTemplateDetail', () => {
         return Promise.resolve(jsonResponse(templatePayload));
       }
 
+      if (url.includes('/api/v1/scheduled-workouts') && (init?.method ?? 'GET') === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (url.includes('/api/v1/workout-sessions?') && (init?.method ?? 'GET') === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
       if (url.endsWith('/api/v1/workout-sessions') && init?.method === 'POST') {
         return Promise.resolve(jsonResponse(createdSessionPayload, { status: 201 }));
       }
@@ -274,6 +282,14 @@ describe('WorkoutTemplateDetail', () => {
         return Promise.resolve(jsonResponse(templatePayload));
       }
 
+      if (url.includes('/api/v1/scheduled-workouts?') && (init?.method ?? 'GET') === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (url.includes('/api/v1/workout-sessions?') && (init?.method ?? 'GET') === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
       if (url.endsWith('/api/v1/scheduled-workouts') && init?.method === 'POST') {
         return Promise.resolve(
           jsonResponse({
@@ -313,6 +329,59 @@ describe('WorkoutTemplateDetail', () => {
 
       expect(scheduleCall).toBeDefined();
     });
+  });
+
+  it('shows duplicate warning before starting when the day already has workouts', async () => {
+    const createSessionSpy = vi.fn();
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = String(input);
+
+      if (url.endsWith('/api/v1/workout-templates/upper-push')) {
+        return Promise.resolve(jsonResponse(templatePayload));
+      }
+
+      if (url.includes('/api/v1/scheduled-workouts?') && (init?.method ?? 'GET') === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'scheduled-1',
+                date: '2026-03-07',
+                templateId: 'upper-push',
+                templateName: 'Upper Push',
+                sessionId: null,
+                createdAt: 1,
+              },
+            ],
+          }),
+        );
+      }
+
+      if (url.includes('/api/v1/workout-sessions?') && (init?.method ?? 'GET') === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (url.endsWith('/api/v1/workout-sessions') && init?.method === 'POST') {
+        createSessionSpy();
+        return Promise.resolve(jsonResponse(createdSessionPayload, { status: 201 }));
+      }
+
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutTemplateDetail templateId="upper-push" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Start Workout' }));
+
+    const dialog = await screen.findByRole('alertdialog');
+    expect(within(dialog).getByText('This day already has a workout')).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    expect(createSessionSpy).not.toHaveBeenCalled();
   });
 
   it('renames an exercise from the template exercise menu', async () => {

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -24,6 +24,7 @@ import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -41,6 +42,10 @@ import {
   useWorkoutTemplate,
 } from '../api/workouts';
 import { buildInitialSessionSets } from '../lib/workout-session-sets';
+import {
+  formatWorkoutConflictDescription,
+  getDayWorkoutConflicts,
+} from '../lib/day-workout-conflicts';
 import { FormCueChips } from './form-cue-chips';
 import { RenameExerciseDialog } from './rename-exercise-dialog';
 import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
@@ -58,6 +63,7 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3
 
 export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps) {
   const navigate = useNavigate();
+  const { confirm, dialog } = useConfirmation();
   const templateQuery = useWorkoutTemplate(templateId);
   const startWorkoutMutation = useStartSession();
   const scheduleWorkoutMutation = useScheduleWorkout();
@@ -78,6 +84,26 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
       coordinateGetter: sortableKeyboardCoordinates,
     }),
   );
+
+  async function confirmDuplicateDayWorkouts(dateKey: string) {
+    const conflicts = await getDayWorkoutConflicts(dateKey);
+
+    if (conflicts.length === 0) {
+      return true;
+    }
+
+    return await new Promise<boolean>((resolve) => {
+      confirm({
+        title: 'This day already has a workout',
+        description: formatWorkoutConflictDescription(conflicts),
+        cancelLabel: 'Cancel',
+        confirmLabel: 'Create another anyway',
+        variant: 'default',
+        onConfirm: () => resolve(true),
+        onCancel: () => resolve(false),
+      });
+    });
+  }
 
   if (templateQuery.isPending) {
     return <TemplateDetailSkeleton />;
@@ -298,22 +324,30 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
             className="w-full sm:w-auto"
             disabled={startWorkoutMutation.isPending}
             onClick={() => {
-              const startedAt = Date.now();
+              const todayDateKey = toDateKey(new Date());
+              void (async () => {
+                const shouldCreateAnother = await confirmDuplicateDayWorkouts(todayDateKey);
+                if (!shouldCreateAnother) {
+                  return;
+                }
 
-              startWorkoutMutation.mutate(
-                {
-                  date: toDateKey(new Date(startedAt)),
-                  name: template.name,
-                  sets: buildInitialSessionSets(template),
-                  startedAt,
-                  templateId: template.id,
-                },
-                {
-                  onSuccess: (session) => {
-                    navigate(`/workouts/active?template=${template.id}&sessionId=${session.id}`);
+                const startedAt = Date.now();
+
+                startWorkoutMutation.mutate(
+                  {
+                    date: toDateKey(new Date(startedAt)),
+                    name: template.name,
+                    sets: buildInitialSessionSets(template),
+                    startedAt,
+                    templateId: template.id,
                   },
-                },
-              );
+                  {
+                    onSuccess: (session) => {
+                      navigate(`/workouts/active?template=${template.id}&sessionId=${session.id}`);
+                    },
+                  },
+                );
+              })();
             }}
             size="lg"
             type="button"
@@ -340,16 +374,22 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
         initialDate={toDateKey(new Date())}
         isPending={scheduleWorkoutMutation.isPending}
         onOpenChange={setIsScheduleDialogOpen}
-        onSubmitDate={(date) =>
-          scheduleWorkoutMutation.mutateAsync({
+        onSubmitDate={async (date) => {
+          const shouldCreateAnother = await confirmDuplicateDayWorkouts(date);
+          if (!shouldCreateAnother) {
+            return;
+          }
+
+          await scheduleWorkoutMutation.mutateAsync({
             date,
             templateId: template.id,
-          })
-        }
+          });
+        }}
         open={isScheduleDialogOpen}
         submitLabel="Schedule"
         title="Schedule workout"
       />
+      {dialog}
     </section>
   );
 }

--- a/apps/web/src/features/workouts/components/workout-calendar.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.test.tsx
@@ -89,6 +89,22 @@ describe('WorkoutCalendar', () => {
         );
       }
 
+      if (url.pathname.startsWith('/api/v1/workout-templates/')) {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: url.pathname.split('/').at(-1),
+              name: 'Template',
+              description: null,
+              sections: [],
+              tags: [],
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          }),
+        );
+      }
+
       throw new Error(`Unhandled request: ${url.pathname}`);
     });
 
@@ -106,20 +122,47 @@ describe('WorkoutCalendar', () => {
       'href',
       '/workouts/session/session-1',
     );
-    expect(screen.queryByRole('button', { name: 'Scheduled workout actions' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /selected/i })).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('shows one dot per workout for days with two workouts', async () => {
-    const firstDay = new Date();
-    firstDay.setDate(Math.min(firstDay.getDate(), 9));
-    const dateKey = toDateKey(firstDay);
+  it('shows selected-day workouts with status-aware actions', async () => {
+    const dateKey = toDateKey(new Date());
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
       const url = new URL(String(input), 'https://pulse.test');
 
       if (url.pathname === '/api/v1/workout-sessions') {
-        return Promise.resolve(jsonResponse({ data: [] }));
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'session-in-progress',
+                name: 'Conditioning',
+                date: dateKey,
+                status: 'in-progress',
+                templateId: 'template-conditioning',
+                templateName: 'Conditioning',
+                startedAt: Date.parse(`${dateKey}T08:00:00Z`),
+                completedAt: null,
+                duration: null,
+                exerciseCount: 4,
+                createdAt: 2,
+              },
+              {
+                id: 'session-completed',
+                name: 'Recovery Flow',
+                date: dateKey,
+                status: 'completed',
+                templateId: 'template-recovery',
+                templateName: 'Recovery Flow',
+                startedAt: Date.parse(`${dateKey}T06:00:00Z`),
+                completedAt: Date.parse(`${dateKey}T06:45:00Z`),
+                duration: 45,
+                exerciseCount: 3,
+                createdAt: 1,
+              },
+            ],
+          }),
+        );
       }
 
       if (url.pathname === '/api/v1/scheduled-workouts') {
@@ -129,22 +172,64 @@ describe('WorkoutCalendar', () => {
               {
                 id: 'schedule-1',
                 date: dateKey,
-                templateId: 'template-1',
+                templateId: 'template-upper',
                 templateName: 'Upper Push',
                 sessionId: null,
-                createdAt: 1,
-              },
-              {
-                id: 'schedule-2',
-                date: dateKey,
-                templateId: 'template-2',
-                templateName: 'Upper Pull',
-                sessionId: null,
-                createdAt: 2,
+                createdAt: 3,
               },
             ],
           }),
         );
+      }
+
+      if (url.pathname.startsWith('/api/v1/workout-templates/')) {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: url.pathname.split('/').at(-1),
+              name: 'Template',
+              description: null,
+              sections: [],
+              tags: [],
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutCalendar buildSessionHref={(sessionId) => `/workouts/session/${sessionId}`} />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Upper Push');
+    const detailsPanel = document.getElementById('workout-day-details');
+    expect(detailsPanel).not.toBeNull();
+    expect(within(detailsPanel as HTMLElement).getByText('Conditioning')).toBeInTheDocument();
+    expect(within(detailsPanel as HTMLElement).getByText('Recovery Flow')).toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: 'Start' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Resume' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View details' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Delete' })).toHaveLength(3);
+  });
+
+  it('shows empty selected-day state with a schedule CTA', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/workout-sessions') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (url.pathname === '/api/v1/scheduled-workouts') {
+        return Promise.resolve(jsonResponse({ data: [] }));
       }
 
       throw new Error(`Unhandled request: ${url.pathname}`);
@@ -156,14 +241,12 @@ describe('WorkoutCalendar', () => {
       </MemoryRouter>,
     );
 
-    await screen.findByText('Workout Calendar');
-    const tile = getCalendarDayTile(firstDay);
-
-    expect(await within(tile).findAllByLabelText('Scheduled workout')).toHaveLength(2);
-    expect(within(tile).queryByText(/\+\d+/)).not.toBeInTheDocument();
+    expect(await screen.findByText('Workout Calendar')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'No workouts on this day' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Schedule a workout' })).toBeInTheDocument();
   });
 
-  it('updates day details when a calendar day is tapped', async () => {
+  it('updates selected-day details when a calendar day is tapped', async () => {
     const targetDate = new Date();
     targetDate.setDate(Math.min(targetDate.getDate(), 11));
     const targetDateKey = toDateKey(targetDate);
@@ -192,6 +275,22 @@ describe('WorkoutCalendar', () => {
         );
       }
 
+      if (url.pathname.startsWith('/api/v1/workout-templates/')) {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: url.pathname.split('/').at(-1),
+              name: 'Template',
+              description: null,
+              sections: [],
+              tags: [],
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          }),
+        );
+      }
+
       throw new Error(`Unhandled request: ${url.pathname}`);
     });
 
@@ -204,33 +303,9 @@ describe('WorkoutCalendar', () => {
     await screen.findByText('Workout Calendar');
     fireEvent.click(getCalendarDayTile(targetDate));
 
-    expect(screen.getByRole('heading', { name: 'Leg Day' })).toBeInTheDocument();
-  });
-
-  it('shows empty calendar details when no workouts exist', async () => {
-    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
-      const url = new URL(String(input), 'https://pulse.test');
-
-      if (url.pathname === '/api/v1/workout-sessions') {
-        return Promise.resolve(jsonResponse({ data: [] }));
-      }
-
-      if (url.pathname === '/api/v1/scheduled-workouts') {
-        return Promise.resolve(jsonResponse({ data: [] }));
-      }
-
-      throw new Error(`Unhandled request: ${url.pathname}`);
-    });
-
-    renderWithQueryClient(
-      <MemoryRouter>
-        <WorkoutCalendar />
-      </MemoryRouter>,
-    );
-
-    expect(await screen.findByText('Workout Calendar')).toBeInTheDocument();
-    expect(screen.queryByLabelText('Completed workout')).not.toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'No workout planned' })).toBeInTheDocument();
+    const detailsPanel = document.getElementById('workout-day-details');
+    expect(detailsPanel).not.toBeNull();
+    expect(within(detailsPanel as HTMLElement).getByText('Leg Day')).toBeInTheDocument();
   });
 
   it('navigates between months', async () => {

--- a/apps/web/src/features/workouts/components/workout-calendar.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -19,10 +19,22 @@ afterEach(() => {
 });
 
 describe('WorkoutCalendar', () => {
-  it('renders completed and scheduled workouts with session links', async () => {
+  it('renders per-workout indicators and a count badge for days with 3+ workouts', async () => {
     const sessionDate = new Date();
-    sessionDate.setDate(Math.min(sessionDate.getDate(), 10));
     const sessionDateKey = toDateKey(sessionDate);
+    const inProgressSession = {
+      id: 'session-in-progress',
+      name: 'Morning Conditioning',
+      date: sessionDateKey,
+      status: 'in-progress' as const,
+      templateId: 'template-3',
+      templateName: 'Morning Conditioning',
+      startedAt: Date.parse(`${sessionDateKey}T06:30:00Z`),
+      completedAt: null,
+      duration: null,
+      exerciseCount: 4,
+      createdAt: 3,
+    };
     const completedSession = {
       id: 'session-1',
       name: 'Upper Push',
@@ -41,16 +53,7 @@ describe('WorkoutCalendar', () => {
       const url = new URL(String(input), 'https://pulse.test');
 
       if (url.pathname === '/api/v1/workout-sessions') {
-        const statuses = url.searchParams.getAll('status');
-        if (statuses.includes('completed')) {
-          return Promise.resolve(jsonResponse({ data: [completedSession] }));
-        }
-
-        if (statuses.includes('in-progress') || statuses.includes('paused')) {
-          return Promise.resolve(jsonResponse({ data: [] }));
-        }
-
-        return Promise.resolve(jsonResponse({ data: [] }));
+        return Promise.resolve(jsonResponse({ data: [completedSession, inProgressSession] }));
       }
 
       if (url.pathname === '/api/v1/scheduled-workouts') {
@@ -73,6 +76,14 @@ describe('WorkoutCalendar', () => {
                 sessionId: null,
                 createdAt: 2,
               },
+              {
+                id: 'schedule-3',
+                date: sessionDateKey,
+                templateId: 'template-3',
+                templateName: 'Morning Conditioning',
+                sessionId: 'session-in-progress',
+                createdAt: 3,
+              },
             ],
           }),
         );
@@ -88,14 +99,112 @@ describe('WorkoutCalendar', () => {
     );
 
     expect(await screen.findByText('Workout Calendar')).toBeInTheDocument();
+    expect((await screen.findAllByLabelText('In-progress workout')).length).toBeGreaterThan(0);
     expect((await screen.findAllByLabelText('Completed workout')).length).toBeGreaterThan(0);
-    expect((await screen.findAllByLabelText('Scheduled workout')).length).toBeGreaterThan(0);
-    expect(screen.getByText('+1')).toBeInTheDocument();
+    expect(screen.getByText('+2')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Done' })).toHaveAttribute(
       'href',
       '/workouts/session/session-1',
     );
+    expect(screen.queryByRole('button', { name: 'Scheduled workout actions' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /selected/i })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('shows one dot per workout for days with two workouts', async () => {
+    const firstDay = new Date();
+    firstDay.setDate(Math.min(firstDay.getDate(), 9));
+    const dateKey = toDateKey(firstDay);
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/workout-sessions') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (url.pathname === '/api/v1/scheduled-workouts') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'schedule-1',
+                date: dateKey,
+                templateId: 'template-1',
+                templateName: 'Upper Push',
+                sessionId: null,
+                createdAt: 1,
+              },
+              {
+                id: 'schedule-2',
+                date: dateKey,
+                templateId: 'template-2',
+                templateName: 'Upper Pull',
+                sessionId: null,
+                createdAt: 2,
+              },
+            ],
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutCalendar />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Workout Calendar');
+    const tile = getCalendarDayTile(firstDay);
+
+    expect(await within(tile).findAllByLabelText('Scheduled workout')).toHaveLength(2);
+    expect(within(tile).queryByText(/\+\d+/)).not.toBeInTheDocument();
+  });
+
+  it('updates day details when a calendar day is tapped', async () => {
+    const targetDate = new Date();
+    targetDate.setDate(Math.min(targetDate.getDate(), 11));
+    const targetDateKey = toDateKey(targetDate);
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/workout-sessions') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (url.pathname === '/api/v1/scheduled-workouts') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'schedule-target',
+                date: targetDateKey,
+                templateId: 'template-target',
+                templateName: 'Leg Day',
+                sessionId: null,
+                createdAt: 1,
+              },
+            ],
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutCalendar />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Workout Calendar');
+    fireEvent.click(getCalendarDayTile(targetDate));
+
+    expect(screen.getByRole('heading', { name: 'Leg Day' })).toBeInTheDocument();
   });
 
   it('shows empty calendar details when no workouts exist', async () => {
@@ -160,4 +269,21 @@ function formatMonth(date: Date) {
     month: 'long',
     year: 'numeric',
   }).format(date);
+}
+
+function getCalendarDayTile(date: Date) {
+  const fullLabel = new Intl.DateTimeFormat('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+
+  return screen.getByRole('button', {
+    name: new RegExp(`^${escapeRegExp(fullLabel)}(?:, selected)?$`),
+  });
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { ChevronLeft, ChevronRight, EllipsisVertical, TriangleAlert } from 'lucide-react';
+import { ChevronLeft, ChevronRight, TriangleAlert } from 'lucide-react';
 import type { ScheduledWorkoutListItem, WorkoutSessionListItem } from '@pulse/shared';
 import { Link } from 'react-router';
 
@@ -54,6 +54,12 @@ type WorkoutCalendarProps = {
 };
 
 type DayStatus = 'completed' | 'scheduled' | 'in-progress' | 'mixed' | 'none';
+type WorkoutIndicatorStatus = 'completed' | 'scheduled' | 'in-progress' | 'unavailable';
+
+type WorkoutIndicator = {
+  id: string;
+  status: WorkoutIndicatorStatus;
+};
 
 type DayDetails = {
   date: Date;
@@ -61,15 +67,17 @@ type DayDetails = {
   completedSession: WorkoutSessionListItem | null;
   inProgressSession: WorkoutSessionListItem | null;
   scheduledWorkouts: ScheduledWorkoutListItem[];
+  workoutIndicators: WorkoutIndicator[];
   status: DayStatus;
   templateName: string | null;
   notes: string | null;
 };
 
 type DayLookupContext = {
-  completedSessionByDate: Map<string, WorkoutSessionListItem>;
+  completedSessionsByDate: Map<string, WorkoutSessionListItem[]>;
+  inProgressSessions: WorkoutSessionListItem[];
+  sessionById: Map<string, WorkoutSessionListItem>;
   scheduledByDate: Map<string, ScheduledWorkoutListItem[]>;
-  inProgressTodaySession: WorkoutSessionListItem | null;
 };
 
 export function WorkoutCalendar({
@@ -115,13 +123,18 @@ export function WorkoutCalendar({
     [activeSessions, dateRange.from, dateRange.to],
   );
   const completedSessionByDate = useMemo(
-    () =>
-      new Map(
-        activeCompletedSessions
-          .slice()
-          .sort((left, right) => right.startedAt - left.startedAt)
-          .map((session) => [session.date, session]),
-      ),
+    () => {
+      const grouped = new Map<string, WorkoutSessionListItem[]>();
+      for (const session of activeCompletedSessions
+        .slice()
+        .sort((left, right) => right.startedAt - left.startedAt)) {
+        const sessionsForDate = grouped.get(session.date) ?? [];
+        sessionsForDate.push(session);
+        grouped.set(session.date, sessionsForDate);
+      }
+
+      return grouped;
+    },
     [activeCompletedSessions],
   );
   const scheduledByDate = useMemo(() => {
@@ -134,21 +147,28 @@ export function WorkoutCalendar({
 
     return grouped;
   }, [scheduledQuery.data]);
-  const inProgressTodaySession = useMemo(
+  const inProgressSessions = useMemo(
     () =>
-      activeSessions
-        .filter((session) => session.status === 'in-progress' || session.status === 'paused')
-        .find((session) => spansToday(session, todayKey)) ?? null,
+      activeSessions.filter(
+        (session) =>
+          (session.status === 'in-progress' || session.status === 'paused') &&
+          spansToday(session, todayKey),
+      ),
     [activeSessions, todayKey],
+  );
+  const sessionById = useMemo(
+    () => new Map(activeSessions.map((session) => [session.id, session])),
+    [activeSessions],
   );
 
   const lookupContext = useMemo(
     () => ({
-      completedSessionByDate,
-      inProgressTodaySession,
+      completedSessionsByDate: completedSessionByDate,
+      inProgressSessions,
+      sessionById,
       scheduledByDate,
     }),
-    [completedSessionByDate, inProgressTodaySession, scheduledByDate],
+    [completedSessionByDate, inProgressSessions, scheduledByDate, sessionById],
   );
 
   const [selectedDateKey, setSelectedDateKey] = useState(
@@ -284,26 +304,15 @@ export function WorkoutCalendar({
                           Done
                         </Link>
                       ) : null}
-                      {details.scheduledWorkouts[0] ? (
-                        details.scheduledWorkouts[0].templateId != null &&
-                        details.scheduledWorkouts[0].templateName != null ? (
-                          <ScheduledWorkoutActions
-                            buildStartWorkoutHref={buildStartWorkoutHref}
-                            compact
-                            scheduledWorkout={details.scheduledWorkouts[0]}
-                          />
-                        ) : (
-                          <span
-                            aria-label="Unavailable scheduled workout"
-                            className="inline-flex items-center rounded-full border border-destructive/50 bg-destructive/10 p-1 text-destructive"
-                          >
-                            <TriangleAlert aria-hidden="true" className="size-3" />
-                          </span>
-                        )
-                      ) : null}
-                      {details.scheduledWorkouts.length > 1 ? (
-                        <span className="rounded-full border border-slate-500/70 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground">
-                          +{details.scheduledWorkouts.length - 1}
+                      {details.scheduledWorkouts.some(
+                        (scheduledWorkout) =>
+                          scheduledWorkout.templateId == null || scheduledWorkout.templateName == null,
+                      ) ? (
+                        <span
+                          aria-label="Unavailable scheduled workout"
+                          className="inline-flex items-center rounded-full border border-destructive/50 bg-destructive/10 p-1 text-destructive"
+                        >
+                          <TriangleAlert aria-hidden="true" className="size-3" />
                         </span>
                       ) : null}
                     </div>
@@ -324,32 +333,20 @@ export function WorkoutCalendar({
                   </div>
 
                   <div className="mt-auto flex items-center gap-1 pt-1 sm:gap-1.5 sm:pt-3">
-                    {details.completedSession ? (
+                    {getTileIndicators(details.workoutIndicators).map((indicator) => (
                       <span
-                        aria-label="Completed workout"
-                        className="size-2 rounded-full bg-emerald-500 sm:size-2.5"
+                        aria-label={`${statusToLabel(indicator.status)} workout`}
+                        className={cn(
+                          'size-2 rounded-full sm:size-2.5',
+                          indicatorDotClassName(indicator.status),
+                        )}
+                        key={indicator.id}
                       />
-                    ) : null}
-                    {details.scheduledWorkouts.length > 0 ? (
-                      <span
-                        aria-label="Scheduled workout"
-                        className="size-2 rounded-full border border-slate-500 bg-transparent sm:size-2.5"
-                      />
-                    ) : null}
-                    {details.scheduledWorkouts.some(
-                      (scheduledWorkout) =>
-                        scheduledWorkout.templateId == null || scheduledWorkout.templateName == null,
-                    ) ? (
-                      <span
-                        aria-label="Unavailable scheduled workout"
-                        className="size-2 rounded-full bg-destructive/80 sm:size-2.5"
-                      />
-                    ) : null}
-                    {details.inProgressSession ? (
-                      <span
-                        aria-label="In-progress workout"
-                        className="size-2 rounded-full bg-orange-500 animate-pulse sm:size-2.5"
-                      />
+                    ))}
+                    {details.workoutIndicators.length >= 3 ? (
+                      <span className="rounded-full border border-slate-500/70 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground">
+                        +{details.workoutIndicators.length - 2}
+                      </span>
                     ) : null}
                     {isToday ? (
                       <span className="hidden text-[11px] font-medium text-primary sm:inline">
@@ -488,11 +485,9 @@ export function WorkoutCalendar({
 
 function ScheduledWorkoutActions({
   buildStartWorkoutHref,
-  compact = false,
   scheduledWorkout,
 }: {
   buildStartWorkoutHref: (templateId: string) => string;
-  compact?: boolean;
   scheduledWorkout: ScheduledWorkoutListItem;
 }) {
   const rescheduleWorkoutMutation = useRescheduleWorkout();
@@ -523,27 +518,16 @@ function ScheduledWorkoutActions({
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button
-            aria-label={
-              compact
-                ? 'Scheduled workout actions'
-                : `Actions for ${scheduledWorkout.templateName ?? 'scheduled workout'}`
-            }
+            aria-label={`Actions for ${scheduledWorkout.templateName ?? 'scheduled workout'}`}
             className={cn(
               'inline-flex items-center justify-center rounded-full border border-slate-500 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-foreground hover:bg-secondary',
               isUnavailable &&
                 'border-destructive/55 bg-destructive/10 text-destructive hover:bg-destructive/20',
-              compact && 'size-5 border-slate-500/70 px-0 py-0',
             )}
             onClick={(event) => event.stopPropagation()}
             type="button"
           >
-            {compact ? (
-              isUnavailable ? (
-                <TriangleAlert aria-hidden="true" className="size-3" />
-              ) : (
-                <EllipsisVertical aria-hidden="true" className="size-3" />
-              )
-            ) : isUnavailable ? (
+            {isUnavailable ? (
               'Unavailable'
             ) : (
               'Scheduled'
@@ -611,13 +595,23 @@ function LegendDot({ className, label }: { className: string; label: string }) {
 
 function getDayDetails(dateKey: string, context: DayLookupContext, todayKey: string): DayDetails {
   const date = parseDateKey(dateKey);
-  const completedSession = context.completedSessionByDate.get(dateKey) ?? null;
+  const completedSessions = context.completedSessionsByDate.get(dateKey) ?? [];
+  const completedSession = completedSessions[0] ?? null;
   const scheduledWorkouts = context.scheduledByDate.get(dateKey) ?? [];
-  const inProgressSession = dateKey === todayKey ? context.inProgressTodaySession : null;
+  const inProgressSession =
+    dateKey === todayKey ? (context.inProgressSessions[0] ?? null) : null;
+  const workoutIndicators = buildWorkoutIndicators({
+    scheduledWorkouts,
+    completedSessions,
+    inProgressSessions: dateKey === todayKey ? context.inProgressSessions : [],
+    sessionById: context.sessionById,
+  });
 
-  const hasCompleted = completedSession != null;
-  const hasScheduled = scheduledWorkouts.length > 0;
-  const hasInProgress = inProgressSession != null;
+  const hasCompleted = workoutIndicators.some((indicator) => indicator.status === 'completed');
+  const hasScheduled = workoutIndicators.some(
+    (indicator) => indicator.status === 'scheduled' || indicator.status === 'unavailable',
+  );
+  const hasInProgress = workoutIndicators.some((indicator) => indicator.status === 'in-progress');
 
   let status: DayStatus = 'none';
   if (hasCompleted && (hasScheduled || hasInProgress)) {
@@ -638,7 +632,9 @@ function getDayDetails(dateKey: string, context: DayLookupContext, todayKey: str
     inProgressSession?.templateName ??
     null;
   const notes = hasCompleted
-    ? `${completedSession.exerciseCount} exercise${completedSession.exerciseCount === 1 ? '' : 's'} logged`
+    ? completedSession
+      ? `${completedSession.exerciseCount} exercise${completedSession.exerciseCount === 1 ? '' : 's'} logged`
+      : `${workoutIndicators.length} workout${workoutIndicators.length === 1 ? '' : 's'} logged`
     : hasScheduled
       ? `${scheduledWorkouts.length} scheduled workout${scheduledWorkouts.length === 1 ? '' : 's'}`
       : hasInProgress
@@ -652,6 +648,7 @@ function getDayDetails(dateKey: string, context: DayLookupContext, todayKey: str
     inProgressSession,
     notes,
     scheduledWorkouts,
+    workoutIndicators,
     status,
     templateName,
   };
@@ -713,7 +710,7 @@ function getDetailStats(selectedDay: DayDetails) {
 
 function getDefaultSelectedDateKey(
   month: Date,
-  completedByDate: Map<string, WorkoutSessionListItem>,
+  completedByDate: Map<string, WorkoutSessionListItem[]>,
   scheduledByDate: Map<string, ScheduledWorkoutListItem[]>,
   todayKey: string,
 ): string {
@@ -777,4 +774,112 @@ function spansToday(session: WorkoutSessionListItem, todayKey: string) {
   const sessionEnd = session.completedAt ?? Number.POSITIVE_INFINITY;
 
   return session.startedAt <= dayEnd && sessionEnd >= dayStart;
+}
+
+function buildWorkoutIndicators({
+  scheduledWorkouts,
+  completedSessions,
+  inProgressSessions,
+  sessionById,
+}: {
+  scheduledWorkouts: ScheduledWorkoutListItem[];
+  completedSessions: WorkoutSessionListItem[];
+  inProgressSessions: WorkoutSessionListItem[];
+  sessionById: Map<string, WorkoutSessionListItem>;
+}): WorkoutIndicator[] {
+  const indicators: WorkoutIndicator[] = [];
+  const consumedSessionIds = new Set<string>();
+
+  for (const scheduledWorkout of scheduledWorkouts) {
+    const linkedSession = scheduledWorkout.sessionId
+      ? (sessionById.get(scheduledWorkout.sessionId) ?? null)
+      : null;
+
+    if (linkedSession && linkedSession.status === 'completed') {
+      indicators.push({ id: `scheduled-${scheduledWorkout.id}`, status: 'completed' });
+      consumedSessionIds.add(linkedSession.id);
+      continue;
+    }
+
+    if (linkedSession && (linkedSession.status === 'in-progress' || linkedSession.status === 'paused')) {
+      indicators.push({ id: `scheduled-${scheduledWorkout.id}`, status: 'in-progress' });
+      consumedSessionIds.add(linkedSession.id);
+      continue;
+    }
+
+    indicators.push({
+      id: `scheduled-${scheduledWorkout.id}`,
+      status:
+        scheduledWorkout.templateId == null || scheduledWorkout.templateName == null
+          ? 'unavailable'
+          : 'scheduled',
+    });
+  }
+
+  for (const session of completedSessions) {
+    if (!consumedSessionIds.has(session.id)) {
+      indicators.push({ id: `completed-${session.id}`, status: 'completed' });
+    }
+  }
+
+  for (const session of inProgressSessions) {
+    if (!consumedSessionIds.has(session.id)) {
+      indicators.push({ id: `in-progress-${session.id}`, status: 'in-progress' });
+    }
+  }
+
+  return indicators.sort((left, right) => indicatorPriority(left.status) - indicatorPriority(right.status));
+}
+
+function indicatorPriority(status: WorkoutIndicatorStatus) {
+  switch (status) {
+    case 'in-progress':
+      return 0;
+    case 'completed':
+      return 1;
+    case 'scheduled':
+      return 2;
+    case 'unavailable':
+      return 3;
+    default:
+      return 4;
+  }
+}
+
+function getTileIndicators(indicators: WorkoutIndicator[]) {
+  if (indicators.length <= 2) {
+    return indicators;
+  }
+
+  return indicators.slice(0, 2);
+}
+
+function indicatorDotClassName(status: WorkoutIndicatorStatus) {
+  switch (status) {
+    case 'completed':
+      return 'bg-emerald-500';
+    case 'scheduled':
+      return 'border border-slate-500 bg-transparent';
+    case 'in-progress':
+      return 'animate-pulse bg-orange-500 ring-2 ring-orange-500/30 ring-offset-1 ring-offset-background';
+    case 'unavailable':
+      return 'bg-destructive/80';
+    default:
+      return 'bg-muted';
+  }
+}
+
+function statusToLabel(status: WorkoutIndicatorStatus) {
+  switch (status) {
+    case 'completed':
+      return 'Completed';
+    case 'scheduled':
+      return 'Scheduled';
+    case 'in-progress':
+      return 'In-progress';
+    case 'unavailable':
+      return 'Unavailable scheduled';
+    default:
+      return 'Workout';
+  }
 }

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -197,15 +197,7 @@ export function WorkoutCalendar({
   function handleMonthChange(offset: number) {
     const nextMonth = addMonths(visibleMonth, offset);
     setVisibleMonth(nextMonth);
-    setSelectedDateKey(
-      getDefaultSelectedDateKey(
-        nextMonth,
-        completedSessionByDate,
-        inProgressSessionsByDate,
-        scheduledByDate,
-        todayKey,
-      ),
-    );
+    setSelectedDateKey(toDateKey(startOfMonth(nextMonth)));
   }
 
   return (

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -44,7 +44,7 @@ const fullDateFormatter = new Intl.DateTimeFormat('en-US', {
 type WorkoutCalendarProps = {
   buildDayHref?: (date: string) => string;
   buildSessionHref?: (sessionId: string, status?: WorkoutSessionStatus) => string;
-  buildStartWorkoutHref?: (templateId: string) => string;
+  buildTemplateHref?: (templateId: string) => string;
 };
 
 type DayStatus = 'completed' | 'scheduled' | 'in-progress' | 'mixed' | 'none';
@@ -86,7 +86,7 @@ type DayLookupContext = {
 export function WorkoutCalendar({
   buildDayHref,
   buildSessionHref,
-  buildStartWorkoutHref = (templateId) => `/workouts/active?template=${templateId}`,
+  buildTemplateHref = (templateId) => `/workouts/template/${templateId}`,
 }: WorkoutCalendarProps) {
   const todayKey = useTodayKey();
   const initialMonth = startOfMonth(parseDateKey(todayKey));
@@ -410,7 +410,7 @@ export function WorkoutCalendar({
               {selectedDay.workouts.map((workout) => (
                 <DayWorkoutItemCard
                   buildSessionHref={buildSessionHref}
-                  buildStartWorkoutHref={buildStartWorkoutHref}
+                  buildTemplateHref={buildTemplateHref}
                   dateKey={selectedDay.dateKey}
                   key={workout.id}
                   workout={workout}
@@ -436,12 +436,12 @@ export function WorkoutCalendar({
 
 function DayWorkoutItemCard({
   buildSessionHref,
-  buildStartWorkoutHref,
+  buildTemplateHref,
   dateKey,
   workout,
 }: {
   buildSessionHref?: (sessionId: string, status?: WorkoutSessionStatus) => string;
-  buildStartWorkoutHref: (templateId: string) => string;
+  buildTemplateHref: (templateId: string) => string;
   dateKey: string;
   workout: DayWorkout;
 }) {
@@ -450,7 +450,9 @@ function DayWorkoutItemCard({
   const startSessionMutation = useStartSession();
   const deleteSessionMutation = useDeleteSession(workout.session?.id ?? null);
   const updateSessionStatusMutation = useUpdateSessionStatus(workout.session?.id ?? null);
-  const templateQuery = useWorkoutTemplate(workout.status === 'scheduled' ? (workout.templateId ?? '') : '');
+  const templateId = workout.templateId ?? '';
+  const shouldFetchTemplate = workout.status === 'scheduled' && templateId.trim().length > 0;
+  const templateQuery = useWorkoutTemplate(templateId, { enabled: shouldFetchTemplate });
   const { confirm, dialog } = useConfirmation();
   const canStart = workout.status === 'scheduled' && !workout.isUnavailable;
   const isMutating =
@@ -476,12 +478,26 @@ function DayWorkoutItemCard({
   }
 
   async function handleDelete() {
-    if (workout.scheduledWorkout) {
+    if (workout.status === 'scheduled' && workout.scheduledWorkout) {
       await unscheduleWorkoutMutation.mutateAsync({ id: workout.scheduledWorkout.id });
       return;
     }
 
-    await deleteSessionMutation.mutateAsync();
+    const pendingMutations: Array<Promise<unknown>> = [];
+
+    if (workout.scheduledWorkout) {
+      pendingMutations.push(unscheduleWorkoutMutation.mutateAsync({ id: workout.scheduledWorkout.id }));
+    }
+
+    if (workout.session) {
+      pendingMutations.push(deleteSessionMutation.mutateAsync());
+    }
+
+    if (pendingMutations.length === 0) {
+      return;
+    }
+
+    await Promise.all(pendingMutations);
   }
 
   async function handleCancel() {
@@ -575,7 +591,7 @@ function DayWorkoutItemCard({
               description:
                 workout.status === 'scheduled'
                   ? `This will remove "${workout.name}" from ${fullDateFormatter.format(parseDateKey(dateKey))}.`
-                  : `This will permanently delete "${workout.name}".`,
+                  : `This will delete "${workout.name}".`,
               confirmLabel: 'Delete workout',
               variant: 'destructive',
               onConfirm: handleDelete,
@@ -589,7 +605,7 @@ function DayWorkoutItemCard({
         </Button>
         {workout.status === 'scheduled' && workout.templateId && workout.isUnavailable ? (
           <Button asChild size="sm" variant="secondary">
-            <Link to={buildStartWorkoutHref(workout.templateId)}>Open template</Link>
+            <Link to={buildTemplateHref(workout.templateId)}>View template</Link>
           </Button>
         ) : null}
       </div>

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -1,17 +1,15 @@
 import { useMemo, useState } from 'react';
 import { ChevronLeft, ChevronRight, TriangleAlert } from 'lucide-react';
-import type { ScheduledWorkoutListItem, WorkoutSessionListItem } from '@pulse/shared';
-import { Link } from 'react-router';
+import type {
+  ScheduledWorkoutListItem,
+  WorkoutSessionListItem,
+  WorkoutSessionStatus,
+} from '@pulse/shared';
+import { Link, useNavigate } from 'react-router';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useConfirmation } from '@/components/ui/confirmation-dialog';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import {
   addDays,
   differenceInDays,
@@ -21,15 +19,16 @@ import {
 } from '@/lib/date-utils';
 import { accentCardStyles } from '@/lib/accent-card-styles';
 import { cn } from '@/lib/utils';
+import { useDeleteSession, useStartSession, useUpdateSessionStatus } from '@/hooks/use-workout-session';
 import {
-  useRescheduleWorkout,
   useScheduledWorkouts,
   useUnscheduleWorkout,
+  useWorkoutTemplate,
   useWorkoutSessions,
 } from '../api/workouts';
 import { useTodayKey } from '../hooks/use-today-key';
 import { hasAvailableTemplate } from '../lib/workout-filters';
-import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
+import { buildInitialSessionSets } from '../lib/workout-session-sets';
 
 const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
 const monthFormatter = new Intl.DateTimeFormat('en-US', {
@@ -42,14 +41,9 @@ const fullDateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
   year: 'numeric',
 });
-const timeFormatter = new Intl.DateTimeFormat('en-US', {
-  hour: 'numeric',
-  minute: '2-digit',
-});
-
 type WorkoutCalendarProps = {
   buildDayHref?: (date: string) => string;
-  buildSessionHref?: (sessionId: string) => string;
+  buildSessionHref?: (sessionId: string, status?: WorkoutSessionStatus) => string;
   buildStartWorkoutHref?: (templateId: string) => string;
 };
 
@@ -61,21 +55,30 @@ type WorkoutIndicator = {
   status: WorkoutIndicatorStatus;
 };
 
+type DayWorkoutStatus = 'scheduled' | 'in-progress' | 'completed';
+
+type DayWorkout = {
+  id: string;
+  isUnavailable: boolean;
+  name: string;
+  scheduledWorkout: ScheduledWorkoutListItem | null;
+  session: WorkoutSessionListItem | null;
+  status: DayWorkoutStatus;
+  templateId: string | null;
+};
+
 type DayDetails = {
   date: Date;
   dateKey: string;
   completedSession: WorkoutSessionListItem | null;
-  inProgressSession: WorkoutSessionListItem | null;
-  scheduledWorkouts: ScheduledWorkoutListItem[];
+  workouts: DayWorkout[];
   workoutIndicators: WorkoutIndicator[];
   status: DayStatus;
-  templateName: string | null;
-  notes: string | null;
 };
 
 type DayLookupContext = {
   completedSessionsByDate: Map<string, WorkoutSessionListItem[]>;
-  inProgressSessions: WorkoutSessionListItem[];
+  inProgressSessionsByDate: Map<string, WorkoutSessionListItem[]>;
   sessionById: Map<string, WorkoutSessionListItem>;
   scheduledByDate: Map<string, ScheduledWorkoutListItem[]>;
 };
@@ -147,15 +150,19 @@ export function WorkoutCalendar({
 
     return grouped;
   }, [scheduledQuery.data]);
-  const inProgressSessions = useMemo(
-    () =>
-      activeSessions.filter(
-        (session) =>
-          (session.status === 'in-progress' || session.status === 'paused') &&
-          spansToday(session, todayKey),
-      ),
-    [activeSessions, todayKey],
-  );
+  const inProgressSessionsByDate = useMemo(() => {
+    const grouped = new Map<string, WorkoutSessionListItem[]>();
+    for (const session of activeSessions) {
+      if (session.status !== 'in-progress' && session.status !== 'paused') {
+        continue;
+      }
+      const sessionsForDate = grouped.get(session.date) ?? [];
+      sessionsForDate.push(session);
+      grouped.set(session.date, sessionsForDate);
+    }
+
+    return grouped;
+  }, [activeSessions]);
   const sessionById = useMemo(
     () => new Map(activeSessions.map((session) => [session.id, session])),
     [activeSessions],
@@ -164,28 +171,40 @@ export function WorkoutCalendar({
   const lookupContext = useMemo(
     () => ({
       completedSessionsByDate: completedSessionByDate,
-      inProgressSessions,
+      inProgressSessionsByDate,
       sessionById,
       scheduledByDate,
     }),
-    [completedSessionByDate, inProgressSessions, scheduledByDate, sessionById],
+    [completedSessionByDate, inProgressSessionsByDate, scheduledByDate, sessionById],
   );
 
   const [selectedDateKey, setSelectedDateKey] = useState(
-    getDefaultSelectedDateKey(initialMonth, completedSessionByDate, scheduledByDate, todayKey),
+    getDefaultSelectedDateKey(
+      initialMonth,
+      completedSessionByDate,
+      inProgressSessionsByDate,
+      scheduledByDate,
+      todayKey,
+    ),
   );
 
-  const selectedDay = getDayDetails(selectedDateKey, lookupContext, todayKey);
-  const openDayHref = buildDayHref?.(selectedDateKey) ?? `?date=${selectedDateKey}`;
-  const detailStats = getDetailStats(selectedDay);
-  const hasWorkout = selectedDay.status !== 'none';
+  const selectedDay = getDayDetails(selectedDateKey, lookupContext);
+  const scheduleDayHref =
+    buildDayHref?.(selectedDateKey) ?? `/workouts?view=templates&date=${selectedDateKey}`;
+  const hasWorkout = selectedDay.workouts.length > 0;
   const accentPanel = hasWorkout ? accentCardStyles.mint : 'bg-card text-foreground';
 
   function handleMonthChange(offset: number) {
     const nextMonth = addMonths(visibleMonth, offset);
     setVisibleMonth(nextMonth);
     setSelectedDateKey(
-      getDefaultSelectedDateKey(nextMonth, completedSessionByDate, scheduledByDate, todayKey),
+      getDefaultSelectedDateKey(
+        nextMonth,
+        completedSessionByDate,
+        inProgressSessionsByDate,
+        scheduledByDate,
+        todayKey,
+      ),
     );
   }
 
@@ -251,7 +270,7 @@ export function WorkoutCalendar({
           <div className="grid grid-cols-7 gap-2">
             {calendarDays.map((day) => {
               const dateKey = toDateKey(day);
-              const details = getDayDetails(dateKey, lookupContext, todayKey);
+              const details = getDayDetails(dateKey, lookupContext);
               const isSelected = selectedDateKey === dateKey;
               const isToday = dateKey === todayKey;
               const isInMonth = day.getMonth() === visibleMonth.getMonth();
@@ -297,17 +316,14 @@ export function WorkoutCalendar({
                           className="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[9px] font-bold uppercase leading-none tracking-wide text-emerald-700 hover:bg-emerald-500/25 dark:text-emerald-400"
                           onClick={(event) => event.stopPropagation()}
                           to={
-                            buildSessionHref?.(details.completedSession.id) ??
+                            buildSessionHref?.(details.completedSession.id, details.completedSession.status) ??
                             `/workouts/session/${details.completedSession.id}`
                           }
                         >
                           Done
                         </Link>
                       ) : null}
-                      {details.scheduledWorkouts.some(
-                        (scheduledWorkout) =>
-                          scheduledWorkout.templateId == null || scheduledWorkout.templateName == null,
-                      ) ? (
+                      {details.workouts.some((workout) => workout.isUnavailable) ? (
                         <span
                           aria-label="Unavailable scheduled workout"
                           className="inline-flex items-center rounded-full border border-destructive/50 bg-destructive/10 p-1 text-destructive"
@@ -325,10 +341,10 @@ export function WorkoutCalendar({
                         isInMonth ? 'text-foreground' : 'text-muted',
                       )}
                     >
-                      {details.templateName ?? 'No workout'}
+                      {details.workouts[0]?.name ?? 'No workout'}
                     </p>
                     <p className="truncate text-[10px] leading-snug text-muted">
-                      {details.notes ?? ''}
+                      {getDaySubtitle(details)}
                     </p>
                   </div>
 
@@ -367,221 +383,255 @@ export function WorkoutCalendar({
           )}
           id="workout-day-details"
         >
-          <div className="space-y-1">
+          <div className="space-y-2">
             <p
               className={cn(
                 'text-xs font-semibold uppercase tracking-[0.2em]',
                 hasWorkout ? 'opacity-70 dark:text-muted dark:opacity-100' : 'text-muted',
               )}
             >
-              Day details
+              Selected day
             </p>
-            <h3 className="text-2xl font-semibold">
-              {selectedDay.templateName ?? 'No workout planned'}
-            </h3>
+            <h3 className="text-2xl font-semibold">{fullDateFormatter.format(selectedDay.date)}</h3>
             <p
               className={cn(
                 'text-sm',
                 hasWorkout ? 'opacity-80 dark:text-muted dark:opacity-100' : 'text-muted',
               )}
             >
-              {fullDateFormatter.format(selectedDay.date)}
+              {hasWorkout
+                ? `${selectedDay.workouts.length} workout${selectedDay.workouts.length === 1 ? '' : 's'} on this day`
+                : 'No workouts on this day yet.'}
             </p>
           </div>
 
-          <div className="grid gap-3 sm:grid-cols-2">
-            {detailStats.map((stat) => (
-              <div
-                className={cn(
-                  'rounded-2xl border p-3',
-                  hasWorkout
-                    ? 'border-white/35 bg-white/45 dark:border-border dark:bg-secondary/60'
-                    : 'border-border bg-secondary/40 text-foreground',
-                )}
-                key={stat.label}
-              >
-                <p
-                  className={cn(
-                    'text-[11px] font-semibold uppercase tracking-[0.18em]',
-                    hasWorkout ? 'opacity-70 dark:text-muted dark:opacity-100' : 'text-muted',
-                  )}
-                >
-                  {stat.label}
-                </p>
-                <p className="mt-2 text-base font-semibold">{stat.value}</p>
-              </div>
-            ))}
-          </div>
-
-          <p
-            className={cn(
-              'text-sm leading-6',
-              hasWorkout ? 'opacity-85 dark:text-muted dark:opacity-100' : 'text-muted',
-            )}
-          >
-            {selectedDay.notes ??
-              'No workout is attached to this day yet. Complete or schedule a workout to see it here.'}
-          </p>
-
-          {selectedDay.completedSession ? (
-            <Button
-              asChild
-              className="mt-auto self-start bg-white/60 hover:bg-white/75 dark:bg-primary dark:text-primary-foreground dark:hover:bg-primary/90"
-              size="sm"
-              variant="secondary"
-            >
-              <Link
-                to={
-                  buildSessionHref?.(selectedDay.completedSession.id) ??
-                  `/workouts/session/${selectedDay.completedSession.id}`
-                }
-              >
-                View Session
-              </Link>
-            </Button>
-          ) : null}
-
-          {selectedDay.scheduledWorkouts.length > 0 ? (
-            <div className="space-y-2">
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted">
-                Scheduled
-              </p>
-              <div className="space-y-2">
-                {selectedDay.scheduledWorkouts.map((scheduledWorkout) => (
-                  <div
-                    className="flex items-center justify-between gap-2 rounded-2xl border border-border/70 bg-secondary/40 px-3 py-2"
-                    key={scheduledWorkout.id}
-                  >
-                    <div>
-                      <p className="text-sm font-medium text-foreground">
-                        {scheduledWorkout.templateName ?? 'Workout unavailable'}
-                      </p>
-                      <p className="text-xs text-muted">
-                        {scheduledWorkout.templateName == null || scheduledWorkout.templateId == null
-                          ? 'Unavailable'
-                          : 'Scheduled'}
-                      </p>
-                    </div>
-                    <ScheduledWorkoutActions
-                      buildStartWorkoutHref={buildStartWorkoutHref}
-                      scheduledWorkout={scheduledWorkout}
-                    />
-                  </div>
-                ))}
-              </div>
+          {selectedDay.workouts.length > 0 ? (
+            <div className="space-y-3">
+              {selectedDay.workouts.map((workout) => (
+                <DayWorkoutItemCard
+                  buildSessionHref={buildSessionHref}
+                  buildStartWorkoutHref={buildStartWorkoutHref}
+                  dateKey={selectedDay.dateKey}
+                  key={workout.id}
+                  workout={workout}
+                />
+              ))}
             </div>
-          ) : null}
-
-          {!selectedDay.completedSession && selectedDay.scheduledWorkouts.length === 0 ? (
-            <Button asChild className="mt-auto self-start" size="sm" variant="outline">
-              <Link to={openDayHref}>Open Day</Link>
-            </Button>
-          ) : null}
+          ) : (
+            <div className="rounded-2xl border border-border bg-secondary/35 p-4">
+              <h4 className="text-base font-semibold text-foreground">No workouts on this day</h4>
+              <p className="mt-1 text-sm text-muted">
+                Schedule a workout to plan this day from your templates.
+              </p>
+              <Button asChild className="mt-4" size="sm">
+                <Link to={scheduleDayHref}>Schedule a workout</Link>
+              </Button>
+            </div>
+          )}
         </aside>
       </CardContent>
     </Card>
   );
 }
 
-function ScheduledWorkoutActions({
+function DayWorkoutItemCard({
+  buildSessionHref,
   buildStartWorkoutHref,
-  scheduledWorkout,
+  dateKey,
+  workout,
 }: {
+  buildSessionHref?: (sessionId: string, status?: WorkoutSessionStatus) => string;
   buildStartWorkoutHref: (templateId: string) => string;
-  scheduledWorkout: ScheduledWorkoutListItem;
+  dateKey: string;
+  workout: DayWorkout;
 }) {
-  const rescheduleWorkoutMutation = useRescheduleWorkout();
+  const navigate = useNavigate();
   const unscheduleWorkoutMutation = useUnscheduleWorkout();
+  const startSessionMutation = useStartSession();
+  const deleteSessionMutation = useDeleteSession(workout.session?.id ?? null);
+  const updateSessionStatusMutation = useUpdateSessionStatus(workout.session?.id ?? null);
+  const templateQuery = useWorkoutTemplate(workout.status === 'scheduled' ? (workout.templateId ?? '') : '');
   const { confirm, dialog } = useConfirmation();
-  const [isRescheduleDialogOpen, setIsRescheduleDialogOpen] = useState(false);
-  const isUnavailable =
-    scheduledWorkout.templateId == null || scheduledWorkout.templateName == null;
-  const templateId = scheduledWorkout.templateId;
+  const canStart = workout.status === 'scheduled' && !workout.isUnavailable;
+  const isMutating =
+    unscheduleWorkoutMutation.isPending ||
+    startSessionMutation.isPending ||
+    deleteSessionMutation.isPending ||
+    updateSessionStatusMutation.isPending;
 
-  async function handleReschedule(requestedDate: string) {
-    if (isUnavailable) {
+  async function handleStart() {
+    if (!workout.scheduledWorkout || !workout.templateId || !templateQuery.data) {
       return;
     }
 
-    await rescheduleWorkoutMutation.mutateAsync({
-      date: requestedDate,
-      id: scheduledWorkout.id,
+    const startedAt = Date.now();
+    const session = await startSessionMutation.mutateAsync({
+      date: toDateKey(new Date(startedAt)),
+      name: workout.name,
+      sets: buildInitialSessionSets(templateQuery.data),
+      startedAt,
+      templateId: workout.templateId,
     });
+    navigate(`/workouts/active?template=${workout.templateId}&sessionId=${session.id}`);
   }
 
-  async function handleRemove() {
-    await unscheduleWorkoutMutation.mutateAsync({ id: scheduledWorkout.id });
+  async function handleDelete() {
+    if (workout.scheduledWorkout) {
+      await unscheduleWorkoutMutation.mutateAsync({ id: workout.scheduledWorkout.id });
+      return;
+    }
+
+    await deleteSessionMutation.mutateAsync();
+  }
+
+  async function handleCancel() {
+    await updateSessionStatusMutation.mutateAsync({ status: 'cancelled' });
   }
 
   return (
-    <>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            aria-label={`Actions for ${scheduledWorkout.templateName ?? 'scheduled workout'}`}
-            className={cn(
-              'inline-flex items-center justify-center rounded-full border border-slate-500 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-foreground hover:bg-secondary',
-              isUnavailable &&
-                'border-destructive/55 bg-destructive/10 text-destructive hover:bg-destructive/20',
-            )}
-            onClick={(event) => event.stopPropagation()}
+    <div className="rounded-2xl border border-border/70 bg-secondary/40 p-3">
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-sm font-medium text-foreground">{workout.name}</p>
+        <span
+          className={cn(
+            'inline-flex items-center rounded-full px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em]',
+            workout.status === 'completed'
+              ? 'bg-emerald-500/15 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400'
+              : workout.status === 'in-progress'
+                ? 'bg-orange-500/15 text-orange-700 dark:bg-orange-500/20 dark:text-orange-300'
+                : workout.isUnavailable
+                  ? 'bg-destructive/10 text-destructive'
+                  : 'bg-secondary text-muted-foreground',
+          )}
+        >
+          {workoutStatusLabel(workout)}
+        </span>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {workout.status === 'scheduled' ? (
+          <Button
+            disabled={isMutating || !canStart || templateQuery.isPending}
+            onClick={() => {
+              void handleStart();
+            }}
+            size="sm"
             type="button"
           >
-            {isUnavailable ? (
-              'Unavailable'
-            ) : (
-              'Scheduled'
-            )}
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          align="end"
-          className="w-44"
-          onClick={(event) => event.stopPropagation()}
-        >
-          {!isUnavailable && templateId ? (
-            <DropdownMenuItem asChild>
-              <Link to={buildStartWorkoutHref(templateId)}>Start workout</Link>
-            </DropdownMenuItem>
-          ) : null}
-          {!isUnavailable ? (
-            <DropdownMenuItem onSelect={() => setIsRescheduleDialogOpen(true)}>
-              Reschedule
-            </DropdownMenuItem>
-          ) : null}
-          <DropdownMenuItem
-            onSelect={() =>
+            Start
+          </Button>
+        ) : null}
+
+        {workout.status === 'in-progress' && workout.session ? (
+          <Button asChild size="sm">
+            <Link
+              to={
+                buildSessionHref?.(workout.session.id, workout.session.status) ??
+                `/workouts/active?sessionId=${workout.session.id}`
+              }
+            >
+              Resume
+            </Link>
+          </Button>
+        ) : null}
+
+        {workout.status === 'completed' && workout.session ? (
+          <Button asChild size="sm" variant="secondary">
+            <Link
+              to={
+                buildSessionHref?.(workout.session.id, workout.session.status) ??
+                `/workouts/session/${workout.session.id}`
+              }
+            >
+              View details
+            </Link>
+          </Button>
+        ) : null}
+
+        {workout.status === 'in-progress' ? (
+          <Button
+            disabled={isMutating}
+            onClick={() =>
               confirm({
-                title: 'Delete scheduled workout?',
-                description: `This will remove "${scheduledWorkout.templateName ?? 'this workout'}" from ${fullDateFormatter.format(parseDateKey(scheduledWorkout.date))}.`,
-                confirmLabel: 'Delete workout',
-                variant: 'destructive',
-                onConfirm: handleRemove,
+                title: 'Cancel workout?',
+                description: `This will mark "${workout.name}" as cancelled.`,
+                confirmLabel: 'Cancel workout',
+                onConfirm: handleCancel,
               })
             }
-            variant="destructive"
+            size="sm"
+            type="button"
+            variant="outline"
           >
-            Remove
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-      {!isUnavailable ? (
-        <ScheduleWorkoutDialog
-          description={`Move ${scheduledWorkout.templateName ?? 'this workout'} to a new date.`}
-          disallowDateKey={scheduledWorkout.date}
-          disallowDateMessage="Pick a different date to reschedule."
-          initialDate={scheduledWorkout.date}
-          isPending={rescheduleWorkoutMutation.isPending}
-          onOpenChange={setIsRescheduleDialogOpen}
-          onSubmitDate={handleReschedule}
-          open={isRescheduleDialogOpen}
-          submitLabel="Save"
-          title="Reschedule workout"
-        />
-      ) : null}
+            Cancel
+          </Button>
+        ) : null}
+
+        <Button
+          disabled={isMutating}
+          onClick={() =>
+            confirm({
+              title: workout.status === 'scheduled' ? 'Delete scheduled workout?' : 'Delete workout?',
+              description:
+                workout.status === 'scheduled'
+                  ? `This will remove "${workout.name}" from ${fullDateFormatter.format(parseDateKey(dateKey))}.`
+                  : `This will permanently delete "${workout.name}".`,
+              confirmLabel: 'Delete workout',
+              variant: 'destructive',
+              onConfirm: handleDelete,
+            })
+          }
+          size="sm"
+          type="button"
+          variant={workout.status === 'scheduled' ? 'outline' : 'ghost'}
+        >
+          Delete
+        </Button>
+        {workout.status === 'scheduled' && workout.templateId && workout.isUnavailable ? (
+          <Button asChild size="sm" variant="secondary">
+            <Link to={buildStartWorkoutHref(workout.templateId)}>Open template</Link>
+          </Button>
+        ) : null}
+      </div>
       {dialog}
-    </>
+    </div>
   );
+}
+
+function workoutStatusLabel(workout: DayWorkout) {
+  if (workout.status === 'completed') {
+    return 'Completed';
+  }
+  if (workout.status === 'in-progress') {
+    return 'In progress';
+  }
+  if (workout.isUnavailable) {
+    return 'Unavailable';
+  }
+  return 'Scheduled';
+}
+
+function getDaySubtitle(day: DayDetails) {
+  if (day.workouts.length === 0) {
+    return '';
+  }
+
+  const completed = day.workouts.filter((workout) => workout.status === 'completed').length;
+  const inProgress = day.workouts.filter((workout) => workout.status === 'in-progress').length;
+  const scheduled = day.workouts.filter((workout) => workout.status === 'scheduled').length;
+  const parts: string[] = [];
+
+  if (inProgress > 0) {
+    parts.push(`${inProgress} in progress`);
+  }
+  if (scheduled > 0) {
+    parts.push(`${scheduled} scheduled`);
+  }
+  if (completed > 0) {
+    parts.push(`${completed} completed`);
+  }
+
+  return parts.join(' · ');
 }
 
 function LegendDot({ className, label }: { className: string; label: string }) {
@@ -593,25 +643,23 @@ function LegendDot({ className, label }: { className: string; label: string }) {
   );
 }
 
-function getDayDetails(dateKey: string, context: DayLookupContext, todayKey: string): DayDetails {
+function getDayDetails(dateKey: string, context: DayLookupContext): DayDetails {
   const date = parseDateKey(dateKey);
   const completedSessions = context.completedSessionsByDate.get(dateKey) ?? [];
-  const completedSession = completedSessions[0] ?? null;
   const scheduledWorkouts = context.scheduledByDate.get(dateKey) ?? [];
-  const inProgressSession =
-    dateKey === todayKey ? (context.inProgressSessions[0] ?? null) : null;
-  const workoutIndicators = buildWorkoutIndicators({
+  const inProgressSessions = context.inProgressSessionsByDate.get(dateKey) ?? [];
+  const workouts = buildDayWorkouts({
     scheduledWorkouts,
     completedSessions,
-    inProgressSessions: dateKey === todayKey ? context.inProgressSessions : [],
+    inProgressSessions,
     sessionById: context.sessionById,
   });
+  const completedSession = workouts.find((workout) => workout.status === 'completed')?.session ?? null;
+  const workoutIndicators = buildWorkoutIndicators(workouts);
 
-  const hasCompleted = workoutIndicators.some((indicator) => indicator.status === 'completed');
-  const hasScheduled = workoutIndicators.some(
-    (indicator) => indicator.status === 'scheduled' || indicator.status === 'unavailable',
-  );
-  const hasInProgress = workoutIndicators.some((indicator) => indicator.status === 'in-progress');
+  const hasCompleted = workouts.some((workout) => workout.status === 'completed');
+  const hasScheduled = workouts.some((workout) => workout.status === 'scheduled');
+  const hasInProgress = workouts.some((workout) => workout.status === 'in-progress');
 
   let status: DayStatus = 'none';
   if (hasCompleted && (hasScheduled || hasInProgress)) {
@@ -624,104 +672,133 @@ function getDayDetails(dateKey: string, context: DayLookupContext, todayKey: str
     status = 'in-progress';
   }
 
-  const templateName =
-    completedSession?.templateName ??
-    (scheduledWorkouts[0]
-      ? (scheduledWorkouts[0].templateName ?? 'Workout unavailable')
-      : null) ??
-    inProgressSession?.templateName ??
-    null;
-  const notes = hasCompleted
-    ? completedSession
-      ? `${completedSession.exerciseCount} exercise${completedSession.exerciseCount === 1 ? '' : 's'} logged`
-      : `${workoutIndicators.length} workout${workoutIndicators.length === 1 ? '' : 's'} logged`
-    : hasScheduled
-      ? `${scheduledWorkouts.length} scheduled workout${scheduledWorkouts.length === 1 ? '' : 's'}`
-      : hasInProgress
-        ? 'Workout currently in progress'
-        : null;
-
   return {
     completedSession,
     date,
     dateKey,
-    inProgressSession,
-    notes,
-    scheduledWorkouts,
+    workouts,
     workoutIndicators,
     status,
-    templateName,
   };
 }
 
-function getDetailStats(selectedDay: DayDetails) {
-  if (selectedDay.completedSession) {
-    return [
-      { label: 'Status', value: 'Completed' },
-      {
-        label: 'Duration',
-        value:
-          selectedDay.completedSession.duration != null
-            ? `${selectedDay.completedSession.duration} min`
-            : 'Not tracked',
-      },
-      {
-        label: 'Exercises',
-        value: `${selectedDay.completedSession.exerciseCount}`,
-      },
-      {
-        label: 'Started',
-        value: timeFormatter.format(new Date(selectedDay.completedSession.startedAt)),
-      },
-    ];
+function buildDayWorkouts({
+  scheduledWorkouts,
+  completedSessions,
+  inProgressSessions,
+  sessionById,
+}: {
+  scheduledWorkouts: ScheduledWorkoutListItem[];
+  completedSessions: WorkoutSessionListItem[];
+  inProgressSessions: WorkoutSessionListItem[];
+  sessionById: Map<string, WorkoutSessionListItem>;
+}) {
+  const workouts: DayWorkout[] = [];
+  const consumedSessionIds = new Set<string>();
+
+  for (const scheduledWorkout of scheduledWorkouts) {
+    const linkedSession = scheduledWorkout.sessionId
+      ? (sessionById.get(scheduledWorkout.sessionId) ?? null)
+      : null;
+    const fallbackName = scheduledWorkout.templateName ?? 'Workout unavailable';
+
+    if (linkedSession && linkedSession.status === 'completed') {
+      workouts.push({
+        id: `scheduled-${scheduledWorkout.id}`,
+        isUnavailable: false,
+        name: linkedSession.templateName ?? linkedSession.name ?? fallbackName,
+        scheduledWorkout: scheduledWorkout,
+        session: linkedSession,
+        status: 'completed',
+        templateId: linkedSession.templateId ?? scheduledWorkout.templateId ?? null,
+      });
+      consumedSessionIds.add(linkedSession.id);
+      continue;
+    }
+
+    if (linkedSession && (linkedSession.status === 'in-progress' || linkedSession.status === 'paused')) {
+      workouts.push({
+        id: `scheduled-${scheduledWorkout.id}`,
+        isUnavailable: false,
+        name: linkedSession.templateName ?? linkedSession.name ?? fallbackName,
+        scheduledWorkout: scheduledWorkout,
+        session: linkedSession,
+        status: 'in-progress',
+        templateId: linkedSession.templateId ?? scheduledWorkout.templateId ?? null,
+      });
+      consumedSessionIds.add(linkedSession.id);
+      continue;
+    }
+
+    workouts.push({
+      id: `scheduled-${scheduledWorkout.id}`,
+      isUnavailable: scheduledWorkout.templateId == null || scheduledWorkout.templateName == null,
+      name: fallbackName,
+      scheduledWorkout: scheduledWorkout,
+      session: null,
+      status: 'scheduled',
+      templateId: scheduledWorkout.templateId ?? null,
+    });
   }
 
-  if (selectedDay.inProgressSession) {
-    return [
-      { label: 'Status', value: 'In progress' },
-      { label: 'Duration', value: 'Timer running' },
-      { label: 'Exercises', value: `${selectedDay.inProgressSession.exerciseCount}` },
-      {
-        label: 'Started',
-        value: timeFormatter.format(new Date(selectedDay.inProgressSession.startedAt)),
-      },
-    ];
+  for (const session of completedSessions) {
+    if (consumedSessionIds.has(session.id)) {
+      continue;
+    }
+    workouts.push({
+      id: `completed-${session.id}`,
+      isUnavailable: false,
+      name: session.templateName ?? session.name,
+      scheduledWorkout: null,
+      session,
+      status: 'completed',
+      templateId: session.templateId ?? null,
+    });
   }
 
-  if (selectedDay.scheduledWorkouts.length > 0) {
-    return [
-      { label: 'Status', value: 'Scheduled' },
-      { label: 'Planned', value: `${selectedDay.scheduledWorkouts.length} workouts` },
-      {
-        label: 'Focus',
-        value: selectedDay.scheduledWorkouts[0]?.templateName ?? 'Workout planned',
-      },
-      { label: 'Readiness', value: 'Ready to start' },
-    ];
+  for (const session of inProgressSessions) {
+    if (consumedSessionIds.has(session.id)) {
+      continue;
+    }
+    workouts.push({
+      id: `in-progress-${session.id}`,
+      isUnavailable: false,
+      name: session.templateName ?? session.name,
+      scheduledWorkout: null,
+      session,
+      status: 'in-progress',
+      templateId: session.templateId ?? null,
+    });
   }
 
-  return [
-    { label: 'Status', value: 'Open day' },
-    { label: 'Focus', value: 'No session linked' },
-    { label: 'Plan', value: 'Use for flexibility' },
-    { label: 'Readiness', value: 'Template can be added later' },
-  ];
+  return workouts.sort((left, right) => {
+    const priority = workoutPriority(left.status) - workoutPriority(right.status);
+    if (priority !== 0) {
+      return priority;
+    }
+    const leftTime = left.session?.startedAt ?? left.scheduledWorkout?.createdAt ?? 0;
+    const rightTime = right.session?.startedAt ?? right.scheduledWorkout?.createdAt ?? 0;
+    return rightTime - leftTime;
+  });
 }
 
 function getDefaultSelectedDateKey(
   month: Date,
   completedByDate: Map<string, WorkoutSessionListItem[]>,
+  inProgressByDate: Map<string, WorkoutSessionListItem[]>,
   scheduledByDate: Map<string, ScheduledWorkoutListItem[]>,
   todayKey: string,
 ): string {
   if (
     isSameMonth(parseDateKey(todayKey), month) &&
-    (completedByDate.has(todayKey) || (scheduledByDate.get(todayKey)?.length ?? 0) > 0)
+    (completedByDate.has(todayKey) ||
+      inProgressByDate.has(todayKey) ||
+      (scheduledByDate.get(todayKey)?.length ?? 0) > 0)
   ) {
     return todayKey;
   }
 
-  const monthActivity = [...completedByDate.keys(), ...scheduledByDate.keys()]
+  const monthActivity = [...completedByDate.keys(), ...inProgressByDate.keys(), ...scheduledByDate.keys()]
     .map((dateKey) => parseDateKey(dateKey))
     .filter((date) => isSameMonth(date, month))
     .sort((left, right) => left.getTime() - right.getTime());
@@ -768,67 +845,31 @@ function isSameMonth(left: Date, right: Date) {
   return left.getFullYear() === right.getFullYear() && left.getMonth() === right.getMonth();
 }
 
-function spansToday(session: WorkoutSessionListItem, todayKey: string) {
-  const dayStart = new Date(`${todayKey}T00:00:00`).getTime();
-  const dayEnd = new Date(`${todayKey}T23:59:59.999`).getTime();
-  const sessionEnd = session.completedAt ?? Number.POSITIVE_INFINITY;
-
-  return session.startedAt <= dayEnd && sessionEnd >= dayStart;
+function workoutPriority(status: DayWorkoutStatus) {
+  switch (status) {
+    case 'in-progress':
+      return 0;
+    case 'scheduled':
+      return 1;
+    case 'completed':
+      return 2;
+    default:
+      return 3;
+  }
 }
 
-function buildWorkoutIndicators({
-  scheduledWorkouts,
-  completedSessions,
-  inProgressSessions,
-  sessionById,
-}: {
-  scheduledWorkouts: ScheduledWorkoutListItem[];
-  completedSessions: WorkoutSessionListItem[];
-  inProgressSessions: WorkoutSessionListItem[];
-  sessionById: Map<string, WorkoutSessionListItem>;
-}): WorkoutIndicator[] {
-  const indicators: WorkoutIndicator[] = [];
-  const consumedSessionIds = new Set<string>();
-
-  for (const scheduledWorkout of scheduledWorkouts) {
-    const linkedSession = scheduledWorkout.sessionId
-      ? (sessionById.get(scheduledWorkout.sessionId) ?? null)
-      : null;
-
-    if (linkedSession && linkedSession.status === 'completed') {
-      indicators.push({ id: `scheduled-${scheduledWorkout.id}`, status: 'completed' });
-      consumedSessionIds.add(linkedSession.id);
-      continue;
-    }
-
-    if (linkedSession && (linkedSession.status === 'in-progress' || linkedSession.status === 'paused')) {
-      indicators.push({ id: `scheduled-${scheduledWorkout.id}`, status: 'in-progress' });
-      consumedSessionIds.add(linkedSession.id);
-      continue;
-    }
-
-    indicators.push({
-      id: `scheduled-${scheduledWorkout.id}`,
+function buildWorkoutIndicators(workouts: DayWorkout[]): WorkoutIndicator[] {
+  return workouts
+    .map((workout): WorkoutIndicator => ({
+      id: workout.id,
       status:
-        scheduledWorkout.templateId == null || scheduledWorkout.templateName == null
-          ? 'unavailable'
-          : 'scheduled',
-    });
-  }
-
-  for (const session of completedSessions) {
-    if (!consumedSessionIds.has(session.id)) {
-      indicators.push({ id: `completed-${session.id}`, status: 'completed' });
-    }
-  }
-
-  for (const session of inProgressSessions) {
-    if (!consumedSessionIds.has(session.id)) {
-      indicators.push({ id: `in-progress-${session.id}`, status: 'in-progress' });
-    }
-  }
-
-  return indicators.sort((left, right) => indicatorPriority(left.status) - indicatorPriority(right.status));
+        workout.status === 'scheduled'
+          ? workout.isUnavailable
+            ? 'unavailable'
+            : 'scheduled'
+          : workout.status,
+    }))
+    .sort((left, right) => indicatorPriority(left.status) - indicatorPriority(right.status));
 }
 
 function indicatorPriority(status: WorkoutIndicatorStatus) {

--- a/apps/web/src/features/workouts/components/workout-list.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.test.tsx
@@ -8,7 +8,7 @@ import { renderWithQueryClient } from '@/test/render-with-query-client';
 import { WorkoutList } from './workout-list';
 
 describe('WorkoutList', () => {
-  it('renders scheduled workouts above upcoming/completed with missed indicator', async () => {
+  it('renders sections in order and includes in-progress actions', async () => {
     const sessions = [
       createSession({
         id: 'session-in-progress',
@@ -18,145 +18,163 @@ describe('WorkoutList', () => {
         templateName: 'Upper Push',
       }),
       createSession({
-        id: 'session-paused',
-        date: '2026-03-13',
-        status: 'paused',
-        templateId: 'template-pull',
-        templateName: 'Upper Pull',
-      }),
-      createSession({
         id: 'session-completed',
         date: '2026-03-10',
         status: 'completed',
         templateId: 'template-legs',
         templateName: 'Lower Body',
-        duration: 49,
       }),
     ];
 
-    const scheduledWorkouts = [
-      createScheduledWorkout({
-        id: 'schedule-upcoming',
-        date: '2026-03-15',
-        templateId: 'template-push',
-        templateName: 'Upper Push',
-        sessionId: null,
-      }),
-      createScheduledWorkout({
-        id: 'schedule-missed',
-        date: '2026-03-01',
-        templateId: 'template-pull',
-        templateName: 'Upper Pull',
-        sessionId: 'session-soft-deleted',
-      }),
-    ];
-
-    renderWorkoutList(sessions, scheduledWorkouts);
-
-    expect(await screen.findByRole('heading', { level: 2, name: 'Scheduled' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 2, name: 'Upcoming' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 2, name: 'Completed' })).toBeInTheDocument();
-    expect(screen.getByText('Missed')).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Start now' }).length).toBeGreaterThan(0);
-    expect(screen.getAllByText('In Progress').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Paused').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Completed').length).toBeGreaterThan(0);
-  });
-
-  it('shows unavailable state for soft-deleted scheduled templates and hides stale start actions', async () => {
-    const sessions = [
-      createSession({
-        id: 'session-hidden',
-        templateId: 'template-deleted',
-        templateName: null,
-      }),
-      createSession({
-        id: 'session-visible',
-        templateId: 'template-kept',
-        templateName: 'Visible Workout',
-      }),
-    ];
-    const scheduledWorkouts = [
-      createScheduledWorkout({
-        id: 'schedule-hidden',
-        templateId: 'template-deleted',
-        templateName: null,
-      }),
-      createScheduledWorkout({
-        id: 'schedule-visible',
-        templateId: 'template-kept',
-        templateName: 'Visible Workout',
-      }),
-    ];
-
-    renderWorkoutList(sessions, scheduledWorkouts);
-
-    expect(await screen.findByRole('link', { name: /visible workout/i })).toBeInTheDocument();
-    expect(screen.getByText('Workout unavailable')).toBeInTheDocument();
-    const unavailableCard = screen.getByText('Workout unavailable').closest('[data-slot="card"]');
-    expect(unavailableCard).not.toBeNull();
-    expect(
-      within(unavailableCard as HTMLElement).getByRole('button', { name: 'Start now' }),
-    ).toBeDisabled();
-  });
-
-  it('shows planned-workout onboarding when no scheduled or active workouts exist', async () => {
-    renderWorkoutList(
-      [
-        createSession({
-          id: 'session-11',
-          status: 'completed',
-          date: '2026-03-01',
-        }),
-      ],
-      [],
-    );
-
-    expect(await screen.findByText('No workouts planned')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Plan a workout' })).toHaveAttribute(
-      'href',
-      '/workouts?view=templates',
-    );
-    expect(screen.getByRole('link', { name: 'Browse templates' })).toHaveAttribute(
-      'href',
-      '/workouts?view=templates',
-    );
-  });
-
-  it('shows an empty state when no workout sessions or schedules are returned', async () => {
-    renderWorkoutList([], []);
+    renderWorkoutList(sessions, []);
 
     expect(
-      await screen.findByText('No workouts yet. Plan one to get started.'),
+      await screen.findByRole('heading', { level: 2, name: 'In Progress' }),
     ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Scheduled' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Completed' })).toBeInTheDocument();
+
+    const headings = screen
+      .getAllByRole('heading', { level: 2 })
+      .map((heading) => heading.textContent);
+    expect(headings).toEqual(['In Progress', 'Scheduled', 'Completed']);
+
+    const inProgressSection = getSectionByTitle('In Progress');
+    expect(within(inProgressSection).getByRole('link', { name: 'Resume' })).toBeInTheDocument();
+    expect(within(inProgressSection).getByRole('button', { name: /Cancel/i })).toBeInTheDocument();
+    expect(within(inProgressSection).getByRole('button', { name: /Delete/i })).toBeInTheDocument();
   });
 
-  it('opens a calendar dialog for rescheduling', async () => {
+  it('does not render completed linked scheduled workouts in scheduled section', async () => {
     const sessions = [
       createSession({
         id: 'session-completed',
         status: 'completed',
         date: '2026-03-10',
+        templateId: 'template-a',
+        templateName: 'Completed Linked Session',
       }),
     ];
     const scheduledWorkouts = [
       createScheduledWorkout({
-        id: 'schedule-upcoming',
+        id: 'schedule-linked-completed',
+        date: '2026-03-10',
+        templateId: 'template-a',
+        templateName: 'Completed Linked Session',
+        sessionId: 'session-completed',
+      }),
+      createScheduledWorkout({
+        id: 'schedule-unlinked',
         date: '2026-03-15',
-        templateId: 'template-push',
-        templateName: 'Upper Push',
+        templateId: 'template-b',
+        templateName: 'Still Scheduled',
         sessionId: null,
       }),
     ];
 
     renderWorkoutList(sessions, scheduledWorkouts);
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Reschedule' }));
+    await screen.findByRole('heading', { level: 2, name: 'Scheduled' });
+    const scheduledSection = getSectionByTitle('Scheduled');
 
-    expect(await screen.findByRole('heading', { name: 'Reschedule workout' })).toBeInTheDocument();
-    expect(screen.getByText('Move Upper Push to a new date.')).toBeInTheDocument();
+    expect(within(scheduledSection).getByText('Still Scheduled')).toBeInTheDocument();
+    expect(
+      within(scheduledSection).queryByText('Completed Linked Session'),
+    ).not.toBeInTheDocument();
+    expect(within(scheduledSection).getAllByRole('button', { name: 'Start now' })).toHaveLength(1);
+  });
+
+  it('does not render in-progress linked scheduled workouts in scheduled section', async () => {
+    const sessions = [
+      createSession({
+        id: 'session-in-progress',
+        status: 'in-progress',
+        date: '2026-03-12',
+        templateId: 'template-a',
+        templateName: 'In Progress Linked Session',
+      }),
+    ];
+    const scheduledWorkouts = [
+      createScheduledWorkout({
+        id: 'schedule-linked-progress',
+        date: '2026-03-12',
+        templateId: 'template-a',
+        templateName: 'In Progress Linked Session',
+        sessionId: 'session-in-progress',
+      }),
+      createScheduledWorkout({
+        id: 'schedule-unlinked',
+        date: '2026-03-16',
+        templateId: 'template-b',
+        templateName: 'Scheduled Only',
+        sessionId: null,
+      }),
+    ];
+
+    renderWorkoutList(sessions, scheduledWorkouts);
+
+    await screen.findByRole('heading', { level: 2, name: 'Scheduled' });
+    const scheduledSection = getSectionByTitle('Scheduled');
+    const inProgressSection = getSectionByTitle('In Progress');
+
+    expect(within(scheduledSection).getByText('Scheduled Only')).toBeInTheDocument();
+    expect(
+      within(scheduledSection).queryByText('In Progress Linked Session'),
+    ).not.toBeInTheDocument();
+    expect(within(inProgressSection).getByText('In Progress Linked Session')).toBeInTheDocument();
+  });
+
+  it('reveals more scheduled workouts when clicking show more', async () => {
+    const scheduledWorkouts = Array.from({ length: 5 }, (_, index) =>
+      createScheduledWorkout({
+        id: `schedule-${index + 1}`,
+        date: `2026-03-${String(index + 10).padStart(2, '0')}`,
+        templateName: `Scheduled ${index + 1}`,
+      }),
+    );
+
+    renderWorkoutList([], scheduledWorkouts);
+
+    await screen.findByRole('heading', { level: 2, name: 'Scheduled' });
+    const scheduledSection = getSectionByTitle('Scheduled');
+
+    expect(within(scheduledSection).queryByText('Scheduled 5')).not.toBeInTheDocument();
+
+    fireEvent.click(within(scheduledSection).getByRole('button', { name: 'Show more' }));
+
+    expect(within(scheduledSection).getByText('Scheduled 5')).toBeInTheDocument();
+  });
+
+  it('reveals more completed workouts when clicking show more', async () => {
+    const sessions = Array.from({ length: 7 }, (_, index) =>
+      createSession({
+        id: `session-completed-${index + 1}`,
+        status: 'completed',
+        date: `2026-03-${String(index + 1).padStart(2, '0')}`,
+        templateId: `template-${index + 1}`,
+        templateName: `Completed ${index + 1}`,
+      }),
+    );
+
+    renderWorkoutList(sessions, []);
+
+    await screen.findByRole('heading', { level: 2, name: 'Completed' });
+    const completedSection = getSectionByTitle('Completed');
+
+    expect(within(completedSection).queryByText('Completed 1')).not.toBeInTheDocument();
+
+    fireEvent.click(within(completedSection).getByRole('button', { name: 'Show more' }));
+
+    expect(within(completedSection).getByText('Completed 1')).toBeInTheDocument();
   });
 });
+
+function getSectionByTitle(title: 'In Progress' | 'Scheduled' | 'Completed') {
+  const heading = screen.getByRole('heading', { level: 2, name: title });
+  const section = heading.closest('section');
+  expect(section).not.toBeNull();
+  return section as HTMLElement;
+}
 
 function renderWorkoutList(
   sessions: WorkoutSessionListItem[],

--- a/apps/web/src/features/workouts/components/workout-list.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.tsx
@@ -36,8 +36,11 @@ import {
 import { useTodayKey } from '../hooks/use-today-key';
 import { hasAvailableTemplate } from '../lib/workout-filters';
 import { buildInitialSessionSets } from '../lib/workout-session-sets';
-import { useStartSession } from '@/hooks/use-workout-session';
-import { useDeleteSession, useUpdateSessionStatus } from '@/hooks/use-workout-session';
+import {
+  useDeleteSession,
+  useStartSession,
+  useUpdateSessionStatus,
+} from '@/hooks/use-workout-session';
 import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
 
 const sessionDateFormatter = new Intl.DateTimeFormat('en-US', {

--- a/apps/web/src/features/workouts/components/workout-list.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.tsx
@@ -9,6 +9,8 @@ import {
   Dumbbell,
   Timer,
   TriangleAlert,
+  Trash2,
+  XCircle,
 } from 'lucide-react';
 import { Link } from 'react-router';
 import type {
@@ -35,6 +37,7 @@ import { useTodayKey } from '../hooks/use-today-key';
 import { hasAvailableTemplate } from '../lib/workout-filters';
 import { buildInitialSessionSets } from '../lib/workout-session-sets';
 import { useStartSession } from '@/hooks/use-workout-session';
+import { useDeleteSession, useUpdateSessionStatus } from '@/hooks/use-workout-session';
 import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
 
 const sessionDateFormatter = new Intl.DateTimeFormat('en-US', {
@@ -65,6 +68,9 @@ type WorkoutListViewItem = {
   statusLabel: string;
 };
 
+const SCHEDULED_PAGE_SIZE = 4;
+const COMPLETED_PAGE_SIZE = 6;
+
 export function WorkoutList({
   buildSessionHref = (sessionId, status) =>
     status === 'in-progress' || status === 'paused'
@@ -84,28 +90,42 @@ export function WorkoutList({
   });
 
   const resolvedSessions = sessions ?? sessionsQuery.data ?? [];
-  const activeSessions = resolvedSessions.filter(hasAvailableTemplate);
-  const linkedSessionIds = new Set(activeSessions.map((session) => session.id));
+  const sessionsById = new Map(resolvedSessions.map((session) => [session.id, session]));
+  const visibleSessions = resolvedSessions.filter(hasAvailableTemplate);
   const resolvedScheduledWorkouts = scheduledWorkouts ?? scheduledQuery.data ?? [];
+  const dedupedScheduledWorkouts = Array.from(
+    new Map(resolvedScheduledWorkouts.map((workout) => [workout.id, workout])).values(),
+  );
 
-  const scheduledItems = resolvedScheduledWorkouts
+  const scheduledItems = dedupedScheduledWorkouts
+    .filter((scheduledWorkout) => {
+      if (scheduledWorkout.sessionId == null) {
+        return true;
+      }
+
+      return !sessionsById.has(scheduledWorkout.sessionId);
+    })
     .map((scheduledWorkout) => ({
       ...scheduledWorkout,
       isMissed:
         scheduledWorkout.date < todayKey &&
-        (scheduledWorkout.sessionId == null || !linkedSessionIds.has(scheduledWorkout.sessionId)),
+        (scheduledWorkout.sessionId == null || !sessionsById.has(scheduledWorkout.sessionId)),
       isUnavailable: scheduledWorkout.templateId == null || scheduledWorkout.templateName == null,
     }))
     .sort((left, right) => left.date.localeCompare(right.date));
 
-  const listItems = activeSessions.map((session) => buildWorkoutListItem(session));
-  const upcomingSessions = listItems
-    .filter((session) => session.status !== 'completed' && session.status !== 'scheduled')
+  const listItems = visibleSessions.map((session) => buildWorkoutListItem(session));
+  const inProgressSessions = listItems
+    .filter((session) => session.status === 'in-progress' || session.status === 'paused')
     .sort((left, right) => left.date.getTime() - right.date.getTime());
   const completedSessions = listItems
     .filter((session) => session.status === 'completed')
     .sort((left, right) => right.date.getTime() - left.date.getTime());
-  const hasPlannedWorkouts = scheduledItems.length > 0 || upcomingSessions.length > 0;
+  const hasPlannedWorkouts = scheduledItems.length > 0 || inProgressSessions.length > 0;
+  const [scheduledVisibleCount, setScheduledVisibleCount] = useState(SCHEDULED_PAGE_SIZE);
+  const [completedVisibleCount, setCompletedVisibleCount] = useState(COMPLETED_PAGE_SIZE);
+  const visibleScheduledItems = scheduledItems.slice(0, scheduledVisibleCount);
+  const visibleCompletedSessions = completedSessions.slice(0, completedVisibleCount);
 
   if ((sessionsQuery.isLoading && !sessions) || (scheduledQuery.isLoading && !scheduledWorkouts)) {
     return (
@@ -130,24 +150,24 @@ export function WorkoutList({
   return (
     <div className="space-y-6">
       <section className="space-y-3">
-        <SectionHeading count={scheduledItems.length} title="Scheduled" />
-        {scheduledItems.length > 0 ? (
+        <SectionHeading count={inProgressSessions.length} title="In Progress" />
+        {inProgressSessions.length > 0 ? (
           <div className="grid gap-3">
-            {scheduledItems.map((scheduledWorkout) => (
-              <ScheduledWorkoutCard
-                buildStartWorkoutHref={buildStartWorkoutHref}
-                key={scheduledWorkout.id}
-                scheduledWorkout={scheduledWorkout}
+            {inProgressSessions.map((session) => (
+              <InProgressWorkoutCard
+                buildSessionHref={buildSessionHref}
+                key={session.id}
+                session={session}
               />
             ))}
           </div>
         ) : (
-          <p className="text-sm text-muted">No scheduled workouts right now.</p>
+          <p className="text-sm text-muted">No workouts in progress.</p>
         )}
       </section>
 
       <section className="space-y-3">
-        <SectionHeading count={upcomingSessions.length} title="Upcoming" />
+        <SectionHeading count={scheduledItems.length} title="Scheduled" />
         {!hasPlannedWorkouts ? (
           <Card className="border-dashed">
             <CardContent className="space-y-4 py-5">
@@ -168,26 +188,36 @@ export function WorkoutList({
             </CardContent>
           </Card>
         ) : null}
-        {upcomingSessions.length > 0 ? (
+        {scheduledItems.length > 0 ? (
           <div className="grid gap-3">
-            {upcomingSessions.map((session) => (
-              <WorkoutListCard
-                buildSessionHref={buildSessionHref}
-                key={session.id}
-                session={session}
+            {visibleScheduledItems.map((scheduledWorkout) => (
+              <ScheduledWorkoutCard
+                buildStartWorkoutHref={buildStartWorkoutHref}
+                key={scheduledWorkout.id}
+                scheduledWorkout={scheduledWorkout}
               />
             ))}
           </div>
         ) : (
-          <p className="text-sm text-muted">No upcoming sessions right now.</p>
+          <p className="text-sm text-muted">No scheduled workouts right now.</p>
         )}
+        {scheduledItems.length > scheduledVisibleCount ? (
+          <Button
+            onClick={() => setScheduledVisibleCount((count) => count + SCHEDULED_PAGE_SIZE)}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            Show more
+          </Button>
+        ) : null}
       </section>
 
       <section className="space-y-3">
         <SectionHeading count={completedSessions.length} title="Completed" />
         {completedSessions.length > 0 ? (
           <div className="grid gap-3">
-            {completedSessions.map((session) => (
+            {visibleCompletedSessions.map((session) => (
               <WorkoutListCard
                 buildSessionHref={buildSessionHref}
                 key={session.id}
@@ -198,8 +228,118 @@ export function WorkoutList({
         ) : (
           <p className="text-sm text-muted">No completed workouts yet.</p>
         )}
+        {completedSessions.length > completedVisibleCount ? (
+          <Button
+            onClick={() => setCompletedVisibleCount((count) => count + COMPLETED_PAGE_SIZE)}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            Show more
+          </Button>
+        ) : null}
       </section>
     </div>
+  );
+}
+
+function InProgressWorkoutCard({
+  buildSessionHref,
+  session,
+}: {
+  buildSessionHref: (sessionId: string, status: WorkoutSessionStatus) => string;
+  session: WorkoutListViewItem;
+}) {
+  const { confirm, dialog } = useConfirmation();
+  const updateSessionStatusMutation = useUpdateSessionStatus(session.id);
+  const deleteSessionMutation = useDeleteSession(session.id);
+  const isMutating = updateSessionStatusMutation.isPending || deleteSessionMutation.isPending;
+
+  async function handleCancel() {
+    await updateSessionStatusMutation.mutateAsync({ status: 'cancelled' });
+  }
+
+  async function handleDelete() {
+    await deleteSessionMutation.mutateAsync();
+  }
+
+  return (
+    <Card
+      className={cn(
+        'h-full gap-4 border-l-4 py-0 transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-md',
+        session.cardClass,
+      )}
+      style={{ borderLeftColor: session.accentColor }}
+    >
+      <CardHeader className="gap-3 py-5">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <CardTitle>{session.name}</CardTitle>
+            <p className="text-sm text-muted">{sessionDateFormatter.format(session.date)}</p>
+          </div>
+
+          <span
+            className={cn(
+              'inline-flex w-fit items-center gap-1 rounded-full px-3 py-1 text-[11px] font-semibold tracking-[0.18em] uppercase',
+              session.statusBadgeClass,
+            )}
+          >
+            {getStatusBadgeIcon(session.status)}
+            {session.statusLabel}
+          </span>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-4 pb-5">
+        <ul className="flex flex-wrap gap-3 text-sm text-muted">
+          {buildStatusStats(session).map((stat) => (
+            <WorkoutStat icon={stat.icon} key={`${session.id}-${stat.label}`} label={stat.label} />
+          ))}
+        </ul>
+
+        <div className="flex flex-wrap gap-2">
+          <Button asChild size="sm">
+            <Link to={buildSessionHref(session.id, session.status)}>Resume</Link>
+          </Button>
+          <Button
+            disabled={isMutating}
+            onClick={() =>
+              confirm({
+                title: 'Cancel workout?',
+                description: `This will mark "${session.name}" as cancelled.`,
+                confirmLabel: 'Cancel workout',
+                onConfirm: handleCancel,
+              })
+            }
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <XCircle aria-hidden="true" className="size-4" />
+            Cancel
+          </Button>
+          <Button
+            disabled={isMutating}
+            onClick={() =>
+              confirm({
+                title: 'Delete workout?',
+                description: `This will permanently delete "${session.name}".`,
+                confirmLabel: 'Delete workout',
+                variant: 'destructive',
+                onConfirm: handleDelete,
+              })
+            }
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            <Trash2 aria-hidden="true" className="size-4" />
+            Delete
+          </Button>
+        </div>
+      </CardContent>
+      {dialog}
+    </Card>
   );
 }
 

--- a/apps/web/src/features/workouts/lib/day-workout-conflicts.ts
+++ b/apps/web/src/features/workouts/lib/day-workout-conflicts.ts
@@ -19,60 +19,65 @@ const scheduledWorkoutListResponseSchema = z.array(scheduledWorkoutListItemSchem
 const workoutSessionListResponseSchema = z.array(workoutSessionListItemSchema);
 
 export async function getDayWorkoutConflicts(dateKey: string): Promise<DayWorkoutConflict[]> {
-  // Intentionally fetch fresh server state before mutating to avoid stale duplicate checks.
-  const [scheduledData, sessionData] = await Promise.all([
-    apiRequest<unknown>(`/api/v1/scheduled-workouts?from=${dateKey}&to=${dateKey}`, {
-      method: 'GET',
-    }),
-    apiRequest<unknown>(
-      `/api/v1/workout-sessions?from=${dateKey}&to=${dateKey}&status=completed&status=in-progress&status=paused`,
-      {
+  try {
+    // Intentionally fetch fresh server state before mutating to avoid stale duplicate checks.
+    const [scheduledData, sessionData] = await Promise.all([
+      apiRequest<unknown>(`/api/v1/scheduled-workouts?from=${dateKey}&to=${dateKey}`, {
         method: 'GET',
-      },
-    ),
-  ]);
+      }),
+      apiRequest<unknown>(
+        `/api/v1/workout-sessions?from=${dateKey}&to=${dateKey}&status=completed&status=in-progress&status=paused`,
+        {
+          method: 'GET',
+        },
+      ),
+    ]);
 
-  const scheduledWorkouts = scheduledWorkoutListResponseSchema.parse(scheduledData);
-  const sessions = workoutSessionListResponseSchema.parse(sessionData);
-  const sessionById = new Map(sessions.map((session) => [session.id, session]));
-  const consumedSessionIds = new Set<string>();
-  const conflicts: DayWorkoutConflict[] = [];
+    const scheduledWorkouts = scheduledWorkoutListResponseSchema.parse(scheduledData);
+    const sessions = workoutSessionListResponseSchema.parse(sessionData);
+    const sessionById = new Map(sessions.map((session) => [session.id, session]));
+    const consumedSessionIds = new Set<string>();
+    const conflicts: DayWorkoutConflict[] = [];
 
-  for (const scheduledWorkout of scheduledWorkouts) {
-    const linkedSession = scheduledWorkout.sessionId
-      ? (sessionById.get(scheduledWorkout.sessionId) ?? null)
-      : null;
+    for (const scheduledWorkout of scheduledWorkouts) {
+      const linkedSession = scheduledWorkout.sessionId
+        ? (sessionById.get(scheduledWorkout.sessionId) ?? null)
+        : null;
 
-    if (linkedSession && isConflictSessionStatus(linkedSession.status)) {
+      if (linkedSession && isConflictSessionStatus(linkedSession.status)) {
+        conflicts.push({
+          id: `scheduled-${scheduledWorkout.id}`,
+          name: linkedSession.templateName ?? linkedSession.name,
+          status: mapSessionStatus(linkedSession.status),
+        });
+        consumedSessionIds.add(linkedSession.id);
+        continue;
+      }
+
       conflicts.push({
         id: `scheduled-${scheduledWorkout.id}`,
-        name: linkedSession.templateName ?? linkedSession.name,
-        status: mapSessionStatus(linkedSession.status),
+        name: scheduledWorkout.templateName ?? 'Workout unavailable',
+        status: 'scheduled',
       });
-      consumedSessionIds.add(linkedSession.id);
-      continue;
     }
 
-    conflicts.push({
-      id: `scheduled-${scheduledWorkout.id}`,
-      name: scheduledWorkout.templateName ?? 'Workout unavailable',
-      status: 'scheduled',
-    });
-  }
+    for (const session of sessions) {
+      if (!isConflictSessionStatus(session.status) || consumedSessionIds.has(session.id)) {
+        continue;
+      }
 
-  for (const session of sessions) {
-    if (!isConflictSessionStatus(session.status) || consumedSessionIds.has(session.id)) {
-      continue;
+      conflicts.push({
+        id: `session-${session.id}`,
+        name: session.templateName ?? session.name,
+        status: mapSessionStatus(session.status),
+      });
     }
 
-    conflicts.push({
-      id: `session-${session.id}`,
-      name: session.templateName ?? session.name,
-      status: mapSessionStatus(session.status),
-    });
+    return conflicts;
+  } catch {
+    // Fail open so schedule/start flows still work if conflict lookup fails.
+    return [];
   }
-
-  return conflicts;
 }
 
 export function formatWorkoutConflictDescription(conflicts: DayWorkoutConflict[]) {

--- a/apps/web/src/features/workouts/lib/day-workout-conflicts.ts
+++ b/apps/web/src/features/workouts/lib/day-workout-conflicts.ts
@@ -1,0 +1,107 @@
+import {
+  scheduledWorkoutListItemSchema,
+  workoutSessionListItemSchema,
+  type WorkoutSessionStatus,
+} from '@pulse/shared';
+import { z } from 'zod';
+
+import { apiRequest } from '@/lib/api-client';
+
+export type DayWorkoutConflictStatus = 'scheduled' | 'in-progress' | 'completed';
+
+export type DayWorkoutConflict = {
+  id: string;
+  name: string;
+  status: DayWorkoutConflictStatus;
+};
+
+const scheduledWorkoutListResponseSchema = z.array(scheduledWorkoutListItemSchema);
+const workoutSessionListResponseSchema = z.array(workoutSessionListItemSchema);
+
+export async function getDayWorkoutConflicts(dateKey: string): Promise<DayWorkoutConflict[]> {
+  const [scheduledData, sessionData] = await Promise.all([
+    apiRequest<unknown>(`/api/v1/scheduled-workouts?from=${dateKey}&to=${dateKey}`, {
+      method: 'GET',
+    }),
+    apiRequest<unknown>(
+      `/api/v1/workout-sessions?from=${dateKey}&to=${dateKey}&status=completed&status=in-progress&status=paused`,
+      {
+        method: 'GET',
+      },
+    ),
+  ]);
+
+  const scheduledWorkouts = scheduledWorkoutListResponseSchema.parse(scheduledData);
+  const sessions = workoutSessionListResponseSchema.parse(sessionData);
+  const sessionById = new Map(sessions.map((session) => [session.id, session]));
+  const consumedSessionIds = new Set<string>();
+  const conflicts: DayWorkoutConflict[] = [];
+
+  for (const scheduledWorkout of scheduledWorkouts) {
+    const linkedSession = scheduledWorkout.sessionId
+      ? (sessionById.get(scheduledWorkout.sessionId) ?? null)
+      : null;
+
+    if (linkedSession && isConflictSessionStatus(linkedSession.status)) {
+      conflicts.push({
+        id: `scheduled-${scheduledWorkout.id}`,
+        name: linkedSession.templateName ?? linkedSession.name,
+        status: mapSessionStatus(linkedSession.status),
+      });
+      consumedSessionIds.add(linkedSession.id);
+      continue;
+    }
+
+    conflicts.push({
+      id: `scheduled-${scheduledWorkout.id}`,
+      name: scheduledWorkout.templateName ?? 'Workout unavailable',
+      status: 'scheduled',
+    });
+  }
+
+  for (const session of sessions) {
+    if (!isConflictSessionStatus(session.status) || consumedSessionIds.has(session.id)) {
+      continue;
+    }
+
+    conflicts.push({
+      id: `session-${session.id}`,
+      name: session.templateName ?? session.name,
+      status: mapSessionStatus(session.status),
+    });
+  }
+
+  return conflicts;
+}
+
+export function formatWorkoutConflictDescription(conflicts: DayWorkoutConflict[]) {
+  const lines = conflicts.map(
+    (conflict) => `- ${conflict.name} (${formatConflictStatusLabel(conflict.status)})`,
+  );
+
+  return ['Existing workouts:', ...lines].join('\n');
+}
+
+function isConflictSessionStatus(status: WorkoutSessionStatus) {
+  return status === 'completed' || status === 'in-progress' || status === 'paused';
+}
+
+function mapSessionStatus(status: WorkoutSessionStatus): DayWorkoutConflictStatus {
+  if (status === 'completed') {
+    return 'completed';
+  }
+
+  if (status === 'in-progress' || status === 'paused') {
+    return 'in-progress';
+  }
+
+  return 'scheduled';
+}
+
+function formatConflictStatusLabel(status: DayWorkoutConflictStatus) {
+  if (status === 'in-progress') {
+    return 'in progress';
+  }
+
+  return status;
+}

--- a/apps/web/src/features/workouts/lib/day-workout-conflicts.ts
+++ b/apps/web/src/features/workouts/lib/day-workout-conflicts.ts
@@ -19,6 +19,7 @@ const scheduledWorkoutListResponseSchema = z.array(scheduledWorkoutListItemSchem
 const workoutSessionListResponseSchema = z.array(workoutSessionListItemSchema);
 
 export async function getDayWorkoutConflicts(dateKey: string): Promise<DayWorkoutConflict[]> {
+  // Intentionally fetch fresh server state before mutating to avoid stale duplicate checks.
   const [scheduledData, sessionData] = await Promise.all([
     apiRequest<unknown>(`/api/v1/scheduled-workouts?from=${dateKey}&to=${dateKey}`, {
       method: 'GET',

--- a/apps/web/src/hooks/use-workout-session.ts
+++ b/apps/web/src/hooks/use-workout-session.ts
@@ -271,7 +271,13 @@ export function useDeleteSession(sessionId: string | null | undefined) {
           queryKey: workoutSessionQueryKeys.all,
         }),
         queryClient.invalidateQueries({
+          queryKey: workoutSessionQueryKeys.detail(normalizedSessionId),
+        }),
+        queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.sessions(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.session(normalizedSessionId),
         }),
       ]);
       toast.success('Workout deleted');

--- a/apps/web/src/hooks/use-workout-session.ts
+++ b/apps/web/src/hooks/use-workout-session.ts
@@ -31,6 +31,9 @@ type UpdateSessionTimeSegmentsRequest = {
   timeSegments: WorkoutSessionTimeSegment[];
 };
 type ReorderSessionExercisesRequest = ReorderWorkoutSessionExercisesInput;
+type DeleteSessionResult = {
+  success: boolean;
+};
 
 export const workoutSessionQueryKeys = {
   all: ['workout-sessions'] as const,
@@ -106,6 +109,12 @@ async function reorderSessionExercises(sessionId: string, input: ReorderSessionE
   const payload = workoutSessionResponseSchema.parse({ data });
 
   return payload.data;
+}
+
+async function deleteSession(sessionId: string) {
+  return await apiRequest<DeleteSessionResult>(`/api/v1/workout-sessions/${sessionId}`, {
+    method: 'DELETE',
+  });
 }
 
 async function syncSessionMutationCache(
@@ -240,6 +249,32 @@ export function useReorderSessionExercises(sessionId: string | null | undefined)
     },
     onSuccess: async (session) => {
       await syncSessionMutationCache(queryClient, session);
+    },
+  });
+}
+
+export function useDeleteSession(sessionId: string | null | undefined) {
+  const queryClient = useQueryClient();
+  const normalizedSessionId = sessionId?.trim() ?? '';
+
+  return useMutation<DeleteSessionResult, Error>({
+    mutationFn: async () => {
+      if (!normalizedSessionId) {
+        throw new Error('Session id is required to delete workout session');
+      }
+
+      return deleteSession(normalizedSessionId);
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: workoutSessionQueryKeys.all,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.sessions(),
+        }),
+      ]);
+      toast.success('Workout deleted');
     },
   });
 }

--- a/apps/web/src/pages/workouts.test.tsx
+++ b/apps/web/src/pages/workouts.test.tsx
@@ -292,7 +292,9 @@ describe('WorkoutsPage', () => {
 
     expect(screen.getByRole('button', { name: 'List' })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByTestId('location-search')).toHaveTextContent('?view=list');
-    expect(await screen.findByRole('heading', { level: 2, name: 'Upcoming' })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { level: 2, name: 'In Progress' }),
+    ).toBeInTheDocument();
     expect(screen.queryByText('Workout Calendar')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Templates' }));
@@ -395,10 +397,7 @@ describe('WorkoutsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Templates' }));
 
     const searchbox = await screen.findByRole('searchbox', { name: /search templates by name/i });
-    expect(searchbox).toHaveAttribute(
-      'id',
-      'template-search',
-    );
+    expect(searchbox).toHaveAttribute('id', 'template-search');
     expect(await screen.findByRole('link', { name: 'Upper Push' })).toBeInTheDocument();
     expect(await screen.findByRole('link', { name: 'Lower Quad-Dominant' })).toBeInTheDocument();
 
@@ -564,7 +563,9 @@ describe('WorkoutsPage', () => {
   it('shows a completion notice when redirected from an already-completed active session', () => {
     renderWithQueryClient(
       <MemoryRouter
-        initialEntries={[`/workouts?${WORKOUT_SESSION_NOTICE_QUERY_KEY}=${WORKOUT_SESSION_COMPLETED_NOTICE}`]}
+        initialEntries={[
+          `/workouts?${WORKOUT_SESSION_NOTICE_QUERY_KEY}=${WORKOUT_SESSION_COMPLETED_NOTICE}`,
+        ]}
       >
         <Routes>
           <Route element={<WorkoutsPage />} path="/workouts" />

--- a/apps/web/src/pages/workouts.tsx
+++ b/apps/web/src/pages/workouts.tsx
@@ -221,7 +221,7 @@ export function WorkoutsPage() {
 
       {activeView === 'calendar' ? (
         <WorkoutCalendar
-          buildDayHref={(date) => `/workouts?date=${date}`}
+          buildDayHref={(date) => `/workouts?view=templates&date=${date}`}
           buildSessionHref={buildSessionHref}
         />
       ) : activeView === 'list' ? (


### PR DESCRIPTION
## Summary
This PR redesigns the workouts calendar and list views to better reflect real workout state and reduce duplicate/confusing entries. The workout list is now organized into **In Progress**, **Scheduled**, and **Completed** sections, with deduplication for linked scheduled/session records and incremental “Show more” pagination for long sections. The calendar now supports per-workout status indicators (including multi-workout days), and the sidebar has been rebuilt into a selected-day control panel with direct status-aware actions (start, resume, view, cancel, delete). It also adds duplicate-day warnings when starting or scheduling from templates so users can intentionally confirm creating another workout on an already-occupied day. Overall, this makes workout planning/execution flows clearer while tightening linked calendar/session cleanup behavior.

## Key Changes
- Reworked `WorkoutList` into state-based sections:
  - In-progress sessions split out from scheduled/completed.
  - Scheduled items deduped and linked session duplicates filtered out.
  - Added “Show more” pagination for scheduled and completed sections.
  - Added in-progress card actions for `Resume`, `Cancel`, and `Delete`.
- Rebuilt `WorkoutCalendar` day modeling:
  - Switched from single-item day assumptions to multi-workout day aggregation.
  - Added multi-status tile dots (`in-progress`, `completed`, `scheduled`, `unavailable`) and `+N` overflow badge.
  - Removed tile action menu in favor of richer selected-day sidebar controls.
- Redesigned selected-day sidebar into actionable workout cards:
  - Status-aware controls for scheduled/in-progress/completed items.
  - Start flow now creates a session from template data and navigates to active workout.
  - Empty-day state now includes a direct “Schedule a workout” CTA.
- Added duplicate-day warnings before creating/scheduling workouts:
  - Implemented shared conflict detection utility (`day-workout-conflicts.ts`) that fetches fresh server state for the target day.
  - Integrated warnings in both template browser scheduling and template detail start/schedule flows.
- Added `useDeleteSession` hook and wired deletion flows to invalidate relevant workout/session queries.

## Technical Notes
- `useWorkoutTemplate` now accepts an optional `{ enabled }` flag so template fetching can be deferred until needed (used in calendar day action cards).
- Calendar/list dedup logic intentionally prioritizes linked session state over standalone scheduled entries to prevent double rendering and stale linkage artifacts.
- Day-card delete behavior handles linked records defensively (unschedule and/or delete session) to avoid orphaned calendar state.
- Tests were expanded across calendar/list/template components to cover multi-indicator rendering, section dedupe rules, pagination, and duplicate-warning confirmations.
- Minor housekeeping: added YAML frontmatter to `.agents/skills/pulse-app-usage/SKILL.md`.

## Commits

- `ba1a7e0 fix(workouts): clean up linked calendar deletions`
- `86d1a6c chore(skills): add YAML frontmatter to pulse-app-usage skill`
- `a419412 feat(workouts): redesign calendar sidebar controls and duplicate warnings`
- `648909c feat(workouts): add multi-status calendar indicators`
- `b8acbb9 feat(workouts): redesign list sections with dedup and pagination`

## Tasks

- **Restructure workout list with state-based sections**: In Progress / Scheduled / Completed sections with deduplication and Show more pagination
- **Add calendar in-progress indicators and multi-workout dots**: Distinct in-progress indicators, multi-dot support, remove tile menu
- **Calendar sidebar as control panel with duplicate warnings**: Sidebar shows all workouts for selected day with status actions and duplicate-creation warnings

## Diff Stats

```
.agents/skills/pulse-app-usage/SKILL.md            |   5 +
 apps/web/src/features/workouts/api/workouts.ts     |   4 +-
 .../workouts/components/template-browser.test.tsx  | 104 ++-
 .../workouts/components/template-browser.tsx       |  39 +-
 .../workouts/components/template-detail.test.tsx   |  69 ++
 .../workouts/components/template-detail.tsx        |  78 +-
 .../workouts/components/workout-calendar.test.tsx  | 239 +++++-
 .../workouts/components/workout-calendar.tsx       | 876 ++++++++++++---------
 .../workouts/components/workout-list.test.tsx      | 200 ++---
 .../features/workouts/components/workout-list.tsx  | 190 ++++-
 .../features/workouts/lib/day-workout-conflicts.ts | 108 +++
 apps/web/src/hooks/use-workout-session.ts          |  35 +
 apps/web/src/pages/workouts.test.tsx               |  13 +-
 apps/web/src/pages/workouts.tsx                    |   2 +-
 14 files changed, 1434 insertions(+), 528 deletions(-)
```