### PR TITLE
feat: dashboard improvements — workout card, recent workouts, weight widget

### DIFF
--- a/apps/api/src/routes/v1/dashboard-store.test.ts
+++ b/apps/api/src/routes/v1/dashboard-store.test.ts
@@ -86,14 +86,27 @@ describe('dashboard store', () => {
         fat: 70,
       },
       {
-        name: 'Upper Push A',
-        status: 'completed',
-        duration: 64,
-      },
-      {
         total: 6,
         completed: 4,
       },
+    );
+    testState.selectAllResults.push(
+      [
+        {
+          scheduledWorkoutId: 'scheduled-upper-push-a',
+          scheduledTemplateId: 'template-upper-push-a',
+          linkedSessionId: 'session-upper-push-a',
+          scheduledTemplateName: 'Upper Push A',
+          scheduledCreatedAt: 100,
+          linkedSessionName: 'Upper Push A',
+          linkedSessionStatus: 'completed',
+          linkedSessionDuration: 64,
+          linkedSessionTemplateId: 'template-upper-push-a',
+          linkedSessionStartedAt: 200,
+          linkedSessionCompletedAt: 260,
+        },
+      ],
+      [],
     );
 
     const { getDashboardSnapshot } = await import('./dashboard-store.js');
@@ -123,6 +136,8 @@ describe('dashboard store', () => {
       workout: {
         name: 'Upper Push A',
         status: 'completed',
+        templateId: 'template-upper-push-a',
+        sessionId: 'session-upper-push-a',
         duration: 64,
       },
       habits: {
@@ -131,7 +146,7 @@ describe('dashboard store', () => {
         percentage: 66.7,
       },
     });
-    expect(testState.select).toHaveBeenCalledTimes(5);
+    expect(testState.select).toHaveBeenCalledTimes(6);
   });
 
   it('returns null sections and zeroed values when no data exists for the date', async () => {
@@ -162,14 +177,15 @@ describe('dashboard store', () => {
         percentage: 0,
       },
     });
-    expect(testState.select).toHaveBeenCalledTimes(5);
+    expect(testState.select).toHaveBeenCalledTimes(6);
   });
 
   it('rounds habit completion percentage to one decimal place', async () => {
-    testState.selectGetResults.push(undefined, undefined, undefined, undefined, {
+    testState.selectGetResults.push(undefined, undefined, undefined, {
       total: 3,
       completed: 2,
     });
+    testState.selectAllResults.push([], []);
 
     const { getDashboardSnapshot } = await import('./dashboard-store.js');
     const snapshot = await getDashboardSnapshot('user-1', '2026-03-11');
@@ -182,17 +198,77 @@ describe('dashboard store', () => {
   });
 
   it('scopes dashboard workout snapshot lookup by local workout date', async () => {
-    testState.selectGetResults.push(undefined, undefined, undefined, undefined, undefined);
+    testState.selectGetResults.push(undefined, undefined, undefined, undefined);
+    testState.selectAllResults.push([], []);
 
     const { getDashboardSnapshot } = await import('./dashboard-store.js');
     await getDashboardSnapshot('user-1', '2026-03-11');
 
-    const workoutWhereClause = testState.whereCalls[3];
+    const workoutWhereClause = testState.whereCalls[4];
     const dialect = new SQLiteSyncDialect();
     const workoutWhereSql = dialect.sqlToQuery(workoutWhereClause as never).sql;
 
     expect(workoutWhereSql).toContain('"workout_sessions"."date"');
     expect(workoutWhereSql).not.toContain('"workout_sessions"."started_at"');
+  });
+
+  it('selects in_progress over scheduled and completed when multiple workouts exist', async () => {
+    testState.selectGetResults.push(undefined, undefined, undefined, {
+      total: 0,
+      completed: 0,
+    });
+    testState.selectAllResults.push(
+      [
+        {
+          scheduledWorkoutId: 'scheduled-1',
+          scheduledTemplateId: 'template-scheduled',
+          linkedSessionId: null,
+          scheduledTemplateName: 'Scheduled Session',
+          scheduledCreatedAt: 20,
+          linkedSessionName: null,
+          linkedSessionStatus: null,
+          linkedSessionDuration: null,
+          linkedSessionTemplateId: null,
+          linkedSessionStartedAt: null,
+          linkedSessionCompletedAt: null,
+        },
+        {
+          scheduledWorkoutId: 'scheduled-2',
+          scheduledTemplateId: 'template-completed',
+          linkedSessionId: 'session-completed',
+          scheduledTemplateName: 'Completed Session',
+          scheduledCreatedAt: 10,
+          linkedSessionName: 'Completed Session',
+          linkedSessionStatus: 'completed',
+          linkedSessionDuration: 55,
+          linkedSessionTemplateId: 'template-completed',
+          linkedSessionStartedAt: 100,
+          linkedSessionCompletedAt: 200,
+        },
+      ],
+      [
+        {
+          sessionId: 'session-in-progress',
+          sessionName: 'In Progress Session',
+          sessionStatus: 'in-progress',
+          sessionDuration: 22,
+          sessionTemplateId: 'template-in-progress',
+          sessionStartedAt: 300,
+          sessionCompletedAt: null,
+        },
+      ],
+    );
+
+    const { getDashboardSnapshot } = await import('./dashboard-store.js');
+    const snapshot = await getDashboardSnapshot('user-1', '2026-03-11');
+
+    expect(snapshot.workout).toEqual({
+      name: 'In Progress Session',
+      status: 'in_progress',
+      templateId: 'template-in-progress',
+      sessionId: 'session-in-progress',
+      duration: 22,
+    });
   });
 
   it('returns weight trend points in ascending date order', async () => {

--- a/apps/api/src/routes/v1/dashboard-store.test.ts
+++ b/apps/api/src/routes/v1/dashboard-store.test.ts
@@ -271,6 +271,42 @@ describe('dashboard store', () => {
     });
   });
 
+  it('falls back to scheduled workout when linked session is cancelled', async () => {
+    testState.selectGetResults.push(undefined, undefined, undefined, {
+      total: 0,
+      completed: 0,
+    });
+    testState.selectAllResults.push(
+      [
+        {
+          scheduledWorkoutId: 'scheduled-1',
+          scheduledTemplateId: 'template-scheduled',
+          linkedSessionId: 'session-cancelled',
+          scheduledTemplateName: 'Scheduled Session',
+          scheduledCreatedAt: 20,
+          linkedSessionName: 'Cancelled Session',
+          linkedSessionStatus: 'cancelled',
+          linkedSessionDuration: null,
+          linkedSessionTemplateId: 'template-scheduled',
+          linkedSessionStartedAt: null,
+          linkedSessionCompletedAt: null,
+        },
+      ],
+      [],
+    );
+
+    const { getDashboardSnapshot } = await import('./dashboard-store.js');
+    const snapshot = await getDashboardSnapshot('user-1', '2026-03-11');
+
+    expect(snapshot.workout).toEqual({
+      name: 'Scheduled Session',
+      status: 'scheduled',
+      templateId: 'template-scheduled',
+      sessionId: null,
+      duration: null,
+    });
+  });
+
   it('returns weight trend points in ascending date order', async () => {
     testState.selectAllResults.push([
       { date: '2026-03-07', value: 181.6 },

--- a/apps/api/src/routes/v1/dashboard-store.ts
+++ b/apps/api/src/routes/v1/dashboard-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, between, desc, eq, isNull, lte, sql } from 'drizzle-orm';
+import { and, asc, between, desc, eq, inArray, isNull, lte, sql } from 'drizzle-orm';
 
 import type {
   DashboardConfig,
@@ -24,7 +24,9 @@ import {
   meals,
   nutritionLogs,
   nutritionTargets,
+  scheduledWorkouts,
   workoutSessions,
+  workoutTemplates,
 } from '../../db/schema/index.js';
 import { getDatesInRange } from './dashboard-utils.js';
 
@@ -47,10 +49,28 @@ const macroTargetSelection = {
   fat: nutritionTargets.fat,
 };
 
-const workoutSelection = {
-  name: workoutSessions.name,
-  status: workoutSessions.status,
-  duration: workoutSessions.duration,
+const scheduledWorkoutSelection = {
+  scheduledWorkoutId: scheduledWorkouts.id,
+  scheduledTemplateId: scheduledWorkouts.templateId,
+  linkedSessionId: scheduledWorkouts.sessionId,
+  scheduledTemplateName: workoutTemplates.name,
+  scheduledCreatedAt: scheduledWorkouts.createdAt,
+  linkedSessionName: workoutSessions.name,
+  linkedSessionStatus: workoutSessions.status,
+  linkedSessionDuration: workoutSessions.duration,
+  linkedSessionTemplateId: workoutSessions.templateId,
+  linkedSessionStartedAt: workoutSessions.startedAt,
+  linkedSessionCompletedAt: workoutSessions.completedAt,
+};
+
+const standaloneSessionSelection = {
+  sessionId: workoutSessions.id,
+  sessionName: workoutSessions.name,
+  sessionStatus: workoutSessions.status,
+  sessionDuration: workoutSessions.duration,
+  sessionTemplateId: workoutSessions.templateId,
+  sessionStartedAt: workoutSessions.startedAt,
+  sessionCompletedAt: workoutSessions.completedAt,
 };
 
 const habitSummarySelection = {
@@ -128,8 +148,11 @@ const toWorkoutSnapshot = (
     | {
         name: string;
         status: DashboardWorkoutSnapshot['status'];
+        templateId: string | null;
+        sessionId: string | null;
         duration: number | null;
       }
+    | null
     | undefined,
 ): DashboardWorkoutSnapshot | null => {
   if (!value) {
@@ -139,6 +162,8 @@ const toWorkoutSnapshot = (
   return {
     name: value.name,
     status: value.status,
+    templateId: value.templateId,
+    sessionId: value.sessionId,
     duration: value.duration === null ? null : Number(value.duration),
   };
 };
@@ -176,6 +201,135 @@ const toMacroTrendPoint = (
   date,
   ...toMacroTotals(value),
 });
+
+type DashboardWorkoutCandidate = {
+  name: string;
+  status: DashboardWorkoutSnapshot['status'];
+  templateId: string | null;
+  sessionId: string | null;
+  duration: number | null;
+  sortTime: number;
+};
+
+const workoutStatusToDashboardState = (
+  status: 'scheduled' | 'in-progress' | 'paused' | 'completed',
+): DashboardWorkoutSnapshot['status'] => {
+  switch (status) {
+    case 'in-progress':
+    case 'paused':
+      return 'in_progress';
+    case 'completed':
+      return 'completed';
+    case 'scheduled':
+    default:
+      return 'scheduled';
+  }
+};
+
+const workoutPriority = (status: DashboardWorkoutSnapshot['status']) => {
+  switch (status) {
+    case 'in_progress':
+      return 0;
+    case 'scheduled':
+      return 1;
+    case 'completed':
+      return 2;
+    default:
+      return 3;
+  }
+};
+
+const selectTodayWorkoutCandidate = (
+  scheduledRows: Array<{
+    scheduledWorkoutId: string;
+    scheduledTemplateId: string | null;
+    linkedSessionId: string | null;
+    scheduledTemplateName: string | null;
+    scheduledCreatedAt: number;
+    linkedSessionName: string | null;
+    linkedSessionStatus: 'scheduled' | 'in-progress' | 'paused' | 'cancelled' | 'completed' | null;
+    linkedSessionDuration: number | null;
+    linkedSessionTemplateId: string | null;
+    linkedSessionStartedAt: number | null;
+    linkedSessionCompletedAt: number | null;
+  }>,
+  standaloneSessions: Array<{
+    sessionId: string;
+    sessionName: string;
+    sessionStatus: 'scheduled' | 'in-progress' | 'paused' | 'cancelled' | 'completed';
+    sessionDuration: number | null;
+    sessionTemplateId: string | null;
+    sessionStartedAt: number;
+    sessionCompletedAt: number | null;
+  }>,
+): DashboardWorkoutCandidate | null => {
+  const candidates: DashboardWorkoutCandidate[] = [];
+  const consumedSessionIds = new Set<string>();
+
+  for (const scheduledWorkout of scheduledRows) {
+    if (scheduledWorkout.linkedSessionId && scheduledWorkout.linkedSessionStatus) {
+      const linkedStatus = scheduledWorkout.linkedSessionStatus;
+      if (linkedStatus !== 'cancelled') {
+        candidates.push({
+          name:
+            scheduledWorkout.linkedSessionName ??
+            scheduledWorkout.scheduledTemplateName ??
+            'Workout unavailable',
+          status: workoutStatusToDashboardState(linkedStatus),
+          templateId:
+            scheduledWorkout.linkedSessionTemplateId ??
+            scheduledWorkout.scheduledTemplateId ??
+            null,
+          sessionId: scheduledWorkout.linkedSessionId,
+          duration: scheduledWorkout.linkedSessionDuration,
+          sortTime:
+            Number(
+              scheduledWorkout.linkedSessionCompletedAt ??
+                scheduledWorkout.linkedSessionStartedAt ??
+                scheduledWorkout.scheduledCreatedAt,
+            ) || 0,
+        });
+      }
+      consumedSessionIds.add(scheduledWorkout.linkedSessionId);
+      continue;
+    }
+
+    candidates.push({
+      name: scheduledWorkout.scheduledTemplateName ?? 'Workout unavailable',
+      status: 'scheduled',
+      templateId: scheduledWorkout.scheduledTemplateId,
+      sessionId: null,
+      duration: null,
+      sortTime: Number(scheduledWorkout.scheduledCreatedAt) || 0,
+    });
+  }
+
+  for (const session of standaloneSessions) {
+    if (session.sessionStatus === 'cancelled' || consumedSessionIds.has(session.sessionId)) {
+      continue;
+    }
+
+    candidates.push({
+      name: session.sessionName,
+      status: workoutStatusToDashboardState(session.sessionStatus),
+      templateId: session.sessionTemplateId,
+      sessionId: session.sessionId,
+      duration: session.sessionDuration,
+      sortTime: Number(session.sessionCompletedAt ?? session.sessionStartedAt) || 0,
+    });
+  }
+
+  candidates.sort((left, right) => {
+    const priorityDiff = workoutPriority(left.status) - workoutPriority(right.status);
+    if (priorityDiff !== 0) {
+      return priorityDiff;
+    }
+
+    return right.sortTime - left.sortTime;
+  });
+
+  return candidates[0] ?? null;
+};
 
 const trendMetricSet = new Set<DashboardTrendMetric>(DEFAULT_DASHBOARD_TREND_METRICS);
 
@@ -244,19 +398,42 @@ export const getDashboardSnapshot = async (
       .limit(1)
       .get() ?? undefined;
 
-  const workout = db
-    .select(workoutSelection)
+  const scheduledRows = db
+    .select(scheduledWorkoutSelection)
+    .from(scheduledWorkouts)
+    .leftJoin(
+      workoutSessions,
+      and(
+        eq(workoutSessions.id, scheduledWorkouts.sessionId),
+        eq(workoutSessions.userId, userId),
+        isNull(workoutSessions.deletedAt),
+      ),
+    )
+    .leftJoin(
+      workoutTemplates,
+      and(
+        eq(workoutTemplates.id, scheduledWorkouts.templateId),
+        eq(workoutTemplates.userId, userId),
+      ),
+    )
+    .where(and(eq(scheduledWorkouts.userId, userId), eq(scheduledWorkouts.date, date)))
+    .all();
+
+  const standaloneSessions = db
+    .select(standaloneSessionSelection)
     .from(workoutSessions)
     .where(
       and(
         eq(workoutSessions.userId, userId),
         isNull(workoutSessions.deletedAt),
         eq(workoutSessions.date, date),
+        inArray(workoutSessions.status, ['scheduled', 'in-progress', 'paused', 'completed']),
       ),
     )
     .orderBy(desc(workoutSessions.completedAt), desc(workoutSessions.startedAt))
-    .limit(1)
-    .get();
+    .all();
+
+  const workout = selectTodayWorkoutCandidate(scheduledRows, standaloneSessions);
 
   const habitsSummary =
     db

--- a/apps/api/src/routes/v1/dashboard-store.ts
+++ b/apps/api/src/routes/v1/dashboard-store.ts
@@ -289,6 +289,15 @@ const selectTodayWorkoutCandidate = (
                 scheduledWorkout.scheduledCreatedAt,
             ) || 0,
         });
+      } else {
+        candidates.push({
+          name: scheduledWorkout.scheduledTemplateName ?? 'Workout unavailable',
+          status: 'scheduled',
+          templateId: scheduledWorkout.scheduledTemplateId,
+          sessionId: null,
+          duration: null,
+          sortTime: Number(scheduledWorkout.scheduledCreatedAt) || 0,
+        });
       }
       consumedSessionIds.add(scheduledWorkout.linkedSessionId);
       continue;

--- a/apps/api/src/routes/v1/dashboard.test.ts
+++ b/apps/api/src/routes/v1/dashboard.test.ts
@@ -67,6 +67,8 @@ describe('dashboard routes', () => {
       workout: {
         name: 'Upper Push A',
         status: 'completed',
+        templateId: 'template-upper-push-a',
+        sessionId: 'session-upper-push-a',
         duration: 64,
       },
       habits: {
@@ -113,6 +115,8 @@ describe('dashboard routes', () => {
           workout: {
             name: 'Upper Push A',
             status: 'completed',
+            templateId: 'template-upper-push-a',
+            sessionId: 'session-upper-push-a',
             duration: 64,
           },
           habits: {
@@ -555,42 +559,41 @@ describe('dashboard routes', () => {
         missingConfigPutAuthResponse,
         missingConfigPostAuthResponse,
         invalidSnapshotAuthResponse,
-      ] =
-        await Promise.all([
-          app.inject({
-            method: 'GET',
-            url: '/api/v1/dashboard/snapshot',
-          }),
-          app.inject({
-            method: 'GET',
-            url: '/api/v1/dashboard/trends/weight',
-          }),
-          app.inject({
-            method: 'GET',
-            url: '/api/v1/dashboard/config',
-          }),
-          app.inject({
-            method: 'PUT',
-            url: '/api/v1/dashboard/config',
-            payload: {
-              habitChainIds: ['habit-1'],
-              trendMetrics: ['weight'],
-            },
-          }),
-          app.inject({
-            method: 'POST',
-            url: '/api/v1/dashboard/config',
-            payload: {
-              habitChainIds: ['habit-1'],
-              trendMetrics: ['weight'],
-            },
-          }),
-          app.inject({
-            method: 'GET',
-            url: '/api/v1/dashboard/snapshot',
-            headers: createAuthorizationHeader('not-a-valid-token'),
-          }),
-        ]);
+      ] = await Promise.all([
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/dashboard/snapshot',
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/dashboard/trends/weight',
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/dashboard/config',
+        }),
+        app.inject({
+          method: 'PUT',
+          url: '/api/v1/dashboard/config',
+          payload: {
+            habitChainIds: ['habit-1'],
+            trendMetrics: ['weight'],
+          },
+        }),
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/dashboard/config',
+          payload: {
+            habitChainIds: ['habit-1'],
+            trendMetrics: ['weight'],
+          },
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/dashboard/snapshot',
+          headers: createAuthorizationHeader('not-a-valid-token'),
+        }),
+      ]);
 
       for (const response of [
         missingSnapshotAuthResponse,

--- a/apps/api/src/routes/weight/index.test.ts
+++ b/apps/api/src/routes/weight/index.test.ts
@@ -11,6 +11,7 @@ import {
   findBodyWeightEntryByDate,
   getLatestBodyWeightEntry,
   listBodyWeightEntries,
+  listBodyWeightEntriesPaginated,
   patchBodyWeightEntryById,
   upsertBodyWeightEntry,
 } from './store.js';
@@ -21,6 +22,7 @@ vi.mock('./store.js', () => ({
   findBodyWeightEntryByDate: vi.fn(),
   getLatestBodyWeightEntry: vi.fn(),
   listBodyWeightEntries: vi.fn(),
+  listBodyWeightEntriesPaginated: vi.fn(),
   patchBodyWeightEntryById: vi.fn(),
   upsertBodyWeightEntry: vi.fn(),
 }));
@@ -41,6 +43,7 @@ describe('weight routes', () => {
     vi.mocked(findBodyWeightEntryByDate).mockReset();
     vi.mocked(getLatestBodyWeightEntry).mockReset();
     vi.mocked(listBodyWeightEntries).mockReset();
+    vi.mocked(listBodyWeightEntriesPaginated).mockReset();
     vi.mocked(patchBodyWeightEntryById).mockReset();
     vi.mocked(upsertBodyWeightEntry).mockReset();
     vi.mocked(findAgentTokenByHash).mockReset();
@@ -273,32 +276,19 @@ describe('weight routes', () => {
   });
 
   it('supports paginated listing with meta when page or limit is provided', async () => {
-    vi.mocked(listBodyWeightEntries).mockResolvedValue([
-      {
-        id: 'entry-1',
-        date: '2026-03-01',
-        weight: 183.2,
-        notes: null,
-        createdAt: 1_700_000_000_000,
-        updatedAt: 1_700_000_000_000,
-      },
-      {
-        id: 'entry-2',
-        date: '2026-03-02',
-        weight: 182.9,
-        notes: null,
-        createdAt: 1_700_000_000_100,
-        updatedAt: 1_700_000_000_100,
-      },
-      {
-        id: 'entry-3',
-        date: '2026-03-03',
-        weight: 182.7,
-        notes: 'After cardio',
-        createdAt: 1_700_000_000_200,
-        updatedAt: 1_700_000_000_200,
-      },
-    ]);
+    vi.mocked(listBodyWeightEntriesPaginated).mockResolvedValue({
+      entries: [
+        {
+          id: 'entry-2',
+          date: '2026-03-02',
+          weight: 182.9,
+          notes: null,
+          createdAt: 1_700_000_000_100,
+          updatedAt: 1_700_000_000_100,
+        },
+      ],
+      total: 3,
+    });
 
     const app = buildServer();
 
@@ -312,10 +302,19 @@ describe('weight routes', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(vi.mocked(listBodyWeightEntries)).toHaveBeenCalledWith('user-1', {
-        page: 2,
-        limit: 1,
-      });
+      expect(vi.mocked(listBodyWeightEntriesPaginated)).toHaveBeenCalledWith(
+        'user-1',
+        {
+          days: undefined,
+          from: undefined,
+          to: undefined,
+        },
+        {
+          limit: 1,
+          offset: 1,
+        },
+      );
+      expect(vi.mocked(listBodyWeightEntries)).not.toHaveBeenCalled();
       expect(response.json()).toEqual({
         data: [
           {

--- a/apps/api/src/routes/weight/index.test.ts
+++ b/apps/api/src/routes/weight/index.test.ts
@@ -272,6 +272,72 @@ describe('weight routes', () => {
     }
   });
 
+  it('supports paginated listing with meta when page or limit is provided', async () => {
+    vi.mocked(listBodyWeightEntries).mockResolvedValue([
+      {
+        id: 'entry-1',
+        date: '2026-03-01',
+        weight: 183.2,
+        notes: null,
+        createdAt: 1_700_000_000_000,
+        updatedAt: 1_700_000_000_000,
+      },
+      {
+        id: 'entry-2',
+        date: '2026-03-02',
+        weight: 182.9,
+        notes: null,
+        createdAt: 1_700_000_000_100,
+        updatedAt: 1_700_000_000_100,
+      },
+      {
+        id: 'entry-3',
+        date: '2026-03-03',
+        weight: 182.7,
+        notes: 'After cardio',
+        createdAt: 1_700_000_000_200,
+        updatedAt: 1_700_000_000_200,
+      },
+    ]);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/weight?page=2&limit=1',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(vi.mocked(listBodyWeightEntries)).toHaveBeenCalledWith('user-1', {
+        page: 2,
+        limit: 1,
+      });
+      expect(response.json()).toEqual({
+        data: [
+          {
+            id: 'entry-2',
+            date: '2026-03-02',
+            weight: 182.9,
+            notes: null,
+            createdAt: 1_700_000_000_100,
+            updatedAt: 1_700_000_000_100,
+          },
+        ],
+        meta: {
+          page: 2,
+          limit: 1,
+          total: 3,
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
   it('rejects invalid date range queries', async () => {
     const app = buildServer();
 

--- a/apps/api/src/routes/weight/index.ts
+++ b/apps/api/src/routes/weight/index.ts
@@ -14,6 +14,7 @@ import {
   findBodyWeightEntryByDate,
   getLatestBodyWeightEntry,
   listBodyWeightEntries,
+  listBodyWeightEntriesPaginated,
   patchBodyWeightEntryById,
   upsertBodyWeightEntry,
 } from './store.js';
@@ -49,25 +50,33 @@ export const weightRoutes: FastifyPluginAsync = async (app) => {
       return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid weight query params');
     }
 
-    const entries = await listBodyWeightEntries(request.userId, parsedQuery.data);
-    const { page, limit } = parsedQuery.data;
+    const { days, from, limit, page, to } = parsedQuery.data;
+    const queryFilters = {
+      days,
+      from,
+      to,
+    };
 
     if (page !== undefined || limit !== undefined) {
       const resolvedPage = page ?? 1;
       const resolvedLimit = limit ?? 50;
       const offset = (resolvedPage - 1) * resolvedLimit;
-      const paginatedEntries = entries.slice(offset, offset + resolvedLimit);
+      const { entries, total } = await listBodyWeightEntriesPaginated(request.userId, queryFilters, {
+        limit: resolvedLimit,
+        offset,
+      });
 
       return reply.send({
-        data: paginatedEntries,
+        data: entries,
         meta: {
           page: resolvedPage,
           limit: resolvedLimit,
-          total: entries.length,
+          total,
         },
       });
     }
 
+    const entries = await listBodyWeightEntries(request.userId, queryFilters);
     return reply.send({ data: entries });
   });
 

--- a/apps/api/src/routes/weight/index.ts
+++ b/apps/api/src/routes/weight/index.ts
@@ -50,10 +50,25 @@ export const weightRoutes: FastifyPluginAsync = async (app) => {
     }
 
     const entries = await listBodyWeightEntries(request.userId, parsedQuery.data);
+    const { page, limit } = parsedQuery.data;
 
-    return reply.send({
-      data: entries,
-    });
+    if (page !== undefined || limit !== undefined) {
+      const resolvedPage = page ?? 1;
+      const resolvedLimit = limit ?? 50;
+      const offset = (resolvedPage - 1) * resolvedLimit;
+      const paginatedEntries = entries.slice(offset, offset + resolvedLimit);
+
+      return reply.send({
+        data: paginatedEntries,
+        meta: {
+          page: resolvedPage,
+          limit: resolvedLimit,
+          total: entries.length,
+        },
+      });
+    }
+
+    return reply.send({ data: entries });
   });
 
   app.patch<{ Params: { id: string } }>('/:id', async (request, reply) => {

--- a/apps/api/src/routes/weight/store.test.ts
+++ b/apps/api/src/routes/weight/store.test.ts
@@ -27,8 +27,12 @@ const testState = vi.hoisted(() => {
 
   const selectGet = vi.fn();
   const selectAll = vi.fn();
+  const selectOffset = vi.fn(() => ({
+    all: selectAll,
+  }));
   const selectLimit = vi.fn(() => ({
     get: selectGet,
+    offset: selectOffset,
   }));
   const selectOrderBy = vi.fn(() => ({
     all: selectAll,
@@ -37,6 +41,7 @@ const testState = vi.hoisted(() => {
   const selectWhere = vi.fn(() => ({
     orderBy: selectOrderBy,
     limit: selectLimit,
+    get: selectGet,
   }));
   const selectFrom = vi.fn(() => ({
     where: selectWhere,
@@ -65,6 +70,7 @@ const testState = vi.hoisted(() => {
       selectWhere.mockClear();
       selectOrderBy.mockClear();
       selectLimit.mockClear();
+      selectOffset.mockClear();
       selectAll.mockClear();
       selectGet.mockClear();
     },
@@ -81,6 +87,7 @@ const testState = vi.hoisted(() => {
     selectWhere,
     selectOrderBy,
     selectLimit,
+    selectOffset,
     selectAll,
     selectGet,
   };
@@ -254,6 +261,50 @@ describe('weight store', () => {
     });
     await expect(getLatestBodyWeightEntry('user-1')).resolves.toBeNull();
     expect(testState.selectLimit).toHaveBeenCalledTimes(2);
+  });
+
+  it('applies database pagination and returns total count for paginated listing', async () => {
+    testState.selectAll.mockReturnValue([
+      {
+        id: 'entry-5',
+        date: '2026-03-08',
+        weight: 182.1,
+        notes: null,
+        createdAt: 1_700_000_000_400,
+        updatedAt: 1_700_000_000_400,
+      },
+    ]);
+    testState.selectGet.mockReturnValue({ total: 12 });
+
+    const { listBodyWeightEntriesPaginated } = await import('./store.js');
+    const result = await listBodyWeightEntriesPaginated(
+      'user-1',
+      {
+        from: '2026-03-01',
+        to: '2026-03-31',
+      },
+      {
+        limit: 10,
+        offset: 10,
+      },
+    );
+
+    expect(result).toEqual({
+      entries: [
+        {
+          id: 'entry-5',
+          date: '2026-03-08',
+          weight: 182.1,
+          notes: null,
+          createdAt: 1_700_000_000_400,
+          updatedAt: 1_700_000_000_400,
+        },
+      ],
+      total: 12,
+    });
+    expect(testState.selectLimit).toHaveBeenCalledWith(10);
+    expect(testState.selectOffset).toHaveBeenCalledWith(10);
+    expect(testState.selectGet).toHaveBeenCalledTimes(1);
   });
 
   it('deletes an entry only when id and userId match', async () => {

--- a/apps/api/src/routes/weight/store.ts
+++ b/apps/api/src/routes/weight/store.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gte, lte } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, lte, sql } from 'drizzle-orm';
 
 import type {
   BodyWeightEntry,
@@ -17,6 +17,28 @@ const bodyWeightEntrySelection = {
   notes: bodyWeight.notes,
   createdAt: bodyWeight.createdAt,
   updatedAt: bodyWeight.updatedAt,
+};
+
+type WeightListFilters = Omit<WeightQueryParams, 'page' | 'limit'>;
+
+const toBodyWeightConditions = (userId: string, query: WeightListFilters) => {
+  const conditions = [eq(bodyWeight.userId, userId)];
+
+  if (query.days !== undefined) {
+    const rangeEnd = query.to ?? getTodayDate();
+    const rangeStart = addUtcDays(rangeEnd, -(query.days - 1));
+    conditions.push(gte(bodyWeight.date, rangeStart));
+  }
+
+  if (query.from) {
+    conditions.push(gte(bodyWeight.date, query.from));
+  }
+
+  if (query.to) {
+    conditions.push(lte(bodyWeight.date, query.to));
+  }
+
+  return conditions;
 };
 
 export const findBodyWeightEntryByDate = async (
@@ -87,25 +109,10 @@ export const upsertBodyWeightEntry = async (
 
 export const listBodyWeightEntries = async (
   userId: string,
-  query: WeightQueryParams,
+  query: WeightListFilters,
 ): Promise<BodyWeightEntry[]> => {
   const { db } = await import('../../db/index.js');
-
-  const conditions = [eq(bodyWeight.userId, userId)];
-
-  if (query.days !== undefined) {
-    const rangeEnd = query.to ?? getTodayDate();
-    const rangeStart = addUtcDays(rangeEnd, -(query.days - 1));
-    conditions.push(gte(bodyWeight.date, rangeStart));
-  }
-
-  if (query.from) {
-    conditions.push(gte(bodyWeight.date, query.from));
-  }
-
-  if (query.to) {
-    conditions.push(lte(bodyWeight.date, query.to));
-  }
+  const conditions = toBodyWeightConditions(userId, query);
 
   return db
     .select(bodyWeightEntrySelection)
@@ -113,6 +120,36 @@ export const listBodyWeightEntries = async (
     .where(and(...conditions))
     .orderBy(asc(bodyWeight.date))
     .all();
+};
+
+export const listBodyWeightEntriesPaginated = async (
+  userId: string,
+  query: WeightListFilters,
+  pagination: { limit: number; offset: number },
+): Promise<{ entries: BodyWeightEntry[]; total: number }> => {
+  const { db } = await import('../../db/index.js');
+  const conditions = toBodyWeightConditions(userId, query);
+  const whereClause = and(...conditions);
+
+  const entries = db
+    .select(bodyWeightEntrySelection)
+    .from(bodyWeight)
+    .where(whereClause)
+    .orderBy(asc(bodyWeight.date))
+    .limit(pagination.limit)
+    .offset(pagination.offset)
+    .all();
+
+  const countResult = db
+    .select({ total: sql<number>`count(*)` })
+    .from(bodyWeight)
+    .where(whereClause)
+    .get();
+
+  return {
+    entries,
+    total: countResult?.total ?? 0,
+  };
 };
 
 export const getLatestBodyWeightEntry = async (userId: string): Promise<BodyWeightEntry | null> => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -133,19 +133,11 @@ function AppRoutes() {
   return (
     <Routes>
       <Route
-        element={
-          <GuestRoute>
-            {renderWithAuthFallback(<LoginPage />)}
-          </GuestRoute>
-        }
+        element={<GuestRoute>{renderWithAuthFallback(<LoginPage />)}</GuestRoute>}
         path="/login"
       />
       <Route
-        element={
-          <GuestRoute>
-            {renderWithAuthFallback(<RegisterPage />)}
-          </GuestRoute>
-        }
+        element={<GuestRoute>{renderWithAuthFallback(<RegisterPage />)}</GuestRoute>}
         path="/register"
       />
       <Route
@@ -165,8 +157,20 @@ function AppRoutes() {
           path="workouts/session/:sessionId"
         />
         <Route
+          element={renderWithPageFallback(<WorkoutSessionDetailPage />)}
+          path="workouts/sessions/:sessionId"
+        />
+        <Route
+          element={renderWithPageFallback(<WorkoutSessionDetailPage />)}
+          path="workouts/sessions/:sessionId/summary"
+        />
+        <Route
           element={renderWithPageFallback(<WorkoutTemplateDetailPage />)}
           path="workouts/template/:templateId"
+        />
+        <Route
+          element={renderWithPageFallback(<WorkoutTemplateDetailPage />)}
+          path="workouts/templates/:templateId"
         />
         <Route element={renderWithPageFallback(<NutritionPage />)} path="nutrition" />
         <Route element={renderWithPageFallback(<HabitsPage />)} path="habits" />
@@ -176,10 +180,7 @@ function AppRoutes() {
         <Route element={renderWithPageFallback(<JournalEntryPage />)} path="journal/:entryId" />
         <Route element={renderWithPageFallback(<WeightHistoryPage />)} path="weight" />
         <Route element={renderWithPageFallback(<ProfilePage />)} path="profile" />
-        <Route
-          element={renderWithPageFallback(<EquipmentRoutePage />)}
-          path="profile/equipment"
-        />
+        <Route element={renderWithPageFallback(<EquipmentRoutePage />)} path="profile/equipment" />
         <Route element={renderWithPageFallback(<InjuriesPage />)} path="profile/injuries" />
         <Route
           element={renderWithPageFallback(<InjuryDetailPage />)}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -179,6 +179,7 @@ function AppRoutes() {
         <Route element={renderWithPageFallback(<JournalPage />)} path="journal" />
         <Route element={renderWithPageFallback(<JournalEntryPage />)} path="journal/:entryId" />
         <Route element={renderWithPageFallback(<WeightHistoryPage />)} path="weight" />
+        <Route element={renderWithPageFallback(<WeightHistoryPage />)} path="weight/history" />
         <Route element={renderWithPageFallback(<ProfilePage />)} path="profile" />
         <Route element={renderWithPageFallback(<EquipmentRoutePage />)} path="profile/equipment" />
         <Route element={renderWithPageFallback(<InjuriesPage />)} path="profile/injuries" />

--- a/apps/web/src/features/dashboard/components/recent-workouts.test.tsx
+++ b/apps/web/src/features/dashboard/components/recent-workouts.test.tsx
@@ -97,7 +97,7 @@ describe('RecentWorkouts', () => {
     recentWorkoutsFixture.forEach((workout) => {
       const link = screen.getByRole('link', { name: `Open ${workout.name}` });
 
-      expect(link).toHaveAttribute('href', `/workouts/session/${workout.id}`);
+      expect(link).toHaveAttribute('href', `/workouts/sessions/${workout.id}`);
       expect(within(link).getByText(workout.name)).toBeInTheDocument();
       expect(within(link).getByText(`${workout.exerciseCount} exercises`)).toBeInTheDocument();
       expect(

--- a/apps/web/src/features/dashboard/components/recent-workouts.test.tsx
+++ b/apps/web/src/features/dashboard/components/recent-workouts.test.tsx
@@ -106,6 +106,58 @@ describe('RecentWorkouts', () => {
     });
   });
 
+  it('uses compact card spacing and inline metadata pills', () => {
+    vi.mocked(useRecentWorkouts).mockReturnValue({
+      data: recentWorkoutsFixture,
+      isLoading: false,
+    } as ReturnType<typeof useRecentWorkouts>);
+
+    const { container } = render(
+      <MemoryRouter>
+        <RecentWorkouts />
+      </MemoryRouter>,
+    );
+
+    const cards = container.querySelectorAll('[data-slot="recent-workout-card"]');
+    expect(cards.length).toBe(5);
+    cards.forEach((card) => {
+      expect(card).toHaveClass('py-2');
+      expect(card).toHaveClass('overflow-hidden');
+    });
+
+    const metadataPills = screen.getAllByText('6 exercises');
+    metadataPills.forEach((pill) => {
+      expect(pill).toHaveClass('rounded-full');
+      expect(pill.parentElement).toHaveClass('text-xs');
+    });
+  });
+
+  it('keeps workout names untruncated while preventing container overflow', () => {
+    vi.mocked(useRecentWorkouts).mockReturnValue({
+      data: [
+        {
+          ...recentWorkoutsFixture[0],
+          name: 'Very Long Workout Name That Should Stay Readable Across Narrow Mobile Dashboard Layout Widths',
+        },
+      ],
+      isLoading: false,
+    } as ReturnType<typeof useRecentWorkouts>);
+
+    const { container } = render(
+      <MemoryRouter>
+        <RecentWorkouts />
+      </MemoryRouter>,
+    );
+
+    const title = screen.getByText(
+      'Very Long Workout Name That Should Stay Readable Across Narrow Mobile Dashboard Layout Widths',
+    );
+    expect(title).not.toHaveClass('truncate');
+
+    const cardContent = container.querySelector('[data-slot="card-content"]');
+    expect(cardContent).toHaveClass('overflow-hidden');
+  });
+
   it('shows relative date labels for recent sessions', () => {
     vi.mocked(useRecentWorkouts).mockReturnValue({
       data: recentWorkoutsFixture,

--- a/apps/web/src/features/dashboard/components/recent-workouts.tsx
+++ b/apps/web/src/features/dashboard/components/recent-workouts.tsx
@@ -73,7 +73,7 @@ export function RecentWorkouts() {
                 <Link
                   aria-label={`Open ${workout.name}`}
                   className="block cursor-pointer rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-                  to={`/workouts/session/${workout.id}`}
+                  to={`/workouts/sessions/${workout.id}`}
                 >
                   <Card
                     className="h-full gap-3 overflow-hidden px-4 py-2 transition-transform duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"

--- a/apps/web/src/features/dashboard/components/recent-workouts.tsx
+++ b/apps/web/src/features/dashboard/components/recent-workouts.tsx
@@ -24,8 +24,8 @@ function RecentWorkoutRowsSkeleton() {
     <ul className="grid gap-3" data-slot="recent-workout-skeleton-list">
       {Array.from({ length: WORKOUT_SKELETON_ROWS }).map((_, index) => (
         <li key={`workout-skeleton-${index}`}>
-          <Card className="h-full gap-4 px-4 py-4" data-slot="recent-workout-card-skeleton">
-            <div className="space-y-3">
+          <Card className="h-full gap-3 overflow-hidden px-4 py-2" data-slot="recent-workout-card-skeleton">
+            <div className="space-y-2">
               <div className="flex items-start justify-between gap-2">
                 <div className="min-w-0 space-y-2">
                   <div className="h-5 w-40 animate-pulse rounded bg-muted/50" />
@@ -33,9 +33,9 @@ function RecentWorkoutRowsSkeleton() {
                 </div>
                 <div className="h-6 w-20 animate-pulse rounded-full bg-muted/50" />
               </div>
-              <div className="flex flex-wrap gap-2">
-                <div className="h-8 w-24 animate-pulse rounded-full bg-muted/50" />
-                <div className="h-8 w-20 animate-pulse rounded-full bg-muted/50" />
+              <div className="flex flex-wrap gap-1.5">
+                <div className="h-6 w-24 animate-pulse rounded-full bg-muted/50" />
+                <div className="h-6 w-20 animate-pulse rounded-full bg-muted/50" />
               </div>
             </div>
           </Card>
@@ -61,7 +61,7 @@ export function RecentWorkouts() {
         </Button>
       </CardHeader>
 
-      <CardContent>
+      <CardContent className="overflow-hidden">
         {recentWorkoutsQuery.isLoading ? (
           <RecentWorkoutRowsSkeleton />
         ) : recentWorkoutsQuery.isError ? (
@@ -69,20 +69,20 @@ export function RecentWorkouts() {
         ) : recentWorkoutsQuery.data && recentWorkoutsQuery.data.length > 0 ? (
           <ul className="grid gap-3">
             {recentWorkoutsQuery.data.map((workout) => (
-              <li key={workout.id}>
+              <li className="min-w-0" key={workout.id}>
                 <Link
                   aria-label={`Open ${workout.name}`}
                   className="block cursor-pointer rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
                   to={`/workouts/session/${workout.id}`}
                 >
                   <Card
-                    className="h-full gap-4 px-4 py-4 transition-transform duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
+                    className="h-full gap-3 overflow-hidden px-4 py-2 transition-transform duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
                     data-slot="recent-workout-card"
                   >
-                    <div className="space-y-3">
+                    <div className="space-y-2">
                       <div className="flex items-start justify-between gap-2">
                         <div className="min-w-0 space-y-1">
-                          <p className="truncate text-base font-semibold text-foreground">{workout.name}</p>
+                          <p className="text-base font-semibold leading-tight text-foreground">{workout.name}</p>
                           <time className="text-sm text-muted" dateTime={workout.date}>
                             {formatWorkoutDate(workout.date)}
                           </time>
@@ -93,11 +93,11 @@ export function RecentWorkouts() {
                         </span>
                       </div>
 
-                      <div className="flex flex-wrap gap-2 text-sm text-foreground">
-                        <span className="rounded-full bg-secondary px-3 py-1">
+                      <div className="flex min-w-0 flex-wrap gap-1.5 text-xs text-foreground sm:text-sm">
+                        <span className="rounded-full bg-secondary px-2.5 py-0.5">
                           {`${workout.exerciseCount} exercises`}
                         </span>
-                        <span className="rounded-full bg-secondary px-3 py-1">
+                        <span className="rounded-full bg-secondary px-2.5 py-0.5">
                           {workout.duration === null ? 'Duration n/a' : `${workout.duration} min`}
                         </span>
                       </div>

--- a/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
@@ -34,6 +34,8 @@ const snapshotFixture: DashboardSnapshot = {
   workout: {
     name: 'Upper Push A',
     status: 'completed',
+    templateId: 'template-upper-push-a',
+    sessionId: 'session-upper-push-a',
     duration: 62,
   },
   habits: {
@@ -99,6 +101,10 @@ describe('SnapshotCards', () => {
     expect(screen.getByText('170g / 190g')).toBeInTheDocument();
     expect(screen.getByText('3/4')).toBeInTheDocument();
     expect(screen.getByText('Upper Push A (Completed)')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /open today's workout/i })).toHaveAttribute(
+      'href',
+      '/workouts/sessions/session-upper-push-a/summary',
+    );
   });
 
   it('applies accent card backgrounds and neutral trends', () => {
@@ -126,6 +132,7 @@ describe('SnapshotCards', () => {
 
     expect(within(weightCard as HTMLElement).getByLabelText('trend neutral')).toBeInTheDocument();
     expect(within(weightCard as HTMLElement).getByText('0%')).toBeInTheDocument();
+    expect(screen.getByText('Completed')).toBeInTheDocument();
   });
 
   it('renders placeholders for loading and null weight/workout states', () => {
@@ -190,10 +197,61 @@ describe('SnapshotCards', () => {
     expect(within(habitsCard).getByText('No habits')).toBeInTheDocument();
     expect(within(habitsCard).queryByLabelText(/trend/i)).not.toBeInTheDocument();
     expect(within(workoutCard).getByText('Rest Day')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /open today's workout/i })).not.toBeInTheDocument();
     expect(weightCard).toHaveClass('border-dashed');
     expect(caloriesCard).toHaveClass('border-dashed');
     expect(proteinCard).toHaveClass('border-dashed');
     expect(habitsCard).toHaveClass('border-dashed');
+  });
+
+  it('links scheduled workouts to template preview', () => {
+    render(
+      <MemoryRouter>
+        <SnapshotCards
+          snapshot={{
+            ...snapshotFixture,
+            workout: {
+              name: 'Lower Strength',
+              status: 'scheduled',
+              templateId: 'template-lower-strength',
+              sessionId: null,
+              duration: null,
+            },
+          }}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('link', { name: /open today's workout/i })).toHaveAttribute(
+      'href',
+      '/workouts/templates/template-lower-strength',
+    );
+    expect(screen.getByText('Scheduled')).toBeInTheDocument();
+  });
+
+  it('links in-progress workouts to active session', () => {
+    render(
+      <MemoryRouter>
+        <SnapshotCards
+          snapshot={{
+            ...snapshotFixture,
+            workout: {
+              name: 'Upper Pull',
+              status: 'in_progress',
+              templateId: 'template-upper-pull',
+              sessionId: 'session-upper-pull',
+              duration: 24,
+            },
+          }}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('link', { name: /open today's workout/i })).toHaveAttribute(
+      'href',
+      '/workouts/sessions/session-upper-pull',
+    );
+    expect(screen.getByText('In Progress')).toBeInTheDocument();
   });
 
   it('applies compact font sizing classes to long macro values to avoid overflow', () => {

--- a/apps/web/src/features/dashboard/components/snapshot-cards.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router';
 import { StatCard, type StatTrend } from '@/components/ui/stat-card';
 import { accentCardStyles } from '@/lib/accent-card-styles';
 import { formatCalories, formatGrams, formatTrendChange, formatWeight } from '@/lib/format-utils';
+import { cn } from '@/lib/utils';
 
 type SnapshotCardsProps = {
   snapshot?: DashboardSnapshot;
@@ -77,6 +78,52 @@ const formatWorkoutStatus = (status: DashboardWorkoutSnapshot['status']) => {
     .join(' ');
 };
 
+const getWorkoutHref = (workout: DashboardWorkoutSnapshot | null | undefined): string | null => {
+  if (!workout) {
+    return null;
+  }
+
+  if (workout.status === 'scheduled') {
+    return workout.templateId ? `/workouts/templates/${workout.templateId}` : null;
+  }
+
+  if (!workout.sessionId) {
+    return null;
+  }
+
+  if (workout.status === 'in_progress') {
+    return `/workouts/sessions/${workout.sessionId}`;
+  }
+
+  return `/workouts/sessions/${workout.sessionId}/summary`;
+};
+
+const getWorkoutStatusBadge = (status: DashboardWorkoutSnapshot['status']) => {
+  switch (status) {
+    case 'completed':
+      return {
+        label: 'Completed',
+        badgeClassName:
+          'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
+        dotClassName: 'bg-emerald-500',
+      };
+    case 'in_progress':
+      return {
+        label: 'In Progress',
+        badgeClassName:
+          'border-orange-500/40 bg-orange-500/10 text-orange-700 dark:text-orange-300',
+        dotClassName: 'animate-pulse bg-orange-500',
+      };
+    case 'scheduled':
+    default:
+      return {
+        label: 'Scheduled',
+        badgeClassName: 'border-border bg-background/70 text-muted-foreground',
+        dotClassName: 'border border-slate-500 bg-transparent',
+      };
+  }
+};
+
 export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
   const hasWeight = !!snapshot?.weight;
   const hasCaloriesTarget = (snapshot?.macros.target.calories ?? 0) > 0;
@@ -139,6 +186,41 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
     : snapshot
       ? 'Rest Day'
       : '--';
+  const workoutHref = getWorkoutHref(snapshot?.workout);
+  const workoutStatusBadge = snapshot?.workout
+    ? getWorkoutStatusBadge(snapshot.workout.status)
+    : null;
+  const workoutCard = (
+    <StatCard
+      className={cn(
+        'border-primary/20 bg-secondary',
+        workoutHref
+          ? 'cursor-pointer transition-colors hover:border-primary/40 hover:bg-secondary/80'
+          : undefined,
+      )}
+      data-stagger="4"
+      icon={
+        workoutStatusBadge ? (
+          <span
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-semibold',
+              workoutStatusBadge.badgeClassName,
+            )}
+          >
+            <span
+              aria-hidden="true"
+              className={cn('inline-flex size-2 rounded-full', workoutStatusBadge.dotClassName)}
+            />
+            {workoutStatusBadge.label}
+          </span>
+        ) : null
+      }
+      label="Today's Workout"
+      value={workoutValue}
+      valueClassName={getSnapshotValueClassName(workoutValue)}
+      valueTitle={workoutValue}
+    />
+  );
 
   return (
     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
@@ -202,14 +284,17 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
         valueTitle={habitsValueText}
       />
 
-      <StatCard
-        className="border-primary/20 bg-secondary"
-        data-stagger="4"
-        label="Today's Workout"
-        value={workoutValue}
-        valueClassName={getSnapshotValueClassName(workoutValue)}
-        valueTitle={workoutValue}
-      />
+      {workoutHref ? (
+        <Link
+          aria-label={`Open today's workout: ${snapshot?.workout?.name ?? 'workout'}`}
+          className="block rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          to={workoutHref}
+        >
+          {workoutCard}
+        </Link>
+      ) : (
+        workoutCard
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.test.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.test.tsx
@@ -118,7 +118,10 @@ describe('WeightTrendChart', () => {
       expect.objectContaining({ method: 'GET' }),
     );
     expect(screen.getByRole('heading', { name: 'Weight Trend' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'View history' })).toHaveAttribute('href', '/weight');
+    expect(screen.getByRole('link', { name: 'View history' })).toHaveAttribute(
+      'href',
+      '/weight/history',
+    );
     expect(screen.getByText('Current trend')).toBeInTheDocument();
     expect(screen.getByText('Period average')).toBeInTheDocument();
     expect(screen.getByText(/3-day change:/)).toBeInTheDocument();

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
@@ -167,7 +167,7 @@ export function WeightTrendChart() {
             </h2>
           </CardTitle>
           <p className="text-sm text-muted-foreground">Scale weight with EWMA smoothing.</p>
-          <a className="text-sm font-medium text-primary hover:underline" href="/weight">
+          <a className="text-sm font-medium text-primary hover:underline" href="/weight/history">
             View history
           </a>
         </div>

--- a/apps/web/src/features/weight/api/weight.test.tsx
+++ b/apps/web/src/features/weight/api/weight.test.tsx
@@ -8,6 +8,7 @@ import {
   useDeleteWeight,
   useLatestWeight,
   useLogWeight,
+  useUpdateWeight,
   useWeightTrend,
   weightKeys,
 } from './weight';
@@ -180,5 +181,40 @@ describe('weight api hooks', () => {
     });
 
     expect(toast.error).toHaveBeenCalledWith('Failed to delete weight entry');
+  });
+
+  it('patches a weight entry and invalidates weight queries', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        id: 'weight-2',
+        date: '2026-03-07',
+        weight: 180.1,
+        notes: null,
+        createdAt: 1,
+        updatedAt: 3,
+      }),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateWeight(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: 'weight-2',
+        input: { weight: 180.1 },
+      });
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/weight/weight-2',
+      expect.objectContaining({
+        body: JSON.stringify({
+          weight: 180.1,
+        }),
+        method: 'PATCH',
+      }),
+    );
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: weightKeys.all });
   });
 });

--- a/apps/web/src/features/weight/api/weight.ts
+++ b/apps/web/src/features/weight/api/weight.ts
@@ -1,5 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import type { BodyWeightEntry, CreateWeightInput, DeleteWeightResult } from '@pulse/shared';
+import type {
+  BodyWeightEntry,
+  CreateWeightInput,
+  DeleteWeightResult,
+  PatchWeightInput,
+} from '@pulse/shared';
 import { toast } from 'sonner';
 
 import { apiRequest } from '@/lib/api-client';
@@ -48,6 +53,12 @@ const deleteWeightEntry = (id: string) =>
     method: 'DELETE',
   });
 
+const patchWeightEntry = (id: string, input: PatchWeightInput) =>
+  apiRequest<BodyWeightEntry>(`/api/v1/weight/${id}`, {
+    body: JSON.stringify(input),
+    method: 'PATCH',
+  });
+
 export const useLatestWeight = () =>
   useQuery({
     queryKey: weightKeys.latest(),
@@ -83,6 +94,21 @@ export const useDeleteWeight = () => {
     },
     onError: () => {
       toast.error('Failed to delete weight entry');
+    },
+  });
+};
+
+export const useUpdateWeight = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: PatchWeightInput }) => patchWeightEntry(id, input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: weightKeys.all });
+      toast.success('Weight entry updated');
+    },
+    onError: () => {
+      toast.error('Failed to update weight entry');
     },
   });
 };

--- a/apps/web/src/features/weight/components/weight-history.tsx
+++ b/apps/web/src/features/weight/components/weight-history.tsx
@@ -27,6 +27,7 @@ export function WeightHistory() {
   const updateWeightMutation = useUpdateWeight();
   const [editingEntryId, setEditingEntryId] = useState<string | null>(null);
   const [editingWeight, setEditingWeight] = useState('');
+  const [editingWeightError, setEditingWeightError] = useState('');
   const { formatWeight } = useWeightUnit();
   const sortedWeightEntries = useMemo(
     () =>
@@ -56,6 +57,7 @@ export function WeightHistory() {
   async function handleSaveEdit(entryId: string) {
     const parsedWeight = Number(editingWeight);
     if (Number.isNaN(parsedWeight) || parsedWeight <= 0) {
+      setEditingWeightError('Enter a valid weight above 0.');
       return;
     }
 
@@ -66,6 +68,7 @@ export function WeightHistory() {
       });
       setEditingEntryId(null);
       setEditingWeight('');
+      setEditingWeightError('');
     } catch {
       return;
     }
@@ -117,7 +120,10 @@ export function WeightHistory() {
                         className="h-9 w-32"
                         inputMode="decimal"
                         min="0.1"
-                        onChange={(event) => setEditingWeight(event.currentTarget.value)}
+                        onChange={(event) => {
+                          setEditingWeight(event.currentTarget.value);
+                          setEditingWeightError('');
+                        }}
                         step="0.1"
                         type="number"
                         value={editingWeight}
@@ -137,12 +143,18 @@ export function WeightHistory() {
                         onClick={() => {
                           setEditingEntryId(null);
                           setEditingWeight('');
+                          setEditingWeightError('');
                         }}
                         type="button"
                         variant="ghost"
                       >
                         Cancel
                       </Button>
+                      {editingWeightError ? (
+                        <p className="text-sm text-destructive" role="status">
+                          {editingWeightError}
+                        </p>
+                      ) : null}
                     </div>
                   ) : (
                     <button
@@ -150,6 +162,7 @@ export function WeightHistory() {
                       onClick={() => {
                         setEditingEntryId(entry.id);
                         setEditingWeight(entry.weight.toFixed(1));
+                        setEditingWeightError('');
                       }}
                       type="button"
                     >

--- a/apps/web/src/features/weight/components/weight-history.tsx
+++ b/apps/web/src/features/weight/components/weight-history.tsx
@@ -1,10 +1,11 @@
 import { Scale, Trash2 } from 'lucide-react';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import { EmptyState } from '@/components/ui/empty-state';
 import { Button } from '@/components/ui/button';
 import { useConfirmation } from '@/components/ui/confirmation-dialog';
-import { useDeleteWeight, useWeightTrend } from '@/features/weight/api/weight';
+import { Input } from '@/components/ui/input';
+import { useDeleteWeight, useUpdateWeight, useWeightTrend } from '@/features/weight/api/weight';
 import { useWeightUnit } from '@/hooks/use-weight-unit';
 import { parseDateInput } from '@/lib/date';
 
@@ -23,6 +24,9 @@ export function WeightHistory() {
   // Intentional for now: this view is a full history log. Add pagination/date bounds if dataset size becomes a UX issue.
   const weightEntriesQuery = useWeightTrend();
   const deleteWeightMutation = useDeleteWeight();
+  const updateWeightMutation = useUpdateWeight();
+  const [editingEntryId, setEditingEntryId] = useState<string | null>(null);
+  const [editingWeight, setEditingWeight] = useState('');
   const { formatWeight } = useWeightUnit();
   const sortedWeightEntries = useMemo(
     () =>
@@ -47,6 +51,24 @@ export function WeightHistory() {
         }
       },
     });
+  }
+
+  async function handleSaveEdit(entryId: string) {
+    const parsedWeight = Number(editingWeight);
+    if (Number.isNaN(parsedWeight) || parsedWeight <= 0) {
+      return;
+    }
+
+    try {
+      await updateWeightMutation.mutateAsync({
+        id: entryId,
+        input: { weight: parsedWeight },
+      });
+      setEditingEntryId(null);
+      setEditingWeight('');
+    } catch {
+      return;
+    }
   }
 
   const isLoading = weightEntriesQuery.isLoading;
@@ -88,7 +110,52 @@ export function WeightHistory() {
               >
                 <div className="space-y-1">
                   <p className="text-sm font-semibold text-foreground">{formattedDate}</p>
-                  <p className="text-lg font-semibold text-primary">{formatWeight(entry.weight)}</p>
+                  {editingEntryId === entry.id ? (
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Input
+                        aria-label={`Weight value for ${formattedDate}`}
+                        className="h-9 w-32"
+                        inputMode="decimal"
+                        min="0.1"
+                        onChange={(event) => setEditingWeight(event.currentTarget.value)}
+                        step="0.1"
+                        type="number"
+                        value={editingWeight}
+                      />
+                      <Button
+                        className="h-9 px-3"
+                        disabled={updateWeightMutation.isPending}
+                        onClick={() => {
+                          void handleSaveEdit(entry.id);
+                        }}
+                        type="button"
+                      >
+                        Save
+                      </Button>
+                      <Button
+                        className="h-9 px-3"
+                        onClick={() => {
+                          setEditingEntryId(null);
+                          setEditingWeight('');
+                        }}
+                        type="button"
+                        variant="ghost"
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  ) : (
+                    <button
+                      className="text-left text-lg font-semibold text-primary hover:underline"
+                      onClick={() => {
+                        setEditingEntryId(entry.id);
+                        setEditingWeight(entry.weight.toFixed(1));
+                      }}
+                      type="button"
+                    >
+                      {formatWeight(entry.weight)}
+                    </button>
+                  )}
                   {entry.notes ? <p className="text-sm text-muted">{entry.notes}</p> : null}
                 </div>
 

--- a/apps/web/src/hooks/use-dashboard-snapshot.test.tsx
+++ b/apps/web/src/hooks/use-dashboard-snapshot.test.tsx
@@ -40,6 +40,8 @@ const snapshotFixture: DashboardSnapshot = {
   workout: {
     name: 'Upper Push A',
     status: 'completed',
+    templateId: 'template-upper-push-a',
+    sessionId: 'session-upper-push-a',
     duration: 62,
   },
   habits: {

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -124,6 +124,8 @@ const snapshotForToday: DashboardSnapshot = {
   workout: {
     name: 'Upper Push A',
     status: 'completed',
+    templateId: 'template-upper-push-a',
+    sessionId: 'session-upper-push-a',
     duration: 62,
   },
   habits: {

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -5,7 +5,7 @@ import {
   type Habit,
   type HabitEntry,
 } from '@pulse/shared';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -437,7 +437,7 @@ describe('DashboardPage', () => {
       expect.objectContaining({ method: 'GET' }),
     );
 
-    const bodyWeightCard = screen.getByText('Body Weight').closest('[data-slot="stat-card"]');
+    const bodyWeightCard = screen.getAllByText('Body Weight')[0]?.closest('[data-slot="stat-card"]');
     expect(bodyWeightCard).toBeInTheDocument();
     expect(
       within(bodyWeightCard as HTMLElement).getByText(formatWeight(181.4)),
@@ -458,38 +458,14 @@ describe('DashboardPage', () => {
     expect(screen.getByText('1900 / 2300')).toBeInTheDocument();
     expect(screen.getByText('170g / 190g')).toBeInTheDocument();
     expect(screen.getByText('1/1')).toBeInTheDocument();
-    expect(screen.getByLabelText('Weight (lbs)')).toHaveAttribute('id', 'dashboard-weight-input');
-    expect(screen.getByLabelText('Weight (lbs)')).toHaveAttribute('name', 'weight');
-    expect(screen.getByLabelText('Weight (lbs)')).toHaveAttribute(
-      'data-qa',
-      'dashboard-weight-input',
-    );
-    expect(screen.getByText('Log Weight').closest('[data-qa]')).toHaveAttribute(
-      'data-qa',
-      'dashboard-log-weight-card',
-    );
     expect(screen.getByTestId('dashboard-log-weight-card')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Save Weight' })).toHaveAttribute(
-      'data-qa',
-      'dashboard-save-weight',
-    );
-    expect(screen.getByRole('button', { name: 'Save Weight' })).toHaveAttribute(
-      'id',
-      'dashboard-save-weight',
-    );
-    expect(screen.getByTestId('dashboard-weight-input')).toHaveAttribute(
-      'data-testid',
-      'dashboard-weight-input',
-    );
-    expect(screen.getByTestId('dashboard-save-weight')).toHaveAttribute(
-      'data-testid',
-      'dashboard-save-weight',
-    );
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'History' })).toHaveAttribute('href', '/weight/history');
+    expect(screen.queryByTestId('dashboard-log-weight-form')).not.toBeInTheDocument();
 
     const layout = container.querySelector('[data-slot="dashboard-layout"]');
     const mainColumn = container.querySelector('[data-slot="dashboard-main-column"]');
     const sidebarColumn = container.querySelector('[data-slot="dashboard-sidebar-column"]');
-    const logWeightForm = container.querySelector('[data-qa="dashboard-log-weight-form"]');
     const recentColumn = container.querySelector('[data-slot="dashboard-recent-workouts-column"]');
     const weightTrendRow = container.querySelector('[data-slot="dashboard-weight-trend-row"]');
     const calendarPanel = container.querySelector('[data-slot="dashboard-calendar-panel"]');
@@ -506,7 +482,7 @@ describe('DashboardPage', () => {
     );
     expect(mainColumn).toHaveClass('order-1', 'md:order-1', 'xl:order-2');
     expect(sidebarColumn).toHaveClass('order-2', 'md:order-2', 'xl:order-1');
-    expect(logWeightForm).toBeInTheDocument();
+    expect(container.querySelector('[data-qa="dashboard-log-weight-form"]')).not.toBeInTheDocument();
     expect(recentColumn).toHaveClass('order-3', 'md:col-span-2', 'xl:col-span-1', 'xl:col-start-3');
     expect(weightTrendRow).toHaveClass('order-4', 'md:col-span-2', 'xl:col-span-3');
     expect(calendarPanel).toHaveClass('order-1', 'md:order-3');
@@ -643,7 +619,7 @@ describe('DashboardPage', () => {
 
     await vi.runAllTimersAsync();
     await Promise.resolve();
-    expect(screen.getByText('Body Weight')).toBeInTheDocument();
+    expect(screen.getAllByText('Body Weight')[0]).toBeInTheDocument();
   });
 
   it('updates snapshot and habit chain windows when a new calendar day is selected', async () => {
@@ -658,7 +634,7 @@ describe('DashboardPage', () => {
     await vi.runAllTimersAsync();
     await Promise.resolve();
 
-    const bodyWeightCard = screen.getByText('Body Weight').closest('[data-slot="stat-card"]');
+    const bodyWeightCard = screen.getAllByText('Body Weight')[0]?.closest('[data-slot="stat-card"]');
     const habitsCard = screen.getByText('Habits').closest('[data-slot="stat-card"]');
 
     expect(bodyWeightCard).toBeInTheDocument();
@@ -677,8 +653,8 @@ describe('DashboardPage', () => {
     await Promise.resolve();
 
     const refreshedBodyWeightCard = screen
-      .getByText('Body Weight')
-      .closest('[data-slot="stat-card"]') as HTMLElement;
+      .getAllByText('Body Weight')[0]
+      ?.closest('[data-slot="stat-card"]') as HTMLElement;
     const refreshedHabitsCard = screen
       .getByText('Habits')
       .closest('[data-slot="stat-card"]') as HTMLElement;
@@ -715,9 +691,7 @@ describe('DashboardPage', () => {
     expect(screen.queryByRole('button', { name: 'Back to today' })).not.toBeInTheDocument();
   });
 
-  it('logs a new weight entry and refreshes the body weight card', async () => {
-    vi.useRealTimers();
-
+  it('edits a logged weight entry and refreshes the body weight card', async () => {
     const { wrapper } = createQueryClientWrapper();
     render(
       <MemoryRouter>
@@ -726,30 +700,55 @@ describe('DashboardPage', () => {
       { wrapper },
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Body Weight')).toBeInTheDocument();
-    });
-    await waitFor(() => {
-      const initialBodyWeightCard = screen
-        .getByText('Body Weight')
-        .closest('[data-slot="stat-card"]') as HTMLElement;
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
 
-      expect(within(initialBodyWeightCard).getByText(formatWeight(181.4))).toBeInTheDocument();
-    });
+    const initialBodyWeightCard = screen
+      .getAllByText('Body Weight')[0]
+      .closest('[data-slot="stat-card"]') as HTMLElement;
 
+    expect(within(initialBodyWeightCard).getByText(formatWeight(181.4))).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
     fireEvent.change(screen.getByLabelText('Weight (lbs)'), { target: { value: '175.5' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save Weight' }));
 
-    await waitFor(() => {
-      expect(screen.getByText('Weight entry saved.')).toBeInTheDocument();
-    });
-    await waitFor(() => {
-      const refreshedBodyWeightCard = screen
-        .getByText('Body Weight')
-        .closest('[data-slot="stat-card"]') as HTMLElement;
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
 
-      expect(within(refreshedBodyWeightCard).getByText('175.5 lbs')).toBeInTheDocument();
-    });
+    expect(screen.queryByLabelText('Weight (lbs)')).not.toBeInTheDocument();
+    const refreshedBodyWeightCard = screen
+      .getAllByText('Body Weight')[0]
+      .closest('[data-slot="stat-card"]') as HTMLElement;
+
+    expect(within(refreshedBodyWeightCard).getByText('175.5 lbs')).toBeInTheDocument();
+  });
+
+  it('shows a log weight CTA for days without an entry and opens the inline form', async () => {
+    const { wrapper } = createQueryClientWrapper();
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+      { wrapper },
+    );
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    fireEvent.click(screen.getByRole('button', { name: /select wednesday, march 4, 2026/i }));
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(screen.getByTestId('dashboard-log-weight-cta')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Weight (lbs)')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('dashboard-log-weight-cta'));
+
+    expect(screen.getByLabelText('Weight (lbs)')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save Weight' })).toBeInTheDocument();
   });
 
   it('renders only configured habit chains and trend metrics', async () => {

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -78,6 +78,11 @@ function isDashboardWidgetId(value: string): value is DashboardWidgetId {
   return value in DASHBOARD_WIDGET_IDS;
 }
 
+type DashboardWeightStatus = {
+  message: string;
+  type: 'error' | 'success';
+};
+
 function DashboardWidgetFrame({
   children,
   className,
@@ -105,7 +110,7 @@ export function DashboardPage() {
   const queryClient = useQueryClient();
   const [selectedDate, setSelectedDate] = useState<Date>(() => getToday());
   const [weightInput, setWeightInput] = useState('');
-  const [weightMessage, setWeightMessage] = useState('');
+  const [weightStatus, setWeightStatus] = useState<DashboardWeightStatus | null>(null);
   const [isWeightEditorOpen, setIsWeightEditorOpen] = useState(false);
   const [isEditMode, setIsEditMode] = useState(false);
   const [visibleWidgetsDraft, setVisibleWidgetsDraft] = useState<DashboardWidgetId[] | null>(null);
@@ -147,7 +152,7 @@ export function DashboardPage() {
   function handleSelectedDateChange(nextDate: Date) {
     setIsWeightEditorOpen(false);
     setWeightInput('');
-    setWeightMessage('');
+    setWeightStatus(null);
     setSelectedDate(nextDate);
   }
 
@@ -199,7 +204,10 @@ export function DashboardPage() {
 
     const parsedWeight = Number(weightInput);
     if (Number.isNaN(parsedWeight) || parsedWeight <= 0) {
-      setWeightMessage('Enter a valid weight above 0.');
+      setWeightStatus({
+        message: 'Enter a valid weight above 0.',
+        type: 'error',
+      });
       return;
     }
 
@@ -210,10 +218,16 @@ export function DashboardPage() {
       });
       await queryClient.invalidateQueries({ queryKey: dashboardSnapshotKeys.all });
       setWeightInput('');
-      setWeightMessage('Weight entry saved.');
+      setWeightStatus({
+        message: 'Weight entry saved.',
+        type: 'success',
+      });
       setIsWeightEditorOpen(false);
     } catch {
-      setWeightMessage('Unable to save weight. Please try again.');
+      setWeightStatus({
+        message: 'Unable to save weight. Please try again.',
+        type: 'error',
+      });
     }
   }
 
@@ -399,7 +413,7 @@ export function DashboardPage() {
                                 <Button
                                   onClick={() => {
                                     setWeightInput(selectedWeight.value.toFixed(1));
-                                    setWeightMessage('');
+                                    setWeightStatus(null);
                                     setIsWeightEditorOpen(true);
                                   }}
                                   type="button"
@@ -414,7 +428,7 @@ export function DashboardPage() {
                                 data-testid="dashboard-log-weight-cta"
                                 onClick={() => {
                                   setWeightInput('');
-                                  setWeightMessage('');
+                                  setWeightStatus(null);
                                   setIsWeightEditorOpen(true);
                                 }}
                                 type="button"
@@ -447,7 +461,7 @@ export function DashboardPage() {
                                     name="weight"
                                     onChange={(event) => {
                                       setWeightInput(event.currentTarget.value);
-                                      setWeightMessage('');
+                                      setWeightStatus(null);
                                     }}
                                     placeholder="e.g. 175.5"
                                     step="0.1"
@@ -468,7 +482,7 @@ export function DashboardPage() {
                                   <Button
                                     onClick={() => {
                                       setIsWeightEditorOpen(false);
-                                      setWeightMessage('');
+                                      setWeightStatus(null);
                                     }}
                                     type="button"
                                     variant="ghost"
@@ -476,13 +490,18 @@ export function DashboardPage() {
                                     Cancel
                                   </Button>
                                 </div>
-                                {weightMessage ? (
+                                {weightStatus ? (
                                   <p
-                                    className="text-sm text-muted-foreground"
+                                    className={cn(
+                                      'text-sm',
+                                      weightStatus.type === 'error'
+                                        ? 'text-destructive'
+                                        : 'text-muted-foreground',
+                                    )}
                                     id="dashboard-weight-status"
                                     role="status"
                                   >
-                                    {weightMessage}
+                                    {weightStatus.message}
                                   </p>
                                 ) : null}
                               </form>

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -2,6 +2,7 @@ import { DASHBOARD_WIDGET_IDS } from '@pulse/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { EyeOff, LayoutDashboard, Pencil, Plus } from 'lucide-react';
 import { type FormEvent, type ReactNode, useEffect, useState } from 'react';
+import { Link } from 'react-router';
 
 import { StatCardSkeleton } from '@/components/skeletons';
 import { Button } from '@/components/ui/button';
@@ -105,6 +106,7 @@ export function DashboardPage() {
   const [selectedDate, setSelectedDate] = useState<Date>(() => getToday());
   const [weightInput, setWeightInput] = useState('');
   const [weightMessage, setWeightMessage] = useState('');
+  const [isWeightEditorOpen, setIsWeightEditorOpen] = useState(false);
   const [isEditMode, setIsEditMode] = useState(false);
   const [visibleWidgetsDraft, setVisibleWidgetsDraft] = useState<DashboardWidgetId[] | null>(null);
   const [widgetVisibilityMessage, setWidgetVisibilityMessage] = useState('');
@@ -128,6 +130,8 @@ export function DashboardPage() {
   const hiddenWidgets = DEFAULT_VISIBLE_WIDGETS.filter((widgetId) => !visibleWidgets.includes(widgetId));
   const showWeightTrendChart = visibleWidgets.includes('weight-trend');
   const isSavingDashboardConfig = saveDashboardConfigMutation.isPending;
+  const selectedWeight = snapshotQuery.data?.weight;
+  const hasWeightForSelectedDay = selectedWeight?.date === selectedDateKey;
 
   function showWidget(widgetId: DashboardWidgetId) {
     setVisibleWidgetsDraft((currentDraft) => {
@@ -138,6 +142,13 @@ export function DashboardPage() {
 
       return [...current, widgetId];
     });
+  }
+
+  function handleSelectedDateChange(nextDate: Date) {
+    setIsWeightEditorOpen(false);
+    setWeightInput('');
+    setWeightMessage('');
+    setSelectedDate(nextDate);
   }
 
   function hideWidget(widgetId: DashboardWidgetId) {
@@ -200,6 +211,7 @@ export function DashboardPage() {
       await queryClient.invalidateQueries({ queryKey: dashboardSnapshotKeys.all });
       setWeightInput('');
       setWeightMessage('Weight entry saved.');
+      setIsWeightEditorOpen(false);
     } catch {
       setWeightMessage('Unable to save weight. Please try again.');
     }
@@ -241,7 +253,12 @@ export function DashboardPage() {
               </HelpIcon>
             </div>
             {!isViewingToday ? (
-              <Button onClick={() => setSelectedDate(getToday())} size="sm" type="button" variant="outline">
+              <Button
+                onClick={() => handleSelectedDateChange(getToday())}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
                 Back to today
               </Button>
             ) : null}
@@ -319,7 +336,7 @@ export function DashboardPage() {
                 onHide={() => hideWidget('calendar')}
                 widgetLabel={DASHBOARD_WIDGET_IDS.calendar}
               >
-                <CalendarPicker onDateSelect={setSelectedDate} selectedDate={selectedDate} />
+                <CalendarPicker onDateSelect={handleSelectedDateChange} selectedDate={selectedDate} />
               </DashboardWidgetFrame>
             ) : null}
 
@@ -354,55 +371,123 @@ export function DashboardPage() {
                     >
                       <Card data-qa="dashboard-log-weight-card" data-testid="dashboard-log-weight-card">
                         <CardHeader className="space-y-1">
-                          <CardTitle>Log Weight</CardTitle>
-                          <CardDescription>Track your body weight for the selected day.</CardDescription>
+                          <div className="flex items-center justify-between gap-3">
+                            <div className="space-y-1">
+                              <CardTitle>Body Weight</CardTitle>
+                              <CardDescription>Track your body weight for the selected day.</CardDescription>
+                            </div>
+                            <Link
+                              className="text-sm font-medium text-primary hover:underline"
+                              to="/weight/history"
+                            >
+                              History
+                            </Link>
+                          </div>
                         </CardHeader>
                         <CardContent>
-                          <form
-                            className="space-y-3"
-                            data-qa="dashboard-log-weight-form"
-                            data-testid="dashboard-log-weight-form"
-                            onSubmit={handleWeightSubmit}
-                          >
-                            <div className="space-y-2">
-                              <Label htmlFor="dashboard-weight-input">Weight (lbs)</Label>
-                              <Input
-                                aria-describedby="dashboard-weight-status"
-                                data-qa="dashboard-weight-input"
-                                data-testid="dashboard-weight-input"
-                                id="dashboard-weight-input"
-                                inputMode="decimal"
-                                min="0.1"
-                                name="weight"
-                                onChange={(event) => {
-                                  setWeightInput(event.currentTarget.value);
+                          <div className="space-y-4">
+                            {hasWeightForSelectedDay ? (
+                              <div className="flex items-center justify-between gap-3 rounded-xl border border-border/80 bg-secondary/30 px-4 py-3">
+                                <div className="space-y-1">
+                                  <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                                    Logged
+                                  </p>
+                                  <p className="text-2xl font-semibold text-foreground">
+                                    {selectedWeight.value.toFixed(1)} lbs
+                                  </p>
+                                </div>
+                                <Button
+                                  onClick={() => {
+                                    setWeightInput(selectedWeight.value.toFixed(1));
+                                    setWeightMessage('');
+                                    setIsWeightEditorOpen(true);
+                                  }}
+                                  type="button"
+                                  variant="outline"
+                                >
+                                  Edit
+                                </Button>
+                              </div>
+                            ) : (
+                              <Button
+                                className="w-full justify-between border-accent bg-accent/20 text-foreground shadow-[0_0_0_1px_var(--color-accent)] hover:bg-accent/25"
+                                data-testid="dashboard-log-weight-cta"
+                                onClick={() => {
+                                  setWeightInput('');
                                   setWeightMessage('');
+                                  setIsWeightEditorOpen(true);
                                 }}
-                                placeholder="e.g. 175.5"
-                                step="0.1"
-                                type="number"
-                                value={weightInput}
-                              />
-                            </div>
-                            <Button
-                              data-qa="dashboard-save-weight"
-                              data-testid="dashboard-save-weight"
-                              id="dashboard-save-weight"
-                              disabled={logWeightMutation.isPending}
-                              type="submit"
-                            >
-                              {logWeightMutation.isPending ? 'Saving...' : 'Save Weight'}
-                            </Button>
-                            {weightMessage ? (
-                              <p
-                                className="text-sm text-muted-foreground"
-                                id="dashboard-weight-status"
-                                role="status"
+                                type="button"
+                                variant="outline"
                               >
-                                {weightMessage}
-                              </p>
+                                <span>Log weight</span>
+                                <span
+                                  aria-hidden="true"
+                                  className="size-2 rounded-full bg-accent animate-pulse"
+                                />
+                              </Button>
+                            )}
+
+                            {isWeightEditorOpen ? (
+                              <form
+                                className="space-y-3"
+                                data-qa="dashboard-log-weight-form"
+                                data-testid="dashboard-log-weight-form"
+                                onSubmit={handleWeightSubmit}
+                              >
+                                <div className="space-y-2">
+                                  <Label htmlFor="dashboard-weight-input">Weight (lbs)</Label>
+                                  <Input
+                                    aria-describedby="dashboard-weight-status"
+                                    data-qa="dashboard-weight-input"
+                                    data-testid="dashboard-weight-input"
+                                    id="dashboard-weight-input"
+                                    inputMode="decimal"
+                                    min="0.1"
+                                    name="weight"
+                                    onChange={(event) => {
+                                      setWeightInput(event.currentTarget.value);
+                                      setWeightMessage('');
+                                    }}
+                                    placeholder="e.g. 175.5"
+                                    step="0.1"
+                                    type="number"
+                                    value={weightInput}
+                                  />
+                                </div>
+                                <div className="flex gap-2">
+                                  <Button
+                                    data-qa="dashboard-save-weight"
+                                    data-testid="dashboard-save-weight"
+                                    id="dashboard-save-weight"
+                                    disabled={logWeightMutation.isPending}
+                                    type="submit"
+                                  >
+                                    {logWeightMutation.isPending ? 'Saving...' : 'Save Weight'}
+                                  </Button>
+                                  <Button
+                                    onClick={() => {
+                                      setIsWeightEditorOpen(false);
+                                      setWeightMessage('');
+                                    }}
+                                    type="button"
+                                    variant="ghost"
+                                  >
+                                    Cancel
+                                  </Button>
+                                </div>
+                                {weightMessage ? (
+                                  <p
+                                    className="text-sm text-muted-foreground"
+                                    id="dashboard-weight-status"
+                                    role="status"
+                                  >
+                                    {weightMessage}
+                                  </p>
+                                ) : null}
+                              </form>
                             ) : null}
-                          </form>
+                          </div>
                         </CardContent>
                       </Card>
                     </DashboardWidgetFrame>

--- a/apps/web/src/pages/weight-history.test.tsx
+++ b/apps/web/src/pages/weight-history.test.tsx
@@ -86,9 +86,9 @@ describe('WeightHistoryPage', () => {
     });
 
     renderWithQueryClient(
-      <MemoryRouter initialEntries={['/weight']}>
+      <MemoryRouter initialEntries={['/weight/history']}>
         <Routes>
-          <Route element={<WeightHistoryPage />} path="/weight" />
+          <Route element={<WeightHistoryPage />} path="/weight/history" />
         </Routes>
       </MemoryRouter>,
     );
@@ -101,7 +101,7 @@ describe('WeightHistoryPage', () => {
     expect(screen.getByText('After cardio')).toBeInTheDocument();
 
     const list = screen.getByRole('list', { name: 'Weight history entries' });
-    const weightsInOrder = Array.from(list.querySelectorAll('li p.text-lg')).map(
+    const weightsInOrder = Array.from(list.querySelectorAll('li button.text-lg')).map(
       (element) => element.textContent,
     );
     expect(weightsInOrder).toEqual(['181.4 lbs', '181.2 lbs', '181.8 lbs']);
@@ -175,9 +175,9 @@ describe('WeightHistoryPage', () => {
     });
 
     renderWithQueryClient(
-      <MemoryRouter initialEntries={['/weight']}>
+      <MemoryRouter initialEntries={['/weight/history']}>
         <Routes>
-          <Route element={<WeightHistoryPage />} path="/weight" />
+          <Route element={<WeightHistoryPage />} path="/weight/history" />
         </Routes>
       </MemoryRouter>,
     );
@@ -226,9 +226,9 @@ describe('WeightHistoryPage', () => {
     });
 
     renderWithQueryClient(
-      <MemoryRouter initialEntries={['/weight']}>
+      <MemoryRouter initialEntries={['/weight/history']}>
         <Routes>
-          <Route element={<WeightHistoryPage />} path="/weight" />
+          <Route element={<WeightHistoryPage />} path="/weight/history" />
         </Routes>
       </MemoryRouter>,
     );
@@ -278,14 +278,85 @@ describe('WeightHistoryPage', () => {
     });
 
     renderWithQueryClient(
-      <MemoryRouter initialEntries={['/weight']}>
+      <MemoryRouter initialEntries={['/weight/history']}>
         <Routes>
-          <Route element={<WeightHistoryPage />} path="/weight" />
+          <Route element={<WeightHistoryPage />} path="/weight/history" />
         </Routes>
       </MemoryRouter>,
     );
 
     expect(await screen.findByText('81.2 kg')).toBeInTheDocument();
+  });
+
+  it('supports inline editing of a weight value', async () => {
+    let weights = [
+      {
+        id: 'weight-1',
+        date: '2026-03-06',
+        weight: 181.4,
+        notes: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const rawUrl =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url = new URL(rawUrl, 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/users/me' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: 'user-1',
+              username: 'test-user',
+              name: 'Test User',
+              weightUnit: 'lbs',
+              createdAt: 1,
+            },
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/weight' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: weights }));
+      }
+
+      if (url.pathname === '/api/v1/weight/weight-1' && method === 'PATCH') {
+        const payload =
+          typeof init?.body === 'string' ? (JSON.parse(init.body) as { weight: number }) : null;
+        const nextWeight = payload?.weight ?? weights[0]?.weight ?? 0;
+
+        weights = weights.map((entry) =>
+          entry.id === 'weight-1' ? { ...entry, weight: nextWeight, updatedAt: entry.updatedAt + 1 } : entry,
+        );
+
+        return Promise.resolve(jsonResponse({ data: weights[0] }));
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter initialEntries={['/weight/history']}>
+        <Routes>
+          <Route element={<WeightHistoryPage />} path="/weight/history" />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('181.4 lbs')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '181.4 lbs' }));
+    fireEvent.change(screen.getByLabelText('Weight value for Mar 6, 2026'), {
+      target: { value: '180.2' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('180.2 lbs')).toBeInTheDocument();
+    });
   });
 
   it('shows contextual help for weight history', async () => {
@@ -321,9 +392,9 @@ describe('WeightHistoryPage', () => {
     });
 
     renderWithQueryClient(
-      <MemoryRouter initialEntries={['/weight']}>
+      <MemoryRouter initialEntries={['/weight/history']}>
         <Routes>
-          <Route element={<WeightHistoryPage />} path="/weight" />
+          <Route element={<WeightHistoryPage />} path="/weight/history" />
         </Routes>
       </MemoryRouter>,
     );
@@ -341,7 +412,7 @@ describe('WeightHistoryPage', () => {
       screen.getByText('The dashboard trend line uses an exponentially weighted moving average (EWMA).'),
     ).toBeInTheDocument();
     expect(
-      screen.getByText('Use this history page to delete incorrect entries and keep your trend clean.'),
+      screen.getByText('Tap any logged value to edit it inline when an entry needs correction.'),
     ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/weight-history.test.tsx
+++ b/apps/web/src/pages/weight-history.test.tsx
@@ -359,6 +359,80 @@ describe('WeightHistoryPage', () => {
     });
   });
 
+  it('shows validation feedback when saving an invalid inline weight edit', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const rawUrl =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url = new URL(rawUrl, 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/users/me' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: 'user-1',
+              username: 'test-user',
+              name: 'Test User',
+              weightUnit: 'lbs',
+              createdAt: 1,
+            },
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/weight' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'weight-1',
+                date: '2026-03-06',
+                weight: 181.4,
+                notes: null,
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            ],
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/weight/weight-1' && method === 'PATCH') {
+        throw new Error('PATCH should not be called for invalid edits');
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter initialEntries={['/weight/history']}>
+        <Routes>
+          <Route element={<WeightHistoryPage />} path="/weight/history" />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('181.4 lbs')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '181.4 lbs' }));
+    fireEvent.change(screen.getByLabelText('Weight value for Mar 6, 2026'), {
+      target: { value: '0' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(screen.getByText('Enter a valid weight above 0.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    const hasPatchToWeightEntry = fetchSpy.mock.calls.some((call) => {
+      const input = call[0];
+      const rawUrl =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url = new URL(rawUrl, 'https://pulse.test');
+      const method = call[1]?.method ?? 'GET';
+
+      return url.pathname === '/api/v1/weight/weight-1' && method === 'PATCH';
+    });
+    expect(hasPatchToWeightEntry).toBe(false);
+  });
+
   it('shows contextual help for weight history', async () => {
     vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
       const rawUrl =

--- a/apps/web/src/pages/weight-history.tsx
+++ b/apps/web/src/pages/weight-history.tsx
@@ -16,12 +16,12 @@ export function WeightHistoryPage() {
           <ul className="list-disc space-y-1 pl-5">
             <li>The dashboard trend line uses an exponentially weighted moving average (EWMA).</li>
             <li>You can log weight manually in the app or ask your AI agent to log it.</li>
-            <li>Use this history page to delete incorrect entries and keep your trend clean.</li>
+            <li>Tap any logged value to edit it inline when an entry needs correction.</li>
           </ul>
         </HelpIcon>
       </div>
       <p className="max-w-2xl text-sm text-muted">
-        Review your full body weight log and remove entries you no longer want to keep.
+        Review your full body weight log, update values inline, or remove entries you no longer want.
       </p>
       <WeightHistory />
     </main>

--- a/packages/shared/src/schemas/dashboard.test.ts
+++ b/packages/shared/src/schemas/dashboard.test.ts
@@ -95,6 +95,8 @@ describe('dashboardSnapshotSchema', () => {
       workout: {
         name: 'Upper Push A',
         status: 'completed',
+        templateId: 'template-upper-push-a',
+        sessionId: 'session-upper-push-a',
         duration: 64,
       },
       habits: {
@@ -164,6 +166,74 @@ describe('dashboardSnapshotSchema', () => {
     };
 
     expect(snapshot.habits.completed).toBe(1);
+  });
+
+  it('accepts scheduled and in_progress workout states', () => {
+    expect(
+      dashboardSnapshotSchema.parse({
+        date: '2026-03-09',
+        weight: null,
+        macros: {
+          actual: {
+            calories: 0,
+            protein: 0,
+            carbs: 0,
+            fat: 0,
+          },
+          target: {
+            calories: 0,
+            protein: 0,
+            carbs: 0,
+            fat: 0,
+          },
+        },
+        workout: {
+          name: 'Lower Strength',
+          status: 'scheduled',
+          templateId: 'template-lower-strength',
+          sessionId: null,
+          duration: null,
+        },
+        habits: {
+          total: 0,
+          completed: 0,
+          percentage: 0,
+        },
+      }),
+    ).toBeTruthy();
+
+    expect(
+      dashboardSnapshotSchema.parse({
+        date: '2026-03-09',
+        weight: null,
+        macros: {
+          actual: {
+            calories: 0,
+            protein: 0,
+            carbs: 0,
+            fat: 0,
+          },
+          target: {
+            calories: 0,
+            protein: 0,
+            carbs: 0,
+            fat: 0,
+          },
+        },
+        workout: {
+          name: 'Upper Push A',
+          status: 'in_progress',
+          templateId: 'template-upper-push',
+          sessionId: 'session-upper-push',
+          duration: 25,
+        },
+        habits: {
+          total: 0,
+          completed: 0,
+          percentage: 0,
+        },
+      }),
+    ).toBeTruthy();
   });
 });
 

--- a/packages/shared/src/schemas/dashboard.ts
+++ b/packages/shared/src/schemas/dashboard.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 
 import { dateSchema } from './common.js';
-import { workoutSessionStatusSchema } from './workout-sessions.js';
 
 const macroValueSchema = z.number().nonnegative().finite();
 const percentageSchema = z.number().min(0).max(100).finite();
@@ -61,7 +60,9 @@ export const dashboardMacroSnapshotSchema = z.object({
 
 export const dashboardWorkoutSnapshotSchema = z.object({
   name: z.string(),
-  status: workoutSessionStatusSchema,
+  status: z.enum(['scheduled', 'in_progress', 'completed']),
+  templateId: z.string().nullable(),
+  sessionId: z.string().nullable(),
   duration: z.number().int().nonnegative().nullable(),
 });
 

--- a/packages/shared/src/schemas/weight.test.ts
+++ b/packages/shared/src/schemas/weight.test.ts
@@ -195,6 +195,18 @@ describe('weightQueryParamsSchema', () => {
     ).toThrow();
   });
 
+  it('parses pagination params from string input', () => {
+    const params = weightQueryParamsSchema.parse({
+      page: '2',
+      limit: '25',
+    });
+
+    expect(params).toEqual({
+      page: 2,
+      limit: 25,
+    });
+  });
+
   it('infers the WeightQueryParams type from the schema', () => {
     const params: WeightQueryParams = {
       to: '2026-03-07',

--- a/packages/shared/src/schemas/weight.ts
+++ b/packages/shared/src/schemas/weight.ts
@@ -46,6 +46,8 @@ export const weightQueryParamsSchema = z
     from: dateSchema.optional(),
     to: dateSchema.optional(),
     days: z.coerce.number().int().positive().max(3650).optional(),
+    page: z.coerce.number().int().positive().optional(),
+    limit: z.coerce.number().int().positive().max(200).optional(),
   })
   .refine(({ from, to }) => !from || !to || from <= to, {
     message: '`from` must be on or before `to`',


### PR DESCRIPTION
## Summary
This PR upgrades the dashboard experience across workout and weight flows by making “Today’s Workout” actionable, tightening recent workout cards, and improving weight logging/history editing. The workout snapshot now returns routing metadata (`templateId`, `sessionId`) and a normalized dashboard state so the card can deep-link to the correct destination based on whether the workout is scheduled, active, or completed. The weight widget now shows a clear “Log weight” CTA only when no entry exists for the selected day, while existing entries surface as a logged value with inline edit access. It also introduces a dedicated `/weight/history` route with inline value editing to correct past entries without leaving the list. Overall, the changes improve dashboard clarity and reduce friction for common daily actions.

## Key Changes
- Made the dashboard “Today’s Workout” card clickable with state-aware routing:
  - `scheduled` -> template page
  - `in_progress` -> active session page
  - `completed` -> session summary page
- Expanded dashboard workout snapshot payload to include `templateId` and `sessionId`, and standardized status values for dashboard usage.
- Reworked backend workout snapshot selection to combine scheduled workouts + standalone sessions, ignore cancelled items, dedupe linked sessions, and prioritize `in_progress` over `scheduled` over `completed`.
- Compacted Recent Workouts cards with reduced vertical spacing, tighter metadata pills, and overflow-safe layout for long titles.
- Updated dashboard weight widget behavior:
  - Show “Log weight” CTA only when no entry exists for selected day
  - Show logged value + “Edit” when an entry exists
  - Inline editor can be opened/closed and resets on date change
  - Added direct History link from the widget
- Added `/weight/history` route and inline editing in the history list, backed by PATCH support in the frontend weight API hook.

## Technical Notes
- `dashboardWorkoutSnapshotSchema` now uses dashboard-specific statuses (`scheduled`, `in_progress`, `completed`) rather than the broader workout session status enum, and requires nullable `templateId`/`sessionId`.
- The dashboard-store workout candidate algorithm now merges data from `scheduled_workouts`, `workout_sessions`, and templates, then sorts by status priority and recency timestamp; reviewers should focus on this selection logic and tie-breaking behavior.
- `GET /api/v1/weight` now supports optional `page`/`limit` query params and returns `{ data, meta }` only when pagination params are provided; pagination is currently applied in-route by slicing returned entries.
- Route aliases were added (`/workouts/sessions/:id`, `/workouts/sessions/:id/summary`, `/workouts/templates/:id`, `/weight/history`) while existing singular routes remain, preserving compatibility.
- Test coverage was expanded across shared schemas, API route/store logic, and dashboard/weight frontend behavior for the new routing, compact layout, and inline editing flows.

## Commits

- `d0dde91 feat(dashboard): add conditional weight CTA and editable history`
- `edb3443 feat(dashboard): compact recent workouts layout`
- `f1d912f feat(dashboard): add state-aware today's workout routing`

## Tasks

- **Today's Workout card clickable + state-aware routing**: Make dashboard workout card clickable with state-aware routing to template/session/receipt
- **Recent Workouts compact layout**: Reduce per-item height in Recent Workouts dashboard section with tighter padding and inline pills
- **Log Weight widget conditional + weight history**: Show Log Weight CTA only when no entry exists for the day, add /weight/history page with inline editing

## Diff Stats

```
apps/api/src/routes/v1/dashboard-store.test.ts     |  96 ++++++++--
 apps/api/src/routes/v1/dashboard-store.ts          | 195 ++++++++++++++++++++-
 apps/api/src/routes/v1/dashboard.test.ts           |  75 ++++----
 apps/api/src/routes/weight/index.test.ts           |  66 +++++++
 apps/api/src/routes/weight/index.ts                |  21 ++-
 apps/web/src/App.tsx                               |  30 ++--
 .../dashboard/components/recent-workouts.test.tsx  |  52 ++++++
 .../dashboard/components/recent-workouts.tsx       |  26 +--
 .../dashboard/components/snapshot-cards.test.tsx   |  58 ++++++
 .../dashboard/components/snapshot-cards.tsx        | 101 ++++++++++-
 .../components/weight-trend-chart.test.tsx         |   5 +-
 .../dashboard/components/weight-trend-chart.tsx    |   2 +-
 apps/web/src/features/weight/api/weight.test.tsx   |  36 ++++
 apps/web/src/features/weight/api/weight.ts         |  28 ++-
 .../features/weight/components/weight-history.tsx  |  73 +++++++-
 apps/web/src/hooks/use-dashboard-snapshot.test.tsx |   2 +
 apps/web/src/pages/dashboard.test.tsx              | 111 ++++++------
 apps/web/src/pages/dashboard.tsx                   | 175 +++++++++++++-----
 apps/web/src/pages/weight-history.test.tsx         |  95 ++++++++--
 apps/web/src/pages/weight-history.tsx              |   4 +-
 packages/shared/src/schemas/dashboard.test.ts      |  70 ++++++++
 packages/shared/src/schemas/dashboard.ts           |   5 +-
 packages/shared/src/schemas/weight.test.ts         |  12 ++
 packages/shared/src/schemas/weight.ts              |   2 +
 24 files changed, 1125 insertions(+), 215 deletions(-)
```