### PR TITLE
feat: nutrition week calendar strip

### DIFF
--- a/apps/api/src/routes/nutrition/index.test.ts
+++ b/apps/api/src/routes/nutrition/index.test.ts
@@ -10,6 +10,7 @@ import {
   findMealItemForDate,
   getDailyNutritionForDate,
   getDailyNutritionSummaryForDate,
+  getNutritionWeekSummaryForDate,
   patchMealById,
   patchMealItemById,
 } from './store.js';
@@ -21,6 +22,7 @@ vi.mock('./store.js', () => ({
   findMealItemForDate: vi.fn(),
   getDailyNutritionForDate: vi.fn(),
   getDailyNutritionSummaryForDate: vi.fn(),
+  getNutritionWeekSummaryForDate: vi.fn(),
   patchMealById: vi.fn(),
   patchMealItemById: vi.fn(),
 }));
@@ -117,6 +119,72 @@ const nutritionSummary = {
   },
 };
 
+const nutritionWeekSummary = [
+  {
+    date: '2026-03-02',
+    calories: 1900,
+    caloriesTarget: 2200,
+    protein: 160,
+    proteinTarget: 180,
+    mealCount: 3,
+    completeness: 0.88,
+  },
+  {
+    date: '2026-03-03',
+    calories: 0,
+    caloriesTarget: 2200,
+    protein: 0,
+    proteinTarget: 180,
+    mealCount: 0,
+    completeness: 0,
+  },
+  {
+    date: '2026-03-04',
+    calories: 2200,
+    caloriesTarget: 2200,
+    protein: 180,
+    proteinTarget: 180,
+    mealCount: 4,
+    completeness: 1,
+  },
+  {
+    date: '2026-03-05',
+    calories: 2100,
+    caloriesTarget: 2200,
+    protein: 172,
+    proteinTarget: 180,
+    mealCount: 3,
+    completeness: 0.95,
+  },
+  {
+    date: '2026-03-06',
+    calories: 2050,
+    caloriesTarget: 2200,
+    protein: 170,
+    proteinTarget: 180,
+    mealCount: 3,
+    completeness: 0.93,
+  },
+  {
+    date: '2026-03-07',
+    calories: 1800,
+    caloriesTarget: 2200,
+    protein: 150,
+    proteinTarget: 180,
+    mealCount: 2,
+    completeness: 0.83,
+  },
+  {
+    date: '2026-03-08',
+    calories: 1750,
+    caloriesTarget: 2200,
+    protein: 145,
+    proteinTarget: 180,
+    mealCount: 2,
+    completeness: 0.8,
+  },
+];
+
 describe('nutrition routes', () => {
   beforeEach(() => {
     vi.mocked(createMealForDate).mockReset();
@@ -125,6 +193,7 @@ describe('nutrition routes', () => {
     vi.mocked(findMealItemForDate).mockReset();
     vi.mocked(getDailyNutritionForDate).mockReset();
     vi.mocked(getDailyNutritionSummaryForDate).mockReset();
+    vi.mocked(getNutritionWeekSummaryForDate).mockReset();
     vi.mocked(patchMealById).mockReset();
     vi.mocked(patchMealItemById).mockReset();
     vi.mocked(updateFoodLastUsedAt).mockReset();
@@ -337,6 +406,32 @@ describe('nutrition routes', () => {
         2,
         'user-1',
         '2026-03-10',
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns week summary data for the requested center date', async () => {
+    vi.mocked(getNutritionWeekSummaryForDate).mockResolvedValueOnce(nutritionWeekSummary);
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign({ userId: 'user-1' });
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/nutrition/week-summary?date=2026-03-06T12:00:00.000Z',
+        headers: createAuthorizationHeader(authToken),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: nutritionWeekSummary,
+      });
+      expect(vi.mocked(getNutritionWeekSummaryForDate)).toHaveBeenCalledWith(
+        'user-1',
+        new Date('2026-03-06T12:00:00.000Z'),
       );
     } finally {
       await app.close();
@@ -770,6 +865,7 @@ describe('nutrition routes', () => {
         invalidDateResponse,
         invalidCalendarDateResponse,
         invalidSummaryDateResponse,
+        invalidWeekDateResponse,
         invalidPayloadResponse,
         invalidDeleteParamsResponse,
         invalidPatchMealPayloadResponse,
@@ -788,6 +884,11 @@ describe('nutrition routes', () => {
         app.inject({
           method: 'GET',
           url: '/api/v1/nutrition/03-09-2026/summary',
+          headers: createAuthorizationHeader(authToken),
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/nutrition/week-summary?date=invalid',
           headers: createAuthorizationHeader(authToken),
         }),
         app.inject({
@@ -838,6 +939,13 @@ describe('nutrition routes', () => {
         error: {
           code: 'VALIDATION_ERROR',
           message: 'Invalid nutrition date',
+        },
+      });
+      expect(invalidWeekDateResponse.statusCode).toBe(400);
+      expect(invalidWeekDateResponse.json()).toEqual({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid nutrition week date',
         },
       });
 
@@ -908,6 +1016,10 @@ describe('nutrition routes', () => {
         app.inject({
           method: 'GET',
           url: '/api/v1/nutrition/2026-03-09/summary',
+        }),
+        app.inject({
+          method: 'GET',
+          url: '/api/v1/nutrition/week-summary?date=2026-03-09T00:00:00.000Z',
         }),
         app.inject({
           method: 'DELETE',

--- a/apps/api/src/routes/nutrition/index.ts
+++ b/apps/api/src/routes/nutrition/index.ts
@@ -1,4 +1,8 @@
-import { createMealInputSchema, patchMealInputSchema, patchMealItemInputSchema } from '@pulse/shared';
+import {
+  createMealInputSchema,
+  patchMealInputSchema,
+  patchMealItemInputSchema,
+} from '@pulse/shared';
 import type { FastifyPluginAsync } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
@@ -12,6 +16,7 @@ import {
   findMealItemForDate,
   getDailyNutritionForDate,
   getDailyNutritionSummaryForDate,
+  getNutritionWeekSummaryForDate,
   patchMealById,
   patchMealItemById,
 } from './store.js';
@@ -31,8 +36,34 @@ const isValidItemIdParam = (itemId: string) => itemId.trim().length > 0;
 const isNonEmptyString = (value: string | null): value is string =>
   typeof value === 'string' && value.length > 0;
 
+const parseIsoDate = (value: unknown): Date | null => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return null;
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return parsed;
+};
+
 export const nutritionRoutes: FastifyPluginAsync = async (app) => {
   app.addHook('onRequest', requireAuth);
+
+  app.get<{ Querystring: { date?: string } }>('/week-summary', async (request, reply) => {
+    const parsedDate = parseIsoDate(request.query.date);
+    if (!parsedDate) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid nutrition week date');
+    }
+
+    const summary = await getNutritionWeekSummaryForDate(request.userId, parsedDate);
+
+    return reply.send({
+      data: summary,
+    });
+  });
 
   app.post<{ Params: { date: string } }>('/:date/meals', async (request, reply) => {
     if (!isValidDateParam(request.params.date)) {
@@ -124,7 +155,11 @@ export const nutritionRoutes: FastifyPluginAsync = async (app) => {
         return sendError(reply, 404, 'MEAL_NOT_FOUND', 'Meal not found');
       }
 
-      const updatedMeal = await patchMealById(request.userId, request.params.mealId, parsedBody.data);
+      const updatedMeal = await patchMealById(
+        request.userId,
+        request.params.mealId,
+        parsedBody.data,
+      );
       if (!updatedMeal) {
         return sendError(reply, 404, 'MEAL_NOT_FOUND', 'Meal not found');
       }

--- a/apps/api/src/routes/nutrition/store.test.ts
+++ b/apps/api/src/routes/nutrition/store.test.ts
@@ -124,14 +124,8 @@ describe('nutrition store', () => {
 
     expect(testState.select).toHaveBeenCalledTimes(2);
     expect(testState.aggregateFrom).toHaveBeenCalledWith(nutritionLogs);
-    expect(testState.aggregateLeftJoinMeals).toHaveBeenCalledWith(
-      meals,
-      expect.anything(),
-    );
-    expect(testState.aggregateLeftJoinMealItems).toHaveBeenCalledWith(
-      mealItems,
-      expect.anything(),
-    );
+    expect(testState.aggregateLeftJoinMeals).toHaveBeenCalledWith(meals, expect.anything());
+    expect(testState.aggregateLeftJoinMealItems).toHaveBeenCalledWith(mealItems, expect.anything());
     expect(testState.targetFrom).toHaveBeenCalledWith(nutritionTargets);
     expect(testState.targetLimit).toHaveBeenCalledWith(1);
   });
@@ -155,5 +149,33 @@ describe('nutrition store', () => {
       target: null,
     });
     expect(testState.targetOrderBy).toHaveBeenCalledOnce();
+  });
+
+  it('calculates completeness as zero when no meals are logged', async () => {
+    const { calculateNutritionCompleteness } = await import('./store.js');
+
+    expect(
+      calculateNutritionCompleteness({
+        calories: 1500,
+        caloriesTarget: 2200,
+        protein: 120,
+        proteinTarget: 180,
+        mealCount: 0,
+      }),
+    ).toBe(0);
+  });
+
+  it('calculates completeness as one when calories and protein are at target', async () => {
+    const { calculateNutritionCompleteness } = await import('./store.js');
+
+    expect(
+      calculateNutritionCompleteness({
+        calories: 2200,
+        caloriesTarget: 2200,
+        protein: 180,
+        proteinTarget: 180,
+        mealCount: 3,
+      }),
+    ).toBe(1);
   });
 });

--- a/apps/api/src/routes/nutrition/store.test.ts
+++ b/apps/api/src/routes/nutrition/store.test.ts
@@ -178,4 +178,18 @@ describe('nutrition store', () => {
       }),
     ).toBe(1);
   });
+
+  it('calculates completeness as partial when meals exist but macros are below target', async () => {
+    const { calculateNutritionCompleteness } = await import('./store.js');
+
+    expect(
+      calculateNutritionCompleteness({
+        calories: 1_650,
+        caloriesTarget: 2_200,
+        protein: 135,
+        proteinTarget: 180,
+        mealCount: 2,
+      }),
+    ).toBe(0.75);
+  });
 });

--- a/apps/api/src/routes/nutrition/store.test.ts
+++ b/apps/api/src/routes/nutrition/store.test.ts
@@ -31,6 +31,37 @@ const testState = vi.hoisted(() => {
     where: targetWhere,
   }));
 
+  const weekActualAll = vi.fn();
+  const weekActualGroupBy = vi.fn(() => ({
+    all: weekActualAll,
+  }));
+  const weekActualWhere = vi.fn(() => ({
+    groupBy: weekActualGroupBy,
+  }));
+  const weekActualLeftJoinMealItems = vi.fn(() => ({
+    where: weekActualWhere,
+  }));
+  const weekActualLeftJoinMeals = vi.fn(() => ({
+    leftJoin: weekActualLeftJoinMealItems,
+  }));
+  const weekActualFrom = vi.fn(() => ({
+    leftJoin: weekActualLeftJoinMeals,
+  }));
+
+  const weekTargetAll = vi.fn();
+  const weekTargetLimit = vi.fn(() => ({
+    all: weekTargetAll,
+  }));
+  const weekTargetOrderBy = vi.fn(() => ({
+    limit: weekTargetLimit,
+  }));
+  const weekTargetWhere = vi.fn(() => ({
+    orderBy: weekTargetOrderBy,
+  }));
+  const weekTargetFrom = vi.fn(() => ({
+    where: weekTargetWhere,
+  }));
+
   const select = vi.fn();
 
   const queueSummarySelects = () => {
@@ -39,6 +70,15 @@ const testState = vi.hoisted(() => {
     }));
     select.mockImplementationOnce(() => ({
       from: targetFrom,
+    }));
+  };
+
+  const queueWeekSummarySelects = () => {
+    select.mockImplementationOnce(() => ({
+      from: weekActualFrom,
+    }));
+    select.mockImplementationOnce(() => ({
+      from: weekTargetFrom,
     }));
   };
 
@@ -58,8 +98,20 @@ const testState = vi.hoisted(() => {
       targetOrderBy.mockClear();
       targetLimit.mockClear();
       targetGet.mockClear();
+      weekActualFrom.mockClear();
+      weekActualLeftJoinMeals.mockClear();
+      weekActualLeftJoinMealItems.mockClear();
+      weekActualWhere.mockClear();
+      weekActualGroupBy.mockClear();
+      weekActualAll.mockClear();
+      weekTargetFrom.mockClear();
+      weekTargetWhere.mockClear();
+      weekTargetOrderBy.mockClear();
+      weekTargetLimit.mockClear();
+      weekTargetAll.mockClear();
       queueSummarySelects();
     },
+    queueWeekSummarySelects,
     select,
     aggregateFrom,
     aggregateLeftJoinMeals,
@@ -71,6 +123,17 @@ const testState = vi.hoisted(() => {
     targetOrderBy,
     targetLimit,
     targetGet,
+    weekActualFrom,
+    weekActualLeftJoinMeals,
+    weekActualLeftJoinMealItems,
+    weekActualWhere,
+    weekActualGroupBy,
+    weekActualAll,
+    weekTargetFrom,
+    weekTargetWhere,
+    weekTargetOrderBy,
+    weekTargetLimit,
+    weekTargetAll,
   };
 });
 
@@ -191,5 +254,90 @@ describe('nutrition store', () => {
         mealCount: 2,
       }),
     ).toBe(0.75);
+  });
+
+  it('returns monday-start week summary with carry-forward targets and zeroed missing days', async () => {
+    testState.select.mockReset();
+    testState.queueWeekSummarySelects();
+    testState.weekActualAll.mockReturnValue([
+      {
+        date: '2026-03-04',
+        calories: 1500,
+        protein: 100,
+        mealCount: 2,
+      },
+      {
+        date: '2026-03-07',
+        calories: 2100,
+        protein: 170,
+        mealCount: 3,
+      },
+    ]);
+    testState.weekTargetAll.mockReturnValue([
+      {
+        effectiveDate: '2026-03-06',
+        calories: 2100,
+        protein: 170,
+      },
+      {
+        effectiveDate: '2026-03-03',
+        calories: 1900,
+        protein: 150,
+      },
+      {
+        effectiveDate: '2026-02-25',
+        calories: 1700,
+        protein: 130,
+      },
+    ]);
+
+    const { getNutritionWeekSummaryForDate } = await import('./store.js');
+    const summary = await getNutritionWeekSummaryForDate('user-1', new Date('2026-03-05T09:30:00Z'));
+
+    expect(summary.map((day) => day.date)).toEqual([
+      '2026-03-02',
+      '2026-03-03',
+      '2026-03-04',
+      '2026-03-05',
+      '2026-03-06',
+      '2026-03-07',
+      '2026-03-08',
+    ]);
+    expect(summary[0]).toMatchObject({
+      date: '2026-03-02',
+      calories: 0,
+      protein: 0,
+      mealCount: 0,
+      caloriesTarget: 1700,
+      proteinTarget: 130,
+      completeness: 0,
+    });
+    expect(summary[2]).toMatchObject({
+      date: '2026-03-04',
+      calories: 1500,
+      protein: 100,
+      mealCount: 2,
+      caloriesTarget: 1900,
+      proteinTarget: 150,
+      completeness: 0.7280701754385965,
+    });
+    expect(summary[4]).toMatchObject({
+      date: '2026-03-06',
+      caloriesTarget: 2100,
+      proteinTarget: 170,
+    });
+    expect(summary[6]).toMatchObject({
+      date: '2026-03-08',
+      calories: 0,
+      protein: 0,
+      mealCount: 0,
+      caloriesTarget: 2100,
+      proteinTarget: 170,
+      completeness: 0,
+    });
+
+    expect(testState.weekActualFrom).toHaveBeenCalledWith(nutritionLogs);
+    expect(testState.weekTargetFrom).toHaveBeenCalledWith(nutritionTargets);
+    expect(testState.weekTargetLimit).toHaveBeenCalledWith(8);
   });
 });

--- a/apps/api/src/routes/nutrition/store.ts
+++ b/apps/api/src/routes/nutrition/store.ts
@@ -1,6 +1,12 @@
-import { and, asc, desc, eq, inArray, lte, sql } from 'drizzle-orm';
+import { and, asc, between, desc, eq, inArray, lte, sql } from 'drizzle-orm';
 
-import type { CreateMealInput, PatchMealInput, PatchMealItemInput } from '@pulse/shared';
+import type {
+  CreateMealInput,
+  NutritionWeekDaySummary,
+  NutritionWeekSummary,
+  PatchMealInput,
+  PatchMealItemInput,
+} from '@pulse/shared';
 
 import { foods, mealItems, meals, nutritionLogs, nutritionTargets } from '../../db/schema/index.js';
 
@@ -67,6 +73,8 @@ export type NutritionSummaryRecord = {
   } | null;
 };
 
+const WEEK_DAYS = 7;
+
 const nutritionLogSelection = {
   id: nutritionLogs.id,
   userId: nutritionLogs.userId,
@@ -121,6 +129,50 @@ const nutritionTargetMacroSelection = {
 };
 
 const toNullable = <T>(value: T | undefined): T | null => value ?? null;
+
+const clampToUnitRange = (value: number) => Math.max(0, Math.min(1, value));
+
+const toDateKey = (date: Date) => date.toISOString().slice(0, 10);
+
+const addUtcDays = (date: Date, days: number) => {
+  const nextDate = new Date(date);
+  nextDate.setUTCDate(nextDate.getUTCDate() + days);
+  return nextDate;
+};
+
+const getWeekStartMonday = (date: Date) => {
+  const day = date.getUTCDay();
+  const offset = day === 0 ? -6 : 1 - day;
+  return addUtcDays(date, offset);
+};
+
+export const calculateNutritionCompleteness = (input: {
+  calories: number;
+  caloriesTarget: number;
+  protein: number;
+  proteinTarget: number;
+  mealCount: number;
+}): number => {
+  if (input.mealCount <= 0) {
+    return 0;
+  }
+
+  const ratios: number[] = [];
+
+  if (input.caloriesTarget > 0) {
+    ratios.push(input.calories / input.caloriesTarget);
+  }
+  if (input.proteinTarget > 0) {
+    ratios.push(input.protein / input.proteinTarget);
+  }
+
+  if (ratios.length === 0) {
+    return 0;
+  }
+
+  const averageRatio = ratios.reduce((sum, ratio) => sum + ratio, 0) / ratios.length;
+  return clampToUnitRange(averageRatio);
+};
 
 export const createMealForDate = async (
   userId: string,
@@ -312,6 +364,95 @@ export const getDailyNutritionSummaryForDate = async (
         }
       : null,
   };
+};
+
+export const getNutritionWeekSummaryForDate = async (
+  userId: string,
+  centerDate: Date,
+): Promise<NutritionWeekSummary> => {
+  const { db } = await import('../../db/index.js');
+
+  const normalizedCenterDate = new Date(
+    Date.UTC(centerDate.getUTCFullYear(), centerDate.getUTCMonth(), centerDate.getUTCDate()),
+  );
+  const weekStart = getWeekStartMonday(normalizedCenterDate);
+  const weekDates = Array.from({ length: WEEK_DAYS }, (_unused, index) =>
+    toDateKey(addUtcDays(weekStart, index)),
+  );
+  const weekFrom = toDateKey(weekStart);
+  const weekTo = toDateKey(addUtcDays(weekStart, WEEK_DAYS - 1));
+
+  const actualRows = db
+    .select({
+      date: nutritionLogs.date,
+      calories: sql<number>`coalesce(sum(${mealItems.calories}), 0)`,
+      protein: sql<number>`coalesce(sum(${mealItems.protein}), 0)`,
+      mealCount: sql<number>`count(distinct ${meals.id})`,
+    })
+    .from(nutritionLogs)
+    .leftJoin(meals, eq(meals.nutritionLogId, nutritionLogs.id))
+    .leftJoin(mealItems, eq(mealItems.mealId, meals.id))
+    .where(and(eq(nutritionLogs.userId, userId), between(nutritionLogs.date, weekFrom, weekTo)))
+    .groupBy(nutritionLogs.date)
+    .all();
+
+  const targetRows = db
+    .select({
+      effectiveDate: nutritionTargets.effectiveDate,
+      calories: nutritionTargets.calories,
+      protein: nutritionTargets.protein,
+    })
+    .from(nutritionTargets)
+    .where(and(eq(nutritionTargets.userId, userId), lte(nutritionTargets.effectiveDate, weekTo)))
+    .orderBy(asc(nutritionTargets.effectiveDate))
+    .all();
+
+  const actualByDate = new Map(
+    actualRows.map((row) => [
+      row.date,
+      {
+        calories: Number(row.calories ?? 0),
+        protein: Number(row.protein ?? 0),
+        mealCount: Number(row.mealCount ?? 0),
+      },
+    ]),
+  );
+
+  const resolveTargetForDate = (date: string) => {
+    let calories = 0;
+    let protein = 0;
+    for (const target of targetRows) {
+      if (target.effectiveDate <= date) {
+        calories = Number(target.calories);
+        protein = Number(target.protein);
+      } else {
+        break;
+      }
+    }
+
+    return { calories, protein };
+  };
+
+  return weekDates.map<NutritionWeekDaySummary>((date) => {
+    const actual = actualByDate.get(date) ?? { calories: 0, protein: 0, mealCount: 0 };
+    const target = resolveTargetForDate(date);
+
+    return {
+      date,
+      calories: actual.calories,
+      caloriesTarget: target.calories,
+      protein: actual.protein,
+      proteinTarget: target.protein,
+      mealCount: actual.mealCount,
+      completeness: calculateNutritionCompleteness({
+        calories: actual.calories,
+        caloriesTarget: target.calories,
+        protein: actual.protein,
+        proteinTarget: target.protein,
+        mealCount: actual.mealCount,
+      }),
+    };
+  });
 };
 
 export const deleteMealForDate = async (

--- a/apps/api/src/routes/nutrition/store.ts
+++ b/apps/api/src/routes/nutrition/store.ts
@@ -404,8 +404,10 @@ export const getNutritionWeekSummaryForDate = async (
     })
     .from(nutritionTargets)
     .where(and(eq(nutritionTargets.userId, userId), lte(nutritionTargets.effectiveDate, weekTo)))
-    .orderBy(asc(nutritionTargets.effectiveDate))
+    .orderBy(desc(nutritionTargets.effectiveDate))
+    .limit(WEEK_DAYS + 1)
     .all();
+  const targetRowsAsc = targetRows.reverse();
 
   const actualByDate = new Map(
     actualRows.map((row) => [
@@ -418,24 +420,28 @@ export const getNutritionWeekSummaryForDate = async (
     ]),
   );
 
-  const resolveTargetForDate = (date: string) => {
-    let calories = 0;
-    let protein = 0;
-    for (const target of targetRows) {
-      if (target.effectiveDate <= date) {
-        calories = Number(target.calories);
-        protein = Number(target.protein);
-      } else {
-        break;
-      }
-    }
+  const targetsByDate = new Map<string, { calories: number; protein: number }>();
+  let targetIndex = 0;
+  let currentTarget: { calories: number; protein: number } = { calories: 0, protein: 0 };
 
-    return { calories, protein };
-  };
+  for (const date of weekDates) {
+    while (
+      targetIndex < targetRowsAsc.length &&
+      targetRowsAsc[targetIndex]?.effectiveDate <= date
+    ) {
+      const target = targetRowsAsc[targetIndex];
+      currentTarget = {
+        calories: Number(target.calories),
+        protein: Number(target.protein),
+      };
+      targetIndex += 1;
+    }
+    targetsByDate.set(date, currentTarget);
+  }
 
   return weekDates.map<NutritionWeekDaySummary>((date) => {
     const actual = actualByDate.get(date) ?? { calories: 0, protein: 0, mealCount: 0 };
-    const target = resolveTargetForDate(date);
+    const target = targetsByDate.get(date) ?? { calories: 0, protein: 0 };
 
     return {
       date,

--- a/apps/web/src/features/nutrition/api/keys.test.ts
+++ b/apps/web/src/features/nutrition/api/keys.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { nutritionKeys } from './keys';
+
+describe('nutritionKeys.weekSummary', () => {
+  it('normalizes date keys to the Monday for the containing week', () => {
+    expect(nutritionKeys.weekSummary('2026-03-03')).toEqual([
+      'nutrition',
+      'week-summary',
+      '2026-03-02',
+    ]);
+    expect(nutritionKeys.weekSummary('2026-03-08')).toEqual([
+      'nutrition',
+      'week-summary',
+      '2026-03-02',
+    ]);
+  });
+
+  it('accepts ISO timestamps and normalizes to the same week boundary', () => {
+    expect(nutritionKeys.weekSummary('2026-03-05T12:00:00.000Z')).toEqual([
+      'nutrition',
+      'week-summary',
+      '2026-03-02',
+    ]);
+  });
+});

--- a/apps/web/src/features/nutrition/api/keys.ts
+++ b/apps/web/src/features/nutrition/api/keys.ts
@@ -1,6 +1,18 @@
+import { formatDateKey, getWeekStart, parseDateInput } from '@/lib/date';
+
+const toWeekStartDateKey = (date: string): string => {
+  const parsedDate = parseDateInput(date);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return date;
+  }
+
+  return formatDateKey(getWeekStart(parsedDate));
+};
+
 export const nutritionKeys = {
   all: ['nutrition'] as const,
   daily: (date: string) => [...nutritionKeys.all, 'daily', date] as const,
   summary: (date: string) => [...nutritionKeys.all, 'summary', date] as const,
-  weekSummary: (date: string) => [...nutritionKeys.all, 'week-summary', date] as const,
+  weekSummary: (date: string) =>
+    [...nutritionKeys.all, 'week-summary', toWeekStartDateKey(date)] as const,
 };

--- a/apps/web/src/features/nutrition/api/keys.ts
+++ b/apps/web/src/features/nutrition/api/keys.ts
@@ -2,4 +2,5 @@ export const nutritionKeys = {
   all: ['nutrition'] as const,
   daily: (date: string) => [...nutritionKeys.all, 'daily', date] as const,
   summary: (date: string) => [...nutritionKeys.all, 'summary', date] as const,
+  weekSummary: (date: string) => [...nutritionKeys.all, 'week-summary', date] as const,
 };

--- a/apps/web/src/features/nutrition/api/nutrition.test.tsx
+++ b/apps/web/src/features/nutrition/api/nutrition.test.tsx
@@ -150,6 +150,24 @@ describe('nutrition api hooks', () => {
     );
   });
 
+  it('normalizes week summary request when called with an ISO timestamp', async () => {
+    mockFetch.mockResolvedValueOnce(createJsonResponse([]));
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useNutritionWeekSummary('2026-03-06T03:00:00.000Z'), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/nutrition/week-summary?date=2026-03-06T12%3A00%3A00.000Z',
+      expect.any(Object),
+    );
+  });
+
   it('deletes a meal and invalidates daily + summary + week-summary cache for that date', async () => {
     mockFetch.mockResolvedValueOnce(createJsonResponse({ success: true }));
 

--- a/apps/web/src/features/nutrition/api/nutrition.test.tsx
+++ b/apps/web/src/features/nutrition/api/nutrition.test.tsx
@@ -150,7 +150,7 @@ describe('nutrition api hooks', () => {
     );
   });
 
-  it('deletes a meal and invalidates daily + summary cache for that date', async () => {
+  it('deletes a meal and invalidates daily + summary + week-summary cache for that date', async () => {
     mockFetch.mockResolvedValueOnce(createJsonResponse({ success: true }));
 
     const { queryClient, wrapper } = createQueryClientWrapper();
@@ -175,6 +175,9 @@ describe('nutrition api hooks', () => {
     });
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: nutritionKeys.summary('2026-03-09'),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: nutritionKeys.weekSummary('2026-03-09'),
     });
   });
 });

--- a/apps/web/src/features/nutrition/api/nutrition.test.tsx
+++ b/apps/web/src/features/nutrition/api/nutrition.test.tsx
@@ -4,7 +4,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createQueryClientWrapper } from '@/test/query-client';
 
 import { nutritionKeys } from './keys';
-import { useDailyNutrition, useDeleteMeal, useNutritionSummary } from './nutrition';
+import {
+  useDailyNutrition,
+  useDeleteMeal,
+  useNutritionSummary,
+  useNutritionWeekSummary,
+} from './nutrition';
 
 const mockFetch = vi.fn();
 
@@ -112,6 +117,35 @@ describe('nutrition api hooks', () => {
     expect(result.current.data?.target?.protein).toBe(180);
     expect(mockFetch).toHaveBeenCalledWith(
       '/api/v1/nutrition/2026-03-09/summary',
+      expect.any(Object),
+    );
+  });
+
+  it('loads nutrition week summary for the selected date', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse(
+        Array.from({ length: 7 }, (_, index) => ({
+          date: `2026-03-${String(index + 2).padStart(2, '0')}`,
+          calories: 2000 + index * 10,
+          caloriesTarget: 2200,
+          protein: 160 + index,
+          proteinTarget: 180,
+          mealCount: index % 2 === 0 ? 3 : 2,
+          completeness: 0.9,
+        })),
+      ),
+    );
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useNutritionWeekSummary('2026-03-06'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toHaveLength(7);
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/nutrition/week-summary?date=2026-03-06T12%3A00%3A00.000Z',
       expect.any(Object),
     );
   });

--- a/apps/web/src/features/nutrition/api/nutrition.ts
+++ b/apps/web/src/features/nutrition/api/nutrition.ts
@@ -1,5 +1,10 @@
 import { type QueryClient, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import type { DailyNutrition, DeleteMealResult, NutritionSummary } from '@pulse/shared';
+import type {
+  DailyNutrition,
+  DeleteMealResult,
+  NutritionSummary,
+  NutritionWeekSummary,
+} from '@pulse/shared';
 import { toast } from 'sonner';
 
 import { apiRequest } from '@/lib/api-client';
@@ -23,6 +28,15 @@ const fetchNutritionSummary = (date: string, signal?: AbortSignal) =>
     signal,
   });
 
+const fetchNutritionWeekSummary = (date: string, signal?: AbortSignal) =>
+  apiRequest<NutritionWeekSummary>(
+    `/api/v1/nutrition/week-summary?date=${encodeURIComponent(`${date}T12:00:00.000Z`)}`,
+    {
+      method: 'GET',
+      signal,
+    },
+  );
+
 const deleteMeal = ({ date, mealId }: DeleteMealInput) =>
   apiRequest<DeleteMealResult>(`/api/v1/nutrition/${date}/meals/${mealId}`, {
     method: 'DELETE',
@@ -38,6 +52,12 @@ export const useNutritionSummary = (date: string) =>
   useQuery({
     queryKey: nutritionKeys.summary(date),
     queryFn: ({ signal }) => fetchNutritionSummary(date, signal),
+  });
+
+export const useNutritionWeekSummary = (date: string) =>
+  useQuery({
+    queryKey: nutritionKeys.weekSummary(date),
+    queryFn: ({ signal }) => fetchNutritionWeekSummary(date, signal),
   });
 
 export const prefetchNutritionDay = async (queryClient: QueryClient, date: string) => {

--- a/apps/web/src/features/nutrition/api/nutrition.ts
+++ b/apps/web/src/features/nutrition/api/nutrition.ts
@@ -28,14 +28,17 @@ const fetchNutritionSummary = (date: string, signal?: AbortSignal) =>
     signal,
   });
 
-const fetchNutritionWeekSummary = (date: string, signal?: AbortSignal) =>
-  apiRequest<NutritionWeekSummary>(
-    `/api/v1/nutrition/week-summary?date=${encodeURIComponent(`${date}T12:00:00.000Z`)}`,
+const fetchNutritionWeekSummary = (date: string, signal?: AbortSignal) => {
+  const dateOnly = date.length > 10 ? date.slice(0, 10) : date;
+
+  return apiRequest<NutritionWeekSummary>(
+    `/api/v1/nutrition/week-summary?date=${encodeURIComponent(`${dateOnly}T12:00:00.000Z`)}`,
     {
       method: 'GET',
       signal,
     },
   );
+};
 
 const deleteMeal = ({ date, mealId }: DeleteMealInput) =>
   apiRequest<DeleteMealResult>(`/api/v1/nutrition/${date}/meals/${mealId}`, {

--- a/apps/web/src/features/nutrition/api/nutrition.ts
+++ b/apps/web/src/features/nutrition/api/nutrition.ts
@@ -86,6 +86,9 @@ export const useDeleteMeal = () => {
         queryClient.invalidateQueries({
           queryKey: nutritionKeys.summary(variables.date),
         }),
+        queryClient.invalidateQueries({
+          queryKey: nutritionKeys.weekSummary(variables.date),
+        }),
       ]);
       toast.success('Meal deleted');
     },

--- a/apps/web/src/features/nutrition/components/nutrition-week-strip.test.tsx
+++ b/apps/web/src/features/nutrition/components/nutrition-week-strip.test.tsx
@@ -1,0 +1,139 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { NutritionWeekSummary } from '@pulse/shared';
+import { describe, expect, it, vi } from 'vitest';
+
+import { NutritionWeekStrip } from '@/features/nutrition/components/nutrition-week-strip';
+
+const weekSummary: NutritionWeekSummary = [
+  {
+    date: '2026-03-02',
+    calories: 0,
+    caloriesTarget: 2200,
+    protein: 0,
+    proteinTarget: 180,
+    mealCount: 0,
+    completeness: 0,
+  },
+  {
+    date: '2026-03-03',
+    calories: 1800,
+    caloriesTarget: 2200,
+    protein: 140,
+    proteinTarget: 180,
+    mealCount: 2,
+    completeness: 0.79,
+  },
+  {
+    date: '2026-03-04',
+    calories: 2200,
+    caloriesTarget: 2200,
+    protein: 180,
+    proteinTarget: 180,
+    mealCount: 3,
+    completeness: 1,
+  },
+  {
+    date: '2026-03-05',
+    calories: 2100,
+    caloriesTarget: 2200,
+    protein: 172,
+    proteinTarget: 180,
+    mealCount: 3,
+    completeness: 0.95,
+  },
+  {
+    date: '2026-03-06',
+    calories: 2000,
+    caloriesTarget: 2200,
+    protein: 160,
+    proteinTarget: 180,
+    mealCount: 3,
+    completeness: 0.9,
+  },
+  {
+    date: '2026-03-07',
+    calories: 1700,
+    caloriesTarget: 2200,
+    protein: 135,
+    proteinTarget: 180,
+    mealCount: 2,
+    completeness: 0.76,
+  },
+  {
+    date: '2026-03-08',
+    calories: 1500,
+    caloriesTarget: 2200,
+    protein: 120,
+    proteinTarget: 180,
+    mealCount: 2,
+    completeness: 0.67,
+  },
+];
+
+describe('NutritionWeekStrip', () => {
+  it('renders seven day cells', () => {
+    render(
+      <NutritionWeekStrip
+        days={weekSummary}
+        selectedDate={new Date('2026-03-06T09:00:00')}
+        onSelectDate={() => {}}
+      />,
+    );
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(7);
+  });
+
+  it('marks the selected day cell as distinct', () => {
+    render(
+      <NutritionWeekStrip
+        days={weekSummary}
+        selectedDate={new Date('2026-03-06T09:00:00')}
+        onSelectDate={() => {}}
+      />,
+    );
+
+    const selectedButton = screen.getByRole('button', { name: 'Select 2026-03-06' });
+    const unselectedButton = screen.getByRole('button', { name: 'Select 2026-03-05' });
+
+    expect(selectedButton).toHaveAttribute('data-selected', 'true');
+    expect(unselectedButton).toHaveAttribute('data-selected', 'false');
+  });
+
+  it('fires date select handler for the clicked day', () => {
+    const onSelectDate = vi.fn();
+    render(
+      <NutritionWeekStrip
+        days={weekSummary}
+        selectedDate={new Date('2026-03-06T09:00:00')}
+        onSelectDate={onSelectDate}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select 2026-03-03' }));
+
+    expect(onSelectDate).toHaveBeenCalledWith(new Date('2026-03-03T00:00:00'));
+  });
+
+  it('renders indicator states for empty, partial, and complete days', () => {
+    render(
+      <NutritionWeekStrip
+        days={weekSummary}
+        selectedDate={new Date('2026-03-06T09:00:00')}
+        onSelectDate={() => {}}
+      />,
+    );
+
+    expect(screen.getByLabelText('Completeness empty for 2026-03-02')).toHaveAttribute(
+      'data-state',
+      'empty',
+    );
+    expect(screen.getByLabelText('Completeness partial for 2026-03-03')).toHaveAttribute(
+      'data-state',
+      'partial',
+    );
+    expect(screen.getByLabelText('Completeness complete for 2026-03-04')).toHaveAttribute(
+      'data-state',
+      'complete',
+    );
+  });
+});

--- a/apps/web/src/features/nutrition/components/nutrition-week-strip.tsx
+++ b/apps/web/src/features/nutrition/components/nutrition-week-strip.tsx
@@ -13,8 +13,6 @@ type NutritionWeekStripProps = {
   className?: string;
 };
 
-const clampToUnitRange = (value: number) => Math.max(0, Math.min(1, value));
-
 const getIndicatorState = (
   mealCount: number,
   completeness: number,
@@ -48,7 +46,7 @@ export function NutritionWeekStrip({
           const dayLabel = DAY_ABBREVIATIONS[index] ?? '·';
           const isSelected = day.date === selectedDateKey;
           const indicatorState = getIndicatorState(day.mealCount, day.completeness);
-          const progress = clampToUnitRange(day.completeness);
+          const progress = day.completeness;
 
           return (
             <div key={day.date} role="listitem">
@@ -80,7 +78,7 @@ export function NutritionWeekStrip({
                     <span
                       className="h-3 w-3 rounded-full border border-accent/45"
                       style={{
-                        background: `conic-gradient(from 0deg, hsl(var(--accent)) ${Math.round(progress * 360)}deg, transparent 0deg)`,
+                        background: `conic-gradient(from 0deg, var(--color-accent) ${Math.round(progress * 360)}deg, transparent 0deg)`,
                       }}
                     />
                   ) : null}

--- a/apps/web/src/features/nutrition/components/nutrition-week-strip.tsx
+++ b/apps/web/src/features/nutrition/components/nutrition-week-strip.tsx
@@ -42,7 +42,7 @@ export function NutritionWeekStrip({
     >
       <div className="grid grid-cols-7 gap-1" role="list" aria-label="Nutrition week summary">
         {days.map((day, index) => {
-          const dateNumber = new Date(`${day.date}T12:00:00`).getDate();
+          const dateNumber = new Date(`${day.date}T12:00:00Z`).getUTCDate();
           const dayLabel = DAY_ABBREVIATIONS[index] ?? '·';
           const isSelected = day.date === selectedDateKey;
           const indicatorState = getIndicatorState(day.mealCount, day.completeness);
@@ -60,6 +60,7 @@ export function NutritionWeekStrip({
                 )}
                 data-selected={isSelected ? 'true' : 'false'}
                 type="button"
+                // Intentionally local time; nutrition page date state and keys are local-day based.
                 onClick={() => onSelectDate(startOfDay(new Date(`${day.date}T00:00:00`)))}
               >
                 <span className="text-[0.65rem] font-semibold uppercase tracking-[0.14em]">

--- a/apps/web/src/features/nutrition/components/nutrition-week-strip.tsx
+++ b/apps/web/src/features/nutrition/components/nutrition-week-strip.tsx
@@ -1,0 +1,100 @@
+import { Check } from 'lucide-react';
+import type { NutritionWeekSummary } from '@pulse/shared';
+
+import { formatDateKey, startOfDay } from '@/features/nutrition/lib/nutrition-utils';
+import { cn } from '@/lib/utils';
+
+const DAY_ABBREVIATIONS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'] as const;
+
+type NutritionWeekStripProps = {
+  days: NutritionWeekSummary;
+  selectedDate: Date;
+  onSelectDate: (date: Date) => void;
+  className?: string;
+};
+
+const clampToUnitRange = (value: number) => Math.max(0, Math.min(1, value));
+
+const getIndicatorState = (
+  mealCount: number,
+  completeness: number,
+): 'empty' | 'partial' | 'complete' => {
+  if (mealCount <= 0) {
+    return 'empty';
+  }
+
+  if (completeness >= 1) {
+    return 'complete';
+  }
+
+  return 'partial';
+};
+
+export function NutritionWeekStrip({
+  days,
+  selectedDate,
+  onSelectDate,
+  className,
+}: NutritionWeekStripProps) {
+  const selectedDateKey = formatDateKey(selectedDate);
+
+  return (
+    <section
+      className={cn('rounded-2xl border border-border/70 bg-card px-2 py-2 shadow-sm', className)}
+    >
+      <div className="grid grid-cols-7 gap-1" role="list" aria-label="Nutrition week summary">
+        {days.map((day, index) => {
+          const dateNumber = new Date(`${day.date}T12:00:00`).getDate();
+          const dayLabel = DAY_ABBREVIATIONS[index] ?? '·';
+          const isSelected = day.date === selectedDateKey;
+          const indicatorState = getIndicatorState(day.mealCount, day.completeness);
+          const progress = clampToUnitRange(day.completeness);
+
+          return (
+            <div key={day.date} role="listitem">
+              <button
+                aria-label={`Select ${day.date}`}
+                className={cn(
+                  'flex w-full min-w-0 flex-col items-center gap-1 rounded-xl px-2 py-2 transition-colors',
+                  isSelected
+                    ? 'bg-accent text-accent-foreground ring-1 ring-accent-foreground/20'
+                    : 'text-muted hover:bg-muted/70 hover:text-foreground',
+                )}
+                data-selected={isSelected ? 'true' : 'false'}
+                type="button"
+                onClick={() => onSelectDate(startOfDay(new Date(`${day.date}T00:00:00`)))}
+              >
+                <span className="text-[0.65rem] font-semibold uppercase tracking-[0.14em]">
+                  {dayLabel}
+                </span>
+                <span className="text-sm font-semibold tabular-nums">{dateNumber}</span>
+                <span
+                  aria-label={`Completeness ${indicatorState} for ${day.date}`}
+                  className="flex h-5 w-5 items-center justify-center"
+                  data-state={indicatorState}
+                >
+                  {indicatorState === 'empty' ? (
+                    <span className="h-3 w-3 rounded-full border border-border/80 bg-transparent" />
+                  ) : null}
+                  {indicatorState === 'partial' ? (
+                    <span
+                      className="h-3 w-3 rounded-full border border-accent/45"
+                      style={{
+                        background: `conic-gradient(from 0deg, hsl(var(--accent)) ${Math.round(progress * 360)}deg, transparent 0deg)`,
+                      }}
+                    />
+                  ) : null}
+                  {indicatorState === 'complete' ? (
+                    <span className="flex h-3 w-3 items-center justify-center rounded-full bg-accent text-accent-foreground">
+                      <Check aria-hidden="true" className="size-2.5" />
+                    </span>
+                  ) : null}
+                </span>
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/nutrition/index.ts
+++ b/apps/web/src/features/nutrition/index.ts
@@ -2,3 +2,4 @@ export { DateNavBar } from './components/date-nav-bar';
 export { MacroRings } from './components/macro-rings';
 export { MealCard } from './components/meal-card';
 export { NutritionMacroRings } from './components/nutrition-macro-rings';
+export { NutritionWeekStrip } from './components/nutrition-week-strip';

--- a/apps/web/src/pages/nutrition.test.tsx
+++ b/apps/web/src/pages/nutrition.test.tsx
@@ -470,6 +470,45 @@ describe('NutritionPage', () => {
     expect(getMealToggleButton('Breakfast')).toBeInTheDocument();
   });
 
+  it('shows a non-blocking fallback message when week summary fails', async () => {
+    const { fetchMock: baseFetchMock } = createNutritionApiMock({
+      '2026-03-06': {
+        daily: null,
+        target: TARGETS,
+      },
+    });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(typeof input === 'string' ? input : input.toString(), 'http://localhost');
+      if (url.pathname === '/api/v1/nutrition/week-summary') {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: 'INTERNAL_ERROR',
+              message: 'Week summary failed',
+            },
+          }),
+          {
+            headers: { 'Content-Type': 'application/json' },
+            status: 500,
+          },
+        );
+      }
+
+      return baseFetchMock(input, init);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { wrapper } = createQueryClientWrapper();
+    render(<NutritionPage />, { wrapper });
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(screen.getByText('Unable to load week summary.')).toBeInTheDocument();
+    expect(screen.getByLabelText('Daily macro totals')).toBeInTheDocument();
+    expect(screen.queryByText('Unable to load nutrition')).not.toBeInTheDocument();
+  });
+
   it('opens contextual nutrition help from the page header', async () => {
     const { fetchMock } = createNutritionApiMock({
       '2026-03-06': {

--- a/apps/web/src/pages/nutrition.test.tsx
+++ b/apps/web/src/pages/nutrition.test.tsx
@@ -123,6 +123,47 @@ function createNutritionApiMock(initialState: Record<string, DateState>) {
       throw new Error(`Unhandled request: ${method} ${url.pathname}`);
     }
 
+    if (method === 'GET' && pathParts.length === 4 && pathParts[3] === 'week-summary') {
+      const requestedDate = url.searchParams.get('date');
+      const parsedDate = requestedDate ? new Date(requestedDate) : null;
+      if (!parsedDate || Number.isNaN(parsedDate.getTime())) {
+        throw new Error(`Unhandled request: ${method} ${url.pathname}${url.search}`);
+      }
+
+      const selectedDate = `${parsedDate.getUTCFullYear()}-${String(parsedDate.getUTCMonth() + 1).padStart(2, '0')}-${String(parsedDate.getUTCDate()).padStart(2, '0')}`;
+      const selectedDateValue = new Date(`${selectedDate}T00:00:00.000Z`).getTime();
+      const dayOfWeek = new Date(`${selectedDate}T00:00:00.000Z`).getUTCDay();
+      const offsetToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+      const mondayValue = selectedDateValue + offsetToMonday * 24 * 60 * 60 * 1000;
+
+      return createJsonResponse(
+        Array.from({ length: 7 }, (_unused, index) => {
+          const dayValue = mondayValue + index * 24 * 60 * 60 * 1000;
+          const dayDate = new Date(dayValue);
+          const date = `${dayDate.getUTCFullYear()}-${String(dayDate.getUTCMonth() + 1).padStart(2, '0')}-${String(dayDate.getUTCDate()).padStart(2, '0')}`;
+          const dayState = state.get(date) ?? { daily: null, target: null };
+          const actual = calculateActuals(dayState.daily);
+          const mealCount = dayState.daily?.meals.length ?? 0;
+          const caloriesTarget = dayState.target?.calories ?? 0;
+          const proteinTarget = dayState.target?.protein ?? 0;
+          const completeness =
+            mealCount > 0 && caloriesTarget > 0 && proteinTarget > 0
+              ? Math.min(1, (actual.calories / caloriesTarget + actual.protein / proteinTarget) / 2)
+              : 0;
+
+          return {
+            date,
+            calories: actual.calories,
+            caloriesTarget,
+            protein: actual.protein,
+            proteinTarget,
+            mealCount,
+            completeness,
+          };
+        }),
+      );
+    }
+
     const date = pathParts[3];
     const dateState = state.get(date) ?? {
       daily: null,
@@ -406,7 +447,9 @@ describe('NutritionPage', () => {
 
     expect(screen.getByRole('heading', { name: 'Nutrition help' })).toBeInTheDocument();
     expect(screen.getByText(/nutrition is read-only for meal data/i)).toBeInTheDocument();
-    expect(screen.getByText(/food definition edits later will not retroactively change/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/food definition edits later will not retroactively change/i),
+    ).toBeInTheDocument();
   });
 
   it('shows date-aware empty-state copy and go-to-today action on non-today dates', async () => {
@@ -615,7 +658,10 @@ describe('NutritionPage', () => {
 
     const didDeleteMeal = fetchMock.mock.calls.some(([input, init]) => {
       const url = new URL(String(input), 'http://localhost');
-      return url.pathname === '/api/v1/nutrition/2026-03-05/meals/meal-breakfast' && init?.method === 'DELETE';
+      return (
+        url.pathname === '/api/v1/nutrition/2026-03-05/meals/meal-breakfast' &&
+        init?.method === 'DELETE'
+      );
     });
     expect(didDeleteMeal).toBe(true);
   });
@@ -635,6 +681,20 @@ describe('NutritionPage', () => {
         return deferredSummary.promise;
       }
 
+      if (url.pathname === '/api/v1/nutrition/week-summary') {
+        return createJsonResponse(
+          Array.from({ length: 7 }, (_, index) => ({
+            date: `2026-03-${String(index + 2).padStart(2, '0')}`,
+            calories: 0,
+            caloriesTarget: TARGETS.calories,
+            protein: 0,
+            proteinTarget: TARGETS.protein,
+            mealCount: 0,
+            completeness: 0,
+          })),
+        );
+      }
+
       throw new Error(`Unhandled request: ${url.pathname}`);
     });
     vi.stubGlobal('fetch', fetchMock);
@@ -645,6 +705,7 @@ describe('NutritionPage', () => {
     expect(screen.getByLabelText('Loading nutrition')).toBeInTheDocument();
     expect(screen.getByLabelText('Loading nutrition rings')).toBeInTheDocument();
     expect(screen.getByLabelText('Loading nutrition meals')).toBeInTheDocument();
+    expect(screen.getByLabelText('Loading nutrition week strip')).toBeInTheDocument();
     expect(screen.getAllByTestId('meal-card-skeleton')).toHaveLength(4);
   });
 

--- a/apps/web/src/pages/nutrition.test.tsx
+++ b/apps/web/src/pages/nutrition.test.tsx
@@ -428,6 +428,48 @@ describe('NutritionPage', () => {
     );
   });
 
+  it('renders week strip above date navigation and updates selected date when a strip day is tapped', async () => {
+    const { fetchMock } = createNutritionApiMock({
+      '2026-03-06': {
+        daily: null,
+        target: TARGETS,
+      },
+      '2026-03-05': {
+        daily: {
+          log: {
+            id: 'log-2026-03-05',
+            userId: 'user-1',
+            date: '2026-03-05',
+            notes: null,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          meals: previousDayMeals,
+        },
+        target: TARGETS,
+      },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { wrapper } = createQueryClientWrapper();
+    render(<NutritionPage />, { wrapper });
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    const strip = screen.getByRole('list', { name: 'Nutrition week summary' });
+    const dateNavPreviousButton = screen.getByRole('button', { name: 'Go to previous day' });
+    expect(strip.compareDocumentPosition(dateNavPreviousButton) & Node.DOCUMENT_POSITION_FOLLOWING)
+      .toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select 2026-03-05' }));
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(screen.getByText('Thursday, March 5')).toBeInTheDocument();
+    expect(getMealToggleButton('Breakfast')).toBeInTheDocument();
+  });
+
   it('opens contextual nutrition help from the page header', async () => {
     const { fetchMock } = createNutritionApiMock({
       '2026-03-06': {

--- a/apps/web/src/pages/nutrition.tsx
+++ b/apps/web/src/pages/nutrition.tsx
@@ -8,12 +8,18 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { HelpIcon } from '@/components/ui/help-icon';
 import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import { Skeleton } from '@/components/ui/skeleton';
-import { DateNavBar, MealCard, NutritionMacroRings } from '@/features/nutrition';
+import {
+  DateNavBar,
+  MealCard,
+  NutritionMacroRings,
+  NutritionWeekStrip,
+} from '@/features/nutrition';
 import {
   prefetchNutritionDay,
   useDailyNutrition,
   useDeleteMeal,
   useNutritionSummary,
+  useNutritionWeekSummary,
 } from '@/features/nutrition/api/nutrition';
 import {
   formatDateKey,
@@ -59,6 +65,7 @@ export function NutritionPage() {
 
   const dailyNutritionQuery = useDailyNutrition(dateKey);
   const dailySummaryQuery = useNutritionSummary(dateKey);
+  const weekSummaryQuery = useNutritionWeekSummary(dateKey);
   const deleteMealMutation = useDeleteMeal();
 
   const selectedMeals = sortMeals(
@@ -92,6 +99,7 @@ export function NutritionPage() {
   const nutritionError =
     (dailyNutritionQuery.isError && dailyNutritionQuery.error) ||
     (dailySummaryQuery.isError && dailySummaryQuery.error) ||
+    (weekSummaryQuery.isError && weekSummaryQuery.error) ||
     null;
   const deleteErrorMessage =
     deleteMealMutation.isError && deleteMealMutation.error instanceof Error
@@ -164,7 +172,9 @@ export function NutritionPage() {
           type="button"
           variant="outline"
           onClick={() =>
-            setMealSortDirection((currentDirection) => (currentDirection === 'asc' ? 'desc' : 'asc'))
+            setMealSortDirection((currentDirection) =>
+              currentDirection === 'asc' ? 'desc' : 'asc',
+            )
           }
         >
           {mealSortDirection === 'asc' ? (
@@ -175,6 +185,16 @@ export function NutritionPage() {
           <span>{mealSortDirection === 'asc' ? 'Oldest first' : 'Newest first'}</span>
         </Button>
       </div>
+
+      {weekSummaryQuery.isLoading ? (
+        <NutritionWeekStripSkeleton />
+      ) : weekSummaryQuery.data ? (
+        <NutritionWeekStrip
+          days={weekSummaryQuery.data}
+          selectedDate={selectedDate}
+          onSelectDate={setSelectedDate}
+        />
+      ) : null}
 
       {nutritionError ? (
         <section className="rounded-2xl border border-destructive/30 px-5 py-6">
@@ -226,8 +246,8 @@ export function NutritionPage() {
                             target === null
                               ? 'text-foreground'
                               : isOverTarget
-                              ? 'text-red-900 dark:text-red-400'
-                              : 'text-emerald-950 dark:text-emerald-400',
+                                ? 'text-red-900 dark:text-red-400'
+                                : 'text-emerald-950 dark:text-emerald-400',
                             'text-lg tracking-tight',
                           )}
                         >
@@ -296,7 +316,9 @@ export function NutritionPage() {
                 }
                 description="Ask your agent to log a meal."
                 icon={UtensilsCrossed}
-                title={isSelectedDateToday ? 'No meals logged today' : 'No meals logged for this day'}
+                title={
+                  isSelectedDateToday ? 'No meals logged today' : 'No meals logged for this day'
+                }
               />
             )}
           </div>
@@ -341,6 +363,21 @@ function NutritionRingsSkeleton() {
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {Array.from({ length: 4 }).map((_, index) => (
           <Skeleton key={index} className="h-44 rounded-2xl border border-border/70 bg-card/90" />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function NutritionWeekStripSkeleton() {
+  return (
+    <section
+      aria-label="Loading nutrition week strip"
+      className="rounded-2xl border border-border/70 p-2"
+    >
+      <div className="grid grid-cols-7 gap-1">
+        {Array.from({ length: 7 }).map((_, index) => (
+          <Skeleton key={index} className="h-14 rounded-xl bg-muted/60" />
         ))}
       </div>
     </section>

--- a/apps/web/src/pages/nutrition.tsx
+++ b/apps/web/src/pages/nutrition.tsx
@@ -99,7 +99,6 @@ export function NutritionPage() {
   const nutritionError =
     (dailyNutritionQuery.isError && dailyNutritionQuery.error) ||
     (dailySummaryQuery.isError && dailySummaryQuery.error) ||
-    (weekSummaryQuery.isError && weekSummaryQuery.error) ||
     null;
   const deleteErrorMessage =
     deleteMealMutation.isError && deleteMealMutation.error instanceof Error
@@ -370,14 +369,16 @@ function NutritionRingsSkeleton() {
 }
 
 function NutritionWeekStripSkeleton() {
+  const dayKeys = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const;
+
   return (
     <section
       aria-label="Loading nutrition week strip"
       className="rounded-2xl border border-border/70 p-2"
     >
       <div className="grid grid-cols-7 gap-1">
-        {Array.from({ length: 7 }).map((_, index) => (
-          <Skeleton key={index} className="h-14 rounded-xl bg-muted/60" />
+        {dayKeys.map((dayKey) => (
+          <Skeleton key={dayKey} className="h-14 rounded-xl bg-muted/60" />
         ))}
       </div>
     </section>

--- a/apps/web/src/pages/nutrition.tsx
+++ b/apps/web/src/pages/nutrition.tsx
@@ -169,6 +169,8 @@ export function NutritionPage() {
           selectedDate={selectedDate}
           onSelectDate={setSelectedDate}
         />
+      ) : weekSummaryQuery.isError ? (
+        <p className="text-sm text-muted">Unable to load week summary.</p>
       ) : null}
 
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center">

--- a/apps/web/src/pages/nutrition.tsx
+++ b/apps/web/src/pages/nutrition.tsx
@@ -161,6 +161,16 @@ export function NutritionPage() {
         </p>
       </header>
 
+      {weekSummaryQuery.isLoading ? (
+        <NutritionWeekStripSkeleton />
+      ) : weekSummaryQuery.data ? (
+        <NutritionWeekStrip
+          days={weekSummaryQuery.data}
+          selectedDate={selectedDate}
+          onSelectDate={setSelectedDate}
+        />
+      ) : null}
+
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
         <DateNavBar className="flex-1" selectedDate={selectedDate} onDateChange={setSelectedDate} />
         <Button
@@ -184,16 +194,6 @@ export function NutritionPage() {
           <span>{mealSortDirection === 'asc' ? 'Oldest first' : 'Newest first'}</span>
         </Button>
       </div>
-
-      {weekSummaryQuery.isLoading ? (
-        <NutritionWeekStripSkeleton />
-      ) : weekSummaryQuery.data ? (
-        <NutritionWeekStrip
-          days={weekSummaryQuery.data}
-          selectedDate={selectedDate}
-          onSelectDate={setSelectedDate}
-        />
-      ) : null}
 
       {nutritionError ? (
         <section className="rounded-2xl border border-destructive/30 px-5 py-6">

--- a/packages/shared/src/schemas/nutrition.test.ts
+++ b/packages/shared/src/schemas/nutrition.test.ts
@@ -8,10 +8,12 @@ import {
   type PatchMealInput,
   type PatchMealItemInput,
   type NutritionSummary,
+  type NutritionWeekSummary,
   createMealInputSchema,
   dailyNutritionSchema,
   deleteMealResultSchema,
   mealItemInputSchema,
+  nutritionWeekSummarySchema,
   patchMealInputSchema,
   patchMealItemInputSchema,
   nutritionSummarySchema,
@@ -419,5 +421,92 @@ describe('deleteMealResultSchema', () => {
   it('infers DeleteMealResult from the schema', () => {
     const result: DeleteMealResult = { success: true };
     expect(result.success).toBe(true);
+  });
+});
+
+describe('nutritionWeekSummarySchema', () => {
+  it('parses a valid seven-day week summary payload', () => {
+    const summary = nutritionWeekSummarySchema.parse([
+      {
+        date: '2026-03-02',
+        calories: 2100,
+        caloriesTarget: 2200,
+        protein: 175,
+        proteinTarget: 180,
+        mealCount: 3,
+        completeness: 0.96,
+      },
+      {
+        date: '2026-03-03',
+        calories: 0,
+        caloriesTarget: 2200,
+        protein: 0,
+        proteinTarget: 180,
+        mealCount: 0,
+        completeness: 0,
+      },
+      {
+        date: '2026-03-04',
+        calories: 1800,
+        caloriesTarget: 2200,
+        protein: 150,
+        proteinTarget: 180,
+        mealCount: 2,
+        completeness: 0.83,
+      },
+      {
+        date: '2026-03-05',
+        calories: 2200,
+        caloriesTarget: 2200,
+        protein: 180,
+        proteinTarget: 180,
+        mealCount: 4,
+        completeness: 1,
+      },
+      {
+        date: '2026-03-06',
+        calories: 2000,
+        caloriesTarget: 2200,
+        protein: 160,
+        proteinTarget: 180,
+        mealCount: 3,
+        completeness: 0.9,
+      },
+      {
+        date: '2026-03-07',
+        calories: 2300,
+        caloriesTarget: 2200,
+        protein: 190,
+        proteinTarget: 180,
+        mealCount: 4,
+        completeness: 1,
+      },
+      {
+        date: '2026-03-08',
+        calories: 1700,
+        caloriesTarget: 2200,
+        protein: 120,
+        proteinTarget: 180,
+        mealCount: 2,
+        completeness: 0.72,
+      },
+    ]);
+
+    expect(summary).toHaveLength(7);
+    expect(summary[0]?.date).toBe('2026-03-02');
+  });
+
+  it('infers NutritionWeekSummary from the schema', () => {
+    const summary: NutritionWeekSummary = Array.from({ length: 7 }, (_, index) => ({
+      date: `2026-03-${String(index + 2).padStart(2, '0')}`,
+      calories: 0,
+      caloriesTarget: 2200,
+      protein: 0,
+      proteinTarget: 180,
+      mealCount: 0,
+      completeness: 0,
+    }));
+
+    expect(summary[6]?.mealCount).toBe(0);
   });
 });

--- a/packages/shared/src/schemas/nutrition.ts
+++ b/packages/shared/src/schemas/nutrition.ts
@@ -71,6 +71,18 @@ export const nutritionSummarySchema = z.object({
   target: nutritionMacroTotalsSchema.nullable(),
 });
 
+export const nutritionWeekDaySummarySchema = z.object({
+  date: dateSchema,
+  calories: nonnegativeNumber,
+  caloriesTarget: nonnegativeNumber,
+  protein: nonnegativeNumber,
+  proteinTarget: nonnegativeNumber,
+  mealCount: z.number().int().nonnegative(),
+  completeness: z.number().min(0).max(1),
+});
+
+export const nutritionWeekSummarySchema = z.array(nutritionWeekDaySummarySchema).length(7);
+
 export const deleteMealResultSchema = z.object({
   success: z.literal(true),
 });
@@ -135,4 +147,6 @@ export type NutritionMealItem = z.infer<typeof nutritionMealItemSchema>;
 export type DailyNutritionMeal = z.infer<typeof dailyNutritionMealSchema>;
 export type DailyNutrition = z.infer<typeof dailyNutritionSchema>;
 export type NutritionSummary = z.infer<typeof nutritionSummarySchema>;
+export type NutritionWeekDaySummary = z.infer<typeof nutritionWeekDaySummarySchema>;
+export type NutritionWeekSummary = z.infer<typeof nutritionWeekSummarySchema>;
 export type DeleteMealResult = z.infer<typeof deleteMealResultSchema>;


### PR DESCRIPTION
## Summary
This PR adds a new nutrition week-summary flow end to end, from shared schemas and API support through a new UI week strip on the Nutrition page. The backend now exposes `GET /api/v1/nutrition/week-summary?date=...`, returning a Monday-start 7-day window with per-day calories/protein totals, targets, meal count, and a computed completeness score. On the frontend, a `NutritionWeekStrip` component renders those 7 days as a horizontal selector with empty/partial/complete visual states and keeps date selection in sync with the existing daily view. Query behavior was updated so week data is cached by normalized week start and invalidated alongside daily/summary data after meal deletion. The result is faster week-level context and navigation without changing existing daily nutrition workflows.

## Key Changes
- Added shared schema/types for week summaries:
  - `nutritionWeekDaySummarySchema`
  - `nutritionWeekSummarySchema` (fixed length of 7)
- Added backend week summary endpoint and validation:
  - `GET /api/v1/nutrition/week-summary?date=<ISO date>`
  - Returns `VALIDATION_ERROR` for invalid week date input
- Implemented store logic to build Monday-based week windows, aggregate daily actuals, resolve effective targets by date, and compute bounded completeness.
- Added `NutritionWeekStrip` UI component with:
  - 7-day horizontal layout
  - selected-day styling
  - empty/partial/complete indicator states
  - day selection callback into page state
- Integrated week strip into `NutritionPage` above `DateNavBar`, including a loading skeleton.
- Extended TanStack Query API layer:
  - `useNutritionWeekSummary(date)`
  - `nutritionKeys.weekSummary(date)` normalized to week start (Monday)
  - week-summary invalidation on meal delete mutations.

## Technical Notes
- Week query keys are normalized to Monday boundaries to prevent duplicate cache entries for different dates in the same week and improve reuse.
- The frontend sends noon UTC (`T12:00:00.000Z`) for week-summary requests to reduce timezone boundary drift when deriving date keys.
- Completeness intentionally returns `0` when no meals are logged and otherwise uses the average of calories/protein progress, clamped to `[0,1]`.
- Tests were added across shared schema validation, route/store behavior, query keys/hooks, component rendering/interaction, and Nutrition page integration (including loading and placement).

## Commits

- `2e1ff6b feat(nutrition): wire week strip date sync and week cache invalidation`
- `83426f2 fix(nutrition): address week strip review findings`
- `827c4a0 feat(nutrition): add week summary API and week strip`

## Tasks

- **Week summary API + NutritionWeekStrip component**: Add week-summary API endpoint with per-day completeness and build horizontal week strip component
- **Wire week strip into nutrition page**: Integrate NutritionWeekStrip above DateNavBar with TanStack Query data fetching and completeness tests

## Diff Stats

```
apps/api/src/routes/nutrition/index.test.ts        | 112 ++++++++++++++++
 apps/api/src/routes/nutrition/index.ts             |  39 +++++-
 apps/api/src/routes/nutrition/store.test.ts        |  52 ++++++--
 apps/api/src/routes/nutrition/store.ts             | 145 ++++++++++++++++++++-
 apps/web/src/features/nutrition/api/keys.test.ts   |  26 ++++
 apps/web/src/features/nutrition/api/keys.ts        |  13 ++
 .../src/features/nutrition/api/nutrition.test.tsx  |  41 +++++-
 apps/web/src/features/nutrition/api/nutrition.ts   |  25 +++-
 .../components/nutrition-week-strip.test.tsx       | 139 ++++++++++++++++++++
 .../nutrition/components/nutrition-week-strip.tsx  |  98 ++++++++++++++
 apps/web/src/features/nutrition/index.ts           |   1 +
 apps/web/src/pages/nutrition.test.tsx              | 107 ++++++++++++++-
 apps/web/src/pages/nutrition.tsx                   |  48 ++++++-
 packages/shared/src/schemas/nutrition.test.ts      |  89 +++++++++++++
 packages/shared/src/schemas/nutrition.ts           |  14 ++
 15 files changed, 927 insertions(+), 22 deletions(-)
```