### PR TITLE
feat: swap/replace exercise in templates and sessions

### DIFF
--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -953,7 +953,7 @@ describe('workout session routes', () => {
     expect(response.json()).toEqual({
       error: {
         code: 'WORKOUT_SESSION_NOT_SWAPPABLE',
-        message: 'Workout session must be planned or in progress to swap exercises',
+        message: 'Workout session must be planned, in progress, or paused to swap exercises',
       },
     });
   });

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -140,9 +140,15 @@ const seedSessionSet = (values: {
   id: string;
   sessionId: string;
   exerciseId: string;
+  orderIndex?: number;
   setNumber: number;
   weight?: number | null;
   reps?: number | null;
+  targetWeight?: number | null;
+  targetWeightMin?: number | null;
+  targetWeightMax?: number | null;
+  targetSeconds?: number | null;
+  targetDistance?: number | null;
   completed?: boolean;
   skipped?: boolean;
   section?: 'warmup' | 'main' | 'cooldown' | null;
@@ -154,9 +160,15 @@ const seedSessionSet = (values: {
       id: values.id,
       sessionId: values.sessionId,
       exerciseId: values.exerciseId,
+      orderIndex: values.orderIndex ?? 0,
       setNumber: values.setNumber,
       weight: values.weight ?? null,
       reps: values.reps ?? null,
+      targetWeight: values.targetWeight ?? null,
+      targetWeightMin: values.targetWeightMin ?? null,
+      targetWeightMax: values.targetWeightMax ?? null,
+      targetSeconds: values.targetSeconds ?? null,
+      targetDistance: values.targetDistance ?? null,
       completed: values.completed ?? false,
       skipped: values.skipped ?? false,
       section: values.section ?? null,
@@ -259,6 +271,13 @@ describe('workout session routes', () => {
       name: 'Lat Pulldown',
     });
     seedExercise({
+      id: 'user-1-plank',
+      userId: 'user-1',
+      name: 'RKC Plank',
+      trackingType: 'seconds_only',
+      category: 'mobility',
+    });
+    seedExercise({
       id: 'user-2-private-row',
       userId: 'user-2',
       name: 'Private Row',
@@ -331,6 +350,13 @@ describe('workout session routes', () => {
         payload: {
           section: 'main',
           exerciseIds: [],
+        },
+      }),
+      context.app.inject({
+        method: 'PATCH',
+        url: '/api/v1/workout-sessions/session-1/exercises/global-bench-press/swap',
+        payload: {
+          newExerciseId: 'user-1-lat-pulldown',
         },
       }),
     ]);
@@ -743,6 +769,279 @@ describe('workout session routes', () => {
       { exerciseId: 'global-bench-press', orderIndex: 1 },
       { exerciseId: 'global-bench-press', orderIndex: 1 },
     ]);
+  });
+
+  it('swaps a session exercise while preserving entered set data', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    seedWorkoutSession({
+      id: 'session-swap',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      status: 'in-progress',
+      startedAt: 1_700_000_000_000,
+    });
+    seedSessionSet({
+      id: 'set-swap-1',
+      sessionId: 'session-swap',
+      exerciseId: 'global-bench-press',
+      orderIndex: 1,
+      setNumber: 1,
+      weight: 185,
+      reps: 8,
+      targetWeight: 190,
+      completed: true,
+      section: 'main',
+      notes: 'Smooth reps',
+    });
+    seedSessionSet({
+      id: 'set-swap-2',
+      sessionId: 'session-swap',
+      exerciseId: 'global-bench-press',
+      orderIndex: 1,
+      setNumber: 2,
+      weight: 195,
+      reps: 6,
+      targetWeightMin: 190,
+      targetWeightMax: 200,
+      skipped: true,
+      section: 'main',
+      notes: 'Tweaked shoulder',
+    });
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-sessions/session-swap/exercises/global-bench-press/swap',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        newExerciseId: 'user-1-plank',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        id: 'session-swap',
+        exercises: expect.arrayContaining([
+          expect.objectContaining({
+            exerciseId: 'user-1-plank',
+          }),
+        ]),
+        sets: [
+          expect.objectContaining({
+            id: 'set-swap-1',
+            exerciseId: 'user-1-plank',
+            orderIndex: 1,
+            setNumber: 1,
+            weight: 185,
+            reps: 8,
+            targetWeight: 190,
+            completed: true,
+            skipped: false,
+            section: 'main',
+            notes: 'Smooth reps',
+          }),
+          expect.objectContaining({
+            id: 'set-swap-2',
+            exerciseId: 'user-1-plank',
+            orderIndex: 1,
+            setNumber: 2,
+            weight: 195,
+            reps: 6,
+            targetWeightMin: 190,
+            targetWeightMax: 200,
+            completed: false,
+            skipped: true,
+            section: 'main',
+            notes: 'Tweaked shoulder',
+          }),
+        ],
+      }),
+      meta: {
+        warning:
+          'Swapped to an exercise with a different tracking type. Review entered sets and targets.',
+      },
+    });
+
+    const persistedSets = context.db
+      .select({
+        id: sessionSets.id,
+        exerciseId: sessionSets.exerciseId,
+        orderIndex: sessionSets.orderIndex,
+        setNumber: sessionSets.setNumber,
+        weight: sessionSets.weight,
+        reps: sessionSets.reps,
+        targetWeight: sessionSets.targetWeight,
+        targetWeightMin: sessionSets.targetWeightMin,
+        targetWeightMax: sessionSets.targetWeightMax,
+        completed: sessionSets.completed,
+        skipped: sessionSets.skipped,
+        section: sessionSets.section,
+        notes: sessionSets.notes,
+      })
+      .from(sessionSets)
+      .where(eq(sessionSets.sessionId, 'session-swap'))
+      .all()
+      .sort((left, right) => left.setNumber - right.setNumber);
+
+    expect(persistedSets).toEqual([
+      {
+        id: 'set-swap-1',
+        exerciseId: 'user-1-plank',
+        orderIndex: 1,
+        setNumber: 1,
+        weight: 185,
+        reps: 8,
+        targetWeight: 190,
+        targetWeightMin: null,
+        targetWeightMax: null,
+        completed: true,
+        skipped: false,
+        section: 'main',
+        notes: 'Smooth reps',
+      },
+      {
+        id: 'set-swap-2',
+        exerciseId: 'user-1-plank',
+        orderIndex: 1,
+        setNumber: 2,
+        weight: 195,
+        reps: 6,
+        targetWeight: null,
+        targetWeightMin: 190,
+        targetWeightMax: 200,
+        completed: false,
+        skipped: true,
+        section: 'main',
+        notes: 'Tweaked shoulder',
+      },
+    ]);
+  });
+
+  it('rejects swaps for completed sessions', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    seedWorkoutSession({
+      id: 'session-completed-swap',
+      userId: 'user-1',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: 1_700_000_000_000,
+      completedAt: 1_700_000_003_000,
+    });
+    seedSessionSet({
+      id: 'set-completed-1',
+      sessionId: 'session-completed-swap',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      section: 'main',
+    });
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-sessions/session-completed-swap/exercises/global-bench-press/swap',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        newExerciseId: 'user-1-plank',
+      },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'WORKOUT_SESSION_NOT_SWAPPABLE',
+        message: 'Workout session must be planned or in progress to swap exercises',
+      },
+    });
+  });
+
+  it('returns 404 when swapping an exercise not present in the session', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    seedWorkoutSession({
+      id: 'session-missing-source',
+      userId: 'user-1',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      status: 'in-progress',
+      startedAt: 1_700_000_000_000,
+    });
+    seedSessionSet({
+      id: 'set-present-1',
+      sessionId: 'session-missing-source',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      section: 'main',
+    });
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-sessions/session-missing-source/exercises/user-1-lat-pulldown/swap',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        newExerciseId: 'user-1-plank',
+      },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'WORKOUT_SESSION_EXERCISE_NOT_FOUND',
+        message: 'Session exercise not found',
+      },
+    });
+  });
+
+  it('rejects swap targets that are not user-owned exercises', async () => {
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    seedWorkoutSession({
+      id: 'session-invalid-target',
+      userId: 'user-1',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      status: 'in-progress',
+      startedAt: 1_700_000_000_000,
+    });
+    seedSessionSet({
+      id: 'set-invalid-target-1',
+      sessionId: 'session-invalid-target',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      section: 'main',
+    });
+
+    const [globalResponse, otherUserResponse] = await Promise.all([
+      context.app.inject({
+        method: 'PATCH',
+        url: '/api/v1/workout-sessions/session-invalid-target/exercises/global-bench-press/swap',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          newExerciseId: 'global-bench-press',
+        },
+      }),
+      context.app.inject({
+        method: 'PATCH',
+        url: '/api/v1/workout-sessions/session-invalid-target/exercises/global-bench-press/swap',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          newExerciseId: 'user-2-private-row',
+        },
+      }),
+    ]);
+
+    for (const response of [globalResponse, otherUserResponse]) {
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'INVALID_SESSION_EXERCISE',
+          message: 'Session references one or more unavailable exercises',
+        },
+      });
+    }
   });
 
   it('applies save-as-template metadata overrides when provided', async () => {

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -73,7 +73,7 @@ const WORKOUT_SESSION_INVALID_TRANSITION_RESPONSE = {
 
 const WORKOUT_SESSION_NOT_SWAPPABLE_RESPONSE = {
   code: 'WORKOUT_SESSION_NOT_SWAPPABLE',
-  message: 'Workout session must be planned or in progress to swap exercises',
+  message: 'Workout session must be planned, in progress, or paused to swap exercises',
 } as const;
 
 const WORKOUT_SESSION_EXERCISE_NOT_FOUND_RESPONSE = {
@@ -881,7 +881,11 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
         );
       }
 
-      if (existingSession.status !== 'scheduled' && existingSession.status !== 'in-progress') {
+      if (
+        existingSession.status !== 'scheduled' &&
+        existingSession.status !== 'in-progress' &&
+        existingSession.status !== 'paused'
+      ) {
         return sendError(
           reply,
           409,

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -5,6 +5,7 @@ import {
   createSetSchema,
   reorderWorkoutSessionExercisesInputSchema,
   saveWorkoutSessionAsTemplateInputSchema,
+  swapWorkoutSessionExerciseInputSchema,
   createWorkoutSessionInputSchema,
   type CreateWorkoutSessionInput,
   type SessionSetInput,
@@ -17,6 +18,7 @@ import type { FastifyPluginAsync, FastifyReply } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
 import { requireUserAuth } from '../../middleware/auth.js';
+import { allRelatedExercisesOwned } from '../exercises/store.js';
 import { templateBelongsToUser } from '../workout-templates/template-access.js';
 import { linkTodayScheduledWorkoutToSession } from '../scheduled-workouts/store.js';
 
@@ -33,6 +35,7 @@ import {
   SessionSetNotFoundError,
   listWorkoutSessions,
   saveCompletedSessionAsTemplate,
+  swapWorkoutSessionExercise,
   updateSessionSet,
   updateWorkoutSession,
 } from './store.js';
@@ -66,6 +69,21 @@ const WORKOUT_SESSION_NOT_COMPLETED_RESPONSE = {
 const WORKOUT_SESSION_INVALID_TRANSITION_RESPONSE = {
   code: 'WORKOUT_SESSION_INVALID_TRANSITION',
   message: 'Invalid workout session status transition',
+} as const;
+
+const WORKOUT_SESSION_NOT_SWAPPABLE_RESPONSE = {
+  code: 'WORKOUT_SESSION_NOT_SWAPPABLE',
+  message: 'Workout session must be planned or in progress to swap exercises',
+} as const;
+
+const WORKOUT_SESSION_EXERCISE_NOT_FOUND_RESPONSE = {
+  code: 'WORKOUT_SESSION_EXERCISE_NOT_FOUND',
+  message: 'Session exercise not found',
+} as const;
+
+const WORKOUT_SESSION_DUPLICATE_EXERCISE_RESPONSE = {
+  code: 'WORKOUT_SESSION_DUPLICATE_EXERCISE',
+  message: 'Session already contains the replacement exercise',
 } as const;
 
 const SESSION_SET_NOT_FOUND_RESPONSE = {
@@ -844,6 +862,109 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       data: reordered,
     });
   });
+
+  app.patch<{ Params: { id: string; exerciseId: string } }>(
+    '/:id/exercises/:exerciseId/swap',
+    async (request, reply) => {
+      const parsedBody = swapWorkoutSessionExerciseInputSchema.safeParse(request.body);
+      if (!parsedBody.success) {
+        return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid workout session payload');
+      }
+
+      const existingSession = await findWorkoutSessionById(request.params.id, request.userId);
+      if (!existingSession) {
+        return sendError(
+          reply,
+          404,
+          WORKOUT_SESSION_NOT_FOUND_RESPONSE.code,
+          WORKOUT_SESSION_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      if (existingSession.status !== 'scheduled' && existingSession.status !== 'in-progress') {
+        return sendError(
+          reply,
+          409,
+          WORKOUT_SESSION_NOT_SWAPPABLE_RESPONSE.code,
+          WORKOUT_SESSION_NOT_SWAPPABLE_RESPONSE.message,
+        );
+      }
+
+      const sessionExercises = existingSession.exercises ?? [];
+
+      const existingExercise = sessionExercises.find(
+        (exercise) => exercise.exerciseId === request.params.exerciseId,
+      );
+      if (!existingExercise) {
+        return sendError(
+          reply,
+          404,
+          WORKOUT_SESSION_EXERCISE_NOT_FOUND_RESPONSE.code,
+          WORKOUT_SESSION_EXERCISE_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      if (
+        request.params.exerciseId !== parsedBody.data.newExerciseId &&
+        sessionExercises.some((exercise) => exercise.exerciseId === parsedBody.data.newExerciseId)
+      ) {
+        return sendError(
+          reply,
+          409,
+          WORKOUT_SESSION_DUPLICATE_EXERCISE_RESPONSE.code,
+          WORKOUT_SESSION_DUPLICATE_EXERCISE_RESPONSE.message,
+        );
+      }
+
+      const hasValidSwapTarget = await allRelatedExercisesOwned({
+        userId: request.userId,
+        exerciseIds: [parsedBody.data.newExerciseId],
+      });
+      if (!hasValidSwapTarget) {
+        return sendError(
+          reply,
+          400,
+          INVALID_SESSION_EXERCISE_RESPONSE.code,
+          INVALID_SESSION_EXERCISE_RESPONSE.message,
+        );
+      }
+
+      const swapped = await swapWorkoutSessionExercise({
+        sessionId: request.params.id,
+        userId: request.userId,
+        exerciseId: request.params.exerciseId,
+        newExerciseId: parsedBody.data.newExerciseId,
+      });
+      if (!swapped) {
+        return sendError(
+          reply,
+          404,
+          WORKOUT_SESSION_EXERCISE_NOT_FOUND_RESPONSE.code,
+          WORKOUT_SESSION_EXERCISE_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      const swappedExercises = swapped.exercises ?? [];
+      const swappedExercise = swappedExercises.find(
+        (exercise) => exercise.exerciseId === parsedBody.data.newExerciseId,
+      );
+      const hasTrackingTypeWarning =
+        swappedExercise?.trackingType !== undefined &&
+        existingExercise.trackingType !== swappedExercise.trackingType;
+
+      return reply.send({
+        data: swapped,
+        ...(hasTrackingTypeWarning
+          ? {
+              meta: {
+                warning:
+                  'Swapped to an exercise with a different tracking type. Review entered sets and targets.',
+              },
+            }
+          : {}),
+      });
+    },
+  );
 
   app.put<{ Params: { id: string } }>('/:id', updateSessionById);
   app.patch<{ Params: { id: string } }>('/:id', updateSessionById);

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -947,6 +947,7 @@ export const swapWorkoutSessionExercise = async ({
       .set({
         exerciseId: newExerciseId,
       })
+      // Session swaps intentionally replace every set tied to the source exercise across sections.
       .where(and(eq(sessionSets.sessionId, sessionId), eq(sessionSets.exerciseId, exerciseId)))
       .run();
 

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -368,10 +368,7 @@ export const findInvalidSessionExerciseIds = async ({
       and(
         inArray(exercises.id, uniqueIds),
         isNull(exercises.deletedAt),
-        or(
-          isNull(exercises.userId),
-          eq(exercises.userId, userId),
-        ),
+        or(isNull(exercises.userId), eq(exercises.userId, userId)),
       ),
     )
     .all()
@@ -908,6 +905,70 @@ export const reorderWorkoutSessionExercises = async ({
   });
 
   if (!reordered) {
+    return undefined;
+  }
+
+  return findWorkoutSessionById(sessionId, userId);
+};
+
+export const swapWorkoutSessionExercise = async ({
+  sessionId,
+  userId,
+  exerciseId,
+  newExerciseId,
+}: {
+  sessionId: string;
+  userId: string;
+  exerciseId: string;
+  newExerciseId: string;
+}): Promise<WorkoutSession | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  const swapped = db.transaction((tx) => {
+    const session = tx
+      .select(workoutSessionAccessSelection)
+      .from(workoutSessions)
+      .where(
+        and(
+          eq(workoutSessions.id, sessionId),
+          eq(workoutSessions.userId, userId),
+          isNull(workoutSessions.deletedAt),
+        ),
+      )
+      .limit(1)
+      .get();
+
+    if (!session) {
+      return false;
+    }
+
+    const updateResult = tx
+      .update(sessionSets)
+      .set({
+        exerciseId: newExerciseId,
+      })
+      .where(and(eq(sessionSets.sessionId, sessionId), eq(sessionSets.exerciseId, exerciseId)))
+      .run();
+
+    if (updateResult.changes === 0) {
+      return false;
+    }
+
+    tx.update(workoutSessions)
+      .set({ updatedAt: Date.now() })
+      .where(
+        and(
+          eq(workoutSessions.id, sessionId),
+          eq(workoutSessions.userId, userId),
+          isNull(workoutSessions.deletedAt),
+        ),
+      )
+      .run();
+
+    return true;
+  });
+
+  if (!swapped) {
     return undefined;
   }
 

--- a/apps/api/src/routes/workout-templates/index.test.ts
+++ b/apps/api/src/routes/workout-templates/index.test.ts
@@ -852,6 +852,46 @@ describe('workout template routes', () => {
     });
   });
 
+  it('returns 409 when swapping to an exercise already in the template', async () => {
+    seedTemplate({
+      id: 'template-duplicate-target',
+      userId: 'user-1',
+      name: 'Upper Push',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-press',
+      templateId: 'template-duplicate-target',
+      exerciseId: 'user-press',
+      orderIndex: 0,
+      section: 'main',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-row',
+      templateId: 'template-duplicate-target',
+      exerciseId: 'user-row',
+      orderIndex: 1,
+      section: 'main',
+    });
+
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-templates/template-duplicate-target/exercises/user-press/swap',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        newExerciseId: 'user-row',
+      },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'WORKOUT_TEMPLATE_DUPLICATE_EXERCISE',
+        message: 'Template already contains the replacement exercise',
+      },
+    });
+  });
+
   it('rejects swap targets that are not user-owned exercises', async () => {
     seedTemplate({
       id: 'template-invalid-target',

--- a/apps/api/src/routes/workout-templates/index.test.ts
+++ b/apps/api/src/routes/workout-templates/index.test.ts
@@ -43,6 +43,15 @@ const seedExercise = (values: {
   muscleGroups: string[];
   equipment: string;
   category: 'compound' | 'isolation' | 'cardio' | 'mobility';
+  trackingType?:
+    | 'weight_reps'
+    | 'weight_seconds'
+    | 'bodyweight_reps'
+    | 'reps_only'
+    | 'reps_seconds'
+    | 'seconds_only'
+    | 'distance'
+    | 'cardio';
   formCues?: string[];
   coachingNotes?: string | null;
   instructions?: string | null;
@@ -51,6 +60,7 @@ const seedExercise = (values: {
     .insert(exercises)
     .values({
       ...values,
+      trackingType: values.trackingType ?? 'weight_reps',
       formCues: values.formCues ?? [],
       instructions: values.instructions ?? null,
       coachingNotes: values.coachingNotes ?? null,
@@ -191,6 +201,15 @@ describe('workout template routes', () => {
       category: 'compound',
     });
     seedExercise({
+      id: 'user-plank',
+      userId: 'user-1',
+      name: 'RKC Plank',
+      muscleGroups: ['core'],
+      equipment: 'bodyweight',
+      category: 'mobility',
+      trackingType: 'seconds_only',
+    });
+    seedExercise({
       id: 'other-user-private',
       userId: 'user-2',
       name: 'Private Exercise',
@@ -232,6 +251,13 @@ describe('workout template routes', () => {
         payload: {
           section: 'main',
           exerciseIds: [],
+        },
+      }),
+      context.app.inject({
+        method: 'PATCH',
+        url: '/api/v1/workout-templates/template-1/exercises/user-press/swap',
+        payload: {
+          newExerciseId: 'user-row',
         },
       }),
       context.app.inject({
@@ -688,6 +714,188 @@ describe('workout template routes', () => {
       { id: 'template-exercise-main-2', orderIndex: 0 },
       { id: 'template-exercise-main-1', orderIndex: 1 },
     ]);
+  });
+
+  it('swaps a template exercise while preserving row configuration', async () => {
+    seedTemplate({
+      id: 'template-swap',
+      userId: 'user-1',
+      name: 'Upper Push',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-swap',
+      templateId: 'template-swap',
+      exerciseId: 'user-press',
+      orderIndex: 2,
+      section: 'main',
+      sets: 4,
+      repsMin: 6,
+      repsMax: 8,
+      restSeconds: 120,
+      notes: 'Top set and backoff',
+      cues: ['Drive feet'],
+      programmingNotes: 'Leave one rep in reserve.',
+      setTargets: [
+        { setNumber: 1, targetWeight: 100 },
+        { setNumber: 2, targetWeightMin: 90, targetWeightMax: 95 },
+      ],
+    });
+
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-templates/template-swap/exercises/user-press/swap',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        newExerciseId: 'user-plank',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        id: 'template-swap',
+        sections: [
+          { type: 'warmup', exercises: [] },
+          {
+            type: 'main',
+            exercises: [
+              expect.objectContaining({
+                id: 'template-exercise-swap',
+                exerciseId: 'user-plank',
+                sets: 4,
+                repsMin: 6,
+                repsMax: 8,
+                restSeconds: 120,
+                notes: 'Top set and backoff',
+                setTargets: [
+                  { setNumber: 1, targetWeight: 100 },
+                  { setNumber: 2, targetWeightMin: 90, targetWeightMax: 95 },
+                ],
+                programmingNotes: 'Leave one rep in reserve.',
+              }),
+            ],
+          },
+          { type: 'cooldown', exercises: [] },
+        ],
+      }),
+      meta: {
+        warning:
+          'Swapped to an exercise with a different tracking type. Review set targets and expectations.',
+      },
+    });
+
+    const persisted = context.db
+      .select({
+        exerciseId: templateExercises.exerciseId,
+        sets: templateExercises.sets,
+        repsMin: templateExercises.repsMin,
+        repsMax: templateExercises.repsMax,
+        restSeconds: templateExercises.restSeconds,
+        notes: templateExercises.notes,
+        cues: templateExercises.cues,
+        setTargets: templateExercises.setTargets,
+        programmingNotes: templateExercises.programmingNotes,
+        orderIndex: templateExercises.orderIndex,
+      })
+      .from(templateExercises)
+      .where(eq(templateExercises.id, 'template-exercise-swap'))
+      .get();
+
+    expect(persisted).toEqual({
+      exerciseId: 'user-plank',
+      sets: 4,
+      repsMin: 6,
+      repsMax: 8,
+      restSeconds: 120,
+      notes: 'Top set and backoff',
+      cues: null,
+      setTargets: [
+        { setNumber: 1, targetWeight: 100 },
+        { setNumber: 2, targetWeightMin: 90, targetWeightMax: 95 },
+      ],
+      programmingNotes: 'Leave one rep in reserve.',
+      orderIndex: 2,
+    });
+  });
+
+  it('returns 404 when swapping an exercise not present in the template', async () => {
+    seedTemplate({
+      id: 'template-missing-source',
+      userId: 'user-1',
+      name: 'Upper Push',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-1',
+      templateId: 'template-missing-source',
+      exerciseId: 'user-press',
+      orderIndex: 0,
+      section: 'main',
+    });
+
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-templates/template-missing-source/exercises/user-row/swap',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        newExerciseId: 'user-plank',
+      },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'WORKOUT_TEMPLATE_EXERCISE_NOT_FOUND',
+        message: 'Template exercise not found',
+      },
+    });
+  });
+
+  it('rejects swap targets that are not user-owned exercises', async () => {
+    seedTemplate({
+      id: 'template-invalid-target',
+      userId: 'user-1',
+      name: 'Upper Push',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-1',
+      templateId: 'template-invalid-target',
+      exerciseId: 'user-press',
+      orderIndex: 0,
+      section: 'main',
+    });
+
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    const [globalResponse, otherUserResponse] = await Promise.all([
+      context.app.inject({
+        method: 'PATCH',
+        url: '/api/v1/workout-templates/template-invalid-target/exercises/user-press/swap',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          newExerciseId: 'global-row-erg',
+        },
+      }),
+      context.app.inject({
+        method: 'PATCH',
+        url: '/api/v1/workout-templates/template-invalid-target/exercises/user-press/swap',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          newExerciseId: 'other-user-private',
+        },
+      }),
+    ]);
+
+    for (const response of [globalResponse, otherUserResponse]) {
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'INVALID_TEMPLATE_EXERCISE',
+          message: 'Template references one or more unavailable exercises',
+        },
+      });
+    }
   });
 
   it('soft-deletes only owned templates', async () => {

--- a/apps/api/src/routes/workout-templates/index.ts
+++ b/apps/api/src/routes/workout-templates/index.ts
@@ -39,6 +39,11 @@ const WORKOUT_TEMPLATE_EXERCISE_NOT_FOUND_RESPONSE = {
   message: 'Template exercise not found',
 } as const;
 
+const WORKOUT_TEMPLATE_DUPLICATE_EXERCISE_RESPONSE = {
+  code: 'WORKOUT_TEMPLATE_DUPLICATE_EXERCISE',
+  message: 'Template already contains the replacement exercise',
+} as const;
+
 const getReferencedExerciseIds = (
   sections: Array<{ exercises: Array<{ exerciseId: string }> }>,
 ): string[] =>
@@ -286,6 +291,20 @@ export const workoutTemplateRoutes: FastifyPluginAsync = async (app) => {
         );
       }
 
+      if (
+        request.params.exerciseId !== parsedBody.data.newExerciseId &&
+        existingTemplate.sections
+          .flatMap((section) => section.exercises)
+          .some((exercise) => exercise.exerciseId === parsedBody.data.newExerciseId)
+      ) {
+        return sendError(
+          reply,
+          409,
+          WORKOUT_TEMPLATE_DUPLICATE_EXERCISE_RESPONSE.code,
+          WORKOUT_TEMPLATE_DUPLICATE_EXERCISE_RESPONSE.message,
+        );
+      }
+
       const hasValidSwapTarget = await allRelatedExercisesOwned({
         userId: request.userId,
         exerciseIds: [parsedBody.data.newExerciseId],
@@ -314,17 +333,7 @@ export const workoutTemplateRoutes: FastifyPluginAsync = async (app) => {
         );
       }
 
-      const updatedTemplate = await findWorkoutTemplateById(request.params.id, request.userId);
-      if (!updatedTemplate) {
-        return sendError(
-          reply,
-          404,
-          WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE.code,
-          WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE.message,
-        );
-      }
-
-      const swappedExercise = updatedTemplate.sections
+      const swappedExercise = swapped.sections
         .flatMap((section) => section.exercises)
         .find((exercise) => exercise.exerciseId === parsedBody.data.newExerciseId);
       const hasTrackingTypeWarning =
@@ -332,7 +341,7 @@ export const workoutTemplateRoutes: FastifyPluginAsync = async (app) => {
         sourceExercise.trackingType !== swappedExercise.trackingType;
 
       return reply.send({
-        data: updatedTemplate,
+        data: swapped,
         ...(hasTrackingTypeWarning
           ? {
               meta: {

--- a/apps/api/src/routes/workout-templates/index.ts
+++ b/apps/api/src/routes/workout-templates/index.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import {
   createWorkoutTemplateInputSchema,
   reorderWorkoutTemplateExercisesInputSchema,
+  swapWorkoutTemplateExerciseInputSchema,
   type UpdateWorkoutTemplateInput,
   updateWorkoutTemplateInputSchema,
 } from '@pulse/shared';
@@ -10,6 +11,7 @@ import type { FastifyPluginAsync, FastifyReply } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
 import { requireUserAuth } from '../../middleware/auth.js';
+import { allRelatedExercisesOwned } from '../exercises/store.js';
 
 import {
   allTemplateExercisesAccessible,
@@ -18,6 +20,7 @@ import {
   findWorkoutTemplateById,
   listWorkoutTemplates,
   reorderWorkoutTemplateExercises,
+  swapWorkoutTemplateExercise,
   updateWorkoutTemplate,
 } from './store.js';
 
@@ -29,6 +32,11 @@ const WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE = {
 const INVALID_TEMPLATE_EXERCISE_RESPONSE = {
   code: 'INVALID_TEMPLATE_EXERCISE',
   message: 'Template references one or more unavailable exercises',
+} as const;
+
+const WORKOUT_TEMPLATE_EXERCISE_NOT_FOUND_RESPONSE = {
+  code: 'WORKOUT_TEMPLATE_EXERCISE_NOT_FOUND',
+  message: 'Template exercise not found',
 } as const;
 
 const getReferencedExerciseIds = (
@@ -247,6 +255,95 @@ export const workoutTemplateRoutes: FastifyPluginAsync = async (app) => {
 
     return reply.send({ data: template });
   });
+
+  app.patch<{ Params: { id: string; exerciseId: string } }>(
+    '/:id/exercises/:exerciseId/swap',
+    async (request, reply) => {
+      const parsedBody = swapWorkoutTemplateExerciseInputSchema.safeParse(request.body);
+      if (!parsedBody.success) {
+        return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid workout template payload');
+      }
+
+      const existingTemplate = await findWorkoutTemplateById(request.params.id, request.userId);
+      if (!existingTemplate) {
+        return sendError(
+          reply,
+          404,
+          WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE.code,
+          WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      const sourceExercise = existingTemplate.sections
+        .flatMap((section) => section.exercises)
+        .find((exercise) => exercise.exerciseId === request.params.exerciseId);
+      if (!sourceExercise) {
+        return sendError(
+          reply,
+          404,
+          WORKOUT_TEMPLATE_EXERCISE_NOT_FOUND_RESPONSE.code,
+          WORKOUT_TEMPLATE_EXERCISE_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      const hasValidSwapTarget = await allRelatedExercisesOwned({
+        userId: request.userId,
+        exerciseIds: [parsedBody.data.newExerciseId],
+      });
+      if (!hasValidSwapTarget) {
+        return sendError(
+          reply,
+          400,
+          INVALID_TEMPLATE_EXERCISE_RESPONSE.code,
+          INVALID_TEMPLATE_EXERCISE_RESPONSE.message,
+        );
+      }
+
+      const swapped = await swapWorkoutTemplateExercise({
+        templateId: request.params.id,
+        userId: request.userId,
+        exerciseId: request.params.exerciseId,
+        newExerciseId: parsedBody.data.newExerciseId,
+      });
+      if (!swapped) {
+        return sendError(
+          reply,
+          404,
+          WORKOUT_TEMPLATE_EXERCISE_NOT_FOUND_RESPONSE.code,
+          WORKOUT_TEMPLATE_EXERCISE_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      const updatedTemplate = await findWorkoutTemplateById(request.params.id, request.userId);
+      if (!updatedTemplate) {
+        return sendError(
+          reply,
+          404,
+          WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE.code,
+          WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      const swappedExercise = updatedTemplate.sections
+        .flatMap((section) => section.exercises)
+        .find((exercise) => exercise.exerciseId === parsedBody.data.newExerciseId);
+      const hasTrackingTypeWarning =
+        swappedExercise?.trackingType !== undefined &&
+        sourceExercise.trackingType !== swappedExercise.trackingType;
+
+      return reply.send({
+        data: updatedTemplate,
+        ...(hasTrackingTypeWarning
+          ? {
+              meta: {
+                warning:
+                  'Swapped to an exercise with a different tracking type. Review set targets and expectations.',
+              },
+            }
+          : {}),
+      });
+    },
+  );
 
   app.delete<{ Params: { id: string } }>('/:id', async (request, reply) => {
     const deleted = await deleteWorkoutTemplate(request.params.id, request.userId);

--- a/apps/api/src/routes/workout-templates/store.ts
+++ b/apps/api/src/routes/workout-templates/store.ts
@@ -460,6 +460,73 @@ export const reorderWorkoutTemplateExercises = async ({
   });
 };
 
+export const swapWorkoutTemplateExercise = async ({
+  templateId,
+  userId,
+  exerciseId,
+  newExerciseId,
+}: {
+  templateId: string;
+  userId: string;
+  exerciseId: string;
+  newExerciseId: string;
+}): Promise<boolean> => {
+  const { db } = await import('../../db/index.js');
+
+  return db.transaction((tx) => {
+    const templateExists = tx
+      .select({ id: workoutTemplates.id })
+      .from(workoutTemplates)
+      .where(
+        and(
+          eq(workoutTemplates.id, templateId),
+          eq(workoutTemplates.userId, userId),
+          isNull(workoutTemplates.deletedAt),
+        ),
+      )
+      .limit(1)
+      .get();
+
+    if (!templateExists) {
+      return false;
+    }
+
+    const updateResult = tx
+      .update(templateExercises)
+      .set({
+        exerciseId: newExerciseId,
+        // Existing template cues are often exercise-specific; clear on swap.
+        cues: null,
+      })
+      .where(
+        and(
+          eq(templateExercises.templateId, templateId),
+          eq(templateExercises.exerciseId, exerciseId),
+        ),
+      )
+      .run();
+
+    if (updateResult.changes === 0) {
+      return false;
+    }
+
+    tx.update(workoutTemplates)
+      .set({
+        updatedAt: Date.now(),
+      })
+      .where(
+        and(
+          eq(workoutTemplates.id, templateId),
+          eq(workoutTemplates.userId, userId),
+          isNull(workoutTemplates.deletedAt),
+        ),
+      )
+      .run();
+
+    return true;
+  });
+};
+
 export const deleteWorkoutTemplate = async (id: string, userId: string): Promise<boolean> => {
   const { db } = await import('../../db/index.js');
 

--- a/apps/api/src/routes/workout-templates/store.ts
+++ b/apps/api/src/routes/workout-templates/store.ts
@@ -470,10 +470,10 @@ export const swapWorkoutTemplateExercise = async ({
   userId: string;
   exerciseId: string;
   newExerciseId: string;
-}): Promise<boolean> => {
+}): Promise<WorkoutTemplate | undefined> => {
   const { db } = await import('../../db/index.js');
 
-  return db.transaction((tx) => {
+  const swapped = db.transaction((tx) => {
     const templateExists = tx
       .select({ id: workoutTemplates.id })
       .from(workoutTemplates)
@@ -525,6 +525,12 @@ export const swapWorkoutTemplateExercise = async ({
 
     return true;
   });
+
+  if (!swapped) {
+    return undefined;
+  }
+
+  return findWorkoutTemplateById(templateId, userId);
 };
 
 export const deleteWorkoutTemplate = async (id: string, userId: string): Promise<boolean> => {

--- a/apps/api/src/routes/workout-templates/store.ts
+++ b/apps/api/src/routes/workout-templates/store.ts
@@ -501,6 +501,8 @@ export const swapWorkoutTemplateExercise = async ({
       .where(
         and(
           eq(templateExercises.templateId, templateId),
+          // Route-level duplicate guards assume one row per (templateId, exerciseId).
+          // Legacy duplicates would all update together until a row-id-based swap is introduced.
           eq(templateExercises.exerciseId, exerciseId),
         ),
       )

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -8,6 +8,8 @@ import {
   scheduledWorkoutQueryParamsSchema,
   scheduledWorkoutSchema,
   reorderWorkoutTemplateExercisesInputSchema,
+  swapWorkoutSessionExerciseInputSchema,
+  swapWorkoutTemplateExerciseInputSchema,
   updateScheduledWorkoutInputSchema,
   updateExerciseInputSchema,
   updateWorkoutTemplateInputSchema,
@@ -69,6 +71,16 @@ type ReorderTemplateExercisesRequest = {
   section: 'warmup' | 'main' | 'cooldown';
   exerciseIds: string[];
 };
+type SwapTemplateExerciseRequest = {
+  templateId: string;
+  exerciseId: string;
+  newExerciseId: string;
+};
+type SwapSessionExerciseRequest = {
+  sessionId: string;
+  exerciseId: string;
+  newExerciseId: string;
+};
 type CreateScheduledWorkoutRequest = CreateScheduledWorkoutInput;
 type UpdateScheduledWorkoutRequest = {
   id: string;
@@ -81,6 +93,17 @@ type DeleteScheduledWorkoutResponse = {
   data: {
     success: boolean;
   };
+};
+type SwapResponseMeta = {
+  warning?: string;
+};
+type SwapTemplateExerciseResponse = {
+  data: WorkoutTemplate;
+  meta?: SwapResponseMeta;
+};
+type SwapSessionExerciseResponse = {
+  data: WorkoutSession;
+  meta?: SwapResponseMeta;
 };
 
 // Preprocess in shared schemas widens inference here, so we pin the parsed response shape explicitly.
@@ -319,6 +342,56 @@ async function reorderTemplateExercises(input: ReorderTemplateExercisesRequest) 
   return payload.data;
 }
 
+async function swapTemplateExercise(input: SwapTemplateExerciseRequest) {
+  const parsedInput = swapWorkoutTemplateExerciseInputSchema.parse({
+    newExerciseId: input.newExerciseId,
+  });
+  const payload = await apiRequestWithMeta<unknown, unknown>(
+    `/api/v1/workout-templates/${input.templateId}/exercises/${input.exerciseId}/swap`,
+    {
+      body: JSON.stringify(parsedInput),
+      method: 'PATCH',
+    },
+  );
+  const parsedPayload = z
+    .object({
+      data: workoutTemplateSchema,
+      meta: z
+        .object({
+          warning: z.string().optional(),
+        })
+        .optional(),
+    })
+    .parse(payload) as SwapTemplateExerciseResponse;
+
+  return parsedPayload;
+}
+
+async function swapSessionExercise(input: SwapSessionExerciseRequest) {
+  const parsedInput = swapWorkoutSessionExerciseInputSchema.parse({
+    newExerciseId: input.newExerciseId,
+  });
+  const payload = await apiRequestWithMeta<unknown, unknown>(
+    `/api/v1/workout-sessions/${input.sessionId}/exercises/${input.exerciseId}/swap`,
+    {
+      body: JSON.stringify(parsedInput),
+      method: 'PATCH',
+    },
+  );
+  const parsedPayload = z
+    .object({
+      data: workoutSessionSchema,
+      meta: z
+        .object({
+          warning: z.string().optional(),
+        })
+        .optional(),
+    })
+    .parse(payload) as SwapSessionExerciseResponse;
+
+  return parsedPayload;
+}
+
 async function createScheduledWorkout(input: CreateScheduledWorkoutRequest) {
   const parsedInput = createScheduledWorkoutInputSchema.parse(input);
   const data = await apiRequest<unknown>('/api/v1/scheduled-workouts', {
@@ -414,8 +487,9 @@ export const prefetchWorkoutTemplate = (queryClient: QueryClient, id: string) =>
     queryFn: ({ signal }) => getWorkoutTemplate(id, signal),
   });
 
-export function useExercises(params: ExerciseQueryParams) {
+export function useExercises(params: ExerciseQueryParams, options?: { enabled?: boolean }) {
   return useQuery<ExercisesResponse>({
+    enabled: options?.enabled,
     placeholderData: (previousData) => previousData,
     // getExercises already validates/normalizes with the shared schema.
     queryFn: () => getExercises(params),
@@ -576,6 +650,48 @@ export function useReorderTemplateExercises() {
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.template(variables.templateId),
+        }),
+      ]);
+    },
+  });
+}
+
+export function useSwapTemplateExercise() {
+  const queryClient = useQueryClient();
+
+  return useMutation<SwapTemplateExerciseResponse, Error, SwapTemplateExerciseRequest>({
+    mutationFn: swapTemplateExercise,
+    onSuccess: async (_, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.templates(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.template(variables.templateId),
+        }),
+      ]);
+    },
+  });
+}
+
+export function useSwapSessionExercise() {
+  const queryClient = useQueryClient();
+
+  return useMutation<SwapSessionExerciseResponse, Error, SwapSessionExerciseRequest>({
+    mutationFn: swapSessionExercise,
+    onSuccess: async (_, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.sessions(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.session(variables.sessionId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ['workout-sessions'],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ['workout-sessions', variables.sessionId],
         }),
       ]);
     },

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -687,12 +687,6 @@ export function useSwapSessionExercise() {
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.session(variables.sessionId),
         }),
-        queryClient.invalidateQueries({
-          queryKey: ['workout-sessions'],
-        }),
-        queryClient.invalidateQueries({
-          queryKey: ['workout-sessions', variables.sessionId],
-        }),
       ]);
     },
   });

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -1,11 +1,13 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import type { MouseEvent, ReactNode } from 'react';
-import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
 
 import { createAppQueryClient } from '@/lib/query-client';
 import { mockTemplates } from '@/lib/mock-data/workouts';
 import { renderWithQueryClient } from '@/test/render-with-query-client';
+import { jsonResponse } from '@/test/test-utils';
 
 import {
   buildActiveWorkoutSession,
@@ -378,6 +380,175 @@ describe('SessionExerciseList', () => {
     const dialog = await screen.findByRole('dialog');
     expect(within(dialog).getByLabelText('Exercise name')).toHaveValue('Row Erg');
     expect(within(dialog).getByRole('button', { name: 'Rename' })).toBeDisabled();
+  });
+
+  it('opens swap dialog from the exercise actions menu and calls session swap endpoint', async () => {
+    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/exercises') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'row-erg',
+                userId: 'user-1',
+                name: 'Row Erg',
+                muscleGroups: ['back'],
+                equipment: 'Erg',
+                category: 'cardio',
+                trackingType: 'seconds_only',
+                tags: [],
+                formCues: [],
+                instructions: null,
+                coachingNotes: null,
+                relatedExerciseIds: ['assault-bike'],
+                createdAt: 1,
+                updatedAt: 1,
+              },
+              {
+                id: 'assault-bike',
+                userId: 'user-1',
+                name: 'Assault Bike',
+                muscleGroups: ['legs', 'cardio'],
+                equipment: 'Bike',
+                category: 'cardio',
+                trackingType: 'seconds_only',
+                tags: [],
+                formCues: [],
+                instructions: null,
+                coachingNotes: null,
+                relatedExerciseIds: [],
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            ],
+            meta: {
+              page: 1,
+              limit: 100,
+              total: 2,
+            },
+          }),
+        );
+      }
+
+      if (
+        url.pathname === '/api/v1/workout-sessions/session-1/exercises/row-erg/swap' &&
+        init?.method === 'PATCH'
+      ) {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: 'session-1',
+              userId: 'user-1',
+              templateId: 'template-1',
+              name: 'Upper Push',
+              date: '2026-03-06',
+              status: 'in-progress',
+              startedAt: 1,
+              completedAt: null,
+              duration: null,
+              timeSegments: [
+                {
+                  start: '2026-03-06T00:00:00.000Z',
+                  end: null,
+                },
+              ],
+              feedback: null,
+              notes: null,
+              exercises: [
+                {
+                  exerciseId: 'assault-bike',
+                  exerciseName: 'Assault Bike',
+                  trackingType: 'seconds_only',
+                  orderIndex: 0,
+                  section: 'warmup',
+                  sets: [
+                    {
+                      id: 'set-1',
+                      exerciseId: 'assault-bike',
+                      setNumber: 1,
+                      weight: null,
+                      reps: 30,
+                      completed: false,
+                      skipped: false,
+                      section: 'warmup',
+                      notes: null,
+                      createdAt: 1,
+                    },
+                  ],
+                },
+              ],
+              sets: [
+                {
+                  id: 'set-1',
+                  exerciseId: 'assault-bike',
+                  setNumber: 1,
+                  weight: null,
+                  reps: 30,
+                  completed: false,
+                  skipped: false,
+                  section: 'warmup',
+                  notes: null,
+                  createdAt: 1,
+                },
+              ],
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          }),
+        );
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch request: ${String(input)}`));
+    });
+
+    if (!activeTemplate) {
+      throw new Error('Expected upper-push template in mock data.');
+    }
+
+    const session = buildActiveWorkoutSession(
+      activeTemplate,
+      createInitialWorkoutSetDrafts(activeTemplate, new Set()),
+    );
+
+    renderWithQueryClient(
+      <SessionExerciseList
+        onAddSet={vi.fn()}
+        onExerciseNotesChange={vi.fn()}
+        onRemoveSet={vi.fn()}
+        onRestTimerComplete={vi.fn()}
+        onSetUpdate={vi.fn()}
+        session={session}
+        sessionId="session-1"
+      />,
+    );
+
+    const rowErgCard = screen
+      .getByRole('heading', { level: 3, name: 'Row Erg' })
+      .closest('[data-slot="card"]');
+
+    if (!rowErgCard) {
+      throw new Error('Expected Row Erg card.');
+    }
+
+    fireEvent.click(within(rowErgCard as HTMLElement).getByRole('button', { name: 'Swap exercise' }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(await within(dialog).findByText('Related exercises')).toBeInTheDocument();
+    fireEvent.click(await within(dialog).findByRole('button', { name: /Assault Bike/i }));
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(
+          ([input, init]) =>
+            String(input).includes('/api/v1/workout-sessions/session-1/exercises/row-erg/swap') &&
+            init?.method === 'PATCH',
+        ),
+      ).toBe(true);
+    });
+    window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
   });
 
   it('shows move up/down actions and calls onReorderExercises for active workout lists', () => {

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -73,6 +73,7 @@ import { FormCueChips } from './form-cue-chips';
 import { RenameExerciseDialog } from './rename-exercise-dialog';
 import { RestTimer } from './rest-timer';
 import { SetRow, type SetRowUpdate } from './set-row';
+import { SwapExerciseDialog } from './swap-exercise-dialog';
 
 type RestTimerState = {
   duration: number;
@@ -99,6 +100,7 @@ type SessionExerciseListProps = {
   onSetUpdate: (exerciseId: string, setId: string, update: SetRowUpdate) => void;
   restTimer?: RestTimerState | null;
   session: ActiveWorkoutSessionData;
+  sessionId?: string | null;
   sessionCuesByExercise?: Record<string, string[]>;
   weightUnit?: WeightUnit;
 };
@@ -146,6 +148,7 @@ export function SessionExerciseList({
   onSetUpdate,
   restTimer = null,
   session,
+  sessionId = null,
   sessionCuesByExercise,
   weightUnit = 'lbs',
 }: SessionExerciseListProps) {
@@ -156,6 +159,10 @@ export function SessionExerciseList({
   >({});
   const [visibleNotesPanels, setVisibleNotesPanels] = useState<Record<string, boolean>>({});
   const [renameTarget, setRenameTarget] = useState<{
+    exerciseId: string;
+    exerciseName: string;
+  } | null>(null);
+  const [swapTarget, setSwapTarget] = useState<{
     exerciseId: string;
     exerciseName: string;
   } | null>(null);
@@ -334,6 +341,12 @@ export function SessionExerciseList({
                                 exerciseName: item.exercise.name,
                               })
                             }
+                            onSwapExercise={() =>
+                              setSwapTarget({
+                                exerciseId: item.exercise.id,
+                                exerciseName: item.exercise.name,
+                              })
+                            }
                             onRemoveSet={onRemoveSet}
                             onRestTimerComplete={onRestTimerComplete}
                             onSetUpdate={onSetUpdate}
@@ -419,6 +432,12 @@ export function SessionExerciseList({
                                         exerciseName: exercise.name,
                                       })
                                     }
+                                    onSwapExercise={() =>
+                                      setSwapTarget({
+                                        exerciseId: exercise.id,
+                                        exerciseName: exercise.name,
+                                      })
+                                    }
                                     onRemoveSet={onRemoveSet}
                                     onRestTimerComplete={onRestTimerComplete}
                                     onSetUpdate={onSetUpdate}
@@ -498,6 +517,21 @@ export function SessionExerciseList({
         sourceLabel="the active workout"
         value={renameTarget?.exerciseName ?? ''}
       />
+      {sessionId ? (
+        <SwapExerciseDialog
+          contextId={sessionId}
+          mode="session"
+          onOpenChange={(open) => {
+            if (!open) {
+              setSwapTarget(null);
+            }
+          }}
+          open={swapTarget != null}
+          sourceExerciseId={swapTarget?.exerciseId ?? ''}
+          sourceExerciseName={swapTarget?.exerciseName ?? ''}
+          sourceLabel="this workout"
+        />
+      ) : null}
     </div>
   );
 
@@ -528,6 +562,7 @@ type ExerciseCardItemProps = {
   onMoveDown: () => void;
   onMoveUp: () => void;
   onRenameExercise: () => void;
+  onSwapExercise: () => void;
   onRemoveSet: (exerciseId: string) => void;
   onRestTimerComplete: () => void;
   onAddSessionCue: (cue: string) => void;
@@ -555,6 +590,7 @@ function ExerciseCardItem({
   onMoveDown,
   onMoveUp,
   onRenameExercise,
+  onSwapExercise,
   onRemoveSet,
   onRestTimerComplete,
   onAddSessionCue,
@@ -727,6 +763,7 @@ function ExerciseCardItem({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={onSwapExercise}>Swap exercise</DropdownMenuItem>
             <DropdownMenuItem disabled={isMoveUpDisabled} onClick={onMoveUp}>
               <ArrowUp aria-hidden="true" className="size-4" />
               Move up

--- a/apps/web/src/features/workouts/components/swap-exercise-dialog.test.tsx
+++ b/apps/web/src/features/workouts/components/swap-exercise-dialog.test.tsx
@@ -1,0 +1,248 @@
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
+import { renderWithQueryClient } from '@/test/render-with-query-client';
+import { jsonResponse } from '@/test/test-utils';
+
+import { SwapExerciseDialog } from './swap-exercise-dialog';
+
+describe('SwapExerciseDialog', () => {
+  beforeEach(() => {
+    window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
+  });
+
+  afterEach(() => {
+    window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
+    vi.restoreAllMocks();
+  });
+
+  it('surfaces related exercises first and filters search results', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/exercises') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'row-erg',
+                userId: 'user-1',
+                name: 'Row Erg',
+                muscleGroups: ['back'],
+                equipment: 'Erg',
+                category: 'cardio',
+                trackingType: 'seconds_only',
+                tags: [],
+                formCues: [],
+                instructions: null,
+                coachingNotes: null,
+                relatedExerciseIds: ['assault-bike'],
+                createdAt: 1,
+                updatedAt: 1,
+              },
+              {
+                id: 'assault-bike',
+                userId: 'user-1',
+                name: 'Assault Bike',
+                muscleGroups: ['legs'],
+                equipment: 'Bike',
+                category: 'cardio',
+                trackingType: 'seconds_only',
+                tags: [],
+                formCues: [],
+                instructions: null,
+                coachingNotes: null,
+                relatedExerciseIds: [],
+                createdAt: 1,
+                updatedAt: 1,
+              },
+              {
+                id: 'incline-dumbbell-press',
+                userId: 'user-1',
+                name: 'Incline Dumbbell Press',
+                muscleGroups: ['chest'],
+                equipment: 'Dumbbells',
+                category: 'compound',
+                trackingType: 'weight_reps',
+                tags: [],
+                formCues: [],
+                instructions: null,
+                coachingNotes: null,
+                relatedExerciseIds: [],
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            ],
+            meta: {
+              page: 1,
+              limit: 100,
+              total: 3,
+            },
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <SwapExerciseDialog
+        contextId="template-1"
+        mode="template"
+        onOpenChange={vi.fn()}
+        open
+        sourceExerciseId="row-erg"
+        sourceExerciseName="Row Erg"
+        sourceLabel="this template"
+      />,
+    );
+
+    const dialog = await screen.findByRole('dialog');
+    const relatedTitle = await within(dialog).findByText('Related exercises');
+    const allTitle = await within(dialog).findByText('All exercises');
+    const relatedSection = relatedTitle.closest('div');
+    const allSection = allTitle.closest('div');
+
+    expect(relatedSection).not.toBeNull();
+    expect(allSection).not.toBeNull();
+    expect(within(relatedSection as HTMLElement).getByText('Assault Bike')).toBeInTheDocument();
+    expect(
+      within(allSection as HTMLElement).getByText('Incline Dumbbell Press'),
+    ).toBeInTheDocument();
+
+    fireEvent.change(within(dialog).getByLabelText('Search exercises'), {
+      target: { value: 'incline' },
+    });
+
+    expect(within(dialog).queryByText('Assault Bike')).not.toBeInTheDocument();
+    expect(within(dialog).getByText('Incline Dumbbell Press')).toBeInTheDocument();
+  });
+
+  it('calls swap API when an exercise is selected', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/exercises') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'row-erg',
+                userId: 'user-1',
+                name: 'Row Erg',
+                muscleGroups: ['back'],
+                equipment: 'Erg',
+                category: 'cardio',
+                trackingType: 'seconds_only',
+                tags: [],
+                formCues: [],
+                instructions: null,
+                coachingNotes: null,
+                relatedExerciseIds: ['assault-bike'],
+                createdAt: 1,
+                updatedAt: 1,
+              },
+              {
+                id: 'assault-bike',
+                userId: 'user-1',
+                name: 'Assault Bike',
+                muscleGroups: ['legs'],
+                equipment: 'Bike',
+                category: 'cardio',
+                trackingType: 'seconds_only',
+                tags: [],
+                formCues: [],
+                instructions: null,
+                coachingNotes: null,
+                relatedExerciseIds: [],
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            ],
+            meta: {
+              page: 1,
+              limit: 100,
+              total: 2,
+            },
+          }),
+        );
+      }
+
+      if (
+        url.pathname === '/api/v1/workout-templates/template-1/exercises/row-erg/swap' &&
+        init?.method === 'PATCH'
+      ) {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: 'template-1',
+              userId: 'user-1',
+              name: 'Template',
+              description: null,
+              tags: [],
+              sections: [
+                {
+                  type: 'warmup',
+                  exercises: [
+                    {
+                      id: 'template-row',
+                      exerciseId: 'assault-bike',
+                      exerciseName: 'Assault Bike',
+                      trackingType: 'seconds_only',
+                      sets: 1,
+                      repsMin: 30,
+                      repsMax: 30,
+                      tempo: null,
+                      restSeconds: 0,
+                      supersetGroup: null,
+                      notes: null,
+                      cues: [],
+                    },
+                  ],
+                },
+                {
+                  type: 'main',
+                  exercises: [],
+                },
+                {
+                  type: 'cooldown',
+                  exercises: [],
+                },
+              ],
+              createdAt: 1,
+              updatedAt: 2,
+            },
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <SwapExerciseDialog
+        contextId="template-1"
+        mode="template"
+        onOpenChange={vi.fn()}
+        open
+        sourceExerciseId="row-erg"
+        sourceExerciseName="Row Erg"
+        sourceLabel="this template"
+      />,
+    );
+
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.click(await within(dialog).findByRole('button', { name: /Assault Bike/i }));
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(
+          ([input, init]) =>
+            String(input).includes('/api/v1/workout-templates/template-1/exercises/row-erg/swap') &&
+            init?.method === 'PATCH',
+        ),
+      ).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/features/workouts/components/swap-exercise-dialog.tsx
+++ b/apps/web/src/features/workouts/components/swap-exercise-dialog.tsx
@@ -1,0 +1,287 @@
+import { useMemo, useState } from 'react';
+import type { Exercise } from '@pulse/shared';
+import { toast } from 'sonner';
+
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { ApiError } from '@/lib/api-client';
+
+import { useExercises, useSwapSessionExercise, useSwapTemplateExercise } from '../api/workouts';
+import { getTrackingTypeLabel } from '../lib/tracking';
+
+type SwapExerciseDialogProps = {
+  contextId: string;
+  mode: 'session' | 'template';
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  sourceExerciseId: string;
+  sourceExerciseName: string;
+  sourceLabel: string;
+};
+
+export function SwapExerciseDialog({
+  contextId,
+  mode,
+  onOpenChange,
+  open,
+  sourceExerciseId,
+  sourceExerciseName,
+  sourceLabel,
+}: SwapExerciseDialogProps) {
+  const [search, setSearch] = useState('');
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const exercisesQuery = useExercises(
+    {
+      limit: 100,
+      page: 1,
+    },
+    {
+      enabled: open,
+    },
+  );
+  const swapTemplateExerciseMutation = useSwapTemplateExercise();
+  const swapSessionExerciseMutation = useSwapSessionExercise();
+  const isPending =
+    swapTemplateExerciseMutation.isPending || swapSessionExerciseMutation.isPending;
+  const selectedExerciseId = useMemo(() => {
+    if (swapTemplateExerciseMutation.isPending) {
+      return swapTemplateExerciseMutation.variables?.newExerciseId;
+    }
+
+    if (swapSessionExerciseMutation.isPending) {
+      return swapSessionExerciseMutation.variables?.newExerciseId;
+    }
+
+    return null;
+  }, [
+    swapSessionExerciseMutation.isPending,
+    swapSessionExerciseMutation.variables?.newExerciseId,
+    swapTemplateExerciseMutation.isPending,
+    swapTemplateExerciseMutation.variables?.newExerciseId,
+  ]);
+
+  const exercises = useMemo(() => exercisesQuery.data?.data ?? [], [exercisesQuery.data?.data]);
+  const exerciseMap = useMemo(() => new Map(exercises.map((exercise) => [exercise.id, exercise])), [exercises]);
+  const sourceExercise = exerciseMap.get(sourceExerciseId);
+  const relatedIds = useMemo(
+    () => sourceExercise?.relatedExerciseIds ?? [],
+    [sourceExercise?.relatedExerciseIds],
+  );
+  const normalizedSearch = search.trim().toLowerCase();
+
+  const filteredExercises = useMemo(() => {
+    return exercises
+      .filter((exercise) => exercise.id !== sourceExerciseId)
+      .filter((exercise) => matchesSearch(exercise, normalizedSearch))
+      .sort((left, right) => left.name.localeCompare(right.name));
+  }, [exercises, normalizedSearch, sourceExerciseId]);
+
+  const relatedExercises = useMemo(() => {
+    if (relatedIds.length === 0) {
+      return [];
+    }
+
+    return relatedIds
+      .map((id) => exerciseMap.get(id))
+      .filter((exercise): exercise is Exercise => exercise !== undefined)
+      .filter((exercise) => exercise.id !== sourceExerciseId)
+      .filter((exercise) => matchesSearch(exercise, normalizedSearch));
+  }, [exerciseMap, normalizedSearch, relatedIds, sourceExerciseId]);
+
+  const relatedIdSet = useMemo(
+    () => new Set(relatedExercises.map((exercise) => exercise.id)),
+    [relatedExercises],
+  );
+  const allExercises = useMemo(
+    () => filteredExercises.filter((exercise) => !relatedIdSet.has(exercise.id)),
+    [filteredExercises, relatedIdSet],
+  );
+
+  async function handleSwapSelection(targetExercise: Exercise) {
+    if (isPending) {
+      return;
+    }
+
+    setSubmitError(null);
+
+    try {
+      const payload =
+        mode === 'template'
+          ? await swapTemplateExerciseMutation.mutateAsync({
+              templateId: contextId,
+              exerciseId: sourceExerciseId,
+              newExerciseId: targetExercise.id,
+            })
+          : await swapSessionExerciseMutation.mutateAsync({
+              sessionId: contextId,
+              exerciseId: sourceExerciseId,
+              newExerciseId: targetExercise.id,
+            });
+
+      toast.success(`Swapped ${sourceExerciseName} → ${targetExercise.name}`);
+      if (payload.meta?.warning) {
+        toast(payload.meta.warning);
+      }
+      onOpenChange(false);
+    } catch (error) {
+      setSubmitError(
+        error instanceof ApiError ? error.message : 'Unable to swap exercise. Try again.',
+      );
+    }
+  }
+
+  return (
+    <Dialog
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          setSearch('');
+          setSubmitError(null);
+        }
+        onOpenChange(nextOpen);
+      }}
+      open={open}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Swap exercise</DialogTitle>
+          <DialogDescription>{`Replace ${sourceExerciseName} in ${sourceLabel}.`}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <Input
+            aria-label="Search exercises"
+            autoFocus
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search exercises..."
+            value={search}
+          />
+
+          {submitError ? <p className="text-sm text-destructive">{submitError}</p> : null}
+
+          {exercisesQuery.isPending ? (
+            <p className="text-sm text-muted">Loading exercises...</p>
+          ) : null}
+
+          {exercisesQuery.isError ? (
+            <p className="text-sm text-destructive">Unable to load exercises.</p>
+          ) : null}
+
+          {!exercisesQuery.isPending && !exercisesQuery.isError ? (
+            <div className="max-h-[22rem] space-y-4 overflow-y-auto">
+              {relatedExercises.length > 0 ? (
+                <div className="space-y-2">
+                  <h3 className="text-xs font-semibold tracking-[0.14em] text-muted uppercase">
+                    Related exercises
+                  </h3>
+                  <div className="space-y-2">
+                    {relatedExercises.map((exercise) => (
+                      <ExerciseOptionRow
+                        exercise={exercise}
+                        isPending={isPending}
+                        key={exercise.id}
+                        onSelect={handleSwapSelection}
+                        selectedExerciseId={selectedExerciseId}
+                      />
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+
+              <div className="space-y-2">
+                <h3 className="text-xs font-semibold tracking-[0.14em] text-muted uppercase">
+                  All exercises
+                </h3>
+                {allExercises.length > 0 ? (
+                  <div className="space-y-2">
+                    {allExercises.map((exercise) => (
+                      <ExerciseOptionRow
+                        exercise={exercise}
+                        isPending={isPending}
+                        key={exercise.id}
+                        onSelect={handleSwapSelection}
+                        selectedExerciseId={selectedExerciseId}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted">No exercises match your search.</p>
+                )}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ExerciseOptionRow({
+  exercise,
+  isPending,
+  onSelect,
+  selectedExerciseId,
+}: {
+  exercise: Exercise;
+  isPending: boolean;
+  onSelect: (exercise: Exercise) => void;
+  selectedExerciseId: string | null;
+}) {
+  const isSelected = selectedExerciseId === exercise.id;
+
+  return (
+    <button
+      className="flex w-full items-center justify-between gap-3 rounded-xl border border-border bg-background px-3 py-2 text-left transition-colors hover:bg-secondary/45 disabled:cursor-not-allowed disabled:opacity-60"
+      disabled={isPending}
+      onClick={() => onSelect(exercise)}
+      type="button"
+    >
+      <div className="min-w-0 space-y-0.5">
+        <p className="truncate text-sm font-medium text-foreground">{exercise.name}</p>
+        <p className="truncate text-xs text-muted">{formatMuscleGroupLabel(exercise.muscleGroups)}</p>
+      </div>
+
+      <Badge className="shrink-0 border-border bg-secondary/70 text-secondary-foreground" variant="outline">
+        {isSelected ? 'Swapping...' : getTrackingTypeLabel(exercise.trackingType)}
+      </Badge>
+    </button>
+  );
+}
+
+function formatMuscleGroupLabel(muscleGroups: string[]) {
+  if (muscleGroups.length === 0) {
+    return 'General';
+  }
+
+  return muscleGroups.map(formatLabel).join(', ');
+}
+
+function formatLabel(value: string) {
+  return value
+    .split(/[- ]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function matchesSearch(exercise: Exercise, normalizedSearch: string) {
+  if (!normalizedSearch) {
+    return true;
+  }
+
+  const searchTarget = [
+    exercise.name,
+    ...exercise.muscleGroups,
+    getTrackingTypeLabel(exercise.trackingType),
+  ]
+    .join(' ')
+    .toLowerCase();
+
+  return searchTarget.includes(normalizedSearch);
+}

--- a/apps/web/src/features/workouts/components/swap-exercise-dialog.tsx
+++ b/apps/web/src/features/workouts/components/swap-exercise-dialog.tsx
@@ -41,6 +41,7 @@ export function SwapExerciseDialog({
     {
       limit: 100,
       page: 1,
+      q: search.trim() ? search.trim() : undefined,
     },
     {
       enabled: open,
@@ -52,11 +53,11 @@ export function SwapExerciseDialog({
     swapTemplateExerciseMutation.isPending || swapSessionExerciseMutation.isPending;
   const selectedExerciseId = useMemo(() => {
     if (swapTemplateExerciseMutation.isPending) {
-      return swapTemplateExerciseMutation.variables?.newExerciseId;
+      return swapTemplateExerciseMutation.variables?.newExerciseId ?? null;
     }
 
     if (swapSessionExerciseMutation.isPending) {
-      return swapSessionExerciseMutation.variables?.newExerciseId;
+      return swapSessionExerciseMutation.variables?.newExerciseId ?? null;
     }
 
     return null;
@@ -127,7 +128,7 @@ export function SwapExerciseDialog({
 
       toast.success(`Swapped ${sourceExerciseName} → ${targetExercise.name}`);
       if (payload.meta?.warning) {
-        toast(payload.meta.warning);
+        toast.warning(payload.meta.warning);
       }
       onOpenChange(false);
     } catch (error) {

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -645,6 +645,132 @@ describe('WorkoutTemplateDetail', () => {
     expect(screen.queryByText('Incline Dumbbell Press')).not.toBeInTheDocument();
   });
 
+  it('opens swap dialog from template exercise menu and swaps to a related exercise', async () => {
+    const mutableTemplate = structuredClone(templatePayload);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/workout-templates/upper-push') {
+        return Promise.resolve(jsonResponse(mutableTemplate));
+      }
+
+      if (url.pathname === '/api/v1/exercises') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'incline-dumbbell-press',
+                userId: 'user-1',
+                name: 'Incline Dumbbell Press',
+                muscleGroups: ['upper chest', 'triceps'],
+                equipment: 'Dumbbells',
+                category: 'compound',
+                trackingType: 'weight_reps',
+                tags: [],
+                formCues: [],
+                instructions: null,
+                coachingNotes: null,
+                relatedExerciseIds: ['seated-dumbbell-shoulder-press'],
+                createdAt: 1,
+                updatedAt: 1,
+              },
+              {
+                id: 'seated-dumbbell-shoulder-press',
+                userId: 'user-1',
+                name: 'Seated Dumbbell Shoulder Press',
+                muscleGroups: ['shoulders', 'triceps'],
+                equipment: 'Dumbbells',
+                category: 'compound',
+                trackingType: 'weight_reps',
+                tags: [],
+                formCues: [],
+                instructions: null,
+                coachingNotes: null,
+                relatedExerciseIds: [],
+                createdAt: 1,
+                updatedAt: 1,
+              },
+              {
+                id: 'cable-fly',
+                userId: 'user-1',
+                name: 'Cable Fly',
+                muscleGroups: ['chest'],
+                equipment: 'Cable',
+                category: 'isolation',
+                trackingType: 'reps_only',
+                tags: [],
+                formCues: [],
+                instructions: null,
+                coachingNotes: null,
+                relatedExerciseIds: [],
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            ],
+            meta: {
+              page: 1,
+              limit: 100,
+              total: 3,
+            },
+          }),
+        );
+      }
+
+      if (
+        url.pathname === '/api/v1/workout-templates/upper-push/exercises/incline-dumbbell-press/swap' &&
+        init?.method === 'PATCH'
+      ) {
+        mutableTemplate.data.sections[1].exercises[0].exerciseId = 'seated-dumbbell-shoulder-press';
+        mutableTemplate.data.sections[1].exercises[0].exerciseName = 'Seated Dumbbell Shoulder Press';
+
+        return Promise.resolve(jsonResponse(mutableTemplate));
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutTemplateDetail templateId="upper-push" />
+      </MemoryRouter>,
+    );
+
+    const exerciseCard = (await screen.findByText('Incline Dumbbell Press')).closest(
+      '[data-slot="card"]',
+    );
+    expect(exerciseCard).not.toBeNull();
+
+    fireEvent.click(
+      within(exerciseCard as HTMLElement).getByRole('button', {
+        name: 'Exercise actions for Incline Dumbbell Press',
+      }),
+    );
+    fireEvent.click(
+      within(exerciseCard as HTMLElement).getByRole('button', { name: 'Swap exercise' }),
+    );
+
+    const dialog = await screen.findByRole('dialog');
+    expect(await within(dialog).findByText('Related exercises')).toBeInTheDocument();
+    expect(
+      await within(dialog).findByRole('button', { name: /Seated Dumbbell Shoulder Press/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      within(dialog).getByRole('button', { name: /Seated Dumbbell Shoulder Press/i }),
+    );
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(
+          ([input, init]) =>
+            String(input).includes(
+              '/api/v1/workout-templates/upper-push/exercises/incline-dumbbell-press/swap',
+            ) && init?.method === 'PATCH',
+        ),
+      ).toBe(true);
+    });
+  });
+
   it('moves template exercises down from the exercise menu and calls reorder endpoint', async () => {
     const mutableTemplate = structuredClone(templatePayload);
     const mainExercises = mutableTemplate.data.sections[1].exercises as Array<

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -51,6 +51,7 @@ import {
 import { FormCueChips } from './form-cue-chips';
 import { RenameExerciseDialog } from './rename-exercise-dialog';
 import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
+import { SwapExerciseDialog } from './swap-exercise-dialog';
 
 type WorkoutTemplateDetailProps = {
   templateId: string;
@@ -73,6 +74,10 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
   const renameExerciseMutation = useRenameExercise();
   const reorderExercisesMutation = useReorderTemplateExercises();
   const [renameTarget, setRenameTarget] = useState<{
+    exerciseId: string;
+    exerciseName: string;
+  } | null>(null);
+  const [swapTarget, setSwapTarget] = useState<{
     exerciseId: string;
     exerciseName: string;
   } | null>(null);
@@ -275,6 +280,12 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
                             exerciseName: exercise.exerciseName,
                           })
                         }
+                        onSwap={() =>
+                          setSwapTarget({
+                            exerciseId: exercise.exerciseId,
+                            exerciseName: exercise.exerciseName,
+                          })
+                        }
                       />
                     ))}
                   </SortableContext>
@@ -320,6 +331,19 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
         open={renameTarget != null}
         sourceLabel="this template"
         value={renameTarget?.exerciseName ?? ''}
+      />
+      <SwapExerciseDialog
+        contextId={template.id}
+        mode="template"
+        onOpenChange={(open) => {
+          if (!open) {
+            setSwapTarget(null);
+          }
+        }}
+        open={swapTarget != null}
+        sourceExerciseId={swapTarget?.exerciseId ?? ''}
+        sourceExerciseName={swapTarget?.exerciseName ?? ''}
+        sourceLabel="this template"
       />
 
       <div className="space-y-2">
@@ -439,6 +463,7 @@ function TemplateExerciseCard({
   onMoveDown,
   onMoveUp,
   onRename,
+  onSwap,
 }: {
   exercise: WorkoutTemplateExercise;
   index: number;
@@ -448,6 +473,7 @@ function TemplateExerciseCard({
   onMoveDown: () => void;
   onMoveUp: () => void;
   onRename: () => void;
+  onSwap: () => void;
 }) {
   const prescription = formatPrescription(exercise, weightUnit);
   const targetBreakdown = formatSetTargetBreakdown(exercise, weightUnit);
@@ -496,6 +522,7 @@ function TemplateExerciseCard({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={onSwap}>Swap exercise</DropdownMenuItem>
               <DropdownMenuItem disabled={isMoveUpDisabled} onClick={onMoveUp}>
                 <ArrowUp aria-hidden="true" className="size-4" />
                 Move up

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -630,6 +630,7 @@ export function ActiveWorkoutPage() {
             onSetUpdate={handleSetUpdate}
             restTimer={restTimer}
             session={session}
+            sessionId={activeSessionId}
             sessionCuesByExercise={sessionCuesByExercise}
             weightUnit={weightUnit}
           />

--- a/packages/shared/src/schemas/workout-sessions.test.ts
+++ b/packages/shared/src/schemas/workout-sessions.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, it } from 'vitest';
 import {
   createWorkoutSessionInputSchema,
   reorderWorkoutSessionExercisesInputSchema,
+  swapWorkoutSessionExerciseInputSchema,
   sessionSetSchema,
   saveWorkoutSessionAsTemplateInputSchema,
   sessionSetInputSchema,
   type CreateWorkoutSessionInput,
   type SaveWorkoutSessionAsTemplateInput,
+  type SwapWorkoutSessionExerciseInput,
   type UpdateWorkoutSessionInput,
   type UpdateWorkoutSessionTimeSegmentsInput,
   type WorkoutSession,
@@ -460,6 +462,26 @@ describe('reorderWorkoutSessionExercisesInputSchema', () => {
       reorderWorkoutSessionExercisesInputSchema.parse({
         section: 'warmup',
         exerciseIds: ['exercise-1', ''],
+      }),
+    ).toThrow();
+  });
+});
+
+describe('swapWorkoutSessionExerciseInputSchema', () => {
+  it('accepts a replacement exercise id', () => {
+    const payload: SwapWorkoutSessionExerciseInput = swapWorkoutSessionExerciseInputSchema.parse({
+      newExerciseId: 'exercise-2',
+    });
+
+    expect(payload).toEqual({
+      newExerciseId: 'exercise-2',
+    });
+  });
+
+  it('rejects blank replacement ids', () => {
+    expect(() =>
+      swapWorkoutSessionExerciseInputSchema.parse({
+        newExerciseId: '',
       }),
     ).toThrow();
   });

--- a/packages/shared/src/schemas/workout-sessions.ts
+++ b/packages/shared/src/schemas/workout-sessions.ts
@@ -393,6 +393,10 @@ export const reorderWorkoutSessionExercisesInputSchema = z.object({
   exerciseIds: z.array(requiredStringSchema).max(100),
 });
 
+export const swapWorkoutSessionExerciseInputSchema = z.object({
+  newExerciseId: requiredStringSchema,
+});
+
 export const saveWorkoutSessionAsTemplateInputSchema = z.preprocess(
   (value) => (value === null || value === undefined ? {} : value),
   z.object({
@@ -439,6 +443,7 @@ export type UpdateWorkoutSessionTimeSegmentsInput = z.infer<
 export type ReorderWorkoutSessionExercisesInput = z.infer<
   typeof reorderWorkoutSessionExercisesInputSchema
 >;
+export type SwapWorkoutSessionExerciseInput = z.infer<typeof swapWorkoutSessionExerciseInputSchema>;
 export type SaveWorkoutSessionAsTemplateInput = z.infer<
   typeof saveWorkoutSessionAsTemplateInputSchema
 >;

--- a/packages/shared/src/schemas/workout-templates.test.ts
+++ b/packages/shared/src/schemas/workout-templates.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest';
 import {
   createWorkoutTemplateInputSchema,
   reorderWorkoutTemplateExercisesInputSchema,
+  swapWorkoutTemplateExerciseInputSchema,
   type CreateWorkoutTemplateInput,
+  type SwapWorkoutTemplateExerciseInput,
   type UpdateWorkoutTemplateInput,
   type WorkoutTemplate,
   type WorkoutTemplateSectionType,
@@ -347,6 +349,26 @@ describe('reorderWorkoutTemplateExercisesInputSchema', () => {
       reorderWorkoutTemplateExercisesInputSchema.parse({
         section: 'main',
         exerciseIds: ['exercise-1', '  '],
+      }),
+    ).toThrow();
+  });
+});
+
+describe('swapWorkoutTemplateExerciseInputSchema', () => {
+  it('accepts a replacement exercise id', () => {
+    const payload: SwapWorkoutTemplateExerciseInput = swapWorkoutTemplateExerciseInputSchema.parse({
+      newExerciseId: 'exercise-2',
+    });
+
+    expect(payload).toEqual({
+      newExerciseId: 'exercise-2',
+    });
+  });
+
+  it('rejects blank replacement ids', () => {
+    expect(() =>
+      swapWorkoutTemplateExerciseInputSchema.parse({
+        newExerciseId: '   ',
       }),
     ).toThrow();
   });

--- a/packages/shared/src/schemas/workout-templates.ts
+++ b/packages/shared/src/schemas/workout-templates.ts
@@ -218,6 +218,10 @@ export const reorderWorkoutTemplateExercisesInputSchema = z.object({
   exerciseIds: z.array(z.string().trim().min(1)).max(100),
 });
 
+export const swapWorkoutTemplateExerciseInputSchema = z.object({
+  newExerciseId: requiredStringSchema,
+});
+
 export type WorkoutTemplateSectionType = z.infer<typeof workoutTemplateSectionTypeSchema>;
 export type WorkoutTemplateExerciseSet = z.infer<typeof workoutTemplateExerciseSetSchema>;
 export type WorkoutTemplateExercise = z.infer<typeof workoutTemplateExerciseSchema>;
@@ -227,4 +231,7 @@ export type CreateWorkoutTemplateInput = z.infer<typeof createWorkoutTemplateInp
 export type UpdateWorkoutTemplateInput = z.infer<typeof updateWorkoutTemplateInputSchema>;
 export type ReorderWorkoutTemplateExercisesInput = z.infer<
   typeof reorderWorkoutTemplateExercisesInputSchema
+>;
+export type SwapWorkoutTemplateExerciseInput = z.infer<
+  typeof swapWorkoutTemplateExerciseInputSchema
 >;


### PR DESCRIPTION
## Summary
This PR adds first-class exercise swapping for both workout templates and active workout sessions. It introduces new PATCH endpoints and shared request schemas so clients can replace one exercise with another without rebuilding the surrounding workout structure. On the frontend, a new `SwapExerciseDialog` is wired into template and session exercise action menus, with search and related-exercise prioritization to speed selection. The implementation also adds guardrails for ownership, duplicates, and invalid session states, plus tracking-type mismatch warnings so users can review targets/sets after a swap.

## Key Changes
- Added API endpoints:
  - `PATCH /api/v1/workout-templates/:id/exercises/:exerciseId/swap`
  - `PATCH /api/v1/workout-sessions/:id/exercises/:exerciseId/swap`
- Added shared Zod input schemas/types for template and session swap payloads (`newExerciseId`).
- Implemented backend swap operations in template/session stores using transactions and `updatedAt` touches.
- Enforced swap validation:
  - source exercise must exist in the target template/session
  - replacement exercise must be user-owned and not soft-deleted
  - duplicate replacement within the same template/session is rejected (`409`)
  - session swaps are blocked unless status is `scheduled` or `in-progress`
- Preserved core configuration/data during swap:
  - template row programming fields and set targets are retained
  - session set values (weights/reps/targets/completion flags/notes/order) are retained
- Built `SwapExerciseDialog` UI and integrated it into:
  - template detail exercise menus
  - active session exercise menus
- Added client mutations/hooks for both swap endpoints, cache invalidation, and optional warning metadata handling.
- Expanded API/UI/schema test coverage for happy paths and failure cases.

## Technical Notes
- Swap target validation intentionally uses `allRelatedExercisesOwned`, so replacements must be user-owned (global exercises are rejected for swap targets).
- Template swap clears `cues` on the swapped row by design because cues are exercise-specific; other programming fields are preserved.
- Both endpoints can return `meta.warning` when tracking type changes between source and replacement exercise, and the UI surfaces this warning toast after success.
- The exercises list query now supports `enabled`; the swap dialog only fetches candidate exercises when opened to avoid unnecessary background requests.

## Commits

- `8419410 feat(workouts): add swap exercise dialog and menu actions`
- `483ee2a fix(api): prevent duplicate template exercise swaps`
- `c54b33d feat(api): add workout template and session exercise swap endpoints`

## Tasks

- **Swap exercise API endpoints**: Create PATCH swap endpoints for template and session exercises with ownership validation and config preservation
- **SwapExerciseDialog UI**: Build SwapExerciseDialog with exercise picker surfacing related exercises first, wire into template/session menus

## Diff Stats

```
apps/api/src/routes/workout-sessions/index.test.ts | 299 +++++++++++++++++++++
 apps/api/src/routes/workout-sessions/index.ts      | 121 +++++++++
 apps/api/src/routes/workout-sessions/store.ts      |  69 ++++-
 .../api/src/routes/workout-templates/index.test.ts | 248 +++++++++++++++++
 apps/api/src/routes/workout-templates/index.ts     | 106 ++++++++
 apps/api/src/routes/workout-templates/store.ts     |  73 +++++
 apps/web/src/features/workouts/api/workouts.ts     | 118 +++++++-
 .../components/session-exercise-list.test.tsx      | 173 +++++++++++-
 .../workouts/components/session-exercise-list.tsx  |  37 +++
 .../components/swap-exercise-dialog.test.tsx       | 248 +++++++++++++++++
 .../workouts/components/swap-exercise-dialog.tsx   | 287 ++++++++++++++++++++
 .../workouts/components/template-detail.test.tsx   | 126 +++++++++
 .../workouts/components/template-detail.tsx        |  27 ++
 apps/web/src/pages/active-workout.tsx              |   1 +
 .../shared/src/schemas/workout-sessions.test.ts    |  22 ++
 packages/shared/src/schemas/workout-sessions.ts    |   5 +
 .../shared/src/schemas/workout-templates.test.ts   |  22 ++
 packages/shared/src/schemas/workout-templates.ts   |   7 +
 18 files changed, 1983 insertions(+), 6 deletions(-)
```