### PR TITLE
feat: template tags, food organization, ad-hoc meals, related exercises

### DIFF
--- a/.agents/skills/pulse-app-usage/SKILL.md
+++ b/.agents/skills/pulse-app-usage/SKILL.md
@@ -47,6 +47,25 @@ Use referential habits when completion should be inferred from other tracked dat
 3. Read habits with `GET /api/v1/habits`; referential habits auto-resolve completion for today.
 4. Manually override a referential habit with `PATCH /api/agent/habits/:id/entries`; override entries are marked with `isOverride: true` and take precedence over resolver output.
 
+## Nutrition (Meal Logging)
+
+Use `POST /api/agent/meals` with one of two item modes:
+
+1. **Saved-food mode (default):**
+   - Send `foodName` + `quantity` (+ optional display fields).
+   - The API resolves `foodName` to an existing food and snapshots scaled macros.
+
+2. **Ad-hoc mode (no foods library write):**
+   - Set either `adhoc: true` or `saveToFoods: false`.
+   - Include inline snapshots: `foodName`, `quantity`, `unit`, `calories`, `protein`, `carbs`, `fat`.
+   - Item is stored with `foodId: null`.
+
+Decision heuristic:
+
+- **Create/save food (reusable):** staple ingredients, frequently repeated meals, branded/packaged products, anything likely to be logged again.
+- **Log ad-hoc (one-off):** restaurant estimates, custom recipes that will not be reused, temporary experiments, uncertain approximations.
+- If unsure, prefer ad-hoc first; promote to a saved food only after repeated use.
+
 ## Notes
 
 - User-facing records in habits, workout templates, exercises, foods, and workout sessions are soft-deleted via `deletedAt`; deleted records are hidden from normal list/search/get endpoints.

--- a/apps/api/drizzle/0028_food_usage_and_tags.sql
+++ b/apps/api/drizzle/0028_food_usage_and_tags.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `foods` ADD `usage_count` integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `foods` ADD `tags` text DEFAULT '[]' NOT NULL;
+--> statement-breakpoint
+CREATE INDEX `foods_user_usage_count_idx` ON `foods` (`user_id`,`usage_count`);

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1773385000000,
       "tag": "0027_template_set_targets",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "6",
+      "when": 1773390000000,
+      "tag": "0028_food_usage_and_tags",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/__tests__/agent.test.ts
+++ b/apps/api/src/__tests__/agent.test.ts
@@ -211,7 +211,7 @@ vi.mock('../routes/foods/store.js', () => ({
   deleteFood: vi.fn(),
   listFoods: vi.fn(async () => []),
   updateFood: vi.fn(),
-  updateFoodLastUsedAt: vi.fn(async (id: string) => {
+  trackFoodUsage: vi.fn(async (id: string) => {
     const food = testState.foods.get(id);
     if (food) {
       food.lastUsedAt = Date.now();
@@ -909,7 +909,7 @@ describe('agent integration', () => {
         expect(body.data.items[0].amount).toBe(2);
 
         const foodsStore = await import('../routes/foods/store.js');
-        expect(vi.mocked(foodsStore.updateFoodLastUsedAt)).toHaveBeenCalledWith(
+        expect(vi.mocked(foodsStore.trackFoodUsage)).toHaveBeenCalledWith(
           'food-chicken',
           'user-1',
         );
@@ -925,7 +925,7 @@ describe('agent integration', () => {
       try {
         seedAgentToken('user-1');
         const foodsStore = await import('../routes/foods/store.js');
-        vi.mocked(foodsStore.updateFoodLastUsedAt).mockClear();
+        vi.mocked(foodsStore.trackFoodUsage).mockClear();
 
         const response = await app.inject({
           method: 'POST',
@@ -972,7 +972,7 @@ describe('agent integration', () => {
             calories: 780,
           }),
         );
-        expect(vi.mocked(foodsStore.updateFoodLastUsedAt)).not.toHaveBeenCalled();
+        expect(vi.mocked(foodsStore.trackFoodUsage)).not.toHaveBeenCalled();
       } finally {
         await app.close();
       }

--- a/apps/api/src/__tests__/agent.test.ts
+++ b/apps/api/src/__tests__/agent.test.ts
@@ -228,7 +228,7 @@ vi.mock('../routes/nutrition/store.js', () => ({
         name: string;
         time: string | null | undefined;
         items: Array<{
-          foodId: string;
+          foodId: string | null;
           name: string;
           amount: number;
           unit: string | null | undefined;
@@ -245,6 +245,7 @@ vi.mock('../routes/nutrition/store.js', () => ({
         id: mealId,
         nutritionLogId: logId,
         name: input.name,
+        summary: null,
         time: input.time ?? null,
         notes: null,
         createdAt: Date.now(),
@@ -913,6 +914,65 @@ describe('agent integration', () => {
           'user-1',
         );
         expect(testState.foods.get('food-chicken')?.lastUsedAt).toBeTypeOf('number');
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('logs ad-hoc meal items without creating or resolving a food', async () => {
+      const app = await createTestApp();
+
+      try {
+        seedAgentToken('user-1');
+        const foodsStore = await import('../routes/foods/store.js');
+        vi.mocked(foodsStore.updateFoodLastUsedAt).mockClear();
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/meals',
+          headers: { authorization: `AgentToken ${PLAIN_TOKEN}` },
+          payload: {
+            name: 'Dinner',
+            date: '2026-03-09',
+            time: '19:30',
+            items: [
+              {
+                foodName: 'Restaurant Pad Thai',
+                quantity: 1,
+                unit: 'plate',
+                saveToFoods: false,
+                calories: 780,
+                protein: 28,
+                carbs: 96,
+                fat: 30,
+              },
+            ],
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+
+        const body = response.json() as {
+          data: {
+            macros: { calories: number; protein: number; carbs: number; fat: number };
+            items: Array<{ foodId: string | null; name: string; calories: number }>;
+          };
+        };
+        expect(body.data.macros).toEqual({
+          calories: 780,
+          protein: 28,
+          carbs: 96,
+          fat: 30,
+        });
+        expect(body.data.items).toHaveLength(1);
+        expect(body.data.items[0]).toEqual(
+          expect.objectContaining({
+            foodId: null,
+            name: 'Restaurant Pad Thai',
+            calories: 780,
+          }),
+        );
+        expect(vi.mocked(foodsStore.updateFoodLastUsedAt)).not.toHaveBeenCalled();
       } finally {
         await app.close();
       }

--- a/apps/api/src/__tests__/foods-nutrition.test.ts
+++ b/apps/api/src/__tests__/foods-nutrition.test.ts
@@ -238,7 +238,7 @@ vi.mock('../routes/foods/store.js', () => ({
     testState.foods.delete(id);
     return true;
   }),
-  updateFoodLastUsedAt: vi.fn(async (foodId: string, userId: string, lastUsedAt = Date.now()) => {
+  trackFoodUsage: vi.fn(async (foodId: string, userId: string, lastUsedAt = Date.now()) => {
     const existing = testState.foods.get(foodId);
     if (!existing || existing.userId !== userId) {
       throw new Error('Failed to update food last used timestamp');

--- a/apps/api/src/__tests__/foods-nutrition.test.ts
+++ b/apps/api/src/__tests__/foods-nutrition.test.ts
@@ -17,6 +17,8 @@ type StoredFood = {
   verified: boolean;
   source: string | null;
   notes: string | null;
+  usageCount: number;
+  tags: string[];
   lastUsedAt: number | null;
   createdAt: number;
   updatedAt: number;
@@ -95,7 +97,7 @@ const testState = vi.hoisted(() => {
 
 const getLogKey = (userId: string, date: string) => `${userId}:${date}`;
 
-const sortFoods = (foods: StoredFood[], sort: 'name' | 'protein' | 'recent') => {
+const sortFoods = (foods: StoredFood[], sort: 'name' | 'popular' | 'recent') => {
   const byName = (left: StoredFood, right: StoredFood) => {
     const nameCompare = left.name.localeCompare(right.name, undefined, { sensitivity: 'base' });
     if (nameCompare !== 0) {
@@ -107,10 +109,10 @@ const sortFoods = (foods: StoredFood[], sort: 'name' | 'protein' | 'recent') => 
     });
   };
 
-  if (sort === 'protein') {
+  if (sort === 'popular') {
     return [...foods].sort((left, right) => {
-      if (left.protein !== right.protein) {
-        return right.protein - left.protein;
+      if (left.usageCount !== right.usageCount) {
+        return right.usageCount - left.usageCount;
       }
 
       return byName(left, right);
@@ -140,10 +142,12 @@ const sortFoods = (foods: StoredFood[], sort: 'name' | 'protein' | 'recent') => 
 vi.mock('../routes/foods/store.js', () => ({
   createFood: vi.fn(
     async (
-      input: Omit<StoredFood, 'createdAt' | 'updatedAt' | 'lastUsedAt'> & {
+      input: Omit<StoredFood, 'createdAt' | 'updatedAt' | 'lastUsedAt' | 'usageCount' | 'tags'> & {
         createdAt?: number;
         updatedAt?: number;
         lastUsedAt?: number | null;
+        usageCount?: number;
+        tags?: string[];
       },
     ) => {
       const now = testState.nextTimestamp();
@@ -156,6 +160,8 @@ vi.mock('../routes/foods/store.js', () => ({
         sugar: input.sugar ?? null,
         source: input.source ?? null,
         notes: input.notes ?? null,
+        usageCount: input.usageCount ?? 0,
+        tags: input.tags ?? [],
         lastUsedAt: input.lastUsedAt ?? null,
         createdAt: input.createdAt ?? now,
         updatedAt: input.updatedAt ?? now,
@@ -170,7 +176,7 @@ vi.mock('../routes/foods/store.js', () => ({
       userId: string,
       query: {
         q?: string;
-        sort: 'name' | 'protein' | 'recent';
+        sort: 'name' | 'popular' | 'recent';
         page: number;
         limit: number;
       },
@@ -241,6 +247,7 @@ vi.mock('../routes/foods/store.js', () => ({
     const updated: StoredFood = {
       ...existing,
       lastUsedAt,
+      usageCount: existing.usageCount + 1,
     };
 
     testState.foods.set(foodId, updated);
@@ -603,6 +610,15 @@ describe('foods and nutrition integration', () => {
         0,
       );
 
+      const popularResponse = await app.inject({
+        method: 'GET',
+        url: '/api/v1/foods?sort=popular',
+        headers: createAuthorizationHeader(userToken),
+      });
+      expect(popularResponse.statusCode).toBe(200);
+      const popularFoods = parseData<StoredFood[]>(popularResponse);
+      expect(popularFoods[0]?.usageCount).toBeGreaterThanOrEqual(popularFoods[1]?.usageCount ?? 0);
+
       const deleteResponse = await app.inject({
         method: 'DELETE',
         url: `/api/v1/foods/${yogurt.id}`,
@@ -898,6 +914,7 @@ describe('foods and nutrition integration', () => {
       expect(afterSecondUseResponse.statusCode).toBe(200);
       const secondUseFood = parseData<StoredFood[]>(afterSecondUseResponse)[0];
       expect((secondUseFood?.lastUsedAt ?? 0) - (firstUseFood?.lastUsedAt ?? 0)).toBeGreaterThan(0);
+      expect(secondUseFood?.usageCount).toBe(2);
     } finally {
       await app.close();
     }

--- a/apps/api/src/db/migrations.test.ts
+++ b/apps/api/src/db/migrations.test.ts
@@ -945,3 +945,86 @@ describe('migration 0027_template_set_targets', () => {
     }
   });
 });
+
+describe('migration 0028_food_usage_and_tags', () => {
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('adds usage_count and tags defaults for foods', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'pulse-migration-0028-'));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, 'migration.db');
+    const db = new Database(dbPath);
+
+    try {
+      db.exec(`
+        CREATE TABLE foods (
+          id TEXT PRIMARY KEY NOT NULL,
+          user_id TEXT NOT NULL,
+          name TEXT NOT NULL,
+          brand TEXT,
+          serving_size TEXT,
+          serving_grams REAL,
+          calories REAL NOT NULL,
+          protein REAL NOT NULL,
+          carbs REAL NOT NULL,
+          fat REAL NOT NULL,
+          fiber REAL,
+          sugar REAL,
+          verified INTEGER NOT NULL DEFAULT 0,
+          source TEXT,
+          notes TEXT,
+          last_used_at INTEGER,
+          deleted_at TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+      `);
+
+      db.prepare(
+        `
+          INSERT INTO foods (
+            id,
+            user_id,
+            name,
+            calories,
+            protein,
+            carbs,
+            fat,
+            created_at,
+            updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+      ).run('food-pre-migration', 'user-1', 'Greek Yogurt', 90, 18, 5, 0, Date.now(), Date.now());
+
+      const migrationSql = readFileSync(
+        join(process.cwd(), 'drizzle/0028_food_usage_and_tags.sql'),
+        'utf8',
+      );
+      runSqlStatements(db, migrationSql);
+
+      const migratedRow = db
+        .prepare(`SELECT usage_count AS usageCount, tags FROM foods WHERE id = ?`)
+        .get('food-pre-migration') as { usageCount: number; tags: string };
+
+      expect(migratedRow.usageCount).toBe(0);
+      expect(JSON.parse(migratedRow.tags)).toEqual([]);
+
+      const indexRows = db
+        .prepare(`PRAGMA index_list('foods')`)
+        .all() as Array<{ name: string }>;
+      expect(indexRows.some((indexRow) => indexRow.name === 'foods_user_usage_count_idx')).toBe(
+        true,
+      );
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/apps/api/src/db/schema.test.ts
+++ b/apps/api/src/db/schema.test.ts
@@ -128,6 +128,8 @@ describe('foods schema', () => {
       'verified',
       'source',
       'notes',
+      'usageCount',
+      'tags',
       'lastUsedAt',
       'deletedAt',
       'createdAt',
@@ -136,6 +138,8 @@ describe('foods schema', () => {
 
     expect(columns.id.defaultFn).toBeTypeOf('function');
     expect(columns.verified.default).toBe(false);
+    expect(columns.usageCount.default).toBe(0);
+    expect(columns.tags.default).toEqual([]);
     expect(columns.lastUsedAt.notNull).toBe(false);
     expect(columns.createdAt.default).toBeDefined();
     expect(columns.createdAt.defaultFn).toBeTypeOf('function');
@@ -146,7 +150,10 @@ describe('foods schema', () => {
     const config = getTableConfig(foods);
     expect(config.foreignKeys).toHaveLength(1);
     expect(getTableName(config.foreignKeys[0].reference().foreignTable)).toBe('users');
-    expect(config.indexes.map((idx) => idx.config.name)).toEqual(['foods_user_last_used_at_idx']);
+    expect(config.indexes.map((idx) => idx.config.name).sort()).toEqual([
+      'foods_user_last_used_at_idx',
+      'foods_user_usage_count_idx',
+    ]);
     expect(config.checks.map((constraint) => constraint.name).sort()).toEqual([
       'foods_fiber_nonnegative_check',
       'foods_macros_nonnegative_check',

--- a/apps/api/src/db/schema/foods.ts
+++ b/apps/api/src/db/schema/foods.ts
@@ -27,6 +27,8 @@ export const foods = sqliteTable(
     verified: integer('verified', { mode: 'boolean' }).notNull().default(false),
     source: text('source'),
     notes: text('notes'),
+    usageCount: integer('usage_count').notNull().default(0),
+    tags: text('tags', { mode: 'json' }).$type<string[]>().notNull().default([]),
     lastUsedAt: integer('last_used_at', { mode: 'number' }),
     deletedAt: text('deleted_at'),
     createdAt: integer('created_at', { mode: 'number' })
@@ -41,6 +43,7 @@ export const foods = sqliteTable(
   },
   (table) => [
     index('foods_user_last_used_at_idx').on(table.userId, table.lastUsedAt),
+    index('foods_user_usage_count_idx').on(table.userId, table.usageCount),
     check(
       'foods_serving_grams_check',
       sql`${table.servingGrams} is null or ${table.servingGrams} > 0`,

--- a/apps/api/src/routes/agent/foods.test.ts
+++ b/apps/api/src/routes/agent/foods.test.ts
@@ -38,6 +38,8 @@ const agentFood = {
   verified: false,
   source: null,
   notes: null,
+  usageCount: 0,
+  tags: [],
   lastUsedAt: null,
   createdAt: 1_700_000_000_000,
   updatedAt: 1_700_000_000_000,

--- a/apps/api/src/routes/agent/foods.test.ts
+++ b/apps/api/src/routes/agent/foods.test.ts
@@ -16,7 +16,7 @@ vi.mock('../foods/store.js', () => ({
   findFoodById: vi.fn(),
   listFoods: vi.fn(),
   updateFood: vi.fn(),
-  updateFoodLastUsedAt: vi.fn(),
+  trackFoodUsage: vi.fn(),
 }));
 
 const createAuthorizationHeader = (token: string) => ({

--- a/apps/api/src/routes/agent/foods.ts
+++ b/apps/api/src/routes/agent/foods.ts
@@ -49,6 +49,7 @@ export const agentFoodsRoutes: FastifyPluginAsync = async (app) => {
       verified: false,
       source: source ?? null,
       notes: notes ?? null,
+      tags: [],
     });
 
     return reply.code(201).send({

--- a/apps/api/src/routes/agent/meals.test.ts
+++ b/apps/api/src/routes/agent/meals.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildServer } from '../../index.js';
-import { updateFoodLastUsedAt } from '../foods/store.js';
+import { trackFoodUsage } from '../foods/store.js';
 import {
   createMealForDate,
   findMealById,
@@ -22,7 +22,7 @@ vi.mock('../foods/store.js', () => ({
   deleteFood: vi.fn(),
   listFoods: vi.fn(),
   updateFood: vi.fn(),
-  updateFoodLastUsedAt: vi.fn(),
+  trackFoodUsage: vi.fn(),
 }));
 
 vi.mock('../nutrition/store.js', () => ({
@@ -137,8 +137,8 @@ describe('agent meals routes', () => {
     vi.mocked(findMealItemById).mockReset();
     vi.mocked(patchMealById).mockReset();
     vi.mocked(patchMealItemById).mockReset();
-    vi.mocked(updateFoodLastUsedAt).mockReset();
-    vi.mocked(updateFoodLastUsedAt).mockResolvedValue(undefined);
+    vi.mocked(trackFoodUsage).mockReset();
+    vi.mocked(trackFoodUsage).mockResolvedValue(undefined);
     process.env.JWT_SECRET = 'test-agent-meals-secret';
   });
 
@@ -248,13 +248,13 @@ describe('agent meals routes', () => {
             ],
           }),
         );
-        expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenCalledTimes(2);
-        expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenNthCalledWith(
+        expect(vi.mocked(trackFoodUsage)).toHaveBeenCalledTimes(2);
+        expect(vi.mocked(trackFoodUsage)).toHaveBeenNthCalledWith(
           1,
           'food-chicken',
           'user-1',
         );
-        expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenNthCalledWith(
+        expect(vi.mocked(trackFoodUsage)).toHaveBeenNthCalledWith(
           2,
           'food-rice',
           'user-1',
@@ -512,7 +512,7 @@ describe('agent meals routes', () => {
             calories: 850,
           }),
         ]);
-        expect(vi.mocked(updateFoodLastUsedAt)).not.toHaveBeenCalled();
+        expect(vi.mocked(trackFoodUsage)).not.toHaveBeenCalled();
       } finally {
         await app.close();
       }
@@ -574,8 +574,53 @@ describe('agent meals routes', () => {
         expect(response.statusCode).toBe(201);
         expect(vi.mocked(findFoodByName)).toHaveBeenCalledTimes(1);
         expect(vi.mocked(findFoodByName)).toHaveBeenCalledWith('user-1', 'Chicken Breast');
-        expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenCalledTimes(1);
-        expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenCalledWith('food-chicken', 'user-1');
+        expect(vi.mocked(trackFoodUsage)).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(trackFoodUsage)).toHaveBeenCalledWith('food-chicken', 'user-1');
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('logs usage tracking failures without failing meal creation', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findFoodByName).mockResolvedValueOnce(chickenFood);
+        vi.mocked(createMealForDate).mockResolvedValue({
+          meal: {
+            ...createdMeal,
+            summary: 'Chicken Breast',
+          },
+          items: [createdItems[0]],
+        });
+        const usageError = new Error('transient usage tracking failure');
+        vi.mocked(trackFoodUsage).mockRejectedValueOnce(usageError);
+        const warnSpy = vi.spyOn(app.log, 'warn');
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/meals',
+          headers: createAuthorizationHeader(token),
+          body: {
+            name: 'Lunch',
+            date: '2026-03-09',
+            items: [{ foodName: 'Chicken Breast', quantity: 1 }],
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+        expect(vi.mocked(trackFoodUsage)).toHaveBeenCalledWith('food-chicken', 'user-1');
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            err: usageError,
+            foodId: 'food-chicken',
+            userId: 'user-1',
+          }),
+          'Failed to track food usage after agent meal creation',
+        );
       } finally {
         await app.close();
       }

--- a/apps/api/src/routes/agent/meals.test.ts
+++ b/apps/api/src/routes/agent/meals.test.ts
@@ -248,6 +248,17 @@ describe('agent meals routes', () => {
             ],
           }),
         );
+        expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenCalledTimes(2);
+        expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenNthCalledWith(
+          1,
+          'food-chicken',
+          'user-1',
+        );
+        expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenNthCalledWith(
+          2,
+          'food-rice',
+          'user-1',
+        );
       } finally {
         await app.close();
       }

--- a/apps/api/src/routes/agent/meals.test.ts
+++ b/apps/api/src/routes/agent/meals.test.ts
@@ -436,6 +436,151 @@ describe('agent meals routes', () => {
       }
     });
 
+    it('creates ad-hoc items without food resolution and persists null foodId', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(createMealForDate).mockResolvedValue({
+          meal: {
+            ...createdMeal,
+            summary: 'Restaurant Burrito',
+          },
+          items: [
+            {
+              ...createdItems[0],
+              foodId: null,
+              name: 'Restaurant Burrito',
+              amount: 1,
+              unit: 'item',
+              calories: 850,
+              protein: 35,
+              carbs: 90,
+              fat: 38,
+            },
+          ],
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/meals',
+          headers: createAuthorizationHeader(token),
+          body: {
+            name: 'Dinner',
+            date: '2026-03-09',
+            items: [
+              {
+                foodName: 'Restaurant Burrito',
+                quantity: 1,
+                unit: 'item',
+                adhoc: true,
+                calories: 850,
+                protein: 35,
+                carbs: 90,
+                fat: 38,
+              },
+            ],
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+        expect(vi.mocked(findFoodByName)).not.toHaveBeenCalled();
+        expect(vi.mocked(createMealForDate)).toHaveBeenCalledWith(
+          'user-1',
+          '2026-03-09',
+          expect.objectContaining({
+            items: [
+              expect.objectContaining({
+                foodId: null,
+                name: 'Restaurant Burrito',
+                amount: 1,
+                unit: 'item',
+                calories: 850,
+                protein: 35,
+                carbs: 90,
+                fat: 38,
+              }),
+            ],
+          }),
+        );
+        expect(response.json().data.items).toEqual([
+          expect.objectContaining({
+            foodId: null,
+            name: 'Restaurant Burrito',
+            calories: 850,
+          }),
+        ]);
+        expect(vi.mocked(updateFoodLastUsedAt)).not.toHaveBeenCalled();
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('supports mixing resolved foods and ad-hoc items in one meal', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        vi.mocked(findFoodByName).mockResolvedValueOnce(chickenFood);
+        vi.mocked(createMealForDate).mockResolvedValue({
+          meal: {
+            ...createdMeal,
+            summary: 'Chicken Breast, Chef Special Soup',
+          },
+          items: [
+            createdItems[0],
+            {
+              ...createdItems[1],
+              id: 'item-adhoc-1',
+              foodId: null,
+              name: 'Chef Special Soup',
+              amount: 1,
+              unit: 'bowl',
+              calories: 280,
+              protein: 12,
+              carbs: 26,
+              fat: 14,
+            },
+          ],
+        });
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/meals',
+          headers: createAuthorizationHeader(token),
+          body: {
+            name: 'Lunch',
+            date: '2026-03-09',
+            items: [
+              { foodName: 'Chicken Breast', quantity: 2 },
+              {
+                foodName: 'Chef Special Soup',
+                quantity: 1,
+                unit: 'bowl',
+                saveToFoods: false,
+                calories: 280,
+                protein: 12,
+                carbs: 26,
+                fat: 14,
+              },
+            ],
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+        expect(vi.mocked(findFoodByName)).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(findFoodByName)).toHaveBeenCalledWith('user-1', 'Chicken Breast');
+        expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenCalledWith('food-chicken', 'user-1');
+      } finally {
+        await app.close();
+      }
+    });
+
     it('returns 422 when a food name cannot be resolved', async () => {
       const app = buildServer();
 
@@ -467,6 +612,43 @@ describe('agent meals routes', () => {
             code: 'UNRESOLVED_FOODS',
             message: 'Could not find foods: Unknown Food XYZ',
           },
+        });
+        expect(vi.mocked(createMealForDate)).not.toHaveBeenCalled();
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('returns 400 when ad-hoc items omit required macro snapshots', async () => {
+      const app = buildServer();
+
+      try {
+        await app.ready();
+
+        const token = app.jwt.sign({ userId: 'user-1' });
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/agent/meals',
+          headers: createAuthorizationHeader(token),
+          body: {
+            name: 'Dinner',
+            date: '2026-03-09',
+            items: [
+              {
+                foodName: 'Restaurant Pasta',
+                quantity: 1,
+                saveToFoods: false,
+                calories: 650,
+                protein: 20,
+                carbs: 80,
+              },
+            ],
+          },
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.json()).toEqual({
+          error: { code: 'VALIDATION_ERROR', message: 'Invalid meal payload' },
         });
         expect(vi.mocked(createMealForDate)).not.toHaveBeenCalled();
       } finally {

--- a/apps/api/src/routes/agent/meals.ts
+++ b/apps/api/src/routes/agent/meals.ts
@@ -1,4 +1,9 @@
-import { agentCreateMealInputSchema, patchMealInputSchema, patchMealItemInputSchema } from '@pulse/shared';
+import {
+  agentCreateMealInputSchema,
+  type AgentMealItemInput,
+  patchMealInputSchema,
+  patchMealItemInputSchema,
+} from '@pulse/shared';
 import type { FastifyPluginAsync } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
@@ -40,6 +45,20 @@ function buildMealSummary(names: string[], maxLength: number): string {
   return summary;
 }
 
+const isAdhocMealItem = (
+  item: AgentMealItemInput,
+): item is AgentMealItemInput & {
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+} =>
+  (item.adhoc === true || item.saveToFoods === false) &&
+  item.calories !== undefined &&
+  item.protein !== undefined &&
+  item.carbs !== undefined &&
+  item.fat !== undefined;
+
 export const agentMealsRoutes: FastifyPluginAsync = async (app) => {
   app.post('/', async (request, reply) => {
     const parsed = agentCreateMealInputSchema.safeParse(request.body);
@@ -50,17 +69,20 @@ export const agentMealsRoutes: FastifyPluginAsync = async (app) => {
     const { name, date, time, items } = parsed.data;
     const userId = request.userId;
 
-    // Resolve food names to food records
-    const resolvedFoods = await Promise.all(
+    const itemResults = await Promise.all(
       items.map(async (item) => {
+        if (isAdhocMealItem(item)) {
+          return { kind: 'adhoc' as const, item };
+        }
+
         const food = await findFoodByName(userId, item.foodName);
-        return { item, food };
+        return { kind: 'food' as const, item, food };
       }),
     );
 
-    const unresolved = resolvedFoods
-      .filter(({ food }) => food === undefined)
-      .map(({ item }) => item.foodName);
+    const unresolved = itemResults
+      .filter((entry) => entry.kind === 'food' && entry.food === undefined)
+      .map((entry) => entry.item.foodName);
 
     if (unresolved.length > 0) {
       return sendError(
@@ -71,25 +93,40 @@ export const agentMealsRoutes: FastifyPluginAsync = async (app) => {
       );
     }
 
-    // All foods resolved — safe to cast since we checked above
-    const resolvedItems = resolvedFoods as Array<{
-      item: (typeof resolvedFoods)[number]['item'];
-      food: NonNullable<(typeof resolvedFoods)[number]['food']>;
-    }>;
+    const mealItems = itemResults.map((entry) => {
+      if (entry.kind === 'adhoc') {
+        return {
+          foodId: null,
+          name: entry.item.foodName,
+          amount: entry.item.quantity,
+          unit: entry.item.unit,
+          displayQuantity: entry.item.displayQuantity ?? null,
+          displayUnit: entry.item.displayUnit ?? null,
+          calories: entry.item.calories,
+          protein: entry.item.protein,
+          carbs: entry.item.carbs,
+          fat: entry.item.fat,
+        };
+      }
 
-    // Scale macros by quantity (1 unit = 1 serving as defined by the food record)
-    const mealItems = resolvedItems.map(({ item, food }) => ({
-      foodId: food.id,
-      name: food.name,
-      amount: item.quantity,
-      unit: item.unit,
-      displayQuantity: item.displayQuantity ?? null,
-      displayUnit: item.displayUnit ?? null,
-      calories: food.calories * item.quantity,
-      protein: food.protein * item.quantity,
-      carbs: food.carbs * item.quantity,
-      fat: food.fat * item.quantity,
-    }));
+      if (!entry.food) {
+        throw new Error('Unresolved food passed validation guard');
+      }
+
+      // Scale macros by quantity (1 unit = 1 serving as defined by the food record)
+      return {
+        foodId: entry.food.id,
+        name: entry.food.name,
+        amount: entry.item.quantity,
+        unit: entry.item.unit,
+        displayQuantity: entry.item.displayQuantity ?? null,
+        displayUnit: entry.item.displayUnit ?? null,
+        calories: entry.food.calories * entry.item.quantity,
+        protein: entry.food.protein * entry.item.quantity,
+        carbs: entry.food.carbs * entry.item.quantity,
+        fat: entry.food.fat * entry.item.quantity,
+      };
+    });
     const summary = buildMealSummary(
       mealItems.map((item) => item.name),
       MAX_MEAL_SUMMARY_LENGTH,
@@ -102,9 +139,13 @@ export const agentMealsRoutes: FastifyPluginAsync = async (app) => {
       items: mealItems,
     });
 
+    const resolvedFoodIds = itemResults
+      .flatMap((entry) => (entry.kind === 'food' && entry.food ? [entry.food.id] : []))
+      .filter((value, index, list) => list.indexOf(value) === index);
+
     // Update recency/popularity for resolved foods (best-effort)
     await Promise.allSettled(
-      resolvedItems.map(({ food }) => updateFoodLastUsedAt(food.id, userId)),
+      resolvedFoodIds.map((foodId) => updateFoodLastUsedAt(foodId, userId)),
     );
 
     const macros = createdItems.reduce(

--- a/apps/api/src/routes/agent/meals.ts
+++ b/apps/api/src/routes/agent/meals.ts
@@ -102,7 +102,7 @@ export const agentMealsRoutes: FastifyPluginAsync = async (app) => {
       items: mealItems,
     });
 
-    // Update lastUsedAt for resolved foods (best-effort)
+    // Update recency/popularity for resolved foods (best-effort)
     await Promise.allSettled(
       resolvedItems.map(({ food }) => updateFoodLastUsedAt(food.id, userId)),
     );

--- a/apps/api/src/routes/agent/meals.ts
+++ b/apps/api/src/routes/agent/meals.ts
@@ -7,7 +7,7 @@ import {
 import type { FastifyPluginAsync } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
-import { updateFoodLastUsedAt } from '../foods/store.js';
+import { trackFoodUsage } from '../foods/store.js';
 import {
   createMealForDate,
   findMealById,
@@ -144,9 +144,17 @@ export const agentMealsRoutes: FastifyPluginAsync = async (app) => {
       .filter((value, index, list) => list.indexOf(value) === index);
 
     // Update recency/popularity for resolved foods (best-effort)
-    await Promise.allSettled(
-      resolvedFoodIds.map((foodId) => updateFoodLastUsedAt(foodId, userId)),
+    const usageTrackingResults = await Promise.allSettled(
+      resolvedFoodIds.map((foodId) => trackFoodUsage(foodId, userId)),
     );
+    usageTrackingResults.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        request.log.warn(
+          { err: result.reason, foodId: resolvedFoodIds[index], userId },
+          'Failed to track food usage after agent meal creation',
+        );
+      }
+    });
 
     const macros = createdItems.reduce(
       (acc, item) => ({

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -434,6 +434,117 @@ describe('exercise routes', () => {
     });
   });
 
+  it('returns exact and related history when includeRelated=true', async () => {
+    seedExercise({
+      id: 'flat-bench',
+      userId: 'user-1',
+      name: 'Flat Bench Press',
+      muscleGroups: ['chest'],
+      equipment: 'barbell',
+      category: 'compound',
+      relatedExerciseIds: ['incline-bench', 'db-bench'],
+    });
+    seedExercise({
+      id: 'incline-bench',
+      userId: 'user-1',
+      name: 'Incline Bench Press',
+      muscleGroups: ['chest'],
+      equipment: 'barbell',
+      category: 'compound',
+    });
+    seedExercise({
+      id: 'db-bench',
+      userId: 'user-1',
+      name: 'Dumbbell Bench Press',
+      muscleGroups: ['chest'],
+      equipment: 'dumbbell',
+      category: 'compound',
+    });
+
+    seedWorkoutSession({
+      id: 'session-flat',
+      userId: 'user-1',
+      name: 'Push Day',
+      date: '2026-03-10',
+      status: 'completed',
+      startedAt: 1_700_000_000_000,
+      completedAt: 1_700_000_003_000,
+    });
+    seedWorkoutSession({
+      id: 'session-incline',
+      userId: 'user-1',
+      name: 'Push Day 2',
+      date: '2026-03-11',
+      status: 'completed',
+      startedAt: 1_700_000_010_000,
+      completedAt: 1_700_000_015_000,
+    });
+
+    seedSessionSet({
+      id: 'set-flat-1',
+      sessionId: 'session-flat',
+      exerciseId: 'flat-bench',
+      setNumber: 1,
+      weight: 205,
+      reps: 5,
+    });
+    seedSessionSet({
+      id: 'set-incline-1',
+      sessionId: 'session-incline',
+      exerciseId: 'incline-bench',
+      setNumber: 1,
+      weight: 185,
+      reps: 6,
+    });
+
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+
+    const response = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises/flat-bench/last-performance?includeRelated=true',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: {
+        history: {
+          sessionId: 'session-flat',
+          date: '2026-03-10',
+          sets: [
+            {
+              setNumber: 1,
+              weight: 205,
+              reps: 5,
+            },
+          ],
+        },
+        related: [
+          {
+            exerciseId: 'incline-bench',
+            exerciseName: 'Incline Bench Press',
+            history: {
+              sessionId: 'session-incline',
+              date: '2026-03-11',
+              sets: [
+                {
+                  setNumber: 1,
+                  weight: 185,
+                  reps: 6,
+                },
+              ],
+            },
+          },
+          {
+            exerciseId: 'db-bench',
+            exerciseName: 'Dumbbell Bench Press',
+            history: null,
+          },
+        ],
+      },
+    });
+  });
+
   it('creates a user-specific exercise for the authenticated user', async () => {
     const authToken = context.app.jwt.sign({ userId: 'user-1' });
 

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -523,6 +523,7 @@ describe('exercise routes', () => {
           {
             exerciseId: 'incline-bench',
             exerciseName: 'Incline Bench Press',
+            trackingType: 'weight_reps',
             history: {
               sessionId: 'session-incline',
               date: '2026-03-11',
@@ -538,9 +539,50 @@ describe('exercise routes', () => {
           {
             exerciseId: 'db-bench',
             exerciseName: 'Dumbbell Bench Press',
+            trackingType: 'weight_reps',
             history: null,
           },
         ],
+      },
+    });
+  });
+
+  it('excludes soft-deleted related exercises from includeRelated history results', async () => {
+    seedExercise({
+      id: 'flat-bench',
+      userId: 'user-1',
+      name: 'Flat Bench Press',
+      muscleGroups: ['chest'],
+      equipment: 'barbell',
+      category: 'compound',
+      relatedExerciseIds: ['incline-bench'],
+    });
+    seedExercise({
+      id: 'incline-bench',
+      userId: 'user-1',
+      name: 'Incline Bench Press',
+      muscleGroups: ['chest'],
+      equipment: 'barbell',
+      category: 'compound',
+    });
+    context.db
+      .update(exercises)
+      .set({ deletedAt: new Date().toISOString() })
+      .where(eq(exercises.id, 'incline-bench'))
+      .run();
+
+    const authToken = context.app.jwt.sign({ userId: 'user-1' });
+    const response = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises/flat-bench/last-performance?includeRelated=true',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: {
+        history: null,
+        related: [],
       },
     });
   });

--- a/apps/api/src/routes/exercises/index.ts
+++ b/apps/api/src/routes/exercises/index.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import {
   createExerciseInputSchema,
+  exerciseLastPerformanceQuerySchema,
   exerciseQueryParamsSchema,
   updateExerciseInputSchema,
 } from '@pulse/shared';
@@ -14,6 +15,7 @@ import {
   allRelatedExercisesOwned,
   createExercise,
   deleteOwnedExercise,
+  findExerciseHistoryWithRelated,
   findExerciseLastPerformance,
   findExerciseOwnership,
   findVisibleExerciseById,
@@ -188,6 +190,11 @@ export const exerciseRoutes: FastifyPluginAsync = async (app) => {
   });
 
   app.get<{ Params: { id: string } }>('/:id/last-performance', async (request, reply) => {
+    const parsedQuery = exerciseLastPerformanceQuerySchema.safeParse(request.query);
+    if (!parsedQuery.success) {
+      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid exercise history query');
+    }
+
     const exercise = await findVisibleExerciseById({
       id: request.params.id,
       userId: request.userId,
@@ -201,13 +208,26 @@ export const exerciseRoutes: FastifyPluginAsync = async (app) => {
       );
     }
 
-    const lastPerformance = await findExerciseLastPerformance({
-      exerciseId: request.params.id,
-      userId: request.userId,
-    });
+    if (parsedQuery.data.includeRelated) {
+      const historyWithRelated = await findExerciseHistoryWithRelated({
+        exerciseId: request.params.id,
+        relatedExerciseIds: exercise.relatedExerciseIds,
+        userId: request.userId,
+      });
+
+      return reply.send({
+        data: historyWithRelated,
+      });
+    }
+
+    const lastPerformance =
+      (await findExerciseLastPerformance({
+        exerciseId: request.params.id,
+        userId: request.userId,
+      })) ?? null;
 
     return reply.send({
-      data: lastPerformance ?? null,
+      data: lastPerformance,
     });
   });
 

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -3,7 +3,9 @@ import type {
   CreateExerciseInput,
   Exercise,
   ExerciseCategory,
+  ExerciseHistoryWithRelated,
   ExerciseLastPerformance,
+  RelatedExerciseLastPerformance,
   UpdateExerciseInput,
 } from '@pulse/shared';
 
@@ -28,6 +30,10 @@ type ListExercisesInput = {
 type ExerciseOwnershipRecord = {
   id: string;
   userId: string | null;
+};
+
+type VisibleExerciseRecord = ExerciseOwnershipRecord & {
+  relatedExerciseIds: string[];
 };
 
 export type ExerciseDedupCandidate = {
@@ -297,13 +303,14 @@ export const findVisibleExerciseById = async ({
 }: {
   id: string;
   userId: string;
-}): Promise<ExerciseOwnershipRecord | undefined> => {
+}): Promise<VisibleExerciseRecord | undefined> => {
   const { db } = await import('../../db/index.js');
 
   return db
     .select({
       id: exercises.id,
       userId: exercises.userId,
+      relatedExerciseIds: exercises.relatedExerciseIds,
     })
     .from(exercises)
     .where(
@@ -607,5 +614,63 @@ export const findExerciseLastPerformance = async ({
       weight: set.weight,
       reps: set.reps,
     })),
+  };
+};
+
+export const findExerciseHistoryWithRelated = async ({
+  exerciseId,
+  relatedExerciseIds,
+  userId,
+}: {
+  exerciseId: string;
+  relatedExerciseIds: string[];
+  userId: string;
+}): Promise<ExerciseHistoryWithRelated> => {
+  const history = (await findExerciseLastPerformance({
+    exerciseId,
+    userId,
+  })) ?? null;
+
+  const uniqueRelatedIds = [...new Set(relatedExerciseIds)];
+  if (uniqueRelatedIds.length === 0) {
+    return {
+      history,
+      related: [],
+    };
+  }
+
+  const { db } = await import('../../db/index.js');
+  const relatedExercises = await db
+    .select({
+      id: exercises.id,
+      name: exercises.name,
+    })
+    .from(exercises)
+    .where(and(inArray(exercises.id, uniqueRelatedIds), eq(exercises.userId, userId)))
+    .all();
+
+  const relatedNameById = new Map(relatedExercises.map((exercise) => [exercise.id, exercise.name]));
+  const orderedRelated = uniqueRelatedIds
+    .filter((relatedId) => relatedNameById.has(relatedId))
+    .map((relatedId) => ({
+      id: relatedId,
+      name: relatedNameById.get(relatedId) ?? relatedId,
+    }));
+
+  const relatedHistory = await Promise.all(
+    orderedRelated.map(async (relatedExercise): Promise<RelatedExerciseLastPerformance> => ({
+      exerciseId: relatedExercise.id,
+      exerciseName: relatedExercise.name,
+      history:
+        (await findExerciseLastPerformance({
+          exerciseId: relatedExercise.id,
+          userId,
+        })) ?? null,
+    })),
+  );
+
+  return {
+    history,
+    related: relatedHistory,
   };
 };

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -618,6 +618,144 @@ export const findExerciseLastPerformance = async ({
   };
 };
 
+const findExercisesLastPerformanceById = async ({
+  exerciseIds,
+  userId,
+}: {
+  exerciseIds: string[];
+  userId: string;
+}): Promise<Map<string, ExerciseLastPerformance>> => {
+  const uniqueExerciseIds = [...new Set(exerciseIds)];
+  if (uniqueExerciseIds.length === 0) {
+    return new Map();
+  }
+
+  const { db } = await import('../../db/index.js');
+  const latestSessionCandidates = await db
+    .select({
+      exerciseId: sessionSets.exerciseId,
+      sessionId: workoutSessions.id,
+      date: workoutSessions.date,
+    })
+    .from(sessionSets)
+    .innerJoin(workoutSessions, eq(workoutSessions.id, sessionSets.sessionId))
+    .where(
+      and(
+        inArray(sessionSets.exerciseId, uniqueExerciseIds),
+        eq(workoutSessions.userId, userId),
+        isNull(workoutSessions.deletedAt),
+        eq(workoutSessions.status, 'completed'),
+      ),
+    )
+    .groupBy(
+      sessionSets.exerciseId,
+      workoutSessions.id,
+      workoutSessions.date,
+      workoutSessions.completedAt,
+      workoutSessions.startedAt,
+      workoutSessions.createdAt,
+    )
+    .orderBy(
+      desc(workoutSessions.completedAt),
+      desc(workoutSessions.startedAt),
+      desc(workoutSessions.createdAt),
+    )
+    .all();
+
+  const latestSessionByExerciseId = new Map<
+    string,
+    {
+      sessionId: string;
+      date: string;
+    }
+  >();
+
+  for (const row of latestSessionCandidates) {
+    if (!latestSessionByExerciseId.has(row.exerciseId)) {
+      latestSessionByExerciseId.set(row.exerciseId, {
+        sessionId: row.sessionId,
+        date: row.date,
+      });
+    }
+  }
+
+  const latestSessionIds = [...new Set([...latestSessionByExerciseId.values()].map((row) => row.sessionId))];
+  if (latestSessionIds.length === 0) {
+    return new Map();
+  }
+
+  const latestSets = await db
+    .select({
+      exerciseId: sessionSets.exerciseId,
+      sessionId: sessionSets.sessionId,
+      setNumber: sessionSets.setNumber,
+      weight: sessionSets.weight,
+      reps: sessionSets.reps,
+      createdAt: sessionSets.createdAt,
+    })
+    .from(sessionSets)
+    .innerJoin(workoutSessions, eq(workoutSessions.id, sessionSets.sessionId))
+    .where(
+      and(
+        inArray(sessionSets.exerciseId, uniqueExerciseIds),
+        inArray(sessionSets.sessionId, latestSessionIds),
+        eq(workoutSessions.userId, userId),
+        isNull(workoutSessions.deletedAt),
+      ),
+    )
+    .orderBy(asc(sessionSets.exerciseId), asc(sessionSets.setNumber), asc(sessionSets.createdAt))
+    .all();
+
+  const historyByExerciseId = new Map<
+    string,
+    {
+      sessionId: string;
+      date: string;
+      sets: Array<{ setNumber: number; weight: number | null; reps: number | null }>;
+    }
+  >();
+
+  for (const set of latestSets) {
+    const latestSession = latestSessionByExerciseId.get(set.exerciseId);
+    if (!latestSession || latestSession.sessionId !== set.sessionId) {
+      continue;
+    }
+
+    const existing = historyByExerciseId.get(set.exerciseId);
+    if (!existing) {
+      historyByExerciseId.set(set.exerciseId, {
+        sessionId: set.sessionId,
+        date: latestSession.date,
+        sets: [
+          {
+            setNumber: set.setNumber,
+            weight: set.weight,
+            reps: set.reps,
+          },
+        ],
+      });
+      continue;
+    }
+
+    existing.sets.push({
+      setNumber: set.setNumber,
+      weight: set.weight,
+      reps: set.reps,
+    });
+  }
+
+  return new Map(
+    [...historyByExerciseId.entries()].map(([id, history]) => [
+      id,
+      {
+        sessionId: history.sessionId,
+        date: history.date,
+        sets: history.sets,
+      },
+    ]),
+  );
+};
+
 export const findExerciseHistoryWithRelated = async ({
   exerciseId,
   relatedExerciseIds,
@@ -627,35 +765,27 @@ export const findExerciseHistoryWithRelated = async ({
   relatedExerciseIds: string[];
   userId: string;
 }): Promise<ExerciseHistoryWithRelated> => {
-  const history = (await findExerciseLastPerformance({
-    exerciseId,
-    userId,
-  })) ?? null;
-
   const uniqueRelatedIds = [...new Set(relatedExerciseIds)];
-  if (uniqueRelatedIds.length === 0) {
-    return {
-      history,
-      related: [],
-    };
-  }
 
   const { db } = await import('../../db/index.js');
-  const relatedExercises = await db
-    .select({
-      id: exercises.id,
-      name: exercises.name,
-      trackingType: exercises.trackingType,
-    })
-    .from(exercises)
-    .where(
-      and(
-        inArray(exercises.id, uniqueRelatedIds),
-        eq(exercises.userId, userId),
-        isNull(exercises.deletedAt),
-      ),
-    )
-    .all();
+  const relatedExercises =
+    uniqueRelatedIds.length === 0
+      ? []
+      : await db
+          .select({
+            id: exercises.id,
+            name: exercises.name,
+            trackingType: exercises.trackingType,
+          })
+          .from(exercises)
+          .where(
+            and(
+              inArray(exercises.id, uniqueRelatedIds),
+              eq(exercises.userId, userId),
+              isNull(exercises.deletedAt),
+            ),
+          )
+          .all();
 
   const relatedMetaById = new Map(
     relatedExercises.map((exercise) => [
@@ -680,18 +810,18 @@ export const findExerciseHistoryWithRelated = async ({
     ];
   });
 
-  const relatedHistory = await Promise.all(
-    orderedRelated.map(async (relatedExercise): Promise<RelatedExerciseLastPerformance> => ({
-      exerciseId: relatedExercise.id,
-      exerciseName: relatedExercise.name,
-      trackingType: relatedExercise.trackingType,
-      history:
-        (await findExerciseLastPerformance({
-          exerciseId: relatedExercise.id,
-          userId,
-        })) ?? null,
-    })),
-  );
+  const historiesByExerciseId = await findExercisesLastPerformanceById({
+    exerciseIds: [exerciseId, ...orderedRelated.map((relatedExercise) => relatedExercise.id)],
+    userId,
+  });
+
+  const history = historiesByExerciseId.get(exerciseId) ?? null;
+  const relatedHistory: RelatedExerciseLastPerformance[] = orderedRelated.map((relatedExercise) => ({
+    exerciseId: relatedExercise.id,
+    exerciseName: relatedExercise.name,
+    trackingType: relatedExercise.trackingType,
+    history: historiesByExerciseId.get(relatedExercise.id) ?? null,
+  }));
 
   return {
     history,

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -5,6 +5,7 @@ import type {
   ExerciseCategory,
   ExerciseHistoryWithRelated,
   ExerciseLastPerformance,
+  ExerciseTrackingType,
   RelatedExerciseLastPerformance,
   UpdateExerciseInput,
 } from '@pulse/shared';
@@ -644,23 +645,46 @@ export const findExerciseHistoryWithRelated = async ({
     .select({
       id: exercises.id,
       name: exercises.name,
+      trackingType: exercises.trackingType,
     })
     .from(exercises)
-    .where(and(inArray(exercises.id, uniqueRelatedIds), eq(exercises.userId, userId)))
+    .where(
+      and(
+        inArray(exercises.id, uniqueRelatedIds),
+        eq(exercises.userId, userId),
+        isNull(exercises.deletedAt),
+      ),
+    )
     .all();
 
-  const relatedNameById = new Map(relatedExercises.map((exercise) => [exercise.id, exercise.name]));
-  const orderedRelated = uniqueRelatedIds
-    .filter((relatedId) => relatedNameById.has(relatedId))
-    .map((relatedId) => ({
-      id: relatedId,
-      name: relatedNameById.get(relatedId) ?? relatedId,
-    }));
+  const relatedMetaById = new Map(
+    relatedExercises.map((exercise) => [
+      exercise.id,
+      {
+        name: exercise.name,
+        trackingType: exercise.trackingType as ExerciseTrackingType,
+      },
+    ]),
+  );
+  const orderedRelated = uniqueRelatedIds.flatMap((relatedId) => {
+    const meta = relatedMetaById.get(relatedId);
+    if (!meta) {
+      return [];
+    }
+
+    return [
+      {
+        id: relatedId,
+        ...meta,
+      },
+    ];
+  });
 
   const relatedHistory = await Promise.all(
     orderedRelated.map(async (relatedExercise): Promise<RelatedExerciseLastPerformance> => ({
       exerciseId: relatedExercise.id,
       exerciseName: relatedExercise.name,
+      trackingType: relatedExercise.trackingType,
       history:
         (await findExerciseLastPerformance({
           exerciseId: relatedExercise.id,

--- a/apps/api/src/routes/foods/index.test.ts
+++ b/apps/api/src/routes/foods/index.test.ts
@@ -124,7 +124,7 @@ describe('foods routes', () => {
     }
   });
 
-  it('lists foods with parsed search, sort, and pagination params', async () => {
+  it('lists foods with parsed search, tag filters, sort, and pagination params', async () => {
     vi.mocked(listFoods).mockResolvedValue({
       foods: [buildFood()],
       total: 3,
@@ -137,7 +137,7 @@ describe('foods routes', () => {
       const authToken = app.jwt.sign({ userId: 'user-1' });
       const response = await app.inject({
         method: 'GET',
-        url: '/api/v1/foods?q=%20yogurt%20&sort=popular&page=2&limit=1',
+        url: '/api/v1/foods?q=%20yogurt%20&tags=protein,dairy&sort=popular&page=2&limit=1',
         headers: createAuthorizationHeader(authToken),
       });
 
@@ -153,6 +153,7 @@ describe('foods routes', () => {
       });
       expect(vi.mocked(listFoods)).toHaveBeenCalledWith('user-1', {
         q: 'yogurt',
+        tags: ['protein', 'dairy'],
         sort: 'popular',
         page: 2,
         limit: 1,

--- a/apps/api/src/routes/foods/index.test.ts
+++ b/apps/api/src/routes/foods/index.test.ts
@@ -32,6 +32,8 @@ const buildFood = (
     verified: boolean;
     source: string | null;
     notes: string | null;
+    usageCount: number;
+    tags: string[];
     lastUsedAt: number | null;
     createdAt: number;
     updatedAt: number;
@@ -52,6 +54,8 @@ const buildFood = (
   verified: true,
   source: 'Manufacturer label',
   notes: null,
+  usageCount: 0,
+  tags: [],
   lastUsedAt: null,
   createdAt: 1_700_000_000_000,
   updatedAt: 1_700_000_000_001,
@@ -113,6 +117,7 @@ describe('foods routes', () => {
         carbs: 5,
         fat: 0,
         verified: true,
+        tags: [],
       });
     } finally {
       await app.close();
@@ -132,7 +137,7 @@ describe('foods routes', () => {
       const authToken = app.jwt.sign({ userId: 'user-1' });
       const response = await app.inject({
         method: 'GET',
-        url: '/api/v1/foods?q=%20yogurt%20&sort=protein&page=2&limit=1',
+        url: '/api/v1/foods?q=%20yogurt%20&sort=popular&page=2&limit=1',
         headers: createAuthorizationHeader(authToken),
       });
 
@@ -148,7 +153,7 @@ describe('foods routes', () => {
       });
       expect(vi.mocked(listFoods)).toHaveBeenCalledWith('user-1', {
         q: 'yogurt',
-        sort: 'protein',
+        sort: 'popular',
         page: 2,
         limit: 1,
       });

--- a/apps/api/src/routes/foods/store.test.ts
+++ b/apps/api/src/routes/foods/store.test.ts
@@ -208,7 +208,7 @@ describe('foods store', () => {
     ]);
   });
 
-  it('returns paginated foods and performs separate row and total queries', async () => {
+  it('returns paginated foods with search and tag filters and performs separate row and total queries', async () => {
     dbState.selectResults.push(
       {
         all: [
@@ -247,6 +247,7 @@ describe('foods store', () => {
 
     const result = await listFoods('user-1', {
       q: '50%_off',
+      tags: ['protein', 'dairy'],
       sort: 'popular',
       page: 2,
       limit: 1,
@@ -271,6 +272,9 @@ describe('foods store', () => {
     const whereClauseText = flattenSql(dbState.selectBuilders[0].where.mock.calls[0]?.[0]);
     expect(whereClauseText).toContain('%50\\%\\_off%');
     expect(whereClauseText.toLowerCase()).toContain("escape '\\'");
+    expect(whereClauseText.toLowerCase()).toContain('json_each');
+    expect(whereClauseText.toLowerCase()).toContain('protein');
+    expect(whereClauseText.toLowerCase()).toContain('dairy');
   });
 
   it('supports recent sorting without pagination errors when the query is absent', async () => {
@@ -372,6 +376,7 @@ describe('foods store', () => {
       notes: 'Updated note',
       verified: true,
     });
+    expect(dbState.updateSets[0]).not.toHaveProperty('tags');
     expect(dbState.updateSets[0]).toHaveProperty('updatedAt');
 
     dbState.updateRunResult = { changes: 0 };

--- a/apps/api/src/routes/foods/store.test.ts
+++ b/apps/api/src/routes/foods/store.test.ts
@@ -154,6 +154,8 @@ describe('foods store', () => {
         verified: true,
         source: null,
         notes: null,
+        usageCount: 0,
+        tags: [],
         lastUsedAt: null,
         createdAt: 1_700_000_000_000,
         updatedAt: 1_700_000_000_001,
@@ -171,6 +173,7 @@ describe('foods store', () => {
       carbs: 5,
       fat: 0,
       verified: true,
+      tags: [],
     });
 
     expect(created).toMatchObject({
@@ -200,6 +203,7 @@ describe('foods store', () => {
         verified: true,
         source: null,
         notes: null,
+        tags: [],
       },
     ]);
   });
@@ -224,6 +228,8 @@ describe('foods store', () => {
             verified: false,
             source: null,
             notes: null,
+            usageCount: 3,
+            tags: ['breakfast'],
             lastUsedAt: null,
             createdAt: 1,
             updatedAt: 2,
@@ -241,7 +247,7 @@ describe('foods store', () => {
 
     const result = await listFoods('user-1', {
       q: '50%_off',
-      sort: 'protein',
+      sort: 'popular',
       page: 2,
       limit: 1,
     });
@@ -287,6 +293,8 @@ describe('foods store', () => {
             verified: false,
             source: null,
             notes: null,
+            usageCount: 2,
+            tags: [],
             lastUsedAt: 200,
             createdAt: 1,
             updatedAt: 2,
@@ -336,6 +344,8 @@ describe('foods store', () => {
         verified: true,
         source: 'USDA',
         notes: 'Updated note',
+        usageCount: 5,
+        tags: ['lean'],
         lastUsedAt: null,
         createdAt: 1,
         updatedAt: 2,
@@ -373,7 +383,7 @@ describe('foods store', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('soft-deletes foods by scope and scopes lastUsedAt updates to the user', async () => {
+  it('soft-deletes foods by scope and increments usage on lastUsedAt updates', async () => {
     const { deleteFood, updateFoodLastUsedAt } = await import('./store.js');
 
     await expect(deleteFood('food-1', 'user-1')).resolves.toBe(true);
@@ -387,9 +397,10 @@ describe('foods store', () => {
 
     await updateFoodLastUsedAt('food-1', 'user-1', 1_700_000_300_000);
 
-    expect(dbState.updateSets.at(-1)).toEqual({
+    expect(dbState.updateSets.at(-1)).toMatchObject({
       lastUsedAt: 1_700_000_300_000,
     });
+    expect(dbState.updateSets.at(-1)).toHaveProperty('usageCount');
     const updateWhereText = flattenSql(dbState.updateWhereCalls.at(-1));
     expect(updateWhereText).toContain('id = food-1');
     expect(updateWhereText).toContain('user_id = user-1');

--- a/apps/api/src/routes/foods/store.test.ts
+++ b/apps/api/src/routes/foods/store.test.ts
@@ -389,7 +389,7 @@ describe('foods store', () => {
   });
 
   it('soft-deletes foods by scope and increments usage on lastUsedAt updates', async () => {
-    const { deleteFood, updateFoodLastUsedAt } = await import('./store.js');
+    const { deleteFood, trackFoodUsage } = await import('./store.js');
 
     await expect(deleteFood('food-1', 'user-1')).resolves.toBe(true);
     expect(dbState.updateSets[0]).toEqual({
@@ -400,7 +400,7 @@ describe('foods store', () => {
     await expect(deleteFood('food-1', 'user-2')).resolves.toBe(false);
     dbState.updateRunResult = { changes: 1 };
 
-    await updateFoodLastUsedAt('food-1', 'user-1', 1_700_000_300_000);
+    await trackFoodUsage('food-1', 'user-1', 1_700_000_300_000);
 
     expect(dbState.updateSets.at(-1)).toMatchObject({
       lastUsedAt: 1_700_000_300_000,

--- a/apps/api/src/routes/foods/store.ts
+++ b/apps/api/src/routes/foods/store.ts
@@ -38,6 +38,8 @@ const foodSelection = {
   verified: foods.verified,
   source: foods.source,
   notes: foods.notes,
+  usageCount: foods.usageCount,
+  tags: foods.tags,
   lastUsedAt: foods.lastUsedAt,
   createdAt: foods.createdAt,
   updatedAt: foods.updatedAt,
@@ -67,8 +69,8 @@ const buildFoodSort = (sort: FoodSort) => {
   switch (sort) {
     case 'recent':
       return sql`case when ${foods.lastUsedAt} is null then 1 else 0 end asc, ${foods.lastUsedAt} desc, lower(${foods.name}) asc`;
-    case 'protein':
-      return sql`${foods.protein} desc, lower(${foods.name}) asc`;
+    case 'popular':
+      return sql`${foods.usageCount} desc, lower(${foods.name}) asc`;
     case 'name':
     default:
       return sql`lower(${foods.name}) asc, lower(coalesce(${foods.brand}, '')) asc`;
@@ -102,6 +104,7 @@ export const createFood = async ({
   verified,
   source,
   notes,
+  tags,
 }: CreateFoodRecordInput): Promise<FoodRecord> => {
   const { db } = await import('../../db/index.js');
 
@@ -123,6 +126,7 @@ export const createFood = async ({
       verified,
       source: toNullable(source),
       notes: toNullable(notes),
+      tags,
     })
     .run();
 
@@ -232,6 +236,10 @@ export const updateFood = async (
     nextValues.notes = toNullable(updates.notes);
   }
 
+  if ('tags' in updates) {
+    nextValues.tags = updates.tags;
+  }
+
   const result = db
     .update(foods)
     .set(nextValues)
@@ -270,6 +278,7 @@ export const updateFoodLastUsedAt = async (
     .update(foods)
     .set({
       lastUsedAt,
+      usageCount: sql`usage_count + 1`,
     })
     .where(and(eq(foods.id, foodId), eq(foods.userId, userId), isNull(foods.deletedAt)))
     .run();

--- a/apps/api/src/routes/foods/store.ts
+++ b/apps/api/src/routes/foods/store.ts
@@ -74,7 +74,7 @@ const buildFoodFilters = (userId: string, query?: string, tags?: string[]) => {
     }
   }
 
-  return filters.length === 1 ? filters[0] : and(...filters);
+  return and(...filters);
 };
 
 const buildFoodSort = (sort: FoodSort) => {
@@ -279,7 +279,7 @@ export const deleteFood = async (id: string, userId: string): Promise<boolean> =
   return result.changes === 1;
 };
 
-export const updateFoodLastUsedAt = async (
+export const trackFoodUsage = async (
   foodId: string,
   userId: string,
   lastUsedAt = Date.now(),
@@ -296,6 +296,6 @@ export const updateFoodLastUsedAt = async (
     .run();
 
   if (result.changes !== 1) {
-    throw new Error('Failed to update food last used timestamp');
+    throw new Error('Failed to track food usage metrics');
   }
 };

--- a/apps/api/src/routes/foods/store.ts
+++ b/apps/api/src/routes/foods/store.ts
@@ -48,7 +48,7 @@ const foodSelection = {
 const toNullable = <T>(value: T | undefined): T | null => value ?? null;
 const escapeLikePattern = (value: string) => value.toLowerCase().replace(/[%_\\]/g, '\\$&');
 
-const buildFoodFilters = (userId: string, query?: string) => {
+const buildFoodFilters = (userId: string, query?: string, tags?: string[]) => {
   const filters: SQL<unknown>[] = [eq(foods.userId, userId), isNull(foods.deletedAt)];
 
   if (query) {
@@ -60,6 +60,18 @@ const buildFoodFilters = (userId: string, query?: string) => {
         or lower(coalesce(${foods.brand}, '')) like ${pattern} escape '\\'
       )`,
     );
+  }
+
+  if (tags && tags.length > 0) {
+    for (const tag of tags) {
+      filters.push(
+        sql`exists (
+          select 1
+          from json_each(${foods.tags})
+          where lower(json_each.value) = ${tag}
+        )`,
+      );
+    }
   }
 
   return filters.length === 1 ? filters[0] : and(...filters);
@@ -144,11 +156,11 @@ export const createFood = async ({
 
 export const listFoods = async (
   userId: string,
-  { q, sort, page, limit }: FoodQueryParams,
+  { q, tags, sort, page, limit }: FoodQueryParams,
 ): Promise<FoodListResult> => {
   const { db } = await import('../../db/index.js');
 
-  const filters = buildFoodFilters(userId, q);
+  const filters = buildFoodFilters(userId, q, tags);
   const offset = (page - 1) * limit;
 
   const foodRows = db
@@ -236,7 +248,7 @@ export const updateFood = async (
     nextValues.notes = toNullable(updates.notes);
   }
 
-  if ('tags' in updates) {
+  if (updates.tags !== undefined) {
     nextValues.tags = updates.tags;
   }
 

--- a/apps/api/src/routes/nutrition/index.test.ts
+++ b/apps/api/src/routes/nutrition/index.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildServer } from '../../index.js';
-import { updateFoodLastUsedAt } from '../foods/store.js';
+import { trackFoodUsage } from '../foods/store.js';
 
 import {
   createMealForDate,
@@ -28,7 +28,7 @@ vi.mock('./store.js', () => ({
 }));
 
 vi.mock('../foods/store.js', () => ({
-  updateFoodLastUsedAt: vi.fn(),
+  trackFoodUsage: vi.fn(),
 }));
 
 const createAuthorizationHeader = (token: string) => ({
@@ -196,8 +196,8 @@ describe('nutrition routes', () => {
     vi.mocked(getNutritionWeekSummaryForDate).mockReset();
     vi.mocked(patchMealById).mockReset();
     vi.mocked(patchMealItemById).mockReset();
-    vi.mocked(updateFoodLastUsedAt).mockReset();
-    vi.mocked(updateFoodLastUsedAt).mockResolvedValue(undefined);
+    vi.mocked(trackFoodUsage).mockReset();
+    vi.mocked(trackFoodUsage).mockResolvedValue(undefined);
     process.env.JWT_SECRET = 'test-nutrition-routes-secret';
   });
 
@@ -283,8 +283,8 @@ describe('nutrition routes', () => {
           },
         ],
       });
-      expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenCalledTimes(1);
-      expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenCalledWith('food-1', 'user-1');
+      expect(vi.mocked(trackFoodUsage)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(trackFoodUsage)).toHaveBeenCalledWith('food-1', 'user-1');
     } finally {
       await app.close();
     }
@@ -295,7 +295,7 @@ describe('nutrition routes', () => {
       meal,
       items: mealItems,
     });
-    vi.mocked(updateFoodLastUsedAt).mockRejectedValueOnce(new Error('transient update failure'));
+    vi.mocked(trackFoodUsage).mockRejectedValueOnce(new Error('transient update failure'));
 
     const app = buildServer();
 
@@ -330,7 +330,7 @@ describe('nutrition routes', () => {
           items: mealItems,
         },
       });
-      expect(vi.mocked(updateFoodLastUsedAt)).toHaveBeenCalledWith('food-1', 'user-1');
+      expect(vi.mocked(trackFoodUsage)).toHaveBeenCalledWith('food-1', 'user-1');
     } finally {
       await app.close();
     }

--- a/apps/api/src/routes/nutrition/index.ts
+++ b/apps/api/src/routes/nutrition/index.ts
@@ -78,7 +78,17 @@ export const nutritionRoutes: FastifyPluginAsync = async (app) => {
     const created = await createMealForDate(request.userId, request.params.date, parsedBody.data);
 
     const foodIds = [...new Set(created.items.map((item) => item.foodId).filter(isNonEmptyString))];
-    await Promise.allSettled(foodIds.map((foodId) => trackFoodUsage(foodId, request.userId)));
+    const usageTrackingResults = await Promise.allSettled(
+      foodIds.map((foodId) => trackFoodUsage(foodId, request.userId)),
+    );
+    usageTrackingResults.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        request.log.warn(
+          { err: result.reason, foodId: foodIds[index], userId: request.userId },
+          'Failed to track food usage after meal creation',
+        );
+      }
+    });
 
     return reply.code(201).send({
       data: created,

--- a/apps/api/src/routes/nutrition/index.ts
+++ b/apps/api/src/routes/nutrition/index.ts
@@ -7,7 +7,7 @@ import type { FastifyPluginAsync } from 'fastify';
 
 import { sendError } from '../../lib/reply.js';
 import { requireAuth } from '../../middleware/auth.js';
-import { updateFoodLastUsedAt } from '../foods/store.js';
+import { trackFoodUsage } from '../foods/store.js';
 
 import {
   createMealForDate,
@@ -78,7 +78,7 @@ export const nutritionRoutes: FastifyPluginAsync = async (app) => {
     const created = await createMealForDate(request.userId, request.params.date, parsedBody.data);
 
     const foodIds = [...new Set(created.items.map((item) => item.foodId).filter(isNonEmptyString))];
-    await Promise.allSettled(foodIds.map((foodId) => updateFoodLastUsedAt(foodId, request.userId)));
+    await Promise.allSettled(foodIds.map((foodId) => trackFoodUsage(foodId, request.userId)));
 
     return reply.code(201).send({
       data: created,

--- a/apps/web/src/features/foods/api/foods.test.tsx
+++ b/apps/web/src/features/foods/api/foods.test.tsx
@@ -93,6 +93,7 @@ describe('foods api hooks', () => {
       () =>
         useFoods({
           q: 'chicken',
+          tags: ['protein', 'dinner'],
           sort: 'popular',
           page: 2,
           limit: 5,
@@ -110,6 +111,7 @@ describe('foods api hooks', () => {
       queryClient.getQueryState(
         foodKeys.list({
           q: 'chicken',
+          tags: ['protein', 'dinner'],
           sort: 'popular',
           page: 2,
           limit: 5,
@@ -126,6 +128,7 @@ describe('foods api hooks', () => {
     const request = new URL(String(firstRequest), 'http://localhost');
     expect(request.pathname).toBe('/api/v1/foods');
     expect(request.searchParams.get('q')).toBe('chicken');
+    expect(request.searchParams.get('tags')).toBe('protein,dinner');
     expect(request.searchParams.get('sort')).toBe('popular');
     expect(request.searchParams.get('page')).toBe('2');
     expect(request.searchParams.get('limit')).toBe('5');

--- a/apps/web/src/features/foods/api/foods.test.tsx
+++ b/apps/web/src/features/foods/api/foods.test.tsx
@@ -35,6 +35,8 @@ function createFood(id: string, name: string): Food {
     verified: false,
     source: null,
     notes: null,
+    usageCount: 0,
+    tags: [],
     lastUsedAt: null,
     createdAt: 1_700_000_000_000,
     updatedAt: 1_700_000_000_000,
@@ -91,7 +93,7 @@ describe('foods api hooks', () => {
       () =>
         useFoods({
           q: 'chicken',
-          sort: 'protein',
+          sort: 'popular',
           page: 2,
           limit: 5,
         }),
@@ -108,7 +110,7 @@ describe('foods api hooks', () => {
       queryClient.getQueryState(
         foodKeys.list({
           q: 'chicken',
-          sort: 'protein',
+          sort: 'popular',
           page: 2,
           limit: 5,
         }),
@@ -124,7 +126,7 @@ describe('foods api hooks', () => {
     const request = new URL(String(firstRequest), 'http://localhost');
     expect(request.pathname).toBe('/api/v1/foods');
     expect(request.searchParams.get('q')).toBe('chicken');
-    expect(request.searchParams.get('sort')).toBe('protein');
+    expect(request.searchParams.get('sort')).toBe('popular');
     expect(request.searchParams.get('page')).toBe('2');
     expect(request.searchParams.get('limit')).toBe('5');
   });

--- a/apps/web/src/features/foods/api/foods.ts
+++ b/apps/web/src/features/foods/api/foods.ts
@@ -24,6 +24,9 @@ function buildFoodsQueryString(params: FoodQueryParams) {
   if (params.q) {
     searchParams.set('q', params.q);
   }
+  if (params.tags && params.tags.length > 0) {
+    searchParams.set('tags', params.tags.join(','));
+  }
 
   searchParams.set('sort', params.sort);
   searchParams.set('page', String(params.page));

--- a/apps/web/src/features/foods/api/keys.ts
+++ b/apps/web/src/features/foods/api/keys.ts
@@ -6,6 +6,7 @@ function normalizeListParams(params?: Partial<FoodQueryParams>) {
     page: params?.page ?? null,
     q: params?.q ?? null,
     sort: params?.sort ?? null,
+    tags: params?.tags?.join('|') ?? null,
   };
 }
 

--- a/apps/web/src/features/foods/components/food-list.test.tsx
+++ b/apps/web/src/features/foods/components/food-list.test.tsx
@@ -33,6 +33,8 @@ function createFood(id: string, name: string, overrides: Partial<Food> = {}): Fo
     verified: true,
     source: 'USDA',
     notes: null,
+    usageCount: 0,
+    tags: [],
     lastUsedAt: Date.parse('2026-03-05T12:00:00.000Z'),
     createdAt: 1_700_000_000_000,
     updatedAt: 1_700_000_000_000,
@@ -61,9 +63,9 @@ function sortFoods(foods: Food[], sort: string) {
     });
   }
 
-  if (sort === 'protein') {
+  if (sort === 'popular') {
     return copy.sort(
-      (left, right) => right.protein - left.protein || left.name.localeCompare(right.name),
+      (left, right) => right.usageCount - left.usageCount || left.name.localeCompare(right.name),
     );
   }
 
@@ -204,22 +206,30 @@ const paginatedFoods = [
   createFood('food-1', '2% Milk', {
     brand: 'Fairlife',
     protein: 13,
+    usageCount: 12,
+    tags: ['dairy', 'breakfast'],
     servingSize: '1 cup',
     servingGrams: 240,
     lastUsedAt: Date.parse('2026-03-04T07:10:00.000Z'),
   }),
   createFood('food-2', 'Almonds', {
     protein: 6,
+    usageCount: 8,
+    tags: ['snack'],
     lastUsedAt: Date.parse('2026-03-03T20:20:00.000Z'),
   }),
   createFood('food-3', 'Apple', {
     verified: false,
     source: null,
     protein: 0,
+    usageCount: 3,
+    tags: ['fruit', 'snack'],
     lastUsedAt: Date.parse('2026-03-02T12:15:00.000Z'),
   }),
   createFood('food-4', 'Atlantic Salmon', {
     protein: 31,
+    usageCount: 4,
+    tags: ['dinner', 'protein'],
     calories: 290,
     fat: 17,
     carbs: 0,
@@ -227,20 +237,28 @@ const paginatedFoods = [
   }),
   createFood('food-5', 'Avocado', {
     protein: 2,
+    usageCount: 2,
+    tags: ['produce'],
     fat: 11,
     lastUsedAt: Date.parse('2026-03-01T12:15:00.000Z'),
   }),
   createFood('food-6', 'Banana', {
     protein: 1,
+    usageCount: 6,
+    tags: ['fruit'],
     carbs: 27,
     lastUsedAt: Date.parse('2026-03-05T07:15:00.000Z'),
   }),
   createFood('food-7', 'Broccoli', {
     protein: 3,
+    usageCount: 7,
+    tags: ['produce'],
     lastUsedAt: Date.parse('2026-03-05T12:30:00.000Z'),
   }),
   createFood('food-8', 'Chicken Breast', {
     protein: 35,
+    usageCount: 11,
+    tags: ['protein', 'dinner'],
     carbs: 0,
     fat: 4,
     lastUsedAt: Date.parse('2026-03-05T12:30:00.000Z'),
@@ -248,26 +266,36 @@ const paginatedFoods = [
   createFood('food-9', 'Greek Yogurt', {
     brand: 'Fage 0%',
     protein: 18,
+    usageCount: 16,
+    tags: ['dairy', 'protein'],
     lastUsedAt: Date.parse('2026-03-05T15:30:00.000Z'),
   }),
   createFood('food-10', 'Ground Beef 90/10', {
     protein: 23,
+    usageCount: 9,
+    tags: ['protein', 'dinner'],
     fat: 11,
     lastUsedAt: Date.parse('2026-03-03T18:30:00.000Z'),
   }),
   createFood('food-11', 'Olive Oil', {
     protein: 0,
     carbs: 0,
+    usageCount: 5,
+    tags: ['fats'],
     fat: 14,
     lastUsedAt: Date.parse('2026-03-04T18:45:00.000Z'),
   }),
   createFood('food-12', 'Spinach', {
     protein: 3,
+    usageCount: 10,
+    tags: ['produce'],
     lastUsedAt: Date.parse('2026-03-05T16:45:00.000Z'),
   }),
   createFood('food-13', 'Whey Protein', {
     brand: 'Optimum Nutrition Gold Standard',
     protein: 24,
+    usageCount: 25,
+    tags: ['supplement', 'protein'],
     carbs: 3,
     fat: 1,
     calories: 120,
@@ -380,12 +408,12 @@ describe('FoodList', () => {
     const initialUrl = new URL(String(api.fetchMock.mock.calls.at(0)?.[0]), 'http://localhost');
     expect(initialUrl.searchParams.get('sort')).toBe('recent');
 
-    selectSortOption('Highest Protein');
+    selectSortOption('Popular');
 
     expect(await screen.findByRole('button', { name: 'Whey Protein' })).toBeInTheDocument();
 
     let lastUrl = new URL(String(api.fetchMock.mock.calls.at(-1)?.[0]), 'http://localhost');
-    expect(lastUrl.searchParams.get('sort')).toBe('protein');
+    expect(lastUrl.searchParams.get('sort')).toBe('popular');
 
     fireEvent.click(screen.getByRole('button', { name: 'Whey Protein' }));
     const editInput = await screen.findByRole('textbox', { name: 'Edit Whey Protein name' });
@@ -398,7 +426,7 @@ describe('FoodList', () => {
     ).toBeInTheDocument();
     expect(api.getFoods().find((food) => food.id === 'food-13')?.name).toBe('Casein Protein');
 
-    selectSortOption('Alphabetical');
+    selectSortOption('A-Z');
     await waitFor(() => {
       const requestUrl = new URL(String(api.fetchMock.mock.calls.at(-1)?.[0]), 'http://localhost');
 
@@ -433,7 +461,7 @@ describe('FoodList', () => {
 
     expect(await screen.findByRole('heading', { level: 3, name: 'Spinach' })).toBeInTheDocument();
 
-    selectSortOption('Highest Protein');
+    selectSortOption('Popular');
     expect(await screen.findByRole('button', { name: 'Whey Protein' })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Whey Protein' }));
@@ -466,6 +494,37 @@ describe('FoodList', () => {
     expect(screen.getByRole('textbox', { name: 'Edit Whey Protein name' })).toHaveValue(
       'Casein Protein',
     );
+  });
+
+  it('filters foods by tag chips and supports tag add/remove edits', async () => {
+    const api = createFoodsApiMock(paginatedFoods);
+    vi.stubGlobal('fetch', api.fetchMock);
+
+    renderFoodList();
+
+    expect(await screen.findByRole('heading', { level: 3, name: 'Spinach' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'dairy' }));
+    expect(await screen.findByRole('heading', { level: 3, name: 'Greek Yogurt' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { level: 3, name: 'Atlantic Salmon' }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove dairy tag from Greek Yogurt' }));
+    await waitFor(() => {
+      expect(api.getFoods().find((food) => food.id === 'food-9')?.tags).toEqual(['protein']);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+    expect(await screen.findByRole('heading', { level: 3, name: 'Apple' })).toBeInTheDocument();
+
+    const appleTagInput = screen.getByRole('textbox', { name: 'Add tag for Apple' });
+    fireEvent.change(appleTagInput, { target: { value: 'portable' } });
+    fireEvent.keyDown(appleTagInput, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(api.getFoods().find((food) => food.id === 'food-3')?.tags).toContain('portable');
+    });
   });
 
   it('removes foods optimistically and keeps the total count in sync', async () => {

--- a/apps/web/src/features/foods/components/food-list.test.tsx
+++ b/apps/web/src/features/foods/components/food-list.test.tsx
@@ -72,6 +72,10 @@ function sortFoods(foods: Food[], sort: string) {
   return copy.sort((left, right) => left.name.localeCompare(right.name));
 }
 
+function normalizeTags(tags: string[]) {
+  return tags.map((tag) => tag.trim().toLowerCase()).filter((tag) => tag.length > 0);
+}
+
 function createFoodsApiMock(
   initialFoods: Food[],
   options?: {
@@ -88,12 +92,25 @@ function createFoodsApiMock(
 
     if (url.pathname === '/api/v1/foods' && method === 'GET') {
       const q = url.searchParams.get('q')?.toLowerCase() ?? '';
+      const selectedTags = normalizeTags((url.searchParams.get('tags') ?? '').split(','));
       const sort = url.searchParams.get('sort') ?? 'name';
       const page = Number(url.searchParams.get('page') ?? '1');
       const limit = Number(url.searchParams.get('limit') ?? '12');
-      const filteredFoods = foods.filter((food) =>
-        [food.name, food.brand ?? ''].some((value) => value.toLowerCase().includes(q)),
-      );
+      const filteredFoods = foods.filter((food) => {
+        const matchesQuery = [food.name, food.brand ?? ''].some((value) =>
+          value.toLowerCase().includes(q),
+        );
+        if (!matchesQuery) {
+          return false;
+        }
+
+        if (selectedTags.length === 0) {
+          return true;
+        }
+
+        const foodTags = normalizeTags(food.tags);
+        return selectedTags.every((tag) => foodTags.includes(tag));
+      });
       const sortedFoods = sortFoods(filteredFoods, sort);
       const startIndex = (page - 1) * limit;
       const data = sortedFoods.slice(startIndex, startIndex + limit);
@@ -506,9 +523,13 @@ describe('FoodList', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'dairy' }));
     expect(await screen.findByRole('heading', { level: 3, name: 'Greek Yogurt' })).toBeInTheDocument();
-    expect(
-      screen.queryByRole('heading', { level: 3, name: 'Atlantic Salmon' }),
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('heading', { level: 3, name: 'Atlantic Salmon' }),
+      ).not.toBeInTheDocument();
+    });
+    const filterRequest = new URL(String(api.fetchMock.mock.calls.at(-1)?.[0]), 'http://localhost');
+    expect(filterRequest.searchParams.get('tags')).toBe('dairy');
 
     fireEvent.click(screen.getByRole('button', { name: 'Remove dairy tag from Greek Yogurt' }));
     await waitFor(() => {

--- a/apps/web/src/features/foods/components/food-list.tsx
+++ b/apps/web/src/features/foods/components/food-list.tsx
@@ -128,12 +128,14 @@ export function FoodList({
   const shouldUsePageFoodsQuery =
     pageFoodsQuery !== undefined &&
     debouncedSearchQuery.length === 0 &&
+    selectedTags.length === 0 &&
     sortBy === DEFAULT_SORT_BY &&
     page === DEFAULT_PAGE &&
     pageSize === DEFAULT_PAGE_SIZE;
   const fallbackFoodsQuery = useFoods(
     {
       q: debouncedSearchQuery || undefined,
+      tags: selectedTags.length > 0 ? normalizeFoodTags(selectedTags) : undefined,
       sort: sortBy,
       page,
       limit: pageSize,
@@ -144,7 +146,7 @@ export function FoodList({
   const updateFood = useUpdateFood();
   const deleteFood = useDeleteFood();
 
-  const foods = foodsQuery.data?.data ?? [];
+  const foods = useMemo(() => foodsQuery.data?.data ?? [], [foodsQuery.data?.data]);
   const availableTags = useMemo(() => {
     const tagSet = new Set<string>();
     foods.forEach((food) => {
@@ -153,20 +155,12 @@ export function FoodList({
 
     return Array.from(tagSet).sort((left, right) => left.localeCompare(right));
   }, [foods]);
-  const activeSelectedTags = useMemo(
-    () => selectedTags.filter((tag) => availableTags.includes(tag)),
-    [availableTags, selectedTags],
-  );
-  const visibleFoods = useMemo(() => {
-    if (activeSelectedTags.length === 0) {
-      return foods;
-    }
+  const activeSelectedTags = useMemo(() => normalizeFoodTags(selectedTags), [selectedTags]);
+  const filterTags = useMemo(() => {
+    const tagSet = new Set([...availableTags, ...activeSelectedTags]);
 
-    return foods.filter((food) => {
-      const foodTags = normalizeFoodTags(food.tags);
-      return activeSelectedTags.every((tag) => foodTags.includes(tag));
-    });
-  }, [activeSelectedTags, foods]);
+    return Array.from(tagSet).sort((left, right) => left.localeCompare(right));
+  }, [activeSelectedTags, availableTags]);
   const totalFoods = foodsQuery.data?.meta.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(totalFoods / pageSize));
   const updateErrorMessage =
@@ -182,12 +176,6 @@ export function FoodList({
       setPage(totalPages);
     }
   }, [page, totalPages]);
-
-  useEffect(() => {
-    if (activeSelectedTags.length !== selectedTags.length) {
-      setSelectedTags(activeSelectedTags);
-    }
-  }, [activeSelectedTags, selectedTags]);
 
   function beginEditing(food: Food) {
     editCancelledRef.current = false;
@@ -354,11 +342,11 @@ export function FoodList({
         <CardContent className="px-5 pt-0 sm:px-6">
           <div className="space-y-2">
             <p className="text-sm font-medium text-on-cream dark:text-foreground">Filter by tags</p>
-            {availableTags.length === 0 ? (
+            {filterTags.length === 0 ? (
               <p className="text-sm text-muted-foreground">No tags yet</p>
             ) : (
               <div className="flex flex-wrap gap-2">
-                {availableTags.map((tag) => {
+                {filterTags.map((tag) => {
                   const isSelected = activeSelectedTags.includes(tag);
                   return (
                     <Button
@@ -366,9 +354,9 @@ export function FoodList({
                       className="h-7 rounded-full px-3 text-xs"
                       onClick={() => {
                         setSelectedTags((current) =>
-                          current.includes(tag)
-                            ? current.filter((currentTag) => currentTag !== tag)
-                            : [...current, tag],
+                          normalizeFoodTags(current).includes(tag)
+                            ? normalizeFoodTags(current).filter((currentTag) => currentTag !== tag)
+                            : [...normalizeFoodTags(current), tag],
                         );
                         setPage(1);
                       }}
@@ -397,7 +385,7 @@ export function FoodList({
         <CardContent className="px-5 pt-0 sm:px-6">
           <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-muted">
             <p>
-              Showing {visibleFoods.length} of {totalFoods} foods
+              Showing {foods.length} of {totalFoods} foods
             </p>
             {isRefreshing ? <p>Refreshing foods…</p> : null}
           </div>
@@ -427,7 +415,7 @@ export function FoodList({
             <FoodCardSkeleton key={index} />
           ))}
         </div>
-      ) : visibleFoods.length === 0 ? (
+      ) : foods.length === 0 ? (
         <Card className="gap-3 border-dashed py-8 text-center shadow-none">
           <CardHeader className="gap-1 px-5 sm:px-6">
             <CardTitle className="text-lg">No foods found</CardTitle>
@@ -443,7 +431,7 @@ export function FoodList({
       ) : (
         <>
           <div className="grid gap-4 lg:grid-cols-2">
-            {visibleFoods.map((food) => {
+            {foods.map((food) => {
               const isUpdatingFood = updateFood.isPending && updateFood.variables?.id === food.id;
               const isDeletingFood = deleteFood.isPending && deleteFood.variables === food.id;
 
@@ -539,8 +527,12 @@ export function FoodList({
                       <span>Serving: {formatServing(food)}</span>
                       <span aria-hidden="true">•</span>
                       <span>{formatLastUsed(food.lastUsedAt, now)}</span>
-                      <span aria-hidden="true">•</span>
-                      <span>Used {food.usageCount} times</span>
+                      {food.usageCount > 0 ? (
+                        <>
+                          <span aria-hidden="true">•</span>
+                          <span>Used {food.usageCount} times</span>
+                        </>
+                      ) : null}
                     </div>
 
                     <div className="space-y-2">

--- a/apps/web/src/features/foods/components/food-list.tsx
+++ b/apps/web/src/features/foods/components/food-list.tsx
@@ -232,7 +232,9 @@ export function FoodList({
 
   async function saveFoodTags(food: Food, tags: string[]) {
     const normalized = normalizeFoodTags(tags).slice(0, FOOD_TAG_LIMIT);
-    if (normalized.join('|') === normalizeFoodTags(food.tags).join('|')) {
+    if (
+      [...normalized].sort().join('|') === [...normalizeFoodTags(food.tags)].sort().join('|')
+    ) {
       return;
     }
 

--- a/apps/web/src/features/foods/components/food-list.tsx
+++ b/apps/web/src/features/foods/components/food-list.tsx
@@ -1,6 +1,6 @@
-import { CheckCircle2Icon, SearchIcon, Trash2Icon } from 'lucide-react';
+import { CheckCircle2Icon, SearchIcon, Trash2Icon, XIcon } from 'lucide-react';
 import type { Food, FoodSort } from '@pulse/shared';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { FoodCardSkeleton } from '@/components/skeletons';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -29,12 +29,34 @@ const SEARCH_DEBOUNCE_MS = 300;
 const DEFAULT_PAGE_SIZE = 12;
 const DEFAULT_PAGE = 1;
 const DEFAULT_SORT_BY: FoodSort = 'recent';
+const FOOD_TAG_LIMIT = 20;
 
 const SORT_OPTIONS: Array<{ label: string; value: FoodSort }> = [
-  { label: 'Alphabetical', value: 'name' },
-  { label: 'Most Recent', value: 'recent' },
-  { label: 'Highest Protein', value: 'protein' },
+  { label: 'Recent', value: 'recent' },
+  { label: 'Popular', value: 'popular' },
+  { label: 'A-Z', value: 'name' },
 ];
+
+function normalizeFoodTag(tag: string) {
+  return tag.trim().toLowerCase();
+}
+
+function normalizeFoodTags(tags: string[]) {
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+
+  for (const tag of tags) {
+    const nextTag = normalizeFoodTag(tag);
+    if (!nextTag || seen.has(nextTag)) {
+      continue;
+    }
+
+    seen.add(nextTag);
+    normalized.push(nextTag);
+  }
+
+  return normalized;
+}
 
 function startOfDay(date: Date) {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
@@ -85,9 +107,11 @@ export function FoodList({
   const [searchInput, setSearchInput] = useState('');
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState<FoodSort>(DEFAULT_SORT_BY);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [page, setPage] = useState(DEFAULT_PAGE);
   const [editingFoodId, setEditingFoodId] = useState<string | null>(null);
   const [draftFoodName, setDraftFoodName] = useState('');
+  const [tagDrafts, setTagDrafts] = useState<Record<string, string>>({});
   const [isSavingEdit, setIsSavingEdit] = useState(false);
   const editCancelledRef = useRef(false);
 
@@ -121,6 +145,28 @@ export function FoodList({
   const deleteFood = useDeleteFood();
 
   const foods = foodsQuery.data?.data ?? [];
+  const availableTags = useMemo(() => {
+    const tagSet = new Set<string>();
+    foods.forEach((food) => {
+      normalizeFoodTags(food.tags).forEach((tag) => tagSet.add(tag));
+    });
+
+    return Array.from(tagSet).sort((left, right) => left.localeCompare(right));
+  }, [foods]);
+  const activeSelectedTags = useMemo(
+    () => selectedTags.filter((tag) => availableTags.includes(tag)),
+    [availableTags, selectedTags],
+  );
+  const visibleFoods = useMemo(() => {
+    if (activeSelectedTags.length === 0) {
+      return foods;
+    }
+
+    return foods.filter((food) => {
+      const foodTags = normalizeFoodTags(food.tags);
+      return activeSelectedTags.every((tag) => foodTags.includes(tag));
+    });
+  }, [activeSelectedTags, foods]);
   const totalFoods = foodsQuery.data?.meta.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(totalFoods / pageSize));
   const updateErrorMessage =
@@ -136,6 +182,12 @@ export function FoodList({
       setPage(totalPages);
     }
   }, [page, totalPages]);
+
+  useEffect(() => {
+    if (activeSelectedTags.length !== selectedTags.length) {
+      setSelectedTags(activeSelectedTags);
+    }
+  }, [activeSelectedTags, selectedTags]);
 
   function beginEditing(food: Food) {
     editCancelledRef.current = false;
@@ -183,6 +235,41 @@ export function FoodList({
     }
   }
 
+  function setTagDraft(foodId: string, value: string) {
+    setTagDrafts((current) => ({
+      ...current,
+      [foodId]: value,
+    }));
+  }
+
+  async function saveFoodTags(food: Food, tags: string[]) {
+    const normalized = normalizeFoodTags(tags).slice(0, FOOD_TAG_LIMIT);
+    if (normalized.join('|') === normalizeFoodTags(food.tags).join('|')) {
+      return;
+    }
+
+    await updateFood.mutateAsync({
+      id: food.id,
+      updates: { tags: normalized },
+    });
+  }
+
+  async function commitDraftTag(food: Food) {
+    const draftTag = tagDrafts[food.id];
+    if (!draftTag) {
+      return;
+    }
+
+    const nextTag = normalizeFoodTag(draftTag);
+    if (!nextTag) {
+      setTagDraft(food.id, '');
+      return;
+    }
+
+    await saveFoodTags(food, [...food.tags, nextTag]);
+    setTagDraft(food.id, '');
+  }
+
   function handleDeleteFood(foodId: string, foodName: string) {
     confirm({
       title: 'Delete food?',
@@ -212,8 +299,8 @@ export function FoodList({
         <CardHeader className="gap-1 px-5 sm:px-6">
           <CardTitle className="text-xl">Search your foods database</CardTitle>
           <CardDescription className="text-sm opacity-70 dark:text-muted dark:opacity-100">
-            Search by food name or brand, then switch between alphabetical, recency, and
-            protein-focused views.
+            Search by food name or brand, then switch between recency, popularity, or alphabetical
+            views.
           </CardDescription>
         </CardHeader>
 
@@ -265,9 +352,52 @@ export function FoodList({
         </CardContent>
 
         <CardContent className="px-5 pt-0 sm:px-6">
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-on-cream dark:text-foreground">Filter by tags</p>
+            {availableTags.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No tags yet</p>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {availableTags.map((tag) => {
+                  const isSelected = activeSelectedTags.includes(tag);
+                  return (
+                    <Button
+                      key={tag}
+                      className="h-7 rounded-full px-3 text-xs"
+                      onClick={() => {
+                        setSelectedTags((current) =>
+                          current.includes(tag)
+                            ? current.filter((currentTag) => currentTag !== tag)
+                            : [...current, tag],
+                        );
+                        setPage(1);
+                      }}
+                      type="button"
+                      variant={isSelected ? 'default' : 'outline'}
+                    >
+                      {tag}
+                    </Button>
+                  );
+                })}
+                {activeSelectedTags.length > 0 ? (
+                  <Button
+                    className="h-7 rounded-full px-3 text-xs"
+                    onClick={() => setSelectedTags([])}
+                    type="button"
+                    variant="ghost"
+                  >
+                    Clear
+                  </Button>
+                ) : null}
+              </div>
+            )}
+          </div>
+        </CardContent>
+
+        <CardContent className="px-5 pt-0 sm:px-6">
           <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-muted">
             <p>
-              Showing {foods.length} of {totalFoods} foods
+              Showing {visibleFoods.length} of {totalFoods} foods
             </p>
             {isRefreshing ? <p>Refreshing foods…</p> : null}
           </div>
@@ -297,21 +427,23 @@ export function FoodList({
             <FoodCardSkeleton key={index} />
           ))}
         </div>
-      ) : foods.length === 0 ? (
+      ) : visibleFoods.length === 0 ? (
         <Card className="gap-3 border-dashed py-8 text-center shadow-none">
           <CardHeader className="gap-1 px-5 sm:px-6">
             <CardTitle className="text-lg">No foods found</CardTitle>
             <CardDescription>
               {debouncedSearchQuery
                 ? `No saved foods matched “${debouncedSearchQuery}”. Try another search term.`
-                : 'No foods have been saved yet.'}
+                : activeSelectedTags.length > 0
+                  ? 'No foods match the selected tags.'
+                  : 'No foods have been saved yet.'}
             </CardDescription>
           </CardHeader>
         </Card>
       ) : (
         <>
           <div className="grid gap-4 lg:grid-cols-2">
-            {foods.map((food) => {
+            {visibleFoods.map((food) => {
               const isUpdatingFood = updateFood.isPending && updateFood.variables?.id === food.id;
               const isDeletingFood = deleteFood.isPending && deleteFood.variables === food.id;
 
@@ -407,6 +539,76 @@ export function FoodList({
                       <span>Serving: {formatServing(food)}</span>
                       <span aria-hidden="true">•</span>
                       <span>{formatLastUsed(food.lastUsedAt, now)}</span>
+                      <span aria-hidden="true">•</span>
+                      <span>Used {food.usageCount} times</span>
+                    </div>
+
+                    <div className="space-y-2">
+                      <div className="flex flex-wrap gap-2">
+                        {food.tags.length === 0 ? (
+                          <span className="text-xs text-muted-foreground">No tags</span>
+                        ) : (
+                          normalizeFoodTags(food.tags).map((tag) => (
+                            <Badge
+                              key={tag}
+                              className="h-6 rounded-full gap-1 px-2 text-xs"
+                              variant="secondary"
+                            >
+                              {tag}
+                              <button
+                                aria-label={`Remove ${tag} tag from ${food.name}`}
+                                className="rounded-full p-0.5 text-muted-foreground hover:text-foreground"
+                                disabled={isUpdatingFood}
+                                onClick={() => {
+                                  void saveFoodTags(
+                                    food,
+                                    food.tags.filter(
+                                      (foodTag) => normalizeFoodTag(foodTag) !== tag,
+                                    ),
+                                  ).catch(() => {
+                                    return;
+                                  });
+                                }}
+                                type="button"
+                              >
+                                <XIcon className="size-3" />
+                              </button>
+                            </Badge>
+                          ))
+                        )}
+                      </div>
+
+                      <div className="flex items-center gap-2">
+                        <Input
+                          aria-label={`Add tag for ${food.name}`}
+                          className="h-8 text-xs"
+                          onChange={(event) => setTagDraft(food.id, event.target.value)}
+                          onKeyDown={(event) => {
+                            if (event.key === 'Enter' || event.key === ',') {
+                              event.preventDefault();
+                              void commitDraftTag(food).catch(() => {
+                                return;
+                              });
+                            }
+                          }}
+                          placeholder="Add tag"
+                          readOnly={isUpdatingFood}
+                          value={tagDrafts[food.id] ?? ''}
+                        />
+                        <Button
+                          className="h-8 px-2 text-xs"
+                          disabled={isUpdatingFood}
+                          onClick={() => {
+                            void commitDraftTag(food).catch(() => {
+                              return;
+                            });
+                          }}
+                          type="button"
+                          variant="outline"
+                        >
+                          Add
+                        </Button>
+                      </div>
                     </div>
                   </CardHeader>
 

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -4,6 +4,7 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import { describe, expect, it, vi } from 'vitest';
 import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
 
+import * as lastPerformanceHooks from '@/hooks/use-last-performance';
 import { createAppQueryClient } from '@/lib/query-client';
 import { mockTemplates } from '@/lib/mock-data/workouts';
 import { renderWithQueryClient } from '@/test/render-with-query-client';
@@ -1130,5 +1131,103 @@ describe('SessionExerciseList', () => {
     expect(card).not.toBeNull();
     expect(within(card as HTMLElement).getByLabelText('Reps for set 1')).toBeInTheDocument();
     expect(within(card as HTMLElement).queryByLabelText('Weight for set 1')).not.toBeInTheDocument();
+  });
+
+  it('renders related history collapsed by default and expands on demand', () => {
+    if (!activeTemplate) {
+      throw new Error('Expected upper-push template in mock data.');
+    }
+
+    const useLastPerformanceSpy = vi.spyOn(lastPerformanceHooks, 'useLastPerformance');
+    useLastPerformanceSpy.mockReturnValue({
+      data: {
+        history: {
+          date: '2026-03-12',
+          sessionId: 'session-10',
+          sets: [{ completed: true, reps: 10, setNumber: 1, weight: 55 }],
+        },
+        related: [
+          {
+            exerciseId: 'incline-bench',
+            exerciseName: 'Incline Bench Press',
+            history: {
+              date: '2026-03-08',
+              sessionId: 'session-8',
+              sets: [{ completed: true, reps: 8, setNumber: 1, weight: 60 }],
+            },
+          },
+        ],
+      },
+    } as unknown as ReturnType<typeof lastPerformanceHooks.useLastPerformance>);
+
+    const session = buildActiveWorkoutSession(
+      activeTemplate,
+      createInitialWorkoutSetDrafts(activeTemplate, new Set()),
+    );
+
+    renderWithQueryClient(
+      <SessionExerciseList
+        enableApiLastPerformance
+        onAddSet={vi.fn()}
+        onExerciseNotesChange={vi.fn()}
+        onRemoveSet={vi.fn()}
+        onRestTimerComplete={vi.fn()}
+        onSetUpdate={vi.fn()}
+        session={session}
+      />,
+    );
+
+    const rowErgCard = screen
+      .getByRole('heading', { level: 3, name: 'Row Erg' })
+      .closest('[data-slot="card"]');
+    expect(rowErgCard).not.toBeNull();
+    expect(within(rowErgCard as HTMLElement).getByText('History')).toBeInTheDocument();
+    expect(within(rowErgCard as HTMLElement).getByText('Related history')).toBeInTheDocument();
+    expect(within(rowErgCard as HTMLElement).getByText('Incline Bench Press')).not.toBeVisible();
+
+    fireEvent.click(within(rowErgCard as HTMLElement).getByText('Related history'));
+    expect(within(rowErgCard as HTMLElement).getByText('Incline Bench Press')).toBeVisible();
+
+    useLastPerformanceSpy.mockRestore();
+  });
+
+  it('hides related history section when no related exercises are configured', () => {
+    if (!activeTemplate) {
+      throw new Error('Expected upper-push template in mock data.');
+    }
+
+    const useLastPerformanceSpy = vi.spyOn(lastPerformanceHooks, 'useLastPerformance');
+    useLastPerformanceSpy.mockReturnValue({
+      data: {
+        history: null,
+        related: [],
+      },
+    } as unknown as ReturnType<typeof lastPerformanceHooks.useLastPerformance>);
+
+    const session = buildActiveWorkoutSession(
+      activeTemplate,
+      createInitialWorkoutSetDrafts(activeTemplate, new Set()),
+    );
+
+    renderWithQueryClient(
+      <SessionExerciseList
+        enableApiLastPerformance
+        onAddSet={vi.fn()}
+        onExerciseNotesChange={vi.fn()}
+        onRemoveSet={vi.fn()}
+        onRestTimerComplete={vi.fn()}
+        onSetUpdate={vi.fn()}
+        session={session}
+      />,
+    );
+
+    const rowErgCard = screen
+      .getByRole('heading', { level: 3, name: 'Row Erg' })
+      .closest('[data-slot="card"]');
+    expect(rowErgCard).not.toBeNull();
+    expect(within(rowErgCard as HTMLElement).getByText('History')).toBeInTheDocument();
+    expect(within(rowErgCard as HTMLElement).queryByText('Related history')).not.toBeInTheDocument();
+
+    useLastPerformanceSpy.mockRestore();
   });
 });

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -1150,6 +1150,7 @@ describe('SessionExerciseList', () => {
           {
             exerciseId: 'incline-bench',
             exerciseName: 'Incline Bench Press',
+            trackingType: 'weight_reps',
             history: {
               date: '2026-03-08',
               sessionId: 'session-8',
@@ -1186,7 +1187,9 @@ describe('SessionExerciseList', () => {
     expect(within(rowErgCard as HTMLElement).getByText('Incline Bench Press')).not.toBeVisible();
 
     fireEvent.click(within(rowErgCard as HTMLElement).getByText('Related history'));
-    expect(within(rowErgCard as HTMLElement).getByText('Incline Bench Press')).toBeVisible();
+    const relatedExerciseLabel = within(rowErgCard as HTMLElement).getByText('Incline Bench Press');
+    expect(relatedExerciseLabel).toBeVisible();
+    expect(relatedExerciseLabel.closest('div')).toHaveTextContent(/60\.0x8/);
 
     useLastPerformanceSpy.mockRestore();
   });

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -58,6 +58,7 @@ import { cn } from '@/lib/utils';
 import { useRenameExercise } from '../api/workouts';
 import type {
   ActiveWorkoutExercise,
+  ActiveWorkoutExerciseHistorySummary,
   ActiveWorkoutPhaseBadge,
   ActiveWorkoutSessionData,
 } from '../types';
@@ -127,6 +128,11 @@ const phaseBadgeStyles: Record<ActiveWorkoutPhaseBadge, string> = {
   moderate:
     'border-transparent bg-emerald-500/15 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300',
 };
+
+const historyDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+});
 
 const supersetAccentStyles = [
   'border-l-sky-500 before:bg-sky-500',
@@ -613,9 +619,10 @@ function ExerciseCardItem({
   const lastPerformanceQuery = useLastPerformance(exercise.id, {
     enabled: enableApiLastPerformance,
   });
-  const lastPerformance = enableApiLastPerformance
-    ? (lastPerformanceQuery.data ?? null)
-    : exercise.lastPerformance;
+  const historySummary: ActiveWorkoutExerciseHistorySummary = enableApiLastPerformance
+    ? (lastPerformanceQuery.data ?? { history: null, related: [] })
+    : { history: exercise.lastPerformance, related: [] };
+  const lastPerformance = historySummary.history;
   const state = getExerciseState(exercise, sessionCurrentExerciseId);
   const isExerciseComplete = state === 'completed';
   const isExpanded =
@@ -809,6 +816,58 @@ function ExerciseCardItem({
             <p className="text-sm text-muted">
               {formatSetPrescription(exercise.prescribedReps, exercise.restSeconds)}
             </p>
+
+            <div className="space-y-2 rounded-2xl border border-border bg-background/80 p-4">
+              <p className="text-xs font-semibold tracking-[0.18em] text-muted uppercase">
+                History
+              </p>
+              <p className="text-sm text-foreground">
+                {formatHistoryPreview({
+                  history: lastPerformance,
+                  prescribedReps: exercise.prescribedReps,
+                  trackingType: exercise.trackingType,
+                  weightUnit,
+                })}
+              </p>
+            </div>
+
+            {historySummary.related.length > 0 ? (
+              <details className="group rounded-2xl border border-emerald-500/30 bg-emerald-500/10 p-4">
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    <Badge className="border-emerald-500/40 bg-emerald-500/15 text-emerald-700 dark:text-emerald-200">
+                      Related
+                    </Badge>
+                    <p className="text-sm font-semibold text-foreground">Related history</p>
+                  </div>
+                  <ChevronDown
+                    aria-hidden="true"
+                    className="size-4 text-muted transition-transform duration-200 group-open:rotate-180"
+                  />
+                </summary>
+
+                <div className="mt-3 space-y-2">
+                  {historySummary.related.map((relatedExercise) => (
+                    <div
+                      className="rounded-xl border border-emerald-500/20 bg-background/70 px-3 py-2"
+                      key={relatedExercise.exerciseId}
+                    >
+                      <p className="text-xs font-semibold tracking-[0.14em] text-muted uppercase">
+                        {relatedExercise.exerciseName}
+                      </p>
+                      <p className="mt-1 text-sm text-foreground">
+                        {formatHistoryDetail({
+                          history: relatedExercise.history,
+                          prescribedReps: exercise.prescribedReps,
+                          trackingType: exercise.trackingType,
+                          weightUnit,
+                        })}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </details>
+            ) : null}
 
             {hasInjuryCues ? (
               <div className="rounded-2xl border border-amber-500/30 bg-amber-500/12 p-4 text-amber-950 dark:text-amber-100">
@@ -1111,6 +1170,59 @@ function formatExerciseSubtitle({
     .join(', ');
 
   return `${targetText} • Last: ${lastText}`;
+}
+
+function formatHistoryPreview({
+  history,
+  prescribedReps,
+  trackingType,
+  weightUnit,
+}: {
+  history: ActiveWorkoutExercise['lastPerformance'];
+  prescribedReps: string;
+  trackingType: ExerciseTrackingType;
+  weightUnit: WeightUnit;
+}) {
+  if (!history || history.sets.length === 0) {
+    return 'No completed history yet.';
+  }
+
+  const setSummary = history.sets
+    .map((set) =>
+      formatCompactPerformanceSetByTrackingType(
+        trackingType,
+        set.weight,
+        set.reps,
+        prescribedReps,
+        weightUnit,
+      ),
+    )
+    .join(', ');
+
+  return `${historyDateFormatter.format(new Date(`${history.date}T12:00:00`))} • ${setSummary}`;
+}
+
+function formatHistoryDetail({
+  history,
+  prescribedReps,
+  trackingType,
+  weightUnit,
+}: {
+  history: ActiveWorkoutExercise['lastPerformance'];
+  prescribedReps: string;
+  trackingType: ExerciseTrackingType;
+  weightUnit: WeightUnit;
+}) {
+  if (!history || history.sets.length === 0) {
+    return 'No completed sets yet.';
+  }
+
+  return formatHistoryPreview({
+    history,
+    prescribedReps,
+    trackingType,
+    weightUnit,
+  });
 }
 
 function parsePrescribedRepTarget(prescribedReps: string) {

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -856,11 +856,12 @@ function ExerciseCardItem({
                         {relatedExercise.exerciseName}
                       </p>
                       <p className="mt-1 text-sm text-foreground">
-                        {formatHistoryDetail({
+                        {formatHistoryPreview({
                           history: relatedExercise.history,
-                          prescribedReps: exercise.prescribedReps,
-                          trackingType: exercise.trackingType,
+                          prescribedReps: '',
+                          trackingType: relatedExercise.trackingType,
                           weightUnit,
+                          emptyLabel: 'No completed sets yet.',
                         })}
                       </p>
                     </div>
@@ -1177,14 +1178,16 @@ function formatHistoryPreview({
   prescribedReps,
   trackingType,
   weightUnit,
+  emptyLabel = 'No completed history yet.',
 }: {
   history: ActiveWorkoutExercise['lastPerformance'];
   prescribedReps: string;
   trackingType: ExerciseTrackingType;
   weightUnit: WeightUnit;
+  emptyLabel?: string;
 }) {
   if (!history || history.sets.length === 0) {
-    return 'No completed history yet.';
+    return emptyLabel;
   }
 
   const setSummary = history.sets
@@ -1200,29 +1203,6 @@ function formatHistoryPreview({
     .join(', ');
 
   return `${historyDateFormatter.format(new Date(`${history.date}T12:00:00`))} • ${setSummary}`;
-}
-
-function formatHistoryDetail({
-  history,
-  prescribedReps,
-  trackingType,
-  weightUnit,
-}: {
-  history: ActiveWorkoutExercise['lastPerformance'];
-  prescribedReps: string;
-  trackingType: ExerciseTrackingType;
-  weightUnit: WeightUnit;
-}) {
-  if (!history || history.sets.length === 0) {
-    return 'No completed sets yet.';
-  }
-
-  return formatHistoryPreview({
-    history,
-    prescribedReps,
-    trackingType,
-    weightUnit,
-  });
 }
 
 function parsePrescribedRepTarget(prescribedReps: string) {

--- a/apps/web/src/features/workouts/components/session-summary.test.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.test.tsx
@@ -91,8 +91,14 @@ describe('SessionSummary', () => {
     expect(
       screen.getByText('What happened today? Anything notable about this session?'),
     ).toBeInTheDocument();
-    expect(screen.getByTestId('session-summary-notes')).toHaveAttribute('id', 'session-summary-notes');
-    expect(screen.getByTestId('session-summary-notes')).toHaveAttribute('name', 'session-summary-notes');
+    expect(screen.getByTestId('session-summary-notes')).toHaveAttribute(
+      'id',
+      'session-summary-notes',
+    );
+    expect(screen.getByTestId('session-summary-notes')).toHaveAttribute(
+      'name',
+      'session-summary-notes',
+    );
     expect(screen.getByLabelText('Session notes')).toHaveValue('');
     expect(screen.getByRole('textbox', { name: 'Session notes' })).toHaveValue('');
 
@@ -113,14 +119,28 @@ describe('SessionSummary', () => {
     expect(screen.getByLabelText('Description')).toHaveValue(
       'Chest, shoulders, and triceps emphasis with controlled tempo work.',
     );
-    expect(screen.getByLabelText('Tags')).toHaveValue('strength, push, upper-body');
+    expect(screen.getByText('strength')).toBeInTheDocument();
+    expect(screen.getByText('push')).toBeInTheDocument();
+    expect(screen.getByText('upper-body')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove tag upper-body' }));
+    expect(screen.queryByText('upper-body')).not.toBeInTheDocument();
+
+    const tagsInput = screen.getByLabelText('Tags');
+    fireEvent.focus(tagsInput);
+    fireEvent.click(screen.getByRole('button', { name: 'hypertrophy' }));
+    expect(screen.getByText('hypertrophy')).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText('Description'), {
       target: { value: 'Heavy upper emphasis with a slower incline press tempo.' },
     });
-    fireEvent.change(screen.getByLabelText('Tags'), {
-      target: { value: 'strength, push, hypertrophy' },
+    fireEvent.change(tagsInput, {
+      target: { value: 'DELOAD' },
     });
+    fireEvent.keyDown(tagsInput, { key: 'Enter' });
+
+    expect(screen.getByText('deload')).toBeInTheDocument();
+
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(screen.getByText('Saved "Upper Push" to mock templates.')).toBeInTheDocument();

--- a/apps/web/src/features/workouts/components/session-summary.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
-import { CheckCircle2, Clock3, Dumbbell, ListChecks, Save } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { CheckCircle2, Clock3, Dumbbell, ListChecks, Save, X } from 'lucide-react';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { accentCardStyles } from '@/lib/accent-card-styles';
@@ -18,6 +19,12 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
 
+import {
+  appendTemplateTags,
+  normalizeTemplateTags,
+  TEMPLATE_TAG_LIMIT,
+  TEMPLATE_TAG_SUGGESTIONS,
+} from '../lib/template-tags';
 import type { ActiveWorkoutFeedbackDraft } from '../types';
 
 type SessionSummaryProps = {
@@ -59,8 +66,51 @@ export function SessionSummary({
   const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
   const [templateName, setTemplateName] = useState(workoutName);
   const [templateDescription, setTemplateDescription] = useState(defaultDescription);
-  const [templateTags, setTemplateTags] = useState(defaultTags.join(', '));
+  const [templateTags, setTemplateTags] = useState(() => normalizeTemplateTags(defaultTags));
+  const [templateTagInput, setTemplateTagInput] = useState('');
+  const [isTagInputFocused, setIsTagInputFocused] = useState(false);
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
+
+  const hasMaxTemplateTags = templateTags.length >= TEMPLATE_TAG_LIMIT;
+  const normalizedTagQuery = templateTagInput.trim().toLowerCase();
+  const suggestedTemplateTags = useMemo(
+    () =>
+      TEMPLATE_TAG_SUGGESTIONS.filter((tag) => {
+        if (templateTags.includes(tag)) {
+          return false;
+        }
+
+        if (!normalizedTagQuery) {
+          return true;
+        }
+
+        return tag.includes(normalizedTagQuery);
+      }),
+    [normalizedTagQuery, templateTags],
+  );
+
+  function commitTemplateTagInput() {
+    if (!templateTagInput.trim() || hasMaxTemplateTags) {
+      setTemplateTagInput('');
+      return;
+    }
+
+    setTemplateTags((current) => appendTemplateTags(current, templateTagInput));
+    setTemplateTagInput('');
+  }
+
+  function removeTemplateTag(tag: string) {
+    setTemplateTags((current) => current.filter((currentTag) => currentTag !== tag));
+  }
+
+  function addSuggestedTemplateTag(tag: string) {
+    if (hasMaxTemplateTags) {
+      return;
+    }
+
+    setTemplateTags((current) => appendTemplateTags(current, tag));
+    setTemplateTagInput('');
+  }
 
   return (
     <>
@@ -88,9 +138,7 @@ export function SessionSummary({
             <SummaryStat
               icon={ListChecks}
               label="Sets completed"
-              value={
-                completedSets === undefined ? `${totalSets}` : `${completedSets}/${totalSets}`
-              }
+              value={completedSets === undefined ? `${totalSets}` : `${completedSets}/${totalSets}`}
             />
             <SummaryStat icon={CheckCircle2} label="Total reps" value={`${totalReps}`} />
             <SummaryStat icon={Clock3} label="Duration" value={duration} />
@@ -154,7 +202,9 @@ export function SessionSummary({
               onClick={() => {
                 setTemplateName(workoutName);
                 setTemplateDescription(defaultDescription);
-                setTemplateTags(defaultTags.join(', '));
+                setTemplateTags(normalizeTemplateTags(defaultTags));
+                setTemplateTagInput('');
+                setIsTagInputFocused(false);
                 setSaveMessage(null);
                 setIsSaveDialogOpen(true);
               }}
@@ -224,13 +274,71 @@ export function SessionSummary({
               <label className="text-sm font-medium text-foreground" htmlFor="template-tags">
                 Tags
               </label>
+              <div className="flex flex-wrap gap-2">
+                {templateTags.map((tag) => (
+                  <Badge className="gap-1.5" key={tag} variant="secondary">
+                    <span>{tag}</span>
+                    <button
+                      aria-label={`Remove tag ${tag}`}
+                      className="rounded-full p-0.5 transition-colors hover:bg-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      onClick={() => removeTemplateTag(tag)}
+                      type="button"
+                    >
+                      <X aria-hidden="true" className="size-3" />
+                    </button>
+                  </Badge>
+                ))}
+              </div>
               <Input
                 id="template-tags"
-                onChange={(event) => setTemplateTags(event.target.value)}
-                placeholder="strength, upper-body, gym"
-                value={templateTags}
+                onBlur={() => {
+                  setIsTagInputFocused(false);
+                  commitTemplateTagInput();
+                }}
+                onChange={(event) => setTemplateTagInput(event.target.value)}
+                onFocus={() => setIsTagInputFocused(true)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ',') {
+                    event.preventDefault();
+                    commitTemplateTagInput();
+                  }
+
+                  if (
+                    event.key === 'Backspace' &&
+                    templateTagInput.length === 0 &&
+                    templateTags.length > 0
+                  ) {
+                    event.preventDefault();
+                    setTemplateTags((current) => current.slice(0, current.length - 1));
+                  }
+                }}
+                placeholder="Add a tag"
+                value={templateTagInput}
               />
-              <p className="text-xs text-muted">Separate tags with commas.</p>
+              {isTagInputFocused && suggestedTemplateTags.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {suggestedTemplateTags.map((tag) => (
+                    <Button
+                      className="h-7 rounded-full px-3 text-xs"
+                      key={tag}
+                      onMouseDown={(event) => event.preventDefault()}
+                      onClick={() => addSuggestedTemplateTag(tag)}
+                      size="sm"
+                      type="button"
+                      variant="outline"
+                    >
+                      {tag}
+                    </Button>
+                  ))}
+                </div>
+              ) : null}
+              {hasMaxTemplateTags ? (
+                <p className="text-xs text-muted">Tag limit reached ({TEMPLATE_TAG_LIMIT}).</p>
+              ) : (
+                <p className="text-xs text-muted">
+                  Press Enter or comma to add tags. Tags are stored in lowercase.
+                </p>
+              )}
             </div>
           </div>
 
@@ -246,10 +354,7 @@ export function SessionSummary({
                 const payload = {
                   name: templateName.trim(),
                   description: templateDescription.trim(),
-                  tags: templateTags
-                    .split(',')
-                    .map((tag) => tag.trim())
-                    .filter(Boolean),
+                  tags: templateTags,
                 };
 
                 if (sessionId) {

--- a/apps/web/src/features/workouts/components/template-browser.test.tsx
+++ b/apps/web/src/features/workouts/components/template-browser.test.tsx
@@ -118,6 +118,57 @@ describe('TemplateBrowser', () => {
     expect(screen.queryByRole('link', { name: 'Upper Push' })).not.toBeInTheDocument();
   });
 
+  it('filters templates by selected tags using AND logic', () => {
+    render(
+      <MemoryRouter>
+        <TemplateBrowser
+          buildTemplateHref={(templateId) => `/workouts/template/${templateId}`}
+          templates={[
+            {
+              id: 'template-1',
+              name: 'Upper Push Strength',
+              description: null,
+              tags: ['push', 'strength'],
+              sections: [{ exercises: [] }],
+            },
+            {
+              id: 'template-2',
+              name: 'Upper Push Volume',
+              description: null,
+              tags: ['push'],
+              sections: [{ exercises: [] }],
+            },
+            {
+              id: 'template-3',
+              name: 'Lower Strength',
+              description: null,
+              tags: ['strength'],
+              sections: [{ exercises: [] }],
+            },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filter by tag Push' }));
+
+    expect(screen.getByRole('link', { name: 'Upper Push Strength' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Upper Push Volume' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Lower Strength' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filter by tag Strength' }));
+
+    expect(screen.getByRole('link', { name: 'Upper Push Strength' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Upper Push Volume' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Lower Strength' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+    expect(screen.getByRole('link', { name: 'Upper Push Strength' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Upper Push Volume' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Lower Strength' })).toBeInTheDocument();
+  });
+
   it('opens rename dialog and submits new template name', async () => {
     render(
       <MemoryRouter>

--- a/apps/web/src/features/workouts/components/template-browser.tsx
+++ b/apps/web/src/features/workouts/components/template-browser.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { ArrowRight, ListChecks, MoreVertical, Search, Tag } from 'lucide-react';
+import { ArrowRight, ListChecks, MoreVertical, Search, Tag, X } from 'lucide-react';
 import { Link, useSearchParams } from 'react-router';
 import { toast } from 'sonner';
 
@@ -35,6 +35,7 @@ import {
   formatWorkoutConflictDescription,
   getDayWorkoutConflicts,
 } from '@/features/workouts/lib/day-workout-conflicts';
+import { normalizeTemplateTag } from '@/features/workouts/lib/template-tags';
 
 // Minimal structural interface — satisfied by both mock and API WorkoutTemplate shapes.
 interface TemplateSummary {
@@ -59,6 +60,7 @@ export function TemplateBrowser({
   const [searchParams] = useSearchParams();
   const { confirm, dialog } = useConfirmation();
   const [searchQuery, setSearchQuery] = useState('');
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [renameTarget, setRenameTarget] = useState<{ id: string; name: string } | null>(null);
   const [scheduleTarget, setScheduleTarget] = useState<{ id: string; name: string } | null>(null);
   const [renameValue, setRenameValue] = useState('');
@@ -72,9 +74,35 @@ export function TemplateBrowser({
       : toDateKey(new Date());
   const normalizedQuery = searchQuery.trim().toLowerCase();
 
+  const availableTags = useMemo(() => {
+    const tagSet = new Set<string>();
+
+    templates.forEach((template) => {
+      template.tags.forEach((tag) => {
+        const normalizedTag = normalizeTemplateTag(tag);
+        if (normalizedTag) {
+          tagSet.add(normalizedTag);
+        }
+      });
+    });
+
+    return Array.from(tagSet).sort((left, right) => left.localeCompare(right));
+  }, [templates]);
+
+  const activeSelectedTags = useMemo(
+    () => selectedTags.filter((tag) => availableTags.includes(tag)),
+    [availableTags, selectedTags],
+  );
+
   const filteredTemplates = useMemo(
     () =>
       templates.filter((template) => {
+        const templateTags = template.tags.map((tag) => normalizeTemplateTag(tag));
+        const matchesTags = activeSelectedTags.every((tag) => templateTags.includes(tag));
+        if (!matchesTags) {
+          return false;
+        }
+
         if (!normalizedQuery) {
           return true;
         }
@@ -86,7 +114,7 @@ export function TemplateBrowser({
 
         return searchableText.includes(normalizedQuery);
       }),
-    [normalizedQuery, templates],
+    [activeSelectedTags, normalizedQuery, templates],
   );
 
   const trimmedRenameValue = renameValue.trim();
@@ -128,6 +156,12 @@ export function TemplateBrowser({
     });
   }
 
+  function toggleTagFilter(tag: string) {
+    setSelectedTags((current) =>
+      current.includes(tag) ? current.filter((value) => value !== tag) : [...current, tag],
+    );
+  }
+
   return (
     <section className={cn('space-y-4', className)}>
       <div className="space-y-2">
@@ -154,6 +188,47 @@ export function TemplateBrowser({
         />
       </label>
 
+      {availableTags.length > 0 ? (
+        <div className="space-y-2" role="group" aria-label="Filter templates by tag">
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-sm font-medium text-muted">Filter by tags</p>
+            {activeSelectedTags.length > 0 ? (
+              <Button
+                className="h-7 px-2 text-xs"
+                onClick={() => setSelectedTags([])}
+                type="button"
+                variant="ghost"
+              >
+                <X aria-hidden="true" className="size-3.5" />
+                Clear filters
+              </Button>
+            ) : null}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {availableTags.map((tag) => {
+              const isSelected = selectedTags.includes(tag);
+              return (
+                <Button
+                  aria-label={`Filter by tag ${formatLabel(tag)}`}
+                  aria-pressed={isSelected}
+                  className={cn(
+                    'h-7 rounded-full px-3 text-xs',
+                    isSelected && 'border-primary bg-primary/10 text-primary',
+                  )}
+                  key={tag}
+                  onClick={() => toggleTagFilter(tag)}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  {formatLabel(tag)}
+                </Button>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
+
       {templates.length === 0 ? (
         <Card>
           <CardContent className="py-6">
@@ -163,7 +238,7 @@ export function TemplateBrowser({
       ) : filteredTemplates.length === 0 ? (
         <Card>
           <CardContent className="py-6">
-            <p className="text-sm text-muted">No templates match that search.</p>
+            <p className="text-sm text-muted">No templates match the selected filters.</p>
           </CardContent>
         </Card>
       ) : (
@@ -273,66 +348,67 @@ export function TemplateBrowser({
         </div>
       )}
 
-      <Dialog
-        onOpenChange={(open) => {
-          if (!open) {
-            setRenameTarget(null);
-          }
-        }}
-        open={renameTarget != null}
-      >
+      <Dialog onOpenChange={(open) => !open && setRenameTarget(null)} open={renameTarget !== null}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Rename template</DialogTitle>
             <DialogDescription>Update the template name.</DialogDescription>
           </DialogHeader>
-          <form
-            className="space-y-4"
-            onSubmit={(event) => {
-              event.preventDefault();
-              if (!renameTarget || !canSubmitRename) {
-                return;
-              }
-
-              renameTemplateMutation.mutate(
-                {
-                  id: renameTarget.id,
-                  name: trimmedRenameValue,
-                },
-                {
-                  onError: (error) => {
-                    const message =
-                      error instanceof ApiError ? error.message : 'Unable to rename template.';
-                    toast.error(message);
-                  },
-                  onSuccess: () => {
-                    setRenameTarget(null);
-                  },
-                },
-              );
-            }}
-          >
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-foreground" htmlFor="template-rename-input">
+              Template name
+            </label>
             <Input
-              aria-label="Template name"
               autoFocus
+              id="template-rename-input"
               onChange={(event) => setRenameValue(event.target.value)}
               value={renameValue}
             />
-            <DialogFooter>
-              <Button onClick={() => setRenameTarget(null)} type="button" variant="ghost">
-                Cancel
-              </Button>
-              <Button disabled={!canSubmitRename} type="submit">
-                {renameTemplateMutation.isPending ? 'Saving...' : 'Save'}
-              </Button>
-            </DialogFooter>
-          </form>
+          </div>
+          <DialogFooter>
+            <Button
+              onClick={() => {
+                setRenameTarget(null);
+              }}
+              type="button"
+              variant="outline"
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={!canSubmitRename}
+              onClick={() => {
+                if (!renameTarget) {
+                  return;
+                }
+
+                renameTemplateMutation.mutate(
+                  {
+                    id: renameTarget.id,
+                    name: trimmedRenameValue,
+                  },
+                  {
+                    onError: (error) => {
+                      const message =
+                        error instanceof ApiError ? error.message : 'Unable to rename template.';
+                      toast.error(message);
+                    },
+                    onSuccess: () => {
+                      setRenameTarget(null);
+                    },
+                  },
+                );
+              }}
+              type="button"
+            >
+              {renameTemplateMutation.isPending ? 'Saving...' : 'Save'}
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      {dialog}
       <ScheduleWorkoutDialog
-        description={`Pick a date for ${scheduleTarget?.name ?? 'this workout'}.`}
+        description={`Pick a date for ${scheduleTarget?.name ?? 'this template'}.`}
         initialDate={scheduleInitialDate}
         isPending={scheduleWorkoutMutation.isPending}
         onOpenChange={(open) => {
@@ -340,25 +416,29 @@ export function TemplateBrowser({
             setScheduleTarget(null);
           }
         }}
-        onSubmitDate={async (date) => {
+        onSubmitDate={async (dateKey: string) => {
           if (!scheduleTarget) {
             return;
           }
 
-          const shouldCreateAnother = await confirmDuplicateDayWorkouts(date);
-          if (!shouldCreateAnother) {
+          const shouldProceed = await confirmDuplicateDayWorkouts(dateKey);
+          if (!shouldProceed) {
             return;
           }
 
           await scheduleWorkoutMutation.mutateAsync({
-            date,
+            date: dateKey,
             templateId: scheduleTarget.id,
           });
+
+          setScheduleTarget(null);
         }}
-        open={scheduleTarget != null}
+        open={scheduleTarget !== null}
         submitLabel="Schedule"
         title="Schedule workout"
       />
+
+      {dialog}
     </section>
   );
 }
@@ -369,8 +449,8 @@ function countTemplateExercises(template: TemplateSummary) {
 
 function formatLabel(value: string) {
   return value
-    .split(/[- ]+/)
+    .split(/[-\s]+/)
     .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .map((segment) => segment[0]?.toUpperCase() + segment.slice(1))
     .join(' ');
 }

--- a/apps/web/src/features/workouts/lib/template-tags.ts
+++ b/apps/web/src/features/workouts/lib/template-tags.ts
@@ -1,0 +1,50 @@
+export const TEMPLATE_TAG_LIMIT = 20;
+
+export const TEMPLATE_TAG_SUGGESTIONS = [
+  'home gym',
+  'full gym',
+  'rehab',
+  'upper',
+  'lower',
+  'push',
+  'pull',
+  'hypertrophy',
+  'strength',
+  'deload',
+  'shoulder-safe',
+  'tendon',
+] as const;
+
+export function normalizeTemplateTag(tag: string) {
+  return tag.trim().toLowerCase();
+}
+
+export function normalizeTemplateTags(tags: string[], max = TEMPLATE_TAG_LIMIT) {
+  const next: string[] = [];
+  const seen = new Set<string>();
+
+  for (const tag of tags) {
+    const normalized = normalizeTemplateTag(tag);
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+
+    seen.add(normalized);
+    next.push(normalized);
+
+    if (next.length >= max) {
+      break;
+    }
+  }
+
+  return next;
+}
+
+export function appendTemplateTags(
+  existingTags: string[],
+  rawTags: string,
+  max = TEMPLATE_TAG_LIMIT,
+) {
+  const parsedTags = rawTags.split(',');
+  return normalizeTemplateTags([...existingTags, ...parsedTags], max);
+}

--- a/apps/web/src/features/workouts/types.ts
+++ b/apps/web/src/features/workouts/types.ts
@@ -41,6 +41,7 @@ export type ActiveWorkoutLastPerformance = {
 export type ActiveWorkoutRelatedLastPerformance = {
   exerciseId: string;
   exerciseName: string;
+  trackingType: ExerciseTrackingType;
   history: ActiveWorkoutLastPerformance | null;
 };
 

--- a/apps/web/src/features/workouts/types.ts
+++ b/apps/web/src/features/workouts/types.ts
@@ -38,6 +38,17 @@ export type ActiveWorkoutLastPerformance = {
   sets: ActiveWorkoutLastPerformanceSet[];
 };
 
+export type ActiveWorkoutRelatedLastPerformance = {
+  exerciseId: string;
+  exerciseName: string;
+  history: ActiveWorkoutLastPerformance | null;
+};
+
+export type ActiveWorkoutExerciseHistorySummary = {
+  history: ActiveWorkoutLastPerformance | null;
+  related: ActiveWorkoutRelatedLastPerformance[];
+};
+
 export type ActiveWorkoutExerciseMetadata = {
   badges: WorkoutBadgeType[];
   category: WorkoutExerciseCategory;

--- a/apps/web/src/hooks/use-last-performance.test.tsx
+++ b/apps/web/src/hooks/use-last-performance.test.tsx
@@ -21,21 +21,82 @@ describe('use-last-performance hook', () => {
     vi.stubGlobal('fetch', mockFetch);
   });
 
-  it('loads and maps last performance data for an exercise', async () => {
+  it('loads and maps exact history data for an exercise', async () => {
     mockFetch.mockResolvedValueOnce(
       createJsonResponse({
+        history: {
+          sessionId: 'session-2',
+          date: '2026-03-08',
+          sets: [
+            {
+              setNumber: 1,
+              weight: 105,
+              reps: 9,
+            },
+            {
+              setNumber: 2,
+              weight: 100,
+              reps: 8,
+            },
+          ],
+        },
+        related: [],
+      }),
+    );
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useLastPerformance('global-bench-press'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual({
+      history: {
         sessionId: 'session-2',
         date: '2026-03-08',
         sets: [
           {
+            completed: true,
             setNumber: 1,
             weight: 105,
             reps: 9,
           },
           {
+            completed: true,
             setNumber: 2,
             weight: 100,
             reps: 8,
+          },
+        ],
+      },
+      related: [],
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/exercises/global-bench-press/last-performance?includeRelated=true'),
+      expect.any(Object),
+    );
+  });
+
+  it('maps related history entries', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        history: null,
+        related: [
+          {
+            exerciseId: 'incline-bench',
+            exerciseName: 'Incline Bench Press',
+            history: {
+              sessionId: 'session-3',
+              date: '2026-03-10',
+              sets: [
+                {
+                  setNumber: 1,
+                  weight: 95,
+                  reps: 10,
+                },
+              ],
+            },
           },
         ],
       }),
@@ -49,27 +110,45 @@ describe('use-last-performance hook', () => {
     });
 
     expect(result.current.data).toEqual({
-      sessionId: 'session-2',
-      date: '2026-03-08',
-      sets: [
+      history: null,
+      related: [
         {
-          completed: true,
-          setNumber: 1,
-          weight: 105,
-          reps: 9,
-        },
-        {
-          completed: true,
-          setNumber: 2,
-          weight: 100,
-          reps: 8,
+          exerciseId: 'incline-bench',
+          exerciseName: 'Incline Bench Press',
+          history: {
+            sessionId: 'session-3',
+            date: '2026-03-10',
+            sets: [
+              {
+                completed: true,
+                reps: 10,
+                setNumber: 1,
+                weight: 95,
+              },
+            ],
+          },
         },
       ],
     });
   });
 
-  it('returns null when no prior performance exists', async () => {
-    mockFetch.mockResolvedValueOnce(createJsonResponse(null));
+  it('returns null for not-found exercises', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 'EXERCISE_NOT_FOUND',
+            message: 'Exercise not found',
+          },
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 404,
+        },
+      ),
+    );
 
     const { wrapper } = createQueryClientWrapper();
     const { result } = renderHook(() => useLastPerformance('global-bench-press'), { wrapper });

--- a/apps/web/src/hooks/use-last-performance.test.tsx
+++ b/apps/web/src/hooks/use-last-performance.test.tsx
@@ -175,4 +175,57 @@ describe('use-last-performance hook', () => {
     expect(result.current.fetchStatus).toBe('idle');
     expect(mockFetch).not.toHaveBeenCalled();
   });
+
+  it('allows callers to disable related history payloads', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        sessionId: 'session-2',
+        date: '2026-03-08',
+        sets: [
+          {
+            setNumber: 1,
+            weight: 105,
+            reps: 9,
+          },
+        ],
+      }),
+    );
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(
+      () =>
+        useLastPerformance('global-bench-press', {
+          includeRelated: false,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual({
+      history: {
+        sessionId: 'session-2',
+        date: '2026-03-08',
+        sets: [
+          {
+            completed: true,
+            reps: 9,
+            setNumber: 1,
+            weight: 105,
+          },
+        ],
+      },
+      related: [],
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/exercises/global-bench-press/last-performance'),
+      expect.any(Object),
+    );
+    expect(mockFetch).not.toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/exercises/global-bench-press/last-performance?includeRelated=true'),
+      expect.any(Object),
+    );
+  });
 });

--- a/apps/web/src/hooks/use-last-performance.test.tsx
+++ b/apps/web/src/hooks/use-last-performance.test.tsx
@@ -86,6 +86,7 @@ describe('use-last-performance hook', () => {
           {
             exerciseId: 'incline-bench',
             exerciseName: 'Incline Bench Press',
+            trackingType: 'weight_reps',
             history: {
               sessionId: 'session-3',
               date: '2026-03-10',
@@ -115,6 +116,7 @@ describe('use-last-performance hook', () => {
         {
           exerciseId: 'incline-bench',
           exerciseName: 'Incline Bench Press',
+          trackingType: 'weight_reps',
           history: {
             sessionId: 'session-3',
             date: '2026-03-10',

--- a/apps/web/src/hooks/use-last-performance.ts
+++ b/apps/web/src/hooks/use-last-performance.ts
@@ -1,5 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
-import { exerciseHistoryWithRelatedSchema, type ExerciseLastPerformance } from '@pulse/shared';
+import {
+  exerciseHistoryWithRelatedSchema,
+  exerciseLastPerformanceSchema,
+  type ExerciseLastPerformance,
+} from '@pulse/shared';
 
 import type {
   ActiveWorkoutExerciseHistorySummary,
@@ -9,7 +13,8 @@ import { ApiError, apiRequest } from '@/lib/api-client';
 
 const lastPerformanceQueryKeys = {
   all: ['exercise-last-performance'] as const,
-  detail: (exerciseId: string) => ['exercise-last-performance', exerciseId] as const,
+  detail: (exerciseId: string, includeRelated: boolean) =>
+    ['exercise-last-performance', exerciseId, { includeRelated }] as const,
 };
 
 function mapLastPerformance(
@@ -41,14 +46,23 @@ function mapLastPerformance(
 
 async function getLastPerformance(
   exerciseId: string,
+  includeRelated: boolean,
 ): Promise<ActiveWorkoutExerciseHistorySummary | null> {
   try {
     const data = await apiRequest<unknown>(
-      `/api/v1/exercises/${exerciseId}/last-performance?includeRelated=true`,
+      `/api/v1/exercises/${exerciseId}/last-performance${includeRelated ? '?includeRelated=true' : ''}`,
     );
 
     if (data == null) {
       return null;
+    }
+
+    if (!includeRelated) {
+      const payload = exerciseLastPerformanceSchema.parse(data);
+      return {
+        history: mapLastPerformance(payload),
+        related: [],
+      };
     }
 
     const payload = exerciseHistoryWithRelatedSchema.parse(data);
@@ -75,15 +89,17 @@ export function useLastPerformance(
   exerciseId: string,
   options?: {
     enabled?: boolean;
+    includeRelated?: boolean;
   },
 ) {
   const normalizedExerciseId = exerciseId.trim();
   const enabled = options?.enabled ?? true;
+  const includeRelated = options?.includeRelated ?? true;
 
   return useQuery<ActiveWorkoutExerciseHistorySummary | null>({
     enabled: enabled && normalizedExerciseId.length > 0,
-    queryFn: () => getLastPerformance(normalizedExerciseId),
-    queryKey: lastPerformanceQueryKeys.detail(normalizedExerciseId),
+    queryFn: () => getLastPerformance(normalizedExerciseId, includeRelated),
+    queryKey: lastPerformanceQueryKeys.detail(normalizedExerciseId, includeRelated),
   });
 }
 

--- a/apps/web/src/hooks/use-last-performance.ts
+++ b/apps/web/src/hooks/use-last-performance.ts
@@ -1,47 +1,65 @@
 import { useQuery } from '@tanstack/react-query';
-import { exerciseLastPerformanceSchema } from '@pulse/shared';
-import { z } from 'zod';
+import { exerciseHistoryWithRelatedSchema, type ExerciseLastPerformance } from '@pulse/shared';
 
-import type { ActiveWorkoutLastPerformance } from '@/features/workouts/types';
+import type {
+  ActiveWorkoutExerciseHistorySummary,
+  ActiveWorkoutLastPerformance,
+} from '@/features/workouts/types';
 import { ApiError, apiRequest } from '@/lib/api-client';
-
-const exerciseLastPerformanceResponseSchema = z.object({
-  data: exerciseLastPerformanceSchema,
-});
 
 const lastPerformanceQueryKeys = {
   all: ['exercise-last-performance'] as const,
   detail: (exerciseId: string) => ['exercise-last-performance', exerciseId] as const,
 };
 
+function mapLastPerformance(
+  payload: ExerciseLastPerformance | null,
+): ActiveWorkoutLastPerformance | null {
+  if (payload == null) {
+    return null;
+  }
+
+  const sets = payload.sets
+    .filter((set): set is typeof set & { reps: number } => set.reps !== null)
+    .map((set) => ({
+      completed: true,
+      reps: set.reps,
+      setNumber: set.setNumber,
+      weight: set.weight,
+    }));
+
+  if (sets.length === 0) {
+    return null;
+  }
+
+  return {
+    date: payload.date,
+    sessionId: payload.sessionId,
+    sets,
+  };
+}
+
 async function getLastPerformance(
   exerciseId: string,
-): Promise<ActiveWorkoutLastPerformance | null> {
+): Promise<ActiveWorkoutExerciseHistorySummary | null> {
   try {
-    const data = await apiRequest<unknown>(`/api/v1/exercises/${exerciseId}/last-performance`);
+    const data = await apiRequest<unknown>(
+      `/api/v1/exercises/${exerciseId}/last-performance?includeRelated=true`,
+    );
 
     if (data == null) {
       return null;
     }
 
-    const payload = exerciseLastPerformanceResponseSchema.parse({ data });
-    const sets = payload.data.sets
-      .filter((set): set is typeof set & { reps: number } => set.reps !== null)
-      .map((set) => ({
-        completed: true,
-        reps: set.reps,
-        setNumber: set.setNumber,
-        weight: set.weight,
-      }));
-
-    if (sets.length === 0) {
-      return null;
-    }
+    const payload = exerciseHistoryWithRelatedSchema.parse(data);
 
     return {
-      date: payload.data.date,
-      sessionId: payload.data.sessionId,
-      sets,
+      history: mapLastPerformance(payload.history),
+      related: payload.related.map((relatedExercise) => ({
+        exerciseId: relatedExercise.exerciseId,
+        exerciseName: relatedExercise.exerciseName,
+        history: mapLastPerformance(relatedExercise.history),
+      })),
     };
   } catch (error) {
     if (error instanceof ApiError && error.status === 404 && error.code === 'EXERCISE_NOT_FOUND') {
@@ -61,7 +79,7 @@ export function useLastPerformance(
   const normalizedExerciseId = exerciseId.trim();
   const enabled = options?.enabled ?? true;
 
-  return useQuery<ActiveWorkoutLastPerformance | null>({
+  return useQuery<ActiveWorkoutExerciseHistorySummary | null>({
     enabled: enabled && normalizedExerciseId.length > 0,
     queryFn: () => getLastPerformance(normalizedExerciseId),
     queryKey: lastPerformanceQueryKeys.detail(normalizedExerciseId),

--- a/apps/web/src/hooks/use-last-performance.ts
+++ b/apps/web/src/hooks/use-last-performance.ts
@@ -58,6 +58,7 @@ async function getLastPerformance(
       related: payload.related.map((relatedExercise) => ({
         exerciseId: relatedExercise.exerciseId,
         exerciseName: relatedExercise.exerciseName,
+        trackingType: relatedExercise.trackingType,
         history: mapLastPerformance(relatedExercise.history),
       })),
     };

--- a/apps/web/src/pages/foods.test.tsx
+++ b/apps/web/src/pages/foods.test.tsx
@@ -25,6 +25,8 @@ function createFood(id: string, name: string): Food {
     verified: true,
     source: 'USDA',
     notes: null,
+    usageCount: 0,
+    tags: [],
     lastUsedAt: Date.parse('2026-03-06T12:00:00.000Z'),
     createdAt: 1,
     updatedAt: 1,

--- a/apps/web/src/pages/foods.tsx
+++ b/apps/web/src/pages/foods.tsx
@@ -35,7 +35,8 @@ export function FoodsPage() {
         </HelpIcon>
       </div>
       <p className="max-w-2xl text-sm text-muted">
-        Search your saved foods, compare macros at a glance, and sort by recency or protein density.
+        Search your saved foods, compare macros at a glance, and sort by recency, popularity, or
+        name.
       </p>
       {shouldShowEmptyState ? (
         <EmptyState

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -36,13 +36,48 @@ export const agentCreateFoodInputSchema = z.object({
   notes: z.string().trim().nullable().optional(),
 });
 
-export const agentMealItemInputSchema = z.object({
-  foodName: requiredText(),
-  quantity: z.number().positive().finite(),
-  unit: z.string().trim().min(1).max(50).default('serving'),
-  displayQuantity: z.number().positive().finite().optional(),
-  displayUnit: z.string().trim().min(1).max(50).optional(),
-});
+export const agentMealItemInputSchema = z
+  .object({
+    foodName: requiredText(),
+    quantity: z.number().positive().finite(),
+    unit: z.string().trim().min(1).max(50).default('serving'),
+    displayQuantity: z.number().positive().finite().optional(),
+    displayUnit: z.string().trim().min(1).max(50).optional(),
+    adhoc: z.boolean().optional(),
+    saveToFoods: z.boolean().optional(),
+    calories: z.number().nonnegative().finite().optional(),
+    protein: z.number().nonnegative().finite().optional(),
+    carbs: z.number().nonnegative().finite().optional(),
+    fat: z.number().nonnegative().finite().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (
+      value.adhoc !== undefined &&
+      value.saveToFoods !== undefined &&
+      value.adhoc === value.saveToFoods
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '`adhoc` and `saveToFoods` are contradictory',
+      });
+    }
+
+    const isAdhoc = value.adhoc === true || value.saveToFoods === false;
+
+    if (!isAdhoc) {
+      return;
+    }
+
+    for (const field of ['calories', 'protein', 'carbs', 'fat'] as const) {
+      if (value[field] === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [field],
+          message: `${field} is required when logging an ad-hoc meal item`,
+        });
+      }
+    }
+  });
 
 export const agentCreateMealInputSchema = z.object({
   name: requiredText(120),

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -58,7 +58,7 @@ export const agentMealItemInputSchema = z
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: '`adhoc` and `saveToFoods` are contradictory',
+        message: '`adhoc` and `saveToFoods` are aliases; provide at most one',
       });
     }
 

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -181,7 +181,7 @@ export const agentCreateExerciseInputSchema = z.object({
   muscleGroups: z.array(requiredText()).min(1).max(20).optional(),
   equipment: requiredText().optional(),
   coachingNotes: optionalText(8000),
-  relatedExerciseIds: z.array(requiredText()).max(200).optional().default([]),
+  relatedExerciseIds: z.array(requiredText()).max(20).optional().default([]),
   force: z.boolean().optional().default(false),
 });
 
@@ -194,7 +194,7 @@ export const agentPatchExerciseInputSchema = z
     trackingType: exerciseTrackingTypeSchema.optional(),
     instructions: optionalText(4000),
     coachingNotes: optionalText(8000),
-    relatedExerciseIds: z.array(requiredText()).max(200).optional(),
+    relatedExerciseIds: z.array(requiredText()).max(20).optional(),
     formCues: z.array(requiredText(500)).max(50).optional(),
     tags: z.array(requiredText()).max(20).optional(),
   })

--- a/packages/shared/src/schemas/exercises.test.ts
+++ b/packages/shared/src/schemas/exercises.test.ts
@@ -183,6 +183,20 @@ describe('createExerciseInputSchema', () => {
 
     expect(payload.category).toBe('cardio');
   });
+
+  it('rejects relatedExerciseIds beyond the limit', () => {
+    const relatedExerciseIds = Array.from({ length: 21 }, (_, index) => `exercise-${index}`);
+
+    expect(() =>
+      createExerciseInputSchema.parse({
+        name: 'Air Bike',
+        muscleGroups: ['conditioning'],
+        equipment: 'air bike',
+        category: 'cardio',
+        relatedExerciseIds,
+      }),
+    ).toThrow();
+  });
 });
 
 describe('updateExerciseInputSchema', () => {
@@ -342,6 +356,7 @@ describe('exerciseHistoryWithRelatedSchema', () => {
         {
           exerciseId: 'incline-bench',
           exerciseName: 'Incline Bench Press',
+          trackingType: 'weight_reps',
           history: null,
         },
       ],
@@ -350,6 +365,7 @@ describe('exerciseHistoryWithRelatedSchema', () => {
     expect(payload.related[0]).toEqual({
       exerciseId: 'incline-bench',
       exerciseName: 'Incline Bench Press',
+      trackingType: 'weight_reps',
       history: null,
     });
   });

--- a/packages/shared/src/schemas/exercises.test.ts
+++ b/packages/shared/src/schemas/exercises.test.ts
@@ -2,14 +2,18 @@ import { describe, expect, it } from 'vitest';
 
 import {
   createExerciseInputSchema,
+  exerciseHistoryWithRelatedSchema,
+  exerciseLastPerformanceQuerySchema,
   exerciseTrackingTypeSchema,
   exerciseLastPerformanceSchema,
   exerciseQueryParamsSchema,
   exerciseSchema,
   type CreateExerciseInput,
   type Exercise,
+  type ExerciseHistoryWithRelated,
   type ExerciseCategory,
   type ExerciseLastPerformance,
+  type ExerciseLastPerformanceQuery,
   type ExerciseQueryParams,
   type ExerciseTrackingType,
   type UpdateExerciseInput,
@@ -299,5 +303,54 @@ describe('exerciseLastPerformanceSchema', () => {
         ],
       }),
     ).toThrow();
+  });
+});
+
+describe('exerciseLastPerformanceQuerySchema', () => {
+  it('defaults includeRelated to false', () => {
+    const payload: ExerciseLastPerformanceQuery = exerciseLastPerformanceQuerySchema.parse({});
+
+    expect(payload).toEqual({
+      includeRelated: false,
+    });
+  });
+
+  it('coerces includeRelated query string values', () => {
+    const payload = exerciseLastPerformanceQuerySchema.parse({
+      includeRelated: 'true',
+    });
+
+    expect(payload.includeRelated).toBe(true);
+  });
+});
+
+describe('exerciseHistoryWithRelatedSchema', () => {
+  it('parses exact and related history payload', () => {
+    const payload: ExerciseHistoryWithRelated = exerciseHistoryWithRelatedSchema.parse({
+      history: {
+        sessionId: 'session-22',
+        date: '2026-03-08',
+        sets: [
+          {
+            setNumber: 1,
+            reps: 10,
+            weight: 60,
+          },
+        ],
+      },
+      related: [
+        {
+          exerciseId: 'incline-bench',
+          exerciseName: 'Incline Bench Press',
+          history: null,
+        },
+      ],
+    });
+
+    expect(payload.related[0]).toEqual({
+      exerciseId: 'incline-bench',
+      exerciseName: 'Incline Bench Press',
+      history: null,
+    });
   });
 });

--- a/packages/shared/src/schemas/exercises.ts
+++ b/packages/shared/src/schemas/exercises.ts
@@ -62,7 +62,7 @@ export const exerciseSchema = z.object({
   formCues: z.array(z.string()).default([]),
   instructions: nullableInstructionsSchema,
   coachingNotes: z.string().max(8000).nullable().default(null),
-  relatedExerciseIds: z.array(z.string()).default([]),
+  relatedExerciseIds: z.array(z.string()).max(20).default([]),
   createdAt: z.number().int(),
   updatedAt: z.number().int(),
 });
@@ -77,7 +77,7 @@ export const createExerciseInputSchema = z.object({
   formCues: z.array(z.string()).optional(),
   instructions: nullableInstructionsSchema.optional().default(null),
   coachingNotes: nullableCoachingNotesSchema.optional().default(null),
-  relatedExerciseIds: z.array(z.string()).optional().default([]),
+  relatedExerciseIds: z.array(z.string()).max(20).optional().default([]),
 });
 
 export const updateExerciseInputSchema = z
@@ -91,7 +91,7 @@ export const updateExerciseInputSchema = z
     formCues: z.array(z.string()).optional(),
     instructions: nullableInstructionsSchema.optional(),
     coachingNotes: nullableCoachingNotesSchema.optional(),
-    relatedExerciseIds: z.array(z.string()).optional(),
+    relatedExerciseIds: z.array(z.string()).max(20).optional(),
   })
   .refine((value) => Object.values(value).some((field) => field !== undefined), {
     message: 'At least one exercise field must be provided',
@@ -125,12 +125,13 @@ export const exerciseLastPerformanceSchema = z.object({
 export const relatedExerciseLastPerformanceSchema = z.object({
   exerciseId: z.string(),
   exerciseName: requiredStringSchema,
+  trackingType: exerciseTrackingTypeSchema,
   history: exerciseLastPerformanceSchema.nullable(),
 });
 
 export const exerciseHistoryWithRelatedSchema = z.object({
   history: exerciseLastPerformanceSchema.nullable(),
-  related: z.array(relatedExerciseLastPerformanceSchema).max(200),
+  related: z.array(relatedExerciseLastPerformanceSchema).max(20),
 });
 
 export type ExerciseCategory = z.infer<typeof exerciseCategorySchema>;

--- a/packages/shared/src/schemas/exercises.ts
+++ b/packages/shared/src/schemas/exercises.ts
@@ -106,6 +106,10 @@ export const exerciseQueryParamsSchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(20),
 });
 
+export const exerciseLastPerformanceQuerySchema = z.object({
+  includeRelated: z.coerce.boolean().optional().default(false),
+});
+
 export const exerciseLastPerformanceSetSchema = z.object({
   setNumber: z.number().int().min(1),
   weight: z.number().min(0).nullable(),
@@ -118,11 +122,25 @@ export const exerciseLastPerformanceSchema = z.object({
   sets: z.array(exerciseLastPerformanceSetSchema).max(100),
 });
 
+export const relatedExerciseLastPerformanceSchema = z.object({
+  exerciseId: z.string(),
+  exerciseName: requiredStringSchema,
+  history: exerciseLastPerformanceSchema.nullable(),
+});
+
+export const exerciseHistoryWithRelatedSchema = z.object({
+  history: exerciseLastPerformanceSchema.nullable(),
+  related: z.array(relatedExerciseLastPerformanceSchema).max(200),
+});
+
 export type ExerciseCategory = z.infer<typeof exerciseCategorySchema>;
 export type ExerciseTrackingType = z.infer<typeof exerciseTrackingTypeSchema>;
 export type Exercise = z.infer<typeof exerciseSchema>;
 export type CreateExerciseInput = z.infer<typeof createExerciseInputSchema>;
 export type UpdateExerciseInput = z.infer<typeof updateExerciseInputSchema>;
 export type ExerciseQueryParams = z.infer<typeof exerciseQueryParamsSchema>;
+export type ExerciseLastPerformanceQuery = z.infer<typeof exerciseLastPerformanceQuerySchema>;
 export type ExerciseLastPerformance = z.infer<typeof exerciseLastPerformanceSchema>;
 export type ExerciseLastPerformanceSet = z.infer<typeof exerciseLastPerformanceSetSchema>;
+export type RelatedExerciseLastPerformance = z.infer<typeof relatedExerciseLastPerformanceSchema>;
+export type ExerciseHistoryWithRelated = z.infer<typeof exerciseHistoryWithRelatedSchema>;

--- a/packages/shared/src/schemas/foods.test.ts
+++ b/packages/shared/src/schemas/foods.test.ts
@@ -79,7 +79,7 @@ describe('createFoodInputSchema', () => {
       carbs: 5,
       fat: 0,
       notes: ' High protein snack ',
-      tags: [' dairy ', ' snack '],
+      tags: [' dairy ', ' Snack '],
     });
 
     expect(payload).toEqual({
@@ -140,6 +140,14 @@ describe('patchFoodInputSchema', () => {
     });
   });
 
+  it('does not inject tags when patch payload omits tags', () => {
+    const payload = patchFoodInputSchema.parse({
+      notes: 'updated source',
+    });
+
+    expect(payload).not.toHaveProperty('tags');
+  });
+
   it('accepts a valid multi-field patch', () => {
     const payload = patchFoodInputSchema.parse({
       name: ' Greek Yogurt ',
@@ -173,6 +181,7 @@ describe('foodQueryParamsSchema', () => {
   it('coerces pagination params and trims the search query', () => {
     const payload = foodQueryParamsSchema.parse({
       q: '  yogurt ',
+      tags: ' dairy , breakfast ',
       sort: 'popular',
       page: '2',
       limit: '25',
@@ -180,6 +189,7 @@ describe('foodQueryParamsSchema', () => {
 
     expect(payload).toEqual({
       q: 'yogurt',
+      tags: ['dairy', 'breakfast'],
       sort: 'popular',
       page: 2,
       limit: 25,
@@ -193,10 +203,19 @@ describe('foodQueryParamsSchema', () => {
 
     expect(payload).toEqual({
       q: undefined,
+      tags: undefined,
       sort: 'recent',
       page: 1,
       limit: 50,
     });
+  });
+
+  it('parses repeated and comma-delimited tag query params', () => {
+    const payload = foodQueryParamsSchema.parse({
+      tags: ['Protein, Dinner', 'Lean', ''],
+    });
+
+    expect(payload.tags).toEqual(['protein', 'dinner', 'lean']);
   });
 
   it('rejects invalid sort and page values', () => {

--- a/packages/shared/src/schemas/foods.test.ts
+++ b/packages/shared/src/schemas/foods.test.ts
@@ -30,6 +30,8 @@ describe('foodSchema', () => {
       verified: true,
       source: 'Manufacturer label',
       notes: null,
+      usageCount: 12,
+      tags: ['dairy', 'protein'],
       lastUsedAt: 1_700_000_000_000,
       createdAt: 1_700_000_000_000,
       updatedAt: 1_700_000_000_001,
@@ -55,6 +57,8 @@ describe('foodSchema', () => {
       verified: true,
       source: 'USDA',
       notes: null,
+      usageCount: 0,
+      tags: [],
       lastUsedAt: null,
       createdAt: 1,
       updatedAt: 2,
@@ -75,6 +79,7 @@ describe('createFoodInputSchema', () => {
       carbs: 5,
       fat: 0,
       notes: ' High protein snack ',
+      tags: [' dairy ', ' snack '],
     });
 
     expect(payload).toEqual({
@@ -86,6 +91,7 @@ describe('createFoodInputSchema', () => {
       carbs: 5,
       fat: 0,
       notes: 'High protein snack',
+      tags: ['dairy', 'snack'],
       verified: false,
     });
   });
@@ -108,11 +114,13 @@ describe('updateFoodInputSchema', () => {
     const payload: UpdateFoodInput = updateFoodInputSchema.parse({
       brand: ' Chobani ',
       verified: true,
+      tags: ['dairy'],
     });
 
     expect(payload).toEqual({
       brand: 'Chobani',
       verified: true,
+      tags: ['dairy'],
     });
   });
 
@@ -137,12 +145,14 @@ describe('patchFoodInputSchema', () => {
       name: ' Greek Yogurt ',
       brand: ' Fage ',
       verified: true,
+      tags: ['dairy'],
     });
 
     expect(payload).toEqual({
       name: 'Greek Yogurt',
       brand: 'Fage',
       verified: true,
+      tags: ['dairy'],
     });
   });
 
@@ -163,14 +173,14 @@ describe('foodQueryParamsSchema', () => {
   it('coerces pagination params and trims the search query', () => {
     const payload = foodQueryParamsSchema.parse({
       q: '  yogurt ',
-      sort: 'protein',
+      sort: 'popular',
       page: '2',
       limit: '25',
     });
 
     expect(payload).toEqual({
       q: 'yogurt',
-      sort: 'protein',
+      sort: 'popular',
       page: 2,
       limit: 25,
     });
@@ -183,7 +193,7 @@ describe('foodQueryParamsSchema', () => {
 
     expect(payload).toEqual({
       q: undefined,
-      sort: 'name',
+      sort: 'recent',
       page: 1,
       limit: 50,
     });

--- a/packages/shared/src/schemas/foods.ts
+++ b/packages/shared/src/schemas/foods.ts
@@ -15,7 +15,9 @@ const optionalQueryText = z.preprocess((value) => {
   return trimmed.length > 0 ? trimmed : undefined;
 }, z.string().max(255).optional());
 
-export const foodSortSchema = z.enum(['name', 'recent', 'protein']);
+const foodTagSchema = z.string().trim().min(1).max(40);
+
+export const foodSortSchema = z.enum(['name', 'recent', 'popular']);
 
 export const foodSchema = z.object({
   id: z.string(),
@@ -33,6 +35,8 @@ export const foodSchema = z.object({
   verified: z.boolean(),
   source: z.string().nullable(),
   notes: z.string().nullable(),
+  usageCount: z.number().int().default(0),
+  tags: z.array(foodTagSchema).default([]),
   lastUsedAt: z.number().int().nullable(),
   createdAt: z.number().int(),
   updatedAt: z.number().int(),
@@ -52,6 +56,7 @@ const foodMutationFieldsSchema = z.object({
   verified: z.boolean(),
   source: optionalNullableText(),
   notes: optionalNullableText(2000),
+  tags: z.array(foodTagSchema).max(20).optional().default([]),
 });
 
 export const createFoodInputSchema = foodMutationFieldsSchema.extend({
@@ -66,7 +71,7 @@ export const patchFoodInputSchema = updateFoodInputSchema;
 
 export const foodQueryParamsSchema = z.object({
   q: optionalQueryText,
-  sort: foodSortSchema.default('name'),
+  sort: foodSortSchema.default('recent'),
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(100).default(50),
 });

--- a/packages/shared/src/schemas/foods.ts
+++ b/packages/shared/src/schemas/foods.ts
@@ -15,7 +15,26 @@ const optionalQueryText = z.preprocess((value) => {
   return trimmed.length > 0 ? trimmed : undefined;
 }, z.string().max(255).optional());
 
-const foodTagSchema = z.string().trim().min(1).max(40);
+const foodTagSchema = z.string().trim().toLowerCase().min(1).max(40);
+const foodTagsSchema = z.array(foodTagSchema).max(20);
+const optionalQueryTags = z.preprocess((value) => {
+  if (value == null) {
+    return undefined;
+  }
+
+  const rawTags = Array.isArray(value) ? value : [value];
+  const parsedTags = rawTags.flatMap((tag) => {
+    if (typeof tag !== 'string') {
+      return [];
+    }
+
+    return tag.split(',');
+  });
+
+  const normalizedTags = parsedTags.map((tag) => tag.trim()).filter((tag) => tag.length > 0);
+
+  return normalizedTags.length > 0 ? normalizedTags : undefined;
+}, foodTagsSchema.optional());
 
 export const foodSortSchema = z.enum(['name', 'recent', 'popular']);
 
@@ -36,7 +55,7 @@ export const foodSchema = z.object({
   source: z.string().nullable(),
   notes: z.string().nullable(),
   usageCount: z.number().int().default(0),
-  tags: z.array(foodTagSchema).default([]),
+  tags: foodTagsSchema.default([]),
   lastUsedAt: z.number().int().nullable(),
   createdAt: z.number().int(),
   updatedAt: z.number().int(),
@@ -56,11 +75,12 @@ const foodMutationFieldsSchema = z.object({
   verified: z.boolean(),
   source: optionalNullableText(),
   notes: optionalNullableText(2000),
-  tags: z.array(foodTagSchema).max(20).optional().default([]),
+  tags: foodTagsSchema.optional(),
 });
 
 export const createFoodInputSchema = foodMutationFieldsSchema.extend({
   verified: z.boolean().optional().default(false),
+  tags: foodTagsSchema.optional().default([]),
 });
 
 export const updateFoodInputSchema = foodMutationFieldsSchema
@@ -71,6 +91,7 @@ export const patchFoodInputSchema = updateFoodInputSchema;
 
 export const foodQueryParamsSchema = z.object({
   q: optionalQueryText,
+  tags: optionalQueryTags,
   sort: foodSortSchema.default('recent'),
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(100).default(50),

--- a/packages/shared/src/schemas/nutrition.test.ts
+++ b/packages/shared/src/schemas/nutrition.test.ts
@@ -75,6 +75,7 @@ describe('mealItemInputSchema', () => {
 
     expect(
       mealItemInputSchema.parse({
+        foodId: null,
         name: 'Protein Powder',
         amount: 1,
         unit: 'serving',
@@ -86,6 +87,7 @@ describe('mealItemInputSchema', () => {
         fat: 1.5,
       }),
     ).toEqual({
+      foodId: null,
       name: 'Protein Powder',
       amount: 1,
       unit: 'serving',

--- a/packages/shared/src/schemas/nutrition.ts
+++ b/packages/shared/src/schemas/nutrition.ts
@@ -88,7 +88,7 @@ export const deleteMealResultSchema = z.object({
 });
 
 export const mealItemInputSchema = z.object({
-  foodId: z.string().trim().min(1).optional(),
+  foodId: z.string().trim().min(1).nullable().optional(),
   name: requiredText(),
   amount: z.number().positive().finite(),
   unit: requiredText(50),


### PR DESCRIPTION
## Summary
This PR expands workout and nutrition organization flows by introducing template tags, food tags/popularity tracking, ad-hoc agent meal items, and related exercise history in-session. It improves how users and agents can classify reusable data (templates/foods) while still supporting one-off logging when data should not be persisted as a reusable food. On workouts, it upgrades the “last performance” experience to include optional history from related exercises, giving better context during active sessions. The change is end-to-end across shared schemas, API routes/stores, frontend components/hooks, and tests.

## Key Changes
- Added template tag management in the workout save flow (chip-based add/remove, suggestions, normalization, limits) and tag filtering in template browsing.
- Added food `usageCount` and `tags` to schema + migration, with popularity sorting (`sort=popular`) and tag filtering in food list APIs and UI.
- Updated food usage tracking so meal logging increments both `lastUsedAt` and `usageCount`; food cards now surface usage count and support inline tag editing.
- Added agent ad-hoc meal item support (`adhoc: true` or `saveToFoods: false`) with required inline macro snapshots and `foodId: null` persistence for non-library items.
- Extended `GET /api/v1/exercises/:id/last-performance` with `includeRelated=true`, returning exact history plus related exercise history, and surfaced this in active workout exercise cards.

## Technical Notes
- Food/tag normalization is intentionally lowercase and bounded (max 20 tags); tag filtering uses SQL `json_each` and applies AND semantics across selected tags.
- `updateFoodLastUsedAt` now increments popularity as a side effect; meal route deduplicates resolved food IDs before updating, so repeated references to the same food in one request count once.
- Last-performance now has two response modes: legacy single-history payload by default, and `{ history, related }` when `includeRelated=true`; frontend active workout hook now requests the related-aware mode.
- Related exercise payload size is constrained (`relatedExerciseIds` max 20 in shared/agent schemas) to keep request/response size and query fan-out bounded.
- Coverage includes migration tests, route/store tests, schema tests, and frontend behavior tests for tag filtering/editing and related-history rendering.

## Commits

- `6703dd5 fix(exercises): address commit-19 review feedback`
- `54e0dae feat(workouts): add related exercise history sections`
- `596d993 feat(agent): support ad-hoc meal logging without food records`
- `072ec5f fix(foods): address review feedback for tag filtering`
- `a0d6950 feat(foods): add usage tracking, tags, and popularity sorting`
- `c5432ab feat(workouts): add template tag editing and filtering`

## Tasks

- **Implement full template tag support**: Tag CRUD on templates, tag filter UI on template list
- **Add food usage tracking and tags**: DB migration for usageCount + tags, increment on meal log, sort/filter UI
- **Ad-hoc meal logging UI and agent support**: Agent API ad-hoc path, agent skill update, frontend path if applicable
- **Related exercise history UI**: API endpoint for related history, frontend Related section in exercise history views

## Diff Stats

```
.agents/skills/pulse-app-usage/SKILL.md            |  19 ++
 apps/api/drizzle/0028_food_usage_and_tags.sql      |   5 +
 apps/api/drizzle/meta/_journal.json                |   7 +
 apps/api/src/__tests__/agent.test.ts               |  62 +++++-
 apps/api/src/__tests__/foods-nutrition.test.ts     |  29 ++-
 apps/api/src/db/migrations.test.ts                 |  83 ++++++++
 apps/api/src/db/schema.test.ts                     |   9 +-
 apps/api/src/db/schema/foods.ts                    |   3 +
 apps/api/src/routes/agent/foods.test.ts            |   2 +
 apps/api/src/routes/agent/foods.ts                 |   1 +
 apps/api/src/routes/agent/meals.test.ts            | 193 +++++++++++++++++++
 apps/api/src/routes/agent/meals.ts                 |  97 +++++++---
 apps/api/src/routes/exercises/index.test.ts        | 153 +++++++++++++++
 apps/api/src/routes/exercises/index.ts             |  30 ++-
 apps/api/src/routes/exercises/store.ts             |  91 ++++++++-
 apps/api/src/routes/foods/index.test.ts            |  12 +-
 apps/api/src/routes/foods/store.test.ts            |  24 ++-
 apps/api/src/routes/foods/store.ts                 |  31 ++-
 apps/web/src/features/foods/api/foods.test.tsx     |  11 +-
 apps/web/src/features/foods/api/foods.ts           |   3 +
 apps/web/src/features/foods/api/keys.ts            |   1 +
 .../features/foods/components/food-list.test.tsx   |  98 +++++++++-
 .../src/features/foods/components/food-list.tsx    | 212 ++++++++++++++++++++-
 .../components/session-exercise-list.test.tsx      | 102 ++++++++++
 .../workouts/components/session-exercise-list.tsx  |  98 +++++++++-
 .../workouts/components/session-summary.test.tsx   |  30 ++-
 .../workouts/components/session-summary.tsx        | 135 +++++++++++--
 .../workouts/components/template-browser.test.tsx  |  51 +++++
 .../workouts/components/template-browser.tsx       | 192 +++++++++++++------
 .../web/src/features/workouts/lib/template-tags.ts |  50 +++++
 apps/web/src/features/workouts/types.ts            |  12 ++
 apps/web/src/hooks/use-last-performance.test.tsx   | 113 +++++++++--
 apps/web/src/hooks/use-last-performance.ts         |  71 ++++---
 apps/web/src/pages/foods.test.tsx                  |   2 +
 apps/web/src/pages/foods.tsx                       |   3 +-
 packages/shared/src/schemas/agent.ts               |  53 +++++-
 packages/shared/src/schemas/exercises.test.ts      |  69 +++++++
 packages/shared/src/schemas/exercises.ts           |  25 ++-
 packages/shared/src/schemas/foods.test.ts          |  35 +++-
 packages/shared/src/schemas/foods.ts               |  30 ++-
 packages/shared/src/schemas/nutrition.test.ts      |   2 +
 packages/shared/src/schemas/nutrition.ts           |   2 +-
 42 files changed, 2036 insertions(+), 215 deletions(-)
```