### PR TITLE
feat: template editor and receipt redesign

### DIFF
--- a/apps/web/src/components/ui/button.test.tsx
+++ b/apps/web/src/components/ui/button.test.tsx
@@ -64,7 +64,10 @@ describe('Button', () => {
 
     expect(screen.getByRole('button', { name: 'Reschedule' })).toHaveClass(
       'text-foreground',
+      'dark:bg-input/25',
+      'dark:hover:bg-input/70',
       'dark:hover:text-foreground',
+      'dark:active:bg-input/80',
       'active:text-accent-foreground',
       'dark:active:text-foreground',
     );

--- a/apps/web/src/components/ui/button.test.tsx
+++ b/apps/web/src/components/ui/button.test.tsx
@@ -54,4 +54,19 @@ describe('Button', () => {
       'min-w-0',
     );
   });
+
+  it('keeps outline buttons readable on dark surfaces during hover and active states', () => {
+    render(
+      <Button type="button" variant="outline">
+        Reschedule
+      </Button>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Reschedule' })).toHaveClass(
+      'text-foreground',
+      'dark:hover:text-foreground',
+      'active:text-accent-foreground',
+      'dark:active:text-foreground',
+    );
+  });
 });

--- a/apps/web/src/components/ui/button.test.tsx
+++ b/apps/web/src/components/ui/button.test.tsx
@@ -65,11 +65,15 @@ describe('Button', () => {
     expect(screen.getByRole('button', { name: 'Reschedule' })).toHaveClass(
       'text-foreground',
       'dark:bg-input/25',
+      'hover:border-accent-foreground/25',
       'dark:hover:bg-input/70',
       'dark:hover:text-foreground',
+      'dark:hover:border-foreground/35',
       'dark:active:bg-input/80',
       'active:text-accent-foreground',
+      'active:border-accent-foreground/35',
       'dark:active:text-foreground',
+      'dark:active:border-foreground/45',
     );
   });
 });

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -14,7 +14,7 @@ const buttonVariants = cva(
         destructive:
           'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40',
         outline:
-          'border bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground active:bg-accent/80 active:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 dark:hover:text-foreground dark:active:bg-input/70 dark:active:text-foreground',
+          'border bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground active:bg-accent/80 active:text-accent-foreground dark:border-input dark:bg-input/25 dark:hover:bg-input/70 dark:hover:text-foreground dark:active:bg-input/80 dark:active:text-foreground',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
         link: 'text-primary underline-offset-4 hover:underline',

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -14,7 +14,7 @@ const buttonVariants = cva(
         destructive:
           'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40',
         outline:
-          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
+          'border bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground active:bg-accent/80 active:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 dark:hover:text-foreground dark:active:bg-input/70 dark:active:text-foreground',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
         link: 'text-primary underline-offset-4 hover:underline',

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -14,7 +14,7 @@ const buttonVariants = cva(
         destructive:
           'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40',
         outline:
-          'border bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground active:bg-accent/80 active:text-accent-foreground dark:border-input dark:bg-input/25 dark:hover:bg-input/70 dark:hover:text-foreground dark:active:bg-input/80 dark:active:text-foreground',
+          'border bg-background text-foreground shadow-xs hover:border-accent-foreground/25 hover:bg-accent hover:text-accent-foreground active:border-accent-foreground/35 active:bg-accent/80 active:text-accent-foreground dark:border-input dark:bg-input/25 dark:hover:border-foreground/35 dark:hover:bg-input/70 dark:hover:text-foreground dark:active:border-foreground/45 dark:active:bg-input/80 dark:active:text-foreground',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
         link: 'text-primary underline-offset-4 hover:underline',

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -14,6 +14,7 @@ import {
   updateExerciseInputSchema,
   updateWorkoutTemplateInputSchema,
   type UpdateWorkoutTemplateInput,
+  type UpdateExerciseInput,
   type Exercise,
   type ExerciseQueryParams,
   type CreateScheduledWorkoutInput,
@@ -54,6 +55,10 @@ type WorkoutSessionResponse = { data: WorkoutSession };
 type RenameExerciseRequest = {
   id: string;
   name: string;
+};
+type UpdateExerciseRequest = {
+  id: string;
+  input: UpdateExerciseInput;
 };
 type RenameTemplateRequest = {
   id: string;
@@ -294,10 +299,8 @@ async function createWorkoutSession(input: CreateWorkoutSessionRequest) {
   return payload.data;
 }
 
-async function renameExercise(input: RenameExerciseRequest) {
-  const parsedInput = updateExerciseInputSchema.parse({
-    name: input.name,
-  });
+async function updateExercise(input: UpdateExerciseRequest) {
+  const parsedInput = updateExerciseInputSchema.parse(input.input);
   const data = await apiRequest<unknown>(`/api/v1/exercises/${input.id}`, {
     body: JSON.stringify(parsedInput),
     method: 'PATCH',
@@ -601,7 +604,7 @@ export function useRenameExercise() {
   const queryClient = useQueryClient();
 
   return useMutation<Exercise, Error, RenameExerciseRequest>({
-    mutationFn: renameExercise,
+    mutationFn: ({ id, name }) => updateExercise({ id, input: { name } }),
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({
@@ -612,6 +615,24 @@ export function useRenameExercise() {
         }),
       ]);
       toast.success('Exercise renamed');
+    },
+  });
+}
+
+export function useUpdateExercise() {
+  const queryClient = useQueryClient();
+
+  return useMutation<Exercise, Error, UpdateExerciseRequest>({
+    mutationFn: updateExercise,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.all,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.sessions(),
+        }),
+      ]);
     },
   });
 }

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -13,6 +13,7 @@ import {
   updateScheduledWorkoutInputSchema,
   updateExerciseInputSchema,
   updateWorkoutTemplateInputSchema,
+  type UpdateWorkoutTemplateInput,
   type Exercise,
   type ExerciseQueryParams,
   type CreateScheduledWorkoutInput,
@@ -57,6 +58,10 @@ type RenameExerciseRequest = {
 type RenameTemplateRequest = {
   id: string;
   name: string;
+};
+type UpdateTemplateRequest = {
+  id: string;
+  input: UpdateWorkoutTemplateInput;
 };
 type DeleteTemplateRequest = {
   id: string;
@@ -306,6 +311,17 @@ async function renameTemplate(input: RenameTemplateRequest) {
   const parsedInput = updateWorkoutTemplateInputSchema.parse({
     name: input.name,
   });
+  const data = await apiRequest<unknown>(`/api/v1/workout-templates/${input.id}`, {
+    body: JSON.stringify(parsedInput),
+    method: 'PATCH',
+  });
+  const payload = workoutTemplateResponseSchema.parse({ data });
+
+  return payload.data;
+}
+
+async function updateTemplate(input: UpdateTemplateRequest) {
+  const parsedInput = updateWorkoutTemplateInputSchema.parse(input.input);
   const data = await apiRequest<unknown>(`/api/v1/workout-templates/${input.id}`, {
     body: JSON.stringify(parsedInput),
     method: 'PATCH',
@@ -615,6 +631,24 @@ export function useRenameTemplate() {
         }),
       ]);
       toast.success('Template renamed');
+    },
+  });
+}
+
+export function useUpdateTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation<WorkoutTemplate, Error, UpdateTemplateRequest>({
+    mutationFn: updateTemplate,
+    onSuccess: async (_, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.templates(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.template(variables.id),
+        }),
+      ]);
     },
   });
 }

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -149,6 +149,8 @@ type CreateWorkoutSessionRequest = z.input<typeof createWorkoutSessionInputSchem
 export const workoutQueryKeys = {
   all: ['workouts'] as const,
   completedSessions: () => ['workouts', 'completed-sessions'] as const,
+  exercise: (id: string) => ['workouts', 'exercise', id] as const,
+  exercisesRoot: () => ['workouts', 'exercises'] as const,
   exercises: (params: ExerciseQueryParams) => ['workouts', 'exercises', params] as const,
   exerciseFilters: () => ['workouts', 'exercise-filters'] as const,
   scheduledWorkoutsAll: () => ['workouts', 'scheduled-workouts'] as const,
@@ -158,6 +160,7 @@ export const workoutQueryKeys = {
   sessions: () => ['workouts', 'sessions'] as const,
   sessionsList: (params: WorkoutSessionQueryParams = {}) =>
     ['workouts', 'sessions', params] as const,
+  templateRoot: () => ['workouts', 'template'] as const,
   template: (id: string) => ['workouts', 'template', id] as const,
   templates: () => ['workouts', 'templates'] as const,
 };
@@ -281,6 +284,16 @@ async function getExercises(params: ExerciseQueryParams) {
   );
 
   return exercisesResponseSchema.parse(payload);
+}
+
+async function getExercise(id: string, signal?: AbortSignal) {
+  const data = await apiRequest<unknown>(`/api/v1/exercises/${id}`, {
+    method: 'GET',
+    signal,
+  });
+  const payload = z.object({ data: exerciseSchema }).parse({ data });
+
+  return payload.data;
 }
 
 async function getExerciseFilters() {
@@ -516,6 +529,14 @@ export function useExercises(params: ExerciseQueryParams, options?: { enabled?: 
   });
 }
 
+export function useExercise(id: string, options?: { enabled?: boolean }) {
+  return useQuery<Exercise>({
+    enabled: (options?.enabled ?? true) && id.trim().length > 0,
+    queryFn: ({ signal }) => getExercise(id, signal),
+    queryKey: workoutQueryKeys.exercise(id),
+  });
+}
+
 export function useExerciseFilters() {
   return useQuery<ExerciseFiltersResponse>({
     queryFn: getExerciseFilters,
@@ -624,13 +645,19 @@ export function useUpdateExercise() {
 
   return useMutation<Exercise, Error, UpdateExerciseRequest>({
     mutationFn: updateExercise,
-    onSuccess: async () => {
+    onSuccess: async (_, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.all,
+          queryKey: workoutQueryKeys.exercise(variables.id),
         }),
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.sessions(),
+          queryKey: workoutQueryKeys.exercisesRoot(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.templates(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.templateRoot(),
         }),
       ]);
     },

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -235,21 +235,29 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
 
       <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
         <StatCard
+          accentTextClassName="text-blue-900 dark:text-blue-200"
+          className="border-blue-200/70 bg-blue-500/10 dark:border-blue-400/30 dark:bg-blue-500/15"
           icon={<Dumbbell aria-hidden="true" className="size-4" />}
           label="Exercises"
           value={`${summary.totalExercises}`}
         />
         <StatCard
+          accentTextClassName="text-fuchsia-900 dark:text-fuchsia-200"
+          className="border-fuchsia-200/70 bg-fuchsia-500/10 dark:border-fuchsia-400/30 dark:bg-fuchsia-500/15"
           icon={<ListChecks aria-hidden="true" className="size-4" />}
           label="Sets"
           value={`${summary.totalSets}`}
         />
         <StatCard
+          accentTextClassName="text-fuchsia-900 dark:text-fuchsia-200"
+          className="border-fuchsia-200/70 bg-fuchsia-500/10 dark:border-fuchsia-400/30 dark:bg-fuchsia-500/15"
           icon={<Repeat2 aria-hidden="true" className="size-4" />}
           label="Reps"
           value={integerFormatter.format(summary.totalReps)}
         />
         <StatCard
+          accentTextClassName="text-emerald-900 dark:text-emerald-200"
+          className="border-emerald-200/70 bg-emerald-500/10 dark:border-emerald-400/30 dark:bg-emerald-500/15"
           icon={<Scale aria-hidden="true" className="size-4" />}
           label={formatLabel(summary.metricLabel)}
           value={formatSummaryMetric(summary.totalVolume, summary.metricLabel, weightUnit)}

--- a/apps/web/src/features/workouts/components/session-summary.test.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.test.tsx
@@ -14,6 +14,26 @@ describe('SessionSummary', () => {
         defaultDescription="Chest, shoulders, and triceps emphasis with controlled tempo work."
         defaultTags={['strength', 'push', 'upper-body']}
         duration="47:12"
+        exerciseResults={[
+          {
+            id: 'incline-press',
+            name: 'Incline Dumbbell Press',
+            notes: 'Kept shoulder blades pinned and reduced ROM for shoulder comfort.',
+            reps: 32,
+            setsCompleted: 4,
+            totalSets: 4,
+            volume: 1760,
+          },
+          {
+            id: 'lateral-raise',
+            name: 'Cable Lateral Raise',
+            notes: '',
+            reps: 28,
+            setsCompleted: 4,
+            totalSets: 4,
+            volume: 420,
+          },
+        ]}
         exercisesCompleted={7}
         feedback={[
           {
@@ -72,10 +92,26 @@ describe('SessionSummary', () => {
         sessionNotes=""
         totalReps={124}
         totalSets={14}
+        totalVolume={7460}
         workoutName="Upper Push"
       />,
     );
 
+    expect(screen.getByTestId('summary-pill-volume-total-volume')).toHaveClass('bg-blue-500/12');
+    expect(screen.getByTestId('summary-pill-time-duration')).toHaveClass('bg-emerald-500/12');
+    expect(screen.getByTestId('summary-pill-count-sets')).toHaveClass('bg-fuchsia-500/12');
+    expect(screen.getByTestId('summary-pill-count-reps')).toHaveClass('bg-fuchsia-500/12');
+    expect(screen.getByText('Total volume')).toBeInTheDocument();
+    expect(screen.getByText('7,460 lbs')).toBeInTheDocument();
+    expect(screen.getByText('47:12')).toBeInTheDocument();
+    expect(screen.getByText('14/14')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Exercise results' })).toBeInTheDocument();
+    expect(screen.getByText('Incline Dumbbell Press')).toBeInTheDocument();
+    expect(
+      screen.getByText('Kept shoulder blades pinned and reduced ROM for shoulder comfort.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Volume: 1,760 lbs')).toBeInTheDocument();
+    expect(screen.getByText('Reps: 32')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Session feedback' })).toBeInTheDocument();
     expect(screen.getByText('2 / 5')).toBeInTheDocument();
     expect(screen.getByText('🙂')).toBeInTheDocument();

--- a/apps/web/src/features/workouts/components/session-summary.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { CheckCircle2, Clock3, Dumbbell, ListChecks, Save, X } from 'lucide-react';
+import { formatWeight, type WeightUnit } from '@pulse/shared';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -32,6 +33,7 @@ type SessionSummaryProps = {
   defaultDescription?: string;
   defaultTags?: string[];
   duration: string;
+  exerciseResults?: SessionSummaryExerciseResult[];
   exercisesCompleted: number;
   feedback?: ActiveWorkoutFeedbackDraft;
   onDone: () => void;
@@ -40,9 +42,21 @@ type SessionSummaryProps = {
   sessionId?: string | null;
   completedSets?: number;
   summarySaving?: boolean;
+  totalVolume?: number;
   totalReps: number;
   totalSets: number;
+  weightUnit?: WeightUnit;
   workoutName: string;
+};
+
+export type SessionSummaryExerciseResult = {
+  id: string;
+  name: string;
+  notes?: string | null;
+  reps: number;
+  setsCompleted: number;
+  totalSets: number;
+  volume: number;
 };
 
 export function SessionSummary({
@@ -50,6 +64,7 @@ export function SessionSummary({
   defaultDescription = '',
   defaultTags = [],
   duration,
+  exerciseResults = [],
   exercisesCompleted,
   feedback = [],
   onDone,
@@ -58,8 +73,10 @@ export function SessionSummary({
   sessionId = null,
   completedSets,
   summarySaving = false,
+  totalVolume = 0,
   totalReps,
   totalSets,
+  weightUnit = 'lbs',
   workoutName,
 }: SessionSummaryProps) {
   const saveAsTemplateMutation = useSaveAsTemplate(sessionId);
@@ -115,33 +132,73 @@ export function SessionSummary({
   return (
     <>
       <Card className={cn(`overflow-hidden py-0 shadow-lg ${accentCardStyles.mint}`, className)}>
-        <CardContent className="space-y-5 px-5 py-6 sm:px-6">
+        <CardContent className="space-y-4 px-4 py-5 sm:px-5 sm:py-5">
           <div className="space-y-2">
             <div className="inline-flex items-center gap-2 rounded-full border border-black/10 bg-white/40 px-3 py-1 text-xs font-semibold tracking-[0.18em] uppercase dark:border-border dark:bg-secondary/60">
               <CheckCircle2 aria-hidden="true" className="size-3.5" />
               Session complete
             </div>
             <div className="space-y-1">
-              <h1 className="text-3xl font-semibold tracking-tight">Workout summary</h1>
+              <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Workout summary</h1>
               <p className="max-w-2xl text-sm opacity-75 dark:text-muted dark:opacity-100">
                 Logged, reflected, and ready to head back to the workouts overview.
               </p>
             </div>
           </div>
 
-          <div className="grid gap-3 sm:grid-cols-2">
-            <SummaryStat
+          <div className="flex flex-wrap gap-2">
+            <SummaryPill
               icon={Dumbbell}
-              label="Exercises completed"
-              value={`${exercisesCompleted}`}
+              label="Total volume"
+              tone="volume"
+              value={formatWeight(totalVolume, weightUnit)}
             />
-            <SummaryStat
+            <SummaryPill icon={Clock3} label="Duration" tone="time" value={duration} />
+            <SummaryPill
               icon={ListChecks}
-              label="Sets completed"
+              label="Sets"
+              tone="count"
               value={completedSets === undefined ? `${totalSets}` : `${completedSets}/${totalSets}`}
             />
-            <SummaryStat icon={CheckCircle2} label="Total reps" value={`${totalReps}`} />
-            <SummaryStat icon={Clock3} label="Duration" value={duration} />
+            <SummaryPill icon={CheckCircle2} label="Reps" tone="count" value={`${totalReps}`} />
+          </div>
+
+          {exerciseResults.length > 0 ? (
+            <section className="space-y-2 rounded-3xl border border-black/10 bg-white/35 p-3 dark:border-border dark:bg-secondary/50">
+              <h2 className="text-sm font-semibold tracking-[0.18em] uppercase opacity-70 dark:text-muted dark:opacity-100">
+                Exercise results
+              </h2>
+              <div className="space-y-2">
+                {exerciseResults.map((exercise) => (
+                  <article
+                    className="rounded-2xl border border-black/10 bg-white/45 p-3 dark:border-border dark:bg-card"
+                    key={exercise.id}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <p className="text-sm font-semibold text-foreground">{exercise.name}</p>
+                      <span className="shrink-0 rounded-full bg-fuchsia-500/15 px-2 py-0.5 text-[11px] font-semibold text-fuchsia-700 dark:text-fuchsia-300">
+                        {`${exercise.setsCompleted}/${exercise.totalSets} sets`}
+                      </span>
+                    </div>
+                    <div className="mt-1 flex flex-wrap gap-1.5">
+                      <MetricChip
+                        label="Volume"
+                        tone="volume"
+                        value={formatWeight(exercise.volume, weightUnit)}
+                      />
+                      <MetricChip label="Reps" tone="count" value={`${exercise.reps}`} />
+                    </div>
+                    {exercise.notes?.trim() ? (
+                      <p className="mt-2 text-xs text-muted">{exercise.notes.trim()}</p>
+                    ) : null}
+                  </article>
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs font-medium text-muted">
+            <span>{`${exercisesCompleted} exercise${exercisesCompleted === 1 ? '' : 's'} logged`}</span>
           </div>
 
           <section className="space-y-2 rounded-3xl border border-black/10 bg-white/35 p-4 dark:border-border dark:bg-secondary/50">
@@ -167,28 +224,28 @@ export function SessionSummary({
           </section>
 
           {feedback.length > 0 ? (
-            <section className="space-y-3 rounded-3xl border border-black/10 bg-white/35 p-4 dark:border-border dark:bg-secondary/50">
-              <div className="space-y-1">
+            <section className="space-y-2 rounded-3xl border border-black/10 bg-white/35 p-3.5 dark:border-border dark:bg-secondary/50">
+              <div className="space-y-0.5">
                 <h2 className="text-lg font-semibold text-foreground">Session feedback</h2>
                 <p className="text-sm opacity-75 dark:text-muted dark:opacity-100">
                   Saved check-ins from the end of this workout.
                 </p>
               </div>
 
-              <div className="grid gap-3 sm:grid-cols-2">
+              <div className="grid gap-2 sm:grid-cols-2">
                 {feedback.map((field) => (
                   <div
-                    className="rounded-2xl border border-black/10 bg-white/45 p-4 dark:border-border dark:bg-card"
+                    className="rounded-2xl border border-black/10 bg-white/45 p-3 dark:border-border dark:bg-card"
                     key={field.id}
                   >
                     <p className="text-xs font-semibold tracking-[0.18em] uppercase opacity-65 dark:text-muted dark:opacity-100">
                       {field.label}
                     </p>
-                    <p className="mt-2 text-base font-semibold text-foreground">
+                    <p className="mt-1.5 text-lg leading-none font-semibold text-foreground">
                       {formatFeedbackFieldValue(field)}
                     </p>
                     {field.notes?.trim() ? (
-                      <p className="mt-2 text-sm text-muted">{field.notes.trim()}</p>
+                      <p className="mt-1.5 text-xs text-muted">{field.notes.trim()}</p>
                     ) : null}
                   </div>
                 ))}
@@ -409,22 +466,61 @@ function formatFeedbackFieldValue(field: ActiveWorkoutFeedbackDraft[number]) {
   }
 }
 
-function SummaryStat({
+function SummaryPill({
   icon: Icon,
   label,
+  tone,
   value,
 }: {
   icon: typeof CheckCircle2;
   label: string;
+  tone: 'count' | 'time' | 'volume';
   value: string;
 }) {
+  const toneClass =
+    tone === 'volume'
+      ? 'border-blue-500/25 bg-blue-500/12 text-blue-900 dark:text-blue-100'
+      : tone === 'time'
+        ? 'border-emerald-500/25 bg-emerald-500/12 text-emerald-900 dark:text-emerald-100'
+        : 'border-fuchsia-500/25 bg-fuchsia-500/12 text-fuchsia-900 dark:text-fuchsia-100';
+  const testIdLabel = label.toLowerCase().replace(/\s+/g, '-');
+
   return (
-    <div className="rounded-2xl border border-black/10 bg-white/40 p-4 dark:border-border dark:bg-secondary/60">
-      <div className="flex items-center gap-2 text-[11px] font-semibold tracking-[0.18em] uppercase opacity-65 dark:text-muted dark:opacity-100">
-        <Icon aria-hidden="true" className="size-3.5" />
+    <div
+      data-testid={`summary-pill-${tone}-${testIdLabel}`}
+      className={cn(
+        'inline-flex min-w-[120px] items-center gap-2 rounded-full border px-3 py-1.5',
+        toneClass,
+      )}
+    >
+      <div className="flex items-center gap-1.5 text-[10px] font-semibold tracking-[0.14em] uppercase opacity-85">
+        <Icon aria-hidden="true" className="size-3" />
         <span>{label}</span>
       </div>
-      <p className="mt-2 text-2xl font-semibold">{value}</p>
+      <p className="text-sm font-semibold">{value}</p>
     </div>
+  );
+}
+
+function MetricChip({
+  label,
+  tone,
+  value,
+}: {
+  label: string;
+  tone: 'count' | 'time' | 'volume';
+  value: string;
+}) {
+  const toneClass =
+    tone === 'volume'
+      ? 'bg-blue-500/12 text-blue-800 dark:text-blue-200'
+      : tone === 'time'
+        ? 'bg-emerald-500/12 text-emerald-800 dark:text-emerald-200'
+        : 'bg-fuchsia-500/12 text-fuchsia-800 dark:text-fuchsia-200';
+
+  return (
+    <span className={cn('rounded-full px-2 py-0.5 text-[11px] font-medium', toneClass)}>
+      {`${label}: ${value}`}
+    </span>
   );
 }

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -121,6 +121,13 @@ const createdSessionPayload = {
   },
 };
 
+type MutableTemplateExercise = Omit<
+  (typeof templatePayload)['data']['sections'][number]['exercises'][number],
+  'supersetGroup'
+> & {
+  supersetGroup: string | null;
+};
+
 beforeEach(() => {
   window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
 });
@@ -1015,6 +1022,279 @@ describe('WorkoutTemplateDetail', () => {
     expect(JSON.parse(String(reorderCall?.[1]?.body))).toEqual({
       section: 'main',
       exerciseIds: ['template-exercise-shoulder-press', 'template-exercise-incline'],
+    });
+  });
+
+  it('creates and removes supersets from selected exercises', async () => {
+    const mutableTemplate = structuredClone(templatePayload);
+    const mainExercises = mutableTemplate.data.sections[1].exercises as MutableTemplateExercise[];
+    mainExercises.push({
+      id: 'template-exercise-shoulder-press',
+      exerciseId: 'seated-dumbbell-shoulder-press',
+      exerciseName: 'Seated Dumbbell Shoulder Press',
+      sets: 3,
+      repsMin: 8,
+      repsMax: 10,
+      tempo: null,
+      restSeconds: 90,
+      supersetGroup: null,
+      notes: null,
+      exercise: {
+        formCues: [],
+        coachingNotes: null,
+        instructions: null,
+      },
+      formCues: [],
+      cues: [],
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/workout-templates/upper-push' && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body ?? '{}'));
+        mutableTemplate.data.sections = body.sections as typeof mutableTemplate.data.sections;
+        return Promise.resolve(jsonResponse(mutableTemplate));
+      }
+
+      if (url.pathname === '/api/v1/workout-templates/upper-push') {
+        return Promise.resolve(jsonResponse(mutableTemplate));
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutTemplateDetail templateId="upper-push" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Manage supersets' }));
+    const dialog = await screen.findByRole('dialog');
+
+    fireEvent.click(
+      within(dialog).getByRole('checkbox', {
+        name: /Incline Dumbbell Press/i,
+      }),
+    );
+    fireEvent.click(
+      within(dialog).getByRole('checkbox', {
+        name: /Seated Dumbbell Shoulder Press/i,
+      }),
+    );
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Create superset' }));
+
+    await waitFor(() => {
+      const patchCalls = fetchSpy.mock.calls.filter(
+        ([input, init]) =>
+          String(input).includes('/api/v1/workout-templates/upper-push') && init?.method === 'PATCH',
+      );
+      const firstPatch = patchCalls[0];
+      expect(firstPatch).toBeDefined();
+      const payload = JSON.parse(String(firstPatch?.[1]?.body ?? '{}'));
+      expect(payload.sections[1].exercises[0].supersetGroup).toBe('superset-a');
+      expect(payload.sections[1].exercises[1].supersetGroup).toBe('superset-a');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Manage supersets' }));
+    const removeDialog = await screen.findByRole('dialog');
+    fireEvent.click(
+      within(removeDialog).getByRole('checkbox', {
+        name: /Incline Dumbbell Press/i,
+      }),
+    );
+    fireEvent.click(
+      within(removeDialog).getByRole('checkbox', {
+        name: /Seated Dumbbell Shoulder Press/i,
+      }),
+    );
+    fireEvent.click(within(removeDialog).getByRole('button', { name: 'Remove superset' }));
+
+    await waitFor(() => {
+      const patchCalls = fetchSpy.mock.calls.filter(
+        ([input, init]) =>
+          String(input).includes('/api/v1/workout-templates/upper-push') && init?.method === 'PATCH',
+      );
+      const lastPatch = patchCalls.at(-1);
+      expect(lastPatch).toBeDefined();
+      const payload = JSON.parse(String(lastPatch?.[1]?.body ?? '{}'));
+      expect(payload.sections[1].exercises[0].supersetGroup).toBeNull();
+      expect(payload.sections[1].exercises[1].supersetGroup).toBeNull();
+    });
+  });
+
+  it('renders visual superset grouping when contiguous exercises share a superset group', async () => {
+    const groupedTemplate = structuredClone(templatePayload);
+    const groupedMainExercises =
+      groupedTemplate.data.sections[1].exercises as MutableTemplateExercise[];
+    groupedMainExercises.push({
+      id: 'template-exercise-shoulder-press',
+      exerciseId: 'seated-dumbbell-shoulder-press',
+      exerciseName: 'Seated Dumbbell Shoulder Press',
+      sets: 3,
+      repsMin: 8,
+      repsMax: 10,
+      tempo: null,
+      restSeconds: 90,
+      supersetGroup: 'superset-a',
+      notes: null,
+      exercise: {
+        formCues: [],
+        coachingNotes: null,
+        instructions: null,
+      },
+      formCues: [],
+      cues: [],
+    });
+    (groupedTemplate.data.sections[1].exercises[0] as MutableTemplateExercise).supersetGroup =
+      'superset-a';
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = String(input);
+
+      if (url.endsWith('/api/v1/workout-templates/upper-push')) {
+        return Promise.resolve(jsonResponse(groupedTemplate));
+      }
+
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutTemplateDetail templateId="upper-push" />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Superset A')).toBeInTheDocument();
+  });
+
+  it('opens exercise detail modal with overview, history, and related data and saves coaching notes', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/workout-templates/upper-push') {
+        return Promise.resolve(jsonResponse(templatePayload));
+      }
+
+      if (url.pathname === '/api/v1/exercises' && init?.method !== 'PATCH') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'incline-dumbbell-press',
+                userId: 'user-1',
+                name: 'Incline Dumbbell Press',
+                muscleGroups: ['upper chest', 'triceps'],
+                equipment: 'Dumbbells',
+                category: 'compound',
+                trackingType: 'weight_reps',
+                tags: [],
+                formCues: ['Tuck shoulder blades', 'Drive elbows 45°'],
+                instructions: 'Lower dumbbells with control, then drive up.',
+                coachingNotes: 'Keep your upper back pinned to the bench.',
+                relatedExerciseIds: ['seated-dumbbell-shoulder-press'],
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            ],
+            meta: { page: 1, limit: 20, total: 1 },
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/exercises/incline-dumbbell-press/last-performance') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              history: {
+                sessionId: 'session-1',
+                date: '2026-03-06',
+                sets: [
+                  { setNumber: 1, reps: 10, weight: 70 },
+                  { setNumber: 2, reps: 9, weight: 70 },
+                ],
+              },
+              related: [
+                {
+                  exerciseId: 'seated-dumbbell-shoulder-press',
+                  exerciseName: 'Seated Dumbbell Shoulder Press',
+                  trackingType: 'weight_reps',
+                  history: {
+                    sessionId: 'session-2',
+                    date: '2026-03-04',
+                    sets: [{ setNumber: 1, reps: 8, weight: 55 }],
+                  },
+                },
+              ],
+            },
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/exercises/incline-dumbbell-press' && init?.method === 'PATCH') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: 'incline-dumbbell-press',
+              userId: 'user-1',
+              name: 'Incline Dumbbell Press',
+              muscleGroups: ['upper chest', 'triceps'],
+              equipment: 'Dumbbells',
+              category: 'compound',
+              trackingType: 'weight_reps',
+              tags: [],
+              formCues: ['Tuck shoulder blades'],
+              instructions: 'Lower dumbbells with control, then drive up.',
+              coachingNotes: JSON.parse(String(init.body ?? '{}')).coachingNotes,
+              relatedExerciseIds: ['seated-dumbbell-shoulder-press'],
+              createdAt: 1,
+              updatedAt: 2,
+            },
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutTemplateDetail templateId="upper-push" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Incline Dumbbell Press' }));
+    const dialog = await screen.findByRole('dialog');
+
+    expect(await within(dialog).findByText(/upper chest, triceps/i)).toBeInTheDocument();
+    expect(within(dialog).getByText('Form cues')).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'History' }));
+    expect(await within(dialog).findByText(/Mar/i)).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Related' }));
+    expect(
+      await within(dialog).findByText('Seated Dumbbell Shoulder Press'),
+    ).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Overview' }));
+    const notesField = within(dialog).getByLabelText('Coaching notes');
+    fireEvent.change(notesField, {
+      target: { value: 'Keep upper back pinned and pause for one count.' },
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save coaching notes' }));
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(
+          ([input, init]) =>
+            String(input).includes('/api/v1/exercises/incline-dumbbell-press') &&
+            init?.method === 'PATCH' &&
+            JSON.parse(String(init.body ?? '{}')).coachingNotes ===
+              'Keep upper back pinned and pause for one count.',
+        ),
+      ).toBe(true);
     });
   });
 

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -1177,28 +1177,25 @@ describe('WorkoutTemplateDetail', () => {
         return Promise.resolve(jsonResponse(templatePayload));
       }
 
-      if (url.pathname === '/api/v1/exercises' && init?.method !== 'PATCH') {
+      if (url.pathname === '/api/v1/exercises/incline-dumbbell-press' && init?.method !== 'PATCH') {
         return Promise.resolve(
           jsonResponse({
-            data: [
-              {
-                id: 'incline-dumbbell-press',
-                userId: 'user-1',
-                name: 'Incline Dumbbell Press',
-                muscleGroups: ['upper chest', 'triceps'],
-                equipment: 'Dumbbells',
-                category: 'compound',
-                trackingType: 'weight_reps',
-                tags: [],
-                formCues: ['Tuck shoulder blades', 'Drive elbows 45°'],
-                instructions: 'Lower dumbbells with control, then drive up.',
-                coachingNotes: 'Keep your upper back pinned to the bench.',
-                relatedExerciseIds: ['seated-dumbbell-shoulder-press'],
-                createdAt: 1,
-                updatedAt: 1,
-              },
-            ],
-            meta: { page: 1, limit: 20, total: 1 },
+            data: {
+              id: 'incline-dumbbell-press',
+              userId: 'user-1',
+              name: 'Incline Dumbbell Press',
+              muscleGroups: ['upper chest', 'triceps'],
+              equipment: 'Dumbbells',
+              category: 'compound',
+              trackingType: 'weight_reps',
+              tags: [],
+              formCues: ['Tuck shoulder blades', 'Drive elbows 45°'],
+              instructions: 'Lower dumbbells with control, then drive up.',
+              coachingNotes: 'Keep your upper back pinned to the bench.',
+              relatedExerciseIds: ['seated-dumbbell-shoulder-press'],
+              createdAt: 1,
+              updatedAt: 1,
+            },
           }),
         );
       }

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -128,6 +128,7 @@ beforeEach(() => {
 afterEach(() => {
   window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
   window.localStorage.removeItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY);
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -174,13 +175,17 @@ describe('WorkoutTemplateDetail', () => {
       .closest('[data-slot="card"]');
 
     expect(inclinePressCard).not.toBeNull();
-    expect(within(inclinePressCard as HTMLElement).getByText('3 x 8-10')).toBeInTheDocument();
+    expect(within(inclinePressCard as HTMLElement).getByText('3×8-10')).toBeInTheDocument();
     expect(within(inclinePressCard as HTMLElement).getByText('Tempo: 3-1-1-0')).toBeInTheDocument();
-    expect(within(inclinePressCard as HTMLElement).getByText('Rest: 90s')).toBeInTheDocument();
+    expect(within(inclinePressCard as HTMLElement).getByText(/Rest: 90s/)).toBeInTheDocument();
     expect(
-      within(inclinePressCard as HTMLElement).getByText('Drive feet into the floor.'),
-    ).toBeInTheDocument();
+      within(inclinePressCard as HTMLElement).getAllByText('Drive feet into the floor.').length,
+    ).toBeGreaterThan(0);
 
+    fireEvent.click(within(inclinePressCard as HTMLElement).getByText('Show full set detail'));
+    fireEvent.click(
+      within(inclinePressCard as HTMLElement).getByRole('button', { name: 'Show notes' }),
+    );
     expect(within(inclinePressCard as HTMLElement).getByText('Exercise cues')).toBeInTheDocument();
     expect(within(inclinePressCard as HTMLElement).getByText('Template cues')).toBeInTheDocument();
     expect(
@@ -190,7 +195,6 @@ describe('WorkoutTemplateDetail', () => {
       within(inclinePressCard as HTMLElement).getByText('Keep wrists stacked'),
     ).toBeInTheDocument();
 
-    fireEvent.click(within(inclinePressCard as HTMLElement).getByRole('button', { name: 'Show notes' }));
     expect(
       within(inclinePressCard as HTMLElement).getByText('Exercise coaching notes'),
     ).toBeInTheDocument();
@@ -207,6 +211,164 @@ describe('WorkoutTemplateDetail', () => {
         'Top set first, then reduce load for back-off sets.',
       ),
     ).toBeInTheDocument();
+  });
+
+  it('saves inline sets, reps, rest, and notes on blur with debounce', async () => {
+    const mutableTemplate = structuredClone(templatePayload);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const requestUrl = input instanceof Request ? input.url : String(input);
+      const url = new URL(requestUrl, 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/workout-templates/upper-push' && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body ?? '{}'));
+        mutableTemplate.data.sections = body.sections;
+        return Promise.resolve(jsonResponse(mutableTemplate));
+      }
+
+      if (url.pathname === '/api/v1/workout-templates/upper-push') {
+        return Promise.resolve(jsonResponse(mutableTemplate));
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutTemplateDetail templateId="upper-push" />
+      </MemoryRouter>,
+    );
+
+    const setsInput = await screen.findByLabelText('Sets for Incline Dumbbell Press');
+    const repsInput = screen.getByLabelText('Reps for Incline Dumbbell Press');
+    const restInput = screen.getByLabelText('Rest for Incline Dumbbell Press');
+    const notesInput = screen.getByLabelText('Notes for Incline Dumbbell Press');
+
+    fireEvent.change(setsInput, { target: { value: '4' } });
+    fireEvent.blur(setsInput);
+    fireEvent.change(repsInput, { target: { value: '6-8' } });
+    fireEvent.blur(repsInput);
+    fireEvent.change(restInput, { target: { value: '75' } });
+    fireEvent.blur(restInput);
+    fireEvent.change(notesInput, { target: { value: 'Pause one second at bottom.' } });
+    fireEvent.blur(notesInput);
+
+    await waitFor(
+      () => {
+        expect(
+          fetchSpy.mock.calls.some(
+            ([input, init]) =>
+              String(input).includes('/api/v1/workout-templates/upper-push') &&
+              init?.method === 'PATCH',
+          ),
+        ).toBe(true);
+      },
+      { timeout: 2_000 },
+    );
+
+    const updateCall = fetchSpy.mock.calls.find(
+      ([input, init]) =>
+        String(input).includes('/api/v1/workout-templates/upper-push') && init?.method === 'PATCH',
+    );
+    const body = JSON.parse(String(updateCall?.[1]?.body));
+    const updatedExercise = body.sections[1].exercises[0];
+
+    expect(updatedExercise.sets).toBe(4);
+    expect(updatedExercise.repsMin).toBe(6);
+    expect(updatedExercise.repsMax).toBe(8);
+    expect(updatedExercise.restSeconds).toBe(75);
+    expect(updatedExercise.notes).toBe('Pause one second at bottom.');
+  });
+
+  it('renders add exercise button for each section and adds to selected section', async () => {
+    const mutableTemplate = structuredClone(templatePayload);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const requestUrl = input instanceof Request ? input.url : String(input);
+      const url = new URL(requestUrl, 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/exercises') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'rope-pushdown',
+                userId: 'user-1',
+                name: 'Rope Pushdown',
+                muscleGroups: ['triceps'],
+                equipment: 'cable',
+                category: 'isolation',
+                trackingType: 'weight_reps',
+                tags: [],
+                formCues: [],
+                instructions: null,
+                coachingNotes: null,
+                relatedExerciseIds: [],
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            ],
+            meta: {
+              page: 1,
+              limit: 8,
+              total: 1,
+            },
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/workout-templates/upper-push' && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body ?? '{}'));
+        mutableTemplate.data.sections = body.sections;
+        return Promise.resolve(jsonResponse(mutableTemplate));
+      }
+
+      if (url.pathname === '/api/v1/workout-templates/upper-push') {
+        return Promise.resolve(jsonResponse(mutableTemplate));
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutTemplateDetail templateId="upper-push" />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByRole('button', { name: 'Add exercise to Warmup section' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Add exercise to Main section' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Add exercise to Cooldown section' }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add exercise to Main section' }));
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.click(await within(dialog).findByRole('button', { name: /Rope Pushdown/i }));
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(
+          ([input, init]) =>
+            String(input).includes('/api/v1/workout-templates/upper-push') &&
+            init?.method === 'PATCH',
+        ),
+      ).toBe(true);
+    });
+
+    const updateCall = fetchSpy.mock.calls.find(
+      ([input, init]) =>
+        String(input).includes('/api/v1/workout-templates/upper-push') && init?.method === 'PATCH',
+    );
+    const body = JSON.parse(String(updateCall?.[1]?.body));
+    const mainSection = body.sections.find((section: { type: string }) => section.type === 'main');
+    expect(
+      mainSection.exercises.some(
+        (exercise: { exerciseId: string }) => exercise.exerciseId === 'rope-pushdown',
+      ),
+    ).toBe(true);
   });
 
   it('creates a workout session before navigating to the active workout page', async () => {
@@ -717,11 +879,13 @@ describe('WorkoutTemplateDetail', () => {
       }
 
       if (
-        url.pathname === '/api/v1/workout-templates/upper-push/exercises/incline-dumbbell-press/swap' &&
+        url.pathname ===
+          '/api/v1/workout-templates/upper-push/exercises/incline-dumbbell-press/swap' &&
         init?.method === 'PATCH'
       ) {
         mutableTemplate.data.sections[1].exercises[0].exerciseId = 'seated-dumbbell-shoulder-press';
-        mutableTemplate.data.sections[1].exercises[0].exerciseName = 'Seated Dumbbell Shoulder Press';
+        mutableTemplate.data.sections[1].exercises[0].exerciseName =
+          'Seated Dumbbell Shoulder Press';
 
         return Promise.resolve(jsonResponse(mutableTemplate));
       }

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -169,6 +169,8 @@ describe('WorkoutTemplateDetail', () => {
     expect(warmupSection).not.toHaveAttribute('open');
     expect(mainSection).toHaveAttribute('open');
     expect(cooldownSection).not.toHaveAttribute('open');
+    expect(screen.getAllByText('1 exercise')).toHaveLength(2);
+    expect(screen.getByText('0 exercises')).toBeInTheDocument();
 
     const inclinePressCard = screen
       .getByText('Incline Dumbbell Press')

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -66,6 +66,7 @@ import { useDebouncedCallback } from '@/lib/use-debounced-callback';
 import { cn } from '@/lib/utils';
 
 import {
+  useExercise,
   useExercises,
   useRenameExercise,
   useReorderTemplateExercises,
@@ -896,8 +897,13 @@ function TemplateExerciseCard({
   const compactSummary = formatCompactSetSummary(exercise, weightUnit);
   const targetBreakdown = formatSetTargetBreakdown(exercise, weightUnit);
   const [fields, setFields] = useState<EditableExerciseFields>(() => toEditableFields(exercise));
+  const focusedFieldCountRef = useRef(0);
 
   useEffect(() => {
+    if (focusedFieldCountRef.current > 0) {
+      return;
+    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- local editable state must resync to server snapshot when not actively editing
     setFields(toEditableFields(exercise));
   }, [exercise]);
 
@@ -996,7 +1002,15 @@ function TemplateExerciseCard({
           <InlineEditField
             ariaLabel={`Sets for ${exercise.exerciseName}`}
             label="Sets"
-            onBlur={() => debouncedInlineSave.run(fields)}
+            onBlur={() => {
+              debouncedInlineSave.run(fields);
+              setTimeout(() => {
+                focusedFieldCountRef.current = Math.max(0, focusedFieldCountRef.current - 1);
+              }, 0);
+            }}
+            onFocus={() => {
+              focusedFieldCountRef.current += 1;
+            }}
             onChange={(nextValue) => setFields((current) => ({ ...current, sets: nextValue }))}
             placeholder="3"
             value={fields.sets}
@@ -1004,7 +1018,15 @@ function TemplateExerciseCard({
           <InlineEditField
             ariaLabel={`Reps for ${exercise.exerciseName}`}
             label="Reps"
-            onBlur={() => debouncedInlineSave.run(fields)}
+            onBlur={() => {
+              debouncedInlineSave.run(fields);
+              setTimeout(() => {
+                focusedFieldCountRef.current = Math.max(0, focusedFieldCountRef.current - 1);
+              }, 0);
+            }}
+            onFocus={() => {
+              focusedFieldCountRef.current += 1;
+            }}
             onChange={(nextValue) => setFields((current) => ({ ...current, reps: nextValue }))}
             placeholder="8-10"
             value={fields.reps}
@@ -1012,7 +1034,15 @@ function TemplateExerciseCard({
           <InlineEditField
             ariaLabel={`Rest for ${exercise.exerciseName}`}
             label="Rest (s)"
-            onBlur={() => debouncedInlineSave.run(fields)}
+            onBlur={() => {
+              debouncedInlineSave.run(fields);
+              setTimeout(() => {
+                focusedFieldCountRef.current = Math.max(0, focusedFieldCountRef.current - 1);
+              }, 0);
+            }}
+            onFocus={() => {
+              focusedFieldCountRef.current += 1;
+            }}
             onChange={(nextValue) =>
               setFields((current) => ({ ...current, restSeconds: nextValue }))
             }
@@ -1024,7 +1054,15 @@ function TemplateExerciseCard({
             className="sm:col-span-3 lg:col-span-1"
             label="Notes"
             multiline
-            onBlur={() => debouncedInlineSave.run(fields)}
+            onBlur={() => {
+              debouncedInlineSave.run(fields);
+              setTimeout(() => {
+                focusedFieldCountRef.current = Math.max(0, focusedFieldCountRef.current - 1);
+              }, 0);
+            }}
+            onFocus={() => {
+              focusedFieldCountRef.current += 1;
+            }}
             onChange={(nextValue) => setFields((current) => ({ ...current, notes: nextValue }))}
             placeholder="Optional note"
             value={fields.notes}
@@ -1240,23 +1278,13 @@ function ExerciseDetailModal({
   const [coachingNotes, setCoachingNotes] = useState(exercise.exercise?.coachingNotes ?? '');
   const [isSaving, setIsSaving] = useState(false);
 
-  const exerciseQuery = useExercises(
-    {
-      page: 1,
-      limit: 20,
-      q: exercise.exerciseName,
-    },
-    { enabled: true },
-  );
+  const exerciseQuery = useExercise(exercise.exerciseId, { enabled: true });
   const historyQuery = useLastPerformance(exercise.exerciseId, {
     enabled: true,
     includeRelated: true,
   });
 
-  const matchedExercise = useMemo(
-    () => exerciseQuery.data?.data.find((item) => item.id === exercise.exerciseId) ?? null,
-    [exercise.exerciseId, exerciseQuery.data?.data],
-  );
+  const matchedExercise = exerciseQuery.data ?? null;
 
   const formCues = matchedExercise?.formCues ?? exercise.exercise?.formCues ?? exercise.formCues ?? [];
   const instructionText = matchedExercise?.instructions ?? exercise.exercise?.instructions ?? null;
@@ -1266,145 +1294,143 @@ function ExerciseDetailModal({
   return (
     <Dialog open onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
-          <>
-            <DialogHeader>
-              <DialogTitle>{exercise.exerciseName}</DialogTitle>
-              <DialogDescription>
-                {formatTrackingTypeLabel(trackingType)} •{' '}
-                {muscleGroups.length > 0 ? muscleGroups.join(', ') : 'Muscle groups not specified'}
-              </DialogDescription>
-            </DialogHeader>
+        <DialogHeader>
+          <DialogTitle>{exercise.exerciseName}</DialogTitle>
+          <DialogDescription>
+            {formatTrackingTypeLabel(trackingType)} •{' '}
+            {muscleGroups.length > 0 ? muscleGroups.join(', ') : 'Muscle groups not specified'}
+          </DialogDescription>
+        </DialogHeader>
 
-            <div className="flex gap-2 border-b border-border pb-2">
-              <Button
-                onClick={() => setActiveTab('overview')}
-                size="sm"
-                type="button"
-                variant={activeTab === 'overview' ? 'default' : 'outline'}
-              >
-                Overview
-              </Button>
-              <Button
-                onClick={() => setActiveTab('history')}
-                size="sm"
-                type="button"
-                variant={activeTab === 'history' ? 'default' : 'outline'}
-              >
-                History
-              </Button>
-              <Button
-                onClick={() => setActiveTab('related')}
-                size="sm"
-                type="button"
-                variant={activeTab === 'related' ? 'default' : 'outline'}
-              >
-                Related
-              </Button>
-            </div>
+        <div className="flex gap-2 border-b border-border pb-2">
+          <Button
+            onClick={() => setActiveTab('overview')}
+            size="sm"
+            type="button"
+            variant={activeTab === 'overview' ? 'default' : 'outline'}
+          >
+            Overview
+          </Button>
+          <Button
+            onClick={() => setActiveTab('history')}
+            size="sm"
+            type="button"
+            variant={activeTab === 'history' ? 'default' : 'outline'}
+          >
+            History
+          </Button>
+          <Button
+            onClick={() => setActiveTab('related')}
+            size="sm"
+            type="button"
+            variant={activeTab === 'related' ? 'default' : 'outline'}
+          >
+            Related
+          </Button>
+        </div>
 
-            {activeTab === 'overview' ? (
-              <div className="space-y-4">
-                {formCues.length > 0 ? (
-                  <div className="space-y-2">
-                    <p className="text-xs font-semibold tracking-[0.08em] text-muted uppercase">
-                      Form cues
-                    </p>
-                    <div className="flex flex-wrap gap-2">
-                      {formCues.map((cue) => (
-                        <Badge key={cue} variant="secondary">
-                          {cue}
-                        </Badge>
-                      ))}
-                    </div>
-                  </div>
-                ) : null}
-
-                {instructionText ? (
-                  <div className="space-y-2">
-                    <p className="text-xs font-semibold tracking-[0.08em] text-muted uppercase">
-                      Instructions
-                    </p>
-                    <p className="text-sm text-foreground">{instructionText}</p>
-                  </div>
-                ) : null}
-
-                <div className="space-y-2">
-                  <p className="text-xs font-semibold tracking-[0.08em] text-muted uppercase">
-                    Coaching notes
-                  </p>
-                  <Textarea
-                    aria-label="Coaching notes"
-                    onChange={(event) => setCoachingNotes(event.currentTarget.value)}
-                    rows={4}
-                    value={coachingNotes}
-                  />
-                  <Button
-                    disabled={isPending || isSaving}
-                    onClick={() => {
-                      setIsSaving(true);
-                      onSaveCoachingNotes(exercise.exerciseId, toNullableString(coachingNotes))
-                        .then(() => {
-                          toast.success('Coaching notes saved');
-                        })
-                        .catch((error) => {
-                          const message =
-                            error instanceof Error ? error.message : 'Unable to save coaching notes';
-                          toast.error(message);
-                        })
-                        .finally(() => {
-                          setIsSaving(false);
-                        });
-                    }}
-                    type="button"
-                  >
-                    Save coaching notes
-                  </Button>
+        {activeTab === 'overview' ? (
+          <div className="space-y-4">
+            {formCues.length > 0 ? (
+              <div className="space-y-2">
+                <p className="text-xs font-semibold tracking-[0.08em] text-muted uppercase">
+                  Form cues
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {formCues.map((cue) => (
+                    <Badge key={cue} variant="secondary">
+                      {cue}
+                    </Badge>
+                  ))}
                 </div>
               </div>
             ) : null}
 
-            {activeTab === 'history' ? (
+            {instructionText ? (
               <div className="space-y-2">
-                {historyQuery.isPending ? (
-                  <p className="text-sm text-muted">Loading recent performance...</p>
-                ) : (
-                  <p className="text-sm text-foreground">
-                    {formatLastPerformanceSummary(historyQuery.data?.history ?? null, trackingType)}
-                  </p>
-                )}
+                <p className="text-xs font-semibold tracking-[0.08em] text-muted uppercase">
+                  Instructions
+                </p>
+                <p className="text-sm text-foreground">{instructionText}</p>
               </div>
             ) : null}
 
-            {activeTab === 'related' ? (
-              <div className="space-y-2">
-                {historyQuery.isPending ? (
-                  <p className="text-sm text-muted">Loading related exercises...</p>
-                ) : historyQuery.data?.related.length ? (
-                  historyQuery.data.related.map((relatedExercise) => (
-                    <div
-                      className="space-y-1 rounded-lg border border-border bg-card px-3 py-2"
-                      key={relatedExercise.exerciseId}
-                    >
-                      <p className="text-sm font-semibold text-foreground">
-                        {relatedExercise.exerciseName}
-                      </p>
-                      <p className="text-xs text-muted">
-                        {formatTrackingTypeLabel(relatedExercise.trackingType)}
-                      </p>
-                      <p className="text-xs text-muted">
-                        {formatLastPerformanceSummary(
-                          relatedExercise.history,
-                          relatedExercise.trackingType,
-                        )}
-                      </p>
-                    </div>
-                  ))
-                ) : (
-                  <p className="text-sm text-muted">No related exercises configured.</p>
-                )}
-              </div>
-            ) : null}
-          </>
+            <div className="space-y-2">
+              <p className="text-xs font-semibold tracking-[0.08em] text-muted uppercase">
+                Coaching notes
+              </p>
+              <Textarea
+                aria-label="Coaching notes"
+                onChange={(event) => setCoachingNotes(event.currentTarget.value)}
+                rows={4}
+                value={coachingNotes}
+              />
+              <Button
+                disabled={isPending || isSaving}
+                onClick={() => {
+                  setIsSaving(true);
+                  onSaveCoachingNotes(exercise.exerciseId, toNullableString(coachingNotes))
+                    .then(() => {
+                      toast.success('Coaching notes saved');
+                    })
+                    .catch((error) => {
+                      const message =
+                        error instanceof Error ? error.message : 'Unable to save coaching notes';
+                      toast.error(message);
+                    })
+                    .finally(() => {
+                      setIsSaving(false);
+                    });
+                }}
+                type="button"
+              >
+                Save coaching notes
+              </Button>
+            </div>
+          </div>
+        ) : null}
+
+        {activeTab === 'history' ? (
+          <div className="space-y-2">
+            {historyQuery.isPending ? (
+              <p className="text-sm text-muted">Loading recent performance...</p>
+            ) : (
+              <p className="text-sm text-foreground">
+                {formatLastPerformanceSummary(historyQuery.data?.history ?? null, trackingType)}
+              </p>
+            )}
+          </div>
+        ) : null}
+
+        {activeTab === 'related' ? (
+          <div className="space-y-2">
+            {historyQuery.isPending ? (
+              <p className="text-sm text-muted">Loading related exercises...</p>
+            ) : historyQuery.data?.related.length ? (
+              historyQuery.data.related.map((relatedExercise) => (
+                <div
+                  className="space-y-1 rounded-lg border border-border bg-card px-3 py-2"
+                  key={relatedExercise.exerciseId}
+                >
+                  <p className="text-sm font-semibold text-foreground">
+                    {relatedExercise.exerciseName}
+                  </p>
+                  <p className="text-xs text-muted">
+                    {formatTrackingTypeLabel(relatedExercise.trackingType)}
+                  </p>
+                  <p className="text-xs text-muted">
+                    {formatLastPerformanceSummary(
+                      relatedExercise.history,
+                      relatedExercise.trackingType,
+                    )}
+                  </p>
+                </div>
+              ))
+            ) : (
+              <p className="text-sm text-muted">No related exercises configured.</p>
+            )}
+          </div>
+        ) : null}
       </DialogContent>
     </Dialog>
   );
@@ -1515,6 +1541,7 @@ function InlineEditField({
   label,
   multiline = false,
   onBlur,
+  onFocus,
   onChange,
   placeholder,
   value,
@@ -1524,6 +1551,7 @@ function InlineEditField({
   label: string;
   multiline?: boolean;
   onBlur: () => void;
+  onFocus: () => void;
   onChange: (value: string) => void;
   placeholder: string;
   value: string;
@@ -1538,6 +1566,7 @@ function InlineEditField({
           aria-label={ariaLabel}
           className="min-h-9 px-2 py-1 text-xs focus-visible:border-primary focus-visible:bg-card"
           onBlur={onBlur}
+          onFocus={onFocus}
           onChange={(event) => onChange(event.currentTarget.value)}
           placeholder={placeholder}
           rows={2}
@@ -1548,6 +1577,7 @@ function InlineEditField({
           aria-label={ariaLabel}
           className="h-8 text-xs focus-visible:border-primary focus-visible:bg-card"
           onBlur={onBlur}
+          onFocus={onFocus}
           onChange={(event) => onChange(event.currentTarget.value)}
           placeholder={placeholder}
           value={value}
@@ -1642,13 +1672,13 @@ function buildTemplateExerciseGroups(exercises: WorkoutTemplateExercise[]) {
 }
 
 function getSupersetAccentClass(groupId: string) {
-  let hash = 0;
+  let hash = 5381;
 
   for (const character of groupId) {
-    hash = (hash + character.charCodeAt(0)) % supersetAccentStyles.length;
+    hash = ((hash << 5) + hash + character.charCodeAt(0)) >>> 0;
   }
 
-  return supersetAccentStyles[hash] ?? supersetAccentStyles[0];
+  return supersetAccentStyles[hash % supersetAccentStyles.length] ?? supersetAccentStyles[0];
 }
 
 function formatSupersetLabel(groupId: string) {

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router';
 import {
   DndContext,
@@ -47,6 +47,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import { useWeightUnit } from '@/hooks/use-weight-unit';
 import { useStartSession } from '@/hooks/use-workout-session';
 import { ApiError } from '@/lib/api-client';
@@ -108,6 +109,7 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
   const renameExerciseMutation = useRenameExercise();
   const reorderExercisesMutation = useReorderTemplateExercises();
   const updateTemplateMutation = useUpdateTemplate();
+  const template = templateQuery.data ?? null;
 
   const [renameTarget, setRenameTarget] = useState<{
     exerciseId: string;
@@ -131,6 +133,9 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
     }),
   );
 
+  const updateQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const latestSectionsRef = useRef<NonNullable<UpdateWorkoutTemplateInput['sections']>>([]);
+
   async function confirmDuplicateDayWorkouts(dateKey: string) {
     const conflicts = await getDayWorkoutConflicts(dateKey);
 
@@ -151,11 +156,63 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
     });
   }
 
+  useEffect(() => {
+    if (!template) {
+      latestSectionsRef.current = [];
+      return;
+    }
+
+    if (updateTemplateMutation.isPending) {
+      return;
+    }
+
+    latestSectionsRef.current = template.sections.map(toUpdateSection);
+  }, [template, updateTemplateMutation.isPending]);
+
+  const queueTemplateSectionsUpdate = useCallback(
+    (
+      buildNextSections: (
+        currentSections: NonNullable<UpdateWorkoutTemplateInput['sections']>,
+      ) => NonNullable<UpdateWorkoutTemplateInput['sections']>,
+      options?: {
+        onError?: () => void;
+        onSuccess?: () => void;
+      },
+    ) => {
+      if (!template) {
+        return;
+      }
+
+      updateQueueRef.current = updateQueueRef.current
+        .catch(() => undefined)
+        .then(async () => {
+          try {
+            const nextSections = buildNextSections(latestSectionsRef.current);
+            latestSectionsRef.current = nextSections;
+
+            const updatedTemplate = await updateTemplateMutation.mutateAsync({
+              id: template.id,
+              input: {
+                sections: nextSections,
+              },
+            });
+
+            latestSectionsRef.current = updatedTemplate.sections.map(toUpdateSection);
+            options?.onSuccess?.();
+          } catch {
+            latestSectionsRef.current = template.sections.map(toUpdateSection);
+            options?.onError?.();
+          }
+        });
+    },
+    [template, updateTemplateMutation],
+  );
+
   if (templateQuery.isPending) {
     return <TemplateDetailSkeleton />;
   }
 
-  if (templateQuery.isError) {
+  if (templateQuery.isError || !template) {
     const isLegacyMockTemplate = !UUID_PATTERN.test(templateId);
     const isNotFound =
       isLegacyMockTemplate ||
@@ -182,8 +239,6 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
     );
   }
 
-  const template = templateQuery.data;
-
   const saveExerciseEdits = (
     sectionType: WorkoutTemplateSectionType,
     exerciseId: string,
@@ -202,67 +257,62 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
       return;
     }
 
-    const nextSections = template.sections.map((section) => {
-      if (section.type !== sectionType) {
-        return toUpdateSection(section);
-      }
+    const targetIndex = template.sections
+      .find((section) => section.type === sectionType)
+      ?.exercises.findIndex((exercise) => exercise.id === exerciseId);
 
-      return {
-        type: section.type,
-        exercises: section.exercises.map((exercise) => {
-          if (exercise.id !== exerciseId) {
-            return toUpdateExercise(exercise);
-          }
+    if (targetIndex == null || targetIndex < 0) {
+      return;
+    }
 
-          return {
-            ...toUpdateExercise(exercise),
-            notes: toNullableString(fields.notes),
-            repsMax: parsedReps.repsMax,
-            repsMin: parsedReps.repsMin,
-            restSeconds,
-            sets,
-          };
-        }),
-      };
-    });
+    queueTemplateSectionsUpdate((currentSections) =>
+      currentSections.map((section) => {
+        if (section.type !== sectionType) {
+          return section;
+        }
 
-    updateTemplateMutation.mutate({
-      id: template.id,
-      input: {
-        sections: nextSections,
-      },
-    });
+        return {
+          ...section,
+          exercises: section.exercises.map((exercise, index) =>
+            index === targetIndex
+              ? {
+                  ...exercise,
+                  notes: toNullableString(fields.notes),
+                  repsMax: parsedReps.repsMax,
+                  repsMin: parsedReps.repsMin,
+                  restSeconds,
+                  sets,
+                }
+              : exercise,
+          ),
+        };
+      }),
+    );
   };
 
   const addExerciseToSection = (sectionType: WorkoutTemplateSectionType, exerciseId: string) => {
-    const nextSections = template.sections.map((section) => ({
-      type: section.type,
-      exercises:
-        section.type === sectionType
-          ? [
-              ...section.exercises.map(toUpdateExercise),
-              {
-                cues: [],
-                exerciseId,
-                notes: null,
-                repsMax: 10,
-                repsMin: 8,
-                restSeconds: 90,
-                sets: 3,
-                supersetGroup: null,
-                tempo: null,
-              },
-            ]
-          : section.exercises.map(toUpdateExercise),
-    }));
-
-    updateTemplateMutation.mutate(
-      {
-        id: template.id,
-        input: {
-          sections: nextSections,
-        },
-      },
+    queueTemplateSectionsUpdate(
+      (currentSections) =>
+        currentSections.map((section) => ({
+          ...section,
+          exercises:
+            section.type === sectionType
+              ? [
+                  ...section.exercises,
+                  {
+                    cues: [],
+                    exerciseId,
+                    notes: null,
+                    repsMax: 10,
+                    repsMin: 8,
+                    restSeconds: 90,
+                    sets: 3,
+                    supersetGroup: null,
+                    tempo: null,
+                  },
+                ]
+              : section.exercises,
+        })),
       {
         onError: () => {
           toast.error('Unable to add exercise. Try again.');
@@ -323,9 +373,6 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
                   <h2 className="text-lg font-bold tracking-wide text-foreground">
                     {sectionLabels[section.type]}
                   </h2>
-                  <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted">
-                    {`${section.exercises.length} exercise${section.exercises.length === 1 ? '' : 's'}`}
-                  </p>
                 </div>
                 <Badge
                   className="border-transparent bg-secondary text-secondary-foreground"
@@ -900,9 +947,9 @@ function InlineEditField({
         {label}
       </span>
       {multiline ? (
-        <textarea
+        <Textarea
           aria-label={ariaLabel}
-          className="min-h-9 w-full rounded-md border border-border bg-background px-2 py-1 text-xs outline-none transition-colors focus-visible:border-primary focus-visible:bg-card"
+          className="min-h-9 px-2 py-1 text-xs focus-visible:border-primary focus-visible:bg-card"
           onBlur={onBlur}
           onChange={(event) => onChange(event.currentTarget.value)}
           placeholder={placeholder}

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router';
 import {
   DndContext,
@@ -16,7 +16,15 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { ArrowDown, ArrowUp, GripVertical, MoreVertical, Plus } from 'lucide-react';
+import {
+  ArrowDown,
+  ArrowUp,
+  Braces,
+  GripVertical,
+  Link2Off,
+  MoreVertical,
+  Plus,
+} from 'lucide-react';
 
 import type {
   Exercise,
@@ -32,6 +40,7 @@ import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
 import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import {
   Dialog,
@@ -48,6 +57,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
+import { useLastPerformance } from '@/hooks/use-last-performance';
 import { useWeightUnit } from '@/hooks/use-weight-unit';
 import { useStartSession } from '@/hooks/use-workout-session';
 import { ApiError } from '@/lib/api-client';
@@ -60,6 +70,7 @@ import {
   useRenameExercise,
   useReorderTemplateExercises,
   useScheduleWorkout,
+  useUpdateExercise,
   useUpdateTemplate,
   useWorkoutTemplate,
 } from '../api/workouts';
@@ -97,7 +108,19 @@ const sectionAccentStyles: Record<WorkoutTemplateSectionType, string> = {
   cooldown: 'border-l-[var(--color-accent-cream)]',
 };
 
+const supersetAccentStyles = [
+  'border-l-[var(--color-accent-mint)] bg-[var(--color-accent-mint)]/5',
+  'border-l-[var(--color-accent-blue)] bg-[var(--color-accent-blue)]/5',
+  'border-l-[var(--color-accent-pink)] bg-[var(--color-accent-pink)]/5',
+  'border-l-[var(--color-accent-cream)] bg-[var(--color-accent-cream)]/12',
+];
+
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const historyDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+});
 
 export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps) {
   const { weightUnit } = useWeightUnit();
@@ -108,6 +131,7 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
   const scheduleWorkoutMutation = useScheduleWorkout();
   const renameExerciseMutation = useRenameExercise();
   const reorderExercisesMutation = useReorderTemplateExercises();
+  const updateExerciseMutation = useUpdateExercise();
   const updateTemplateMutation = useUpdateTemplate();
   const template = templateQuery.data ?? null;
 
@@ -120,6 +144,13 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
     exerciseName: string;
   } | null>(null);
   const [addSectionTarget, setAddSectionTarget] = useState<WorkoutTemplateSectionType | null>(null);
+  const [supersetSectionTarget, setSupersetSectionTarget] = useState<WorkoutTemplateSectionType | null>(
+    null,
+  );
+  const [exerciseDetailTarget, setExerciseDetailTarget] = useState<{
+    exerciseId: string;
+    templateExerciseId: string;
+  } | null>(null);
   const [isScheduleDialogOpen, setIsScheduleDialogOpen] = useState(false);
 
   const sensors = useSensors(
@@ -325,6 +356,71 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
     );
   };
 
+  const updateSectionSupersetGroup = (
+    sectionType: WorkoutTemplateSectionType,
+    templateExerciseIds: string[],
+    supersetGroup: string | null,
+  ) => {
+    if (!template || templateExerciseIds.length === 0) {
+      return;
+    }
+
+    const section = template.sections.find((item) => item.type === sectionType);
+    if (!section) {
+      return;
+    }
+
+    const selectedIndexes = new Set<number>();
+    section.exercises.forEach((exercise, index) => {
+      if (templateExerciseIds.includes(exercise.id)) {
+        selectedIndexes.add(index);
+      }
+    });
+
+    if (selectedIndexes.size === 0) {
+      return;
+    }
+
+    queueTemplateSectionsUpdate(
+      (currentSections) =>
+        currentSections.map((section) => {
+          if (section.type !== sectionType) {
+            return section;
+          }
+
+          return {
+            ...section,
+            exercises: section.exercises.map((exercise, index) =>
+              selectedIndexes.has(index) ? { ...exercise, supersetGroup } : exercise,
+            ),
+          };
+        }),
+      {
+        onError: () => toast.error('Unable to update superset. Try again.'),
+      },
+    );
+  };
+
+  const activeExerciseDetail = (() => {
+    if (!template || !exerciseDetailTarget) {
+      return null;
+    }
+
+    for (const section of template.sections) {
+      const exercise = section.exercises.find(
+        (item) => item.id === exerciseDetailTarget.templateExerciseId,
+      );
+      if (exercise) {
+        return {
+          sectionType: section.type,
+          exercise,
+        };
+      }
+    }
+
+    return null;
+  })();
+
   return (
     <section className="space-y-6">
       <Card className="gap-4 overflow-hidden border-transparent bg-card/80 py-0">
@@ -421,60 +517,152 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
                     items={section.exercises.map((exercise) => exercise.id)}
                     strategy={verticalListSortingStrategy}
                   >
-                    {section.exercises.map((exercise, index) => (
-                      <TemplateExerciseCard
-                        exercise={exercise}
-                        index={index}
-                        isMoveDownDisabled={index === section.exercises.length - 1}
-                        isMoveUpDisabled={index === 0}
-                        key={exercise.id}
-                        onMoveDown={() => {
-                          if (index >= section.exercises.length - 1) {
-                            return;
-                          }
+                    {buildTemplateExerciseGroups(section.exercises).map((group) => {
+                      if (group.type === 'single') {
+                        const index = group.index;
+                        const exercise = group.exercise;
+                        return (
+                          <TemplateExerciseCard
+                            exercise={exercise}
+                            index={index}
+                            isMoveDownDisabled={index === section.exercises.length - 1}
+                            isMoveUpDisabled={index === 0}
+                            key={exercise.id}
+                            onMoveDown={() => {
+                              if (index >= section.exercises.length - 1) {
+                                return;
+                              }
 
-                          const reordered = arrayMove(section.exercises, index, index + 1);
-                          reorderExercisesMutation.mutate({
-                            templateId: template.id,
-                            section: section.type,
-                            exerciseIds: reordered.map((item) => item.id),
-                          });
-                        }}
-                        onMoveUp={() => {
-                          if (index <= 0) {
-                            return;
-                          }
+                              const reordered = arrayMove(section.exercises, index, index + 1);
+                              reorderExercisesMutation.mutate({
+                                templateId: template.id,
+                                section: section.type,
+                                exerciseIds: reordered.map((item) => item.id),
+                              });
+                            }}
+                            onMoveUp={() => {
+                              if (index <= 0) {
+                                return;
+                              }
 
-                          const reordered = arrayMove(section.exercises, index, index - 1);
-                          reorderExercisesMutation.mutate({
-                            templateId: template.id,
-                            section: section.type,
-                            exerciseIds: reordered.map((item) => item.id),
-                          });
-                        }}
-                        onRename={() =>
-                          setRenameTarget({
-                            exerciseId: exercise.exerciseId,
-                            exerciseName: exercise.exerciseName,
-                          })
-                        }
-                        onSaveInline={(fields) =>
-                          saveExerciseEdits(section.type, exercise.id, fields)
-                        }
-                        onSwap={() =>
-                          setSwapTarget({
-                            exerciseId: exercise.exerciseId,
-                            exerciseName: exercise.exerciseName,
-                          })
-                        }
-                        weightUnit={weightUnit}
-                      />
-                    ))}
+                              const reordered = arrayMove(section.exercises, index, index - 1);
+                              reorderExercisesMutation.mutate({
+                                templateId: template.id,
+                                section: section.type,
+                                exerciseIds: reordered.map((item) => item.id),
+                              });
+                            }}
+                            onOpenDetails={() =>
+                              setExerciseDetailTarget({
+                                exerciseId: exercise.exerciseId,
+                                templateExerciseId: exercise.id,
+                              })
+                            }
+                            onRename={() =>
+                              setRenameTarget({
+                                exerciseId: exercise.exerciseId,
+                                exerciseName: exercise.exerciseName,
+                              })
+                            }
+                            onSaveInline={(fields) =>
+                              saveExerciseEdits(section.type, exercise.id, fields)
+                            }
+                            onSwap={() =>
+                              setSwapTarget({
+                                exerciseId: exercise.exerciseId,
+                                exerciseName: exercise.exerciseName,
+                              })
+                            }
+                            weightUnit={weightUnit}
+                          />
+                        );
+                      }
+
+                      const supersetAccentClass = getSupersetAccentClass(group.groupId);
+
+                      return (
+                        <div
+                          className={cn(
+                            'relative space-y-2 rounded-2xl border border-border/90 border-l-4 px-3 py-3',
+                            supersetAccentClass,
+                          )}
+                          data-testid={`superset-group-${group.groupId}`}
+                          key={`${group.groupId}-${group.exercises[0]?.id ?? 'group'}`}
+                        >
+                          <div className="flex items-center gap-2">
+                            <Braces aria-hidden="true" className="size-4 text-muted" />
+                            <p className="text-xs font-semibold tracking-[0.08em] text-muted uppercase">
+                              {formatSupersetLabel(group.groupId)}
+                            </p>
+                          </div>
+                          <div className="space-y-2">
+                            {group.exercises.map((exercise, exerciseIndex) => {
+                              const index = group.startIndex + exerciseIndex;
+                              return (
+                                <TemplateExerciseCard
+                                  exercise={exercise}
+                                  index={index}
+                                  isMoveDownDisabled={index === section.exercises.length - 1}
+                                  isMoveUpDisabled={index === 0}
+                                  key={exercise.id}
+                                  onMoveDown={() => {
+                                    if (index >= section.exercises.length - 1) {
+                                      return;
+                                    }
+
+                                    const reordered = arrayMove(section.exercises, index, index + 1);
+                                    reorderExercisesMutation.mutate({
+                                      templateId: template.id,
+                                      section: section.type,
+                                      exerciseIds: reordered.map((item) => item.id),
+                                    });
+                                  }}
+                                  onMoveUp={() => {
+                                    if (index <= 0) {
+                                      return;
+                                    }
+
+                                    const reordered = arrayMove(section.exercises, index, index - 1);
+                                    reorderExercisesMutation.mutate({
+                                      templateId: template.id,
+                                      section: section.type,
+                                      exerciseIds: reordered.map((item) => item.id),
+                                    });
+                                  }}
+                                  onOpenDetails={() =>
+                                    setExerciseDetailTarget({
+                                      exerciseId: exercise.exerciseId,
+                                      templateExerciseId: exercise.id,
+                                    })
+                                  }
+                                  onRename={() =>
+                                    setRenameTarget({
+                                      exerciseId: exercise.exerciseId,
+                                      exerciseName: exercise.exerciseName,
+                                    })
+                                  }
+                                  onSaveInline={(fields) =>
+                                    saveExerciseEdits(section.type, exercise.id, fields)
+                                  }
+                                  onSwap={() =>
+                                    setSwapTarget({
+                                      exerciseId: exercise.exerciseId,
+                                      exerciseName: exercise.exerciseName,
+                                    })
+                                  }
+                                  weightUnit={weightUnit}
+                                />
+                              );
+                            })}
+                          </div>
+                        </div>
+                      );
+                    })}
                   </SortableContext>
                 </DndContext>
               )}
 
-              <div className="pt-1">
+              <div className="flex flex-wrap gap-2 pt-1">
                 <Button
                   aria-label={`Add exercise to ${sectionLabels[section.type]} section`}
                   className="w-full justify-center text-sm sm:w-auto"
@@ -486,6 +674,18 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
                   <Plus aria-hidden="true" className="size-4" />
                   Add exercise
                 </Button>
+                {section.exercises.length >= 2 ? (
+                  <Button
+                    className="w-full justify-center text-sm sm:w-auto"
+                    onClick={() => setSupersetSectionTarget(section.type)}
+                    size="sm"
+                    type="button"
+                    variant="outline"
+                  >
+                    <Braces aria-hidden="true" className="size-4" />
+                    Manage supersets
+                  </Button>
+                ) : null}
               </div>
             </div>
           </details>
@@ -558,6 +758,39 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
         sourceExerciseName={swapTarget?.exerciseName ?? ''}
         sourceLabel="this template"
       />
+      {supersetSectionTarget ? (
+        <SupersetManagerDialog
+          onApply={(exerciseIds, supersetGroup) => {
+            updateSectionSupersetGroup(supersetSectionTarget, exerciseIds, supersetGroup);
+          }}
+          onOpenChange={(open) => {
+            if (!open) {
+              setSupersetSectionTarget(null);
+            }
+          }}
+          section={template.sections.find((section) => section.type === supersetSectionTarget) ?? null}
+        />
+      ) : null}
+      {exerciseDetailTarget && activeExerciseDetail ? (
+        <ExerciseDetailModal
+          key={exerciseDetailTarget.templateExerciseId}
+          exercise={activeExerciseDetail.exercise}
+          isPending={updateExerciseMutation.isPending}
+          onOpenChange={(open) => {
+            if (!open) {
+              setExerciseDetailTarget(null);
+            }
+          }}
+          onSaveCoachingNotes={(exerciseId, coachingNotes) =>
+            updateExerciseMutation.mutateAsync({
+              id: exerciseId,
+              input: {
+                coachingNotes,
+              },
+            })
+          }
+        />
+      ) : null}
 
       <div className="space-y-2">
         <div className="flex flex-wrap gap-2">
@@ -642,6 +875,7 @@ function TemplateExerciseCard({
   isMoveUpDisabled,
   onMoveDown,
   onMoveUp,
+  onOpenDetails,
   onRename,
   onSaveInline,
   onSwap,
@@ -653,6 +887,7 @@ function TemplateExerciseCard({
   isMoveUpDisabled: boolean;
   onMoveDown: () => void;
   onMoveUp: () => void;
+  onOpenDetails: () => void;
   onRename: () => void;
   onSaveInline: (fields: EditableExerciseFields) => void;
   onSwap: () => void;
@@ -706,7 +941,13 @@ function TemplateExerciseCard({
             </Button>
             <div className="min-w-0 space-y-0.5">
               <CardTitle className="truncate text-base font-semibold sm:text-lg">
-                {exercise.exerciseName}
+                <button
+                  className="cursor-pointer truncate text-left hover:text-primary hover:underline"
+                  onClick={onOpenDetails}
+                  type="button"
+                >
+                  {exercise.exerciseName}
+                </button>
               </CardTitle>
               <p className="text-xs font-medium text-muted sm:text-sm">{compactSummary}</p>
               {exercise.notes ? (
@@ -820,6 +1061,352 @@ function TemplateExerciseCard({
         </details>
       </CardContent>
     </Card>
+  );
+}
+
+function SupersetManagerDialog({
+  onApply,
+  onOpenChange,
+  section,
+}: {
+  onApply: (templateExerciseIds: string[], supersetGroup: string | null) => void;
+  onOpenChange: (open: boolean) => void;
+  section: WorkoutTemplate['sections'][number] | null;
+}) {
+  const supersetGroups = useMemo(() => {
+    if (!section) {
+      return [];
+    }
+
+    return [
+      ...new Set(
+        section.exercises
+          .map((exercise) => exercise.supersetGroup)
+          .filter((group): group is string => typeof group === 'string' && group.length > 0),
+      ),
+    ];
+  }, [section]);
+  const [newSupersetName, setNewSupersetName] = useState(() => getNextSupersetName(supersetGroups));
+  const [selectedGroup, setSelectedGroup] = useState(() => supersetGroups[0] ?? '');
+  const [selectedExerciseIds, setSelectedExerciseIds] = useState<string[]>([]);
+
+  return (
+    <Dialog open onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Manage supersets</DialogTitle>
+          <DialogDescription>
+            Select exercises to create a new superset, edit an existing group, or remove grouping.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!section ? null : (
+          <div className="space-y-4">
+            <div className="space-y-2 rounded-xl border border-border bg-secondary/20 p-3">
+              <p className="text-xs font-semibold tracking-[0.08em] text-muted uppercase">
+                Exercises
+              </p>
+              <div className="space-y-2">
+                {section.exercises.map((exercise, index) => (
+                  <label
+                    className="flex cursor-pointer items-center justify-between gap-3 rounded-lg border border-border bg-card px-3 py-2"
+                    key={exercise.id}
+                  >
+                    <span className="flex items-center gap-2">
+                      <Checkbox
+                        checked={selectedExerciseIds.includes(exercise.id)}
+                        onCheckedChange={(checked) => {
+                          setSelectedExerciseIds((current) => {
+                            if (checked !== true) {
+                              return current.filter((value) => value !== exercise.id);
+                            }
+
+                            if (current.includes(exercise.id)) {
+                              return current;
+                            }
+
+                            return [...current, exercise.id];
+                          });
+                        }}
+                      />
+                      <span className="text-sm text-foreground">
+                        {index + 1}. {exercise.exerciseName}
+                      </span>
+                    </span>
+                    {exercise.supersetGroup ? (
+                      <Badge variant="secondary">{formatSupersetLabel(exercise.supersetGroup)}</Badge>
+                    ) : (
+                      <Badge variant="outline">Ungrouped</Badge>
+                    )}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div className="grid gap-2 sm:grid-cols-2">
+              <div className="space-y-2 rounded-xl border border-border bg-card p-3">
+                <p className="text-xs font-semibold tracking-[0.08em] text-muted uppercase">
+                  Create superset
+                </p>
+                <Input
+                  aria-label="Superset name"
+                  onChange={(event) => setNewSupersetName(event.currentTarget.value)}
+                  placeholder="Superset A"
+                  value={newSupersetName}
+                />
+                <Button
+                  className="w-full"
+                  disabled={selectedExerciseIds.length < 2}
+                  onClick={() => {
+                    const supersetGroup = toSupersetGroupId(newSupersetName);
+                    if (!supersetGroup) {
+                      toast.error('Superset name is required');
+                      return;
+                    }
+
+                    onApply(selectedExerciseIds, supersetGroup);
+                    onOpenChange(false);
+                  }}
+                  type="button"
+                >
+                  Create superset
+                </Button>
+              </div>
+
+              <div className="space-y-2 rounded-xl border border-border bg-card p-3">
+                <p className="text-xs font-semibold tracking-[0.08em] text-muted uppercase">
+                  Edit superset
+                </p>
+                <select
+                  aria-label="Existing superset"
+                  className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+                  onChange={(event) => setSelectedGroup(event.currentTarget.value)}
+                  value={selectedGroup}
+                >
+                  <option value="">Select superset</option>
+                  {supersetGroups.map((group) => (
+                    <option key={group} value={group}>
+                      {formatSupersetLabel(group)}
+                    </option>
+                  ))}
+                </select>
+                <Button
+                  className="w-full"
+                  disabled={!selectedGroup || selectedExerciseIds.length === 0}
+                  onClick={() => {
+                    onApply(selectedExerciseIds, selectedGroup);
+                    onOpenChange(false);
+                  }}
+                  type="button"
+                  variant="outline"
+                >
+                  Add selected to superset
+                </Button>
+              </div>
+            </div>
+
+            <Button
+              className="w-full"
+              disabled={selectedExerciseIds.length === 0}
+              onClick={() => {
+                onApply(selectedExerciseIds, null);
+                onOpenChange(false);
+              }}
+              type="button"
+              variant="outline"
+            >
+              <Link2Off aria-hidden="true" className="size-4" />
+              Remove superset
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ExerciseDetailModal({
+  exercise,
+  isPending,
+  onOpenChange,
+  onSaveCoachingNotes,
+}: {
+  exercise: WorkoutTemplateExercise;
+  isPending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaveCoachingNotes: (exerciseId: string, coachingNotes: string | null) => Promise<unknown>;
+}) {
+  const [activeTab, setActiveTab] = useState<'overview' | 'history' | 'related'>('overview');
+  const [coachingNotes, setCoachingNotes] = useState(exercise.exercise?.coachingNotes ?? '');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const exerciseQuery = useExercises(
+    {
+      page: 1,
+      limit: 20,
+      q: exercise.exerciseName,
+    },
+    { enabled: true },
+  );
+  const historyQuery = useLastPerformance(exercise.exerciseId, {
+    enabled: true,
+    includeRelated: true,
+  });
+
+  const matchedExercise = useMemo(
+    () => exerciseQuery.data?.data.find((item) => item.id === exercise.exerciseId) ?? null,
+    [exercise.exerciseId, exerciseQuery.data?.data],
+  );
+
+  const formCues = matchedExercise?.formCues ?? exercise.exercise?.formCues ?? exercise.formCues ?? [];
+  const instructionText = matchedExercise?.instructions ?? exercise.exercise?.instructions ?? null;
+  const muscleGroups = matchedExercise?.muscleGroups ?? [];
+  const trackingType = matchedExercise?.trackingType ?? exercise.trackingType;
+
+  return (
+    <Dialog open onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+          <>
+            <DialogHeader>
+              <DialogTitle>{exercise.exerciseName}</DialogTitle>
+              <DialogDescription>
+                {formatTrackingTypeLabel(trackingType)} •{' '}
+                {muscleGroups.length > 0 ? muscleGroups.join(', ') : 'Muscle groups not specified'}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="flex gap-2 border-b border-border pb-2">
+              <Button
+                onClick={() => setActiveTab('overview')}
+                size="sm"
+                type="button"
+                variant={activeTab === 'overview' ? 'default' : 'outline'}
+              >
+                Overview
+              </Button>
+              <Button
+                onClick={() => setActiveTab('history')}
+                size="sm"
+                type="button"
+                variant={activeTab === 'history' ? 'default' : 'outline'}
+              >
+                History
+              </Button>
+              <Button
+                onClick={() => setActiveTab('related')}
+                size="sm"
+                type="button"
+                variant={activeTab === 'related' ? 'default' : 'outline'}
+              >
+                Related
+              </Button>
+            </div>
+
+            {activeTab === 'overview' ? (
+              <div className="space-y-4">
+                {formCues.length > 0 ? (
+                  <div className="space-y-2">
+                    <p className="text-xs font-semibold tracking-[0.08em] text-muted uppercase">
+                      Form cues
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {formCues.map((cue) => (
+                        <Badge key={cue} variant="secondary">
+                          {cue}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+
+                {instructionText ? (
+                  <div className="space-y-2">
+                    <p className="text-xs font-semibold tracking-[0.08em] text-muted uppercase">
+                      Instructions
+                    </p>
+                    <p className="text-sm text-foreground">{instructionText}</p>
+                  </div>
+                ) : null}
+
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold tracking-[0.08em] text-muted uppercase">
+                    Coaching notes
+                  </p>
+                  <Textarea
+                    aria-label="Coaching notes"
+                    onChange={(event) => setCoachingNotes(event.currentTarget.value)}
+                    rows={4}
+                    value={coachingNotes}
+                  />
+                  <Button
+                    disabled={isPending || isSaving}
+                    onClick={() => {
+                      setIsSaving(true);
+                      onSaveCoachingNotes(exercise.exerciseId, toNullableString(coachingNotes))
+                        .then(() => {
+                          toast.success('Coaching notes saved');
+                        })
+                        .catch((error) => {
+                          const message =
+                            error instanceof Error ? error.message : 'Unable to save coaching notes';
+                          toast.error(message);
+                        })
+                        .finally(() => {
+                          setIsSaving(false);
+                        });
+                    }}
+                    type="button"
+                  >
+                    Save coaching notes
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+
+            {activeTab === 'history' ? (
+              <div className="space-y-2">
+                {historyQuery.isPending ? (
+                  <p className="text-sm text-muted">Loading recent performance...</p>
+                ) : (
+                  <p className="text-sm text-foreground">
+                    {formatLastPerformanceSummary(historyQuery.data?.history ?? null, trackingType)}
+                  </p>
+                )}
+              </div>
+            ) : null}
+
+            {activeTab === 'related' ? (
+              <div className="space-y-2">
+                {historyQuery.isPending ? (
+                  <p className="text-sm text-muted">Loading related exercises...</p>
+                ) : historyQuery.data?.related.length ? (
+                  historyQuery.data.related.map((relatedExercise) => (
+                    <div
+                      className="space-y-1 rounded-lg border border-border bg-card px-3 py-2"
+                      key={relatedExercise.exerciseId}
+                    >
+                      <p className="text-sm font-semibold text-foreground">
+                        {relatedExercise.exerciseName}
+                      </p>
+                      <p className="text-xs text-muted">
+                        {formatTrackingTypeLabel(relatedExercise.trackingType)}
+                      </p>
+                      <p className="text-xs text-muted">
+                        {formatLastPerformanceSummary(
+                          relatedExercise.history,
+                          relatedExercise.trackingType,
+                        )}
+                      </p>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-muted">No related exercises configured.</p>
+                )}
+              </div>
+            ) : null}
+          </>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -992,6 +1579,148 @@ function TemplateDetailSkeleton() {
       ))}
     </section>
   );
+}
+
+function buildTemplateExerciseGroups(exercises: WorkoutTemplateExercise[]) {
+  const groups: Array<
+    | { type: 'single'; exercise: WorkoutTemplateExercise; index: number }
+    | {
+        type: 'superset';
+        groupId: string;
+        exercises: WorkoutTemplateExercise[];
+        startIndex: number;
+      }
+  > = [];
+
+  let index = 0;
+  while (index < exercises.length) {
+    const currentExercise = exercises[index];
+    if (!currentExercise) {
+      break;
+    }
+
+    if (!currentExercise.supersetGroup) {
+      groups.push({
+        type: 'single',
+        exercise: currentExercise,
+        index,
+      });
+      index += 1;
+      continue;
+    }
+
+    const groupedExercises = [currentExercise];
+    let nextIndex = index + 1;
+    while (nextIndex < exercises.length && exercises[nextIndex]?.supersetGroup === currentExercise.supersetGroup) {
+      const nextExercise = exercises[nextIndex];
+      if (nextExercise) {
+        groupedExercises.push(nextExercise);
+      }
+      nextIndex += 1;
+    }
+
+    if (groupedExercises.length >= 2) {
+      groups.push({
+        type: 'superset',
+        groupId: currentExercise.supersetGroup,
+        exercises: groupedExercises,
+        startIndex: index,
+      });
+      index = nextIndex;
+      continue;
+    }
+
+    groups.push({
+      type: 'single',
+      exercise: currentExercise,
+      index,
+    });
+    index += 1;
+  }
+
+  return groups;
+}
+
+function getSupersetAccentClass(groupId: string) {
+  let hash = 0;
+
+  for (const character of groupId) {
+    hash = (hash + character.charCodeAt(0)) % supersetAccentStyles.length;
+  }
+
+  return supersetAccentStyles[hash] ?? supersetAccentStyles[0];
+}
+
+function formatSupersetLabel(groupId: string) {
+  return groupId
+    .replace(/^superset-?/i, '')
+    .replace(/-/g, ' ')
+    .replace(/\b\w/g, (character) => character.toUpperCase())
+    .trim()
+    .replace(/^/, 'Superset ');
+}
+
+function getNextSupersetName(existingGroups: string[]) {
+  const used = new Set(
+    existingGroups
+      .map((group) => group.replace(/^superset-?/i, '').trim().toUpperCase())
+      .filter(Boolean),
+  );
+
+  const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  for (const letter of letters) {
+    if (!used.has(letter)) {
+      return `Superset ${letter}`;
+    }
+  }
+
+  return `Superset ${existingGroups.length + 1}`;
+}
+
+function toSupersetGroupId(value: string) {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/^superset\s+/, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  if (!normalized) {
+    return null;
+  }
+
+  return `superset-${normalized}`.slice(0, 255);
+}
+
+function formatTrackingTypeLabel(trackingType: ExerciseTrackingType) {
+  return trackingType.replaceAll('_', ' ');
+}
+
+function formatLastPerformanceSummary(
+  history: { date: string; sets: Array<{ reps: number; weight: number | null }> } | null,
+  trackingType: ExerciseTrackingType,
+) {
+  if (!history || history.sets.length === 0) {
+    return 'No history yet.';
+  }
+
+  const setSummary = history.sets
+    .map((set) => {
+      switch (trackingType) {
+        case 'weight_reps':
+        case 'weight_seconds':
+          return set.weight != null ? `${set.weight} x ${set.reps}` : `${set.reps}`;
+        case 'seconds_only':
+          return `${set.reps}s`;
+        case 'distance':
+          return `${set.reps} distance`;
+        default:
+          return `${set.reps} reps`;
+      }
+    })
+    .join(', ');
+
+  return `${historyDateFormatter.format(new Date(`${history.date}T12:00:00`))} • ${setSummary}`;
 }
 
 function formatLabel(value: string) {

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router';
 import {
   DndContext,
@@ -16,9 +16,17 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { ArrowDown, ArrowUp, GripVertical, MoreVertical } from 'lucide-react';
+import { ArrowDown, ArrowUp, GripVertical, MoreVertical, Plus } from 'lucide-react';
 
-import type { ExerciseTrackingType, WeightUnit, WorkoutTemplateExercise } from '@pulse/shared';
+import type {
+  Exercise,
+  ExerciseTrackingType,
+  UpdateWorkoutTemplateInput,
+  WorkoutTemplate,
+  WorkoutTemplateExercise,
+  WorkoutTemplateSectionType,
+  WeightUnit,
+} from '@pulse/shared';
 import { toast } from 'sonner';
 
 import { Badge } from '@/components/ui/badge';
@@ -26,28 +34,40 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
 import { useWeightUnit } from '@/hooks/use-weight-unit';
 import { useStartSession } from '@/hooks/use-workout-session';
 import { ApiError } from '@/lib/api-client';
 import { toDateKey } from '@/lib/date-utils';
+import { useDebouncedCallback } from '@/lib/use-debounced-callback';
+import { cn } from '@/lib/utils';
 
 import {
-  useScheduleWorkout,
+  useExercises,
   useRenameExercise,
   useReorderTemplateExercises,
+  useScheduleWorkout,
+  useUpdateTemplate,
   useWorkoutTemplate,
 } from '../api/workouts';
-import { getDistanceUnit } from '../lib/tracking';
-import { buildInitialSessionSets } from '../lib/workout-session-sets';
 import {
   formatWorkoutConflictDescription,
   getDayWorkoutConflicts,
 } from '../lib/day-workout-conflicts';
+import { getDistanceUnit } from '../lib/tracking';
+import { buildInitialSessionSets } from '../lib/workout-session-sets';
 import { FormCueChips } from './form-cue-chips';
 import { RenameExerciseDialog } from './rename-exercise-dialog';
 import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
@@ -57,11 +77,25 @@ type WorkoutTemplateDetailProps = {
   templateId: string;
 };
 
+type EditableExerciseFields = {
+  notes: string;
+  reps: string;
+  restSeconds: string;
+  sets: string;
+};
+
 const sectionLabels = {
   warmup: 'Warmup',
   main: 'Main',
   cooldown: 'Cooldown',
 } as const;
+
+const sectionAccentStyles: Record<WorkoutTemplateSectionType, string> = {
+  warmup: 'border-l-[var(--color-accent-mint)]',
+  main: 'border-l-[var(--color-accent-pink)]',
+  cooldown: 'border-l-[var(--color-accent-cream)]',
+};
+
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps) {
@@ -73,6 +107,8 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
   const scheduleWorkoutMutation = useScheduleWorkout();
   const renameExerciseMutation = useRenameExercise();
   const reorderExercisesMutation = useReorderTemplateExercises();
+  const updateTemplateMutation = useUpdateTemplate();
+
   const [renameTarget, setRenameTarget] = useState<{
     exerciseId: string;
     exerciseName: string;
@@ -81,7 +117,9 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
     exerciseId: string;
     exerciseName: string;
   } | null>(null);
+  const [addSectionTarget, setAddSectionTarget] = useState<WorkoutTemplateSectionType | null>(null);
   const [isScheduleDialogOpen, setIsScheduleDialogOpen] = useState(false);
+
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
@@ -146,6 +184,97 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
 
   const template = templateQuery.data;
 
+  const saveExerciseEdits = (
+    sectionType: WorkoutTemplateSectionType,
+    exerciseId: string,
+    fields: EditableExerciseFields,
+  ) => {
+    const parsedReps = parseRepsInput(fields.reps);
+    if (!parsedReps.valid) {
+      toast.error('Reps must be like 8, 8-10, or 8+');
+      return;
+    }
+
+    const sets = parseNullablePositiveInt(fields.sets);
+    const restSeconds = parseNullableNonNegativeInt(fields.restSeconds);
+    if (sets === undefined || restSeconds === undefined) {
+      toast.error('Sets and rest must be numbers');
+      return;
+    }
+
+    const nextSections = template.sections.map((section) => {
+      if (section.type !== sectionType) {
+        return toUpdateSection(section);
+      }
+
+      return {
+        type: section.type,
+        exercises: section.exercises.map((exercise) => {
+          if (exercise.id !== exerciseId) {
+            return toUpdateExercise(exercise);
+          }
+
+          return {
+            ...toUpdateExercise(exercise),
+            notes: toNullableString(fields.notes),
+            repsMax: parsedReps.repsMax,
+            repsMin: parsedReps.repsMin,
+            restSeconds,
+            sets,
+          };
+        }),
+      };
+    });
+
+    updateTemplateMutation.mutate({
+      id: template.id,
+      input: {
+        sections: nextSections,
+      },
+    });
+  };
+
+  const addExerciseToSection = (sectionType: WorkoutTemplateSectionType, exerciseId: string) => {
+    const nextSections = template.sections.map((section) => ({
+      type: section.type,
+      exercises:
+        section.type === sectionType
+          ? [
+              ...section.exercises.map(toUpdateExercise),
+              {
+                cues: [],
+                exerciseId,
+                notes: null,
+                repsMax: 10,
+                repsMin: 8,
+                restSeconds: 90,
+                sets: 3,
+                supersetGroup: null,
+                tempo: null,
+              },
+            ]
+          : section.exercises.map(toUpdateExercise),
+    }));
+
+    updateTemplateMutation.mutate(
+      {
+        id: template.id,
+        input: {
+          sections: nextSections,
+        },
+      },
+      {
+        onError: () => {
+          toast.error('Unable to add exercise. Try again.');
+        },
+        onSuccess: () => {
+          setAddSectionTarget(null);
+          toast.success('Exercise added');
+        },
+      },
+    );
+  };
+
   return (
     <section className="space-y-6">
       <Card className="gap-4 overflow-hidden border-transparent bg-card/80 py-0">
@@ -181,17 +310,20 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
       <div className="space-y-4">
         {template.sections.map((section) => (
           <details
-            className="overflow-hidden rounded-3xl border border-border bg-card shadow-sm"
+            className={cn(
+              'overflow-hidden rounded-3xl border border-border border-l-4 bg-card shadow-sm',
+              sectionAccentStyles[section.type],
+            )}
             key={section.type}
             open={section.type === 'main'}
           >
-            <summary className="cursor-pointer list-outside px-6 py-5">
+            <summary className="cursor-pointer list-outside px-5 py-4">
               <div className="flex flex-col gap-2 pr-6 sm:flex-row sm:items-center sm:justify-between">
                 <div className="space-y-1">
-                  <h2 className="text-xl font-semibold text-foreground">
+                  <h2 className="text-lg font-bold tracking-wide text-foreground">
                     {sectionLabels[section.type]}
                   </h2>
-                  <p className="text-sm text-muted">
+                  <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted">
                     {`${section.exercises.length} exercise${section.exercises.length === 1 ? '' : 's'}`}
                   </p>
                 </div>
@@ -204,7 +336,7 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
               </div>
             </summary>
 
-            <div className="space-y-3 border-t border-border px-4 py-4 sm:px-6 sm:py-5">
+            <div className="space-y-2 border-t border-border/80 px-4 py-4 sm:px-5 sm:py-4">
               {section.exercises.length === 0 ? (
                 <Card>
                   <CardContent className="py-5">
@@ -249,7 +381,6 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
                         isMoveDownDisabled={index === section.exercises.length - 1}
                         isMoveUpDisabled={index === 0}
                         key={exercise.id}
-                        weightUnit={weightUnit}
                         onMoveDown={() => {
                           if (index >= section.exercises.length - 1) {
                             return;
@@ -280,21 +411,56 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
                             exerciseName: exercise.exerciseName,
                           })
                         }
+                        onSaveInline={(fields) =>
+                          saveExerciseEdits(section.type, exercise.id, fields)
+                        }
                         onSwap={() =>
                           setSwapTarget({
                             exerciseId: exercise.exerciseId,
                             exerciseName: exercise.exerciseName,
                           })
                         }
+                        weightUnit={weightUnit}
                       />
                     ))}
                   </SortableContext>
                 </DndContext>
               )}
+
+              <div className="pt-1">
+                <Button
+                  aria-label={`Add exercise to ${sectionLabels[section.type]} section`}
+                  className="w-full justify-center text-sm sm:w-auto"
+                  onClick={() => setAddSectionTarget(section.type)}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  <Plus aria-hidden="true" className="size-4" />
+                  Add exercise
+                </Button>
+              </div>
             </div>
           </details>
         ))}
       </div>
+
+      <AddExerciseDialog
+        isPending={updateTemplateMutation.isPending}
+        onOpenChange={(open) => {
+          if (!open) {
+            setAddSectionTarget(null);
+          }
+        }}
+        onSelect={(exerciseId) => {
+          if (!addSectionTarget) {
+            return;
+          }
+
+          addExerciseToSection(addSectionTarget, exerciseId);
+        }}
+        open={addSectionTarget != null}
+      />
 
       <RenameExerciseDialog
         key={renameTarget ? `${renameTarget.exerciseId}-open` : 'rename-template-closed'}
@@ -422,80 +588,67 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
   );
 }
 
-function MetadataPill({ label }: { label: string }) {
-  return (
-    <span className="inline-flex rounded-full border border-border bg-secondary/55 px-3 py-1.5 text-foreground">
-      {label}
-    </span>
-  );
-}
-
-function TemplateDetailSkeleton() {
-  return (
-    <section aria-label="Loading workout template" className="space-y-6">
-      <Card className="py-0">
-        <CardContent className="space-y-4 py-6">
-          <div className="h-3 w-28 animate-pulse rounded-full bg-secondary" />
-          <div className="h-10 w-64 animate-pulse rounded-2xl bg-secondary" />
-          <div className="h-4 w-full animate-pulse rounded-full bg-secondary" />
-          <div className="h-4 w-3/4 animate-pulse rounded-full bg-secondary" />
-        </CardContent>
-      </Card>
-
-      {Array.from({ length: 3 }).map((_, index) => (
-        <Card key={index}>
-          <CardContent className="space-y-4 py-6">
-            <div className="h-8 w-40 animate-pulse rounded-2xl bg-secondary" />
-            <div className="h-24 w-full animate-pulse rounded-3xl bg-secondary/70" />
-          </CardContent>
-        </Card>
-      ))}
-    </section>
-  );
-}
-
 function TemplateExerciseCard({
   exercise,
   index,
   isMoveDownDisabled,
   isMoveUpDisabled,
-  weightUnit,
   onMoveDown,
   onMoveUp,
   onRename,
+  onSaveInline,
   onSwap,
+  weightUnit,
 }: {
   exercise: WorkoutTemplateExercise;
   index: number;
   isMoveDownDisabled: boolean;
   isMoveUpDisabled: boolean;
-  weightUnit: WeightUnit;
   onMoveDown: () => void;
   onMoveUp: () => void;
   onRename: () => void;
+  onSaveInline: (fields: EditableExerciseFields) => void;
   onSwap: () => void;
+  weightUnit: WeightUnit;
 }) {
-  const prescription = formatPrescription(exercise, weightUnit);
+  const compactSummary = formatCompactSetSummary(exercise, weightUnit);
   const targetBreakdown = formatSetTargetBreakdown(exercise, weightUnit);
+  const [fields, setFields] = useState<EditableExerciseFields>(() => toEditableFields(exercise));
+
+  useEffect(() => {
+    setFields(toEditableFields(exercise));
+  }, [exercise]);
+
+  const debouncedInlineSave = useDebouncedCallback((nextFields: EditableExerciseFields) => {
+    onSaveInline(nextFields);
+  });
+
+  useEffect(
+    () => () => {
+      debouncedInlineSave.flush();
+    },
+    [debouncedInlineSave],
+  );
+
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
     id: exercise.id,
   });
 
   return (
     <Card
-      className="gap-4 py-0"
+      className="gap-2 py-0"
       ref={setNodeRef}
       style={{
         transform: CSS.Transform.toString(transform),
         transition,
       }}
     >
-      <CardHeader className="gap-3 py-5">
-        <div className="flex items-start justify-between gap-3">
-          <div className="flex items-start gap-2">
+      <CardHeader className="gap-2 py-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex min-w-0 items-start gap-1.5">
             <Button
               aria-label={`Drag handle for ${exercise.exerciseName}`}
-              className="mt-1 size-9 touch-none"
+              className="mt-0.5 size-8 touch-none"
               size="icon"
               type="button"
               variant="ghost"
@@ -504,10 +657,21 @@ function TemplateExerciseCard({
             >
               <GripVertical aria-hidden="true" className="size-4" />
             </Button>
-            <div className="space-y-2">
-              <CardTitle>{exercise.exerciseName}</CardTitle>
-              <p className="text-sm font-medium text-foreground">{prescription}</p>
-              {targetBreakdown ? <p className="text-xs text-muted">{targetBreakdown}</p> : null}
+            <div className="min-w-0 space-y-0.5">
+              <CardTitle className="truncate text-base font-semibold sm:text-lg">
+                {exercise.exerciseName}
+              </CardTitle>
+              <p className="text-xs font-medium text-muted sm:text-sm">{compactSummary}</p>
+              {exercise.notes ? (
+                <p className="line-clamp-2 text-[11px] italic text-muted/85">{exercise.notes}</p>
+              ) : null}
+              {exercise.tempo || exercise.restSeconds !== null ? (
+                <p className="text-[11px] text-muted">
+                  {exercise.tempo ? `Tempo: ${formatTempo(exercise.tempo)}` : null}
+                  {exercise.tempo && exercise.restSeconds !== null ? ' • ' : null}
+                  {exercise.restSeconds !== null ? `Rest: ${exercise.restSeconds}s` : null}
+                </p>
+              ) : null}
             </div>
           </div>
           <DropdownMenu>
@@ -537,36 +701,249 @@ function TemplateExerciseCard({
         </div>
       </CardHeader>
 
-      <CardContent className="space-y-4 pb-5">
-        <p className="text-xs font-medium tracking-[0.16em] text-muted uppercase">{`Exercise #${index + 1}`}</p>
-        <div className="flex flex-wrap gap-2 text-sm">
-          {exercise.restSeconds !== null ? (
-            <MetadataPill label={`Rest: ${exercise.restSeconds}s`} />
-          ) : null}
-          {exercise.tempo ? <MetadataPill label={`Tempo: ${formatTempo(exercise.tempo)}`} /> : null}
+      <CardContent className="space-y-2 pb-3">
+        <p className="text-[10px] font-semibold tracking-[0.14em] text-muted uppercase">{`Exercise #${index + 1}`}</p>
+
+        <div className="grid gap-2 sm:grid-cols-3 lg:grid-cols-4">
+          <InlineEditField
+            ariaLabel={`Sets for ${exercise.exerciseName}`}
+            label="Sets"
+            onBlur={() => debouncedInlineSave.run(fields)}
+            onChange={(nextValue) => setFields((current) => ({ ...current, sets: nextValue }))}
+            placeholder="3"
+            value={fields.sets}
+          />
+          <InlineEditField
+            ariaLabel={`Reps for ${exercise.exerciseName}`}
+            label="Reps"
+            onBlur={() => debouncedInlineSave.run(fields)}
+            onChange={(nextValue) => setFields((current) => ({ ...current, reps: nextValue }))}
+            placeholder="8-10"
+            value={fields.reps}
+          />
+          <InlineEditField
+            ariaLabel={`Rest for ${exercise.exerciseName}`}
+            label="Rest (s)"
+            onBlur={() => debouncedInlineSave.run(fields)}
+            onChange={(nextValue) =>
+              setFields((current) => ({ ...current, restSeconds: nextValue }))
+            }
+            placeholder="90"
+            value={fields.restSeconds}
+          />
+          <InlineEditField
+            ariaLabel={`Notes for ${exercise.exerciseName}`}
+            className="sm:col-span-3 lg:col-span-1"
+            label="Notes"
+            multiline
+            onBlur={() => debouncedInlineSave.run(fields)}
+            onChange={(nextValue) => setFields((current) => ({ ...current, notes: nextValue }))}
+            placeholder="Optional note"
+            value={fields.notes}
+          />
         </div>
 
-        {exercise.notes ? (
-          <div className="space-y-1 rounded-2xl border border-border bg-secondary/35 px-4 py-3">
-            <p className="text-sm font-medium text-foreground">Notes</p>
-            <p className="text-sm text-muted">{exercise.notes}</p>
+        <details className="rounded-xl border border-border/80 bg-secondary/20 px-3 py-2">
+          <summary className="cursor-pointer text-xs font-semibold text-muted">
+            Show full set detail
+          </summary>
+          <div className="mt-2 space-y-2">
+            <p className="text-xs font-medium text-foreground">
+              {formatPrescription(exercise, weightUnit)}
+            </p>
+            {targetBreakdown ? <p className="text-xs text-muted">{targetBreakdown}</p> : null}
+            {exercise.tempo ? (
+              <p className="text-xs text-muted">Tempo: {formatTempo(exercise.tempo)}</p>
+            ) : null}
+
+            {(exercise.exercise?.formCues?.length ?? exercise.formCues?.length ?? 0) > 0 ||
+            exercise.cues.length > 0 ||
+            Boolean(exercise.exercise?.coachingNotes) ||
+            Boolean(exercise.programmingNotes) ? (
+              <div className="rounded-lg border border-border bg-card px-3 py-2">
+                <FormCueChips
+                  exerciseCoachingNotes={exercise.exercise?.coachingNotes ?? null}
+                  exerciseCues={exercise.exercise?.formCues ?? exercise.formCues ?? []}
+                  templateCues={exercise.cues}
+                  templateProgrammingNotes={exercise.programmingNotes ?? null}
+                />
+              </div>
+            ) : null}
           </div>
-        ) : null}
-        {(exercise.exercise?.formCues?.length ?? exercise.formCues?.length ?? 0) > 0 ||
-        exercise.cues.length > 0 ||
-        Boolean(exercise.exercise?.coachingNotes) ||
-        Boolean(exercise.programmingNotes) ? (
-          <div className="rounded-2xl border border-border bg-secondary/35 px-4 py-3">
-            <FormCueChips
-              exerciseCoachingNotes={exercise.exercise?.coachingNotes ?? null}
-              exerciseCues={exercise.exercise?.formCues ?? exercise.formCues ?? []}
-              templateCues={exercise.cues}
-              templateProgrammingNotes={exercise.programmingNotes ?? null}
-            />
-          </div>
-        ) : null}
+        </details>
       </CardContent>
     </Card>
+  );
+}
+
+function AddExerciseDialog({
+  isPending,
+  onOpenChange,
+  onSelect,
+  open,
+}: {
+  isPending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (exerciseId: string) => void;
+  open: boolean;
+}) {
+  const [query, setQuery] = useState('');
+
+  const exercisesQuery = useExercises(
+    {
+      limit: 8,
+      page: 1,
+      q: query.trim() || undefined,
+    },
+    { enabled: open },
+  );
+
+  const exerciseOptions = exercisesQuery.data?.data ?? [];
+
+  return (
+    <Dialog
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          setQuery('');
+        }
+        onOpenChange(nextOpen);
+      }}
+      open={open}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add exercise</DialogTitle>
+          <DialogDescription>Select an exercise to add to this section.</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <Input
+            aria-label="Search exercise to add"
+            onChange={(event) => setQuery(event.currentTarget.value)}
+            placeholder="Search exercises"
+            value={query}
+          />
+
+          <div className="max-h-72 space-y-2 overflow-y-auto">
+            {exercisesQuery.isPending ? (
+              <p className="text-sm text-muted">Loading exercises...</p>
+            ) : null}
+
+            {!exercisesQuery.isPending && exerciseOptions.length === 0 ? (
+              <p className="text-sm text-muted">No exercises found.</p>
+            ) : null}
+
+            {exerciseOptions.map((exercise) => (
+              <AddExerciseOption
+                exercise={exercise}
+                isPending={isPending}
+                key={exercise.id}
+                onSelect={onSelect}
+              />
+            ))}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AddExerciseOption({
+  exercise,
+  isPending,
+  onSelect,
+}: {
+  exercise: Exercise;
+  isPending: boolean;
+  onSelect: (exerciseId: string) => void;
+}) {
+  return (
+    <Button
+      className="h-auto w-full items-start justify-start px-3 py-2 text-left"
+      disabled={isPending}
+      onClick={() => onSelect(exercise.id)}
+      type="button"
+      variant="outline"
+    >
+      <span className="w-full">
+        <span className="block text-sm font-semibold text-foreground">{exercise.name}</span>
+        <span className="block text-xs text-muted">
+          {exercise.trackingType.replaceAll('_', ' ')}
+        </span>
+      </span>
+    </Button>
+  );
+}
+
+function InlineEditField({
+  ariaLabel,
+  className,
+  label,
+  multiline = false,
+  onBlur,
+  onChange,
+  placeholder,
+  value,
+}: {
+  ariaLabel: string;
+  className?: string;
+  label: string;
+  multiline?: boolean;
+  onBlur: () => void;
+  onChange: (value: string) => void;
+  placeholder: string;
+  value: string;
+}) {
+  return (
+    <label className={cn('space-y-1', className)}>
+      <span className="text-[10px] font-semibold tracking-[0.08em] text-muted uppercase">
+        {label}
+      </span>
+      {multiline ? (
+        <textarea
+          aria-label={ariaLabel}
+          className="min-h-9 w-full rounded-md border border-border bg-background px-2 py-1 text-xs outline-none transition-colors focus-visible:border-primary focus-visible:bg-card"
+          onBlur={onBlur}
+          onChange={(event) => onChange(event.currentTarget.value)}
+          placeholder={placeholder}
+          rows={2}
+          value={value}
+        />
+      ) : (
+        <Input
+          aria-label={ariaLabel}
+          className="h-8 text-xs focus-visible:border-primary focus-visible:bg-card"
+          onBlur={onBlur}
+          onChange={(event) => onChange(event.currentTarget.value)}
+          placeholder={placeholder}
+          value={value}
+        />
+      )}
+    </label>
+  );
+}
+
+function TemplateDetailSkeleton() {
+  return (
+    <section aria-label="Loading workout template" className="space-y-6">
+      <Card className="py-0">
+        <CardContent className="space-y-4 py-6">
+          <div className="h-3 w-28 animate-pulse rounded-full bg-secondary" />
+          <div className="h-10 w-64 animate-pulse rounded-2xl bg-secondary" />
+          <div className="h-4 w-full animate-pulse rounded-full bg-secondary" />
+          <div className="h-4 w-3/4 animate-pulse rounded-full bg-secondary" />
+        </CardContent>
+      </Card>
+
+      {Array.from({ length: 3 }).map((_, index) => (
+        <Card key={index}>
+          <CardContent className="space-y-4 py-6">
+            <div className="h-8 w-40 animate-pulse rounded-2xl bg-secondary" />
+            <div className="h-24 w-full animate-pulse rounded-3xl bg-secondary/70" />
+          </CardContent>
+        </Card>
+      ))}
+    </section>
   );
 }
 
@@ -634,6 +1011,25 @@ function formatPrescription(exercise: WorkoutTemplateExercise, weightUnit: Weigh
   return 'Prescription not set';
 }
 
+function formatCompactSetSummary(exercise: WorkoutTemplateExercise, weightUnit: WeightUnit) {
+  const setTargetSummary = summarizeSetTargets(exercise, weightUnit);
+  const repsTarget = formatRepTarget(exercise.repsMin, exercise.repsMax);
+
+  if (exercise.sets !== null && setTargetSummary) {
+    return `${exercise.sets}×${setTargetSummary}`;
+  }
+
+  if (exercise.sets !== null && repsTarget) {
+    return `${exercise.sets}×${repsTarget}`;
+  }
+
+  if (exercise.sets !== null) {
+    return `${exercise.sets} set${exercise.sets === 1 ? '' : 's'}`;
+  }
+
+  return formatPrescription(exercise, weightUnit);
+}
+
 function formatSetTargetBreakdown(exercise: WorkoutTemplateExercise, weightUnit: WeightUnit) {
   const repsTarget = formatRepTarget(exercise.repsMin, exercise.repsMax);
   const targets = (exercise.setTargets ?? [])
@@ -653,7 +1049,6 @@ function formatSetTargetBreakdown(exercise: WorkoutTemplateExercise, weightUnit:
     })
     .filter((value): value is string => value !== null);
 
-  // Keep the secondary breakdown line for multi-set prescriptions only.
   if (targets.length <= 1) {
     return null;
   }
@@ -681,7 +1076,6 @@ function summarizeSetTargets(exercise: WorkoutTemplateExercise, weightUnit: Weig
     return uniqueLabels[0] ?? null;
   }
 
-  // Representative summary; detailed per-set differences are shown in formatSetTargetBreakdown.
   return labels[0] ?? null;
 }
 
@@ -694,7 +1088,9 @@ function formatTargetByTrackingType(
   const weightLabel = formatTargetWeight(target, weightUnit);
   const secondsLabel = target?.targetSeconds != null ? `${target.targetSeconds}s` : null;
   const distanceLabel =
-    target?.targetDistance != null ? `${target.targetDistance} ${getDistanceUnit(weightUnit)}` : null;
+    target?.targetDistance != null
+      ? `${target.targetDistance} ${getDistanceUnit(weightUnit)}`
+      : null;
 
   switch (trackingType) {
     case 'seconds_only':
@@ -759,4 +1155,139 @@ function formatRepTarget(repsMin: number | null, repsMax: number | null) {
 
 function formatTempo(tempo: string) {
   return tempo.split('').join('-');
+}
+
+function toUpdateSection(
+  section: WorkoutTemplate['sections'][number],
+): NonNullable<UpdateWorkoutTemplateInput['sections']>[number] {
+  return {
+    type: section.type,
+    exercises: section.exercises.map(toUpdateExercise),
+  };
+}
+
+function toUpdateExercise(
+  exercise: WorkoutTemplate['sections'][number]['exercises'][number],
+): NonNullable<NonNullable<UpdateWorkoutTemplateInput['sections']>[number]['exercises']>[number] {
+  return {
+    exerciseId: exercise.exerciseId,
+    cues: exercise.cues,
+    notes: exercise.notes,
+    programmingNotes: exercise.programmingNotes ?? null,
+    repsMax: exercise.repsMax,
+    repsMin: exercise.repsMin,
+    restSeconds: exercise.restSeconds,
+    setTargets: exercise.setTargets,
+    sets: exercise.sets,
+    supersetGroup: exercise.supersetGroup,
+    tempo: exercise.tempo,
+  };
+}
+
+function toNullableString(value: string) {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function parseNullablePositiveInt(value: string) {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(normalized, 10);
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function parseNullableNonNegativeInt(value: string) {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(normalized, 10);
+  if (Number.isNaN(parsed) || parsed < 0) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function parseRepsInput(
+  value: string,
+): { valid: true; repsMax: number | null; repsMin: number | null } | { valid: false } {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    return {
+      valid: true,
+      repsMax: null,
+      repsMin: null,
+    };
+  }
+
+  if (/^\d+$/.test(normalized)) {
+    const parsed = Number.parseInt(normalized, 10);
+    return {
+      valid: true,
+      repsMax: parsed,
+      repsMin: parsed,
+    };
+  }
+
+  const rangeMatch = normalized.match(/^(\d+)\s*-\s*(\d+)$/);
+  if (rangeMatch) {
+    const min = Number.parseInt(rangeMatch[1] ?? '', 10);
+    const max = Number.parseInt(rangeMatch[2] ?? '', 10);
+
+    if (min <= max) {
+      return {
+        valid: true,
+        repsMax: max,
+        repsMin: min,
+      };
+    }
+
+    return { valid: false };
+  }
+
+  const plusMatch = normalized.match(/^(\d+)\+$/);
+  if (plusMatch) {
+    const min = Number.parseInt(plusMatch[1] ?? '', 10);
+    return {
+      valid: true,
+      repsMax: null,
+      repsMin: min,
+    };
+  }
+
+  return { valid: false };
+}
+
+function toEditableFields(exercise: WorkoutTemplateExercise): EditableExerciseFields {
+  return {
+    notes: exercise.notes ?? '',
+    reps: formatEditableReps(exercise.repsMin, exercise.repsMax),
+    restSeconds: exercise.restSeconds?.toString() ?? '',
+    sets: exercise.sets?.toString() ?? '',
+  };
+}
+
+function formatEditableReps(repsMin: number | null, repsMax: number | null) {
+  if (repsMin !== null && repsMax !== null) {
+    return repsMin === repsMax ? `${repsMin}` : `${repsMin}-${repsMax}`;
+  }
+
+  if (repsMin !== null) {
+    return `${repsMin}+`;
+  }
+
+  if (repsMax !== null) {
+    return `${repsMax}`;
+  }
+
+  return '';
 }

--- a/apps/web/src/lib/use-debounced-callback.test.tsx
+++ b/apps/web/src/lib/use-debounced-callback.test.tsx
@@ -123,4 +123,29 @@ describe('useDebouncedCallback', () => {
     expect(callback).toHaveBeenNthCalledWith(1, first);
     expect(callback).toHaveBeenNthCalledWith(2, second);
   });
+
+  it('invokes the latest callback after rerender without resetting pending args', async () => {
+    const firstCallback = vi.fn();
+    const secondCallback = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ callback }) => useDebouncedCallback(callback, 500),
+      {
+        initialProps: { callback: firstCallback },
+      },
+    );
+
+    act(() => {
+      result.current.run('value-1');
+    });
+
+    rerender({ callback: secondCallback });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(firstCallback).not.toHaveBeenCalled();
+    expect(secondCallback).toHaveBeenCalledTimes(1);
+    expect(secondCallback).toHaveBeenCalledWith('value-1');
+  });
 });

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -229,10 +229,11 @@ describe('ActiveWorkoutPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Finalize session' }));
 
     expect(await screen.findByRole('heading', { level: 1, name: 'Workout summary' })).toBeVisible();
-    expect(screen.getByText('Exercises completed')).toBeInTheDocument();
-    expect(screen.getByText('Sets completed')).toBeInTheDocument();
-    expect(screen.getByText('Total reps')).toBeInTheDocument();
+    expect(screen.getByText('Total volume')).toBeInTheDocument();
+    expect(screen.getByText('Sets')).toBeInTheDocument();
+    expect(screen.getByText('Reps')).toBeInTheDocument();
     expect(screen.getByText('Duration')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Exercise results' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 2, name: 'Session feedback' })).toBeInTheDocument();
     expect(screen.getByText('3 / 5')).toBeInTheDocument();
     expect(screen.getByText('Shoulders stayed stable, keep the same setup.')).toBeInTheDocument();
@@ -771,10 +772,7 @@ describe('ActiveWorkoutPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Finalize session' }));
 
     expect(await screen.findByRole('heading', { level: 1, name: 'Workout summary' })).toBeVisible();
-    const setsCompletedLabel = screen.getByText('Sets completed');
-    const setsCompletedStat = setsCompletedLabel.closest('div')?.parentElement ?? null;
-    expect(setsCompletedStat).not.toBeNull();
-    expect(within(setsCompletedStat as HTMLElement).getByText(/\d+\/\d+/)).toBeInTheDocument();
+    expect(screen.getByTestId('summary-pill-count-sets')).toHaveTextContent(/\d+\/\d+/);
   });
 
   it('shows standard feedback controls and requires pain details when pain is yes', () => {

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -62,6 +62,7 @@ import {
   useWorkoutTemplate,
 } from '@/features/workouts/api/workouts';
 import {
+  getSetVolume,
   isSetCompleteForTrackingType,
   resolveTrackingType,
 } from '@/features/workouts/lib/tracking';
@@ -408,6 +409,31 @@ export function ActiveWorkoutPage() {
     [session.completedSets, session.totalSets],
   );
   const totalCompletedReps = useMemo(() => countCompletedReps(setDrafts), [setDrafts]);
+  const summaryExerciseResults = useMemo(
+    () =>
+      session.sections.flatMap((section) =>
+        section.exercises.map((exercise) => {
+          const completedSets = exercise.sets.filter((set) => set.completed);
+          return {
+            id: exercise.id,
+            name: exercise.name,
+            notes: exercise.notes,
+            reps: completedSets.reduce((total, set) => total + (set.reps ?? 0), 0),
+            setsCompleted: exercise.completedSets,
+            totalSets: exercise.targetSets,
+            volume: completedSets.reduce(
+              (total, set) => total + getSetVolume(exercise.trackingType, set),
+              0,
+            ),
+          };
+        }),
+      ),
+    [session.sections],
+  );
+  const totalSessionVolume = useMemo(
+    () => summaryExerciseResults.reduce((total, exercise) => total + exercise.volume, 0),
+    [summaryExerciseResults],
+  );
   const estimatedTotalSeconds = useMemo(() => estimateTotalTime(session), [session]);
   const remainingEstimatedSeconds = useMemo(() => estimateRemainingTime(session), [session]);
   const summaryDuration = sessionCompletedAt
@@ -745,6 +771,7 @@ export function ActiveWorkoutPage() {
           defaultDescription={template.description}
           defaultTags={template.tags}
           duration={summaryDuration}
+          exerciseResults={summaryExerciseResults}
           exercisesCompleted={session.totalExercises}
           feedback={sessionFeedback}
           onDone={async () => {
@@ -787,9 +814,11 @@ export function ActiveWorkoutPage() {
           sessionNotes={sessionNotes}
           sessionId={activeSessionId}
           summarySaving={summarySaving}
+          totalVolume={totalSessionVolume}
           totalReps={totalCompletedReps}
           completedSets={session.completedSets}
           totalSets={session.totalSets}
+          weightUnit={weightUnit}
           workoutName={session.workoutName}
         />
       ) : null}


### PR DESCRIPTION
## Summary
This PR overhauls the workout template editor and post-workout receipt experience to make high-frequency actions faster and easier to scan. In template detail, exercise cards were redesigned into a compact, inline-editable format so sets, reps, rest, and notes can be changed in place without leaving the list. It also introduces full superset management (create, assign, remove, and grouped rendering) plus a richer exercise detail modal with overview, performance history, related exercises, and coaching note edits. On the receipt side, the summary layout is tightened into color-coded metric pills, adds per-exercise result cards (sets, reps, volume, notes), and improves readability of outline actions in dark mode by fixing hover/active contrast.

## Key Changes
- Redesigned `WorkoutTemplateDetail` cards for compact density with inline fields for `sets`, `reps`, `restSeconds`, and `notes`, saved on blur through debounced updates.
- Added `useUpdateTemplate` and `useUpdateExercise` mutation hooks to support broader PATCH updates beyond rename-only flows.
- Implemented serialized template section updates (`updateQueueRef` + `latestSectionsRef`) to avoid stale writes/race conditions during rapid inline edits.
- Added superset tooling:
  - `Manage supersets` dialog for create/edit/remove group membership.
  - Visual superset containers in section lists when contiguous exercises share a `supersetGroup`.
  - Utility helpers for group naming/normalization (`getNextSupersetName`, `toSupersetGroupId`).
- Added exercise detail modal tabs (`Overview`, `History`, `Related`) with last-performance fetches and in-modal coaching note saves.
- Refactored session summary/receipt UI into compact pills and exercise result cards, including total volume formatting via `weightUnit`.
- Updated active workout completion flow to compute and pass per-exercise results and total session volume into the summary.
- Strengthened `Button` outline variant dark-state hover/active contrast and added targeted tests for class-level token coverage.

## Technical Notes
- Template editor persistence now updates full `sections` payloads, with explicit mapping helpers (`toUpdateSection`/`toUpdateExercise`) to keep PATCH input shape aligned with shared schemas.
- Inline reps parsing accepts `8`, `8-10`, and `8+`; invalid formats are rejected with toast feedback before mutation.
- Superset visual grouping is intentionally based on contiguous exercises with the same `supersetGroup`; non-contiguous items remain unwrapped in the list.
- Test coverage was expanded substantially around template editing flows (inline save debounce, add exercise, supersets, detail modal tabs/coaching notes), receipt rendering changes, debounce callback rerender behavior, and dark-mode outline button contrast.

## Commits

- `0dac14a fix(workouts): strengthen reschedule outline hover state contrast`
- `159899d fix(workouts): improve outline hover contrast for reschedule actions`
- `7ad8c3c fix(workouts): color-code receipt summary stat categories`
- `9715c17 fix(workouts): improve reschedule button dark-mode contrast`
- `7657590 feat(workouts): compact workout receipt summary redesign`
- `0a19117 feat(workouts): add superset management and exercise detail modal`
- `4fc575b fix(workouts): address template editor review feedback`
- `c62ae5e feat(workouts): redesign template editor cards with inline editing`

## Tasks

- **Template editor compact layout + inline editing**: Redesign template exercise cards for density with inline sets/reps/rest/notes editing
- **Superset management + rich exercise modal**: Add visual superset grouping with create/edit/remove and exercise detail modal with history and cues
- **Workout receipt page compact redesign**: Tighten receipt page layout with color-coded stat categories, exercise notes, and improved feedback section
- **Reschedule button hover/active contrast fix**: Fix text color tokens on Reschedule button for readable contrast on hover/active in dark mode

## Diff Stats

```
apps/web/src/components/ui/button.test.tsx         |   22 +
 apps/web/src/components/ui/button.tsx              |    2 +-
 apps/web/src/features/workouts/api/workouts.ts     |   65 +-
 .../workouts/components/session-detail.tsx         |    8 +
 .../workouts/components/session-summary.test.tsx   |   36 +
 .../workouts/components/session-summary.tsx        |  138 +-
 .../workouts/components/template-detail.test.tsx   |  460 +++++-
 .../workouts/components/template-detail.tsx        | 1575 ++++++++++++++++++--
 apps/web/src/lib/use-debounced-callback.test.tsx   |   25 +
 apps/web/src/pages/active-workout.test.tsx         |   12 +-
 apps/web/src/pages/active-workout.tsx              |   29 +
 11 files changed, 2197 insertions(+), 175 deletions(-)
```