### PR TITLE
fix(nutrition): enforce food usage tracking in store layer

### DIFF
--- a/.agents/skills/pulse-app-usage/SKILL.md
+++ b/.agents/skills/pulse-app-usage/SKILL.md
@@ -62,6 +62,7 @@ Use `POST /api/v1/meals` with one of two item modes:
 1. **Saved-food mode (default):**
    - Send `foodName` + `quantity` (+ optional display fields).
    - The API resolves `foodName` to an existing food and snapshots scaled macros.
+   - `usageCount` and `lastUsedAt` are updated automatically by the meal store layer; agents do not need any separate usage-tracking step.
 
 2. **Ad-hoc mode (no foods library write):**
    - Set either `adhoc: true` or `saveToFoods: false`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ pnpm --filter shared build  # Build shared package
 - **Nutrition**: Meals are entered by AI agents only — no manual entry UI. The frontend is read-only for meal data.
 - **Workouts**: The most complex UI domain. Templates → Sessions → Sets. Active session state is server-side.
 - **Habits**: User-configurable with boolean/numeric/time tracking types, plus referential habits (`weight`, `nutrition_daily`, `nutrition_meal`, `workout`) that auto-resolve completion from linked data unless manually overridden. Feed into dashboard "don't break the chain" widgets.
-- **Foods**: Per-user database. `lastUsedAt` tracks recency for agent quick-matching.
+- **Foods**: Per-user database. `lastUsedAt` and `usageCount` are automatically maintained by the meal store layer whenever saved-food meal items are created, updated, or deleted.
 - **Trash & Soft Delete**: User-facing habits, workout templates, exercises, foods, and workout sessions use `deletedAt` soft delete; restore/purge flows are handled via `/api/v1/trash`.
 
 ## PRD & Build Plan

--- a/apps/api/src/__tests__/foods-nutrition.test.ts
+++ b/apps/api/src/__tests__/foods-nutrition.test.ts
@@ -139,6 +139,31 @@ const sortFoods = (foods: StoredFood[], sort: 'name' | 'popular' | 'recent') => 
   return [...foods].sort(byName);
 };
 
+const incrementFoodUsageInState = (foodId: string, userId: string, lastUsedAt = Date.now()) => {
+  const existing = testState.foods.get(foodId);
+  if (!existing || existing.userId !== userId) {
+    throw new Error('Failed to update food last used timestamp');
+  }
+
+  testState.foods.set(foodId, {
+    ...existing,
+    lastUsedAt,
+    usageCount: existing.usageCount + 1,
+  });
+};
+
+const decrementFoodUsageInState = (foodId: string, userId: string) => {
+  const existing = testState.foods.get(foodId);
+  if (!existing || existing.userId !== userId) {
+    throw new Error('Failed to decrement food usage count');
+  }
+
+  testState.foods.set(foodId, {
+    ...existing,
+    usageCount: Math.max(0, existing.usageCount - 1),
+  });
+};
+
 vi.mock('../routes/foods/store.js', () => ({
   createFood: vi.fn(
     async (
@@ -239,18 +264,10 @@ vi.mock('../routes/foods/store.js', () => ({
     return true;
   }),
   trackFoodUsage: vi.fn(async (foodId: string, userId: string, lastUsedAt = Date.now()) => {
-    const existing = testState.foods.get(foodId);
-    if (!existing || existing.userId !== userId) {
-      throw new Error('Failed to update food last used timestamp');
-    }
-
-    const updated: StoredFood = {
-      ...existing,
-      lastUsedAt,
-      usageCount: existing.usageCount + 1,
-    };
-
-    testState.foods.set(foodId, updated);
+    incrementFoodUsageInState(foodId, userId, lastUsedAt);
+  }),
+  decrementFoodUsage: vi.fn(async (foodId: string, userId: string) => {
+    decrementFoodUsageInState(foodId, userId);
   }),
 }));
 
@@ -326,6 +343,12 @@ vi.mock('../routes/nutrition/store.js', () => ({
         return createdItem;
       });
 
+      items.forEach((item) => {
+        if (item.foodId) {
+          incrementFoodUsageInState(item.foodId, userId);
+        }
+      });
+
       return { meal, items };
     },
   ),
@@ -393,6 +416,8 @@ vi.mock('../routes/nutrition/store.js', () => ({
       return false;
     }
 
+    const deletedItems = [...testState.mealItems.values()].filter((item) => item.mealId === mealId);
+
     testState.meals.delete(mealId);
 
     for (const item of [...testState.mealItems.values()]) {
@@ -400,6 +425,12 @@ vi.mock('../routes/nutrition/store.js', () => ({
         testState.mealItems.delete(item.id);
       }
     }
+
+    deletedItems.forEach((item) => {
+      if (item.foodId) {
+        decrementFoodUsageInState(item.foodId, userId);
+      }
+    });
 
     return true;
   }),
@@ -502,8 +533,14 @@ describe('foods and nutrition integration', () => {
     const { app } = await createTestApp();
 
     try {
-      const userToken = app.jwt.sign({ sub: 'user-a', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
-      const otherUserToken = app.jwt.sign({ sub: 'user-b', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+      const userToken = app.jwt.sign(
+        { sub: 'user-a', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
+      const otherUserToken = app.jwt.sign(
+        { sub: 'user-b', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
 
       const yogurt = await createFoodViaApi(app, userToken, {
         name: 'Greek Yogurt',
@@ -654,7 +691,10 @@ describe('foods and nutrition integration', () => {
     const { app } = await createTestApp();
 
     try {
-      const userToken = app.jwt.sign({ sub: 'user-a', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+      const userToken = app.jwt.sign(
+        { sub: 'user-a', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
       const date = '2026-03-10';
 
       const breakfast = await createMealViaApi(app, userToken, date, {
@@ -762,7 +802,10 @@ describe('foods and nutrition integration', () => {
     const { app } = await createTestApp();
 
     try {
-      const userToken = app.jwt.sign({ sub: 'user-a', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+      const userToken = app.jwt.sign(
+        { sub: 'user-a', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
       const date = '2026-03-11';
 
       await createMealViaApi(app, userToken, date, {
@@ -850,7 +893,10 @@ describe('foods and nutrition integration', () => {
     const { app } = await createTestApp();
 
     try {
-      const userToken = app.jwt.sign({ sub: 'user-a', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+      const userToken = app.jwt.sign(
+        { sub: 'user-a', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
 
       const eggs = await createFoodViaApi(app, userToken, {
         name: 'Eggs',

--- a/apps/api/src/routes/foods/store.test.ts
+++ b/apps/api/src/routes/foods/store.test.ts
@@ -388,8 +388,8 @@ describe('foods store', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('soft-deletes foods by scope and increments usage on lastUsedAt updates', async () => {
-    const { deleteFood, trackFoodUsage } = await import('./store.js');
+  it('soft-deletes foods by scope and updates usage counters safely', async () => {
+    const { decrementFoodUsage, deleteFood, trackFoodUsage } = await import('./store.js');
 
     await expect(deleteFood('food-1', 'user-1')).resolves.toBe(true);
     expect(dbState.updateSets[0]).toEqual({
@@ -409,5 +409,15 @@ describe('foods store', () => {
     const updateWhereText = flattenSql(dbState.updateWhereCalls.at(-1));
     expect(updateWhereText).toContain('id = food-1');
     expect(updateWhereText).toContain('user_id = user-1');
+
+    await decrementFoodUsage('food-1', 'user-1');
+
+    expect(dbState.updateSets.at(-1)).toEqual({
+      usageCount: expect.anything(),
+    });
+    expect(dbState.updateSets.at(-1)).not.toHaveProperty('lastUsedAt');
+    expect(flattenSql((dbState.updateSets.at(-1) as { usageCount: unknown }).usageCount)).toContain(
+      'case when usage_count > 0 then usage_count - 1 else 0 end',
+    );
   });
 });

--- a/apps/api/src/routes/foods/store.ts
+++ b/apps/api/src/routes/foods/store.ts
@@ -417,3 +417,19 @@ export const trackFoodUsage = async (
     throw new Error('Failed to track food usage metrics');
   }
 };
+
+export const decrementFoodUsage = async (foodId: string, userId: string): Promise<void> => {
+  const { db } = await import('../../db/index.js');
+
+  const result = db
+    .update(foods)
+    .set({
+      usageCount: sql`case when usage_count > 0 then usage_count - 1 else 0 end`,
+    })
+    .where(and(eq(foods.id, foodId), eq(foods.userId, userId), isNull(foods.deletedAt)))
+    .run();
+
+  if (result.changes !== 1) {
+    throw new Error('Failed to decrement food usage metrics');
+  }
+};

--- a/apps/api/src/routes/foods/store.ts
+++ b/apps/api/src/routes/foods/store.ts
@@ -421,15 +421,11 @@ export const trackFoodUsage = async (
 export const decrementFoodUsage = async (foodId: string, userId: string): Promise<void> => {
   const { db } = await import('../../db/index.js');
 
-  const result = db
+  db
     .update(foods)
     .set({
       usageCount: sql`case when usage_count > 0 then usage_count - 1 else 0 end`,
     })
-    .where(and(eq(foods.id, foodId), eq(foods.userId, userId), isNull(foods.deletedAt)))
+    .where(and(eq(foods.id, foodId), eq(foods.userId, userId)))
     .run();
-
-  if (result.changes !== 1) {
-    throw new Error('Failed to decrement food usage metrics');
-  }
 };

--- a/apps/api/src/routes/meals/index.test.ts
+++ b/apps/api/src/routes/meals/index.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildServer } from '../../index.js';
-import { findAgentTokenByHash, findUserAuthById, updateAgentTokenLastUsedAt } from '../../middleware/store.js';
-import { createFood, findFoodByName, trackFoodUsage } from '../foods/store.js';
+import {
+  findAgentTokenByHash,
+  findUserAuthById,
+  updateAgentTokenLastUsedAt,
+} from '../../middleware/store.js';
+import { createFood, findFoodByName } from '../foods/store.js';
 import {
   createMealForDate,
   findMealById,
@@ -20,11 +24,11 @@ vi.mock('../../middleware/store.js', () => ({
 vi.mock('../foods/store.js', () => ({
   createFood: vi.fn(),
   findFoodByName: vi.fn(),
-  trackFoodUsage: vi.fn(),
 }));
 
 vi.mock('../nutrition/store.js', async () => {
-  const actual = await vi.importActual<typeof import('../nutrition/store.js')>('../nutrition/store.js');
+  const actual =
+    await vi.importActual<typeof import('../nutrition/store.js')>('../nutrition/store.js');
   return {
     ...actual,
     createMealForDate: vi.fn(),
@@ -46,7 +50,6 @@ describe('meal routes', () => {
     vi.mocked(updateAgentTokenLastUsedAt).mockReset();
     vi.mocked(createFood).mockReset();
     vi.mocked(findFoodByName).mockReset();
-    vi.mocked(trackFoodUsage).mockReset();
     vi.mocked(createMealForDate).mockReset();
     vi.mocked(findMealById).mockReset();
     vi.mocked(findMealItemById).mockReset();
@@ -92,13 +95,14 @@ describe('meal routes', () => {
         },
       ],
     });
-    vi.mocked(trackFoodUsage).mockResolvedValue(undefined);
-
     const app = buildServer();
 
     try {
       await app.ready();
-      const token = app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+      const token = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
       const response = await app.inject({
         method: 'POST',
         url: '/api/v1/meals',
@@ -283,8 +287,6 @@ describe('meal routes', () => {
         },
       ],
     });
-    vi.mocked(trackFoodUsage).mockResolvedValue(undefined);
-
     const app = buildServer();
 
     try {

--- a/apps/api/src/routes/meals/index.ts
+++ b/apps/api/src/routes/meals/index.ts
@@ -11,7 +11,6 @@ import { autoCreateIfMissing, resolveByName } from '../agentEnrichment.js';
 import { sendError } from '../../lib/reply.js';
 import { isAgentRequest, requireAuth } from '../../middleware/auth.js';
 import { buildDataResponse } from '../../middleware/agent-enrichment.js';
-import { trackFoodUsage } from '../foods/store.js';
 import {
   createMealForDate,
   findMealById,
@@ -169,22 +168,6 @@ export const mealRoutes: FastifyPluginAsync = async (app) => {
         items: mealItems,
       });
 
-      const resolvedFoodIds = itemResults
-        .flatMap((entry) => (entry.kind === 'food' && entry.food ? [entry.food.id] : []))
-        .filter((value, index, values) => values.indexOf(value) === index);
-
-      const usageTrackingResults = await Promise.allSettled(
-        resolvedFoodIds.map((foodId) => trackFoodUsage(foodId, userId)),
-      );
-      usageTrackingResults.forEach((result, index) => {
-        if (result.status === 'rejected') {
-          request.log.warn(
-            { err: result.reason, foodId: resolvedFoodIds[index], userId },
-            'Failed to track food usage after agent meal creation',
-          );
-        }
-      });
-
       const macros = created.items.reduce(
         (acc, item) => ({
           calories: acc.calories + item.calories,
@@ -244,25 +227,6 @@ export const mealRoutes: FastifyPluginAsync = async (app) => {
       items: standardBody.data.items,
     });
 
-    const foodIds = [
-      ...new Set(
-        created.items
-          .map((item) => item.foodId)
-          .filter((foodId): foodId is string => typeof foodId === 'string'),
-      ),
-    ];
-    const usageTrackingResults = await Promise.allSettled(
-      foodIds.map((foodId) => trackFoodUsage(foodId, request.userId)),
-    );
-    usageTrackingResults.forEach((result, index) => {
-      if (result.status === 'rejected') {
-        request.log.warn(
-          { err: result.reason, foodId: foodIds[index], userId: request.userId },
-          'Failed to track food usage after meal creation',
-        );
-      }
-    });
-
     return reply.code(201).send(buildDataResponse(request, created));
   });
 
@@ -290,39 +254,46 @@ export const mealRoutes: FastifyPluginAsync = async (app) => {
     );
   });
 
-  app.patch<{ Params: { id: string; itemId: string } }>('/:id/items/:itemId', async (request, reply) => {
-    const parsedBody = patchMealItemInputSchema.safeParse(request.body);
-    if (!parsedBody.success) {
-      return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid meal item payload');
-    }
+  app.patch<{ Params: { id: string; itemId: string } }>(
+    '/:id/items/:itemId',
+    async (request, reply) => {
+      const parsedBody = patchMealItemInputSchema.safeParse(request.body);
+      if (!parsedBody.success) {
+        return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid meal item payload');
+      }
 
-    const existingMealItem = await findMealItemById(request.userId, request.params.id, request.params.itemId);
-    if (!existingMealItem) {
-      return sendError(reply, 404, 'MEAL_ITEM_NOT_FOUND', 'Meal item not found');
-    }
+      const existingMealItem = await findMealItemById(
+        request.userId,
+        request.params.id,
+        request.params.itemId,
+      );
+      if (!existingMealItem) {
+        return sendError(reply, 404, 'MEAL_ITEM_NOT_FOUND', 'Meal item not found');
+      }
 
-    const updatedMealItem = await patchMealItemById(
-      request.userId,
-      request.params.id,
-      request.params.itemId,
-      parsedBody.data,
-    );
-    if (!updatedMealItem) {
-      return sendError(reply, 404, 'MEAL_ITEM_NOT_FOUND', 'Meal item not found');
-    }
+      const updatedMealItem = await patchMealItemById(
+        request.userId,
+        request.params.id,
+        request.params.itemId,
+        parsedBody.data,
+      );
+      if (!updatedMealItem) {
+        return sendError(reply, 404, 'MEAL_ITEM_NOT_FOUND', 'Meal item not found');
+      }
 
-    return reply.send(
-      buildDataResponse(request, updatedMealItem, {
-        endpoint: 'meal.update',
-        mealName: existingMealItem.name,
-        itemCount: 1,
-        mealMacros: {
-          calories: updatedMealItem.calories,
-          protein: updatedMealItem.protein,
-          carbs: updatedMealItem.carbs,
-          fat: updatedMealItem.fat,
-        },
-      }),
-    );
-  });
+      return reply.send(
+        buildDataResponse(request, updatedMealItem, {
+          endpoint: 'meal.update',
+          mealName: existingMealItem.name,
+          itemCount: 1,
+          mealMacros: {
+            calories: updatedMealItem.calories,
+            protein: updatedMealItem.protein,
+            carbs: updatedMealItem.carbs,
+            fat: updatedMealItem.fat,
+          },
+        }),
+      );
+    },
+  );
 };

--- a/apps/api/src/routes/nutrition/index.test.ts
+++ b/apps/api/src/routes/nutrition/index.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildServer } from '../../index.js';
-import { findAgentTokenByHash, findUserAuthById, updateAgentTokenLastUsedAt } from '../../middleware/store.js';
-import { trackFoodUsage } from '../foods/store.js';
+import {
+  findAgentTokenByHash,
+  findUserAuthById,
+  updateAgentTokenLastUsedAt,
+} from '../../middleware/store.js';
 
 import {
   createMealForDate,
@@ -26,10 +29,6 @@ vi.mock('./store.js', () => ({
   getNutritionWeekSummaryForDate: vi.fn(),
   patchMealById: vi.fn(),
   patchMealItemById: vi.fn(),
-}));
-
-vi.mock('../foods/store.js', () => ({
-  trackFoodUsage: vi.fn(),
 }));
 
 vi.mock('../../middleware/store.js', () => ({
@@ -203,11 +202,9 @@ describe('nutrition routes', () => {
     vi.mocked(getNutritionWeekSummaryForDate).mockReset();
     vi.mocked(patchMealById).mockReset();
     vi.mocked(patchMealItemById).mockReset();
-    vi.mocked(trackFoodUsage).mockReset();
     vi.mocked(findAgentTokenByHash).mockReset();
     vi.mocked(findUserAuthById).mockReset();
     vi.mocked(updateAgentTokenLastUsedAt).mockReset();
-    vi.mocked(trackFoodUsage).mockResolvedValue(undefined);
     vi.mocked(updateAgentTokenLastUsedAt).mockResolvedValue(undefined);
     process.env.JWT_SECRET = 'test-nutrition-routes-secret';
   });
@@ -216,7 +213,7 @@ describe('nutrition routes', () => {
     delete process.env.JWT_SECRET;
   });
 
-  it('creates a meal for a date and updates referenced food recency', async () => {
+  it('creates a meal for a date', async () => {
     vi.mocked(createMealForDate).mockResolvedValue({
       meal,
       items: mealItems,
@@ -226,7 +223,10 @@ describe('nutrition routes', () => {
 
     try {
       await app.ready();
-      const authToken = app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+      const authToken = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
       const response = await app.inject({
         method: 'POST',
         url: '/api/v1/nutrition/2026-03-09/meals',
@@ -294,25 +294,25 @@ describe('nutrition routes', () => {
           },
         ],
       });
-      expect(vi.mocked(trackFoodUsage)).toHaveBeenCalledTimes(1);
-      expect(vi.mocked(trackFoodUsage)).toHaveBeenCalledWith('food-1', 'user-1');
     } finally {
       await app.close();
     }
   });
 
-  it('does not fail meal creation when recency updates fail', async () => {
+  it('returns success when the store creates a meal', async () => {
     vi.mocked(createMealForDate).mockResolvedValue({
       meal,
       items: mealItems,
     });
-    vi.mocked(trackFoodUsage).mockRejectedValueOnce(new Error('transient update failure'));
 
     const app = buildServer();
 
     try {
       await app.ready();
-      const authToken = app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+      const authToken = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
       const response = await app.inject({
         method: 'POST',
         url: '/api/v1/nutrition/2026-03-09/meals',
@@ -341,7 +341,6 @@ describe('nutrition routes', () => {
           items: mealItems,
         },
       });
-      expect(vi.mocked(trackFoodUsage)).toHaveBeenCalledWith('food-1', 'user-1');
     } finally {
       await app.close();
     }
@@ -371,7 +370,10 @@ describe('nutrition routes', () => {
 
     try {
       await app.ready();
-      const authToken = app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+      const authToken = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
       const [foundResponse, emptyResponse] = await Promise.all([
         app.inject({
           method: 'GET',
@@ -429,7 +431,10 @@ describe('nutrition routes', () => {
 
     try {
       await app.ready();
-      const authToken = app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+      const authToken = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
       const response = await app.inject({
         method: 'GET',
         url: '/api/v1/nutrition/week-summary?date=2026-03-06T12:00:00.000Z',
@@ -456,7 +461,10 @@ describe('nutrition routes', () => {
 
     try {
       await app.ready();
-      const authToken = app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+      const authToken = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
 
       const deleteResponse = await app.inject({
         method: 'DELETE',
@@ -513,7 +521,10 @@ describe('nutrition routes', () => {
 
     try {
       await app.ready();
-      const authToken = app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+      const authToken = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
 
       const patchNameResponse = await app.inject({
         method: 'PATCH',
@@ -552,7 +563,9 @@ describe('nutrition routes', () => {
       const wrongUserResponse = await app.inject({
         method: 'PATCH',
         url: '/api/v1/nutrition/2026-03-09/meals/meal-1',
-        headers: createAuthorizationHeader(app.jwt.sign({ sub: 'user-2', type: "session", iss: "pulse-api" }, { expiresIn: "7d" })),
+        headers: createAuthorizationHeader(
+          app.jwt.sign({ sub: 'user-2', type: 'session', iss: 'pulse-api' }, { expiresIn: '7d' }),
+        ),
         payload: {
           notes: 'wrong user scope',
         },
@@ -642,7 +655,10 @@ describe('nutrition routes', () => {
 
     try {
       await app.ready();
-      const authToken = app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+      const authToken = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
 
       const patchAmountResponse = await app.inject({
         method: 'PATCH',
@@ -691,7 +707,9 @@ describe('nutrition routes', () => {
       const wrongUserResponse = await app.inject({
         method: 'PATCH',
         url: '/api/v1/nutrition/2026-03-09/meals/meal-1/items/item-1',
-        headers: createAuthorizationHeader(app.jwt.sign({ sub: 'user-2', type: "session", iss: "pulse-api" }, { expiresIn: "7d" })),
+        headers: createAuthorizationHeader(
+          app.jwt.sign({ sub: 'user-2', type: 'session', iss: 'pulse-api' }, { expiresIn: '7d' }),
+        ),
         payload: {
           amount: 8.5,
         },
@@ -818,7 +836,10 @@ describe('nutrition routes', () => {
 
     try {
       await app.ready();
-      const authToken = app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+      const authToken = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
 
       const [foundResponse, emptyResponse] = await Promise.all([
         app.inject({
@@ -912,7 +933,10 @@ describe('nutrition routes', () => {
 
     try {
       await app.ready();
-      const authToken = app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+      const authToken = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
       const [
         invalidDateResponse,
         invalidCalendarDateResponse,

--- a/apps/api/src/routes/nutrition/index.ts
+++ b/apps/api/src/routes/nutrition/index.ts
@@ -8,7 +8,6 @@ import type { FastifyPluginAsync } from 'fastify';
 import { sendError } from '../../lib/reply.js';
 import { isAgentRequest, requireAuth } from '../../middleware/auth.js';
 import { buildDataResponse } from '../../middleware/agent-enrichment.js';
-import { trackFoodUsage } from '../foods/store.js';
 
 import {
   createMealForDate,
@@ -34,9 +33,6 @@ const isValidDateParam = (date: string) => {
 };
 const isValidMealIdParam = (mealId: string) => mealId.trim().length > 0;
 const isValidItemIdParam = (itemId: string) => itemId.trim().length > 0;
-const isNonEmptyString = (value: string | null): value is string =>
-  typeof value === 'string' && value.length > 0;
-
 const parseIsoDate = (value: unknown): Date | null => {
   if (typeof value !== 'string' || value.trim().length === 0) {
     return null;
@@ -77,19 +73,6 @@ export const nutritionRoutes: FastifyPluginAsync = async (app) => {
     }
 
     const created = await createMealForDate(request.userId, request.params.date, parsedBody.data);
-
-    const foodIds = [...new Set(created.items.map((item) => item.foodId).filter(isNonEmptyString))];
-    const usageTrackingResults = await Promise.allSettled(
-      foodIds.map((foodId) => trackFoodUsage(foodId, request.userId)),
-    );
-    usageTrackingResults.forEach((result, index) => {
-      if (result.status === 'rejected') {
-        request.log.warn(
-          { err: result.reason, foodId: foodIds[index], userId: request.userId },
-          'Failed to track food usage after meal creation',
-        );
-      }
-    });
 
     const mealMacros = created.items.reduce(
       (totals, item) => ({

--- a/apps/api/src/routes/nutrition/store.food-usage.test.ts
+++ b/apps/api/src/routes/nutrition/store.food-usage.test.ts
@@ -415,6 +415,44 @@ describe('nutrition store food usage tracking', () => {
     expect(testState.trackFoodUsage).not.toHaveBeenCalled();
   });
 
+  it('does not decrement usage when deleting a meal that does not exist', async () => {
+    testState.db.transaction.mockImplementation(
+      (callback: (tx: ReturnType<typeof createTxForMealDelete>) => unknown) =>
+        callback(
+          createTxForMealDelete({
+            exists: false,
+          }),
+        ),
+    );
+
+    const { deleteMealForDate } = await import('./store.js');
+    const deleted = await deleteMealForDate('user-1', '2026-03-09', 'meal-1');
+
+    expect(deleted).toBe(false);
+    expect(testState.decrementFoodUsage).not.toHaveBeenCalled();
+    expect(testState.trackFoodUsage).not.toHaveBeenCalled();
+  });
+
+  it('decrements only tracked foods when deleting a meal with mixed item types', async () => {
+    testState.db.transaction.mockImplementation(
+      (callback: (tx: ReturnType<typeof createTxForMealDelete>) => unknown) =>
+        callback(
+          createTxForMealDelete({
+            foodIds: ['food-1', null, 'food-2'],
+          }),
+        ),
+    );
+
+    const { deleteMealForDate } = await import('./store.js');
+    const deleted = await deleteMealForDate('user-1', '2026-03-09', 'meal-1');
+
+    expect(deleted).toBe(true);
+    expect(testState.decrementFoodUsage).toHaveBeenCalledTimes(2);
+    expect(testState.decrementFoodUsage).toHaveBeenNthCalledWith(1, 'food-1', 'user-1');
+    expect(testState.decrementFoodUsage).toHaveBeenNthCalledWith(2, 'food-2', 'user-1');
+    expect(testState.trackFoodUsage).not.toHaveBeenCalled();
+  });
+
   it('swaps food usage when updating a meal item food reference', async () => {
     testState.db.transaction.mockImplementation(
       (callback: (tx: ReturnType<typeof createTxForMealItemPatch>) => unknown) =>
@@ -437,6 +475,56 @@ describe('nutrition store food usage tracking', () => {
     });
     expect(testState.decrementFoodUsage).toHaveBeenCalledTimes(1);
     expect(testState.decrementFoodUsage).toHaveBeenCalledWith('food-1', 'user-1');
+    expect(testState.trackFoodUsage).toHaveBeenCalledTimes(1);
+    expect(testState.trackFoodUsage).toHaveBeenCalledWith('food-2', 'user-1');
+  });
+
+  it('decrements usage when clearing a tracked meal item food reference', async () => {
+    testState.db.transaction.mockImplementation(
+      (callback: (tx: ReturnType<typeof createTxForMealItemPatch>) => unknown) =>
+        callback(
+          createTxForMealItemPatch({
+            existingFoodId: 'food-1',
+            updatedFoodId: null,
+          }),
+        ),
+    );
+
+    const { patchMealItemById } = await import('./store.js');
+    const updated = await patchMealItemById('user-1', 'meal-1', 'item-1', {
+      foodId: null,
+    });
+
+    expect(updated).toMatchObject({
+      id: 'item-1',
+      foodId: null,
+    });
+    expect(testState.decrementFoodUsage).toHaveBeenCalledTimes(1);
+    expect(testState.decrementFoodUsage).toHaveBeenCalledWith('food-1', 'user-1');
+    expect(testState.trackFoodUsage).not.toHaveBeenCalled();
+  });
+
+  it('increments usage when attaching a tracked meal item food reference', async () => {
+    testState.db.transaction.mockImplementation(
+      (callback: (tx: ReturnType<typeof createTxForMealItemPatch>) => unknown) =>
+        callback(
+          createTxForMealItemPatch({
+            existingFoodId: null,
+            updatedFoodId: 'food-2',
+          }),
+        ),
+    );
+
+    const { patchMealItemById } = await import('./store.js');
+    const updated = await patchMealItemById('user-1', 'meal-1', 'item-1', {
+      foodId: 'food-2',
+    });
+
+    expect(updated).toMatchObject({
+      id: 'item-1',
+      foodId: 'food-2',
+    });
+    expect(testState.decrementFoodUsage).not.toHaveBeenCalled();
     expect(testState.trackFoodUsage).toHaveBeenCalledTimes(1);
     expect(testState.trackFoodUsage).toHaveBeenCalledWith('food-2', 'user-1');
   });

--- a/apps/api/src/routes/nutrition/store.food-usage.test.ts
+++ b/apps/api/src/routes/nutrition/store.food-usage.test.ts
@@ -1,0 +1,443 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getTableName = (table: object) =>
+  (table as Record<symbol, unknown>)[Symbol.for('drizzle:Name')];
+
+const testState = vi.hoisted(() => {
+  const db = {
+    transaction: vi.fn(),
+  };
+
+  const trackFoodUsage = vi.fn();
+  const decrementFoodUsage = vi.fn();
+
+  const reset = () => {
+    db.transaction.mockReset();
+    trackFoodUsage.mockReset();
+    decrementFoodUsage.mockReset();
+  };
+
+  return {
+    db,
+    trackFoodUsage,
+    decrementFoodUsage,
+    reset,
+  };
+});
+
+vi.mock('../../db/index.js', () => ({
+  db: testState.db,
+}));
+
+vi.mock('../foods/store.js', () => ({
+  trackFoodUsage: testState.trackFoodUsage,
+  decrementFoodUsage: testState.decrementFoodUsage,
+}));
+
+const createTxForMealInsert = (returnedItems: Array<Record<string, unknown>>) => {
+  const getNutritionLog = vi.fn(() => ({
+    id: 'log-1',
+    userId: 'user-1',
+    date: '2026-03-09',
+    notes: null,
+    createdAt: 1,
+    updatedAt: 1,
+  }));
+  const getMeal = vi.fn(() => ({
+    id: 'meal-1',
+    nutritionLogId: 'log-1',
+    name: 'Lunch',
+    summary: null,
+    time: null,
+    notes: null,
+    createdAt: 2,
+    updatedAt: 2,
+  }));
+  const ownedFoodsAll = vi.fn(() =>
+    returnedItems
+      .map((item) => item.foodId)
+      .filter((foodId): foodId is string => typeof foodId === 'string')
+      .filter((foodId, index, foodIds) => foodIds.indexOf(foodId) === index)
+      .map((id) => ({ id })),
+  );
+  const insertedMealItemsAll = vi.fn(() => returnedItems);
+
+  return {
+    insert: vi.fn((table) => {
+      if (getTableName(table) === 'nutrition_logs') {
+        return {
+          values: vi.fn(() => ({
+            onConflictDoNothing: vi.fn(() => ({
+              run: vi.fn(),
+            })),
+          })),
+        };
+      }
+
+      if (getTableName(table) === 'meals') {
+        return {
+          values: vi.fn(() => ({
+            returning: vi.fn(() => ({
+              get: getMeal,
+            })),
+          })),
+        };
+      }
+
+      if (getTableName(table) === 'meal_items') {
+        return {
+          values: vi.fn(() => ({
+            returning: vi.fn(() => ({
+              all: insertedMealItemsAll,
+            })),
+          })),
+        };
+      }
+
+      throw new Error(`Unexpected insert table: ${String(table)}`);
+    }),
+    select: vi.fn(() => ({
+      from: vi.fn((table) => {
+        if (getTableName(table) === 'nutrition_logs') {
+          return {
+            where: vi.fn(() => ({
+              limit: vi.fn(() => ({
+                get: getNutritionLog,
+              })),
+            })),
+          };
+        }
+
+        if (getTableName(table) === 'foods') {
+          return {
+            where: vi.fn(() => ({
+              all: ownedFoodsAll,
+            })),
+          };
+        }
+
+        throw new Error(`Unexpected select table: ${String(table)}`);
+      }),
+    })),
+  };
+};
+
+const createTxForMealDelete = (
+  options: { exists?: boolean; foodIds?: Array<string | null> } = {},
+) => {
+  const exists = options.exists ?? true;
+  const foodIds = options.foodIds ?? ['food-1'];
+
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn((table) => {
+        if (getTableName(table) === 'meals') {
+          return {
+            innerJoin: vi.fn(() => ({
+              where: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  get: vi.fn(() => (exists ? { id: 'meal-1' } : undefined)),
+                })),
+              })),
+            })),
+          };
+        }
+
+        if (getTableName(table) === 'meal_items') {
+          return {
+            where: vi.fn(() => ({
+              all: vi.fn(() => foodIds.map((foodId) => ({ foodId }))),
+            })),
+          };
+        }
+
+        throw new Error(`Unexpected select table: ${String(table)}`);
+      }),
+    })),
+    delete: vi.fn((table) => {
+      if (getTableName(table) === 'meal_items' || getTableName(table) === 'meals') {
+        return {
+          where: vi.fn(() => ({
+            run: vi.fn(() => ({
+              changes: exists ? 1 : 0,
+            })),
+          })),
+        };
+      }
+
+      throw new Error(`Unexpected delete table: ${String(table)}`);
+    }),
+  };
+};
+
+const createTxForMealItemPatch = (options: {
+  existingFoodId: string | null;
+  updatedFoodId: string | null;
+}) => {
+  const existingItem = {
+    id: 'item-1',
+    mealId: 'meal-1',
+    foodId: options.existingFoodId,
+    name: 'Chicken',
+    amount: 1,
+    unit: 'serving',
+    displayQuantity: null,
+    displayUnit: null,
+    calories: 300,
+    protein: 40,
+    carbs: 0,
+    fat: 10,
+    fiber: null,
+    sugar: null,
+    createdAt: 1,
+  };
+  const updatedItem = {
+    ...existingItem,
+    foodId: options.updatedFoodId,
+  };
+
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn((table) => {
+        if (getTableName(table) === 'meal_items') {
+          return {
+            innerJoin: vi.fn(() => ({
+              innerJoin: vi.fn(() => ({
+                where: vi.fn(() => ({
+                  limit: vi.fn(() => ({
+                    get: vi.fn(() => existingItem),
+                  })),
+                })),
+              })),
+            })),
+          };
+        }
+
+        if (getTableName(table) === 'foods') {
+          return {
+            where: vi.fn(() => ({
+              all: vi.fn(() =>
+                options.updatedFoodId === null ? [] : [{ id: options.updatedFoodId }],
+              ),
+            })),
+          };
+        }
+
+        throw new Error(`Unexpected select table: ${String(table)}`);
+      }),
+    })),
+    update: vi.fn((table) => {
+      if (getTableName(table) === 'meal_items') {
+        return {
+          set: vi.fn(() => ({
+            where: vi.fn(() => ({
+              returning: vi.fn(() => ({
+                get: vi.fn(() => updatedItem),
+              })),
+            })),
+          })),
+        };
+      }
+
+      throw new Error(`Unexpected update table: ${String(table)}`);
+    }),
+  };
+};
+
+describe('nutrition store food usage tracking', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    testState.reset();
+    testState.trackFoodUsage.mockResolvedValue(undefined);
+    testState.decrementFoodUsage.mockResolvedValue(undefined);
+  });
+
+  it('tracks saved-food meal item creation', async () => {
+    testState.db.transaction.mockImplementation(
+      (callback: (tx: ReturnType<typeof createTxForMealInsert>) => unknown) =>
+        callback(
+          createTxForMealInsert([
+            {
+              id: 'item-1',
+              mealId: 'meal-1',
+              foodId: 'food-1',
+              name: 'Chicken',
+              amount: 1,
+              unit: 'serving',
+              displayQuantity: null,
+              displayUnit: null,
+              calories: 300,
+              protein: 40,
+              carbs: 0,
+              fat: 10,
+              fiber: null,
+              sugar: null,
+              createdAt: 3,
+            },
+          ]),
+        ),
+    );
+
+    const { createMealForDate } = await import('./store.js');
+    await createMealForDate('user-1', '2026-03-09', {
+      name: 'Lunch',
+      items: [
+        {
+          foodId: 'food-1',
+          name: 'Chicken',
+          amount: 1,
+          unit: 'serving',
+          calories: 300,
+          protein: 40,
+          carbs: 0,
+          fat: 10,
+        },
+      ],
+    });
+
+    expect(testState.trackFoodUsage).toHaveBeenCalledTimes(1);
+    expect(testState.trackFoodUsage).toHaveBeenCalledWith('food-1', 'user-1');
+    expect(testState.decrementFoodUsage).not.toHaveBeenCalled();
+  });
+
+  it('does not track ad-hoc meal item creation', async () => {
+    testState.db.transaction.mockImplementation(
+      (callback: (tx: ReturnType<typeof createTxForMealInsert>) => unknown) =>
+        callback(
+          createTxForMealInsert([
+            {
+              id: 'item-1',
+              mealId: 'meal-1',
+              foodId: null,
+              name: 'Olive Oil',
+              amount: 1,
+              unit: 'tbsp',
+              displayQuantity: null,
+              displayUnit: null,
+              calories: 120,
+              protein: 0,
+              carbs: 0,
+              fat: 14,
+              fiber: null,
+              sugar: null,
+              createdAt: 3,
+            },
+          ]),
+        ),
+    );
+
+    const { createMealForDate } = await import('./store.js');
+    await createMealForDate('user-1', '2026-03-09', {
+      name: 'Lunch',
+      items: [
+        {
+          name: 'Olive Oil',
+          amount: 1,
+          unit: 'tbsp',
+          calories: 120,
+          protein: 0,
+          carbs: 0,
+          fat: 14,
+        },
+      ],
+    });
+
+    expect(testState.trackFoodUsage).not.toHaveBeenCalled();
+    expect(testState.decrementFoodUsage).not.toHaveBeenCalled();
+  });
+
+  it('logs and continues when creation tracking fails', async () => {
+    testState.db.transaction.mockImplementation(
+      (callback: (tx: ReturnType<typeof createTxForMealInsert>) => unknown) =>
+        callback(
+          createTxForMealInsert([
+            {
+              id: 'item-1',
+              mealId: 'meal-1',
+              foodId: 'food-1',
+              name: 'Chicken',
+              amount: 1,
+              unit: 'serving',
+              displayQuantity: null,
+              displayUnit: null,
+              calories: 300,
+              protein: 40,
+              carbs: 0,
+              fat: 10,
+              fiber: null,
+              sugar: null,
+              createdAt: 3,
+            },
+          ]),
+        ),
+    );
+    testState.trackFoodUsage.mockRejectedValueOnce(new Error('transient failure'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { createMealForDate } = await import('./store.js');
+    const result = await createMealForDate('user-1', '2026-03-09', {
+      name: 'Lunch',
+      items: [
+        {
+          foodId: 'food-1',
+          name: 'Chicken',
+          amount: 1,
+          unit: 'serving',
+          calories: 300,
+          protein: 40,
+          carbs: 0,
+          fat: 10,
+        },
+      ],
+    });
+
+    expect(result.meal).toMatchObject({ id: 'meal-1', name: 'Lunch' });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('decrements food usage when deleting a meal', async () => {
+    testState.db.transaction.mockImplementation(
+      (callback: (tx: ReturnType<typeof createTxForMealDelete>) => unknown) =>
+        callback(
+          createTxForMealDelete({
+            foodIds: ['food-1'],
+          }),
+        ),
+    );
+
+    const { deleteMealForDate } = await import('./store.js');
+    const deleted = await deleteMealForDate('user-1', '2026-03-09', 'meal-1');
+
+    expect(deleted).toBe(true);
+    expect(testState.decrementFoodUsage).toHaveBeenCalledTimes(1);
+    expect(testState.decrementFoodUsage).toHaveBeenCalledWith('food-1', 'user-1');
+    expect(testState.trackFoodUsage).not.toHaveBeenCalled();
+  });
+
+  it('swaps food usage when updating a meal item food reference', async () => {
+    testState.db.transaction.mockImplementation(
+      (callback: (tx: ReturnType<typeof createTxForMealItemPatch>) => unknown) =>
+        callback(
+          createTxForMealItemPatch({
+            existingFoodId: 'food-1',
+            updatedFoodId: 'food-2',
+          }),
+        ),
+    );
+
+    const { patchMealItemById } = await import('./store.js');
+    const updated = await patchMealItemById('user-1', 'meal-1', 'item-1', {
+      foodId: 'food-2',
+    });
+
+    expect(updated).toMatchObject({
+      id: 'item-1',
+      foodId: 'food-2',
+    });
+    expect(testState.decrementFoodUsage).toHaveBeenCalledTimes(1);
+    expect(testState.decrementFoodUsage).toHaveBeenCalledWith('food-1', 'user-1');
+    expect(testState.trackFoodUsage).toHaveBeenCalledTimes(1);
+    expect(testState.trackFoodUsage).toHaveBeenCalledWith('food-2', 'user-1');
+  });
+});

--- a/apps/api/src/routes/nutrition/store.ts
+++ b/apps/api/src/routes/nutrition/store.ts
@@ -190,8 +190,13 @@ const applyFoodUsageTrackingEffects = async (
     );
 
     results.forEach((result, index) => {
+      const effect = effects[index];
       if (result.status === 'rejected') {
-        logFoodUsageTrackingFailure(userId, effects[index], result.reason, context);
+        if (!effect) {
+          return;
+        }
+
+        logFoodUsageTrackingFailure(userId, effect, result.reason, context);
       }
     });
   } catch (error) {
@@ -536,7 +541,7 @@ export const deleteMealForDate = async (
 ): Promise<boolean> => {
   const { db } = await import('../../db/index.js');
 
-  const deleted = db.transaction((tx) => {
+  const deleteResult = db.transaction((tx) => {
     const scopedMeal = tx
       .select({ id: meals.id })
       .from(meals)
@@ -569,13 +574,13 @@ export const deleteMealForDate = async (
     };
   });
 
-  if (!deleted.deleted) {
+  if (!deleteResult.deleted) {
     return false;
   }
 
   await applyFoodUsageTrackingEffects(
     userId,
-    deleted.foodIds.map((foodId) => ({
+    deleteResult.foodIds.map((foodId) => ({
       action: 'decrement' as const,
       foodId,
     })),
@@ -705,8 +710,8 @@ export const patchMealItemById = async (
 ): Promise<MealItemRecord | undefined> => {
   const { db } = await import('../../db/index.js');
 
-  const itemUpdate: Partial<typeof mealItems.$inferInsert> = {};
   const updated = db.transaction((tx) => {
+    const itemUpdate: Partial<typeof mealItems.$inferInsert> = {};
     const existingItem = tx
       .select(mealItemSelection)
       .from(mealItems)

--- a/apps/api/src/routes/nutrition/store.ts
+++ b/apps/api/src/routes/nutrition/store.ts
@@ -74,6 +74,15 @@ export type NutritionSummaryRecord = {
 };
 
 const WEEK_DAYS = 7;
+type FoodUsageTrackingEffect =
+  | {
+      action: 'increment';
+      foodId: string;
+    }
+  | {
+      action: 'decrement';
+      foodId: string;
+    };
 
 const nutritionLogSelection = {
   id: nutritionLogs.id,
@@ -129,6 +138,8 @@ const nutritionTargetMacroSelection = {
 };
 
 const toNullable = <T>(value: T | undefined): T | null => value ?? null;
+const isTrackedFoodId = (foodId: string | null): foodId is string =>
+  typeof foodId === 'string' && foodId.length > 0;
 
 const clampToUnitRange = (value: number) => Math.max(0, Math.min(1, value));
 
@@ -144,6 +155,50 @@ const getWeekStartMonday = (date: Date) => {
   const day = date.getUTCDay();
   const offset = day === 0 ? -6 : 1 - day;
   return addUtcDays(date, offset);
+};
+
+const logFoodUsageTrackingFailure = (
+  userId: string,
+  effect: FoodUsageTrackingEffect,
+  reason: unknown,
+  context: string,
+) => {
+  console.warn(`Failed to ${effect.action} food usage in meal store during ${context}`, {
+    err: reason,
+    foodId: effect.foodId,
+    userId,
+  });
+};
+
+const applyFoodUsageTrackingEffects = async (
+  userId: string,
+  effects: FoodUsageTrackingEffect[],
+  context: string,
+) => {
+  if (effects.length === 0) {
+    return;
+  }
+
+  try {
+    const { decrementFoodUsage, trackFoodUsage } = await import('../foods/store.js');
+    const results = await Promise.allSettled(
+      effects.map((effect) =>
+        effect.action === 'increment'
+          ? trackFoodUsage(effect.foodId, userId)
+          : decrementFoodUsage(effect.foodId, userId),
+      ),
+    );
+
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        logFoodUsageTrackingFailure(userId, effects[index], result.reason, context);
+      }
+    });
+  } catch (error) {
+    effects.forEach((effect) => {
+      logFoodUsageTrackingFailure(userId, effect, error, context);
+    });
+  }
 };
 
 export const calculateNutritionCompleteness = (input: {
@@ -181,7 +236,7 @@ export const createMealForDate = async (
 ): Promise<{ meal: MealRecord; items: MealItemRecord[] }> => {
   const { db } = await import('../../db/index.js');
 
-  return db.transaction((tx) => {
+  const created = db.transaction((tx) => {
     tx.insert(nutritionLogs)
       .values({
         userId,
@@ -235,11 +290,7 @@ export const createMealForDate = async (
       sugar: toNullable(item.sugar),
     }));
 
-    const foodIds = [
-      ...new Set(
-        itemValues.map((item) => item.foodId).filter((foodId): foodId is string => foodId !== null),
-      ),
-    ];
+    const foodIds = [...new Set(itemValues.map((item) => item.foodId).filter(isTrackedFoodId))];
     if (foodIds.length > 0) {
       const ownedFoods = tx
         .select({ id: foods.id })
@@ -260,6 +311,23 @@ export const createMealForDate = async (
 
     return { meal, items };
   });
+
+  await applyFoodUsageTrackingEffects(
+    userId,
+    created.items.flatMap((item) =>
+      isTrackedFoodId(item.foodId)
+        ? [
+            {
+              action: 'increment' as const,
+              foodId: item.foodId,
+            },
+          ]
+        : [],
+    ),
+    'meal creation',
+  );
+
+  return created;
 };
 
 export const getDailyNutritionForDate = async (
@@ -468,7 +536,7 @@ export const deleteMealForDate = async (
 ): Promise<boolean> => {
   const { db } = await import('../../db/index.js');
 
-  return db.transaction((tx) => {
+  const deleted = db.transaction((tx) => {
     const scopedMeal = tx
       .select({ id: meals.id })
       .from(meals)
@@ -480,14 +548,41 @@ export const deleteMealForDate = async (
       .get();
 
     if (!scopedMeal) {
-      return false;
+      return {
+        deleted: false,
+        foodIds: [] as string[],
+      };
     }
+
+    const existingItems = tx
+      .select({ foodId: mealItems.foodId })
+      .from(mealItems)
+      .where(eq(mealItems.mealId, mealId))
+      .all();
 
     tx.delete(mealItems).where(eq(mealItems.mealId, mealId)).run();
     const result = tx.delete(meals).where(eq(meals.id, mealId)).run();
 
-    return result.changes === 1;
+    return {
+      deleted: result.changes === 1,
+      foodIds: existingItems.map((item) => item.foodId).filter(isTrackedFoodId),
+    };
   });
+
+  if (!deleted.deleted) {
+    return false;
+  }
+
+  await applyFoodUsageTrackingEffects(
+    userId,
+    deleted.foodIds.map((foodId) => ({
+      action: 'decrement' as const,
+      foodId,
+    })),
+    'meal deletion',
+  );
+
+  return true;
 };
 
 export const findMealForDate = async (
@@ -611,50 +706,107 @@ export const patchMealItemById = async (
   const { db } = await import('../../db/index.js');
 
   const itemUpdate: Partial<typeof mealItems.$inferInsert> = {};
-  if (updates.name !== undefined) {
-    itemUpdate.name = updates.name;
-  }
-  if (updates.amount !== undefined) {
-    itemUpdate.amount = updates.amount;
-  }
-  if (updates.unit !== undefined) {
-    itemUpdate.unit = updates.unit;
-  }
-  if (updates.calories !== undefined) {
-    itemUpdate.calories = updates.calories;
-  }
-  if (updates.protein !== undefined) {
-    itemUpdate.protein = updates.protein;
-  }
-  if (updates.carbs !== undefined) {
-    itemUpdate.carbs = updates.carbs;
-  }
-  if (updates.fat !== undefined) {
-    itemUpdate.fat = updates.fat;
-  }
-  if (updates.fiber !== undefined) {
-    itemUpdate.fiber = updates.fiber;
-  }
-  if (updates.sugar !== undefined) {
-    itemUpdate.sugar = updates.sugar;
+  const updated = db.transaction((tx) => {
+    const existingItem = tx
+      .select(mealItemSelection)
+      .from(mealItems)
+      .innerJoin(meals, eq(meals.id, mealItems.mealId))
+      .innerJoin(nutritionLogs, eq(nutritionLogs.id, meals.nutritionLogId))
+      .where(
+        and(
+          eq(mealItems.id, itemId),
+          eq(mealItems.mealId, mealId),
+          eq(nutritionLogs.userId, userId),
+        ),
+      )
+      .limit(1)
+      .get();
+
+    if (!existingItem) {
+      return undefined;
+    }
+
+    if (updates.name !== undefined) {
+      itemUpdate.name = updates.name;
+    }
+    if (updates.amount !== undefined) {
+      itemUpdate.amount = updates.amount;
+    }
+    if (updates.unit !== undefined) {
+      itemUpdate.unit = updates.unit;
+    }
+    if (updates.calories !== undefined) {
+      itemUpdate.calories = updates.calories;
+    }
+    if (updates.protein !== undefined) {
+      itemUpdate.protein = updates.protein;
+    }
+    if (updates.carbs !== undefined) {
+      itemUpdate.carbs = updates.carbs;
+    }
+    if (updates.fat !== undefined) {
+      itemUpdate.fat = updates.fat;
+    }
+    if (updates.fiber !== undefined) {
+      itemUpdate.fiber = updates.fiber;
+    }
+    if (updates.sugar !== undefined) {
+      itemUpdate.sugar = updates.sugar;
+    }
+    if (updates.foodId !== undefined) {
+      const nextFoodId = toNullable(updates.foodId);
+      if (isTrackedFoodId(nextFoodId)) {
+        const ownedFoods = tx
+          .select({ id: foods.id })
+          .from(foods)
+          .where(and(eq(foods.id, nextFoodId), eq(foods.userId, userId)))
+          .all();
+
+        if (ownedFoods.length !== 1) {
+          throw new Error('One or more foodIds do not belong to this user');
+        }
+      }
+      itemUpdate.foodId = nextFoodId;
+    }
+
+    const updatedItem = tx
+      .update(mealItems)
+      .set(itemUpdate)
+      .where(and(eq(mealItems.id, itemId), eq(mealItems.mealId, mealId)))
+      .returning(mealItemSelection)
+      .get();
+
+    if (!updatedItem) {
+      return undefined;
+    }
+
+    return {
+      previousFoodId: existingItem.foodId,
+      updatedItem,
+    };
+  });
+
+  if (!updated) {
+    return undefined;
   }
 
-  const scopedMealIds = db
-    .select({ id: meals.id })
-    .from(meals)
-    .innerJoin(nutritionLogs, eq(nutritionLogs.id, meals.nutritionLogId))
-    .where(eq(nutritionLogs.userId, userId));
+  const effects: FoodUsageTrackingEffect[] = [];
+  if (updated.previousFoodId !== updated.updatedItem.foodId) {
+    if (isTrackedFoodId(updated.previousFoodId)) {
+      effects.push({
+        action: 'decrement',
+        foodId: updated.previousFoodId,
+      });
+    }
+    if (isTrackedFoodId(updated.updatedItem.foodId)) {
+      effects.push({
+        action: 'increment',
+        foodId: updated.updatedItem.foodId,
+      });
+    }
+  }
 
-  return db
-    .update(mealItems)
-    .set(itemUpdate)
-    .where(
-      and(
-        eq(mealItems.id, itemId),
-        eq(mealItems.mealId, mealId),
-        inArray(mealItems.mealId, scopedMealIds),
-      ),
-    )
-    .returning(mealItemSelection)
-    .get();
+  await applyFoodUsageTrackingEffects(userId, effects, 'meal item update');
+
+  return updated.updatedItem;
 };

--- a/apps/web/src/features/foods/api/foods.ts
+++ b/apps/web/src/features/foods/api/foods.ts
@@ -3,7 +3,7 @@ import type { QueryClient, QueryKey } from '@tanstack/react-query';
 import type { Food, FoodQueryParams, UpdateFoodInput } from '@pulse/shared';
 import { toast } from 'sonner';
 import { apiRequest, apiRequestWithMeta } from '@/lib/api-client';
-import { foodKeys } from './keys';
+import { foodQueryKeys } from './keys';
 
 type FoodListResponse = {
   data: Food[];
@@ -62,7 +62,7 @@ function patchFoodListCache(
   updater: (current: FoodListResponse) => FoodListResponse,
 ) {
   const queries = queryClient.getQueriesData<FoodListResponse>({
-    queryKey: foodKeys.list(),
+    queryKey: foodQueryKeys.foods(),
   });
 
   queries.forEach(([queryKey, value]) => {
@@ -78,7 +78,7 @@ function patchFoodListCache(
 
 export function useFoods(params: FoodQueryParams, options?: UseFoodsOptions) {
   return useQuery({
-    queryKey: foodKeys.list(params),
+    queryKey: foodQueryKeys.foods(params),
     queryFn: ({ signal }) => fetchFoods(params, signal),
     enabled: options?.enabled,
     placeholderData: keepPreviousData,
@@ -96,9 +96,9 @@ export function useUpdateFood() {
         data: current.data.map((food) => (food.id === updatedFood.id ? updatedFood : food)),
       }));
 
-      queryClient.setQueryData(foodKeys.detail(updatedFood.id), updatedFood);
+      queryClient.setQueryData(foodQueryKeys.food(updatedFood.id), updatedFood);
       await queryClient.invalidateQueries({
-        queryKey: foodKeys.list(),
+        queryKey: foodQueryKeys.foods(),
       });
       toast.success('Food updated');
     },
@@ -115,11 +115,11 @@ export function useDeleteFood() {
     },
     onMutate: async (foodId) => {
       await queryClient.cancelQueries({
-        queryKey: foodKeys.list(),
+        queryKey: foodQueryKeys.foods(),
       });
 
       const previousLists = queryClient.getQueriesData<FoodListResponse>({
-        queryKey: foodKeys.list(),
+        queryKey: foodQueryKeys.foods(),
       });
 
       previousLists.forEach(([queryKey, value]) => {
@@ -138,7 +138,7 @@ export function useDeleteFood() {
       });
 
       queryClient.removeQueries({
-        queryKey: foodKeys.detail(foodId),
+        queryKey: foodQueryKeys.food(foodId),
       });
 
       return {
@@ -156,10 +156,10 @@ export function useDeleteFood() {
     onSettled: (_data, _error, foodId) =>
       Promise.all([
         queryClient.invalidateQueries({
-          queryKey: foodKeys.list(),
+          queryKey: foodQueryKeys.foods(),
         }),
         queryClient.invalidateQueries({
-          queryKey: foodKeys.detail(foodId),
+          queryKey: foodQueryKeys.food(foodId),
         }),
       ]),
   });

--- a/apps/web/src/features/foods/api/keys.test.ts
+++ b/apps/web/src/features/foods/api/keys.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { foodKeys } from './keys';
+
+describe('foodKeys.list', () => {
+  it('uses a dedicated list segment', () => {
+    expect(foodKeys.list()).toEqual(['foods', 'list']);
+    expect(foodKeys.list({ page: 2, limit: 10, sort: 'popular' })).toEqual([
+      'foods',
+      'list',
+      {
+        limit: 10,
+        page: 2,
+        q: null,
+        sort: 'popular',
+        tags: null,
+      },
+    ]);
+  });
+});

--- a/apps/web/src/features/foods/api/keys.ts
+++ b/apps/web/src/features/foods/api/keys.ts
@@ -10,11 +10,17 @@ function normalizeListParams(params?: Partial<FoodQueryParams>) {
   };
 }
 
-export const foodKeys = {
+export const foodQueryKeys = {
   all: ['foods'] as const,
-  list: (params?: Partial<FoodQueryParams>) =>
+  food: (id: string) => ['foods', 'food', id] as const,
+  foods: (params?: Partial<FoodQueryParams>) =>
     params
-      ? (['foods', 'list', normalizeListParams(params)] as const)
-      : (['foods', 'list'] as const),
-  detail: (id: string) => ['foods', 'detail', id] as const,
+      ? (['foods', 'foods', normalizeListParams(params)] as const)
+      : (['foods', 'foods'] as const),
+};
+
+export const foodKeys = {
+  all: foodQueryKeys.all,
+  detail: foodQueryKeys.food,
+  list: foodQueryKeys.foods,
 };

--- a/apps/web/src/features/foods/api/keys.ts
+++ b/apps/web/src/features/foods/api/keys.ts
@@ -15,8 +15,8 @@ export const foodQueryKeys = {
   food: (id: string) => ['foods', 'food', id] as const,
   foods: (params?: Partial<FoodQueryParams>) =>
     params
-      ? (['foods', 'foods', normalizeListParams(params)] as const)
-      : (['foods', 'foods'] as const),
+      ? (['foods', 'list', normalizeListParams(params)] as const)
+      : (['foods', 'list'] as const),
 };
 
 export const foodKeys = {

--- a/apps/web/src/features/habits/api/habits.ts
+++ b/apps/web/src/features/habits/api/habits.ts
@@ -16,7 +16,7 @@ import { z } from 'zod';
 
 import { apiRequest } from '@/lib/api-client';
 
-import { habitKeys } from './keys';
+import { habitQueryKeys } from './keys';
 
 const resolvedTodayEntrySchema = z.object({
   completed: z.boolean(),
@@ -28,7 +28,7 @@ const habitWithTodayEntrySchema = habitSchema.extend({
 });
 const habitsWithTodayEntrySchema = z.array(habitWithTodayEntrySchema);
 const habitEntriesSchema = z.array(habitEntrySchema);
-const habitEntriesKeyPrefix = [...habitKeys.all, 'entries'] as const;
+const habitEntriesQueryKey = habitQueryKeys.entries();
 const successSchema = z.object({
   success: z.literal(true),
 });
@@ -95,7 +95,7 @@ const getEntriesParamsFromQueryKey = (queryKey: QueryKey): HabitEntriesParams | 
 
 const snapshotHabitEntryQueries = (queryClient: ReturnType<typeof useQueryClient>) =>
   queryClient.getQueriesData<HabitEntry[]>({
-    queryKey: habitEntriesKeyPrefix,
+    queryKey: habitEntriesQueryKey,
   });
 
 const restoreHabitEntryQueries = (
@@ -191,7 +191,7 @@ export function useHabits() {
 
       return habitsWithTodayEntrySchema.parse(habits).filter((habit) => habit.active);
     },
-    queryKey: habitKeys.list(),
+    queryKey: habitQueryKeys.habits(),
   });
 }
 
@@ -208,7 +208,7 @@ export function useHabitEntries(from: string, to: string) {
 
       return habitEntriesSchema.parse(entries);
     },
-    queryKey: habitKeys.entries({ from, to }),
+    queryKey: habitQueryKeys.entries({ from, to }),
   });
 }
 
@@ -226,13 +226,13 @@ export function useCreateHabit() {
       return habitSchema.parse(habit);
     },
     onSuccess: (habit) => {
-      queryClient.setQueryData<Habit[]>(habitKeys.list(), (currentHabits) =>
+      queryClient.setQueryData<Habit[]>(habitQueryKeys.habits(), (currentHabits) =>
         upsertHabit(currentHabits, habit),
       );
       toast.success('Habit created');
     },
     onSettled: async () => {
-      await queryClient.invalidateQueries({ queryKey: habitKeys.list() });
+      await queryClient.invalidateQueries({ queryKey: habitQueryKeys.habits() });
     },
   });
 }
@@ -251,7 +251,7 @@ export function useUpdateHabit() {
       return habitSchema.parse(habit);
     },
     onSuccess: (habit) => {
-      queryClient.setQueryData<Habit[]>(habitKeys.list(), (currentHabits) => {
+      queryClient.setQueryData<Habit[]>(habitQueryKeys.habits(), (currentHabits) => {
         if (!habit.active) {
           return currentHabits?.filter((item) => item.id !== habit.id);
         }
@@ -261,7 +261,7 @@ export function useUpdateHabit() {
       toast.success('Habit updated');
     },
     onSettled: async () => {
-      await queryClient.invalidateQueries({ queryKey: habitKeys.list() });
+      await queryClient.invalidateQueries({ queryKey: habitQueryKeys.habits() });
     },
   });
 }
@@ -278,13 +278,13 @@ export function useDeleteHabit() {
       return successSchema.parse(response);
     },
     onSuccess: (_response, variables) => {
-      queryClient.setQueryData<Habit[]>(habitKeys.list(), (currentHabits) =>
+      queryClient.setQueryData<Habit[]>(habitQueryKeys.habits(), (currentHabits) =>
         currentHabits?.filter((habit) => habit.id !== variables.id),
       );
       toast.success('Habit deleted');
     },
     onSettled: async () => {
-      await queryClient.invalidateQueries({ queryKey: habitKeys.list() });
+      await queryClient.invalidateQueries({ queryKey: habitQueryKeys.habits() });
     },
   });
 }
@@ -303,10 +303,10 @@ export function useReorderHabits() {
         }).then((response) => successSchema.parse(response));
       },
       onMutate: async (items) => {
-        await queryClient.cancelQueries({ queryKey: habitKeys.list() });
+        await queryClient.cancelQueries({ queryKey: habitQueryKeys.habits() });
 
-        const previousHabits = queryClient.getQueryData<Habit[]>(habitKeys.list());
-        queryClient.setQueryData<Habit[]>(habitKeys.list(), (currentHabits) =>
+        const previousHabits = queryClient.getQueryData<Habit[]>(habitQueryKeys.habits());
+        queryClient.setQueryData<Habit[]>(habitQueryKeys.habits(), (currentHabits) =>
           reorderCachedHabits(currentHabits, items),
         );
 
@@ -317,13 +317,13 @@ export function useReorderHabits() {
           return;
         }
 
-        queryClient.setQueryData(habitKeys.list(), context.previousHabits);
+        queryClient.setQueryData(habitQueryKeys.habits(), context.previousHabits);
       },
       onSuccess: () => {
         toast.success('Habit order updated');
       },
       onSettled: async () => {
-        await queryClient.invalidateQueries({ queryKey: habitKeys.list() });
+        await queryClient.invalidateQueries({ queryKey: habitQueryKeys.habits() });
       },
     },
   );
@@ -347,7 +347,7 @@ export function useToggleHabit() {
       return habitEntrySchema.parse(entry);
     },
     onMutate: async (variables) => {
-      await queryClient.cancelQueries({ queryKey: habitEntriesKeyPrefix });
+      await queryClient.cancelQueries({ queryKey: habitEntriesQueryKey });
 
       const previousEntries = snapshotHabitEntryQueries(queryClient);
       const optimisticEntry: HabitEntry = {
@@ -379,7 +379,7 @@ export function useToggleHabit() {
       applyHabitEntryToCache(queryClient, entry);
     },
     onSettled: async () => {
-      await queryClient.invalidateQueries({ queryKey: habitEntriesKeyPrefix });
+      await queryClient.invalidateQueries({ queryKey: habitEntriesQueryKey });
     },
   });
 }
@@ -401,7 +401,7 @@ export function useUpdateHabitEntry() {
       return habitEntrySchema.parse(entry);
     },
     onMutate: async (variables) => {
-      await queryClient.cancelQueries({ queryKey: habitEntriesKeyPrefix });
+      await queryClient.cancelQueries({ queryKey: habitEntriesQueryKey });
 
       const previousEntries = snapshotHabitEntryQueries(queryClient);
       const existingEntry = findCachedHabitEntry(queryClient, variables.id);
@@ -434,7 +434,7 @@ export function useUpdateHabitEntry() {
       applyHabitEntryToCache(queryClient, entry);
     },
     onSettled: async () => {
-      await queryClient.invalidateQueries({ queryKey: habitEntriesKeyPrefix });
+      await queryClient.invalidateQueries({ queryKey: habitEntriesQueryKey });
     },
   });
 }

--- a/apps/web/src/features/habits/api/keys.ts
+++ b/apps/web/src/features/habits/api/keys.ts
@@ -1,6 +1,14 @@
-export const habitKeys = {
+export const habitQueryKeys = {
   all: ['habits'] as const,
-  detail: (id: string) => [...habitKeys.all, 'detail', id] as const,
-  entries: (params: { from: string; to: string }) => [...habitKeys.all, 'entries', params] as const,
-  list: () => [...habitKeys.all, 'list'] as const,
+  entries: (params?: { from: string; to: string }) =>
+    params ? (['habits', 'entries', params] as const) : (['habits', 'entries'] as const),
+  habit: (id: string) => ['habits', 'habit', id] as const,
+  habits: () => ['habits', 'habits'] as const,
+};
+
+export const habitKeys = {
+  all: habitQueryKeys.all,
+  detail: habitQueryKeys.habit,
+  entries: habitQueryKeys.entries,
+  list: habitQueryKeys.habits,
 };

--- a/apps/web/src/features/nutrition/api/keys.test.ts
+++ b/apps/web/src/features/nutrition/api/keys.test.ts
@@ -3,6 +3,11 @@ import { describe, expect, it } from 'vitest';
 import { nutritionKeys } from './keys';
 
 describe('nutritionKeys.weekSummary', () => {
+  it('exposes day and daily accessors for the same cache key', () => {
+    expect(nutritionKeys.day('2026-03-09')).toEqual(['nutrition', 'day', '2026-03-09']);
+    expect(nutritionKeys.daily('2026-03-09')).toEqual(['nutrition', 'day', '2026-03-09']);
+  });
+
   it('normalizes date keys to the Monday for the containing week', () => {
     expect(nutritionKeys.weekSummary('2026-03-03')).toEqual([
       'nutrition',

--- a/apps/web/src/features/nutrition/api/keys.ts
+++ b/apps/web/src/features/nutrition/api/keys.ts
@@ -9,10 +9,16 @@ const toWeekStartDateKey = (date: string): string => {
   return formatDateKey(getWeekStart(parsedDate));
 };
 
-export const nutritionKeys = {
+export const nutritionQueryKeys = {
   all: ['nutrition'] as const,
-  daily: (date: string) => [...nutritionKeys.all, 'daily', date] as const,
-  summary: (date: string) => [...nutritionKeys.all, 'summary', date] as const,
-  weekSummary: (date: string) =>
-    [...nutritionKeys.all, 'week-summary', toWeekStartDateKey(date)] as const,
+  day: (date: string) => ['nutrition', 'day', date] as const,
+  summary: (date: string) => ['nutrition', 'summary', date] as const,
+  weekSummary: (date: string) => ['nutrition', 'week-summary', toWeekStartDateKey(date)] as const,
+};
+
+export const nutritionKeys = {
+  all: nutritionQueryKeys.all,
+  daily: nutritionQueryKeys.day,
+  summary: nutritionQueryKeys.summary,
+  weekSummary: nutritionQueryKeys.weekSummary,
 };

--- a/apps/web/src/features/nutrition/api/keys.ts
+++ b/apps/web/src/features/nutrition/api/keys.ts
@@ -9,16 +9,12 @@ const toWeekStartDateKey = (date: string): string => {
   return formatDateKey(getWeekStart(parsedDate));
 };
 
-export const nutritionQueryKeys = {
+export const nutritionKeys = {
   all: ['nutrition'] as const,
   day: (date: string) => ['nutrition', 'day', date] as const,
+  daily: (date: string) => ['nutrition', 'day', date] as const,
   summary: (date: string) => ['nutrition', 'summary', date] as const,
   weekSummary: (date: string) => ['nutrition', 'week-summary', toWeekStartDateKey(date)] as const,
 };
 
-export const nutritionKeys = {
-  all: nutritionQueryKeys.all,
-  daily: nutritionQueryKeys.day,
-  summary: nutritionQueryKeys.summary,
-  weekSummary: nutritionQueryKeys.weekSummary,
-};
+export const nutritionQueryKeys = nutritionKeys;

--- a/apps/web/src/features/nutrition/api/nutrition.ts
+++ b/apps/web/src/features/nutrition/api/nutrition.ts
@@ -9,7 +9,7 @@ import { toast } from 'sonner';
 
 import { apiRequest } from '@/lib/api-client';
 
-import { nutritionKeys } from './keys';
+import { nutritionQueryKeys } from './keys';
 
 export type DeleteMealInput = {
   date: string;
@@ -47,30 +47,30 @@ const deleteMeal = ({ date, mealId }: DeleteMealInput) =>
 
 export const useDailyNutrition = (date: string) =>
   useQuery({
-    queryKey: nutritionKeys.daily(date),
+    queryKey: nutritionQueryKeys.day(date),
     queryFn: ({ signal }) => fetchDailyNutrition(date, signal),
   });
 
 export const useNutritionSummary = (date: string) =>
   useQuery({
-    queryKey: nutritionKeys.summary(date),
+    queryKey: nutritionQueryKeys.summary(date),
     queryFn: ({ signal }) => fetchNutritionSummary(date, signal),
   });
 
 export const useNutritionWeekSummary = (date: string) =>
   useQuery({
-    queryKey: nutritionKeys.weekSummary(date),
+    queryKey: nutritionQueryKeys.weekSummary(date),
     queryFn: ({ signal }) => fetchNutritionWeekSummary(date, signal),
   });
 
 export const prefetchNutritionDay = async (queryClient: QueryClient, date: string) => {
   await Promise.all([
     queryClient.prefetchQuery({
-      queryKey: nutritionKeys.daily(date),
+      queryKey: nutritionQueryKeys.day(date),
       queryFn: ({ signal }) => fetchDailyNutrition(date, signal),
     }),
     queryClient.prefetchQuery({
-      queryKey: nutritionKeys.summary(date),
+      queryKey: nutritionQueryKeys.summary(date),
       queryFn: ({ signal }) => fetchNutritionSummary(date, signal),
     }),
   ]);
@@ -84,13 +84,13 @@ export const useDeleteMeal = () => {
     onSuccess: async (_result, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: nutritionKeys.daily(variables.date),
+          queryKey: nutritionQueryKeys.day(variables.date),
         }),
         queryClient.invalidateQueries({
-          queryKey: nutritionKeys.summary(variables.date),
+          queryKey: nutritionQueryKeys.summary(variables.date),
         }),
         queryClient.invalidateQueries({
-          queryKey: nutritionKeys.weekSummary(variables.date),
+          queryKey: nutritionQueryKeys.weekSummary(variables.date),
         }),
       ]);
       toast.success('Meal deleted');

--- a/apps/web/src/features/nutrition/api/targets.ts
+++ b/apps/web/src/features/nutrition/api/targets.ts
@@ -4,10 +4,12 @@ import { toast } from 'sonner';
 
 import { apiRequest } from '@/lib/api-client';
 
-export const nutritionTargetKeys = {
+export const nutritionTargetQueryKeys = {
   all: ['nutrition-targets'] as const,
-  current: () => [...nutritionTargetKeys.all, 'current'] as const,
+  current: () => ['nutrition-targets', 'current'] as const,
 };
+
+export const nutritionTargetKeys = nutritionTargetQueryKeys;
 
 const fetchCurrentNutritionTarget = () =>
   apiRequest<NutritionTarget | null>('/api/v1/nutrition-targets/current');
@@ -20,7 +22,7 @@ const postNutritionTarget = (input: CreateNutritionTargetInput) =>
 
 export const useNutritionTargets = () =>
   useQuery({
-    queryKey: nutritionTargetKeys.current(),
+    queryKey: nutritionTargetQueryKeys.current(),
     queryFn: fetchCurrentNutritionTarget,
   });
 
@@ -30,7 +32,7 @@ export const useUpdateTargets = () => {
   return useMutation({
     mutationFn: postNutritionTarget,
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: nutritionTargetKeys.all });
+      await queryClient.invalidateQueries({ queryKey: nutritionTargetQueryKeys.all });
       toast.success('Nutrition targets updated');
     },
   });

--- a/apps/web/src/features/settings/api/trash.ts
+++ b/apps/web/src/features/settings/api/trash.ts
@@ -1,9 +1,14 @@
 import { type QueryClient, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { trashListResponseSchema, trashTypeSchema, type TrashListResponse, type TrashType } from '@pulse/shared';
+import {
+  trashListResponseSchema,
+  trashTypeSchema,
+  type TrashListResponse,
+  type TrashType,
+} from '@pulse/shared';
 import { z } from 'zod';
 
-import { foodKeys } from '@/features/foods/api/keys';
-import { habitKeys } from '@/features/habits/api/keys';
+import { foodQueryKeys } from '@/features/foods/api/keys';
+import { habitQueryKeys } from '@/features/habits/api/keys';
 import { workoutQueryKeys } from '@/features/workouts/api/workouts';
 import { apiRequest } from '@/lib/api-client';
 
@@ -11,9 +16,14 @@ const mutationResultSchema = z.object({
   success: z.boolean(),
 });
 
-export const trashKeys = {
+export const trashQueryKeys = {
   all: ['trash'] as const,
-  list: () => [...trashKeys.all, 'list'] as const,
+  items: () => ['trash', 'items'] as const,
+};
+
+export const trashKeys = {
+  all: trashQueryKeys.all,
+  list: trashQueryKeys.items,
 };
 
 type TrashMutationInput = {
@@ -32,9 +42,12 @@ async function fetchTrashItems(signal?: AbortSignal): Promise<TrashListResponse>
 
 async function restoreTrashItem(input: TrashMutationInput) {
   const type = trashTypeSchema.parse(input.type);
-  const payload = await apiRequest<{ success: boolean }>(`/api/v1/trash/${type}/${input.id}/restore`, {
-    method: 'POST',
-  });
+  const payload = await apiRequest<{ success: boolean }>(
+    `/api/v1/trash/${type}/${input.id}/restore`,
+    {
+      method: 'POST',
+    },
+  );
 
   return mutationResultSchema.parse(payload);
 }
@@ -50,9 +63,9 @@ async function purgeTrashItem(input: TrashMutationInput) {
 
 async function invalidateRelatedQueries(queryClient: QueryClient) {
   await Promise.all([
-    queryClient.invalidateQueries({ queryKey: trashKeys.all }),
-    queryClient.invalidateQueries({ queryKey: habitKeys.all }),
-    queryClient.invalidateQueries({ queryKey: foodKeys.all }),
+    queryClient.invalidateQueries({ queryKey: trashQueryKeys.all }),
+    queryClient.invalidateQueries({ queryKey: habitQueryKeys.all }),
+    queryClient.invalidateQueries({ queryKey: foodQueryKeys.all }),
     queryClient.invalidateQueries({ queryKey: workoutQueryKeys.all }),
   ]);
 }
@@ -60,7 +73,7 @@ async function invalidateRelatedQueries(queryClient: QueryClient) {
 export function useTrashItems() {
   return useQuery({
     queryFn: ({ signal }) => fetchTrashItems(signal),
-    queryKey: trashKeys.list(),
+    queryKey: trashQueryKeys.items(),
   });
 }
 

--- a/apps/web/src/features/weight/api/weight.ts
+++ b/apps/web/src/features/weight/api/weight.ts
@@ -14,12 +14,19 @@ type WeightTrendFilters = {
   to?: string;
 };
 
-export const weightKeys = {
+const normalizeWeightTrendFilters = ({ from, to }: WeightTrendFilters = {}) => ({
+  from: from ?? null,
+  to: to ?? null,
+});
+
+export const weightQueryKeys = {
   all: ['weight'] as const,
-  latest: () => [...weightKeys.all, 'latest'] as const,
+  latest: () => ['weight', 'latest'] as const,
   trend: ({ from, to }: WeightTrendFilters = {}) =>
-    [...weightKeys.all, 'trend', from ?? null, to ?? null] as const,
+    ['weight', 'trend', normalizeWeightTrendFilters({ from, to })] as const,
 };
+
+export const weightKeys = weightQueryKeys;
 
 const buildWeightTrendPath = ({ from, to }: WeightTrendFilters = {}) => {
   const searchParams = new URLSearchParams();
@@ -61,13 +68,13 @@ const patchWeightEntry = (id: string, input: PatchWeightInput) =>
 
 export const useLatestWeight = () =>
   useQuery({
-    queryKey: weightKeys.latest(),
+    queryKey: weightQueryKeys.latest(),
     queryFn: fetchLatestWeight,
   });
 
 export const useWeightTrend = (from?: string, to?: string) =>
   useQuery({
-    queryKey: weightKeys.trend({ from, to }),
+    queryKey: weightQueryKeys.trend({ from, to }),
     queryFn: () => fetchWeightTrend({ from, to }),
   });
 
@@ -77,7 +84,7 @@ export const useLogWeight = () => {
   return useMutation({
     mutationFn: postWeightEntry,
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: weightKeys.all });
+      await queryClient.invalidateQueries({ queryKey: weightQueryKeys.all });
       toast.success('Weight logged');
     },
   });
@@ -89,7 +96,7 @@ export const useDeleteWeight = () => {
   return useMutation({
     mutationFn: deleteWeightEntry,
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: weightKeys.all });
+      await queryClient.invalidateQueries({ queryKey: weightQueryKeys.all });
       toast.success('Weight entry deleted');
     },
     onError: () => {
@@ -102,9 +109,10 @@ export const useUpdateWeight = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, input }: { id: string; input: PatchWeightInput }) => patchWeightEntry(id, input),
+    mutationFn: ({ id, input }: { id: string; input: PatchWeightInput }) =>
+      patchWeightEntry(id, input),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: weightKeys.all });
+      await queryClient.invalidateQueries({ queryKey: weightQueryKeys.all });
       toast.success('Weight entry updated');
     },
     onError: () => {

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -146,23 +146,64 @@ const workoutSessionResponseSchema = z.object({
 
 type CreateWorkoutSessionRequest = z.input<typeof createWorkoutSessionInputSchema>;
 
+const normalizeExerciseParams = (params: ExerciseQueryParams) => {
+  const parsedParams = exerciseQueryParamsSchema.parse(params);
+
+  return {
+    category: parsedParams.category ?? null,
+    equipment: parsedParams.equipment ?? null,
+    limit: parsedParams.limit,
+    muscleGroup: parsedParams.muscleGroup ?? null,
+    page: parsedParams.page,
+    q: parsedParams.q ?? null,
+  };
+};
+
+const normalizeScheduledWorkoutParams = (params: ScheduledWorkoutQueryParams) => {
+  const parsedParams = scheduledWorkoutQueryParamsSchema.parse(params);
+
+  return {
+    from: parsedParams.from,
+    to: parsedParams.to,
+  };
+};
+
+const normalizeWorkoutSessionParams = (params: WorkoutSessionQueryParams = {}) => {
+  const parsedParams = workoutSessionQueryParamsSchema.parse(params);
+
+  return {
+    from: parsedParams.from ?? null,
+    limit: parsedParams.limit ?? null,
+    status: parsedParams.status?.join('|') ?? null,
+    to: parsedParams.to ?? null,
+  };
+};
+
 export const workoutQueryKeys = {
   all: ['workouts'] as const,
-  completedSessions: () => ['workouts', 'completed-sessions'] as const,
+  completedSessions: () =>
+    ['workouts', 'sessions', { from: null, limit: null, status: 'completed', to: null }] as const,
   exercise: (id: string) => ['workouts', 'exercise', id] as const,
   exercisesRoot: () => ['workouts', 'exercises'] as const,
-  exercises: (params: ExerciseQueryParams) => ['workouts', 'exercises', params] as const,
+  exercises: (params?: ExerciseQueryParams) =>
+    params
+      ? (['workouts', 'exercises', normalizeExerciseParams(params)] as const)
+      : (['workouts', 'exercises'] as const),
   exerciseFilters: () => ['workouts', 'exercise-filters'] as const,
   scheduledWorkoutsAll: () => ['workouts', 'scheduled-workouts'] as const,
-  scheduledWorkouts: (params: ScheduledWorkoutQueryParams) =>
-    ['workouts', 'scheduled-workouts', params] as const,
+  scheduledWorkouts: (params?: ScheduledWorkoutQueryParams) =>
+    params
+      ? (['workouts', 'scheduled-workouts', normalizeScheduledWorkoutParams(params)] as const)
+      : (['workouts', 'scheduled-workouts'] as const),
   session: (id: string) => ['workouts', 'session', id] as const,
   sessions: () => ['workouts', 'sessions'] as const,
   sessionsList: (params: WorkoutSessionQueryParams = {}) =>
-    ['workouts', 'sessions', params] as const,
+    ['workouts', 'sessions', normalizeWorkoutSessionParams(params)] as const,
   templateRoot: () => ['workouts', 'template'] as const,
   template: (id: string) => ['workouts', 'template', id] as const,
   templates: () => ['workouts', 'templates'] as const,
+  workouts: (params: WorkoutSessionQueryParams = {}) =>
+    ['workouts', 'sessions', normalizeWorkoutSessionParams(params)] as const,
 };
 
 async function getWorkoutTemplates() {
@@ -493,7 +534,7 @@ export function useWorkoutSessions(
   return useQuery<WorkoutSessionListItem[]>({
     enabled: options?.enabled,
     queryFn: ({ signal }) => getWorkoutSessions(params, signal),
-    queryKey: workoutQueryKeys.sessionsList(params),
+    queryKey: workoutQueryKeys.workouts(params),
   });
 }
 
@@ -572,7 +613,7 @@ export function useScheduleWorkout() {
     onSuccess: async (_, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.scheduledWorkoutsAll(),
+          queryKey: workoutQueryKeys.scheduledWorkouts(),
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.sessions(),
@@ -591,7 +632,7 @@ export function useRescheduleWorkout() {
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.scheduledWorkoutsAll(),
+          queryKey: workoutQueryKeys.scheduledWorkouts(),
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.sessions(),
@@ -610,7 +651,7 @@ export function useUnscheduleWorkout() {
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.scheduledWorkoutsAll(),
+          queryKey: workoutQueryKeys.scheduledWorkouts(),
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.sessions(),
@@ -651,13 +692,13 @@ export function useUpdateExercise() {
           queryKey: workoutQueryKeys.exercise(variables.id),
         }),
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.exercisesRoot(),
+          queryKey: workoutQueryKeys.exercises(),
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.templates(),
         }),
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.templateRoot(),
+          queryKey: workoutQueryKeys.templates(),
         }),
       ]);
     },

--- a/packages/shared/src/schemas/nutrition.test.ts
+++ b/packages/shared/src/schemas/nutrition.test.ts
@@ -320,12 +320,14 @@ describe('patchMealItemInputSchema', () => {
 
   it('accepts a valid multi-field patch', () => {
     const payload = patchMealItemInputSchema.parse({
+      foodId: ' food-2 ',
       name: ' Grilled Chicken ',
       calories: 220,
       fiber: null,
     });
 
     expect(payload).toEqual({
+      foodId: 'food-2',
       name: 'Grilled Chicken',
       calories: 220,
       fiber: null,

--- a/packages/shared/src/schemas/nutrition.ts
+++ b/packages/shared/src/schemas/nutrition.ts
@@ -126,6 +126,7 @@ export const patchMealInputSchema = z
 
 export const patchMealItemInputSchema = z
   .object({
+    foodId: z.string().trim().min(1).nullable().optional(),
     name: requiredText().optional(),
     amount: z.number().positive().finite().optional(),
     unit: requiredText(50).optional(),


### PR DESCRIPTION
## Summary
This PR fixes food usage tracking by moving it into the nutrition store layer instead of leaving it in route handlers. That closes the gap where some meal write paths could create, update, or delete saved-food meal items without keeping `usageCount` and `lastUsedAt` in sync. Saved-food references are now tracked consistently for agent meal creation, standard meal creation, meal deletion, and meal item reassignment, while ad-hoc items remain excluded. The branch also includes React Query key normalization in the web app so cache invalidation targets are more explicit and stable.

## Key Changes
- Moved food usage bookkeeping behind the meal store so route handlers no longer call `trackFoodUsage` directly.
- Added `decrementFoodUsage` in the foods store and used it when deleting meals or removing/swapping a meal item's saved-food reference.
- Updated `createMealForDate` to increment usage only for persisted saved-food items and to ignore ad-hoc items with no `foodId`.
- Extended `patchMealItemInputSchema` and store patch logic to accept `foodId` changes, validate ownership, and rebalance usage counts when an item is relinked.
- Added a dedicated nutrition store test suite covering create, delete, ad-hoc, reassignment, and tracking-failure scenarios, plus integration test updates for `usageCount`/`lastUsedAt`.
- Normalized frontend query key helpers across foods, habits, nutrition, trash, weight, and workouts to reduce cache invalidation mismatches.

## Technical Notes
- Food usage updates are intentionally applied after the meal transaction completes. Meal writes still succeed if usage tracking fails; failures are logged as warnings rather than surfacing to the client.
- Decrements are clamped at zero and do not modify `lastUsedAt`, so recency remains based on actual use, not cleanup operations.
- Review the web diff separately from the nutrition fix: most of that churn is query-key renaming/normalization rather than API behavior changes.

## Commits

- `8be3016 fix(nutrition): enforce food usage tracking in store`

## Tasks

- **Move food usage tracking into meal store layer**: Move trackFoodUsage into meal store so no code path bypasses it, add decrementFoodUsage, handle ad-hoc items

## Diff Stats

```
.agents/skills/pulse-app-usage/SKILL.md            |   1 +
 AGENTS.md                                          |   2 +-
 apps/api/src/__tests__/foods-nutrition.test.ts     |  80 +++-
 apps/api/src/routes/foods/store.test.ts            |  14 +-
 apps/api/src/routes/foods/store.ts                 |  16 +
 apps/api/src/routes/meals/index.test.ts            |  22 +-
 apps/api/src/routes/meals/index.ts                 | 107 ++---
 apps/api/src/routes/nutrition/index.test.ts        |  74 ++--
 apps/api/src/routes/nutrition/index.ts             |  17 -
 .../src/routes/nutrition/store.food-usage.test.ts  | 443 +++++++++++++++++++++
 apps/api/src/routes/nutrition/store.ts             | 254 +++++++++---
 apps/web/src/features/foods/api/foods.ts           |  20 +-
 apps/web/src/features/foods/api/keys.ts            |  16 +-
 apps/web/src/features/habits/api/habits.ts         |  40 +-
 apps/web/src/features/habits/api/keys.ts           |  16 +-
 apps/web/src/features/nutrition/api/keys.ts        |  16 +-
 apps/web/src/features/nutrition/api/nutrition.ts   |  18 +-
 apps/web/src/features/nutrition/api/targets.ts     |  10 +-
 apps/web/src/features/settings/api/trash.ts        |  37 +-
 apps/web/src/features/weight/api/weight.ts         |  26 +-
 apps/web/src/features/workouts/api/workouts.ts     |  63 ++-
 packages/shared/src/schemas/nutrition.test.ts      |   2 +
 packages/shared/src/schemas/nutrition.ts           |   1 +
 23 files changed, 1015 insertions(+), 280 deletions(-)
```