### PR TITLE
feat(workouts): add correction endpoint for completed sessions

### DIFF
--- a/.agents/skills/pulse-app-usage/SKILL.md
+++ b/.agents/skills/pulse-app-usage/SKILL.md
@@ -39,6 +39,7 @@ Use this flow when an agent creates exercises/templates and then logs workout se
    - remove unstarted exercises: `removeExercises: [exerciseId]`
    - reorder exercises: `reorderExercises: [exerciseId, ...]`
 11. Do not remove exercises that already have completed sets (`409 WORKOUT_SESSION_EXERCISE_HAS_LOGGED_SETS`).
+12. To correct mistakes in a completed session, use `PATCH /api/v1/workout-sessions/:id/corrections` with an array of set corrections.
 
 ## Habits
 
@@ -86,6 +87,9 @@ Decision heuristic:
   - `paused -> in-progress`: appends a new open `timeSegments` entry.
   - `in-progress|paused -> cancelled`: closes any open segment and keeps the session row for history.
   - `in-progress|paused -> completed`: closes the final segment and computes duration from summed segment time.
+  - Completed sessions support set corrections via `PATCH /api/v1/workout-sessions/:id/corrections` with `{ corrections: [{ setId, weight?, reps?, rpe? }] }`.
+  - The correction endpoint only works on completed sessions (`409` on other statuses).
+  - Corrections do not change session status, `completedAt`, or duration.
   - Manual correction is supported via `PATCH /api/v1/workout-sessions/:id/time-segments` with full segment array replacement.
 - Form-cue routing for agent template create/update:
   - `formCues` are durable and persist to `exercises.formCues`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ pnpm --filter shared build  # Build shared package
 ## Key Domain Notes
 
 - **Nutrition**: Meals are entered by AI agents only — no manual entry UI. The frontend is read-only for meal data.
-- **Workouts**: The most complex UI domain. Templates → Sessions → Sets. Active session state is server-side.
+- **Workouts**: The most complex UI domain. Templates → Sessions → Sets. Active session state is server-side. Completed sessions can be corrected via `PATCH /api/v1/workout-sessions/:id/corrections` — set values (weight, reps, rpe) can be updated without changing session status or timestamps.
 - **Habits**: User-configurable with boolean/numeric/time tracking types, plus referential habits (`weight`, `nutrition_daily`, `nutrition_meal`, `workout`) that auto-resolve completion from linked data unless manually overridden. Feed into dashboard "don't break the chain" widgets.
 - **Foods**: Per-user database. `lastUsedAt` and `usageCount` are automatically maintained by the meal store layer whenever saved-food meal items are created, updated, or deleted.
 - **Trash & Soft Delete**: User-facing habits, workout templates, exercises, foods, and workout sessions use `deletedAt` soft delete; restore/purge flows are handled via `/api/v1/trash`.

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -1565,6 +1565,7 @@ describe('workout session routes', () => {
 
   it('applies workout session corrections to completed sessions and preserves session timing', async () => {
     const agentToken = seedAgentToken('user-1', 'session-correction-agent-token');
+    const updatedAtTimestamp = 1_700_000_004_200;
 
     seedWorkoutSession({
       id: 'session-completed',
@@ -1615,6 +1616,8 @@ describe('workout session routes', () => {
       .where(eq(workoutSessions.id, 'session-completed'))
       .get();
 
+    const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(updatedAtTimestamp);
+
     const response = await context.app.inject({
       method: 'PATCH',
       url: '/api/v1/workout-sessions/session-completed/corrections',
@@ -1624,6 +1627,9 @@ describe('workout session routes', () => {
           {
             setId: 'set-1',
             weight: 190,
+          },
+          {
+            setId: 'set-1',
             reps: 6,
           },
           {
@@ -1633,6 +1639,7 @@ describe('workout session routes', () => {
         ],
       },
     });
+    dateNowSpy.mockRestore();
 
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
@@ -1676,7 +1683,10 @@ describe('workout session routes', () => {
       .where(eq(sessionSets.sessionId, 'session-completed'))
       .all();
 
-    expect(afterSessionRow).toEqual(beforeSessionRow);
+    expect(afterSessionRow).toEqual({
+      ...beforeSessionRow,
+      updatedAt: updatedAtTimestamp,
+    });
     expect(correctedSets).toEqual([
       {
         id: 'set-1',
@@ -1756,8 +1766,13 @@ describe('workout session routes', () => {
       section: 'main',
     });
 
-    const [inProgressResponse, otherUserResponse, invalidSetResponse, emptyCorrectionsResponse] =
-      await Promise.all([
+    const [
+      inProgressResponse,
+      otherUserResponse,
+      invalidSetResponse,
+      emptyCorrectionsResponse,
+      unsupportedCorrectionResponse,
+    ] = await Promise.all([
         context.app.inject({
           method: 'PATCH',
           url: '/api/v1/workout-sessions/session-in-progress/corrections',
@@ -1805,6 +1820,19 @@ describe('workout session routes', () => {
             corrections: [],
           },
         }),
+        context.app.inject({
+          method: 'PATCH',
+          url: '/api/v1/workout-sessions/session-completed/corrections',
+          headers: createAuthorizationHeader(authToken),
+          payload: {
+            corrections: [
+              {
+                setId: 'set-1',
+                rpe: 8,
+              },
+            ],
+          },
+        }),
       ]);
 
     expect(inProgressResponse.statusCode).toBe(409);
@@ -1836,6 +1864,15 @@ describe('workout session routes', () => {
       error: {
         code: 'VALIDATION_ERROR',
         message: 'Invalid workout session payload',
+      },
+    });
+
+    expect(unsupportedCorrectionResponse.statusCode).toBe(400);
+    expect(unsupportedCorrectionResponse.json()).toEqual({
+      error: {
+        code: 'INVALID_SESSION_CORRECTION',
+        message:
+          'Workout session corrections must include weight or reps. Set-level RPE corrections are not persisted yet: set-1',
       },
     });
   });

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -351,6 +351,18 @@ describe('workout session routes', () => {
         },
       }),
       context.app.inject({
+        method: 'PATCH',
+        url: '/api/v1/workout-sessions/session-1/corrections',
+        payload: {
+          corrections: [
+            {
+              setId: 'set-1',
+              reps: 10,
+            },
+          ],
+        },
+      }),
+      context.app.inject({
         method: 'GET',
         url: '/api/v1/workout-sessions/session-1/sets',
       }),
@@ -394,7 +406,10 @@ describe('workout session routes', () => {
   });
 
   it('saves a completed session as a template and allows duplicate saves', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-completed',
@@ -574,7 +589,10 @@ describe('workout session routes', () => {
   });
 
   it('includes trackingType on each exercise in session detail responses', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedExercise({
       id: 'user-1-hang',
@@ -629,7 +647,10 @@ describe('workout session routes', () => {
   });
 
   it('omits metadata from soft-deleted exercises in session detail responses', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedExercise({
       id: 'user-1-soft-deleted',
@@ -691,7 +712,10 @@ describe('workout session routes', () => {
   });
 
   it('reorders active session exercises by updating set orderIndex while preserving set data', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-reorder',
@@ -793,7 +817,10 @@ describe('workout session routes', () => {
   });
 
   it('swaps a session exercise while preserving entered set data', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-swap',
@@ -942,7 +969,10 @@ describe('workout session routes', () => {
   });
 
   it('rejects swaps for completed sessions', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-completed-swap',
@@ -980,7 +1010,10 @@ describe('workout session routes', () => {
   });
 
   it('returns 404 when swapping an exercise not present in the session', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-missing-source',
@@ -1017,7 +1050,10 @@ describe('workout session routes', () => {
   });
 
   it('rejects swap targets that are not user-owned exercises', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-invalid-target',
@@ -1066,7 +1102,10 @@ describe('workout session routes', () => {
   });
 
   it('applies save-as-template metadata overrides when provided', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-completed-overrides',
@@ -1130,7 +1169,10 @@ describe('workout session routes', () => {
   });
 
   it('returns a validation error for invalid save-as-template payload', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     const response = await context.app.inject({
       method: 'POST',
@@ -1151,7 +1193,10 @@ describe('workout session routes', () => {
   });
 
   it('creates, updates, lists, and batch-upserts sets for an active owned session', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-1',
@@ -1308,7 +1353,10 @@ describe('workout session routes', () => {
   });
 
   it('enforces ownership, active-session writes, and set-level validation', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-active',
@@ -1442,7 +1490,10 @@ describe('workout session routes', () => {
   });
 
   it('batch upsert is atomic when one set id is invalid', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-1',
@@ -1512,8 +1563,288 @@ describe('workout session routes', () => {
     });
   });
 
+  it('applies workout session corrections to completed sessions and preserves session timing', async () => {
+    const agentToken = seedAgentToken('user-1', 'session-correction-agent-token');
+
+    seedWorkoutSession({
+      id: 'session-completed',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: 1_700_000_000_000,
+      completedAt: 1_700_000_003_600,
+      duration: 60,
+      timeSegments: [
+        {
+          start: '2026-03-12T10:00:00.000Z',
+          end: '2026-03-12T11:00:00.000Z',
+        },
+      ],
+    });
+    seedSessionSet({
+      id: 'set-1',
+      sessionId: 'session-completed',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      weight: 185,
+      reps: 8,
+      completed: true,
+      section: 'main',
+    });
+    seedSessionSet({
+      id: 'set-2',
+      sessionId: 'session-completed',
+      exerciseId: 'global-bench-press',
+      setNumber: 2,
+      weight: 185,
+      reps: 7,
+      completed: true,
+      section: 'main',
+    });
+
+    const beforeSessionRow = context.db
+      .select({
+        status: workoutSessions.status,
+        startedAt: workoutSessions.startedAt,
+        completedAt: workoutSessions.completedAt,
+        updatedAt: workoutSessions.updatedAt,
+      })
+      .from(workoutSessions)
+      .where(eq(workoutSessions.id, 'session-completed'))
+      .get();
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-sessions/session-completed/corrections',
+      headers: createAgentTokenHeader(agentToken),
+      payload: {
+        corrections: [
+          {
+            setId: 'set-1',
+            weight: 190,
+            reps: 6,
+          },
+          {
+            setId: 'set-2',
+            reps: 9,
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        id: 'session-completed',
+        status: 'completed',
+        startedAt: 1_700_000_000_000,
+        completedAt: 1_700_000_003_600,
+        sets: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'set-1',
+            weight: 190,
+            reps: 6,
+          }),
+          expect.objectContaining({
+            id: 'set-2',
+            weight: 185,
+            reps: 9,
+          }),
+        ]),
+      }),
+    });
+
+    const afterSessionRow = context.db
+      .select({
+        status: workoutSessions.status,
+        startedAt: workoutSessions.startedAt,
+        completedAt: workoutSessions.completedAt,
+        updatedAt: workoutSessions.updatedAt,
+      })
+      .from(workoutSessions)
+      .where(eq(workoutSessions.id, 'session-completed'))
+      .get();
+    const correctedSets = context.db
+      .select({
+        id: sessionSets.id,
+        weight: sessionSets.weight,
+        reps: sessionSets.reps,
+      })
+      .from(sessionSets)
+      .where(eq(sessionSets.sessionId, 'session-completed'))
+      .all();
+
+    expect(afterSessionRow).toEqual(beforeSessionRow);
+    expect(correctedSets).toEqual([
+      {
+        id: 'set-1',
+        weight: 190,
+        reps: 6,
+      },
+      {
+        id: 'set-2',
+        weight: 185,
+        reps: 9,
+      },
+    ]);
+  });
+
+  it('rejects invalid workout session correction requests', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'session-completed',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: 1000,
+      completedAt: 1600,
+    });
+    seedSessionSet({
+      id: 'set-1',
+      sessionId: 'session-completed',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      weight: 185,
+      reps: 8,
+      completed: true,
+      section: 'main',
+    });
+    seedWorkoutSession({
+      id: 'session-in-progress',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Lower Body',
+      date: '2026-03-13',
+      status: 'in-progress',
+      startedAt: 2000,
+    });
+    seedSessionSet({
+      id: 'set-2',
+      sessionId: 'session-in-progress',
+      exerciseId: 'user-1-lat-pulldown',
+      setNumber: 1,
+      weight: 150,
+      reps: 10,
+      section: 'main',
+    });
+    seedWorkoutSession({
+      id: 'other-user-session',
+      userId: 'user-2',
+      templateId: 'template-3',
+      name: 'Other User Session',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: 3000,
+      completedAt: 3600,
+    });
+    seedSessionSet({
+      id: 'other-user-set',
+      sessionId: 'other-user-session',
+      exerciseId: 'user-2-private-row',
+      setNumber: 1,
+      weight: 135,
+      reps: 8,
+      completed: true,
+      section: 'main',
+    });
+
+    const [inProgressResponse, otherUserResponse, invalidSetResponse, emptyCorrectionsResponse] =
+      await Promise.all([
+        context.app.inject({
+          method: 'PATCH',
+          url: '/api/v1/workout-sessions/session-in-progress/corrections',
+          headers: createAuthorizationHeader(authToken),
+          payload: {
+            corrections: [
+              {
+                setId: 'set-2',
+                reps: 9,
+              },
+            ],
+          },
+        }),
+        context.app.inject({
+          method: 'PATCH',
+          url: '/api/v1/workout-sessions/other-user-session/corrections',
+          headers: createAuthorizationHeader(authToken),
+          payload: {
+            corrections: [
+              {
+                setId: 'other-user-set',
+                weight: 140,
+              },
+            ],
+          },
+        }),
+        context.app.inject({
+          method: 'PATCH',
+          url: '/api/v1/workout-sessions/session-completed/corrections',
+          headers: createAuthorizationHeader(authToken),
+          payload: {
+            corrections: [
+              {
+                setId: 'missing-set',
+                reps: 10,
+              },
+            ],
+          },
+        }),
+        context.app.inject({
+          method: 'PATCH',
+          url: '/api/v1/workout-sessions/session-completed/corrections',
+          headers: createAuthorizationHeader(authToken),
+          payload: {
+            corrections: [],
+          },
+        }),
+      ]);
+
+    expect(inProgressResponse.statusCode).toBe(409);
+    expect(inProgressResponse.json()).toEqual({
+      error: {
+        code: 'WORKOUT_SESSION_NOT_COMPLETED',
+        message: 'Workout session must be completed before applying corrections',
+      },
+    });
+
+    expect(otherUserResponse.statusCode).toBe(404);
+    expect(otherUserResponse.json()).toEqual({
+      error: {
+        code: 'WORKOUT_SESSION_NOT_FOUND',
+        message: 'Workout session not found',
+      },
+    });
+
+    expect(invalidSetResponse.statusCode).toBe(400);
+    expect(invalidSetResponse.json()).toEqual({
+      error: {
+        code: 'INVALID_SESSION_CORRECTION_SET',
+        message: 'One or more corrections reference sets outside the workout session: missing-set',
+      },
+    });
+
+    expect(emptyCorrectionsResponse.statusCode).toBe(400);
+    expect(emptyCorrectionsResponse.json()).toEqual({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Invalid workout session payload',
+      },
+    });
+  });
+
   it('creates, lists, and fetches workout sessions for the authenticated user', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'existing-session',
@@ -1723,7 +2054,10 @@ describe('workout session routes', () => {
   });
 
   it('filters workout session listings by status and limit', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-completed-1',
@@ -1790,7 +2124,10 @@ describe('workout session routes', () => {
   });
 
   it('includes sessions completed on the same-day range boundary', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-yesterday',
@@ -1834,7 +2171,10 @@ describe('workout session routes', () => {
   });
 
   it('filters workout session listings by multiple statuses', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-paused',
@@ -1888,7 +2228,10 @@ describe('workout session routes', () => {
   });
 
   it('links a newly started session to an unclaimed scheduled workout for today', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
     const today = new Date().toISOString().slice(0, 10);
 
     seedScheduledWorkout({
@@ -1932,7 +2275,10 @@ describe('workout session routes', () => {
   });
 
   it('backfills empty time segments for in-progress sessions at read time', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
     const startedAt = Date.UTC(2026, 2, 12, 14, 30, 0);
 
     seedWorkoutSession({
@@ -1967,7 +2313,10 @@ describe('workout session routes', () => {
   });
 
   it('creates an initial open time segment when starting a new in-progress session', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
     const startedAt = Date.UTC(2026, 2, 12, 10, 0, 0);
 
     const response = await context.app.inject({
@@ -1998,7 +2347,10 @@ describe('workout session routes', () => {
   });
 
   it('pausing closes the current segment and resuming opens a new one', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
     const startedAt = '2026-03-12T10:00:00.000Z';
 
     seedWorkoutSession({
@@ -2062,7 +2414,10 @@ describe('workout session routes', () => {
   });
 
   it('cancelling closes open segment and marks session cancelled', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-cancelled',
@@ -2105,7 +2460,10 @@ describe('workout session routes', () => {
   });
 
   it('completing closes the final segment and calculates duration from segments', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
     const completedAt = Date.parse('2026-03-12T10:25:00.000Z');
 
     seedWorkoutSession({
@@ -2159,7 +2517,10 @@ describe('workout session routes', () => {
   });
 
   it('validates chronological ordering when editing time segments', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-time-edit',
@@ -2205,7 +2566,10 @@ describe('workout session routes', () => {
   });
 
   it('validates out-of-order time segments when editing', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-time-out-of-order',
@@ -2251,7 +2615,10 @@ describe('workout session routes', () => {
   });
 
   it('supports directly editing a segment end timestamp', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-time-end-edit',
@@ -2300,7 +2667,10 @@ describe('workout session routes', () => {
   });
 
   it('supports segment deletion merge and additional split edits', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-time-merge',
@@ -2388,7 +2758,10 @@ describe('workout session routes', () => {
   });
 
   it('updates owned workout sessions by replacing nested set rows', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-1',
@@ -2538,7 +2911,10 @@ describe('workout session routes', () => {
   });
 
   it('patches workout session startedAt and rejects invalid, too-old, or future timestamps', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
     const now = Date.now();
 
     seedWorkoutSession({
@@ -2620,7 +2996,10 @@ describe('workout session routes', () => {
   });
 
   it('patches session notes and exercise notes on an existing completed session', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-1',
@@ -2691,7 +3070,10 @@ describe('workout session routes', () => {
   });
 
   it('rejects reverting a completed session back to in-progress', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-1',
@@ -2725,7 +3107,10 @@ describe('workout session routes', () => {
   });
 
   it('does not overwrite first-set notes when exerciseNotes are normalized to null', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-1',
@@ -2793,7 +3178,10 @@ describe('workout session routes', () => {
   });
 
   it('soft-deletes owned workout sessions', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-1',
@@ -2889,7 +3277,10 @@ describe('workout session routes', () => {
   });
 
   it('rejects inaccessible templates, unavailable exercises, and invalid merged updates', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedWorkoutSession({
       id: 'session-1',
@@ -2964,7 +3355,10 @@ describe('workout session routes', () => {
   });
 
   it('allows patch updates without sets when existing session sets reference now-deleted exercises', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     seedExercise({
       id: 'user-1-soft-delete-lift',
@@ -3012,7 +3406,10 @@ describe('workout session routes', () => {
   });
 
   it('rejects invalid list queries and malformed payloads', async () => {
-    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
 
     const [invalidRangeQueryResponse, invalidStatusQueryResponse, invalidLimitQueryResponse] =
       await Promise.all([

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -6,6 +6,7 @@ import {
   batchUpsertSetsSchema,
   createSetSchema,
   reorderWorkoutSessionExercisesInputSchema,
+  sessionCorrectionRequestSchema,
   saveWorkoutSessionAsTemplateInputSchema,
   swapWorkoutSessionExerciseInputSchema,
   createWorkoutSessionInputSchema,
@@ -33,6 +34,7 @@ import {
 } from '../workout-agent.js';
 
 import {
+  applySessionCorrections,
   batchUpsertSessionSets,
   createSessionSet,
   createWorkoutSession,
@@ -40,6 +42,7 @@ import {
   findInvalidSessionExerciseIds,
   findWorkoutSessionAccess,
   findWorkoutSessionById,
+  InvalidSessionCorrectionSetError,
   listSessionSetGroups,
   reorderWorkoutSessionExercises,
   SessionSetNotFoundError,
@@ -48,6 +51,8 @@ import {
   swapWorkoutSessionExercise,
   updateSessionSet,
   updateWorkoutSession,
+  WorkoutSessionNotCompletedError,
+  WorkoutSessionNotFoundError,
 } from './store.js';
 import { calculateActiveDuration, closeOpenTimeSegment, openTimeSegment } from './time-segments.js';
 
@@ -74,6 +79,11 @@ const WORKOUT_SESSION_NOT_ACTIVE_RESPONSE = {
 const WORKOUT_SESSION_NOT_COMPLETED_RESPONSE = {
   code: 'WORKOUT_SESSION_NOT_COMPLETED',
   message: 'Workout session must be completed before saving as template',
+} as const;
+
+const WORKOUT_SESSION_CORRECTION_NOT_COMPLETED_RESPONSE = {
+  code: 'WORKOUT_SESSION_NOT_COMPLETED',
+  message: 'Workout session must be completed before applying corrections',
 } as const;
 
 const WORKOUT_SESSION_INVALID_TRANSITION_RESPONSE = {
@@ -104,6 +114,11 @@ const WORKOUT_SESSION_EXERCISE_HAS_LOGGED_SETS_RESPONSE = {
 const SESSION_SET_NOT_FOUND_RESPONSE = {
   code: 'SESSION_SET_NOT_FOUND',
   message: 'Session set not found',
+} as const;
+
+const INVALID_SESSION_CORRECTION_SET_RESPONSE = {
+  code: 'INVALID_SESSION_CORRECTION_SET',
+  message: 'One or more corrections reference sets outside the workout session',
 } as const;
 
 const toCreateWorkoutSessionInput = (
@@ -425,6 +440,57 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       return reply.send({
         data: set,
       });
+    },
+  );
+
+  app.patch<{ Params: { sessionId: string } }>(
+    '/:sessionId/corrections',
+    async (request, reply) => {
+      const parsedBody = sessionCorrectionRequestSchema.safeParse(request.body);
+      if (!parsedBody.success) {
+        return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid workout session payload');
+      }
+
+      try {
+        const session = await applySessionCorrections({
+          sessionId: request.params.sessionId,
+          userId: request.userId,
+          corrections: parsedBody.data.corrections,
+        });
+
+        return reply.send({
+          data: session,
+        });
+      } catch (error) {
+        if (error instanceof WorkoutSessionNotFoundError) {
+          return sendError(
+            reply,
+            404,
+            WORKOUT_SESSION_NOT_FOUND_RESPONSE.code,
+            WORKOUT_SESSION_NOT_FOUND_RESPONSE.message,
+          );
+        }
+
+        if (error instanceof WorkoutSessionNotCompletedError) {
+          return sendError(
+            reply,
+            409,
+            WORKOUT_SESSION_CORRECTION_NOT_COMPLETED_RESPONSE.code,
+            WORKOUT_SESSION_CORRECTION_NOT_COMPLETED_RESPONSE.message,
+          );
+        }
+
+        if (error instanceof InvalidSessionCorrectionSetError) {
+          return sendError(
+            reply,
+            400,
+            INVALID_SESSION_CORRECTION_SET_RESPONSE.code,
+            `${INVALID_SESSION_CORRECTION_SET_RESPONSE.message}: ${error.setId}`,
+          );
+        }
+
+        throw error;
+      }
     },
   );
 

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -121,6 +121,11 @@ const INVALID_SESSION_CORRECTION_SET_RESPONSE = {
   message: 'One or more corrections reference sets outside the workout session',
 } as const;
 
+const UNSUPPORTED_SESSION_CORRECTION_RESPONSE = {
+  code: 'INVALID_SESSION_CORRECTION',
+  message: 'Workout session corrections must include weight or reps. Set-level RPE corrections are not persisted yet',
+} as const;
+
 const toCreateWorkoutSessionInput = (
   session: Awaited<ReturnType<typeof findWorkoutSessionById>>,
 ): CreateWorkoutSessionInput => {
@@ -449,6 +454,18 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       const parsedBody = sessionCorrectionRequestSchema.safeParse(request.body);
       if (!parsedBody.success) {
         return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid workout session payload');
+      }
+
+      const unsupportedCorrection = parsedBody.data.corrections.find(
+        (correction) => correction.weight === undefined && correction.reps === undefined,
+      );
+      if (unsupportedCorrection) {
+        return sendError(
+          reply,
+          400,
+          UNSUPPORTED_SESSION_CORRECTION_RESPONSE.code,
+          `${UNSUPPORTED_SESSION_CORRECTION_RESPONSE.message}: ${unsupportedCorrection.setId}`,
+        );
       }
 
       try {

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -7,6 +7,7 @@ import type {
   CreateWorkoutSessionInput,
   ExerciseTrackingType,
   SaveWorkoutSessionAsTemplateInput,
+  SetCorrection,
   SessionSet,
   UpdateSetInput,
   WorkoutSession,
@@ -388,6 +389,36 @@ export class SessionSetNotFoundError extends Error {
   }
 }
 
+export class WorkoutSessionNotFoundError extends Error {
+  readonly sessionId: string;
+
+  constructor(sessionId: string) {
+    super(`Workout session ${sessionId} not found`);
+    this.name = 'WorkoutSessionNotFoundError';
+    this.sessionId = sessionId;
+  }
+}
+
+export class WorkoutSessionNotCompletedError extends Error {
+  readonly sessionId: string;
+
+  constructor(sessionId: string) {
+    super(`Workout session ${sessionId} is not completed`);
+    this.name = 'WorkoutSessionNotCompletedError';
+    this.sessionId = sessionId;
+  }
+}
+
+export class InvalidSessionCorrectionSetError extends Error {
+  readonly setId: string;
+
+  constructor(setId: string) {
+    super(`Session set ${setId} does not belong to the workout session`);
+    this.name = 'InvalidSessionCorrectionSetError';
+    this.setId = setId;
+  }
+}
+
 export const findWorkoutSessionAccess = async (
   id: string,
   userId: string,
@@ -515,6 +546,89 @@ export const listSessionSetGroups = async (sessionId: string): Promise<SessionSe
     .all();
 
   return buildSessionSetGroups(sets);
+};
+
+export const applySessionCorrections = async ({
+  sessionId,
+  userId,
+  corrections,
+}: {
+  sessionId: string;
+  userId: string;
+  corrections: SetCorrection[];
+}): Promise<WorkoutSession> => {
+  const { db } = await import('../../db/index.js');
+
+  db.transaction((tx) => {
+    const session = tx
+      .select(workoutSessionAccessSelection)
+      .from(workoutSessions)
+      .where(
+        and(
+          eq(workoutSessions.id, sessionId),
+          eq(workoutSessions.userId, userId),
+          isNull(workoutSessions.deletedAt),
+        ),
+      )
+      .limit(1)
+      .get();
+
+    if (!session) {
+      throw new WorkoutSessionNotFoundError(sessionId);
+    }
+
+    if (session.status !== 'completed') {
+      throw new WorkoutSessionNotCompletedError(sessionId);
+    }
+
+    const uniqueSetIds = [...new Set(corrections.map((correction) => correction.setId))];
+    const persistedSetIds =
+      uniqueSetIds.length === 0
+        ? []
+        : tx
+            .select({ id: sessionSets.id })
+            .from(sessionSets)
+            .where(and(eq(sessionSets.sessionId, sessionId), inArray(sessionSets.id, uniqueSetIds)))
+            .all()
+            .map((set) => set.id);
+    const persistedSetIdSet = new Set(persistedSetIds);
+
+    for (const setId of uniqueSetIds) {
+      if (!persistedSetIdSet.has(setId)) {
+        throw new InvalidSessionCorrectionSetError(setId);
+      }
+    }
+
+    for (const correction of corrections) {
+      // The correction payload reserves `rpe` for future set-level support.
+      // The current session_sets table only persists weight/reps, so update the fields we can store.
+      const persistedCorrection: Partial<Pick<SessionSetRecord, 'weight' | 'reps'>> = {};
+
+      if (correction.weight !== undefined) {
+        persistedCorrection.weight = correction.weight;
+      }
+
+      if (correction.reps !== undefined) {
+        persistedCorrection.reps = correction.reps;
+      }
+
+      if (Object.keys(persistedCorrection).length === 0) {
+        continue;
+      }
+
+      tx.update(sessionSets)
+        .set(persistedCorrection)
+        .where(and(eq(sessionSets.id, correction.setId), eq(sessionSets.sessionId, sessionId)))
+        .run();
+    }
+  });
+
+  const session = await findWorkoutSessionById(sessionId, userId);
+  if (!session) {
+    throw new Error('Corrected workout session could not be loaded');
+  }
+
+  return session;
 };
 
 export const batchUpsertSessionSets = async ({

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import { and, desc, eq, gte, inArray, isNull, lte, or, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, isNull, lte, or, sql, type SQL } from 'drizzle-orm';
 import type {
   BatchUpsertSetsInput,
   CreateSetInput,
@@ -599,10 +599,21 @@ export const applySessionCorrections = async ({
       }
     }
 
+    const persistedCorrectionsBySetId = new Map<
+      string,
+      {
+        setId: string;
+        weight?: number;
+        reps?: number;
+      }
+    >();
+
     for (const correction of corrections) {
       // The correction payload reserves `rpe` for future set-level support.
       // The current session_sets table only persists weight/reps, so update the fields we can store.
-      const persistedCorrection: Partial<Pick<SessionSetRecord, 'weight' | 'reps'>> = {};
+      const persistedCorrection = persistedCorrectionsBySetId.get(correction.setId) ?? {
+        setId: correction.setId,
+      };
 
       if (correction.weight !== undefined) {
         persistedCorrection.weight = correction.weight;
@@ -612,15 +623,93 @@ export const applySessionCorrections = async ({
         persistedCorrection.reps = correction.reps;
       }
 
-      if (Object.keys(persistedCorrection).length === 0) {
+      persistedCorrectionsBySetId.set(correction.setId, persistedCorrection);
+    }
+
+    const correctionsByPersistedFields = new Map<
+      string,
+      Array<{
+        setId: string;
+        weight?: number;
+        reps?: number;
+      }>
+    >();
+
+    for (const correction of persistedCorrectionsBySetId.values()) {
+      const persistedFieldKey = [
+        correction.weight !== undefined ? 'weight' : null,
+        correction.reps !== undefined ? 'reps' : null,
+      ]
+        .filter((field): field is 'weight' | 'reps' => field !== null)
+        .join(',');
+
+      if (!persistedFieldKey) {
         continue;
       }
 
+      const groupedCorrections = correctionsByPersistedFields.get(persistedFieldKey) ?? [];
+      groupedCorrections.push(correction);
+      correctionsByPersistedFields.set(persistedFieldKey, groupedCorrections);
+    }
+
+    for (const [persistedFieldKey, groupedCorrections] of correctionsByPersistedFields.entries()) {
+      const updatePayload: Partial<Record<'weight' | 'reps', SQL<number>>> = {};
+      const groupedSetIds = groupedCorrections.map((correction) => correction.setId);
+
+      if (persistedFieldKey.includes('weight')) {
+        const weightCorrections = groupedCorrections.filter(
+          (
+            correction,
+          ): correction is {
+            setId: string;
+            weight: number;
+            reps?: number;
+          } => correction.weight !== undefined,
+        );
+        const weightCases = sql.join(
+          weightCorrections.map(
+            (correction) => sql`when ${sessionSets.id} = ${correction.setId} then ${correction.weight}`,
+          ),
+          sql.raw(' '),
+        );
+        updatePayload.weight = sql<number>`case ${weightCases} else ${sessionSets.weight} end`;
+      }
+
+      if (persistedFieldKey.includes('reps')) {
+        const repsCorrections = groupedCorrections.filter(
+          (
+            correction,
+          ): correction is {
+            setId: string;
+            weight?: number;
+            reps: number;
+          } => correction.reps !== undefined,
+        );
+        const repsCases = sql.join(
+          repsCorrections.map(
+            (correction) => sql`when ${sessionSets.id} = ${correction.setId} then ${correction.reps}`,
+          ),
+          sql.raw(' '),
+        );
+        updatePayload.reps = sql<number>`case ${repsCases} else ${sessionSets.reps} end`;
+      }
+
       tx.update(sessionSets)
-        .set(persistedCorrection)
-        .where(and(eq(sessionSets.id, correction.setId), eq(sessionSets.sessionId, sessionId)))
+        .set(updatePayload)
+        .where(and(eq(sessionSets.sessionId, sessionId), inArray(sessionSets.id, groupedSetIds)))
         .run();
     }
+
+    tx.update(workoutSessions)
+      .set({ updatedAt: Date.now() })
+      .where(
+        and(
+          eq(workoutSessions.id, sessionId),
+          eq(workoutSessions.userId, userId),
+          isNull(workoutSessions.deletedAt),
+        ),
+      )
+      .run();
   });
 
   const session = await findWorkoutSessionById(sessionId, userId);

--- a/apps/web/src/features/workouts/api/workouts.test.tsx
+++ b/apps/web/src/features/workouts/api/workouts.test.tsx
@@ -1,0 +1,261 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { WorkoutSession } from '@pulse/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast } from 'sonner';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { useCorrectSessionSets, workoutQueryKeys } from './workouts';
+
+const { toastErrorMock, toastSuccessMock } = vi.hoisted(() => ({
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+  },
+}));
+
+const mockFetch = vi.fn();
+
+const createJsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+
+function createDeferredResponse() {
+  let resolve: ((value: Response) => void) | undefined;
+
+  const promise = new Promise<Response>((nextResolve) => {
+    resolve = nextResolve;
+  });
+
+  if (!resolve) {
+    throw new Error('Expected deferred resolver');
+  }
+
+  return {
+    promise,
+    resolve,
+  };
+}
+
+describe('workouts api corrections', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+    vi.mocked(toast.error).mockClear();
+    vi.mocked(toast.success).mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('optimistically updates the session cache and invalidates receipt queries on success', async () => {
+    const deferredResponse = createDeferredResponse();
+    mockFetch.mockImplementationOnce(() => deferredResponse.promise);
+
+    const initialSession = createSession();
+    const initialExercise = initialSession.exercises?.[0];
+
+    if (!initialExercise) {
+      throw new Error('Expected seeded workout session exercise data');
+    }
+
+    const correctedSession = createSession({
+      exercises: [
+        {
+          ...initialExercise,
+          sets: [
+            {
+              ...initialExercise.sets[0],
+              weight: 190,
+            },
+          ],
+        },
+      ],
+      sets: [
+        {
+          ...initialSession.sets[0],
+          weight: 190,
+        },
+      ],
+    });
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    queryClient.setQueryData(workoutQueryKeys.session(initialSession.id), initialSession);
+
+    const { result } = renderHook(() => useCorrectSessionSets(initialSession.id), { wrapper });
+
+    act(() => {
+      result.current.mutate([
+        {
+          setId: 'set-1',
+          weight: 190,
+        },
+      ]);
+    });
+
+    await waitFor(() => {
+      const optimisticSession = queryClient.getQueryData<WorkoutSession>(
+        workoutQueryKeys.session(initialSession.id),
+      );
+
+      expect(optimisticSession?.sets[0]?.weight).toBe(190);
+      expect(optimisticSession?.exercises?.[0]?.sets[0]?.weight).toBe(190);
+    });
+
+    deferredResponse.resolve(createJsonResponse(correctedSession));
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `/api/v1/workout-sessions/${initialSession.id}/corrections`,
+      expect.objectContaining({
+        body: JSON.stringify({
+          corrections: [
+            {
+              setId: 'set-1',
+              weight: 190,
+            },
+          ],
+        }),
+        method: 'PATCH',
+      }),
+    );
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.session(initialSession.id),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.completedSessions(),
+    });
+    expect(toast.success).toHaveBeenCalledWith('Workout corrections saved');
+  });
+
+  it('rolls back the optimistic session cache when the correction request fails', async () => {
+    const deferredResponse = createDeferredResponse();
+    mockFetch.mockImplementationOnce(() => deferredResponse.promise);
+
+    const initialSession = createSession();
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setQueryData(workoutQueryKeys.session(initialSession.id), initialSession);
+
+    const { result } = renderHook(() => useCorrectSessionSets(initialSession.id), { wrapper });
+
+    act(() => {
+      result.current.mutate([
+        {
+          setId: 'set-1',
+          weight: 190,
+        },
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<WorkoutSession>(workoutQueryKeys.session(initialSession.id))?.sets[0]
+          ?.weight,
+      ).toBe(190);
+    });
+
+    deferredResponse.resolve(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 'WORKOUT_SESSION_NOT_FOUND',
+            message: 'Workout session not found',
+          },
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 404,
+        },
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(
+      queryClient.getQueryData<WorkoutSession>(workoutQueryKeys.session(initialSession.id))?.sets[0]
+        ?.weight,
+    ).toBe(185);
+    expect(toast.error).toHaveBeenCalled();
+  });
+});
+
+function createSession(overrides: Partial<WorkoutSession> = {}): WorkoutSession {
+  return {
+    id: 'session-1',
+    userId: 'user-1',
+    templateId: 'template-1',
+    name: 'Upper Push',
+    date: '2026-03-12',
+    status: 'completed',
+    startedAt: 100,
+    completedAt: 200,
+    duration: 60,
+    timeSegments: [
+      {
+        end: '2026-03-12T11:00:00.000Z',
+        start: '2026-03-12T10:00:00.000Z',
+      },
+    ],
+    feedback: null,
+    notes: null,
+    exercises: [
+      {
+        exerciseId: 'global-bench-press',
+        exerciseName: 'Bench Press',
+        orderIndex: 0,
+        section: 'main',
+        sets: [
+          {
+            id: 'set-1',
+            exerciseId: 'global-bench-press',
+            orderIndex: 0,
+            setNumber: 1,
+            weight: 185,
+            reps: 8,
+            completed: true,
+            skipped: false,
+            section: 'main',
+            notes: null,
+            createdAt: 1,
+          },
+        ],
+        trackingType: 'weight_reps',
+      },
+    ],
+    sets: [
+      {
+        id: 'set-1',
+        exerciseId: 'global-bench-press',
+        orderIndex: 0,
+        setNumber: 1,
+        weight: 185,
+        reps: 8,
+        completed: true,
+        skipped: false,
+        section: 'main',
+        notes: null,
+        createdAt: 1,
+      },
+    ],
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}

--- a/apps/web/src/features/workouts/api/workouts.test.tsx
+++ b/apps/web/src/features/workouts/api/workouts.test.tsx
@@ -192,7 +192,8 @@ describe('workouts api corrections', () => {
       queryClient.getQueryData<WorkoutSession>(workoutQueryKeys.session(initialSession.id))?.sets[0]
         ?.weight,
     ).toBe(185);
-    expect(toast.error).toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    expect(toast.error).toHaveBeenCalledWith('Failed to save corrections. Please try again.');
   });
 });
 

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -4,6 +4,7 @@ import {
   createWorkoutSessionInputSchema,
   exerciseQueryParamsSchema,
   exerciseSchema,
+  sessionCorrectionRequestSchema,
   scheduledWorkoutListItemSchema,
   scheduledWorkoutQueryParamsSchema,
   scheduledWorkoutSchema,
@@ -25,6 +26,7 @@ import {
   type WorkoutSessionListItem,
   type WorkoutSessionQueryParams,
   type WorkoutTemplate,
+  type SetCorrection,
   workoutSessionQueryParamsSchema,
   workoutSessionListItemSchema,
   workoutSessionSchema,
@@ -90,6 +92,10 @@ type SwapSessionExerciseRequest = {
   sessionId: string;
   exerciseId: string;
   newExerciseId: string;
+};
+type CorrectSessionSetsRequest = {
+  sessionId: string;
+  corrections: SetCorrection[];
 };
 type CreateScheduledWorkoutRequest = CreateScheduledWorkoutInput;
 type UpdateScheduledWorkoutRequest = {
@@ -465,6 +471,19 @@ async function swapSessionExercise(input: SwapSessionExerciseRequest) {
   return parsedPayload;
 }
 
+async function correctSessionSets(input: CorrectSessionSetsRequest) {
+  const parsedInput = sessionCorrectionRequestSchema.parse({
+    corrections: input.corrections,
+  });
+  const data = await apiRequest<unknown>(`/api/v1/workout-sessions/${input.sessionId}/corrections`, {
+    body: JSON.stringify(parsedInput),
+    method: 'PATCH',
+  });
+  const payload = workoutSessionResponseSchema.parse({ data });
+
+  return payload.data;
+}
+
 async function createScheduledWorkout(input: CreateScheduledWorkoutRequest) {
   const parsedInput = createScheduledWorkoutInputSchema.parse(input);
   const data = await apiRequest<unknown>('/api/v1/scheduled-workouts', {
@@ -811,6 +830,90 @@ export function useSwapSessionExercise() {
           queryKey: workoutQueryKeys.session(variables.sessionId),
         }),
       ]);
+    },
+  });
+}
+
+function applySetCorrectionsToSession(session: WorkoutSession, corrections: SetCorrection[]) {
+  if (corrections.length === 0) {
+    return session;
+  }
+
+  const correctionsBySetId = new Map(corrections.map((correction) => [correction.setId, correction]));
+  const applyCorrection = <T extends Pick<WorkoutSession['sets'][number], 'id' | 'reps' | 'weight'>>(
+    set: T,
+  ): T => {
+    const correction = correctionsBySetId.get(set.id);
+
+    if (!correction) {
+      return set;
+    }
+
+    return {
+      ...set,
+      ...(correction.weight !== undefined ? { weight: correction.weight } : {}),
+      ...(correction.reps !== undefined ? { reps: correction.reps } : {}),
+    };
+  };
+
+  return {
+    ...session,
+    exercises: session.exercises?.map((exercise) => ({
+      ...exercise,
+      sets: exercise.sets.map((set) => applyCorrection(set)),
+    })),
+    sets: session.sets.map((set) => applyCorrection(set)),
+  };
+}
+
+export function useCorrectSessionSets(sessionId: string) {
+  const queryClient = useQueryClient();
+  const sessionQueryKey = workoutQueryKeys.session(sessionId);
+
+  return useMutation<
+    WorkoutSession,
+    Error,
+    SetCorrection[],
+    {
+      previousSession: WorkoutSession | undefined;
+    }
+  >({
+    mutationFn: (corrections) => correctSessionSets({ sessionId, corrections }),
+    onMutate: async (corrections) => {
+      await queryClient.cancelQueries({
+        queryKey: sessionQueryKey,
+      });
+
+      const previousSession = queryClient.getQueryData<WorkoutSession>(sessionQueryKey);
+
+      if (previousSession) {
+        queryClient.setQueryData<WorkoutSession>(
+          sessionQueryKey,
+          applySetCorrectionsToSession(previousSession, corrections),
+        );
+      }
+
+      return {
+        previousSession,
+      };
+    },
+    onError: (_error, _corrections, context) => {
+      if (context?.previousSession) {
+        queryClient.setQueryData(sessionQueryKey, context.previousSession);
+      }
+    },
+    onSuccess: async (session) => {
+      queryClient.setQueryData(sessionQueryKey, session);
+
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: sessionQueryKey,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.completedSessions(),
+        }),
+      ]);
+      toast.success('Workout corrections saved');
     },
   });
 }

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -878,6 +878,9 @@ export function useCorrectSessionSets(sessionId: string) {
       previousSession: WorkoutSession | undefined;
     }
   >({
+    meta: {
+      suppressGlobalErrorToast: true,
+    },
     mutationFn: (corrections) => correctSessionSets({ sessionId, corrections }),
     onMutate: async (corrections) => {
       await queryClient.cancelQueries({
@@ -901,6 +904,7 @@ export function useCorrectSessionSets(sessionId: string) {
       if (context?.previousSession) {
         queryClient.setQueryData(sessionQueryKey, context.previousSession);
       }
+      toast.error('Failed to save corrections. Please try again.');
     },
     onSuccess: async (session) => {
       queryClient.setQueryData(sessionQueryKey, session);

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -324,6 +324,124 @@ describe('SessionDetail', () => {
     expect(screen.getByLabelText('Incline Dumbbell Press trend chart')).toBeInTheDocument();
   });
 
+  it('supports inline correction editing and only submits changed values', async () => {
+    const currentSession = createSession({
+      id: 'session-correction-save',
+      templateId: 'template-upper-push',
+      sets: [
+        createSet({
+          id: 'set-correction-1',
+          exerciseId: 'incline-dumbbell-press',
+          setNumber: 1,
+          reps: 10,
+          weight: 50,
+          section: 'main',
+        }),
+      ],
+    });
+    const correctedSession = createSession({
+      ...currentSession,
+      sets: [
+        createSet({
+          id: 'set-correction-1',
+          exerciseId: 'incline-dumbbell-press',
+          setNumber: 1,
+          reps: 10,
+          weight: 55,
+          section: 'main',
+        }),
+      ],
+    });
+    let capturedCorrectionPayload: unknown = null;
+
+    mockSessionDetailRequests({
+      correctedSession,
+      onCorrectionRequest: (payload) => {
+        capturedCorrectionPayload = payload;
+      },
+      sessionId: currentSession.id,
+      session: currentSession,
+      sessions: [
+        createSessionListItem({
+          id: currentSession.id,
+          templateId: currentSession.templateId,
+          templateName: 'Upper Push',
+          startedAt: currentSession.startedAt,
+        }),
+      ],
+    });
+
+    renderSessionDetail(currentSession.id);
+    await screen.findByText('Workout receipt');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(screen.getByText(/adjust set values inline/i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Weight for set 1'), {
+      target: { value: '55' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(
+      await screen.findByText('Set 1: 55.0 lbs × 10 reps', { selector: 'span' }),
+    ).toBeInTheDocument();
+    expect(capturedCorrectionPayload).toEqual({
+      corrections: [
+        {
+          setId: 'set-correction-1',
+          weight: 55,
+        },
+      ],
+    });
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+  });
+
+  it('cancels inline correction editing without calling the correction endpoint', async () => {
+    const currentSession = createSession({
+      id: 'session-correction-cancel',
+      templateId: 'template-upper-push',
+      sets: [
+        createSet({
+          id: 'set-correction-cancel-1',
+          exerciseId: 'incline-dumbbell-press',
+          setNumber: 1,
+          reps: 10,
+          weight: 50,
+          section: 'main',
+        }),
+      ],
+    });
+    let correctionCalls = 0;
+
+    mockSessionDetailRequests({
+      onCorrectionRequest: () => {
+        correctionCalls += 1;
+      },
+      sessionId: currentSession.id,
+      session: currentSession,
+      sessions: [
+        createSessionListItem({
+          id: currentSession.id,
+          templateId: currentSession.templateId,
+          templateName: 'Upper Push',
+          startedAt: currentSession.startedAt,
+        }),
+      ],
+    });
+
+    renderSessionDetail(currentSession.id);
+    await screen.findByText('Workout receipt');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(screen.getByLabelText('Weight for set 1'), {
+      target: { value: '55' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByText('Set 1: 50.0 lbs × 10 reps', { selector: 'span' })).toBeInTheDocument();
+    expect(correctionCalls).toBe(0);
+  });
+
   it('keeps sections with exercise notes expanded by default', async () => {
     const currentSession = createSession({
       id: 'session-notes-visible',
@@ -374,6 +492,8 @@ function renderSessionDetail(sessionId: string) {
 }
 
 function mockSessionDetailRequests({
+  correctedSession = null,
+  onCorrectionRequest,
   sessionId,
   session = null,
   sessionStatus = 200,
@@ -381,6 +501,8 @@ function mockSessionDetailRequests({
   sessions,
   templateName = 'Upper Push',
 }: {
+  correctedSession?: WorkoutSession | null;
+  onCorrectionRequest?: (payload: unknown) => void;
   sessionId: string;
   session?: WorkoutSession | null;
   sessionStatus?: number;
@@ -388,15 +510,27 @@ function mockSessionDetailRequests({
   sessions: WorkoutSessionListItem[];
   templateName?: string;
 }) {
-  vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+  let activeSession = session;
+
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
     const url = String(input);
+    const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
 
     if (url.includes('/api/v1/workout-sessions?status=completed')) {
       return Promise.resolve(jsonResponse({ data: sessions }));
     }
 
+    if (method === 'PATCH' && url.includes(`/api/v1/workout-sessions/${sessionId}/corrections`)) {
+      const body =
+        typeof init?.body === 'string' && init.body.length > 0 ? JSON.parse(init.body) : null;
+      onCorrectionRequest?.(body);
+      activeSession = correctedSession ?? session;
+
+      return Promise.resolve(jsonResponse({ data: activeSession }));
+    }
+
     if (url.includes(`/api/v1/workout-sessions/${sessionId}`)) {
-      if (sessionStatus !== 200 || session == null) {
+      if (sessionStatus !== 200 || activeSession == null) {
         return Promise.resolve(
           jsonResponse(
             {
@@ -410,7 +544,7 @@ function mockSessionDetailRequests({
         );
       }
 
-      return Promise.resolve(jsonResponse({ data: session }));
+      return Promise.resolve(jsonResponse({ data: activeSession }));
     }
 
     if (previousSession && url.includes(`/api/v1/workout-sessions/${previousSession.id}`)) {

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -777,7 +777,7 @@ function getSessionSetEditorFields(
 
   const secondsField: SessionSetEditorField = {
     inputMode: 'numeric',
-    key: 'reps',
+    key: 'reps', // seconds are stored in the reps column for time-based tracking types
     label: 'Seconds',
     step: '1',
     suffix: 'sec',

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -31,13 +31,19 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { StatCard } from '@/components/ui/stat-card';
 import { useWeightUnit } from '@/hooks/use-weight-unit';
 import { formatServing, formatWeight as formatWeightValue } from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
 
-import { useCompletedSessions, useWorkoutSession, useWorkoutTemplate } from '../api/workouts';
+import {
+  useCompletedSessions,
+  useCorrectSessionSets,
+  useWorkoutSession,
+  useWorkoutTemplate,
+} from '../api/workouts';
 import {
   getDistanceUnit,
   getSetDistance,
@@ -70,6 +76,21 @@ type SessionDetailSection = {
   exercises: SessionDetailExercise[];
   subtitle: string;
   type: SessionDetailSectionType;
+};
+
+type SessionSetDraft = {
+  reps: string;
+  weight: string;
+};
+
+type SessionSetDraftKey = keyof SessionSetDraft;
+
+type SessionSetEditorField = {
+  inputMode: 'decimal' | 'numeric';
+  key: SessionSetDraftKey;
+  label: string;
+  step: string;
+  suffix?: string;
 };
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
@@ -112,10 +133,13 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
   const comparisonToggleId = useId();
   const [showComparison, setShowComparison] = useState(false);
   const [selectedExerciseId, setSelectedExerciseId] = useState<string | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [setDrafts, setSetDrafts] = useState<Record<string, SessionSetDraft>>({});
   const [searchParams] = useSearchParams();
   const sessionQuery = useWorkoutSession(sessionId);
   const completedSessionsQuery = useCompletedSessions();
   const session = sessionQuery.data;
+  const correctSessionSetsMutation = useCorrectSessionSets(sessionId);
   const templateQuery = useWorkoutTemplate(session?.templateId ?? '');
   const template = templateQuery.data;
   const viewParam = searchParams.get('view');
@@ -180,6 +204,38 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
         })
       : [];
 
+  const startEditing = () => {
+    setSetDrafts(buildSessionSetDrafts(session.sets));
+    setIsEditing(true);
+  };
+
+  const cancelEditing = () => {
+    setIsEditing(false);
+    setSetDrafts({});
+  };
+
+  const updateSetDraft = (set: SessionSet, key: SessionSetDraftKey, value: string) => {
+    setSetDrafts((current) => ({
+      ...current,
+      [set.id]: {
+        ...(current[set.id] ?? createSessionSetDraft(set)),
+        [key]: value,
+      },
+    }));
+  };
+
+  const saveCorrections = async () => {
+    const corrections = buildChangedSetCorrections(session.sets, setDrafts);
+
+    if (corrections.length === 0) {
+      cancelEditing();
+      return;
+    }
+
+    await correctSessionSetsMutation.mutateAsync(corrections);
+    cancelEditing();
+  };
+
   return (
     <section className="space-y-6">
       <Button asChild className="gap-2" size="sm" variant="ghost">
@@ -190,7 +246,12 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
       </Button>
 
       <Card className="gap-0 overflow-hidden border-transparent bg-card/80 py-0">
-        <div className="space-y-4 bg-[var(--color-accent-mint)] px-6 py-6 text-on-mint dark:border-b dark:border-border dark:bg-card dark:text-foreground">
+        <div
+          className={cn(
+            'space-y-4 bg-[var(--color-accent-mint)] px-6 py-6 text-on-mint dark:border-b dark:border-border dark:bg-card dark:text-foreground',
+            isEditing && 'bg-[color-mix(in_srgb,var(--color-accent-mint)_72%,white)]',
+          )}
+        >
           <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
             <div className="space-y-2">
               <div className="flex flex-wrap items-center gap-2">
@@ -216,22 +277,63 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
               </p>
             </div>
 
-            {template?.tags?.length ? (
-              <div className="flex flex-wrap gap-2 lg:max-w-sm lg:justify-end">
-                {template.tags.map((tag) => (
-                  <Badge
-                    className="border-white/45 bg-white/55 dark:border-border dark:bg-secondary"
-                    key={tag}
-                    variant="outline"
-                  >
-                    {formatLabel(tag)}
-                  </Badge>
-                ))}
-              </div>
-            ) : null}
+            <div className="flex flex-col gap-3 lg:items-end">
+              {session.status === 'completed' ? (
+                <div className="flex flex-wrap gap-2 lg:justify-end">
+                  {isEditing ? (
+                    <>
+                      <Button
+                        disabled={correctSessionSetsMutation.isPending}
+                        onClick={cancelEditing}
+                        size="sm"
+                        type="button"
+                        variant="outline"
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        disabled={correctSessionSetsMutation.isPending}
+                        onClick={() => {
+                          void saveCorrections();
+                        }}
+                        size="sm"
+                        type="button"
+                      >
+                        {correctSessionSetsMutation.isPending ? 'Saving…' : 'Save'}
+                      </Button>
+                    </>
+                  ) : (
+                    <Button onClick={startEditing} size="sm" type="button" variant="secondary">
+                      Edit
+                    </Button>
+                  )}
+                </div>
+              ) : null}
+
+              {template?.tags?.length ? (
+                <div className="flex flex-wrap gap-2 lg:max-w-sm lg:justify-end">
+                  {template.tags.map((tag) => (
+                    <Badge
+                      className="border-white/45 bg-white/55 dark:border-border dark:bg-secondary"
+                      key={tag}
+                      variant="outline"
+                    >
+                      {formatLabel(tag)}
+                    </Badge>
+                  ))}
+                </div>
+              ) : null}
+            </div>
           </div>
         </div>
       </Card>
+
+      {isEditing ? (
+        <div className="rounded-3xl border border-[color-mix(in_srgb,var(--color-accent-mint)_55%,transparent)] bg-[color-mix(in_srgb,var(--color-accent-mint)_18%,transparent)] px-4 py-3 text-sm text-foreground shadow-sm">
+          Adjust set values inline, then save the receipt. Weight plus rep or time values are
+          supported here today.
+        </div>
+      ) : null}
 
       <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
         <StatCard
@@ -352,7 +454,14 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
 
             <div className="space-y-3 border-t border-border px-4 py-4 sm:px-6 sm:py-5">
               {section.exercises.map((exercise) => (
-                <Card className="gap-4 py-0" key={`${section.type}-${exercise.exerciseId}`}>
+                <Card
+                  className={cn(
+                    'gap-4 py-0',
+                    isEditing &&
+                      'border-[color-mix(in_srgb,var(--color-accent-mint)_55%,transparent)] bg-[color-mix(in_srgb,var(--color-accent-mint)_10%,transparent)]',
+                  )}
+                  key={`${section.type}-${exercise.exerciseId}`}
+                >
                   <CardHeader className="gap-3 py-5">
                     <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                       <div className="space-y-2">
@@ -387,17 +496,32 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
                   </CardHeader>
 
                   <CardContent className="space-y-4 pb-5">
-                    <div className="flex flex-wrap gap-2">
-                      {exercise.sets.map((set) => (
-                        <span
-                          className="inline-flex rounded-full border border-border bg-secondary/55 px-3 py-1.5 text-sm text-foreground"
-                          key={set.id}
-                        >
-                          {formatSetLabel(set, exercise.trackingType, weightUnit)}
-                        </span>
-                      ))}
-                    </div>
-
+                    {isEditing ? (
+                      <div className="space-y-3 rounded-2xl border border-[color-mix(in_srgb,var(--color-accent-mint)_55%,transparent)] bg-[color-mix(in_srgb,var(--color-accent-mint)_10%,transparent)] p-3">
+                        {exercise.sets.map((set) => (
+                          <SessionSetEditor
+                            draft={setDrafts[set.id] ?? createSessionSetDraft(set)}
+                            key={set.id}
+                            onChange={(key, value) => updateSetDraft(set, key, value)}
+                            set={set}
+                            trackingType={exercise.trackingType}
+                            weightUnit={weightUnit}
+                          />
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="flex flex-wrap gap-2">
+                        {exercise.sets.map((set) => (
+                          <span
+                            className="inline-flex rounded-full border border-border bg-secondary/55 px-3 py-1.5 text-sm text-foreground"
+                            key={set.id}
+                          >
+                            {formatSetLabel(set, exercise.trackingType, weightUnit)}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+ 
                     {showComparison ? (
                       <SessionExerciseComparison
                         currentSession={session}
@@ -407,7 +531,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
                         weightUnit={weightUnit}
                       />
                     ) : null}
-
+ 
                     {exercise.notes ? (
                       <div className="rounded-2xl border border-border bg-secondary/35 px-4 py-3 text-sm text-foreground">
                         <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
@@ -506,6 +630,193 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
       </Dialog>
     </section>
   );
+}
+
+function SessionSetEditor({
+  draft,
+  onChange,
+  set,
+  trackingType,
+  weightUnit,
+}: {
+  draft: SessionSetDraft;
+  onChange: (key: SessionSetDraftKey, value: string) => void;
+  set: SessionSet;
+  trackingType: ExerciseTrackingType;
+  weightUnit: WeightUnit;
+}) {
+  const fields = getSessionSetEditorFields(trackingType, weightUnit);
+  const readOnlySummary = getReadOnlyCorrectionSummary(set, trackingType, weightUnit);
+
+  return (
+    <div className="rounded-2xl border border-border/70 bg-background/70 p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="space-y-1">
+          <p className="text-sm font-semibold text-foreground">{`Set ${set.setNumber}`}</p>
+          <p className="text-xs text-muted">{formatSetLabel(set, trackingType, weightUnit)}</p>
+        </div>
+        {set.skipped ? (
+          <Badge className="border-border bg-secondary/70" variant="outline">
+            Skipped
+          </Badge>
+        ) : null}
+      </div>
+
+      {fields.length > 0 ? (
+        <div
+          className={cn(
+            'mt-3 grid gap-3',
+            fields.length === 1 ? 'sm:grid-cols-[minmax(0,11rem)]' : 'sm:grid-cols-2',
+          )}
+        >
+          {fields.map((field) => {
+            const inputId = `${set.id}-${field.key}`;
+
+            return (
+              <div className="space-y-2" key={field.key}>
+                <Label
+                  className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted"
+                  htmlFor={inputId}
+                >
+                  {field.label}
+                </Label>
+                <div className="relative">
+                  <Input
+                    aria-label={`${field.label} for set ${set.setNumber}`}
+                    className={cn('h-10 pr-10', field.suffix ? 'pr-12' : '')}
+                    id={inputId}
+                    inputMode={field.inputMode}
+                    min={0}
+                    onChange={(event) => onChange(field.key, event.currentTarget.value)}
+                    step={field.step}
+                    type="number"
+                    value={draft[field.key]}
+                  />
+                  {field.suffix ? (
+                    <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-[10px] font-semibold uppercase text-muted">
+                      {field.suffix}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="mt-3 text-sm text-muted">No editable set values are available for this entry.</p>
+      )}
+
+      {readOnlySummary ? <p className="mt-3 text-xs text-muted">{readOnlySummary}</p> : null}
+    </div>
+  );
+}
+
+function buildSessionSetDrafts(sets: SessionSet[]) {
+  return Object.fromEntries(sets.map((set) => [set.id, createSessionSetDraft(set)]));
+}
+
+function createSessionSetDraft(set: SessionSet): SessionSetDraft {
+  return {
+    reps: set.reps != null ? `${set.reps}` : '',
+    weight: set.weight != null ? `${set.weight}` : '',
+  };
+}
+
+function buildChangedSetCorrections(
+  sets: SessionSet[],
+  drafts: Record<string, SessionSetDraft>,
+): { setId: string; reps?: number; weight?: number }[] {
+  return sets.flatMap((set) => {
+    const draft = drafts[set.id];
+
+    if (!draft) {
+      return [];
+    }
+
+    const nextWeight = resolveCorrectionMetric(draft.weight, set.weight);
+    const nextReps = resolveCorrectionMetric(draft.reps, set.reps);
+    const correction = {
+      setId: set.id,
+      ...(nextWeight !== set.weight && nextWeight !== null ? { weight: nextWeight } : {}),
+      ...(nextReps !== set.reps && nextReps !== null ? { reps: nextReps } : {}),
+    };
+
+    return Object.keys(correction).length > 1 ? [correction] : [];
+  });
+}
+
+function resolveCorrectionMetric(value: string, fallback: number | null) {
+  const trimmedValue = value.trim();
+
+  if (trimmedValue.length === 0) {
+    return fallback;
+  }
+
+  const parsedValue = Number(trimmedValue);
+  return Number.isFinite(parsedValue) ? parsedValue : fallback;
+}
+
+function getSessionSetEditorFields(
+  trackingType: ExerciseTrackingType,
+  weightUnit: WeightUnit,
+): SessionSetEditorField[] {
+  const weightField: SessionSetEditorField = {
+    inputMode: 'decimal',
+    key: 'weight',
+    label: 'Weight',
+    step: '0.5',
+    suffix: weightUnit,
+  };
+
+  const repsField: SessionSetEditorField = {
+    inputMode: 'numeric',
+    key: 'reps',
+    label: 'Reps',
+    step: '1',
+  };
+
+  const secondsField: SessionSetEditorField = {
+    inputMode: 'numeric',
+    key: 'reps',
+    label: 'Seconds',
+    step: '1',
+    suffix: 'sec',
+  };
+
+  switch (trackingType) {
+    case 'weight_reps':
+      return [weightField, repsField];
+    case 'weight_seconds':
+      return [weightField, secondsField];
+    case 'bodyweight_reps':
+    case 'reps_only':
+    case 'reps_seconds':
+      return [repsField];
+    case 'seconds_only':
+    case 'cardio':
+      return [secondsField];
+    case 'distance':
+    default:
+      return [];
+  }
+}
+
+function getReadOnlyCorrectionSummary(
+  set: SessionSet,
+  trackingType: ExerciseTrackingType,
+  weightUnit: WeightUnit,
+) {
+  const distance = getSetDistance(set);
+
+  if ((trackingType === 'cardio' || trackingType === 'distance') && distance != null) {
+    return `Logged distance remains ${formatNumber(distance)} ${getDistanceUnit(weightUnit)}.`;
+  }
+
+  if (trackingType === 'reps_seconds') {
+    return 'Time corrections are not persisted separately yet, so only reps can be adjusted here.';
+  }
+
+  return null;
 }
 
 function buildSections(

--- a/apps/web/src/lib/query-client.test.ts
+++ b/apps/web/src/lib/query-client.test.ts
@@ -57,6 +57,24 @@ describe('query-client', () => {
     expect(toastErrorMock).toHaveBeenCalledWith('Network error. Check your connection.');
   });
 
+  it('skips the global mutation toast when the mutation handles its own error feedback', () => {
+    const mutationOnError = createAppQueryClient().getMutationCache().config.onError;
+
+    mutationOnError?.(
+      new ApiError(400, 'Bad Request', 'VALIDATION_ERROR'),
+      {} as never,
+      undefined,
+      {
+        meta: {
+          suppressGlobalErrorToast: true,
+        },
+      } as never,
+      {} as never,
+    );
+
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
   it('logs out and redirects to /login on unauthorized errors', () => {
     const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
     const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -7,6 +7,10 @@ import { useAuthStore } from '@/store/auth-store';
 let appQueryClient: QueryClient | null = null;
 let isHandlingUnauthorized = false;
 
+type GlobalErrorOptions = {
+  skipToast?: boolean;
+};
+
 function redirectToLogin(): void {
   if (typeof window === 'undefined') {
     return;
@@ -20,9 +24,11 @@ function redirectToLogin(): void {
   window.dispatchEvent(new PopStateEvent('popstate'));
 }
 
-function handleGlobalError(error: unknown): void {
+function handleGlobalError(error: unknown, options: GlobalErrorOptions = {}): void {
   if (!isUnauthorizedApiError(error)) {
-    toast.error(toUserFriendlyApiErrorMessage(error));
+    if (!options.skipToast) {
+      toast.error(toUserFriendlyApiErrorMessage(error));
+    }
     return;
   }
 
@@ -50,8 +56,10 @@ export function createAppQueryClient(): QueryClient {
 
   appQueryClient = new QueryClient({
     mutationCache: new MutationCache({
-      onError: (error) => {
-        handleGlobalError(error);
+      onError: (error, _variables, _context, mutation) => {
+        handleGlobalError(error, {
+          skipToast: mutation.meta?.suppressGlobalErrorToast === true,
+        });
       },
     }),
     queryCache: new QueryCache({

--- a/packages/shared/src/schemas/workout-sessions.test.ts
+++ b/packages/shared/src/schemas/workout-sessions.test.ts
@@ -3,12 +3,16 @@ import { describe, expect, it } from 'vitest';
 import {
   createWorkoutSessionInputSchema,
   reorderWorkoutSessionExercisesInputSchema,
+  sessionCorrectionRequestSchema,
+  setCorrectionSchema,
   swapWorkoutSessionExerciseInputSchema,
   sessionSetSchema,
   saveWorkoutSessionAsTemplateInputSchema,
   sessionSetInputSchema,
   type CreateWorkoutSessionInput,
+  type SessionCorrectionRequest,
   type SaveWorkoutSessionAsTemplateInput,
+  type SetCorrection,
   type SwapWorkoutSessionExerciseInput,
   type UpdateWorkoutSessionInput,
   type UpdateWorkoutSessionTimeSegmentsInput,
@@ -181,6 +185,68 @@ describe('sessionSetSchema', () => {
         createdAt: 1_700_000_000_500,
       }),
     ).toThrow('targetWeightMin must be less than or equal to targetWeightMax');
+  });
+});
+
+describe('setCorrectionSchema', () => {
+  it('accepts partial correction updates', () => {
+    const payload: SetCorrection = setCorrectionSchema.parse({
+      setId: ' set-1 ',
+      reps: 9,
+      rpe: 8,
+    });
+
+    expect(payload).toEqual({
+      setId: 'set-1',
+      reps: 9,
+      rpe: 8,
+    });
+  });
+
+  it('rejects corrections without any editable fields', () => {
+    expect(() =>
+      setCorrectionSchema.parse({
+        setId: 'set-1',
+      }),
+    ).toThrow('At least one correction field must be provided');
+  });
+});
+
+describe('sessionCorrectionRequestSchema', () => {
+  it('requires at least one correction row', () => {
+    expect(() =>
+      sessionCorrectionRequestSchema.parse({
+        corrections: [],
+      }),
+    ).toThrow();
+  });
+
+  it('parses a correction request payload', () => {
+    const payload: SessionCorrectionRequest = sessionCorrectionRequestSchema.parse({
+      corrections: [
+        {
+          setId: 'set-1',
+          weight: 190,
+        },
+        {
+          setId: 'set-2',
+          reps: 10,
+        },
+      ],
+    });
+
+    expect(payload).toEqual({
+      corrections: [
+        {
+          setId: 'set-1',
+          weight: 190,
+        },
+        {
+          setId: 'set-2',
+          reps: 10,
+        },
+      ],
+    });
   });
 });
 

--- a/packages/shared/src/schemas/workout-sessions.ts
+++ b/packages/shared/src/schemas/workout-sessions.ts
@@ -388,6 +388,24 @@ export const updateWorkoutSessionTimeSegmentsInputSchema = z.object({
   timeSegments: validatedTimeSegmentsSchema,
 });
 
+export const setCorrectionSchema = z
+  .object({
+    setId: requiredStringSchema,
+    weight: z.number().min(0).optional(),
+    reps: z.number().int().min(0).optional(),
+    rpe: z.number().min(0).max(10).optional(),
+  })
+  .refine(
+    (value) => value.weight !== undefined || value.reps !== undefined || value.rpe !== undefined,
+    {
+      message: 'At least one correction field must be provided',
+    },
+  );
+
+export const sessionCorrectionRequestSchema = z.object({
+  corrections: z.array(setCorrectionSchema).min(1).max(500),
+});
+
 export const reorderWorkoutSessionExercisesInputSchema = z.object({
   section: workoutTemplateSectionTypeSchema,
   exerciseIds: z.array(requiredStringSchema).max(100),
@@ -440,6 +458,8 @@ export type UpdateWorkoutSessionInput = z.infer<typeof updateWorkoutSessionInput
 export type UpdateWorkoutSessionTimeSegmentsInput = z.infer<
   typeof updateWorkoutSessionTimeSegmentsInputSchema
 >;
+export type SetCorrection = z.infer<typeof setCorrectionSchema>;
+export type SessionCorrectionRequest = z.infer<typeof sessionCorrectionRequestSchema>;
 export type ReorderWorkoutSessionExercisesInput = z.infer<
   typeof reorderWorkoutSessionExercisesInputSchema
 >;


### PR DESCRIPTION
## Summary

This PR adds a dedicated correction flow for completed workout sessions so users and agents can fix logged set values without reopening or mutating the session lifecycle. The backend introduces `PATCH /api/v1/workout-sessions/:id/corrections`, validates batched set corrections through shared schemas, and returns the refreshed session detail after applying updates. On the frontend, completed workout receipts now expose an inline edit mode that lets users adjust supported set values directly from the session detail view. The change is designed to preserve session history integrity: corrections update set data only and leave status, `completedAt`, duration, and timing data unchanged.

## Key Changes

- Added `PATCH /api/v1/workout-sessions/:id/corrections` for completed-session set edits.
- Enforced ownership, completed-session-only access, request validation, and rejection of corrections that reference sets outside the target session.
- Added shared Zod schemas/types for correction payloads, including batched corrections and per-row validation.
- Added a completed-session receipt editing flow with `Edit`, `Save`, and `Cancel` actions plus inline per-set inputs.
- Wired the frontend to submit only changed fields and use optimistic TanStack Query updates with rollback/invalidation on completion.
- Added API, schema, mutation, and session-detail tests covering happy path, validation failures, optimistic updates, and cancel behavior.
- Updated `AGENTS.md` and the `pulse-app-usage` skill docs to document the correction endpoint and its constraints.

## Technical Notes

- Corrections are transactional and only allowed when the session status is `completed`; in-progress sessions return `409 WORKOUT_SESSION_NOT_COMPLETED`.
- The backend explicitly preserves session-level timing metadata by updating `session_sets` rows only, not the parent `workout_sessions` row.
- The shared correction contract includes `rpe`, but the store currently persists only `weight` and `reps`; `rpe` is reserved for future set-level persistence support.
- The receipt editor adapts editable inputs by exercise tracking type. Weight/reps and time-based variants are supported where they map to persisted fields, while distance/time data that is not separately stored remains read-only in the UI.
- The client mutation updates both flattened `session.sets` and nested `session.exercises[].sets` caches so the receipt stays consistent during optimistic updates.

## Commits

- `30ab490 docs(workouts): document session correction endpoint`
- `c9b2a5e feat(workouts): add completed session correction editing`
- `c96f89a feat(workouts): add correction endpoint for completed sessions`

## Tasks

- **Add workout session correction API endpoint**: Create PATCH /corrections endpoint for editing set data on completed sessions without changing status
- **Add workout correction UI on completed session detail**: Add Edit button and inline editing for set values on completed workout receipt, wire to correction API
- **Update docs for workout session correction endpoint**: Document correction endpoint in AGENTS.md and pulse-app-usage skill

## Diff Stats

```
.agents/skills/pulse-app-usage/SKILL.md            |   4 +
 AGENTS.md                                          |   2 +-
 apps/api/src/routes/workout-sessions/index.test.ts | 469 +++++++++++++++++++--
 apps/api/src/routes/workout-sessions/index.ts      |  66 +++
 apps/api/src/routes/workout-sessions/store.ts      | 114 +++++
 .../src/features/workouts/api/workouts.test.tsx    | 261 ++++++++++++
 apps/web/src/features/workouts/api/workouts.ts     | 103 +++++
 .../workouts/components/session-detail.test.tsx    | 140 +++++-
 .../workouts/components/session-detail.tsx         | 367 ++++++++++++++--
 .../shared/src/schemas/workout-sessions.test.ts    |  66 +++
 packages/shared/src/schemas/workout-sessions.ts    |  20 +
 11 files changed, 1544 insertions(+), 68 deletions(-)
```