### PR TITLE
refactor(web): standardize query keys, optimistic updates, and invalidation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ci:
+  typecheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -28,8 +29,59 @@ jobs:
       - name: Typecheck
         run: pnpm turbo typecheck
 
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      # Resolve pnpm version from root package.json "packageManager" only.
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
       - name: Lint
         run: pnpm turbo lint
 
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      # Resolve pnpm version from root package.json "packageManager" only.
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
       - name: Build
         run: pnpm turbo build
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      # Resolve pnpm version from root package.json "packageManager" only.
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Test
+        run: pnpm turbo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   typecheck:
+    name: typecheck
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -27,9 +28,10 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Typecheck
-        run: pnpm turbo typecheck
+        run: pnpm typecheck
 
   lint:
+    name: lint
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -46,9 +48,10 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Lint
-        run: pnpm turbo lint
+        run: pnpm lint
 
   build:
+    name: build
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -65,9 +68,10 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: pnpm turbo build
+        run: pnpm build
 
   test:
+    name: test
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -84,4 +88,4 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Test
-        run: pnpm turbo test
+        run: pnpm test

--- a/apps/web/src/features/foods/api/foods.test.tsx
+++ b/apps/web/src/features/foods/api/foods.test.tsx
@@ -4,7 +4,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import type { PropsWithChildren } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useDeleteFood, useFoods, type FoodListResponse } from '@/features/foods/api/foods';
-import { foodKeys } from '@/features/foods/api/keys';
+import { foodQueryKeys } from '@/features/foods/api/keys';
 import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
 import { createAppQueryClient } from '@/lib/query-client';
 
@@ -109,7 +109,7 @@ describe('foods api hooks', () => {
     expect(result.current.data?.meta.total).toBe(12);
     expect(
       queryClient.getQueryState(
-        foodKeys.list({
+        foodQueryKeys.list({
           q: 'chicken',
           tags: ['protein', 'dinner'],
           sort: 'popular',
@@ -149,7 +149,7 @@ describe('foods api hooks', () => {
       },
     };
 
-    queryClient.setQueryData(foodKeys.list({ page: 1, limit: 12, sort: 'name' }), initialData);
+    queryClient.setQueryData(foodQueryKeys.list({ page: 1, limit: 12, sort: 'name' }), initialData);
 
     const { result } = renderHook(() => useDeleteFood(), { wrapper });
 
@@ -160,7 +160,7 @@ describe('foods api hooks', () => {
     await waitFor(() => {
       expect(
         queryClient.getQueryData<FoodListResponse>(
-          foodKeys.list({ page: 1, limit: 12, sort: 'name' }),
+          foodQueryKeys.list({ page: 1, limit: 12, sort: 'name' }),
         )?.data,
       ).toHaveLength(1);
     });
@@ -188,7 +188,7 @@ describe('foods api hooks', () => {
 
     expect(
       queryClient.getQueryData<FoodListResponse>(
-        foodKeys.list({ page: 1, limit: 12, sort: 'name' }),
+        foodQueryKeys.list({ page: 1, limit: 12, sort: 'name' }),
       ),
     ).toEqual(initialData);
   });

--- a/apps/web/src/features/foods/api/foods.ts
+++ b/apps/web/src/features/foods/api/foods.ts
@@ -97,6 +97,8 @@ export function useUpdateFood() {
       }));
 
       queryClient.setQueryData(foodQueryKeys.food(updatedFood.id), updatedFood);
+      queryClient.setQueryData(foodQueryKeys.food(updatedFood.id), updatedFood);
+      queryClient.setQueryData(foodQueryKeys.detail(updatedFood.id), updatedFood);
       await queryClient.invalidateQueries({
         queryKey: foodQueryKeys.foods(),
       });
@@ -140,6 +142,9 @@ export function useDeleteFood() {
       queryClient.removeQueries({
         queryKey: foodQueryKeys.food(foodId),
       });
+      queryClient.removeQueries({
+        queryKey: foodQueryKeys.detail(foodId),
+      });
 
       return {
         previousLists,
@@ -160,6 +165,9 @@ export function useDeleteFood() {
         }),
         queryClient.invalidateQueries({
           queryKey: foodQueryKeys.food(foodId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: foodQueryKeys.detail(foodId),
         }),
       ]),
   });

--- a/apps/web/src/features/foods/api/keys.ts
+++ b/apps/web/src/features/foods/api/keys.ts
@@ -17,10 +17,17 @@ export const foodQueryKeys = {
     params
       ? (['foods', 'list', normalizeListParams(params)] as const)
       : (['foods', 'list'] as const),
+  detail: (id: string) => ['foods', 'detail', id] as const,
+  list: (params?: Partial<FoodQueryParams>) =>
+    params
+      ? (['foods', 'list', normalizeListParams(params)] as const)
+      : (['foods', 'list'] as const),
 };
 
 export const foodKeys = {
   all: foodQueryKeys.all,
-  detail: foodQueryKeys.food,
-  list: foodQueryKeys.foods,
+  detail: foodQueryKeys.detail,
+  food: foodQueryKeys.food,
+  foods: foodQueryKeys.foods,
+  list: foodQueryKeys.list,
 };

--- a/apps/web/src/features/habits/api/habits.test.tsx
+++ b/apps/web/src/features/habits/api/habits.test.tsx
@@ -4,11 +4,13 @@ import type { Habit, HabitEntry } from '@pulse/shared';
 import { type ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { dashboardSnapshotQueryKeys } from '@/hooks/use-dashboard-snapshot';
+import { habitChainQueryKeys } from '@/hooks/use-habit-chains';
 import { apiRequest } from '@/lib/api-client';
 import { createAppQueryClient } from '@/lib/query-client';
 
 import { useHabits, useToggleHabit, useUpdateHabitEntry } from './habits';
-import { habitKeys } from './keys';
+import { habitQueryKeys } from './keys';
 
 vi.mock('@/lib/api-client', () => ({
   apiRequest: vi.fn(),
@@ -124,7 +126,7 @@ describe('habit api hooks', () => {
   it('optimistically updates and rolls back a toggled habit entry on failure', async () => {
     const queryClient = createAppQueryClient();
     const wrapper = createWrapper(queryClient);
-    const queryKey = habitKeys.entries({ from: '2026-03-07', to: '2026-03-07' });
+    const queryKey = habitQueryKeys.entryList({ from: '2026-03-07', to: '2026-03-07' });
     const initialEntries: HabitEntry[] = [
       {
         id: 'entry-1',
@@ -217,7 +219,7 @@ describe('habit api hooks', () => {
   it('optimistically patches a tracked entry and keeps the server result on success', async () => {
     const queryClient = createAppQueryClient();
     const wrapper = createWrapper(queryClient);
-    const queryKey = habitKeys.entries({ from: '2026-03-07', to: '2026-03-07' });
+    const queryKey = habitQueryKeys.entryList({ from: '2026-03-07', to: '2026-03-07' });
     const initialEntries: HabitEntry[] = [
       {
         id: 'entry-2',
@@ -269,6 +271,46 @@ describe('habit api hooks', () => {
 
     await waitFor(() => {
       expect(queryClient.getQueryData<HabitEntry[]>(queryKey)).toEqual([updatedEntry]);
+    });
+  });
+
+  it('invalidates dashboard snapshot and chain queries after a toggle succeeds', async () => {
+    const queryClient = createAppQueryClient();
+    const wrapper = createWrapper(queryClient);
+    const serverEntry: HabitEntry = {
+      id: 'entry-4',
+      habitId: 'habit-4',
+      userId: 'user-1',
+      date: '2026-03-08',
+      completed: true,
+      value: null,
+      isOverride: false,
+      createdAt: 4,
+    };
+    mockedApiRequest.mockResolvedValueOnce(serverEntry);
+
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useToggleHabit(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        habitId: 'habit-4',
+        date: '2026-03-08',
+        completed: true,
+      });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: habitQueryKeys.entryList(),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: habitQueryKeys.list(),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: dashboardSnapshotQueryKeys.all,
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: habitChainQueryKeys.all,
     });
   });
 });

--- a/apps/web/src/features/habits/api/habits.test.tsx
+++ b/apps/web/src/features/habits/api/habits.test.tsx
@@ -127,6 +127,7 @@ describe('habit api hooks', () => {
     const queryClient = createAppQueryClient();
     const wrapper = createWrapper(queryClient);
     const queryKey = habitQueryKeys.entryList({ from: '2026-03-07', to: '2026-03-07' });
+    const chainQueryKey = habitChainQueryKeys.range('2026-02-07', '2026-03-07');
     const initialEntries: HabitEntry[] = [
       {
         id: 'entry-1',
@@ -140,6 +141,7 @@ describe('habit api hooks', () => {
     ];
 
     queryClient.setQueryData(queryKey, initialEntries);
+    queryClient.setQueryData(chainQueryKey, initialEntries);
 
     const deferred = createDeferredPromise<HabitEntry>();
     void deferred.promise.catch(() => undefined);
@@ -164,6 +166,13 @@ describe('habit api hooks', () => {
           id: 'entry-1',
         }),
       ]);
+      expect(queryClient.getQueryData<HabitEntry[]>(chainQueryKey)).toEqual([
+        expect.objectContaining({
+          completed: true,
+          habitId: 'habit-1',
+          id: 'entry-1',
+        }),
+      ]);
     });
 
     act(() => {
@@ -172,6 +181,7 @@ describe('habit api hooks', () => {
 
     await waitFor(() => {
       expect(queryClient.getQueryData<HabitEntry[]>(queryKey)).toEqual(initialEntries);
+      expect(queryClient.getQueryData<HabitEntry[]>(chainQueryKey)).toEqual(initialEntries);
     });
   });
 
@@ -220,6 +230,7 @@ describe('habit api hooks', () => {
     const queryClient = createAppQueryClient();
     const wrapper = createWrapper(queryClient);
     const queryKey = habitQueryKeys.entryList({ from: '2026-03-07', to: '2026-03-07' });
+    const chainQueryKey = habitChainQueryKeys.range('2026-02-07', '2026-03-07');
     const initialEntries: HabitEntry[] = [
       {
         id: 'entry-2',
@@ -238,6 +249,7 @@ describe('habit api hooks', () => {
     };
 
     queryClient.setQueryData(queryKey, initialEntries);
+    queryClient.setQueryData(chainQueryKey, initialEntries);
 
     const deferred = createDeferredPromise<HabitEntry>();
     mockedApiRequest.mockReturnValueOnce(deferred.promise);
@@ -262,6 +274,13 @@ describe('habit api hooks', () => {
           value: 8,
         }),
       ]);
+      expect(queryClient.getQueryData<HabitEntry[]>(chainQueryKey)).toEqual([
+        expect.objectContaining({
+          completed: true,
+          id: 'entry-2',
+          value: 8,
+        }),
+      ]);
     });
 
     await act(async () => {
@@ -271,6 +290,7 @@ describe('habit api hooks', () => {
 
     await waitFor(() => {
       expect(queryClient.getQueryData<HabitEntry[]>(queryKey)).toEqual([updatedEntry]);
+      expect(queryClient.getQueryData<HabitEntry[]>(chainQueryKey)).toEqual([updatedEntry]);
     });
   });
 

--- a/apps/web/src/features/habits/api/habits.test.tsx
+++ b/apps/web/src/features/habits/api/habits.test.tsx
@@ -9,7 +9,14 @@ import { habitChainQueryKeys } from '@/hooks/use-habit-chains';
 import { apiRequest } from '@/lib/api-client';
 import { createAppQueryClient } from '@/lib/query-client';
 
-import { useHabits, useToggleHabit, useUpdateHabitEntry } from './habits';
+import {
+  useCreateHabit,
+  useDeleteHabit,
+  useHabits,
+  useToggleHabit,
+  useUpdateHabit,
+  useUpdateHabitEntry,
+} from './habits';
 import { habitQueryKeys } from './keys';
 
 vi.mock('@/lib/api-client', () => ({
@@ -331,6 +338,104 @@ describe('habit api hooks', () => {
     });
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: habitChainQueryKeys.all,
+    });
+  });
+
+  it('invalidates dashboard snapshot after creating a habit', async () => {
+    const queryClient = createAppQueryClient();
+    const wrapper = createWrapper(queryClient);
+    const createdHabit: Habit = {
+      id: 'habit-created',
+      userId: 'user-1',
+      name: 'Walk',
+      description: null,
+      emoji: '🚶',
+      trackingType: 'boolean',
+      target: null,
+      unit: null,
+      frequency: 'daily',
+      frequencyTarget: null,
+      scheduledDays: null,
+      pausedUntil: null,
+      sortOrder: 2,
+      active: true,
+      createdAt: 3,
+      updatedAt: 3,
+    } as Habit;
+    mockedApiRequest.mockResolvedValueOnce(createdHabit);
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useCreateHabit(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        emoji: '🚶',
+        frequency: 'daily',
+        name: 'Walk',
+        target: null,
+        trackingType: 'boolean',
+        unit: null,
+      });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: dashboardSnapshotQueryKeys.all,
+    });
+  });
+
+  it('invalidates dashboard snapshot after updating a habit definition', async () => {
+    const queryClient = createAppQueryClient();
+    const wrapper = createWrapper(queryClient);
+    const updatedHabit: Habit = {
+      id: 'habit-updated',
+      userId: 'user-1',
+      name: 'Evening Walk',
+      description: null,
+      emoji: '🚶',
+      trackingType: 'boolean',
+      target: null,
+      unit: null,
+      frequency: 'daily',
+      frequencyTarget: null,
+      scheduledDays: null,
+      pausedUntil: null,
+      sortOrder: 2,
+      active: true,
+      createdAt: 3,
+      updatedAt: 4,
+    } as Habit;
+    mockedApiRequest.mockResolvedValueOnce(updatedHabit);
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateHabit(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: 'habit-updated',
+        values: {
+          name: 'Evening Walk',
+        },
+      });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: dashboardSnapshotQueryKeys.all,
+    });
+  });
+
+  it('invalidates dashboard snapshot after deleting a habit', async () => {
+    const queryClient = createAppQueryClient();
+    const wrapper = createWrapper(queryClient);
+    mockedApiRequest.mockResolvedValueOnce({ success: true });
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useDeleteHabit(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: 'habit-delete',
+      });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: dashboardSnapshotQueryKeys.all,
     });
   });
 });

--- a/apps/web/src/features/habits/api/habits.ts
+++ b/apps/web/src/features/habits/api/habits.ts
@@ -15,7 +15,7 @@ import { toast } from 'sonner';
 import { z } from 'zod';
 
 import { habitChainQueryKeys } from '@/hooks/use-habit-chains';
-import { crossFeatureInvalidationMap } from '@/lib/query-invalidation';
+import { crossFeatureInvalidationMap, invalidateQueryKeys } from '@/lib/query-invalidation';
 import { apiRequest } from '@/lib/api-client';
 import { createOptimisticMutation } from '@/lib/optimistic';
 
@@ -244,7 +244,10 @@ export function useCreateHabit() {
       toast.success('Habit created');
     },
     onSettled: async () => {
-      await queryClient.invalidateQueries({ queryKey: habitQueryKeys.habits() });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: habitQueryKeys.habits() }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.habitDefinitionMutation()),
+      ]);
     },
   });
 }
@@ -273,7 +276,10 @@ export function useUpdateHabit() {
       toast.success('Habit updated');
     },
     onSettled: async () => {
-      await queryClient.invalidateQueries({ queryKey: habitQueryKeys.habits() });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: habitQueryKeys.habits() }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.habitDefinitionMutation()),
+      ]);
     },
   });
 }
@@ -296,7 +302,10 @@ export function useDeleteHabit() {
       toast.success('Habit deleted');
     },
     onSettled: async () => {
-      await queryClient.invalidateQueries({ queryKey: habitQueryKeys.habits() });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: habitQueryKeys.habits() }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.habitDefinitionMutation()),
+      ]);
     },
   });
 }
@@ -329,7 +338,6 @@ export function useReorderHabits() {
           return;
         }
 
-        queryClient.setQueryData(habitQueryKeys.habits(), context.previousHabits);
         queryClient.setQueryData(habitQueryKeys.habits(), context.previousHabits);
       },
       onSuccess: () => {
@@ -405,14 +413,14 @@ export function useUpdateHabitEntry() {
       const existingEntry = findCachedHabitEntry(queryClient, variables.id);
       return {
         optimisticEntry: {
-        id: variables.id,
-        habitId: variables.habitId,
-        userId: existingEntry?.userId ?? 'optimistic',
-        date: variables.date,
-        completed: variables.completed ?? existingEntry?.completed ?? false,
-        value: variables.value ?? existingEntry?.value ?? null,
-        isOverride: variables.isOverride ?? existingEntry?.isOverride ?? false,
-        createdAt: existingEntry?.createdAt ?? Date.now(),
+          id: variables.id,
+          habitId: variables.habitId,
+          userId: existingEntry?.userId ?? 'optimistic',
+          date: variables.date,
+          completed: variables.completed ?? existingEntry?.completed ?? false,
+          value: variables.value ?? existingEntry?.value ?? null,
+          isOverride: variables.isOverride ?? existingEntry?.isOverride ?? false,
+          createdAt: existingEntry?.createdAt ?? Date.now(),
         },
       };
     },

--- a/apps/web/src/features/habits/api/habits.ts
+++ b/apps/web/src/features/habits/api/habits.ts
@@ -14,6 +14,7 @@ import {
 import { toast } from 'sonner';
 import { z } from 'zod';
 
+import { invalidateQueryKeys, crossFeatureInvalidationMap } from '@/lib/query-invalidation';
 import { apiRequest } from '@/lib/api-client';
 
 import { habitQueryKeys } from './keys';
@@ -318,6 +319,7 @@ export function useReorderHabits() {
         }
 
         queryClient.setQueryData(habitQueryKeys.habits(), context.previousHabits);
+        queryClient.setQueryData(habitQueryKeys.habits(), context.previousHabits);
       },
       onSuccess: () => {
         toast.success('Habit order updated');
@@ -379,7 +381,11 @@ export function useToggleHabit() {
       applyHabitEntryToCache(queryClient, entry);
     },
     onSettled: async () => {
-      await queryClient.invalidateQueries({ queryKey: habitEntriesQueryKey });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: habitEntriesQueryKey }),
+        queryClient.invalidateQueries({ queryKey: habitQueryKeys.list() }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.habitEntryMutation()),
+      ]);
     },
   });
 }
@@ -434,7 +440,11 @@ export function useUpdateHabitEntry() {
       applyHabitEntryToCache(queryClient, entry);
     },
     onSettled: async () => {
-      await queryClient.invalidateQueries({ queryKey: habitEntriesQueryKey });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: habitEntriesQueryKey }),
+        queryClient.invalidateQueries({ queryKey: habitQueryKeys.list() }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.habitEntryMutation()),
+      ]);
     },
   });
 }

--- a/apps/web/src/features/habits/api/habits.ts
+++ b/apps/web/src/features/habits/api/habits.ts
@@ -14,8 +14,10 @@ import {
 import { toast } from 'sonner';
 import { z } from 'zod';
 
-import { invalidateQueryKeys, crossFeatureInvalidationMap } from '@/lib/query-invalidation';
+import { habitChainQueryKeys } from '@/hooks/use-habit-chains';
+import { crossFeatureInvalidationMap } from '@/lib/query-invalidation';
 import { apiRequest } from '@/lib/api-client';
+import { createOptimisticMutation } from '@/lib/optimistic';
 
 import { habitQueryKeys } from './keys';
 
@@ -57,13 +59,6 @@ type UpdateHabitEntryVariables = {
   isOverride?: boolean;
 };
 
-type HabitEntryQuerySnapshot = Array<readonly [QueryKey, HabitEntry[] | undefined]>;
-
-type MutationContext = {
-  optimisticEntry: HabitEntry;
-  previousEntries: HabitEntryQuerySnapshot;
-};
-
 type ReorderMutationContext = {
   previousHabits: Habit[] | undefined;
 };
@@ -94,18 +89,26 @@ const getEntriesParamsFromQueryKey = (queryKey: QueryKey): HabitEntriesParams | 
   return isHabitEntriesParams(maybeParams) ? maybeParams : null;
 };
 
-const snapshotHabitEntryQueries = (queryClient: ReturnType<typeof useQueryClient>) =>
-  queryClient.getQueriesData<HabitEntry[]>({
-    queryKey: habitEntriesQueryKey,
-  });
+const isHabitChainRangeQueryKey = (queryKey: QueryKey) =>
+  queryKey[0] === 'habits' &&
+  queryKey[1] === 'chains' &&
+  typeof queryKey[2] === 'string' &&
+  typeof queryKey[3] === 'string';
 
-const restoreHabitEntryQueries = (
-  queryClient: ReturnType<typeof useQueryClient>,
-  snapshot: HabitEntryQuerySnapshot,
-) => {
-  snapshot.forEach(([queryKey, entries]) => {
-    queryClient.setQueryData(queryKey, entries);
-  });
+const getRangeFromQueryKey = (queryKey: QueryKey) => {
+  const habitEntryParams = getEntriesParamsFromQueryKey(queryKey);
+  if (habitEntryParams) {
+    return habitEntryParams;
+  }
+
+  if (isHabitChainRangeQueryKey(queryKey)) {
+    return {
+      from: queryKey[2] as string,
+      to: queryKey[3] as string,
+    };
+  }
+
+  return null;
 };
 
 const upsertHabitEntry = (entries: HabitEntry[] | undefined, nextEntry: HabitEntry) => {
@@ -126,24 +129,32 @@ const upsertHabitEntry = (entries: HabitEntry[] | undefined, nextEntry: HabitEnt
 };
 
 const applyHabitEntryToCache = (
-  queryClient: ReturnType<typeof useQueryClient>,
+  entries: HabitEntry[] | undefined,
   nextEntry: HabitEntry,
+  queryKey: QueryKey,
 ) => {
-  snapshotHabitEntryQueries(queryClient).forEach(([queryKey, entries]) => {
-    const params = getEntriesParamsFromQueryKey(queryKey);
-    if (!params || nextEntry.date < params.from || nextEntry.date > params.to) {
-      return;
-    }
+  const range = getRangeFromQueryKey(queryKey);
+  if (!range || nextEntry.date < range.from || nextEntry.date > range.to) {
+    return entries;
+  }
 
-    queryClient.setQueryData(queryKey, upsertHabitEntry(entries, nextEntry));
-  });
+  return upsertHabitEntry(entries, nextEntry);
 };
 
 const findCachedHabitEntry = (
   queryClient: ReturnType<typeof useQueryClient>,
   entryId: string,
 ): HabitEntry | undefined => {
-  for (const [, entries] of snapshotHabitEntryQueries(queryClient)) {
+  const snapshots = [
+    ...queryClient.getQueriesData<HabitEntry[]>({
+      queryKey: habitEntriesQueryKey,
+    }),
+    ...queryClient.getQueriesData<HabitEntry[]>({
+      queryKey: habitChainQueryKeys.all,
+    }),
+  ];
+
+  for (const [, entries] of snapshots) {
     const match = entries?.find((entry) => entry.id === entryId);
     if (match) {
       return match;
@@ -332,9 +343,7 @@ export function useReorderHabits() {
 }
 
 export function useToggleHabit() {
-  const queryClient = useQueryClient();
-
-  return useMutation<HabitEntry, Error, ToggleHabitVariables, MutationContext>({
+  return createOptimisticMutation<HabitEntry[], HabitEntry, ToggleHabitVariables, { optimisticEntry: HabitEntry }>({
     mutationFn: async ({ habitId, date, completed, value, isOverride }) => {
       const entry = await apiRequest<HabitEntry>(`/api/v1/habits/${habitId}/entries`, {
         body: {
@@ -348,11 +357,8 @@ export function useToggleHabit() {
 
       return habitEntrySchema.parse(entry);
     },
-    onMutate: async (variables) => {
-      await queryClient.cancelQueries({ queryKey: habitEntriesQueryKey });
-
-      const previousEntries = snapshotHabitEntryQueries(queryClient);
-      const optimisticEntry: HabitEntry = {
+    getMeta: (variables) => ({
+      optimisticEntry: {
         id: variables.entryId ?? `optimistic-${variables.habitId}-${variables.date}`,
         habitId: variables.habitId,
         userId: 'optimistic',
@@ -361,39 +367,28 @@ export function useToggleHabit() {
         value: variables.value ?? null,
         isOverride: variables.isOverride ?? false,
         createdAt: Date.now(),
-      };
-
-      applyHabitEntryToCache(queryClient, optimisticEntry);
-
-      return {
-        optimisticEntry,
-        previousEntries,
-      };
-    },
-    onError: (_error, _variables, context) => {
-      if (!context) {
-        return;
-      }
-
-      restoreHabitEntryQueries(queryClient, context.previousEntries);
-    },
-    onSuccess: (entry) => {
-      applyHabitEntryToCache(queryClient, entry);
-    },
-    onSettled: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: habitEntriesQueryKey }),
-        queryClient.invalidateQueries({ queryKey: habitQueryKeys.list() }),
-        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.habitEntryMutation()),
-      ]);
-    },
+      },
+    }),
+    invalidateKeys: () => [
+      habitEntriesQueryKey,
+      habitQueryKeys.list(),
+      ...crossFeatureInvalidationMap.habitEntryMutation(),
+    ],
+    queryKey: () => [habitEntriesQueryKey, habitChainQueryKeys.all],
+    reconcile: (current, entry, _variables, context) =>
+      applyHabitEntryToCache(current, entry, context.queryKey),
+    updater: (current, _variables, context) =>
+      applyHabitEntryToCache(current, context.meta.optimisticEntry, context.queryKey),
   });
 }
 
 export function useUpdateHabitEntry() {
-  const queryClient = useQueryClient();
-
-  return useMutation<HabitEntry, Error, UpdateHabitEntryVariables, MutationContext>({
+  return createOptimisticMutation<
+    HabitEntry[],
+    HabitEntry,
+    UpdateHabitEntryVariables,
+    { optimisticEntry: HabitEntry }
+  >({
     mutationFn: async ({ id, completed, value, isOverride }) => {
       const entry = await apiRequest<HabitEntry>(`/api/v1/habit-entries/${id}`, {
         body: {
@@ -406,12 +401,10 @@ export function useUpdateHabitEntry() {
 
       return habitEntrySchema.parse(entry);
     },
-    onMutate: async (variables) => {
-      await queryClient.cancelQueries({ queryKey: habitEntriesQueryKey });
-
-      const previousEntries = snapshotHabitEntryQueries(queryClient);
+    getMeta: (variables, queryClient) => {
       const existingEntry = findCachedHabitEntry(queryClient, variables.id);
-      const optimisticEntry: HabitEntry = {
+      return {
+        optimisticEntry: {
         id: variables.id,
         habitId: variables.habitId,
         userId: existingEntry?.userId ?? 'optimistic',
@@ -420,31 +413,18 @@ export function useUpdateHabitEntry() {
         value: variables.value ?? existingEntry?.value ?? null,
         isOverride: variables.isOverride ?? existingEntry?.isOverride ?? false,
         createdAt: existingEntry?.createdAt ?? Date.now(),
-      };
-
-      applyHabitEntryToCache(queryClient, optimisticEntry);
-
-      return {
-        optimisticEntry,
-        previousEntries,
+        },
       };
     },
-    onError: (_error, _variables, context) => {
-      if (!context) {
-        return;
-      }
-
-      restoreHabitEntryQueries(queryClient, context.previousEntries);
-    },
-    onSuccess: (entry) => {
-      applyHabitEntryToCache(queryClient, entry);
-    },
-    onSettled: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: habitEntriesQueryKey }),
-        queryClient.invalidateQueries({ queryKey: habitQueryKeys.list() }),
-        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.habitEntryMutation()),
-      ]);
-    },
+    invalidateKeys: () => [
+      habitEntriesQueryKey,
+      habitQueryKeys.list(),
+      ...crossFeatureInvalidationMap.habitEntryMutation(),
+    ],
+    queryKey: () => [habitEntriesQueryKey, habitChainQueryKeys.all],
+    reconcile: (current, entry, _variables, context) =>
+      applyHabitEntryToCache(current, entry, context.queryKey),
+    updater: (current, _variables, context) =>
+      applyHabitEntryToCache(current, context.meta.optimisticEntry, context.queryKey),
   });
 }

--- a/apps/web/src/features/habits/api/keys.ts
+++ b/apps/web/src/features/habits/api/keys.ts
@@ -4,11 +4,18 @@ export const habitQueryKeys = {
     params ? (['habits', 'entries', params] as const) : (['habits', 'entries'] as const),
   habit: (id: string) => ['habits', 'habit', id] as const,
   habits: () => ['habits', 'habits'] as const,
+  detail: (id: string) => ['habits', 'detail', id] as const,
+  entryList: (params?: { from: string; to: string }) =>
+    params ? (['habits', 'entries', params] as const) : (['habits', 'entries'] as const),
+  list: () => ['habits', 'list'] as const,
 };
 
 export const habitKeys = {
   all: habitQueryKeys.all,
-  detail: habitQueryKeys.habit,
+  detail: habitQueryKeys.detail,
   entries: habitQueryKeys.entries,
-  list: habitQueryKeys.habits,
+  entryList: habitQueryKeys.entryList,
+  habit: habitQueryKeys.habit,
+  habits: habitQueryKeys.habits,
+  list: habitQueryKeys.list,
 };

--- a/apps/web/src/features/nutrition/api/keys.test.ts
+++ b/apps/web/src/features/nutrition/api/keys.test.ts
@@ -1,20 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
-import { nutritionKeys } from './keys';
+import { nutritionKeys, nutritionQueryKeys } from './keys';
 
 describe('nutritionKeys.weekSummary', () => {
   it('exposes day and daily accessors for the same cache key', () => {
     expect(nutritionKeys.day('2026-03-09')).toEqual(['nutrition', 'day', '2026-03-09']);
     expect(nutritionKeys.daily('2026-03-09')).toEqual(['nutrition', 'day', '2026-03-09']);
   });
-
   it('normalizes date keys to the Monday for the containing week', () => {
-    expect(nutritionKeys.weekSummary('2026-03-03')).toEqual([
+    expect(nutritionQueryKeys.weekSummary('2026-03-03')).toEqual([
       'nutrition',
       'week-summary',
       '2026-03-02',
     ]);
-    expect(nutritionKeys.weekSummary('2026-03-08')).toEqual([
+    expect(nutritionQueryKeys.weekSummary('2026-03-08')).toEqual([
       'nutrition',
       'week-summary',
       '2026-03-02',
@@ -22,7 +21,7 @@ describe('nutritionKeys.weekSummary', () => {
   });
 
   it('accepts ISO timestamps and normalizes to the same week boundary', () => {
-    expect(nutritionKeys.weekSummary('2026-03-05T12:00:00.000Z')).toEqual([
+    expect(nutritionQueryKeys.weekSummary('2026-03-05T12:00:00.000Z')).toEqual([
       'nutrition',
       'week-summary',
       '2026-03-02',

--- a/apps/web/src/features/nutrition/api/nutrition.test.tsx
+++ b/apps/web/src/features/nutrition/api/nutrition.test.tsx
@@ -1,9 +1,13 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { habitQueryKeys } from '@/features/habits/api/keys';
+import { dashboardSnapshotQueryKeys } from '@/hooks/use-dashboard-snapshot';
+import { habitChainQueryKeys } from '@/hooks/use-habit-chains';
+import { macroTrendQueryKeys } from '@/hooks/use-macro-trend';
 import { createQueryClientWrapper } from '@/test/query-client';
 
-import { nutritionKeys } from './keys';
+import { nutritionQueryKeys } from './keys';
 import {
   useDailyNutrition,
   useDeleteMeal,
@@ -189,13 +193,28 @@ describe('nutrition api hooks', () => {
       }),
     );
     expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: nutritionKeys.daily('2026-03-09'),
+      queryKey: nutritionQueryKeys.daily('2026-03-09'),
     });
     expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: nutritionKeys.summary('2026-03-09'),
+      queryKey: nutritionQueryKeys.summary('2026-03-09'),
     });
     expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: nutritionKeys.weekSummary('2026-03-09'),
+      queryKey: nutritionQueryKeys.weekSummary('2026-03-09'),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: dashboardSnapshotQueryKeys.all,
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: macroTrendQueryKeys.all,
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: habitQueryKeys.list(),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: habitQueryKeys.entryList(),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: habitChainQueryKeys.all,
     });
   });
 });

--- a/apps/web/src/features/nutrition/api/nutrition.ts
+++ b/apps/web/src/features/nutrition/api/nutrition.ts
@@ -7,6 +7,7 @@ import type {
 } from '@pulse/shared';
 import { toast } from 'sonner';
 
+import { crossFeatureInvalidationMap, invalidateQueryKeys } from '@/lib/query-invalidation';
 import { apiRequest } from '@/lib/api-client';
 
 import { nutritionQueryKeys } from './keys';
@@ -92,6 +93,7 @@ export const useDeleteMeal = () => {
         queryClient.invalidateQueries({
           queryKey: nutritionQueryKeys.weekSummary(variables.date),
         }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.mealMutation()),
       ]);
       toast.success('Meal deleted');
     },

--- a/apps/web/src/features/nutrition/api/targets.test.tsx
+++ b/apps/web/src/features/nutrition/api/targets.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createQueryClientWrapper } from '@/test/query-client';
 
-import { nutritionTargetKeys, useNutritionTargets, useUpdateTargets } from './targets';
+import { nutritionTargetQueryKeys, useNutritionTargets, useUpdateTargets } from './targets';
 
 const mockFetch = vi.fn();
 
@@ -100,6 +100,6 @@ describe('nutrition target api hooks', () => {
         method: 'POST',
       }),
     );
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: nutritionTargetKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: nutritionTargetQueryKeys.all });
   });
 });

--- a/apps/web/src/features/settings/api/trash.test.tsx
+++ b/apps/web/src/features/settings/api/trash.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createQueryClientWrapper } from '@/test/query-client';
 
-import { trashKeys, usePurgeItem, useRestoreItem, useTrashItems } from './trash';
+import { trashQueryKeys, usePurgeItem, useRestoreItem, useTrashItems } from './trash';
 
 const mockFetch = vi.fn();
 
@@ -64,9 +64,11 @@ describe('trash api hooks', () => {
       });
     });
 
-    expect(mockFetch).toHaveBeenCalledWith('/api/v1/trash/habits/habit-1/restore',
-      expect.objectContaining({ method: 'POST' }));
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: trashKeys.all });
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/trash/habits/habit-1/restore',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: trashQueryKeys.all });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['habits'] });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['foods'] });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['workouts'] });
@@ -86,9 +88,11 @@ describe('trash api hooks', () => {
       });
     });
 
-    expect(mockFetch).toHaveBeenCalledWith('/api/v1/trash/foods/food-1',
-      expect.objectContaining({ method: 'DELETE' }));
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: trashKeys.all });
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/trash/foods/food-1',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: trashQueryKeys.all });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['habits'] });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['foods'] });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['workouts'] });

--- a/apps/web/src/features/settings/api/trash.test.tsx
+++ b/apps/web/src/features/settings/api/trash.test.tsx
@@ -1,9 +1,25 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast } from 'sonner';
 
+import { dashboardSnapshotQueryKeys } from '@/hooks/use-dashboard-snapshot';
+import { habitChainQueryKeys } from '@/hooks/use-habit-chains';
+import { recentWorkoutQueryKeys } from '@/hooks/use-recent-workouts';
 import { createQueryClientWrapper } from '@/test/query-client';
 
 import { trashQueryKeys, usePurgeItem, useRestoreItem, useTrashItems } from './trash';
+
+const { toastErrorMock, toastSuccessMock } = vi.hoisted(() => ({
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+  },
+}));
 
 const mockFetch = vi.fn();
 
@@ -19,6 +35,8 @@ describe('trash api hooks', () => {
   beforeEach(() => {
     mockFetch.mockReset();
     vi.stubGlobal('fetch', mockFetch);
+    vi.mocked(toast.error).mockClear();
+    vi.mocked(toast.success).mockClear();
   });
 
   it('loads grouped trash items', async () => {
@@ -72,6 +90,10 @@ describe('trash api hooks', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['habits'] });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['foods'] });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['workouts'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: dashboardSnapshotQueryKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitChainQueryKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: recentWorkoutQueryKeys.all });
+    expect(toast.success).toHaveBeenCalledWith('Item restored');
   });
 
   it('purges an item and invalidates related queries', async () => {
@@ -96,5 +118,42 @@ describe('trash api hooks', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['habits'] });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['foods'] });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['workouts'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: dashboardSnapshotQueryKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitChainQueryKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: recentWorkoutQueryKeys.all });
+    expect(toast.success).toHaveBeenCalledWith('Item permanently deleted');
+  });
+
+  it('surfaces an error toast when restore fails', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 'NOT_FOUND',
+            message: 'Trash item not found',
+          },
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 404,
+        },
+      ),
+    );
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useRestoreItem(), { wrapper });
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({
+          id: 'habit-missing',
+          type: 'habits',
+        }),
+      ).rejects.toThrow('Trash item not found');
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('The requested item was not found');
   });
 });

--- a/apps/web/src/features/settings/api/trash.ts
+++ b/apps/web/src/features/settings/api/trash.ts
@@ -19,11 +19,13 @@ const mutationResultSchema = z.object({
 export const trashQueryKeys = {
   all: ['trash'] as const,
   items: () => ['trash', 'items'] as const,
+  list: () => ['trash', 'list'] as const,
 };
 
 export const trashKeys = {
   all: trashQueryKeys.all,
-  list: trashQueryKeys.items,
+  items: trashQueryKeys.items,
+  list: trashQueryKeys.list,
 };
 
 type TrashMutationInput = {

--- a/apps/web/src/features/settings/api/trash.ts
+++ b/apps/web/src/features/settings/api/trash.ts
@@ -5,11 +5,15 @@ import {
   type TrashListResponse,
   type TrashType,
 } from '@pulse/shared';
+import { toast } from 'sonner';
 import { z } from 'zod';
 
 import { foodQueryKeys } from '@/features/foods/api/keys';
 import { habitQueryKeys } from '@/features/habits/api/keys';
 import { workoutQueryKeys } from '@/features/workouts/api/workouts';
+import { dashboardSnapshotQueryKeys } from '@/hooks/use-dashboard-snapshot';
+import { habitChainQueryKeys } from '@/hooks/use-habit-chains';
+import { recentWorkoutQueryKeys } from '@/hooks/use-recent-workouts';
 import { apiRequest } from '@/lib/api-client';
 
 const mutationResultSchema = z.object({
@@ -69,6 +73,9 @@ async function invalidateRelatedQueries(queryClient: QueryClient) {
     queryClient.invalidateQueries({ queryKey: habitQueryKeys.all }),
     queryClient.invalidateQueries({ queryKey: foodQueryKeys.all }),
     queryClient.invalidateQueries({ queryKey: workoutQueryKeys.all }),
+    queryClient.invalidateQueries({ queryKey: dashboardSnapshotQueryKeys.all }),
+    queryClient.invalidateQueries({ queryKey: habitChainQueryKeys.all }),
+    queryClient.invalidateQueries({ queryKey: recentWorkoutQueryKeys.all }),
   ]);
 }
 
@@ -86,6 +93,7 @@ export function useRestoreItem() {
     mutationFn: restoreTrashItem,
     onSuccess: async () => {
       await invalidateRelatedQueries(queryClient);
+      toast.success('Item restored');
     },
   });
 }
@@ -97,6 +105,7 @@ export function usePurgeItem() {
     mutationFn: purgeTrashItem,
     onSuccess: async () => {
       await invalidateRelatedQueries(queryClient);
+      toast.success('Item permanently deleted');
     },
   });
 }

--- a/apps/web/src/features/weight/api/weight.test.tsx
+++ b/apps/web/src/features/weight/api/weight.test.tsx
@@ -39,6 +39,34 @@ const createJsonResponse = (data: unknown) =>
     status: 200,
   });
 
+function createDeferredPromise<T>() {
+  let resolveDeferred: ((value: T | PromiseLike<T>) => void) | undefined;
+  let rejectDeferred: ((reason?: unknown) => void) | undefined;
+
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolveDeferred = resolvePromise;
+    rejectDeferred = rejectPromise;
+  });
+
+  return {
+    promise,
+    reject: (reason?: unknown) => {
+      if (!rejectDeferred) {
+        throw new Error('Deferred reject handler was not initialized');
+      }
+
+      rejectDeferred(reason);
+    },
+    resolve: (value: T | PromiseLike<T>) => {
+      if (!resolveDeferred) {
+        throw new Error('Deferred resolve handler was not initialized');
+      }
+
+      resolveDeferred(value);
+    },
+  };
+}
+
 describe('weight api hooks', () => {
   beforeEach(() => {
     mockFetch.mockReset();
@@ -98,27 +126,114 @@ describe('weight api hooks', () => {
     );
   });
 
-  it('posts a weight entry and invalidates weight queries', async () => {
-    mockFetch.mockResolvedValueOnce(
-      createJsonResponse({
-        id: 'weight-2',
-        date: '2026-03-07',
-        weight: 180.8,
-        notes: null,
-        createdAt: 1,
-        updatedAt: 2,
-      }),
-    );
+  it('optimistically logs a weight entry, updates dashboard caches, and invalidates weight queries', async () => {
+    const deferred = createDeferredPromise<Response>();
 
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    queryClient.setQueryData(weightQueryKeys.latest(), {
+      id: 'weight-1',
+      date: '2026-03-06',
+      weight: 181.4,
+      notes: null,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    queryClient.setQueryData(weightQueryKeys.trend({ from: '2026-03-01', to: '2026-03-07' }), [
+      {
+        id: 'weight-1',
+        date: '2026-03-06',
+        weight: 181.4,
+        notes: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ]);
+    queryClient.setQueryData(dashboardSnapshotQueryKeys.detail('2026-03-07'), {
+      date: '2026-03-07',
+      weight: null,
+      macros: {
+        actual: { calories: 0, carbs: 0, fat: 0, protein: 0 },
+        target: { calories: 0, carbs: 0, fat: 0, protein: 0 },
+      },
+      workout: null,
+      habits: {
+        completed: 0,
+        percentage: 0,
+        total: 0,
+      },
+    });
+    queryClient.setQueryData(dashboardWeightTrendQueryKeys.range('2026-03-01', '2026-03-07'), [
+      {
+        date: '2026-03-06',
+        value: 181.4,
+      },
+    ]);
+    mockFetch.mockImplementationOnce(() => deferred.promise);
+
     const { result } = renderHook(() => useLogWeight(), { wrapper });
 
-    await act(async () => {
-      await result.current.mutateAsync({
+    act(() => {
+      result.current.mutate({
         date: '2026-03-07',
         weight: 180.8,
       });
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(weightQueryKeys.latest())).toEqual(
+        expect.objectContaining({
+          date: '2026-03-07',
+          weight: 180.8,
+        }),
+      );
+      expect(
+        queryClient.getQueryData(weightQueryKeys.trend({ from: '2026-03-01', to: '2026-03-07' })),
+      ).toEqual([
+        expect.objectContaining({
+          date: '2026-03-06',
+          id: 'weight-1',
+        }),
+        expect.objectContaining({
+          date: '2026-03-07',
+          weight: 180.8,
+        }),
+      ]);
+      expect(queryClient.getQueryData(dashboardSnapshotQueryKeys.detail('2026-03-07'))).toEqual(
+        expect.objectContaining({
+          weight: {
+            date: '2026-03-07',
+            unit: 'lb',
+            value: 180.8,
+          },
+        }),
+      );
+      expect(
+        queryClient.getQueryData(dashboardWeightTrendQueryKeys.range('2026-03-01', '2026-03-07')),
+      ).toEqual([
+        {
+          date: '2026-03-06',
+          value: 181.4,
+        },
+        {
+          date: '2026-03-07',
+          value: 180.8,
+        },
+      ]);
+    });
+
+    await act(async () => {
+      deferred.resolve(
+        createJsonResponse({
+          id: 'weight-2',
+          date: '2026-03-07',
+          weight: 180.8,
+          notes: null,
+          createdAt: 1,
+          updatedAt: 2,
+        }),
+      );
+      await deferred.promise;
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
@@ -139,6 +254,89 @@ describe('weight api hooks', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitQueryKeys.list() });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitQueryKeys.entryList() });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitChainQueryKeys.all });
+  });
+
+  it('rolls back an optimistic weight entry when logging fails', async () => {
+    const deferred = createDeferredPromise<Response>();
+    void deferred.promise.catch(() => undefined);
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const initialTrend = [
+      {
+        id: 'weight-1',
+        date: '2026-03-06',
+        weight: 181.4,
+        notes: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+
+    queryClient.setQueryData(weightQueryKeys.latest(), initialTrend[0]);
+    queryClient.setQueryData(weightQueryKeys.trend({ from: '2026-03-01', to: '2026-03-07' }), initialTrend);
+    queryClient.setQueryData(dashboardSnapshotQueryKeys.detail('2026-03-07'), {
+      date: '2026-03-07',
+      weight: null,
+      macros: {
+        actual: { calories: 0, carbs: 0, fat: 0, protein: 0 },
+        target: { calories: 0, carbs: 0, fat: 0, protein: 0 },
+      },
+      workout: null,
+      habits: {
+        completed: 0,
+        percentage: 0,
+        total: 0,
+      },
+    });
+    queryClient.setQueryData(dashboardWeightTrendQueryKeys.range('2026-03-01', '2026-03-07'), [
+      {
+        date: '2026-03-06',
+        value: 181.4,
+      },
+    ]);
+    mockFetch.mockImplementationOnce(() => deferred.promise);
+
+    const { result } = renderHook(() => useLogWeight(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        date: '2026-03-07',
+        weight: 180.8,
+      });
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(weightQueryKeys.latest())).toEqual(
+        expect.objectContaining({
+          date: '2026-03-07',
+          weight: 180.8,
+        }),
+      );
+    });
+
+    act(() => {
+      deferred.reject(new Error('log failed'));
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(weightQueryKeys.latest())).toEqual(initialTrend[0]);
+      expect(
+        queryClient.getQueryData(weightQueryKeys.trend({ from: '2026-03-01', to: '2026-03-07' })),
+      ).toEqual(initialTrend);
+      expect(queryClient.getQueryData(dashboardSnapshotQueryKeys.detail('2026-03-07'))).toEqual(
+        expect.objectContaining({
+          weight: null,
+        }),
+      );
+      expect(
+        queryClient.getQueryData(dashboardWeightTrendQueryKeys.range('2026-03-01', '2026-03-07')),
+      ).toEqual([
+        {
+          date: '2026-03-06',
+          value: 181.4,
+        },
+      ]);
+    });
   });
 
   it('deletes a weight entry and invalidates weight queries', async () => {

--- a/apps/web/src/features/weight/api/weight.test.tsx
+++ b/apps/web/src/features/weight/api/weight.test.tsx
@@ -168,6 +168,9 @@ describe('weight api hooks', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: dashboardWeightTrendQueryKeys.all,
     });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitQueryKeys.list() });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitQueryKeys.entryList() });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitChainQueryKeys.all });
   });
 
   it('shows a specific error toast when deleting a weight entry fails', async () => {
@@ -237,5 +240,8 @@ describe('weight api hooks', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: dashboardWeightTrendQueryKeys.all,
     });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitQueryKeys.list() });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitQueryKeys.entryList() });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitChainQueryKeys.all });
   });
 });

--- a/apps/web/src/features/weight/api/weight.test.tsx
+++ b/apps/web/src/features/weight/api/weight.test.tsx
@@ -2,6 +2,10 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { toast } from 'sonner';
 
+import { habitQueryKeys } from '@/features/habits/api/keys';
+import { dashboardSnapshotQueryKeys } from '@/hooks/use-dashboard-snapshot';
+import { habitChainQueryKeys } from '@/hooks/use-habit-chains';
+import { dashboardWeightTrendQueryKeys } from '@/hooks/use-weight-trend';
 import { createQueryClientWrapper } from '@/test/query-client';
 
 import {
@@ -10,7 +14,7 @@ import {
   useLogWeight,
   useUpdateWeight,
   useWeightTrend,
-  weightKeys,
+  weightQueryKeys,
 } from './weight';
 
 const { toastErrorMock, toastSuccessMock } = vi.hoisted(() => ({
@@ -127,7 +131,14 @@ describe('weight api hooks', () => {
         method: 'POST',
       }),
     );
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: weightKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: weightQueryKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: dashboardSnapshotQueryKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: dashboardWeightTrendQueryKeys.all,
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitQueryKeys.list() });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitQueryKeys.entryList() });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitChainQueryKeys.all });
   });
 
   it('deletes a weight entry and invalidates weight queries', async () => {
@@ -152,7 +163,11 @@ describe('weight api hooks', () => {
         method: 'DELETE',
       }),
     );
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: weightKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: weightQueryKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: dashboardSnapshotQueryKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: dashboardWeightTrendQueryKeys.all,
+    });
   });
 
   it('shows a specific error toast when deleting a weight entry fails', async () => {
@@ -177,7 +192,9 @@ describe('weight api hooks', () => {
     const { result } = renderHook(() => useDeleteWeight(), { wrapper });
 
     await act(async () => {
-      await expect(result.current.mutateAsync('missing-weight')).rejects.toThrow('Weight entry not found');
+      await expect(result.current.mutateAsync('missing-weight')).rejects.toThrow(
+        'Weight entry not found',
+      );
     });
 
     expect(toast.error).toHaveBeenCalledWith('Failed to delete weight entry');
@@ -215,6 +232,10 @@ describe('weight api hooks', () => {
         method: 'PATCH',
       }),
     );
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: weightKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: weightQueryKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: dashboardSnapshotQueryKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: dashboardWeightTrendQueryKeys.all,
+    });
   });
 });

--- a/apps/web/src/features/weight/api/weight.test.tsx
+++ b/apps/web/src/features/weight/api/weight.test.tsx
@@ -130,6 +130,7 @@ describe('weight api hooks', () => {
     const deferred = createDeferredPromise<Response>();
 
     const { queryClient, wrapper } = createQueryClientWrapper();
+    const cancelQueries = vi.spyOn(queryClient, 'cancelQueries');
     const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
     queryClient.setQueryData(weightQueryKeys.latest(), {
       id: 'weight-1',
@@ -222,6 +223,11 @@ describe('weight api hooks', () => {
       ]);
     });
 
+    expect(cancelQueries).toHaveBeenCalledWith({ queryKey: weightQueryKeys.latest() });
+    expect(cancelQueries).toHaveBeenCalledWith({ queryKey: weightQueryKeys.trendRoot() });
+    expect(cancelQueries).toHaveBeenCalledWith({ queryKey: dashboardSnapshotQueryKeys.all });
+    expect(cancelQueries).toHaveBeenCalledWith({ queryKey: dashboardWeightTrendQueryKeys.all });
+
     await act(async () => {
       deferred.resolve(
         createJsonResponse({
@@ -254,6 +260,7 @@ describe('weight api hooks', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitQueryKeys.list() });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitQueryKeys.entryList() });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitChainQueryKeys.all });
+    expect(toast.success).toHaveBeenCalledWith('Weight logged');
   });
 
   it('rolls back an optimistic weight entry when logging fails', async () => {

--- a/apps/web/src/features/weight/api/weight.ts
+++ b/apps/web/src/features/weight/api/weight.ts
@@ -20,8 +20,12 @@ type WeightTrendFilters = {
   to?: string;
 };
 
-type DashboardSnapshotCache = Array<readonly [QueryKey, DashboardSnapshot | undefined]>;
-type DashboardWeightTrendCache = Array<readonly [QueryKey, DashboardWeightTrendPoint[] | undefined]>;
+type LogWeightCache =
+  | BodyWeightEntry[]
+  | BodyWeightEntry
+  | null
+  | DashboardSnapshot
+  | DashboardWeightTrendPoint[];
 
 const normalizeWeightTrendFilters = ({ from, to }: WeightTrendFilters = {}) => ({
   from: from ?? null,
@@ -200,6 +204,72 @@ const applyWeightEntryToDashboardTrend = (
   return nextPoints.sort((left, right) => left.date.localeCompare(right.date));
 };
 
+const hasQueryKeyPrefix = (queryKey: QueryKey, prefix: QueryKey) =>
+  prefix.every((segment, index) => queryKey[index] === segment);
+
+const isLatestWeightCache = (
+  cache: LogWeightCache | undefined,
+  queryKey: QueryKey,
+): cache is BodyWeightEntry | null | undefined =>
+  hasQueryKeyPrefix(queryKey, weightQueryKeys.latest()) &&
+  (cache === undefined ||
+    cache === null ||
+    (typeof cache === 'object' && !Array.isArray(cache) && 'createdAt' in cache));
+
+const isWeightTrendCache = (
+  cache: LogWeightCache | undefined,
+  queryKey: QueryKey,
+): cache is BodyWeightEntry[] | undefined =>
+  hasQueryKeyPrefix(queryKey, weightQueryKeys.trendRoot()) &&
+  (cache === undefined ||
+    (Array.isArray(cache) &&
+      (cache.length === 0 || (typeof cache[0] === 'object' && cache[0] !== null && 'createdAt' in cache[0]))));
+
+const isDashboardSnapshotCache = (
+  cache: LogWeightCache | undefined,
+  queryKey: QueryKey,
+): cache is DashboardSnapshot | undefined =>
+  hasQueryKeyPrefix(queryKey, dashboardSnapshotQueryKeys.all) &&
+  (cache === undefined ||
+    (typeof cache === 'object' &&
+      cache !== null &&
+      !Array.isArray(cache) &&
+      'macros' in cache &&
+      'habits' in cache));
+
+const isDashboardWeightTrendCache = (
+  cache: LogWeightCache | undefined,
+  queryKey: QueryKey,
+): cache is DashboardWeightTrendPoint[] | undefined =>
+  hasQueryKeyPrefix(queryKey, dashboardWeightTrendQueryKeys.all) &&
+  (cache === undefined ||
+    (Array.isArray(cache) &&
+      (cache.length === 0 || (typeof cache[0] === 'object' && cache[0] !== null && 'value' in cache[0]))));
+
+const updateLogWeightCache = (
+  current: LogWeightCache | undefined,
+  nextEntry: BodyWeightEntry,
+  queryKey: QueryKey,
+) => {
+  if (isLatestWeightCache(current, queryKey)) {
+    return applyWeightEntryToLatestCache(current, nextEntry);
+  }
+
+  if (isWeightTrendCache(current, queryKey)) {
+    return applyWeightEntryToTrendCache(current, nextEntry, queryKey);
+  }
+
+  if (isDashboardSnapshotCache(current, queryKey)) {
+    return applyWeightEntryToDashboardSnapshot(current, nextEntry);
+  }
+
+  if (isDashboardWeightTrendCache(current, queryKey)) {
+    return applyWeightEntryToDashboardTrend(current, nextEntry, queryKey);
+  }
+
+  return current;
+};
+
 export const useLatestWeight = () =>
   useQuery({
     queryKey: weightQueryKeys.latest(),
@@ -214,18 +284,13 @@ export const useWeightTrend = (from?: string, to?: string) =>
 
 export const useLogWeight = () => {
   return createOptimisticMutation<
-    BodyWeightEntry[],
+    LogWeightCache,
     BodyWeightEntry,
     CreateWeightInput,
-    {
-      optimisticEntry: BodyWeightEntry;
-      previousDashboardSnapshots: DashboardSnapshotCache;
-      previousDashboardWeightTrend: DashboardWeightTrendCache;
-      previousLatest: BodyWeightEntry | null | undefined;
-    }
+    { optimisticEntry: BodyWeightEntry }
   >({
     mutationFn: postWeightEntry,
-    getMeta: (variables, queryClient) => ({
+    getMeta: (variables) => ({
       optimisticEntry: {
         id: `optimistic-weight-${variables.date}`,
         date: variables.date,
@@ -234,70 +299,20 @@ export const useLogWeight = () => {
         createdAt: Date.now(),
         updatedAt: Date.now(),
       },
-      previousDashboardSnapshots: queryClient.getQueriesData<DashboardSnapshot>({
-        queryKey: dashboardSnapshotQueryKeys.all,
-      }),
-      previousDashboardWeightTrend: queryClient.getQueriesData<DashboardWeightTrendPoint[]>({
-        queryKey: dashboardWeightTrendQueryKeys.all,
-      }),
-      previousLatest: queryClient.getQueryData(weightQueryKeys.latest()),
     }),
     invalidateKeys: () => [weightQueryKeys.all, ...crossFeatureInvalidationMap.weightMutation()],
-    onError: async (_error, _variables, context, queryClient) => {
-      if (!context) {
-        return;
-      }
-
-      queryClient.setQueryData(weightQueryKeys.latest(), context.meta.previousLatest);
-      context.meta.previousDashboardSnapshots.forEach(([queryKey, snapshot]) => {
-        queryClient.setQueryData(queryKey, snapshot);
-      });
-      context.meta.previousDashboardWeightTrend.forEach(([queryKey, trend]) => {
-        queryClient.setQueryData(queryKey, trend);
-      });
-    },
-    onMutate: async (_variables, context, queryClient) => {
-      queryClient.setQueryData<BodyWeightEntry | null>(
-        weightQueryKeys.latest(),
-        (current) => applyWeightEntryToLatestCache(current, context.meta.optimisticEntry),
-      );
-
-      context.meta.previousDashboardSnapshots.forEach(([queryKey]) => {
-        queryClient.setQueryData<DashboardSnapshot>(queryKey, (current) =>
-          applyWeightEntryToDashboardSnapshot(current, context.meta.optimisticEntry),
-        );
-      });
-
-      context.meta.previousDashboardWeightTrend.forEach(([queryKey]) => {
-        queryClient.setQueryData<DashboardWeightTrendPoint[]>(queryKey, (current) =>
-          applyWeightEntryToDashboardTrend(current, context.meta.optimisticEntry, queryKey),
-        );
-      });
-    },
-    onSuccess: async (entry, _variables, context, queryClient) => {
-      queryClient.setQueryData<BodyWeightEntry | null>(weightQueryKeys.latest(), (current) =>
-        applyWeightEntryToLatestCache(current, entry),
-      );
-
-      context?.meta.previousDashboardSnapshots.forEach(([queryKey]) => {
-        queryClient.setQueryData<DashboardSnapshot>(queryKey, (current) =>
-          applyWeightEntryToDashboardSnapshot(current, entry),
-        );
-      });
-
-      context?.meta.previousDashboardWeightTrend.forEach(([queryKey]) => {
-        queryClient.setQueryData<DashboardWeightTrendPoint[]>(queryKey, (current) =>
-          applyWeightEntryToDashboardTrend(current, entry, queryKey),
-        );
-      });
-
+    onSuccess: async () => {
       toast.success('Weight logged');
     },
-    queryKey: () => weightQueryKeys.trendRoot(),
-    reconcile: (current, entry, _variables, context) =>
-      applyWeightEntryToTrendCache(current, entry, context.queryKey),
+    queryKey: () => [
+      weightQueryKeys.latest(),
+      weightQueryKeys.trendRoot(),
+      dashboardSnapshotQueryKeys.all,
+      dashboardWeightTrendQueryKeys.all,
+    ],
+    reconcile: (current, entry, _variables, context) => updateLogWeightCache(current, entry, context.queryKey),
     updater: (current, _variables, context) =>
-      applyWeightEntryToTrendCache(current, context.meta.optimisticEntry, context.queryKey),
+      updateLogWeightCache(current, context.meta.optimisticEntry, context.queryKey),
   });
 };
 

--- a/apps/web/src/features/weight/api/weight.ts
+++ b/apps/web/src/features/weight/api/weight.ts
@@ -1,19 +1,27 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { type QueryKey, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type {
   BodyWeightEntry,
   CreateWeightInput,
+  DashboardSnapshot,
+  DashboardWeightTrendPoint,
   DeleteWeightResult,
   PatchWeightInput,
 } from '@pulse/shared';
 import { toast } from 'sonner';
 
-import { crossFeatureInvalidationMap, invalidateQueryKeys } from '@/lib/query-invalidation';
+import { dashboardSnapshotQueryKeys } from '@/hooks/use-dashboard-snapshot';
+import { dashboardWeightTrendQueryKeys } from '@/hooks/use-weight-trend';
 import { apiRequest } from '@/lib/api-client';
+import { createOptimisticMutation } from '@/lib/optimistic';
+import { crossFeatureInvalidationMap, invalidateQueryKeys } from '@/lib/query-invalidation';
 
 type WeightTrendFilters = {
   from?: string;
   to?: string;
 };
+
+type DashboardSnapshotCache = Array<readonly [QueryKey, DashboardSnapshot | undefined]>;
+type DashboardWeightTrendCache = Array<readonly [QueryKey, DashboardWeightTrendPoint[] | undefined]>;
 
 const normalizeWeightTrendFilters = ({ from, to }: WeightTrendFilters = {}) => ({
   from: from ?? null,
@@ -23,6 +31,7 @@ const normalizeWeightTrendFilters = ({ from, to }: WeightTrendFilters = {}) => (
 export const weightQueryKeys = {
   all: ['weight'] as const,
   latest: () => ['weight', 'latest'] as const,
+  trendRoot: () => ['weight', 'trend'] as const,
   trend: ({ from, to }: WeightTrendFilters = {}) =>
     ['weight', 'trend', normalizeWeightTrendFilters({ from, to })] as const,
 };
@@ -67,6 +76,130 @@ const patchWeightEntry = (id: string, input: PatchWeightInput) =>
     method: 'PATCH',
   });
 
+const compareWeightEntries = (left: BodyWeightEntry, right: BodyWeightEntry) =>
+  left.date.localeCompare(right.date) ||
+  left.createdAt - right.createdAt ||
+  left.id.localeCompare(right.id);
+
+const upsertWeightEntry = (entries: BodyWeightEntry[] | undefined, nextEntry: BodyWeightEntry) => {
+  const currentEntries = entries ?? [];
+  const existingIndex = currentEntries.findIndex(
+    (entry) =>
+      entry.id === nextEntry.id ||
+      (entry.id.startsWith('optimistic-weight-') && entry.date === nextEntry.date),
+  );
+
+  if (existingIndex === -1) {
+    return [...currentEntries, nextEntry].sort(compareWeightEntries);
+  }
+
+  const nextEntries = [...currentEntries];
+  nextEntries[existingIndex] = nextEntry;
+
+  return nextEntries.sort(compareWeightEntries);
+};
+
+const getWeightTrendFiltersFromQueryKey = (queryKey: QueryKey) => {
+  const maybeFilters = queryKey[2];
+
+  if (
+    typeof maybeFilters === 'object' &&
+    maybeFilters !== null &&
+    'from' in maybeFilters &&
+    'to' in maybeFilters
+  ) {
+    return maybeFilters as { from: string | null; to: string | null };
+  }
+
+  return null;
+};
+
+const applyWeightEntryToTrendCache = (
+  entries: BodyWeightEntry[] | undefined,
+  nextEntry: BodyWeightEntry,
+  queryKey: QueryKey,
+) => {
+  const filters = getWeightTrendFiltersFromQueryKey(queryKey);
+
+  if (filters) {
+    if ((filters.from && nextEntry.date < filters.from) || (filters.to && nextEntry.date > filters.to)) {
+      return entries;
+    }
+  }
+
+  return upsertWeightEntry(entries, nextEntry);
+};
+
+const isWeightEntryMoreRecent = (
+  candidate: BodyWeightEntry,
+  current: BodyWeightEntry | null | undefined,
+) => {
+  if (!current) {
+    return true;
+  }
+
+  return (
+    candidate.date > current.date ||
+    (candidate.date === current.date && candidate.createdAt >= current.createdAt)
+  );
+};
+
+const applyWeightEntryToLatestCache = (
+  current: BodyWeightEntry | null | undefined,
+  nextEntry: BodyWeightEntry,
+) => (isWeightEntryMoreRecent(nextEntry, current) ? nextEntry : current ?? null);
+
+const applyWeightEntryToDashboardSnapshot = (
+  snapshot: DashboardSnapshot | undefined,
+  nextEntry: BodyWeightEntry,
+) => {
+  if (!snapshot || snapshot.date !== nextEntry.date) {
+    return snapshot;
+  }
+
+  return {
+    ...snapshot,
+    weight: {
+      date: nextEntry.date,
+      unit: 'lb' as const,
+      value: nextEntry.weight,
+    },
+  };
+};
+
+const applyWeightEntryToDashboardTrend = (
+  points: DashboardWeightTrendPoint[] | undefined,
+  nextEntry: BodyWeightEntry,
+  queryKey: QueryKey,
+) => {
+  const from = queryKey[2];
+  const to = queryKey[3];
+
+  if (typeof from !== 'string' || typeof to !== 'string') {
+    return points;
+  }
+
+  if (nextEntry.date < from || nextEntry.date > to) {
+    return points;
+  }
+
+  const currentPoints = points ?? [];
+  const existingIndex = currentPoints.findIndex((point) => point.date === nextEntry.date);
+  const nextPoint = {
+    date: nextEntry.date,
+    value: nextEntry.weight,
+  };
+
+  if (existingIndex === -1) {
+    return [...currentPoints, nextPoint].sort((left, right) => left.date.localeCompare(right.date));
+  }
+
+  const nextPoints = [...currentPoints];
+  nextPoints[existingIndex] = nextPoint;
+
+  return nextPoints.sort((left, right) => left.date.localeCompare(right.date));
+};
+
 export const useLatestWeight = () =>
   useQuery({
     queryKey: weightQueryKeys.latest(),
@@ -80,17 +213,91 @@ export const useWeightTrend = (from?: string, to?: string) =>
   });
 
 export const useLogWeight = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
+  return createOptimisticMutation<
+    BodyWeightEntry[],
+    BodyWeightEntry,
+    CreateWeightInput,
+    {
+      optimisticEntry: BodyWeightEntry;
+      previousDashboardSnapshots: DashboardSnapshotCache;
+      previousDashboardWeightTrend: DashboardWeightTrendCache;
+      previousLatest: BodyWeightEntry | null | undefined;
+    }
+  >({
     mutationFn: postWeightEntry,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: weightQueryKeys.all }),
-        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.weightMutation()),
-      ]);
+    getMeta: (variables, queryClient) => ({
+      optimisticEntry: {
+        id: `optimistic-weight-${variables.date}`,
+        date: variables.date,
+        weight: variables.weight,
+        notes: variables.notes ?? null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+      previousDashboardSnapshots: queryClient.getQueriesData<DashboardSnapshot>({
+        queryKey: dashboardSnapshotQueryKeys.all,
+      }),
+      previousDashboardWeightTrend: queryClient.getQueriesData<DashboardWeightTrendPoint[]>({
+        queryKey: dashboardWeightTrendQueryKeys.all,
+      }),
+      previousLatest: queryClient.getQueryData(weightQueryKeys.latest()),
+    }),
+    invalidateKeys: () => [weightQueryKeys.all, ...crossFeatureInvalidationMap.weightMutation()],
+    onError: async (_error, _variables, context, queryClient) => {
+      if (!context) {
+        return;
+      }
+
+      queryClient.setQueryData(weightQueryKeys.latest(), context.meta.previousLatest);
+      context.meta.previousDashboardSnapshots.forEach(([queryKey, snapshot]) => {
+        queryClient.setQueryData(queryKey, snapshot);
+      });
+      context.meta.previousDashboardWeightTrend.forEach(([queryKey, trend]) => {
+        queryClient.setQueryData(queryKey, trend);
+      });
+    },
+    onMutate: async (_variables, context, queryClient) => {
+      queryClient.setQueryData<BodyWeightEntry | null>(
+        weightQueryKeys.latest(),
+        (current) => applyWeightEntryToLatestCache(current, context.meta.optimisticEntry),
+      );
+
+      context.meta.previousDashboardSnapshots.forEach(([queryKey]) => {
+        queryClient.setQueryData<DashboardSnapshot>(queryKey, (current) =>
+          applyWeightEntryToDashboardSnapshot(current, context.meta.optimisticEntry),
+        );
+      });
+
+      context.meta.previousDashboardWeightTrend.forEach(([queryKey]) => {
+        queryClient.setQueryData<DashboardWeightTrendPoint[]>(queryKey, (current) =>
+          applyWeightEntryToDashboardTrend(current, context.meta.optimisticEntry, queryKey),
+        );
+      });
+    },
+    onSuccess: async (entry, _variables, context, queryClient) => {
+      queryClient.setQueryData<BodyWeightEntry | null>(weightQueryKeys.latest(), (current) =>
+        applyWeightEntryToLatestCache(current, entry),
+      );
+
+      context?.meta.previousDashboardSnapshots.forEach(([queryKey]) => {
+        queryClient.setQueryData<DashboardSnapshot>(queryKey, (current) =>
+          applyWeightEntryToDashboardSnapshot(current, entry),
+        );
+      });
+
+      context?.meta.previousDashboardWeightTrend.forEach(([queryKey]) => {
+        queryClient.setQueryData<DashboardWeightTrendPoint[]>(queryKey, (current) =>
+          applyWeightEntryToDashboardTrend(current, entry, queryKey),
+        );
+      });
+
       toast.success('Weight logged');
     },
+    queryKey: () => weightQueryKeys.trendRoot(),
+    reconcile: (current, entry, _variables, context) =>
+      applyWeightEntryToTrendCache(current, entry, context.queryKey),
+    updater: (current, _variables, context) =>
+      applyWeightEntryToTrendCache(current, context.meta.optimisticEntry, context.queryKey),
   });
 };
 

--- a/apps/web/src/features/weight/api/weight.ts
+++ b/apps/web/src/features/weight/api/weight.ts
@@ -7,6 +7,7 @@ import type {
 } from '@pulse/shared';
 import { toast } from 'sonner';
 
+import { crossFeatureInvalidationMap, invalidateQueryKeys } from '@/lib/query-invalidation';
 import { apiRequest } from '@/lib/api-client';
 
 type WeightTrendFilters = {
@@ -84,7 +85,10 @@ export const useLogWeight = () => {
   return useMutation({
     mutationFn: postWeightEntry,
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: weightQueryKeys.all });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: weightQueryKeys.all }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.weightMutation()),
+      ]);
       toast.success('Weight logged');
     },
   });
@@ -96,7 +100,10 @@ export const useDeleteWeight = () => {
   return useMutation({
     mutationFn: deleteWeightEntry,
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: weightQueryKeys.all });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: weightQueryKeys.all }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.weightMutation()),
+      ]);
       toast.success('Weight entry deleted');
     },
     onError: () => {
@@ -112,7 +119,10 @@ export const useUpdateWeight = () => {
     mutationFn: ({ id, input }: { id: string; input: PatchWeightInput }) =>
       patchWeightEntry(id, input),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: weightQueryKeys.all });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: weightQueryKeys.all }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.weightMutation()),
+      ]);
       toast.success('Weight entry updated');
     },
     onError: () => {

--- a/apps/web/src/features/workouts/api/workouts.keys.test.ts
+++ b/apps/web/src/features/workouts/api/workouts.keys.test.ts
@@ -28,4 +28,8 @@ describe('workoutQueryKeys', () => {
   it('returns a stable template list key', () => {
     expect(workoutQueryKeys.templateList()).toEqual(['workouts', 'templates']);
   });
+
+  it('returns a stable template detail prefix key', () => {
+    expect(workoutQueryKeys.templateDetailPrefix()).toEqual(['workouts', 'template']);
+  });
 });

--- a/apps/web/src/features/workouts/api/workouts.keys.test.ts
+++ b/apps/web/src/features/workouts/api/workouts.keys.test.ts
@@ -32,4 +32,9 @@ describe('workoutQueryKeys', () => {
   it('returns a stable template detail prefix key', () => {
     expect(workoutQueryKeys.templateDetailPrefix()).toEqual(['workouts', 'template']);
   });
+
+  it('returns stable scheduled-workout and session detail prefixes', () => {
+    expect(workoutQueryKeys.scheduledWorkoutListRoot()).toEqual(['workouts', 'scheduled-workouts']);
+    expect(workoutQueryKeys.sessionDetailPrefix()).toEqual(['workouts', 'session']);
+  });
 });

--- a/apps/web/src/features/workouts/api/workouts.keys.test.ts
+++ b/apps/web/src/features/workouts/api/workouts.keys.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { workoutQueryKeys } from './workouts';
+
+describe('workoutQueryKeys', () => {
+  it('returns a stable session detail key', () => {
+    expect(workoutQueryKeys.session('abc')).toEqual(['workouts', 'session', 'abc']);
+  });
+
+  it('normalizes the session list params into the standardized key shape', () => {
+    expect(
+      workoutQueryKeys.sessionList({
+        limit: 10,
+        status: ['completed', 'cancelled'],
+      }),
+    ).toEqual([
+      'workouts',
+      'sessions',
+      {
+        from: null,
+        limit: 10,
+        status: 'completed|cancelled',
+        to: null,
+      },
+    ]);
+  });
+
+  it('returns a stable template list key', () => {
+    expect(workoutQueryKeys.templateList()).toEqual(['workouts', 'templates']);
+  });
+});

--- a/apps/web/src/features/workouts/api/workouts.mutations.test.tsx
+++ b/apps/web/src/features/workouts/api/workouts.mutations.test.tsx
@@ -5,7 +5,15 @@ import { toast } from 'sonner';
 import { dashboardSnapshotQueryKeys } from '@/hooks/use-dashboard-snapshot';
 import { createQueryClientWrapper } from '@/test/query-client';
 
-import { useUpdateExercise, useUpdateTemplate, workoutQueryKeys } from './workouts';
+import {
+  useDeleteTemplate,
+  useReorderTemplateExercises,
+  useSwapSessionExercise,
+  useSwapTemplateExercise,
+  useUpdateExercise,
+  useUpdateTemplate,
+  workoutQueryKeys,
+} from './workouts';
 
 const { toastErrorMock, toastSuccessMock } = vi.hoisted(() => ({
   toastErrorMock: vi.fn(),
@@ -117,6 +125,170 @@ describe('workout mutation hooks', () => {
       queryKey: dashboardSnapshotQueryKeys.all,
     });
     expect(toast.success).toHaveBeenCalledWith('Template updated');
+  });
+
+  it('invalidates dashboard and adjacent workout caches when deleting a template', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        success: true,
+      }),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useDeleteTemplate(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: 'template-1',
+      });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.templateList(),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.template('template-1'),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.scheduledWorkoutListRoot(),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.sessions(),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: dashboardSnapshotQueryKeys.all,
+    });
+    expect(toast.success).toHaveBeenCalledWith('Template deleted');
+  });
+
+  it('invalidates dashboard and scheduled workout caches when swapping a template exercise', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        id: 'template-1',
+        userId: 'user-1',
+        name: 'Upper Push Plus',
+        description: null,
+        tags: [],
+        sections: [
+          { type: 'warmup', exercises: [] },
+          { type: 'main', exercises: [] },
+          { type: 'cooldown', exercises: [] },
+        ],
+        createdAt: 1,
+        updatedAt: 2,
+      }),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useSwapTemplateExercise(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        exerciseId: 'exercise-1',
+        newExerciseId: 'exercise-2',
+        templateId: 'template-1',
+      });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.templateList(),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.template('template-1'),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.scheduledWorkoutListRoot(),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: dashboardSnapshotQueryKeys.all,
+    });
+    expect(toast.success).toHaveBeenCalledWith('Exercise swapped');
+  });
+
+  it('invalidates session detail and list caches when swapping a session exercise', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        id: 'session-1',
+        userId: 'user-1',
+        templateId: 'template-1',
+        name: 'Upper Push Plus',
+        date: '2026-03-08',
+        status: 'in-progress',
+        startedAt: 1,
+        completedAt: null,
+        duration: null,
+        timeSegments: [],
+        feedback: null,
+        notes: null,
+        sets: [],
+        createdAt: 1,
+        updatedAt: 2,
+      }),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useSwapSessionExercise(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        exerciseId: 'exercise-1',
+        newExerciseId: 'exercise-2',
+        sessionId: 'session-1',
+      });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.sessions(),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.session('session-1'),
+    });
+    expect(toast.success).toHaveBeenCalledWith('Exercise swapped');
+  });
+
+  it('invalidates dashboard snapshot queries when reordering template exercises', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        id: 'template-1',
+        userId: 'user-1',
+        name: 'Upper Push Plus',
+        description: null,
+        tags: [],
+        sections: [
+          { type: 'warmup', exercises: [] },
+          { type: 'main', exercises: [] },
+          { type: 'cooldown', exercises: [] },
+        ],
+        createdAt: 1,
+        updatedAt: 2,
+      }),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useReorderTemplateExercises(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        exerciseIds: [],
+        section: 'main',
+        templateId: 'template-1',
+      });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.templateList(),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.template('template-1'),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: dashboardSnapshotQueryKeys.all,
+    });
+    expect(toast.success).toHaveBeenCalledWith('Template exercise order updated');
   });
 
   it('shows the global error toast when updating a template fails', async () => {

--- a/apps/web/src/features/workouts/api/workouts.mutations.test.tsx
+++ b/apps/web/src/features/workouts/api/workouts.mutations.test.tsx
@@ -1,0 +1,156 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast } from 'sonner';
+
+import { dashboardSnapshotQueryKeys } from '@/hooks/use-dashboard-snapshot';
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { useUpdateExercise, useUpdateTemplate, workoutQueryKeys } from './workouts';
+
+const { toastErrorMock, toastSuccessMock } = vi.hoisted(() => ({
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+  },
+}));
+
+const mockFetch = vi.fn();
+
+const createJsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+
+describe('workout mutation hooks', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+    vi.mocked(toast.error).mockClear();
+    vi.mocked(toast.success).mockClear();
+  });
+
+  it('invalidates session detail caches when updating an exercise', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        id: 'exercise-1',
+        userId: 'user-1',
+        name: 'Incline Bench Press',
+        muscleGroups: ['chest'],
+        equipment: 'barbell',
+        category: 'compound',
+        trackingType: 'weight_reps',
+        tags: [],
+        formCues: [],
+        instructions: null,
+        coachingNotes: null,
+        relatedExerciseIds: [],
+        createdAt: 1,
+        updatedAt: 2,
+      }),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateExercise(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: 'exercise-1',
+        input: {
+          name: 'Incline Bench Press',
+        },
+      });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.sessionDetailPrefix(),
+    });
+    expect(toast.success).toHaveBeenCalledWith('Exercise updated');
+  });
+
+  it('invalidates template-adjacent workout caches when updating a template', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        id: 'template-1',
+        userId: 'user-1',
+        name: 'Upper Push Plus',
+        description: null,
+        tags: [],
+        sections: [
+          { type: 'warmup', exercises: [] },
+          { type: 'main', exercises: [] },
+          { type: 'cooldown', exercises: [] },
+        ],
+        createdAt: 1,
+        updatedAt: 2,
+      }),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateTemplate(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: 'template-1',
+        input: {
+          name: 'Upper Push Plus',
+        },
+      });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.scheduledWorkoutListRoot(),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.sessions(),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: dashboardSnapshotQueryKeys.all,
+    });
+    expect(toast.success).toHaveBeenCalledWith('Template updated');
+  });
+
+  it('shows the global error toast when updating a template fails', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 'NOT_FOUND',
+            message: 'Template not found',
+          },
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 404,
+        },
+      ),
+    );
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useUpdateTemplate(), { wrapper });
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({
+          id: 'missing-template',
+          input: {
+            name: 'Does not matter',
+          },
+        }),
+      ).rejects.toThrow('Template not found');
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('The requested item was not found');
+  });
+});

--- a/apps/web/src/features/workouts/api/workouts.optimistic.test.tsx
+++ b/apps/web/src/features/workouts/api/workouts.optimistic.test.tsx
@@ -1,11 +1,13 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { dashboardSnapshotQueryKeys } from '@/hooks/use-dashboard-snapshot';
 import { createQueryClientWrapper } from '@/test/query-client';
 
 import {
   useRenameExercise,
   useRenameTemplate,
+  useScheduleWorkout,
   useRescheduleWorkout,
   useUnscheduleWorkout,
   workoutQueryKeys,
@@ -152,6 +154,7 @@ describe('workout optimistic mutations', () => {
   it('renames a template optimistically in list and detail caches', async () => {
     const deferred = createDeferredPromise<Response>();
     const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
 
     queryClient.setQueryData(workoutQueryKeys.templateList(), [template]);
     queryClient.setQueryData(workoutQueryKeys.template('template-1'), template);
@@ -183,6 +186,18 @@ describe('workout optimistic mutations', () => {
         }),
       );
       await deferred.promise;
+    });
+
+    await waitFor(() => {
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: workoutQueryKeys.scheduledWorkoutListRoot(),
+      });
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: workoutQueryKeys.sessions(),
+      });
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: dashboardSnapshotQueryKeys.all,
+      });
     });
   });
 
@@ -257,6 +272,7 @@ describe('workout optimistic mutations', () => {
     const rescheduleDeferred = createDeferredPromise<Response>();
     const unscheduleDeferred = createDeferredPromise<Response>();
     const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
 
     queryClient.setQueryData(
       workoutQueryKeys.scheduledWorkoutList({ from: '2026-03-01', to: '2026-03-31' }),
@@ -319,6 +335,47 @@ describe('workout optimistic mutations', () => {
         }),
       );
       await unscheduleDeferred.promise;
+    });
+
+    await waitFor(() => {
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: dashboardSnapshotQueryKeys.all,
+      });
+    });
+  });
+
+  it('schedules workouts and invalidates dashboard snapshot queries', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        id: 'scheduled-2',
+        userId: 'user-1',
+        templateId: 'template-1',
+        date: '2026-03-11',
+        sessionId: null,
+        createdAt: 2,
+        updatedAt: 2,
+      }),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useScheduleWorkout(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        date: '2026-03-11',
+        templateId: 'template-1',
+      });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.scheduledWorkoutList(),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.sessions(),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: dashboardSnapshotQueryKeys.all,
     });
   });
 });

--- a/apps/web/src/features/workouts/api/workouts.optimistic.test.tsx
+++ b/apps/web/src/features/workouts/api/workouts.optimistic.test.tsx
@@ -1,0 +1,324 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import {
+  useRenameExercise,
+  useRenameTemplate,
+  useRescheduleWorkout,
+  useUnscheduleWorkout,
+  workoutQueryKeys,
+} from './workouts';
+
+const mockFetch = vi.fn();
+
+const createJsonResponse = (data: unknown) =>
+  new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status: 200,
+  });
+
+function createDeferredPromise<ResponseT>() {
+  let resolveDeferred: ((value: ResponseT | PromiseLike<ResponseT>) => void) | undefined;
+
+  const promise = new Promise<ResponseT>((resolvePromise) => {
+    resolveDeferred = resolvePromise;
+  });
+
+  return {
+    promise,
+    resolve: (value: ResponseT | PromiseLike<ResponseT>) => {
+      if (!resolveDeferred) {
+        throw new Error('Deferred resolve handler was not initialized');
+      }
+
+      resolveDeferred(value);
+    },
+  };
+}
+
+const exercise = {
+  id: 'exercise-1',
+  userId: 'user-1',
+  name: 'Bench Press',
+  muscleGroups: ['chest'],
+  equipment: 'barbell',
+  category: 'compound' as const,
+  trackingType: 'weight_reps' as const,
+  tags: [],
+  formCues: [],
+  instructions: null,
+  coachingNotes: null,
+  relatedExerciseIds: [],
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+const template = {
+  id: 'template-1',
+  userId: 'user-1',
+  name: 'Push Day',
+  description: null,
+  tags: [],
+  sections: [
+    {
+      type: 'warmup' as const,
+      exercises: [],
+    },
+    {
+      type: 'main' as const,
+      exercises: [
+        {
+          id: 'template-exercise-1',
+          exerciseId: 'exercise-1',
+          exerciseName: 'Bench Press',
+          trackingType: 'weight_reps' as const,
+          exercise: {
+            coachingNotes: null,
+            formCues: [],
+            instructions: null,
+          },
+          sets: 3,
+          repsMin: 8,
+          repsMax: 10,
+          tempo: null,
+          restSeconds: null,
+          supersetGroup: null,
+          notes: null,
+          cues: [],
+          setTargets: [],
+          programmingNotes: null,
+        },
+      ],
+    },
+    {
+      type: 'cooldown' as const,
+      exercises: [],
+    },
+  ],
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+const session = {
+  id: 'session-1',
+  userId: 'user-1',
+  templateId: 'template-1',
+  name: 'Push Day',
+  date: '2026-03-07',
+  status: 'in-progress' as const,
+  startedAt: 1,
+  completedAt: null,
+  duration: null,
+  timeSegments: [],
+  feedback: null,
+  notes: null,
+  exercises: [
+    {
+      exerciseId: 'exercise-1',
+      exerciseName: 'Bench Press',
+      trackingType: 'weight_reps' as const,
+      orderIndex: 0,
+      section: 'main' as const,
+      sets: [],
+    },
+  ],
+  sets: [],
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+const scheduledWorkouts = [
+  {
+    id: 'scheduled-1',
+    date: '2026-03-07',
+    templateId: 'template-1',
+    templateName: 'Push Day',
+    templateTrackingTypes: ['weight_reps'] as const,
+    sessionId: null,
+    createdAt: 1,
+  },
+];
+
+describe('workout optimistic mutations', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  it('renames a template optimistically in list and detail caches', async () => {
+    const deferred = createDeferredPromise<Response>();
+    const { queryClient, wrapper } = createQueryClientWrapper();
+
+    queryClient.setQueryData(workoutQueryKeys.templateList(), [template]);
+    queryClient.setQueryData(workoutQueryKeys.template('template-1'), template);
+    mockFetch.mockImplementationOnce(() => deferred.promise);
+
+    const { result } = renderHook(() => useRenameTemplate(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        id: 'template-1',
+        name: 'Upper Push',
+      });
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData<typeof template[]>(workoutQueryKeys.templateList())).toEqual([
+        expect.objectContaining({ name: 'Upper Push' }),
+      ]);
+      expect(queryClient.getQueryData<typeof template>(workoutQueryKeys.template('template-1'))).toEqual(
+        expect.objectContaining({ name: 'Upper Push' }),
+      );
+    });
+
+    await act(async () => {
+      deferred.resolve(
+        createJsonResponse({
+          ...template,
+          name: 'Upper Push',
+        }),
+      );
+      await deferred.promise;
+    });
+  });
+
+  it('renames an exercise optimistically across exercise, template, and session caches', async () => {
+    const deferred = createDeferredPromise<Response>();
+    const { queryClient, wrapper } = createQueryClientWrapper();
+
+    queryClient.setQueryData(workoutQueryKeys.exercise('exercise-1'), exercise);
+    queryClient.setQueryData(workoutQueryKeys.exerciseList(), {
+      data: [exercise],
+      meta: {
+        limit: 20,
+        page: 1,
+        total: 1,
+      },
+    });
+    queryClient.setQueryData(workoutQueryKeys.templateList(), [template]);
+    queryClient.setQueryData(workoutQueryKeys.template('template-1'), template);
+    queryClient.setQueryData(workoutQueryKeys.session('session-1'), session);
+    mockFetch.mockImplementationOnce(() => deferred.promise);
+
+    const { result } = renderHook(() => useRenameExercise(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        id: 'exercise-1',
+        name: 'Paused Bench Press',
+      });
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData<typeof exercise>(workoutQueryKeys.exercise('exercise-1'))).toEqual(
+        expect.objectContaining({ name: 'Paused Bench Press' }),
+      );
+      expect(
+        queryClient.getQueryData<{ data: typeof exercise[]; meta: { limit: number; page: number; total: number } }>(
+          workoutQueryKeys.exerciseList(),
+        ),
+      ).toEqual(
+        expect.objectContaining({
+          data: [expect.objectContaining({ name: 'Paused Bench Press' })],
+        }),
+      );
+      expect(queryClient.getQueryData<typeof template>(workoutQueryKeys.template('template-1'))).toEqual(
+        expect.objectContaining({
+          sections: expect.arrayContaining([
+            expect.objectContaining({
+              exercises: [expect.objectContaining({ exerciseName: 'Paused Bench Press' })],
+            }),
+          ]),
+        }),
+      );
+      expect(queryClient.getQueryData<typeof session>(workoutQueryKeys.session('session-1'))).toEqual(
+        expect.objectContaining({
+          exercises: [expect.objectContaining({ exerciseName: 'Paused Bench Press' })],
+        }),
+      );
+    });
+
+    await act(async () => {
+      deferred.resolve(
+        createJsonResponse({
+          ...exercise,
+          name: 'Paused Bench Press',
+        }),
+      );
+      await deferred.promise;
+    });
+  });
+
+  it('reschedules and removes scheduled workouts optimistically', async () => {
+    const rescheduleDeferred = createDeferredPromise<Response>();
+    const unscheduleDeferred = createDeferredPromise<Response>();
+    const { queryClient, wrapper } = createQueryClientWrapper();
+
+    queryClient.setQueryData(
+      workoutQueryKeys.scheduledWorkoutList({ from: '2026-03-01', to: '2026-03-31' }),
+      scheduledWorkouts,
+    );
+    mockFetch.mockImplementationOnce(() => rescheduleDeferred.promise);
+    mockFetch.mockImplementationOnce(() => unscheduleDeferred.promise);
+
+    const { result: rescheduleResult } = renderHook(() => useRescheduleWorkout(), { wrapper });
+    const { result: unscheduleResult } = renderHook(() => useUnscheduleWorkout(), { wrapper });
+
+    act(() => {
+      rescheduleResult.current.mutate({
+        date: '2026-03-09',
+        id: 'scheduled-1',
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<typeof scheduledWorkouts>(
+          workoutQueryKeys.scheduledWorkoutList({ from: '2026-03-01', to: '2026-03-31' }),
+        ),
+      ).toEqual([expect.objectContaining({ date: '2026-03-09' })]);
+    });
+
+    await act(async () => {
+      rescheduleDeferred.resolve(
+        createJsonResponse({
+          id: 'scheduled-1',
+          userId: 'user-1',
+          templateId: 'template-1',
+          date: '2026-03-09',
+          sessionId: null,
+          createdAt: 1,
+          updatedAt: 2,
+        }),
+      );
+      await rescheduleDeferred.promise;
+    });
+
+    act(() => {
+      unscheduleResult.current.mutate({
+        id: 'scheduled-1',
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<typeof scheduledWorkouts>(
+          workoutQueryKeys.scheduledWorkoutList({ from: '2026-03-01', to: '2026-03-31' }),
+        ),
+      ).toEqual([]);
+    });
+
+    await act(async () => {
+      unscheduleDeferred.resolve(
+        createJsonResponse({
+          success: true,
+        }),
+      );
+      await unscheduleDeferred.promise;
+    });
+  });
+});

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -197,6 +197,7 @@ const scheduledWorkoutsKey = (params?: ScheduledWorkoutQueryParams) =>
     : (['workouts', 'scheduled-workouts'] as const);
 const sessionListKey = (params: WorkoutSessionQueryParams = {}) =>
   ['workouts', 'sessions', normalizeWorkoutSessionParams(params)] as const;
+const templatePrefixKey = () => ['workouts', 'template'] as const;
 const templatesKey = () => ['workouts', 'templates'] as const;
 
 export const workoutQueryKeys = {
@@ -216,7 +217,8 @@ export const workoutQueryKeys = {
   sessionsList: sessionListKey,
   sessionList: sessionListKey,
   workouts: sessionListKey,
-  templateRoot: () => ['workouts', 'template'] as const,
+  templateRoot: templatePrefixKey,
+  templateDetailPrefix: templatePrefixKey,
   template: (id: string) => ['workouts', 'template', id] as const,
   templates: templatesKey,
   templateList: templatesKey,
@@ -725,6 +727,9 @@ export function useUpdateExercise() {
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.templateList(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.templateDetailPrefix(),
         }),
       ]);
     },

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -1,4 +1,4 @@
-import { type QueryClient, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { type QueryClient, type QueryKey, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   createScheduledWorkoutInputSchema,
   createWorkoutSessionInputSchema,
@@ -36,6 +36,7 @@ import { toast } from 'sonner';
 import { z } from 'zod';
 
 import { apiRequest, apiRequestWithMeta } from '@/lib/api-client';
+import { createOptimisticMutation } from '@/lib/optimistic';
 
 const paginationMetaSchema = z.object({
   page: z.number().int(),
@@ -121,6 +122,13 @@ type SwapSessionExerciseResponse = {
   data: WorkoutSession;
   meta?: SwapResponseMeta;
 };
+type RenameTemplateCache = WorkoutTemplate | WorkoutTemplate[];
+type RenameExerciseCache =
+  | Exercise
+  | ExercisesResponse
+  | WorkoutTemplate
+  | WorkoutTemplate[]
+  | WorkoutSession;
 
 // Preprocess in shared schemas widens inference here, so we pin the parsed response shape explicitly.
 const workoutTemplateResponseSchema = z.object({
@@ -212,7 +220,9 @@ export const workoutQueryKeys = {
   scheduledWorkoutsAll: () => ['workouts', 'scheduled-workouts'] as const,
   scheduledWorkouts: scheduledWorkoutsKey,
   scheduledWorkoutList: scheduledWorkoutsKey,
+  scheduledWorkoutListRoot: () => ['workouts', 'scheduled-workouts'] as const,
   session: (id: string) => ['workouts', 'session', id] as const,
+  sessionDetailPrefix: () => ['workouts', 'session'] as const,
   sessions: () => ['workouts', 'sessions'] as const,
   sessionsList: sessionListKey,
   sessionList: sessionListKey,
@@ -223,6 +233,216 @@ export const workoutQueryKeys = {
   templates: templatesKey,
   templateList: templatesKey,
 };
+
+const renameTemplateInTemplate = (template: WorkoutTemplate, request: RenameTemplateRequest) =>
+  template.id === request.id
+    ? {
+        ...template,
+        name: request.name,
+      }
+    : template;
+
+const reorderTemplateExercisesInTemplate = (
+  template: WorkoutTemplate,
+  request: ReorderTemplateExercisesRequest,
+) => {
+  if (template.id !== request.templateId) {
+    return template;
+  }
+
+  return {
+    ...template,
+    sections: template.sections.map((section) => {
+      if (section.type !== request.section) {
+        return section;
+      }
+
+      const exerciseById = new Map(section.exercises.map((exercise) => [exercise.id, exercise]));
+
+      return {
+        ...section,
+        exercises: request.exerciseIds
+          .map((exerciseId) => exerciseById.get(exerciseId))
+          .filter((exercise): exercise is WorkoutTemplate['sections'][number]['exercises'][number] =>
+            exercise !== undefined,
+          ),
+      };
+    }),
+  };
+};
+
+const updateTemplateNameInCache = (
+  cache: RenameTemplateCache | undefined,
+  request: RenameTemplateRequest,
+) => {
+  if (!cache) {
+    return cache;
+  }
+
+  return Array.isArray(cache)
+    ? cache.map((template) => renameTemplateInTemplate(template, request))
+    : renameTemplateInTemplate(cache, request);
+};
+
+const reorderTemplateExercisesInCache = (
+  cache: RenameTemplateCache | undefined,
+  request: ReorderTemplateExercisesRequest,
+) => {
+  if (!cache) {
+    return cache;
+  }
+
+  return Array.isArray(cache)
+    ? cache.map((template) => reorderTemplateExercisesInTemplate(template, request))
+    : reorderTemplateExercisesInTemplate(cache, request);
+};
+
+const isExercisesResponse = (value: RenameExerciseCache | undefined): value is ExercisesResponse =>
+  typeof value === 'object' && value !== null && 'data' in value && 'meta' in value;
+
+const isExerciseRecord = (value: RenameExerciseCache | undefined): value is Exercise =>
+  typeof value === 'object' &&
+  value !== null &&
+  'muscleGroups' in value &&
+  'equipment' in value &&
+  'category' in value;
+
+const isWorkoutTemplateRecord = (
+  value: RenameExerciseCache | undefined,
+): value is WorkoutTemplate =>
+  typeof value === 'object' &&
+  value !== null &&
+  'sections' in value &&
+  Array.isArray(value.sections) &&
+  'name' in value;
+
+const isWorkoutSessionRecord = (value: RenameExerciseCache | undefined): value is WorkoutSession =>
+  typeof value === 'object' &&
+  value !== null &&
+  'sets' in value &&
+  Array.isArray(value.sets) &&
+  'status' in value;
+
+const renameExerciseInTemplate = (template: WorkoutTemplate, request: RenameExerciseRequest) => ({
+  ...template,
+  sections: template.sections.map((section) => ({
+    ...section,
+    exercises: section.exercises.map((exercise) =>
+      exercise.exerciseId === request.id
+        ? {
+            ...exercise,
+            exerciseName: request.name,
+          }
+        : exercise,
+    ),
+  })),
+});
+
+const renameExerciseInSession = (session: WorkoutSession, request: RenameExerciseRequest) => ({
+  ...session,
+  exercises: session.exercises?.map((exercise) =>
+    exercise.exerciseId === request.id
+      ? {
+          ...exercise,
+          exerciseName: request.name,
+        }
+      : exercise,
+  ),
+});
+
+const updateExerciseNameInCache = (
+  cache: RenameExerciseCache | undefined,
+  request: RenameExerciseRequest,
+) => {
+  if (!cache) {
+    return cache;
+  }
+
+  if (Array.isArray(cache)) {
+    return cache.map((entry) => {
+      if (isWorkoutTemplateRecord(entry)) {
+        return renameExerciseInTemplate(entry, request);
+      }
+
+      return entry;
+    });
+  }
+
+  if (isExerciseRecord(cache)) {
+    return {
+      ...cache,
+      name: request.name,
+    };
+  }
+
+  if (isExercisesResponse(cache)) {
+    return {
+      ...cache,
+      data: cache.data.map((exercise) =>
+        exercise.id === request.id
+          ? {
+              ...exercise,
+              name: request.name,
+            }
+          : exercise,
+      ),
+    };
+  }
+
+  if (isWorkoutTemplateRecord(cache)) {
+    return renameExerciseInTemplate(cache, request);
+  }
+
+  if (isWorkoutSessionRecord(cache)) {
+    return renameExerciseInSession(cache, request);
+  }
+
+  return cache;
+};
+
+const getScheduledWorkoutRangeFromKey = (queryKey: QueryKey) => {
+  const maybeParams = queryKey[2];
+
+  if (
+    typeof maybeParams === 'object' &&
+    maybeParams !== null &&
+    'from' in maybeParams &&
+    'to' in maybeParams &&
+    typeof maybeParams.from === 'string' &&
+    typeof maybeParams.to === 'string'
+  ) {
+    return {
+      from: maybeParams.from,
+      to: maybeParams.to,
+    };
+  }
+
+  return null;
+};
+
+const updateScheduledWorkoutInList = (
+  current: ScheduledWorkoutListItem[] | undefined,
+  request: UpdateScheduledWorkoutRequest,
+  queryKey: QueryKey,
+) => {
+  if (!current) {
+    return current;
+  }
+
+  const range = getScheduledWorkoutRangeFromKey(queryKey);
+  const nextItems = current
+    .map((item) => (item.id === request.id ? { ...item, date: request.date } : item))
+    .filter((item) =>
+      range ? item.date >= range.from && item.date <= range.to : true,
+    );
+
+  return nextItems.sort((left, right) => left.date.localeCompare(right.date));
+};
+
+const removeScheduledWorkoutFromList = (
+  current: ScheduledWorkoutListItem[] | undefined,
+  request: DeleteScheduledWorkoutRequest,
+) => current?.filter((item) => item.id !== request.id);
 
 async function getWorkoutTemplates() {
   const data = await apiRequest<unknown>('/api/v1/workout-templates');
@@ -656,59 +876,56 @@ export function useScheduleWorkout() {
 }
 
 export function useRescheduleWorkout() {
-  const queryClient = useQueryClient();
-
-  return useMutation<ScheduledWorkout, Error, UpdateScheduledWorkoutRequest>({
+  return createOptimisticMutation<ScheduledWorkoutListItem[], ScheduledWorkout, UpdateScheduledWorkoutRequest>({
     mutationFn: updateScheduledWorkout,
+    invalidateKeys: () => [workoutQueryKeys.scheduledWorkoutListRoot(), workoutQueryKeys.sessions()],
     onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.scheduledWorkoutList(),
-        }),
-        queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.sessions(),
-        }),
-      ]);
       toast.success('Workout rescheduled');
     },
+    queryKey: () => workoutQueryKeys.scheduledWorkoutListRoot(),
+    reconcile: (current, _data, variables, context) =>
+      updateScheduledWorkoutInList(current, variables, context.queryKey),
+    updater: (current, variables, context) =>
+      updateScheduledWorkoutInList(current, variables, context.queryKey),
   });
 }
 
 export function useUnscheduleWorkout() {
-  const queryClient = useQueryClient();
-
-  return useMutation<DeleteScheduledWorkoutResponse, Error, DeleteScheduledWorkoutRequest>({
+  return createOptimisticMutation<
+    ScheduledWorkoutListItem[],
+    DeleteScheduledWorkoutResponse,
+    DeleteScheduledWorkoutRequest
+  >({
     mutationFn: deleteScheduledWorkout,
+    invalidateKeys: () => [workoutQueryKeys.scheduledWorkoutListRoot(), workoutQueryKeys.sessions()],
     onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.scheduledWorkoutList(),
-        }),
-        queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.sessions(),
-        }),
-      ]);
       toast.success('Scheduled workout removed');
     },
+    queryKey: () => workoutQueryKeys.scheduledWorkoutListRoot(),
+    updater: (current, variables) => removeScheduledWorkoutFromList(current, variables),
   });
 }
 
 export function useRenameExercise() {
-  const queryClient = useQueryClient();
-
-  return useMutation<Exercise, Error, RenameExerciseRequest>({
+  return createOptimisticMutation<RenameExerciseCache, Exercise, RenameExerciseRequest>({
     mutationFn: ({ id, name }) => updateExercise({ id, input: { name } }),
+    invalidateKeys: () => [workoutQueryKeys.all, workoutQueryKeys.sessions()],
     onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.all,
-        }),
-        queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.sessions(),
-        }),
-      ]);
       toast.success('Exercise renamed');
     },
+    queryKey: (params) => [
+      workoutQueryKeys.exercise(params.variables.id),
+      workoutQueryKeys.exerciseList(),
+      workoutQueryKeys.templateList(),
+      workoutQueryKeys.templateDetailPrefix(),
+      workoutQueryKeys.sessionDetailPrefix(),
+    ],
+    reconcile: (current, exercise, variables) =>
+      updateExerciseNameInCache(current, {
+        id: variables.id,
+        name: exercise.name,
+      }),
+    updater: (current, variables) => updateExerciseNameInCache(current, variables),
   });
 }
 
@@ -737,21 +954,25 @@ export function useUpdateExercise() {
 }
 
 export function useRenameTemplate() {
-  const queryClient = useQueryClient();
-
-  return useMutation<WorkoutTemplate, Error, RenameTemplateRequest>({
+  return createOptimisticMutation<RenameTemplateCache, WorkoutTemplate, RenameTemplateRequest>({
     mutationFn: renameTemplate,
-    onSuccess: async (_, variables) => {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.templateList(),
-        }),
-        queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.template(variables.id),
-        }),
-      ]);
+    invalidateKeys: (params) => [
+      workoutQueryKeys.templateList(),
+      workoutQueryKeys.template(params.variables.id),
+    ],
+    onSuccess: async () => {
       toast.success('Template renamed');
     },
+    queryKey: (params) => [
+      workoutQueryKeys.templateList(),
+      workoutQueryKeys.template(params.variables.id),
+    ],
+    reconcile: (current, template, variables) =>
+      updateTemplateNameInCache(current, {
+        id: variables.id,
+        name: template.name,
+      }),
+    updater: (current, variables) => updateTemplateNameInCache(current, variables),
   });
 }
 
@@ -793,20 +1014,25 @@ export function useDeleteTemplate() {
 }
 
 export function useReorderTemplateExercises() {
-  const queryClient = useQueryClient();
-
-  return useMutation<WorkoutTemplate, Error, ReorderTemplateExercisesRequest>({
+  return createOptimisticMutation<RenameTemplateCache, WorkoutTemplate, ReorderTemplateExercisesRequest>({
     mutationFn: reorderTemplateExercises,
-    onSuccess: async (_, variables) => {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.templateList(),
-        }),
-        queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.template(variables.templateId),
-        }),
-      ]);
-    },
+    invalidateKeys: (params) => [
+      workoutQueryKeys.templateList(),
+      workoutQueryKeys.template(params.variables.templateId),
+    ],
+    queryKey: (params) => [
+      workoutQueryKeys.templateList(),
+      workoutQueryKeys.template(params.variables.templateId),
+    ],
+    reconcile: (current, template, variables) =>
+      reorderTemplateExercisesInCache(current, {
+        ...variables,
+        exerciseIds:
+          template.sections.find((section) => section.type === variables.section)?.exercises.map(
+            (exercise) => exercise.id,
+          ) ?? variables.exerciseIds,
+      }),
+    updater: (current, variables) => reorderTemplateExercisesInCache(current, variables),
   });
 }
 

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -37,6 +37,7 @@ import { z } from 'zod';
 
 import { apiRequest, apiRequestWithMeta } from '@/lib/api-client';
 import { createOptimisticMutation } from '@/lib/optimistic';
+import { crossFeatureInvalidationMap, invalidateQueryKeys } from '@/lib/query-invalidation';
 
 const paginationMetaSchema = z.object({
   page: z.number().int(),
@@ -842,10 +843,13 @@ export function useStartWorkoutSession() {
   return useMutation<WorkoutSession, Error, CreateWorkoutSessionRequest>({
     mutationFn: createWorkoutSession,
     onSuccess: async () => {
-      // Intentional prefix invalidation: refreshes both `sessions()` and all `sessionList(params)` caches.
-      await queryClient.invalidateQueries({
-        queryKey: workoutQueryKeys.sessions(),
-      });
+      await Promise.all([
+        // Intentional prefix invalidation: refreshes both `sessions()` and all `sessionList(params)` caches.
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.sessions(),
+        }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.activeWorkoutSessionMutation()),
+      ]);
       toast.success('Workout started');
     },
   });
@@ -869,6 +873,7 @@ export function useScheduleWorkout() {
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.sessions(),
         }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.scheduledWorkoutMutation()),
       ]);
       toast.success(`Scheduled for ${formatter.format(new Date(`${variables.date}T12:00:00`))}`);
     },
@@ -878,7 +883,11 @@ export function useScheduleWorkout() {
 export function useRescheduleWorkout() {
   return createOptimisticMutation<ScheduledWorkoutListItem[], ScheduledWorkout, UpdateScheduledWorkoutRequest>({
     mutationFn: updateScheduledWorkout,
-    invalidateKeys: () => [workoutQueryKeys.scheduledWorkoutListRoot(), workoutQueryKeys.sessions()],
+    invalidateKeys: () => [
+      workoutQueryKeys.scheduledWorkoutListRoot(),
+      workoutQueryKeys.sessions(),
+      ...crossFeatureInvalidationMap.scheduledWorkoutMutation(),
+    ],
     onSuccess: async () => {
       toast.success('Workout rescheduled');
     },
@@ -897,7 +906,11 @@ export function useUnscheduleWorkout() {
     DeleteScheduledWorkoutRequest
   >({
     mutationFn: deleteScheduledWorkout,
-    invalidateKeys: () => [workoutQueryKeys.scheduledWorkoutListRoot(), workoutQueryKeys.sessions()],
+    invalidateKeys: () => [
+      workoutQueryKeys.scheduledWorkoutListRoot(),
+      workoutQueryKeys.sessions(),
+      ...crossFeatureInvalidationMap.scheduledWorkoutMutation(),
+    ],
     onSuccess: async () => {
       toast.success('Scheduled workout removed');
     },
@@ -948,7 +961,11 @@ export function useUpdateExercise() {
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.templateDetailPrefix(),
         }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.sessionDetailPrefix(),
+        }),
       ]);
+      toast.success('Exercise updated');
     },
   });
 }
@@ -959,6 +976,9 @@ export function useRenameTemplate() {
     invalidateKeys: (params) => [
       workoutQueryKeys.templateList(),
       workoutQueryKeys.template(params.variables.id),
+      workoutQueryKeys.scheduledWorkoutListRoot(),
+      workoutQueryKeys.sessions(),
+      ...crossFeatureInvalidationMap.workoutTemplateMutation(),
     ],
     onSuccess: async () => {
       toast.success('Template renamed');
@@ -989,7 +1009,15 @@ export function useUpdateTemplate() {
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.template(variables.id),
         }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.scheduledWorkoutListRoot(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.sessions(),
+        }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.workoutTemplateMutation()),
       ]);
+      toast.success('Template updated');
     },
   });
 }
@@ -1007,6 +1035,13 @@ export function useDeleteTemplate() {
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.template(variables.id),
         }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.scheduledWorkoutListRoot(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.sessions(),
+        }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.workoutTemplateMutation()),
       ]);
       toast.success('Template deleted');
     },
@@ -1049,7 +1084,11 @@ export function useSwapTemplateExercise() {
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.template(variables.templateId),
         }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.scheduledWorkoutListRoot(),
+        }),
       ]);
+      toast.success('Exercise swapped');
     },
   });
 }
@@ -1068,6 +1107,7 @@ export function useSwapSessionExercise() {
           queryKey: workoutQueryKeys.session(variables.sessionId),
         }),
       ]);
+      toast.success('Exercise swapped');
     },
   });
 }

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -1054,7 +1054,11 @@ export function useReorderTemplateExercises() {
     invalidateKeys: (params) => [
       workoutQueryKeys.templateList(),
       workoutQueryKeys.template(params.variables.templateId),
+      ...crossFeatureInvalidationMap.workoutTemplateMutation(),
     ],
+    onSuccess: async () => {
+      toast.success('Template exercise order updated');
+    },
     queryKey: (params) => [
       workoutQueryKeys.templateList(),
       workoutQueryKeys.template(params.variables.templateId),
@@ -1087,6 +1091,7 @@ export function useSwapTemplateExercise() {
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.scheduledWorkoutListRoot(),
         }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.workoutTemplateMutation()),
       ]);
       toast.success('Exercise swapped');
     },

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -185,31 +185,41 @@ const normalizeWorkoutSessionParams = (params: WorkoutSessionQueryParams = {}) =
   };
 };
 
+const completedSessionsKey = () =>
+  ['workouts', 'sessions', { from: null, limit: null, status: 'completed', to: null }] as const;
+const exercisesKey = (params?: ExerciseQueryParams) =>
+  params
+    ? (['workouts', 'exercises', normalizeExerciseParams(params)] as const)
+    : (['workouts', 'exercises'] as const);
+const scheduledWorkoutsKey = (params?: ScheduledWorkoutQueryParams) =>
+  params
+    ? (['workouts', 'scheduled-workouts', normalizeScheduledWorkoutParams(params)] as const)
+    : (['workouts', 'scheduled-workouts'] as const);
+const sessionListKey = (params: WorkoutSessionQueryParams = {}) =>
+  ['workouts', 'sessions', normalizeWorkoutSessionParams(params)] as const;
+const templatesKey = () => ['workouts', 'templates'] as const;
+
 export const workoutQueryKeys = {
   all: ['workouts'] as const,
-  completedSessions: () =>
-    ['workouts', 'sessions', { from: null, limit: null, status: 'completed', to: null }] as const,
+  completedSessions: completedSessionsKey,
+  completedSessionList: completedSessionsKey,
   exercise: (id: string) => ['workouts', 'exercise', id] as const,
   exercisesRoot: () => ['workouts', 'exercises'] as const,
-  exercises: (params?: ExerciseQueryParams) =>
-    params
-      ? (['workouts', 'exercises', normalizeExerciseParams(params)] as const)
-      : (['workouts', 'exercises'] as const),
+  exercises: exercisesKey,
+  exerciseList: exercisesKey,
   exerciseFilters: () => ['workouts', 'exercise-filters'] as const,
   scheduledWorkoutsAll: () => ['workouts', 'scheduled-workouts'] as const,
-  scheduledWorkouts: (params?: ScheduledWorkoutQueryParams) =>
-    params
-      ? (['workouts', 'scheduled-workouts', normalizeScheduledWorkoutParams(params)] as const)
-      : (['workouts', 'scheduled-workouts'] as const),
+  scheduledWorkouts: scheduledWorkoutsKey,
+  scheduledWorkoutList: scheduledWorkoutsKey,
   session: (id: string) => ['workouts', 'session', id] as const,
   sessions: () => ['workouts', 'sessions'] as const,
-  sessionsList: (params: WorkoutSessionQueryParams = {}) =>
-    ['workouts', 'sessions', normalizeWorkoutSessionParams(params)] as const,
+  sessionsList: sessionListKey,
+  sessionList: sessionListKey,
+  workouts: sessionListKey,
   templateRoot: () => ['workouts', 'template'] as const,
   template: (id: string) => ['workouts', 'template', id] as const,
-  templates: () => ['workouts', 'templates'] as const,
-  workouts: (params: WorkoutSessionQueryParams = {}) =>
-    ['workouts', 'sessions', normalizeWorkoutSessionParams(params)] as const,
+  templates: templatesKey,
+  templateList: templatesKey,
 };
 
 async function getWorkoutTemplates() {
@@ -524,14 +534,14 @@ async function deleteScheduledWorkout(input: DeleteScheduledWorkoutRequest) {
 export function useWorkoutTemplates() {
   return useQuery<WorkoutTemplate[]>({
     queryFn: getWorkoutTemplates,
-    queryKey: workoutQueryKeys.templates(),
+    queryKey: workoutQueryKeys.templateList(),
   });
 }
 
 export function useCompletedSessions() {
   return useQuery<WorkoutSessionListItem[]>({
     queryFn: ({ signal }) => getCompletedSessions(signal),
-    queryKey: workoutQueryKeys.completedSessions(),
+    queryKey: workoutQueryKeys.completedSessionList(),
   });
 }
 
@@ -542,7 +552,7 @@ export function useScheduledWorkouts(
   return useQuery<ScheduledWorkoutListItem[]>({
     enabled: options?.enabled,
     queryFn: ({ signal }) => getScheduledWorkouts(params, signal),
-    queryKey: workoutQueryKeys.scheduledWorkouts(params),
+    queryKey: workoutQueryKeys.scheduledWorkoutList(params),
   });
 }
 
@@ -553,7 +563,7 @@ export function useWorkoutSessions(
   return useQuery<WorkoutSessionListItem[]>({
     enabled: options?.enabled,
     queryFn: ({ signal }) => getWorkoutSessions(params, signal),
-    queryKey: workoutQueryKeys.workouts(params),
+    queryKey: workoutQueryKeys.sessionList(params),
   });
 }
 
@@ -585,7 +595,7 @@ export function useExercises(params: ExerciseQueryParams, options?: { enabled?: 
     placeholderData: (previousData) => previousData,
     // getExercises already validates/normalizes with the shared schema.
     queryFn: () => getExercises(params),
-    queryKey: workoutQueryKeys.exercises(params),
+    queryKey: workoutQueryKeys.exerciseList(params),
   });
 }
 
@@ -610,7 +620,7 @@ export function useStartWorkoutSession() {
   return useMutation<WorkoutSession, Error, CreateWorkoutSessionRequest>({
     mutationFn: createWorkoutSession,
     onSuccess: async () => {
-      // Intentional prefix invalidation: refreshes both `sessions()` and all `sessionsList(params)` caches.
+      // Intentional prefix invalidation: refreshes both `sessions()` and all `sessionList(params)` caches.
       await queryClient.invalidateQueries({
         queryKey: workoutQueryKeys.sessions(),
       });
@@ -632,7 +642,7 @@ export function useScheduleWorkout() {
     onSuccess: async (_, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.scheduledWorkouts(),
+          queryKey: workoutQueryKeys.scheduledWorkoutList(),
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.sessions(),
@@ -651,7 +661,7 @@ export function useRescheduleWorkout() {
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.scheduledWorkouts(),
+          queryKey: workoutQueryKeys.scheduledWorkoutList(),
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.sessions(),
@@ -670,7 +680,7 @@ export function useUnscheduleWorkout() {
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.scheduledWorkouts(),
+          queryKey: workoutQueryKeys.scheduledWorkoutList(),
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.sessions(),
@@ -711,13 +721,10 @@ export function useUpdateExercise() {
           queryKey: workoutQueryKeys.exercise(variables.id),
         }),
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.exercises(),
+          queryKey: workoutQueryKeys.exerciseList(),
         }),
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.templates(),
-        }),
-        queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.templates(),
+          queryKey: workoutQueryKeys.templateList(),
         }),
       ]);
     },
@@ -732,7 +739,7 @@ export function useRenameTemplate() {
     onSuccess: async (_, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.templates(),
+          queryKey: workoutQueryKeys.templateList(),
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.template(variables.id),
@@ -751,7 +758,7 @@ export function useUpdateTemplate() {
     onSuccess: async (_, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.templates(),
+          queryKey: workoutQueryKeys.templateList(),
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.template(variables.id),
@@ -769,7 +776,7 @@ export function useDeleteTemplate() {
     onSuccess: async (_, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.templates(),
+          queryKey: workoutQueryKeys.templateList(),
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.template(variables.id),
@@ -788,7 +795,7 @@ export function useReorderTemplateExercises() {
     onSuccess: async (_, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.templates(),
+          queryKey: workoutQueryKeys.templateList(),
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.template(variables.templateId),
@@ -806,7 +813,7 @@ export function useSwapTemplateExercise() {
     onSuccess: async (_, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.templates(),
+          queryKey: workoutQueryKeys.templateList(),
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.template(variables.templateId),

--- a/apps/web/src/features/workouts/components/session-feedback.tsx
+++ b/apps/web/src/features/workouts/components/session-feedback.tsx
@@ -17,7 +17,7 @@ import { cn } from '@/lib/utils';
 
 import type { ActiveWorkoutCustomFeedbackField, ActiveWorkoutFeedbackDraft } from '../types';
 
-export const STANDARD_FEEDBACK_QUESTIONS: ActiveWorkoutCustomFeedbackField[] = [
+const STANDARD_FEEDBACK_QUESTIONS: ActiveWorkoutCustomFeedbackField[] = [
   {
     id: 'session-rpe',
     label: 'Session RPE',

--- a/apps/web/src/hooks/use-agent-tokens.ts
+++ b/apps/web/src/hooks/use-agent-tokens.ts
@@ -19,9 +19,9 @@ type RegenerateTokenResponse = {
   token: string;
 };
 
-export const agentTokenKeys = {
+export const agentTokenQueryKeys = {
   all: ['agent-tokens'] as const,
-  list: () => [...agentTokenKeys.all, 'list'] as const,
+  list: () => [...agentTokenQueryKeys.all, 'list'] as const,
 };
 
 const fetchAgentTokens = async (signal?: AbortSignal): Promise<AgentTokenListItem[]> => {
@@ -53,7 +53,7 @@ const deleteAgentToken = async (id: string): Promise<{ success: boolean }> => {
 export const useAgentTokens = () =>
   useQuery({
     queryFn: ({ signal }) => fetchAgentTokens(signal),
-    queryKey: agentTokenKeys.list(),
+    queryKey: agentTokenQueryKeys.list(),
   });
 
 export const useCreateAgentToken = () => {
@@ -62,7 +62,7 @@ export const useCreateAgentToken = () => {
   return useMutation({
     mutationFn: createAgentToken,
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: agentTokenKeys.all });
+      await queryClient.invalidateQueries({ queryKey: agentTokenQueryKeys.all });
     },
   });
 };
@@ -73,7 +73,7 @@ export const useRegenerateAgentToken = () => {
   return useMutation({
     mutationFn: regenerateAgentToken,
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: agentTokenKeys.all });
+      await queryClient.invalidateQueries({ queryKey: agentTokenQueryKeys.all });
     },
   });
 };
@@ -84,7 +84,7 @@ export const useDeleteAgentToken = () => {
   return useMutation({
     mutationFn: deleteAgentToken,
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: agentTokenKeys.all });
+      await queryClient.invalidateQueries({ queryKey: agentTokenQueryKeys.all });
     },
   });
 };

--- a/apps/web/src/hooks/use-complete-session.test.tsx
+++ b/apps/web/src/hooks/use-complete-session.test.tsx
@@ -2,8 +2,12 @@ import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WorkoutSessionListItem } from '@pulse/shared';
 
+import { habitQueryKeys } from '@/features/habits/api/keys';
 import { workoutQueryKeys } from '@/features/workouts/api/workouts';
 import { ACTIVE_WORKOUT_SESSION_STORAGE_KEY } from '@/features/workouts/lib/session-persistence';
+import { dashboardSnapshotQueryKeys } from '@/hooks/use-dashboard-snapshot';
+import { habitChainQueryKeys } from '@/hooks/use-habit-chains';
+import { recentWorkoutQueryKeys } from '@/hooks/use-recent-workouts';
 import { createQueryClientWrapper } from '@/test/query-client';
 
 import { useCompleteSession } from './use-complete-session';
@@ -58,7 +62,7 @@ describe('use-complete-session hook', () => {
     mockFetch.mockResolvedValueOnce(createJsonResponse(completedSessionResponse));
 
     const { queryClient, wrapper } = createQueryClientWrapper();
-    queryClient.setQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.sessionsList({}), [
+    queryClient.setQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.sessionList({}), [
       {
         completedAt: null,
         createdAt: 100,
@@ -73,7 +77,7 @@ describe('use-complete-session hook', () => {
         templateName: 'Upper Push Template',
       },
     ]);
-    queryClient.setQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.completedSessions(), [
+    queryClient.setQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.completedSessionList(), [
       {
         completedAt: 1_000,
         createdAt: 90,
@@ -140,10 +144,19 @@ describe('use-complete-session hook', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: workoutSessionQueryKeys.detail('session-1'),
     });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: dashboardSnapshotQueryKeys.all,
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: recentWorkoutQueryKeys.all,
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitQueryKeys.list() });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitQueryKeys.entryList() });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitChainQueryKeys.all });
     expect(window.localStorage.getItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY)).toBeNull();
 
     expect(
-      queryClient.getQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.sessionsList({})),
+      queryClient.getQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.sessionList({})),
     ).toEqual([
       {
         completedAt: 2_700_000,
@@ -163,7 +176,7 @@ describe('use-complete-session hook', () => {
       completedSessionResponse,
     );
     expect(
-      queryClient.getQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.completedSessions()),
+      queryClient.getQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.completedSessionList()),
     ).toEqual([
       {
         completedAt: 2_700_000,
@@ -198,7 +211,7 @@ describe('use-complete-session hook', () => {
     mockFetch.mockResolvedValueOnce(createJsonResponse(completedSessionResponse));
 
     const { queryClient, wrapper } = createQueryClientWrapper();
-    queryClient.setQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.sessionsList({}), [
+    queryClient.setQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.sessionList({}), [
       {
         completedAt: 1_000,
         createdAt: 90,
@@ -226,7 +239,7 @@ describe('use-complete-session hook', () => {
     });
 
     expect(
-      queryClient.getQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.sessionsList({})),
+      queryClient.getQueryData<WorkoutSessionListItem[]>(workoutQueryKeys.sessionList({})),
     ).toEqual([
       {
         completedAt: 2_700_000,

--- a/apps/web/src/hooks/use-complete-session.ts
+++ b/apps/web/src/hooks/use-complete-session.ts
@@ -13,6 +13,7 @@ import { z } from 'zod';
 import { workoutQueryKeys } from '@/features/workouts/api/workouts';
 import { clearStoredActiveWorkoutSessionId } from '@/features/workouts/lib/session-persistence';
 import { apiRequest } from '@/lib/api-client';
+import { crossFeatureInvalidationMap, invalidateQueryKeys } from '@/lib/query-invalidation';
 
 import { workoutSessionQueryKeys } from './use-workout-session';
 
@@ -141,7 +142,7 @@ export function useCompleteSession(sessionId: string | null | undefined) {
         },
       );
       queryClient.setQueryData<WorkoutSessionListItem[]>(
-        workoutQueryKeys.sessionsList({}),
+        workoutQueryKeys.sessionList({}),
         (current) => {
           const existing = current?.find((item) => item.id === session.id);
           const nextItem = mergeSessionListItem(session, existing ?? fallbackItem);
@@ -150,7 +151,7 @@ export function useCompleteSession(sessionId: string | null | undefined) {
         },
       );
       queryClient.setQueryData<WorkoutSessionListItem[]>(
-        workoutQueryKeys.completedSessions(),
+        workoutQueryKeys.completedSessionList(),
         (current) => {
           const existing = current?.find((item) => item.id === session.id);
           const nextItem = mergeSessionListItem(session, existing ?? fallbackItem);
@@ -163,6 +164,7 @@ export function useCompleteSession(sessionId: string | null | undefined) {
         queryClient.invalidateQueries({ queryKey: workoutQueryKeys.all }),
         queryClient.invalidateQueries({ queryKey: workoutSessionQueryKeys.all }),
         queryClient.invalidateQueries({ queryKey: workoutSessionQueryKeys.detail(session.id) }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.workoutCompletion()),
       ]);
       toast.success('Workout completed');
     },

--- a/apps/web/src/hooks/use-complete-session.ts
+++ b/apps/web/src/hooks/use-complete-session.ts
@@ -164,7 +164,7 @@ export function useCompleteSession(sessionId: string | null | undefined) {
         queryClient.invalidateQueries({ queryKey: workoutQueryKeys.all }),
         queryClient.invalidateQueries({ queryKey: workoutSessionQueryKeys.all }),
         queryClient.invalidateQueries({ queryKey: workoutSessionQueryKeys.detail(session.id) }),
-        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.workoutCompletion()),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.workoutSessionChange()),
       ]);
       toast.success('Workout completed');
     },

--- a/apps/web/src/hooks/use-dashboard-config.ts
+++ b/apps/web/src/hooks/use-dashboard-config.ts
@@ -3,9 +3,9 @@ import { dashboardConfigSchema, type DashboardConfig } from '@pulse/shared';
 
 import { apiRequest } from '@/lib/api-client';
 
-export const dashboardConfigKeys = {
+export const dashboardConfigQueryKeys = {
   all: ['dashboard', 'config'] as const,
-  detail: () => [...dashboardConfigKeys.all, 'current'] as const,
+  detail: () => [...dashboardConfigQueryKeys.all, 'current'] as const,
 };
 
 const fetchDashboardConfig = async (signal?: AbortSignal): Promise<DashboardConfig> => {
@@ -30,7 +30,7 @@ const putDashboardConfig = async (config: DashboardConfig): Promise<DashboardCon
 export const useDashboardConfig = () =>
   useQuery({
     queryFn: ({ signal }) => fetchDashboardConfig(signal),
-    queryKey: dashboardConfigKeys.detail(),
+    queryKey: dashboardConfigQueryKeys.detail(),
   });
 
 export const useSaveDashboardConfig = () => {
@@ -39,7 +39,7 @@ export const useSaveDashboardConfig = () => {
   return useMutation({
     mutationFn: putDashboardConfig,
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: dashboardConfigKeys.all });
+      await queryClient.invalidateQueries({ queryKey: dashboardConfigQueryKeys.all });
     },
   });
 };

--- a/apps/web/src/hooks/use-dashboard-snapshot.ts
+++ b/apps/web/src/hooks/use-dashboard-snapshot.ts
@@ -3,9 +3,9 @@ import { dashboardSnapshotSchema, type DashboardSnapshot } from '@pulse/shared';
 
 import { apiRequest } from '@/lib/api-client';
 
-export const dashboardSnapshotKeys = {
+export const dashboardSnapshotQueryKeys = {
   all: ['dashboard', 'snapshot'] as const,
-  detail: (date: string) => [...dashboardSnapshotKeys.all, date] as const,
+  detail: (date: string) => [...dashboardSnapshotQueryKeys.all, date] as const,
 };
 
 const fetchDashboardSnapshot = async (
@@ -27,11 +27,11 @@ export const useDashboardSnapshot = (date: string) =>
   useQuery({
     enabled: date.length > 0,
     queryFn: ({ signal }) => fetchDashboardSnapshot(date, signal),
-    queryKey: dashboardSnapshotKeys.detail(date),
+    queryKey: dashboardSnapshotQueryKeys.detail(date),
   });
 
 export const prefetchDashboardSnapshot = (queryClient: QueryClient, date: string) =>
   queryClient.prefetchQuery({
-    queryKey: dashboardSnapshotKeys.detail(date),
+    queryKey: dashboardSnapshotQueryKeys.detail(date),
     queryFn: ({ signal }) => fetchDashboardSnapshot(date, signal),
   });

--- a/apps/web/src/hooks/use-habit-chains.ts
+++ b/apps/web/src/hooks/use-habit-chains.ts
@@ -6,9 +6,9 @@ import { apiRequest } from '@/lib/api-client';
 
 const habitEntriesSchema = z.array(habitEntrySchema);
 
-export const habitChainKeys = {
+export const habitChainQueryKeys = {
   all: ['habits', 'chains'] as const,
-  range: (from: string, to: string) => [...habitChainKeys.all, from, to] as const,
+  range: (from: string, to: string) => [...habitChainQueryKeys.all, from, to] as const,
 };
 
 const fetchHabitChains = async (
@@ -31,5 +31,5 @@ export const useHabitChains = (from: string, to: string) =>
   useQuery({
     enabled: from.length > 0 && to.length > 0,
     queryFn: ({ signal }) => fetchHabitChains(from, to, signal),
-    queryKey: habitChainKeys.range(from, to),
+    queryKey: habitChainQueryKeys.range(from, to),
   });

--- a/apps/web/src/hooks/use-macro-trend.ts
+++ b/apps/web/src/hooks/use-macro-trend.ts
@@ -7,14 +7,15 @@ import { addDays, getToday, parseDateInput, toDateKey } from '@/lib/date';
 const DEFAULT_TREND_DAYS = 30;
 const DEFAULT_QUERY_ENABLED = true;
 
-export const macroTrendKeys = {
+export const macroTrendQueryKeys = {
   all: ['dashboard', 'macro-trend'] as const,
-  range: (from: string, to: string) => [...macroTrendKeys.all, from, to] as const,
+  range: (from: string, to: string) => [...macroTrendQueryKeys.all, from, to] as const,
 };
 
 const resolveDateRange = (from?: string, to?: string) => {
   const resolvedTo = to ?? toDateKey(getToday());
-  const resolvedFrom = from ?? toDateKey(addDays(parseDateInput(resolvedTo), -(DEFAULT_TREND_DAYS - 1)));
+  const resolvedFrom =
+    from ?? toDateKey(addDays(parseDateInput(resolvedTo), -(DEFAULT_TREND_DAYS - 1)));
 
   return {
     from: resolvedFrom,
@@ -39,17 +40,13 @@ const fetchMacroTrend = async (
   return dashboardMacrosTrendSchema.parse(trend);
 };
 
-export const useMacroTrend = (
-  from?: string,
-  to?: string,
-  options: { enabled?: boolean } = {},
-) => {
+export const useMacroTrend = (from?: string, to?: string, options: { enabled?: boolean } = {}) => {
   const range = resolveDateRange(from, to);
   const enabled = options.enabled ?? DEFAULT_QUERY_ENABLED;
 
   return useQuery({
     enabled,
     queryFn: ({ signal }) => fetchMacroTrend(range.from, range.to, signal),
-    queryKey: macroTrendKeys.range(range.from, range.to),
+    queryKey: macroTrendQueryKeys.range(range.from, range.to),
   });
 };

--- a/apps/web/src/hooks/use-recent-workouts.ts
+++ b/apps/web/src/hooks/use-recent-workouts.ts
@@ -1,8 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import {
-  type WorkoutSessionListItem,
-  workoutSessionListItemSchema,
-} from '@pulse/shared';
+import { type WorkoutSessionListItem, workoutSessionListItemSchema } from '@pulse/shared';
 import { z } from 'zod';
 
 import { apiRequest } from '@/lib/api-client';
@@ -15,9 +12,9 @@ export type RecentWorkout = Pick<WorkoutSessionListItem, 'id' | 'name' | 'date' 
   exerciseCount: number;
 };
 
-export const recentWorkoutsKeys = {
+export const recentWorkoutQueryKeys = {
   all: ['dashboard', 'recent-workouts'] as const,
-  list: (limit: number) => [...recentWorkoutsKeys.all, limit] as const,
+  list: (limit: number) => [...recentWorkoutQueryKeys.all, limit] as const,
 };
 
 const fetchRecentWorkouts = async (limit = DEFAULT_WORKOUT_LIMIT, signal?: AbortSignal) => {
@@ -46,6 +43,6 @@ export const useRecentWorkouts = (limit = DEFAULT_WORKOUT_LIMIT) => {
 
   return useQuery({
     queryFn: ({ signal }) => fetchRecentWorkouts(normalizedLimit, signal),
-    queryKey: recentWorkoutsKeys.list(normalizedLimit),
+    queryKey: recentWorkoutQueryKeys.list(normalizedLimit),
   });
 };

--- a/apps/web/src/hooks/use-save-as-template.test.tsx
+++ b/apps/web/src/hooks/use-save-as-template.test.tsx
@@ -91,7 +91,7 @@ describe('use-save-as-template hook', () => {
       tags: ['strength', 'push'],
     });
 
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutQueryKeys.templates() });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutQueryKeys.templateList() });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutSessionQueryKeys.all });
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: workoutSessionQueryKeys.detail('session-1'),

--- a/apps/web/src/hooks/use-save-as-template.ts
+++ b/apps/web/src/hooks/use-save-as-template.ts
@@ -46,7 +46,7 @@ export function useSaveAsTemplate(sessionId: string | null | undefined) {
       queryClient.setQueryData(workoutQueryKeys.template(template.id), template);
 
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: workoutQueryKeys.templates() }),
+        queryClient.invalidateQueries({ queryKey: workoutQueryKeys.templateList() }),
         queryClient.invalidateQueries({ queryKey: workoutSessionQueryKeys.all }),
         queryClient.invalidateQueries({
           queryKey: workoutSessionQueryKeys.detail(normalizedSessionId),

--- a/apps/web/src/hooks/use-session-sets.test.tsx
+++ b/apps/web/src/hooks/use-session-sets.test.tsx
@@ -1,10 +1,15 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { habitQueryKeys } from '@/features/habits/api/keys';
+import { workoutQueryKeys } from '@/features/workouts/api/workouts';
+import { dashboardSnapshotQueryKeys } from '@/hooks/use-dashboard-snapshot';
+import { habitChainQueryKeys } from '@/hooks/use-habit-chains';
+import { recentWorkoutQueryKeys } from '@/hooks/use-recent-workouts';
 import { createQueryClientWrapper } from '@/test/query-client';
 
-import { workoutSessionQueryKeys } from './use-workout-session';
 import { useLogSet, useUpdateSet } from './use-session-sets';
+import { workoutSessionQueryKeys } from './use-workout-session';
 
 const mockFetch = vi.fn();
 
@@ -29,27 +34,107 @@ const sessionSetResponse = {
   createdAt: 100,
 };
 
+const sessionResponse = {
+  id: 'session-1',
+  userId: 'user-1',
+  templateId: 'template-1',
+  name: 'Upper Push',
+  date: '2026-03-08',
+  status: 'in-progress' as const,
+  startedAt: 100,
+  completedAt: null,
+  duration: null,
+  timeSegments: [],
+  feedback: null,
+  notes: null,
+  exercises: [
+    {
+      exerciseId: 'incline-dumbbell-press',
+      exerciseName: 'Incline Dumbbell Press',
+      trackingType: 'weight_reps' as const,
+      orderIndex: 0,
+      section: 'main' as const,
+      sets: [],
+    },
+  ],
+  sets: [],
+  createdAt: 100,
+  updatedAt: 100,
+};
+
+function createDeferredPromise<T>() {
+  let resolveDeferred: ((value: T | PromiseLike<T>) => void) | undefined;
+  let rejectDeferred: ((reason?: unknown) => void) | undefined;
+
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolveDeferred = resolvePromise;
+    rejectDeferred = rejectPromise;
+  });
+
+  return {
+    promise,
+    reject: (reason?: unknown) => {
+      if (!rejectDeferred) {
+        throw new Error('Deferred reject handler was not initialized');
+      }
+
+      rejectDeferred(reason);
+    },
+    resolve: (value: T | PromiseLike<T>) => {
+      if (!resolveDeferred) {
+        throw new Error('Deferred resolve handler was not initialized');
+      }
+
+      resolveDeferred(value);
+    },
+  };
+}
+
 describe('use-session-sets hooks', () => {
   beforeEach(() => {
     mockFetch.mockReset();
     vi.stubGlobal('fetch', mockFetch);
   });
 
-  it('logs a set for a session and invalidates session queries', async () => {
-    mockFetch.mockResolvedValueOnce(createJsonResponse(sessionSetResponse, 201));
-
+  it('optimistically logs a set into the active session caches and invalidates dependents', async () => {
+    const deferred = createDeferredPromise<typeof sessionSetResponse>();
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+
+    queryClient.setQueryData(workoutSessionQueryKeys.detail('session-1'), sessionResponse);
+    queryClient.setQueryData(workoutQueryKeys.session('session-1'), sessionResponse);
+
+    mockFetch.mockImplementationOnce(() => deferred.promise.then((data) => createJsonResponse(data, 201)));
+
     const { result } = renderHook(() => useLogSet('session-1'), { wrapper });
 
-    await act(async () => {
-      await result.current.mutateAsync({
+    act(() => {
+      result.current.mutate({
         exerciseId: 'incline-dumbbell-press',
         reps: 8,
         section: 'main',
         setNumber: 1,
         weight: 60,
       });
+    });
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<typeof sessionResponse>(workoutSessionQueryKeys.detail('session-1'))
+          ?.sets,
+      ).toEqual([
+        expect.objectContaining({
+          exerciseId: 'incline-dumbbell-press',
+          id: 'optimistic-session-1-incline-dumbbell-press-1',
+          reps: 8,
+          weight: 60,
+        }),
+      ]);
+    });
+
+    await act(async () => {
+      deferred.resolve(sessionSetResponse);
+      await deferred.promise;
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
@@ -75,27 +160,53 @@ describe('use-session-sets hooks', () => {
       weight: 60,
     });
 
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<typeof sessionResponse>(workoutSessionQueryKeys.detail('session-1'))
+          ?.sets,
+      ).toEqual([sessionSetResponse]);
+    });
+
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutSessionQueryKeys.all });
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: workoutSessionQueryKeys.detail('session-1'),
     });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutQueryKeys.sessions() });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.session('session-1'),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: dashboardSnapshotQueryKeys.all,
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: recentWorkoutQueryKeys.all });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitQueryKeys.list() });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitQueryKeys.entryList() });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: habitChainQueryKeys.all });
   });
 
-  it('updates a set for a session and invalidates session queries', async () => {
-    mockFetch.mockResolvedValueOnce(
-      createJsonResponse({
-        ...sessionSetResponse,
-        completed: true,
-        reps: 9,
-      }),
+  it('optimistically updates a set and reconciles the server result', async () => {
+    const deferred = createDeferredPromise<typeof sessionSetResponse>();
+    const { queryClient, wrapper } = createQueryClientWrapper();
+
+    queryClient.setQueryData(workoutSessionQueryKeys.detail('session-1'), {
+      ...sessionResponse,
+      exercises: [
+        {
+          ...sessionResponse.exercises[0],
+          sets: [sessionSetResponse],
+        },
+      ],
+      sets: [sessionSetResponse],
+    });
+
+    mockFetch.mockImplementationOnce(() =>
+      deferred.promise.then((data) => createJsonResponse(data)),
     );
 
-    const { queryClient, wrapper } = createQueryClientWrapper();
-    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
     const { result } = renderHook(() => useUpdateSet('session-1'), { wrapper });
 
-    await act(async () => {
-      await result.current.mutateAsync({
+    act(() => {
+      result.current.mutate({
         setId: 'set-1',
         update: {
           completed: true,
@@ -104,28 +215,39 @@ describe('use-session-sets hooks', () => {
       });
     });
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      '/api/v1/workout-sessions/session-1/sets/set-1',
-      expect.objectContaining({
-        method: 'PATCH',
-      }),
-    );
-
-    const request = mockFetch.mock.calls.find(
-      ([input, init]) =>
-        String(input) === '/api/v1/workout-sessions/session-1/sets/set-1' &&
-        init?.method === 'PATCH',
-    );
-
-    expect(request).toBeDefined();
-    expect(JSON.parse(String(request?.[1]?.body))).toEqual({
-      completed: true,
-      reps: 9,
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<typeof sessionResponse>(workoutSessionQueryKeys.detail('session-1'))
+          ?.sets,
+      ).toEqual([
+        expect.objectContaining({
+          completed: true,
+          id: 'set-1',
+          reps: 9,
+        }),
+      ]);
     });
 
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutSessionQueryKeys.all });
-    expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: workoutSessionQueryKeys.detail('session-1'),
+    await act(async () => {
+      deferred.resolve({
+        ...sessionSetResponse,
+        completed: true,
+        reps: 10,
+      });
+      await deferred.promise;
+    });
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<typeof sessionResponse>(workoutSessionQueryKeys.detail('session-1'))
+          ?.sets,
+      ).toEqual([
+        expect.objectContaining({
+          completed: true,
+          id: 'set-1',
+          reps: 10,
+        }),
+      ]);
     });
   });
 });

--- a/apps/web/src/hooks/use-session-sets.ts
+++ b/apps/web/src/hooks/use-session-sets.ts
@@ -1,9 +1,11 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { createSetSchema, sessionSetSchema, type SessionSet, updateSetSchema } from '@pulse/shared';
+import { createSetSchema, sessionSetSchema, type SessionSet, type WorkoutSession, updateSetSchema } from '@pulse/shared';
 import { toast } from 'sonner';
 import { z } from 'zod';
 
+import { workoutQueryKeys } from '@/features/workouts/api/workouts';
 import { apiRequest } from '@/lib/api-client';
+import { createOptimisticMutation } from '@/lib/optimistic';
+import { crossFeatureInvalidationMap } from '@/lib/query-invalidation';
 
 import { workoutSessionQueryKeys } from './use-workout-session';
 
@@ -41,21 +43,113 @@ async function patchSessionSet(sessionId: string, setId: string, input: UpdateSe
   return payload.data;
 }
 
-async function invalidateSessionQueries(
-  queryClient: ReturnType<typeof useQueryClient>,
-  sessionId: string,
-) {
-  await Promise.all([
-    queryClient.invalidateQueries({ queryKey: workoutSessionQueryKeys.all }),
-    queryClient.invalidateQueries({ queryKey: workoutSessionQueryKeys.detail(sessionId) }),
-  ]);
-}
+const compareSessionSets = (left: SessionSet, right: SessionSet) =>
+  left.exerciseId.localeCompare(right.exerciseId) ||
+  left.setNumber - right.setNumber ||
+  left.createdAt - right.createdAt ||
+  left.id.localeCompare(right.id);
+
+const upsertSessionSet = (sets: SessionSet[], nextSet: SessionSet) => {
+  const existingIndex = sets.findIndex(
+    (set) =>
+      set.id === nextSet.id ||
+      (set.exerciseId === nextSet.exerciseId && set.setNumber === nextSet.setNumber),
+  );
+
+  if (existingIndex === -1) {
+    return [...sets, nextSet].sort(compareSessionSets);
+  }
+
+  const nextSets = [...sets];
+  nextSets[existingIndex] = nextSet;
+
+  return nextSets.sort(compareSessionSets);
+};
+
+const replaceSessionSet = (
+  sets: SessionSet[],
+  setId: string,
+  updater: (current: SessionSet) => SessionSet,
+) => {
+  const existingIndex = sets.findIndex((set) => set.id === setId);
+
+  if (existingIndex === -1) {
+    return sets;
+  }
+
+  const nextSets = [...sets];
+  nextSets[existingIndex] = updater(nextSets[existingIndex] as SessionSet);
+
+  return nextSets.sort(compareSessionSets);
+};
+
+const applySessionSet = (session: WorkoutSession | undefined, nextSet: SessionSet) => {
+  if (!session) {
+    return session;
+  }
+
+  return {
+    ...session,
+    exercises: session.exercises?.map((exercise) =>
+      exercise.exerciseId === nextSet.exerciseId
+        ? {
+            ...exercise,
+            sets: upsertSessionSet(exercise.sets, nextSet),
+          }
+        : exercise,
+    ),
+    sets: upsertSessionSet(session.sets, nextSet),
+  };
+};
+
+const updateSessionSet = (
+  session: WorkoutSession | undefined,
+  setId: string,
+  updater: (current: SessionSet) => SessionSet,
+) => {
+  if (!session) {
+    return session;
+  }
+
+  return {
+    ...session,
+    exercises: session.exercises?.map((exercise) => ({
+      ...exercise,
+      sets: replaceSessionSet(exercise.sets, setId, updater),
+    })),
+    sets: replaceSessionSet(session.sets, setId, updater),
+  };
+};
+
+const getSessionCacheKeys = (sessionId: string) => {
+  if (!sessionId) {
+    return [];
+  }
+
+  return [
+    workoutSessionQueryKeys.detail(sessionId),
+    workoutQueryKeys.session(sessionId),
+  ] as const;
+};
+
+const getSessionInvalidateKeys = (sessionId: string) => {
+  if (!sessionId) {
+    return [];
+  }
+
+  return [
+    workoutSessionQueryKeys.all,
+    workoutSessionQueryKeys.detail(sessionId),
+    workoutQueryKeys.sessions(),
+    workoutQueryKeys.session(sessionId),
+    ...crossFeatureInvalidationMap.workoutSessionChange(),
+  ] as const;
+};
 
 export function useLogSet(sessionId: string | null | undefined) {
-  const queryClient = useQueryClient();
   const normalizedSessionId = sessionId?.trim() ?? '';
 
-  return useMutation<SessionSet, Error, CreateSetRequest>({
+  return createOptimisticMutation<WorkoutSession, SessionSet, CreateSetRequest, { optimisticSet: SessionSet }>({
     mutationFn: async (input) => {
       if (!normalizedSessionId) {
         throw new Error('Session id is required to log sets');
@@ -63,22 +157,39 @@ export function useLogSet(sessionId: string | null | undefined) {
 
       return createSessionSet(normalizedSessionId, input);
     },
+    getMeta: (variables) => ({
+      optimisticSet: {
+        id: `optimistic-${normalizedSessionId}-${variables.exerciseId}-${variables.setNumber}`,
+        exerciseId: variables.exerciseId,
+        setNumber: variables.setNumber,
+        weight: variables.weight ?? null,
+        reps: variables.reps ?? null,
+        targetWeight: undefined,
+        targetWeightMin: undefined,
+        targetWeightMax: undefined,
+        targetSeconds: undefined,
+        targetDistance: undefined,
+        completed: false,
+        skipped: false,
+        section: variables.section ?? null,
+        notes: null,
+        createdAt: Date.now(),
+      },
+    }),
+    invalidateKeys: () => getSessionInvalidateKeys(normalizedSessionId),
     onSuccess: async () => {
-      if (!normalizedSessionId) {
-        return;
-      }
-
-      await invalidateSessionQueries(queryClient, normalizedSessionId);
       toast.success('Set added');
     },
+    queryKey: () => getSessionCacheKeys(normalizedSessionId),
+    reconcile: (current, serverSet) => applySessionSet(current, serverSet),
+    updater: (current, _variables, context) => applySessionSet(current, context.meta.optimisticSet),
   });
 }
 
 export function useUpdateSet(sessionId: string | null | undefined) {
-  const queryClient = useQueryClient();
   const normalizedSessionId = sessionId?.trim() ?? '';
 
-  return useMutation<SessionSet, Error, UpdateSetVariables>({
+  return createOptimisticMutation<WorkoutSession, SessionSet, UpdateSetVariables>({
     mutationFn: async ({ setId, update }) => {
       if (!normalizedSessionId) {
         throw new Error('Session id is required to update sets');
@@ -86,16 +197,30 @@ export function useUpdateSet(sessionId: string | null | undefined) {
 
       return patchSessionSet(normalizedSessionId, setId, update);
     },
+    invalidateKeys: () => getSessionInvalidateKeys(normalizedSessionId),
     onSuccess: async (_set, variables) => {
-      if (!normalizedSessionId) {
-        return;
-      }
-
-      await invalidateSessionQueries(queryClient, normalizedSessionId);
-
       if (variables.update.completed) {
         toast.success('Set saved');
       }
     },
+    queryKey: () => getSessionCacheKeys(normalizedSessionId),
+    reconcile: (current, serverSet, variables) => updateSessionSet(current, variables.setId, () => serverSet),
+    updater: (current, variables) =>
+      updateSessionSet(current, variables.setId, (existingSet) => {
+        const nextSet: SessionSet = {
+          ...existingSet,
+          ...(variables.update.completed === undefined
+            ? {}
+            : { completed: variables.update.completed }),
+          ...(variables.update.reps === undefined ? {} : { reps: variables.update.reps }),
+          ...(variables.update.notes === undefined
+            ? {}
+            : { notes: (variables.update.notes ?? null) as string | null }),
+          ...(variables.update.skipped === undefined ? {} : { skipped: variables.update.skipped }),
+          ...(variables.update.weight === undefined ? {} : { weight: variables.update.weight }),
+        };
+
+        return nextSet;
+      }),
   });
 }

--- a/apps/web/src/hooks/use-user.ts
+++ b/apps/web/src/hooks/use-user.ts
@@ -3,9 +3,9 @@ import { userProfileSchema, type UserProfile, type UpdateUserInput } from '@puls
 
 import { apiRequest } from '@/lib/api-client';
 
-export const userKeys = {
+export const userQueryKeys = {
   all: ['user'] as const,
-  me: () => [...userKeys.all, 'me'] as const,
+  current: () => [...userQueryKeys.all, 'current'] as const,
 };
 
 const fetchCurrentUser = async (signal?: AbortSignal): Promise<UserProfile> => {
@@ -29,7 +29,7 @@ const patchCurrentUser = async (data: UpdateUserInput): Promise<UserProfile> => 
 export const useUser = () =>
   useQuery({
     queryFn: ({ signal }) => fetchCurrentUser(signal),
-    queryKey: userKeys.me(),
+    queryKey: userQueryKeys.current(),
   });
 
 export const useUpdateUser = () => {
@@ -38,7 +38,7 @@ export const useUpdateUser = () => {
   return useMutation({
     mutationFn: patchCurrentUser,
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: userKeys.all });
+      await queryClient.invalidateQueries({ queryKey: userQueryKeys.all });
     },
   });
 };

--- a/apps/web/src/hooks/use-weight-trend.ts
+++ b/apps/web/src/hooks/use-weight-trend.ts
@@ -7,14 +7,15 @@ import { addDays, getToday, parseDateInput, toDateKey } from '@/lib/date';
 const DEFAULT_TREND_DAYS = 30;
 const DEFAULT_QUERY_ENABLED = true;
 
-export const weightTrendKeys = {
+export const dashboardWeightTrendQueryKeys = {
   all: ['dashboard', 'weight-trend'] as const,
-  range: (from: string, to: string) => [...weightTrendKeys.all, from, to] as const,
+  range: (from: string, to: string) => [...dashboardWeightTrendQueryKeys.all, from, to] as const,
 };
 
 const resolveDateRange = (from?: string, to?: string) => {
   const resolvedTo = to ?? toDateKey(getToday());
-  const resolvedFrom = from ?? toDateKey(addDays(parseDateInput(resolvedTo), -(DEFAULT_TREND_DAYS - 1)));
+  const resolvedFrom =
+    from ?? toDateKey(addDays(parseDateInput(resolvedTo), -(DEFAULT_TREND_DAYS - 1)));
 
   return {
     from: resolvedFrom,
@@ -39,17 +40,13 @@ const fetchWeightTrend = async (
   return dashboardWeightTrendSchema.parse(trend);
 };
 
-export const useWeightTrend = (
-  from?: string,
-  to?: string,
-  options: { enabled?: boolean } = {},
-) => {
+export const useWeightTrend = (from?: string, to?: string, options: { enabled?: boolean } = {}) => {
   const range = resolveDateRange(from, to);
   const enabled = options.enabled ?? DEFAULT_QUERY_ENABLED;
 
   return useQuery({
     enabled,
     queryFn: ({ signal }) => fetchWeightTrend(range.from, range.to, signal),
-    queryKey: weightTrendKeys.range(range.from, range.to),
+    queryKey: dashboardWeightTrendQueryKeys.range(range.from, range.to),
   });
 };

--- a/apps/web/src/hooks/use-workout-session.test.tsx
+++ b/apps/web/src/hooks/use-workout-session.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast } from 'sonner';
 
 import { ACTIVE_WORKOUT_SESSION_STORAGE_KEY } from '@/features/workouts/lib/session-persistence';
 import { workoutQueryKeys } from '@/features/workouts/api/workouts';
@@ -15,6 +16,18 @@ import {
   useWorkoutSession,
   workoutSessionQueryKeys,
 } from './use-workout-session';
+
+const { toastErrorMock, toastSuccessMock } = vi.hoisted(() => ({
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+  },
+}));
 
 const mockFetch = vi.fn();
 
@@ -53,6 +66,8 @@ describe('use-workout-session hooks', () => {
   beforeEach(() => {
     mockFetch.mockReset();
     vi.stubGlobal('fetch', mockFetch);
+    vi.mocked(toast.error).mockClear();
+    vi.mocked(toast.success).mockClear();
     window.localStorage.removeItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY);
   });
 
@@ -160,6 +175,7 @@ describe('use-workout-session hooks', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: workoutSessionQueryKeys.detail('session-1'),
     });
+    expect(toast.success).toHaveBeenCalledWith('Workout start time updated');
   });
 
   it('updates workout status and refreshes session + list caches', async () => {
@@ -200,6 +216,7 @@ describe('use-workout-session hooks', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: dashboardSnapshotQueryKeys.all,
     });
+    expect(toast.success).toHaveBeenCalledWith('Workout paused');
   });
 
   it('updates workout time segments via dedicated endpoint', async () => {
@@ -237,6 +254,7 @@ describe('use-workout-session hooks', () => {
         method: 'PATCH',
       }),
     );
+    expect(toast.success).toHaveBeenCalledWith('Workout timing updated');
   });
 
   it('reorders workout session exercises via dedicated endpoint', async () => {
@@ -258,5 +276,6 @@ describe('use-workout-session hooks', () => {
         method: 'PATCH',
       }),
     );
+    expect(toast.success).toHaveBeenCalledWith('Workout exercise order updated');
   });
 });

--- a/apps/web/src/hooks/use-workout-session.test.tsx
+++ b/apps/web/src/hooks/use-workout-session.test.tsx
@@ -2,6 +2,8 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ACTIVE_WORKOUT_SESSION_STORAGE_KEY } from '@/features/workouts/lib/session-persistence';
+import { workoutQueryKeys } from '@/features/workouts/api/workouts';
+import { dashboardSnapshotQueryKeys } from '@/hooks/use-dashboard-snapshot';
 import { createQueryClientWrapper } from '@/test/query-client';
 
 import {
@@ -110,6 +112,13 @@ describe('use-workout-session hooks', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: workoutSessionQueryKeys.detail('session-1'),
     });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutQueryKeys.sessions() });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.session('session-1'),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: dashboardSnapshotQueryKeys.all,
+    });
     expect(window.localStorage.getItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY)).toBe('session-1');
   });
 
@@ -187,6 +196,9 @@ describe('use-workout-session hooks', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: workoutSessionQueryKeys.all });
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: workoutSessionQueryKeys.detail('session-1'),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: dashboardSnapshotQueryKeys.all,
     });
   });
 

--- a/apps/web/src/hooks/use-workout-session.ts
+++ b/apps/web/src/hooks/use-workout-session.ts
@@ -15,6 +15,7 @@ import { z } from 'zod';
 import { setStoredActiveWorkoutSessionId } from '@/features/workouts/lib/session-persistence';
 import { workoutQueryKeys } from '@/features/workouts/api/workouts';
 import { apiRequest } from '@/lib/api-client';
+import { crossFeatureInvalidationMap, invalidateQueryKeys } from '@/lib/query-invalidation';
 
 const workoutSessionResponseSchema = z.object({
   data: workoutSessionSchema,
@@ -279,6 +280,7 @@ export function useDeleteSession(sessionId: string | null | undefined) {
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.session(normalizedSessionId),
         }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.workoutCompletion()),
       ]);
       toast.success('Workout deleted');
     },

--- a/apps/web/src/hooks/use-workout-session.ts
+++ b/apps/web/src/hooks/use-workout-session.ts
@@ -121,11 +121,11 @@ async function deleteSession(sessionId: string) {
 async function syncSessionMutationCache(
   queryClient: ReturnType<typeof useQueryClient>,
   session: WorkoutSession,
+  options?: { invalidateDashboard?: boolean },
 ) {
   queryClient.setQueryData(workoutSessionQueryKeys.detail(session.id), session);
   queryClient.setQueryData(workoutQueryKeys.session(session.id), session);
-
-  await Promise.all([
+  const invalidations = [
     queryClient.invalidateQueries({
       queryKey: workoutSessionQueryKeys.all,
     }),
@@ -138,7 +138,15 @@ async function syncSessionMutationCache(
     queryClient.invalidateQueries({
       queryKey: workoutQueryKeys.session(session.id),
     }),
-  ]);
+  ];
+
+  if (options?.invalidateDashboard) {
+    invalidations.push(
+      invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.activeWorkoutSessionMutation()),
+    );
+  }
+
+  await Promise.all(invalidations);
 }
 
 type UseWorkoutSessionOptions = {
@@ -168,6 +176,7 @@ export function useStartSession() {
     onSuccess: async (session) => {
       setStoredActiveWorkoutSessionId(session.id);
       queryClient.setQueryData(workoutSessionQueryKeys.detail(session.id), session);
+      queryClient.setQueryData(workoutQueryKeys.session(session.id), session);
 
       await Promise.all([
         queryClient.invalidateQueries({
@@ -176,6 +185,13 @@ export function useStartSession() {
         queryClient.invalidateQueries({
           queryKey: workoutSessionQueryKeys.detail(session.id),
         }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.sessions(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.session(session.id),
+        }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.activeWorkoutSessionMutation()),
       ]);
       toast.success('Workout started');
     },
@@ -195,7 +211,7 @@ export function useUpdateSessionStartTime(sessionId: string | null | undefined) 
       return updateSessionStartTime(normalizedSessionId, input);
     },
     onSuccess: async (session) => {
-      await syncSessionMutationCache(queryClient, session);
+      await syncSessionMutationCache(queryClient, session, { invalidateDashboard: true });
     },
   });
 }
@@ -213,7 +229,7 @@ export function useUpdateSessionStatus(sessionId: string | null | undefined) {
       return updateSessionStatus(normalizedSessionId, input);
     },
     onSuccess: async (session) => {
-      await syncSessionMutationCache(queryClient, session);
+      await syncSessionMutationCache(queryClient, session, { invalidateDashboard: true });
     },
   });
 }
@@ -231,7 +247,7 @@ export function useUpdateSessionTimeSegments(sessionId: string | null | undefine
       return updateSessionTimeSegments(normalizedSessionId, input);
     },
     onSuccess: async (session) => {
-      await syncSessionMutationCache(queryClient, session);
+      await syncSessionMutationCache(queryClient, session, { invalidateDashboard: true });
     },
   });
 }

--- a/apps/web/src/hooks/use-workout-session.ts
+++ b/apps/web/src/hooks/use-workout-session.ts
@@ -280,7 +280,7 @@ export function useDeleteSession(sessionId: string | null | undefined) {
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.session(normalizedSessionId),
         }),
-        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.workoutCompletion()),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.workoutSessionChange()),
       ]);
       toast.success('Workout deleted');
     },

--- a/apps/web/src/hooks/use-workout-session.ts
+++ b/apps/web/src/hooks/use-workout-session.ts
@@ -149,6 +149,22 @@ async function syncSessionMutationCache(
   await Promise.all(invalidations);
 }
 
+function getSessionStatusSuccessMessage(status: WorkoutSession['status']) {
+  if (status === 'paused') {
+    return 'Workout paused';
+  }
+
+  if (status === 'cancelled') {
+    return 'Workout cancelled';
+  }
+
+  if (status === 'in-progress') {
+    return 'Workout resumed';
+  }
+
+  return 'Workout status updated';
+}
+
 type UseWorkoutSessionOptions = {
   refetchInterval?: number | false;
 };
@@ -212,6 +228,7 @@ export function useUpdateSessionStartTime(sessionId: string | null | undefined) 
     },
     onSuccess: async (session) => {
       await syncSessionMutationCache(queryClient, session, { invalidateDashboard: true });
+      toast.success('Workout start time updated');
     },
   });
 }
@@ -230,6 +247,7 @@ export function useUpdateSessionStatus(sessionId: string | null | undefined) {
     },
     onSuccess: async (session) => {
       await syncSessionMutationCache(queryClient, session, { invalidateDashboard: true });
+      toast.success(getSessionStatusSuccessMessage(session.status));
     },
   });
 }
@@ -248,6 +266,7 @@ export function useUpdateSessionTimeSegments(sessionId: string | null | undefine
     },
     onSuccess: async (session) => {
       await syncSessionMutationCache(queryClient, session, { invalidateDashboard: true });
+      toast.success('Workout timing updated');
     },
   });
 }
@@ -266,6 +285,7 @@ export function useReorderSessionExercises(sessionId: string | null | undefined)
     },
     onSuccess: async (session) => {
       await syncSessionMutationCache(queryClient, session);
+      toast.success('Workout exercise order updated');
     },
   });
 }

--- a/apps/web/src/lib/optimistic.test.tsx
+++ b/apps/web/src/lib/optimistic.test.tsx
@@ -1,0 +1,163 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { createOptimisticMutation } from './optimistic';
+
+type TestItem = {
+  id: string;
+  value: string;
+};
+
+function createDeferredPromise<T>() {
+  let resolveDeferred: ((value: T | PromiseLike<T>) => void) | undefined;
+  let rejectDeferred: ((reason?: unknown) => void) | undefined;
+
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolveDeferred = resolvePromise;
+    rejectDeferred = rejectPromise;
+  });
+
+  return {
+    promise,
+    reject: (reason?: unknown) => {
+      if (!rejectDeferred) {
+        throw new Error('Deferred reject handler was not initialized');
+      }
+
+      rejectDeferred(reason);
+    },
+    resolve: (value: T | PromiseLike<T>) => {
+      if (!resolveDeferred) {
+        throw new Error('Deferred resolve handler was not initialized');
+      }
+
+      resolveDeferred(value);
+    },
+  };
+}
+
+function useTestOptimisticMutation(mutationFn: (value: string) => Promise<TestItem>) {
+  return createOptimisticMutation<
+    TestItem[],
+    TestItem,
+    string,
+    {
+      optimisticItem: TestItem;
+    }
+  >({
+    mutationFn,
+    getMeta: (variables) => ({
+      optimisticItem: {
+        id: 'optimistic-item',
+        value: variables,
+      },
+    }),
+    invalidateKeys: () => [['items']],
+    queryKey: () => [['items']],
+    reconcile: (current, data) =>
+      (current ?? []).map((item) => (item.id === 'optimistic-item' ? data : item)),
+    updater: (current, _variables, context) => [...(current ?? []), context.meta.optimisticItem],
+  });
+}
+
+describe('createOptimisticMutation', () => {
+  it('snapshots cache, applies an optimistic update, and reconciles the server result', async () => {
+    const deferred = createDeferredPromise<TestItem>();
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+
+    queryClient.setQueryData<TestItem[]>(['items'], [{ id: 'seed', value: 'before' }]);
+
+    const { result } = renderHook(() => useTestOptimisticMutation(() => deferred.promise), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.mutate('after');
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData<TestItem[]>(['items'])).toEqual([
+        { id: 'seed', value: 'before' },
+        { id: 'optimistic-item', value: 'after' },
+      ]);
+    });
+
+    await act(async () => {
+      deferred.resolve({ id: 'server-item', value: 'after' });
+      await deferred.promise;
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData<TestItem[]>(['items'])).toEqual([
+        { id: 'seed', value: 'before' },
+        { id: 'server-item', value: 'after' },
+      ]);
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['items'] });
+  });
+
+  it('restores the exact snapshot on error instead of leaving a stale optimistic value', async () => {
+    const deferred = createDeferredPromise<TestItem>();
+    void deferred.promise.catch(() => undefined);
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const initialItems = [{ id: 'seed', value: 'before' }];
+
+    queryClient.setQueryData<TestItem[]>(['items'], initialItems);
+
+    const { result } = renderHook(() => useTestOptimisticMutation(() => deferred.promise), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.mutate('after');
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData<TestItem[]>(['items'])).toEqual([
+        { id: 'seed', value: 'before' },
+        { id: 'optimistic-item', value: 'after' },
+      ]);
+    });
+
+    queryClient.setQueryData<TestItem[]>(['items'], [{ id: 'unexpected', value: 'drifted' }]);
+
+    act(() => {
+      deferred.reject(new Error('mutation failed'));
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData<TestItem[]>(['items'])).toEqual(initialItems);
+    });
+  });
+
+  it('invalidates settled keys even after rollback from an error', async () => {
+    const deferred = createDeferredPromise<TestItem>();
+    void deferred.promise.catch(() => undefined);
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+
+    queryClient.setQueryData<TestItem[]>(['items'], [{ id: 'seed', value: 'before' }]);
+
+    const { result } = renderHook(() => useTestOptimisticMutation(() => deferred.promise), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.mutate('after');
+    });
+
+    act(() => {
+      deferred.reject(new Error('mutation failed'));
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['items'] });
+  });
+});

--- a/apps/web/src/lib/optimistic.ts
+++ b/apps/web/src/lib/optimistic.ts
@@ -1,0 +1,230 @@
+import {
+  useMutation,
+  useQueryClient,
+  type MutationFunction,
+  type QueryClient,
+  type QueryKey,
+} from '@tanstack/react-query';
+
+type QueryKeyResolverParams<TData, TVariables, TMeta> = {
+  data?: TData;
+  error?: Error | null;
+  meta: TMeta;
+  variables: TVariables;
+};
+
+type QueryKeyResolver<TData, TVariables, TMeta> =
+  | QueryKey
+  | readonly QueryKey[]
+  | ((params: QueryKeyResolverParams<TData, TVariables, TMeta>) => QueryKey | readonly QueryKey[]);
+
+type OptimisticUpdaterContext<TMeta> = {
+  meta: TMeta;
+  queryKey: QueryKey;
+};
+
+type SnapshotEntry<TCache> = readonly [QueryKey, TCache | undefined];
+
+type OptimisticMutationContext<TCache, TMeta> = {
+  meta: TMeta;
+  snapshots: SnapshotEntry<TCache>[];
+};
+
+type CreateOptimisticMutationOptions<TCache, TData, TVariables, TMeta> = {
+  mutationFn: MutationFunction<TData, TVariables>;
+  queryKey: QueryKeyResolver<TData, TVariables, TMeta>;
+  updater: (
+    current: TCache | undefined,
+    variables: TVariables,
+    context: OptimisticUpdaterContext<TMeta>,
+  ) => TCache | undefined;
+  invalidateKeys?: QueryKeyResolver<TData, TVariables, TMeta>;
+  getMeta?: (variables: TVariables, queryClient: QueryClient) => TMeta;
+  reconcile?: (
+    current: TCache | undefined,
+    data: TData,
+    variables: TVariables,
+    context: OptimisticUpdaterContext<TMeta>,
+  ) => TCache | undefined;
+  onError?: (
+    error: Error,
+    variables: TVariables,
+    context: OptimisticMutationContext<TCache, TMeta> | undefined,
+    queryClient: QueryClient,
+  ) => Promise<void> | void;
+  onMutate?: (
+    variables: TVariables,
+    context: OptimisticMutationContext<TCache, TMeta>,
+    queryClient: QueryClient,
+  ) => Promise<void> | void;
+  onSettled?: (
+    data: TData | undefined,
+    error: Error | null,
+    variables: TVariables,
+    context: OptimisticMutationContext<TCache, TMeta> | undefined,
+    queryClient: QueryClient,
+  ) => Promise<void> | void;
+  onSuccess?: (
+    data: TData,
+    variables: TVariables,
+    context: OptimisticMutationContext<TCache, TMeta> | undefined,
+    queryClient: QueryClient,
+  ) => Promise<void> | void;
+};
+
+const EMPTY_QUERY_KEYS: readonly QueryKey[] = [];
+
+function dedupeQueryKeys(queryKeys: readonly QueryKey[]) {
+  const seen = new Set<string>();
+  const uniqueKeys: QueryKey[] = [];
+
+  queryKeys.forEach((queryKey) => {
+    const keyId = JSON.stringify(queryKey);
+    if (seen.has(keyId)) {
+      return;
+    }
+
+    seen.add(keyId);
+    uniqueKeys.push(queryKey);
+  });
+
+  return uniqueKeys;
+}
+
+function resolveQueryKeys<TData, TVariables, TMeta>(
+  queryKey: QueryKeyResolver<TData, TVariables, TMeta> | undefined,
+  params: QueryKeyResolverParams<TData, TVariables, TMeta>,
+) {
+  if (!queryKey) {
+    return EMPTY_QUERY_KEYS;
+  }
+
+  const resolvedQueryKey = typeof queryKey === 'function' ? queryKey(params) : queryKey;
+  if (Array.isArray(resolvedQueryKey) && resolvedQueryKey.length === 0) {
+    return EMPTY_QUERY_KEYS;
+  }
+  const queryKeys =
+    Array.isArray(resolvedQueryKey) && Array.isArray(resolvedQueryKey[0])
+      ? (resolvedQueryKey as readonly QueryKey[])
+      : [resolvedQueryKey as QueryKey];
+
+  return dedupeQueryKeys(queryKeys);
+}
+
+function snapshotQueries<TCache>(queryClient: QueryClient, queryKeys: readonly QueryKey[]) {
+  const snapshots = new Map<string, SnapshotEntry<TCache>>();
+
+  queryKeys.forEach((queryKey) => {
+    queryClient.getQueriesData<TCache>({ queryKey }).forEach(([matchedQueryKey, data]) => {
+      const keyId = JSON.stringify(matchedQueryKey);
+      if (!snapshots.has(keyId)) {
+        snapshots.set(keyId, [matchedQueryKey, data]);
+      }
+    });
+  });
+
+  return [...snapshots.values()];
+}
+
+async function invalidateQueryKeys(queryClient: QueryClient, queryKeys: readonly QueryKey[]) {
+  await Promise.all(
+    queryKeys.map((queryKey) =>
+      queryClient.invalidateQueries({
+        queryKey,
+      }),
+    ),
+  );
+}
+
+function useOptimisticMutation<
+  TCache,
+  TData,
+  TVariables,
+  TMeta = undefined,
+>({
+  mutationFn,
+  queryKey,
+  updater,
+  invalidateKeys,
+  getMeta,
+  reconcile,
+  onError,
+  onMutate,
+  onSettled,
+  onSuccess,
+}: CreateOptimisticMutationOptions<TCache, TData, TVariables, TMeta>) {
+  const queryClient = useQueryClient();
+
+  return useMutation<TData, Error, TVariables, OptimisticMutationContext<TCache, TMeta>>({
+    mutationFn,
+    onMutate: async (variables) => {
+      const meta = getMeta
+        ? getMeta(variables, queryClient)
+        : (undefined as unknown as TMeta);
+      const resolvedQueryKeys = resolveQueryKeys(queryKey, { meta, variables });
+
+      await Promise.all(
+        resolvedQueryKeys.map((resolvedQueryKey) =>
+          queryClient.cancelQueries({
+            queryKey: resolvedQueryKey,
+          }),
+        ),
+      );
+
+      const snapshots = snapshotQueries<TCache>(queryClient, resolvedQueryKeys);
+      const context = {
+        meta,
+        snapshots,
+      };
+
+      snapshots.forEach(([snapshotQueryKey]) => {
+        queryClient.setQueryData<TCache>(snapshotQueryKey, (current) =>
+          updater(current, variables, {
+            meta,
+            queryKey: snapshotQueryKey,
+          }),
+        );
+      });
+
+      await onMutate?.(variables, context, queryClient);
+
+      return context;
+    },
+    onError: async (error, variables, context) => {
+      context?.snapshots.forEach(([snapshotQueryKey, snapshotData]) => {
+        queryClient.setQueryData(snapshotQueryKey, snapshotData);
+      });
+
+      await onError?.(error, variables, context, queryClient);
+    },
+    onSuccess: async (data, variables, context) => {
+      if (reconcile && context) {
+        context.snapshots.forEach(([snapshotQueryKey]) => {
+          queryClient.setQueryData<TCache>(snapshotQueryKey, (current) =>
+            reconcile(current, data, variables, {
+              meta: context.meta,
+              queryKey: snapshotQueryKey,
+            }),
+          );
+        });
+      }
+
+      await onSuccess?.(data, variables, context, queryClient);
+    },
+    onSettled: async (data, error, variables, context) => {
+      const meta = context?.meta ?? (undefined as unknown as TMeta);
+      const resolvedInvalidateKeys = resolveQueryKeys(invalidateKeys, {
+        data,
+        error,
+        meta,
+        variables,
+      });
+
+      await invalidateQueryKeys(queryClient, resolvedInvalidateKeys);
+      await onSettled?.(data, error, variables, context, queryClient);
+    },
+  });
+}
+
+export const createOptimisticMutation = useOptimisticMutation;
+export type { OptimisticMutationContext };

--- a/apps/web/src/lib/query-invalidation.test.ts
+++ b/apps/web/src/lib/query-invalidation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { habitQueryKeys } from '@/features/habits/api/keys';
+import { dashboardSnapshotQueryKeys } from '@/hooks/use-dashboard-snapshot';
+import { habitChainQueryKeys } from '@/hooks/use-habit-chains';
+import { macroTrendQueryKeys } from '@/hooks/use-macro-trend';
+import { recentWorkoutQueryKeys } from '@/hooks/use-recent-workouts';
+import { dashboardWeightTrendQueryKeys } from '@/hooks/use-weight-trend';
+
+import { crossFeatureInvalidationMap } from './query-invalidation';
+
+describe('crossFeatureInvalidationMap', () => {
+  it('returns the expected workout-completion invalidations', () => {
+    expect(crossFeatureInvalidationMap.workoutCompletion()).toEqual([
+      dashboardSnapshotQueryKeys.all,
+      recentWorkoutQueryKeys.all,
+      habitQueryKeys.list(),
+      habitQueryKeys.entryList(),
+      habitChainQueryKeys.all,
+    ]);
+  });
+
+  it('returns the expected meal invalidations', () => {
+    expect(crossFeatureInvalidationMap.mealMutation()).toEqual([
+      dashboardSnapshotQueryKeys.all,
+      macroTrendQueryKeys.all,
+      habitQueryKeys.list(),
+      habitQueryKeys.entryList(),
+      habitChainQueryKeys.all,
+    ]);
+  });
+
+  it('returns the expected habit-entry invalidations', () => {
+    expect(crossFeatureInvalidationMap.habitEntryMutation()).toEqual([
+      dashboardSnapshotQueryKeys.all,
+      habitChainQueryKeys.all,
+    ]);
+  });
+
+  it('returns the expected weight invalidations', () => {
+    expect(crossFeatureInvalidationMap.weightMutation()).toEqual([
+      dashboardSnapshotQueryKeys.all,
+      dashboardWeightTrendQueryKeys.all,
+      habitQueryKeys.list(),
+      habitQueryKeys.entryList(),
+      habitChainQueryKeys.all,
+    ]);
+  });
+});

--- a/apps/web/src/lib/query-invalidation.test.ts
+++ b/apps/web/src/lib/query-invalidation.test.ts
@@ -10,8 +10,8 @@ import { dashboardWeightTrendQueryKeys } from '@/hooks/use-weight-trend';
 import { crossFeatureInvalidationMap } from './query-invalidation';
 
 describe('crossFeatureInvalidationMap', () => {
-  it('returns the expected workout-completion invalidations', () => {
-    expect(crossFeatureInvalidationMap.workoutCompletion()).toEqual([
+  it('returns the expected workout-session invalidations', () => {
+    expect(crossFeatureInvalidationMap.workoutSessionChange()).toEqual([
       dashboardSnapshotQueryKeys.all,
       recentWorkoutQueryKeys.all,
       habitQueryKeys.list(),

--- a/apps/web/src/lib/query-invalidation.ts
+++ b/apps/web/src/lib/query-invalidation.ts
@@ -14,7 +14,7 @@ import { dashboardWeightTrendQueryKeys } from '@/hooks/use-weight-trend';
  * - Dynamic ids or normalized params are always the final segment.
  *
  * Cross-feature invalidation map:
- * - Workout completion refreshes dashboard snapshot data, recent workouts, and referential habit caches.
+ * - Workout session changes refresh dashboard snapshot data, recent workouts, and referential habit caches.
  * - Meal mutations refresh dashboard nutrition widgets and referential habit caches.
  * - Habit entry mutations refresh dashboard snapshot and chain views.
  * - Weight mutations refresh dashboard weight widgets and referential habit caches.
@@ -41,7 +41,7 @@ export const crossFeatureInvalidationMap = {
       habitQueryKeys.entryList(),
       habitChainQueryKeys.all,
     ] as const satisfies readonly QueryKey[],
-  workoutCompletion: () =>
+  workoutSessionChange: () =>
     [
       dashboardSnapshotQueryKeys.all,
       recentWorkoutQueryKeys.all,

--- a/apps/web/src/lib/query-invalidation.ts
+++ b/apps/web/src/lib/query-invalidation.ts
@@ -1,0 +1,65 @@
+import type { QueryClient, QueryKey } from '@tanstack/react-query';
+
+import { habitQueryKeys } from '@/features/habits/api/keys';
+import { dashboardSnapshotQueryKeys } from '@/hooks/use-dashboard-snapshot';
+import { habitChainQueryKeys } from '@/hooks/use-habit-chains';
+import { macroTrendQueryKeys } from '@/hooks/use-macro-trend';
+import { recentWorkoutQueryKeys } from '@/hooks/use-recent-workouts';
+import { dashboardWeightTrendQueryKeys } from '@/hooks/use-weight-trend';
+
+/**
+ * Query key convention:
+ * - `all` is the stable feature root used for broad invalidation.
+ * - Static resource segments come next (`detail`, `list`, `sessions`, `summary`).
+ * - Dynamic ids or normalized params are always the final segment.
+ *
+ * Cross-feature invalidation map:
+ * - Workout completion refreshes dashboard snapshot data, recent workouts, and referential habit caches.
+ * - Meal mutations refresh dashboard nutrition widgets and referential habit caches.
+ * - Habit entry mutations refresh dashboard snapshot and chain views.
+ * - Weight mutations refresh dashboard weight widgets and referential habit caches.
+ */
+export const crossFeatureInvalidationMap = {
+  habitEntryMutation: () =>
+    [
+      dashboardSnapshotQueryKeys.all,
+      habitChainQueryKeys.all,
+    ] as const satisfies readonly QueryKey[],
+  mealMutation: () =>
+    [
+      dashboardSnapshotQueryKeys.all,
+      macroTrendQueryKeys.all,
+      habitQueryKeys.list(),
+      habitQueryKeys.entryList(),
+      habitChainQueryKeys.all,
+    ] as const satisfies readonly QueryKey[],
+  weightMutation: () =>
+    [
+      dashboardSnapshotQueryKeys.all,
+      dashboardWeightTrendQueryKeys.all,
+      habitQueryKeys.list(),
+      habitQueryKeys.entryList(),
+      habitChainQueryKeys.all,
+    ] as const satisfies readonly QueryKey[],
+  workoutCompletion: () =>
+    [
+      dashboardSnapshotQueryKeys.all,
+      recentWorkoutQueryKeys.all,
+      habitQueryKeys.list(),
+      habitQueryKeys.entryList(),
+      habitChainQueryKeys.all,
+    ] as const satisfies readonly QueryKey[],
+};
+
+export async function invalidateQueryKeys(
+  queryClient: QueryClient,
+  queryKeys: readonly QueryKey[],
+) {
+  await Promise.all(
+    queryKeys.map((queryKey) =>
+      queryClient.invalidateQueries({
+        queryKey,
+      }),
+    ),
+  );
+}

--- a/apps/web/src/lib/query-invalidation.ts
+++ b/apps/web/src/lib/query-invalidation.ts
@@ -14,12 +14,19 @@ import { dashboardWeightTrendQueryKeys } from '@/hooks/use-weight-trend';
  * - Dynamic ids or normalized params are always the final segment.
  *
  * Cross-feature invalidation map:
+ * - Habit definition mutations refresh dashboard snapshot data.
  * - Workout session changes refresh dashboard snapshot data, recent workouts, and referential habit caches.
+ * - Active/scheduled workout mutations refresh dashboard snapshot data.
+ * - Workout template mutations refresh dashboard snapshot data.
  * - Meal mutations refresh dashboard nutrition widgets and referential habit caches.
  * - Habit entry mutations refresh dashboard snapshot and chain views.
  * - Weight mutations refresh dashboard weight widgets and referential habit caches.
  */
 export const crossFeatureInvalidationMap = {
+  activeWorkoutSessionMutation: () =>
+    [dashboardSnapshotQueryKeys.all] as const satisfies readonly QueryKey[],
+  habitDefinitionMutation: () =>
+    [dashboardSnapshotQueryKeys.all] as const satisfies readonly QueryKey[],
   habitEntryMutation: () =>
     [
       dashboardSnapshotQueryKeys.all,
@@ -41,6 +48,10 @@ export const crossFeatureInvalidationMap = {
       habitQueryKeys.entryList(),
       habitChainQueryKeys.all,
     ] as const satisfies readonly QueryKey[],
+  scheduledWorkoutMutation: () =>
+    [dashboardSnapshotQueryKeys.all] as const satisfies readonly QueryKey[],
+  workoutTemplateMutation: () =>
+    [dashboardSnapshotQueryKeys.all] as const satisfies readonly QueryKey[],
   workoutSessionChange: () =>
     [
       dashboardSnapshotQueryKeys.all,

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -88,6 +88,7 @@ import {
 } from '@/features/workouts/lib/session-persistence';
 import { buildSessionSetInputs, extractExerciseNotes } from '@/features/workouts/lib/session-notes';
 import { ApiError, apiRequest } from '@/lib/api-client';
+import { crossFeatureInvalidationMap, invalidateQueryKeys } from '@/lib/query-invalidation';
 import {
   mockExercises,
   mockTemplates,
@@ -722,7 +723,10 @@ export function ActiveWorkoutPage() {
                 return;
               }
 
-              void queryClient.invalidateQueries({ queryKey: workoutQueryKeys.all });
+              void Promise.all([
+                queryClient.invalidateQueries({ queryKey: workoutQueryKeys.all }),
+                invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.workoutCompletion()),
+              ]);
 
               clearStoredActiveWorkoutDraft(activeWorkoutDraftId);
               setSessionFeedback(feedback);

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -725,7 +725,7 @@ export function ActiveWorkoutPage() {
 
               void Promise.all([
                 queryClient.invalidateQueries({ queryKey: workoutQueryKeys.all }),
-                invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.workoutCompletion()),
+                invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.workoutSessionChange()),
               ]);
 
               clearStoredActiveWorkoutDraft(activeWorkoutDraftId);

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -23,11 +23,7 @@ import { WeightTrendChart } from '@/features/dashboard/components/weight-trend-c
 import { useHabits } from '@/features/habits/api/habits';
 import { useRecentWorkouts } from '@/hooks/use-recent-workouts';
 import { useLogWeight } from '@/features/weight/api/weight';
-import {
-  prefetchDashboardSnapshot,
-  useDashboardSnapshot,
-  dashboardSnapshotKeys,
-} from '@/hooks/use-dashboard-snapshot';
+import { prefetchDashboardSnapshot, useDashboardSnapshot } from '@/hooks/use-dashboard-snapshot';
 import { useDashboardConfig, useSaveDashboardConfig } from '@/hooks/use-dashboard-config';
 import { useHabitChains } from '@/hooks/use-habit-chains';
 import { addDays, getToday, isSameDay, toDateKey } from '@/lib/date';
@@ -129,10 +125,13 @@ export function DashboardPage() {
   const habitsQuery = useHabits();
   const habitChainEntriesQuery = useHabitChains(habitRangeStart, selectedDateKey);
   const recentWorkoutsQuery = useRecentWorkouts();
-  const persistedVisibleWidgets = (dashboardConfigQuery.data?.visibleWidgets ?? DEFAULT_VISIBLE_WIDGETS)
-    .filter(isDashboardWidgetId);
+  const persistedVisibleWidgets = (
+    dashboardConfigQuery.data?.visibleWidgets ?? DEFAULT_VISIBLE_WIDGETS
+  ).filter(isDashboardWidgetId);
   const visibleWidgets = visibleWidgetsDraft ?? persistedVisibleWidgets;
-  const hiddenWidgets = DEFAULT_VISIBLE_WIDGETS.filter((widgetId) => !visibleWidgets.includes(widgetId));
+  const hiddenWidgets = DEFAULT_VISIBLE_WIDGETS.filter(
+    (widgetId) => !visibleWidgets.includes(widgetId),
+  );
   const showWeightTrendChart = visibleWidgets.includes('weight-trend');
   const isSavingDashboardConfig = saveDashboardConfigMutation.isPending;
   const selectedWeight = snapshotQuery.data?.weight;
@@ -216,7 +215,6 @@ export function DashboardPage() {
         date: selectedDateKey,
         weight: parsedWeight,
       });
-      await queryClient.invalidateQueries({ queryKey: dashboardSnapshotKeys.all });
       setWeightInput('');
       setWeightStatus({
         message: 'Weight entry saved.',
@@ -259,10 +257,18 @@ export function DashboardPage() {
                   recent workout activity.
                 </p>
                 <ul className="list-disc space-y-1 pl-5">
-                  <li>Nutrition totals come from meals logged by your AI agent, not manual entry.</li>
-                  <li>Use Weight Trend range buttons to zoom and compare short vs long-term direction.</li>
-                  <li>The trend line smooths daily swings so it is easier to spot overall momentum.</li>
-                  <li>Habit streaks show how many consecutive days each habit has been completed.</li>
+                  <li>
+                    Nutrition totals come from meals logged by your AI agent, not manual entry.
+                  </li>
+                  <li>
+                    Use Weight Trend range buttons to zoom and compare short vs long-term direction.
+                  </li>
+                  <li>
+                    The trend line smooths daily swings so it is easier to spot overall momentum.
+                  </li>
+                  <li>
+                    Habit streaks show how many consecutive days each habit has been completed.
+                  </li>
                 </ul>
               </HelpIcon>
             </div>
@@ -350,7 +356,10 @@ export function DashboardPage() {
                 onHide={() => hideWidget('calendar')}
                 widgetLabel={DASHBOARD_WIDGET_IDS.calendar}
               >
-                <CalendarPicker onDateSelect={handleSelectedDateChange} selectedDate={selectedDate} />
+                <CalendarPicker
+                  onDateSelect={handleSelectedDateChange}
+                  selectedDate={selectedDate}
+                />
               </DashboardWidgetFrame>
             ) : null}
 
@@ -383,12 +392,17 @@ export function DashboardPage() {
                       onHide={() => hideWidget('log-weight')}
                       widgetLabel={DASHBOARD_WIDGET_IDS['log-weight']}
                     >
-                      <Card data-qa="dashboard-log-weight-card" data-testid="dashboard-log-weight-card">
+                      <Card
+                        data-qa="dashboard-log-weight-card"
+                        data-testid="dashboard-log-weight-card"
+                      >
                         <CardHeader className="space-y-1">
                           <div className="flex items-center justify-between gap-3">
                             <div className="space-y-1">
                               <CardTitle>Body Weight</CardTitle>
-                              <CardDescription>Track your body weight for the selected day.</CardDescription>
+                              <CardDescription>
+                                Track your body weight for the selected day.
+                              </CardDescription>
                             </div>
                             <Link
                               className="text-sm font-medium text-primary hover:underline"
@@ -601,10 +615,17 @@ export function DashboardPage() {
                 >
                   <CardContent className="flex items-center justify-between gap-3">
                     <div>
-                      <p className="text-sm font-medium text-foreground">{DASHBOARD_WIDGET_IDS[widgetId]}</p>
+                      <p className="text-sm font-medium text-foreground">
+                        {DASHBOARD_WIDGET_IDS[widgetId]}
+                      </p>
                       <p className="text-xs text-muted-foreground">Currently hidden</p>
                     </div>
-                    <Button onClick={() => showWidget(widgetId)} size="sm" type="button" variant="outline">
+                    <Button
+                      onClick={() => showWidget(widgetId)}
+                      size="sm"
+                      type="button"
+                      variant="outline"
+                    >
                       <Plus />
                       Show
                     </Button>


### PR DESCRIPTION
## Summary

This PR cleans up client-side cache management in the web app by standardizing React Query key factories, centralizing cross-feature invalidation rules, and moving several high-frequency mutations to shared optimistic update flows. Query keys were renamed to a consistent `*QueryKeys` pattern and normalized so list/detail/root invalidations hit the intended caches reliably across workouts, habits, nutrition, weight, dashboard, and settings. It also fixes stale UI cases where mutations were not refreshing related dashboard, recent workout, habit-chain, or referential-habit data. On top of that, workout and settings mutations now restore missing success feedback, and the new cache behavior is covered with focused tests.

## Key Changes

- Standardized query key factories across features to a stable `all` / `list` / `detail` / `root` structure with normalized param objects for list queries.
- Added `crossFeatureInvalidationMap` and a shared `invalidateQueryKeys` utility to make dashboard, habit-chain, macro-trend, recent-workout, and weight-trend refresh rules explicit and reusable.
- Introduced `createOptimisticMutation`, which snapshots matching queries, applies optimistic cache updates, rolls back exact snapshots on failure, reconciles server results on success, and then invalidates the resolved keys.
- Applied optimistic updates to high-frequency mutations:
  - workout set logging and set updates
  - habit toggle and habit-entry edits
  - weight logging
  - workout template renames/reorders
  - exercise renames
  - scheduled workout reschedule/remove
- Completed the invalidation audit for remaining mutations, including meal deletion, template/session mutations, save-as-template, trash restore/purge, active workout completion, and related dashboard sync.
- Restored missing success toasts for workout/session/template mutations and trash actions.
- Added regression tests for query key normalization, optimistic update/reconcile/rollback behavior, and cross-feature invalidation coverage.

## Technical Notes

- Query key normalization now collapses optional params into stable shapes with explicit `null` defaults; for example, workout session status arrays are normalized into a single pipe-delimited string. This reduces cache fragmentation from semantically equivalent param objects.
- The optimistic helper operates on all queries matching the provided key prefixes, not just a single cache entry. That matters for mutations like habit entries, exercise renames, and scheduled workouts where the same entity is represented in multiple cached views.
- `crossFeatureInvalidationMap` is the main reviewer hotspot. It encodes which non-local caches should refresh after meal, weight, workout session, scheduled workout, habit, and template mutations, and replaces a number of scattered ad hoc invalidations.
- Weight logging now updates `weight`, dashboard snapshot, and dashboard weight-trend caches immediately, so the dashboard page no longer needs to manually invalidate snapshot queries after submit.
- The new tests are meant to lock down behavior rather than implementation details: reviewers should expect a larger test surface here because the risk is stale or divergent client cache state, not API shape changes.

## Commits

- `d27a446 fix(web): restore workout mutation feedback`
- `d33abfa fix(web): finish mutation invalidation audit`
- `9ff090f feat(web): add optimistic mutation updates`
- `fcc8bb7 fix(web): restore template detail invalidation`
- `4de79de refactor(web): standardize query keys and invalidations`

## Tasks

- **Audit and standardize query key factories**: Audit all query keys across features, standardize naming pattern, add cross-feature invalidation map
- **Add optimistic updates to high-frequency mutations**: Create shared optimistic mutation helper, add optimistic updates to set logging, habit completion, weight entry
- **Audit remaining mutations for invalidation and error handling**: Complete mutation audit — fix missing invalidations, add error toasts, ensure cross-feature sync

## Diff Stats

```
apps/web/src/features/foods/api/foods.test.tsx     |  10 +-
 apps/web/src/features/foods/api/foods.ts           |  20 +-
 apps/web/src/features/foods/api/keys.ts            |   4 +-
 apps/web/src/features/habits/api/habits.test.tsx   | 175 +++++++-
 apps/web/src/features/habits/api/habits.ts         | 198 +++++----
 apps/web/src/features/habits/api/keys.ts           |   9 +-
 apps/web/src/features/nutrition/api/keys.test.ts   |  10 +-
 apps/web/src/features/nutrition/api/keys.ts        |   9 +-
 .../src/features/nutrition/api/nutrition.test.tsx  |  27 +-
 apps/web/src/features/nutrition/api/nutrition.ts   |  20 +-
 .../src/features/nutrition/api/targets.test.tsx    |   4 +-
 apps/web/src/features/nutrition/api/targets.ts     |   8 +-
 apps/web/src/features/settings/api/trash.test.tsx  |  77 +++-
 apps/web/src/features/settings/api/trash.ts        |  41 +-
 apps/web/src/features/weight/api/weight.test.tsx   | 261 ++++++++++-
 apps/web/src/features/weight/api/weight.ts         | 251 ++++++++++-
 .../features/workouts/api/workouts.keys.test.ts    |  40 ++
 .../workouts/api/workouts.mutations.test.tsx       | 328 ++++++++++++++
 .../workouts/api/workouts.optimistic.test.tsx      | 381 +++++++++++++++++
 apps/web/src/features/workouts/api/workouts.ts     | 476 +++++++++++++++++----
 .../workouts/components/session-feedback.tsx       |   2 +-
 apps/web/src/hooks/use-agent-tokens.ts             |  12 +-
 apps/web/src/hooks/use-complete-session.test.tsx   |  25 +-
 apps/web/src/hooks/use-complete-session.ts         |   6 +-
 apps/web/src/hooks/use-dashboard-config.ts         |   8 +-
 apps/web/src/hooks/use-dashboard-snapshot.ts       |   8 +-
 apps/web/src/hooks/use-habit-chains.ts             |   6 +-
 apps/web/src/hooks/use-macro-trend.ts              |  15 +-
 apps/web/src/hooks/use-recent-workouts.ts          |  11 +-
 apps/web/src/hooks/use-save-as-template.test.tsx   |   2 +-
 apps/web/src/hooks/use-save-as-template.ts         |   2 +-
 apps/web/src/hooks/use-session-sets.test.tsx       | 196 +++++++--
 apps/web/src/hooks/use-session-sets.ts             | 177 ++++++--
 apps/web/src/hooks/use-user.ts                     |   8 +-
 apps/web/src/hooks/use-weight-trend.ts             |  15 +-
 apps/web/src/hooks/use-workout-session.test.tsx    |  31 ++
 apps/web/src/hooks/use-workout-session.ts          |  50 ++-
 apps/web/src/lib/optimistic.test.tsx               | 163 +++++++
 apps/web/src/lib/optimistic.ts                     | 230 ++++++++++
 apps/web/src/lib/query-invalidation.test.ts        |  49 +++
 apps/web/src/lib/query-invalidation.ts             |  76 ++++
 apps/web/src/pages/active-workout.tsx              |   6 +-
 apps/web/src/pages/dashboard.tsx                   |  57 ++-
 43 files changed, 3070 insertions(+), 434 deletions(-)
```