### PR TITLE
feat(ui): app-wide density and compactness audit

### DIFF
--- a/apps/web/src/components/layout/app-layout.test.tsx
+++ b/apps/web/src/components/layout/app-layout.test.tsx
@@ -57,7 +57,7 @@ describe('AppLayout', () => {
     const main = screen.getByRole('main');
 
     expect(main).toHaveClass('pt-4');
-    expect(main).toHaveClass('md:pt-8');
+    expect(main).toHaveClass('md:pt-6');
     expect(main).not.toHaveClass('pt-20');
   });
 });

--- a/apps/web/src/components/layout/app-layout.tsx
+++ b/apps/web/src/components/layout/app-layout.tsx
@@ -19,7 +19,7 @@ export function AppLayout({ children }: PropsWithChildren) {
       <ActiveSessionResumeGate />
       <div className="mx-auto flex min-h-screen w-full max-w-screen-2xl">
         <Sidebar />
-        <main className="min-w-0 flex-1 overflow-x-clip px-4 pb-24 pt-4 md:px-8 md:pb-8 md:pt-8">
+        <main className="min-w-0 flex-1 overflow-x-clip px-4 pb-24 pt-4 md:px-6 md:pb-8 md:pt-6">
           {content}
         </main>
       </div>

--- a/apps/web/src/components/skeletons/habit-row-skeleton.tsx
+++ b/apps/web/src/components/skeletons/habit-row-skeleton.tsx
@@ -4,11 +4,11 @@ import { Skeleton } from '@/components/ui/skeleton';
 export function HabitRowSkeleton() {
   return (
     <Card
-      className="gap-4 border-transparent py-5 shadow-sm"
+      className="gap-3 border-transparent py-4 shadow-sm"
       data-slot="habit-row-skeleton"
       data-testid="habit-row-skeleton"
     >
-      <CardHeader className="space-y-3 pb-0">
+      <CardHeader className="space-y-2.5 pb-0">
         <div className="flex items-center gap-3">
           <Skeleton className="size-9 rounded-full" />
           <div className="space-y-2">
@@ -18,7 +18,7 @@ export function HabitRowSkeleton() {
         </div>
       </CardHeader>
       <CardContent>
-        <div className="flex items-center justify-between gap-3 rounded-xl bg-white/70 px-4 py-3 shadow-sm dark:bg-secondary/60 dark:shadow-none">
+        <div className="flex items-center justify-between gap-3 rounded-xl bg-white/70 px-3 py-2.5 shadow-sm dark:bg-secondary/60 dark:shadow-none">
           <Skeleton className="h-5 w-44" />
           <Skeleton className="size-5 rounded-sm" />
         </div>

--- a/apps/web/src/components/skeletons/meal-card-skeleton.tsx
+++ b/apps/web/src/components/skeletons/meal-card-skeleton.tsx
@@ -4,28 +4,25 @@ import { Skeleton } from '@/components/ui/skeleton';
 export function MealCardSkeleton() {
   return (
     <Card
-      className="gap-0 overflow-hidden border-border bg-[var(--color-card)] py-0 shadow-none"
+      className="gap-0 overflow-hidden rounded-xl border-border/70 bg-[var(--color-card)] py-0 shadow-none"
       data-slot="meal-card-skeleton"
       data-testid="meal-card-skeleton"
     >
-      <div className="space-y-4 px-5 py-4">
-        <div className="space-y-2">
-          <Skeleton className="h-6 w-36" />
-          <Skeleton className="h-4 w-24" />
+      <div className="space-y-3 px-4 py-3 sm:px-5">
+        <div className="space-y-1.5">
+          <div className="flex flex-wrap gap-2">
+            <Skeleton className="h-5 w-28" />
+            <Skeleton className="h-3.5 w-36" />
+          </div>
+          <Skeleton className="h-3.5 w-24" />
         </div>
 
-        <div className="space-y-2">
-          <Skeleton className="h-4 w-full" />
-          <Skeleton className="h-4 w-4/5" />
-          <Skeleton className="h-4 w-2/3" />
-        </div>
-
-        <div className="flex flex-wrap gap-3">
-          <Skeleton className="h-4 w-16" />
-          <Skeleton className="h-4 w-20" />
-          <Skeleton className="h-4 w-16" />
-          <Skeleton className="h-4 w-14" />
-        </div>
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={index} className="space-y-1 border-t border-border/60 pt-2 first:border-t-0 first:pt-0">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3.5 w-48 max-w-full" />
+          </div>
+        ))}
       </div>
     </Card>
   );

--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -44,7 +44,7 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          'fixed top-[50%] left-[50%] z-50 mx-4 grid w-[calc(100%-2rem)] max-w-full translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:mx-0 sm:w-full sm:max-w-lg',
+          'fixed top-[50%] left-[50%] z-50 mx-4 grid w-[calc(100%-2rem)] max-w-full translate-x-[-50%] translate-y-[-50%] gap-3 rounded-lg border bg-background p-5 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:mx-0 sm:w-full sm:max-w-lg',
           className,
         )}
         {...props}
@@ -57,7 +57,7 @@ function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>)
   return (
     <div
       data-slot="alert-dialog-header"
-      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      className={cn('flex flex-col gap-1.5 text-center sm:text-left', className)}
       {...props}
     />
   );
@@ -67,7 +67,7 @@ function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>)
   return (
     <div
       data-slot="alert-dialog-footer"
-      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      className={cn('flex flex-col-reverse gap-2 pt-1 sm:flex-row sm:justify-end', className)}
       {...props}
     />
   );

--- a/apps/web/src/components/ui/confirmation-dialog.test.tsx
+++ b/apps/web/src/components/ui/confirmation-dialog.test.tsx
@@ -17,6 +17,8 @@ describe('ConfirmationDialog', () => {
 
     expect(screen.getByText('Delete template?')).toBeInTheDocument();
     expect(screen.getByText('This action cannot be undone.')).toBeInTheDocument();
+    expect(screen.getByRole('alertdialog')).toHaveClass('gap-3', 'p-5');
+    expect(document.querySelector('[data-slot="alert-dialog-footer"]')).toHaveClass('pt-1');
   });
 
   it('calls onConfirm when confirm button is clicked', () => {

--- a/apps/web/src/components/ui/dialog.test.tsx
+++ b/apps/web/src/components/ui/dialog.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+describe('Dialog', () => {
+  it('uses compact default spacing while keeping the close button touch target', () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogHeader data-testid="dialog-header">
+            <DialogTitle>Compact dialog</DialogTitle>
+            <DialogDescription>Density pass defaults.</DialogDescription>
+          </DialogHeader>
+          <div>Body</div>
+          <DialogFooter data-testid="dialog-footer">Actions</DialogFooter>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(screen.getByRole('dialog')).toHaveClass('gap-3', 'p-5');
+    expect(screen.getByTestId('dialog-header')).toHaveClass('gap-1.5');
+    expect(screen.getByTestId('dialog-footer')).toHaveClass('pt-1');
+    expect(screen.getByRole('button', { name: 'Close' })).toHaveClass(
+      'min-h-[44px]',
+      'min-w-[44px]',
+    );
+  });
+});

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -51,7 +51,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'fixed top-[50%] left-[50%] z-50 mx-4 grid w-[calc(100%-2rem)] max-w-full translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:mx-0 sm:w-full sm:max-w-lg',
+          'fixed top-[50%] left-[50%] z-50 mx-4 grid w-[calc(100%-2rem)] max-w-full translate-x-[-50%] translate-y-[-50%] gap-3 rounded-lg border bg-background p-5 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:mx-0 sm:w-full sm:max-w-lg',
           className,
         )}
         {...props}
@@ -60,7 +60,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="absolute top-3 right-3 flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded-md opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="absolute top-2.5 right-2.5 flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded-md opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>
@@ -75,7 +75,7 @@ function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      className={cn('flex flex-col gap-1.5 text-center sm:text-left', className)}
       {...props}
     />
   );
@@ -92,7 +92,7 @@ function DialogFooter({
   return (
     <div
       data-slot="dialog-footer"
-      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      className={cn('flex flex-col-reverse gap-2 pt-1 sm:flex-row sm:justify-end', className)}
       {...props}
     >
       {children}

--- a/apps/web/src/components/ui/empty-state.test.tsx
+++ b/apps/web/src/components/ui/empty-state.test.tsx
@@ -16,7 +16,11 @@ describe('EmptyState', () => {
 
     expect(screen.getByRole('heading', { name: 'No data yet' })).toBeInTheDocument();
     expect(screen.getByText('Start by adding your first entry.')).toBeInTheDocument();
-    expect(document.querySelector('[data-slot="empty-state"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-slot="empty-state"]')).toHaveClass(
+      'min-h-60',
+      'px-5',
+      'py-9',
+    );
   });
 
   it('renders an action button and calls the click handler', () => {

--- a/apps/web/src/components/ui/empty-state.tsx
+++ b/apps/web/src/components/ui/empty-state.tsx
@@ -15,14 +15,14 @@ type EmptyStateProps = {
 export function EmptyState({ icon: Icon, title, description, action }: EmptyStateProps) {
   return (
     <section
-      className="flex min-h-72 flex-col items-center justify-center rounded-2xl border border-dashed border-border/70 bg-card/70 px-6 py-12 text-center shadow-sm"
+      className="flex min-h-60 flex-col items-center justify-center rounded-2xl border border-dashed border-border/70 bg-card/70 px-5 py-9 text-center shadow-sm sm:px-6 sm:py-10"
       data-slot="empty-state"
     >
-      <Icon aria-hidden="true" className="size-12 text-muted" />
-      <h2 className="mt-5 text-xl font-semibold text-foreground">{title}</h2>
-      <p className="mt-2 max-w-lg text-sm text-muted">{description}</p>
+      <Icon aria-hidden="true" className="size-10 text-muted" />
+      <h2 className="mt-4 text-lg font-semibold text-foreground">{title}</h2>
+      <p className="mt-2 max-w-md text-sm text-muted">{description}</p>
       {action ? (
-        <Button className="mt-6" onClick={action.onClick} type="button">
+        <Button className="mt-5" onClick={action.onClick} type="button">
           {action.label}
         </Button>
       ) : null}

--- a/apps/web/src/components/ui/stat-card.tsx
+++ b/apps/web/src/components/ui/stat-card.tsx
@@ -19,6 +19,7 @@ export type StatCardProps = Omit<React.ComponentProps<typeof Card>, 'children'> 
   accentTextClassName?: string;
   valueClassName?: string;
   valueTitle?: string;
+  density?: 'default' | 'compact';
 };
 
 const TREND_STYLES: Record<
@@ -54,6 +55,7 @@ export function StatCard({
   accentTextClassName,
   valueClassName: customValueClassName,
   valueTitle,
+  density = 'default',
   className,
   ...props
 }: StatCardProps) {
@@ -74,13 +76,26 @@ export function StatCard({
     ? cn(accentClass, 'opacity-80 dark:text-muted dark:opacity-100')
     : trendStyle?.className;
   const resolvedValueTitle = valueTitle ?? (typeof value === 'string' ? value : undefined);
+  const isCompact = density === 'compact';
 
   return (
-    <Card data-slot="stat-card" className={cn('gap-3 py-4 sm:gap-4 sm:py-5', className)} {...props}>
-      <CardHeader className="min-w-0 flex flex-row items-start justify-between gap-2 pb-0">
+    <Card
+      data-density={density}
+      data-slot="stat-card"
+      className={cn(isCompact ? 'gap-2.5 py-2.5' : 'gap-3 py-4 sm:gap-4 sm:py-5', className)}
+      {...props}
+    >
+      <CardHeader
+        className={cn(
+          'min-w-0 flex flex-row items-start justify-between pb-0',
+          isCompact ? 'gap-1.5 px-3' : 'gap-2',
+        )}
+      >
         <p
           className={cn(
-            'min-w-0 truncate text-xs font-semibold uppercase tracking-wide sm:text-sm sm:normal-case sm:tracking-normal',
+            isCompact
+              ? 'min-w-0 truncate text-[11px] leading-4 font-semibold uppercase tracking-[0.14em] sm:text-xs'
+              : 'min-w-0 truncate text-xs font-semibold uppercase tracking-wide sm:text-sm sm:normal-case sm:tracking-normal',
             labelClassName,
           )}
         >
@@ -88,10 +103,12 @@ export function StatCard({
         </p>
         {icon ? <div className={cn('shrink-0', iconClassName)}>{icon}</div> : null}
       </CardHeader>
-      <CardContent className="min-w-0 space-y-1.5">
+      <CardContent className={cn('min-w-0', isCompact ? 'space-y-1 px-3' : 'space-y-1.5')}>
         <p
           className={cn(
-            'min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-lg font-bold tracking-tight sm:text-2xl lg:text-3xl',
+            isCompact
+              ? 'min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-base leading-tight font-bold tracking-tight sm:text-lg lg:text-xl'
+              : 'min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-lg font-bold tracking-tight sm:text-2xl lg:text-3xl',
             valueTextClassName,
             customValueClassName,
           )}
@@ -103,9 +120,14 @@ export function StatCard({
           <div
             aria-label={`trend ${trend.direction}`}
             data-slot="stat-card-trend"
-            className={cn('flex items-center gap-2 text-sm font-medium', trendClassName)}
+            className={cn(
+              isCompact
+                ? 'flex items-center gap-1.5 text-xs font-medium'
+                : 'flex items-center gap-2 text-sm font-medium',
+              trendClassName,
+            )}
           >
-            <TrendIcon className="size-4" />
+            <TrendIcon className={cn(isCompact ? 'size-3.5' : 'size-4')} />
             <span>{formattedTrend}</span>
           </div>
         ) : null}

--- a/apps/web/src/features/dashboard/components/habit-chain.test.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.test.tsx
@@ -349,6 +349,19 @@ describe('HabitChain', () => {
     expect(firstSquare).toHaveAttribute('title', `${formatDateLabel(date)} — ${statusLabel}`);
   });
 
+  it('keeps each day circle at the minimum touch target size', () => {
+    const habit = getHabitByIndex(0);
+    const { container } = render(
+      <HabitChain entries={habitEntryRecords} habitIds={[habit.id]} habits={habitRecords} />,
+    );
+
+    const firstSquare = container.querySelector('[data-slot="habit-chain-day"]');
+    expect(firstSquare).toHaveClass('size-11', 'min-h-11', 'min-w-11');
+
+    const grid = container.querySelector('[data-slot="habit-chain-grid"]');
+    expect(grid).toHaveClass('grid-cols-7', 'gap-1.5', 'sm:grid-cols-10');
+  });
+
   it('includes the status in square aria labels', () => {
     const habit = getHabitByIndex(0);
     const { container } = render(

--- a/apps/web/src/features/dashboard/components/habit-chain.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.tsx
@@ -143,23 +143,28 @@ export function HabitChain({ habitIds, habits = [], entries = [], endDate }: Hab
   }
 
   return (
-    <section aria-label="Habit chains" className="space-y-3">
+    <section aria-label="Habit chains" className="space-y-2.5">
       <TooltipProvider>
         {visibleHabits.map((habit) => (
-          <Card className="gap-2 px-3 py-3" key={habit.id}>
+          <Card className="gap-2 px-3 py-2.5" key={habit.id}>
             <CardContent className="space-y-2 px-0">
               <div className="flex items-start justify-between gap-3">
-                <h2 className="text-sm font-semibold text-foreground">{habit.name}</h2>
+                <h2 className="text-sm leading-tight font-semibold text-foreground">
+                  {habit.name}
+                </h2>
                 <p
-                  className="inline-flex items-center gap-1.5 text-sm font-semibold text-foreground"
+                  className="inline-flex items-center gap-1 text-xs font-semibold text-foreground sm:text-sm"
                   data-slot="habit-chain-streak"
                 >
-                  <Flame aria-hidden className="size-4 text-[var(--color-accent-pink)]" />
-                  <span className="text-base leading-none">{`${habit.currentStreak} day streak`}</span>
+                  <Flame aria-hidden className="size-3.5 text-[var(--color-accent-pink)]" />
+                  <span className="text-sm leading-none sm:text-base">{`${habit.currentStreak} day streak`}</span>
                 </p>
               </div>
 
-              <div className="grid grid-cols-10 gap-[5px]" data-slot="habit-chain-grid">
+              <div
+                className="grid grid-cols-7 gap-1.5 sm:grid-cols-10"
+                data-slot="habit-chain-grid"
+              >
                 {habit.entries.map((entry) => {
                   const isSelectedDay = entry.date === selectedDateKey;
                   const statusLabel =
@@ -181,11 +186,9 @@ export function HabitChain({ habitIds, habits = [], entries = [], endDate }: Hab
                         <button
                           aria-label={`${habit.name} ${entry.date} ${statusLabel}`}
                           className={cn(
-                            'aspect-square w-full cursor-pointer rounded-full border',
+                            'size-11 min-h-11 min-w-11 justify-self-center rounded-full border transition-colors',
                             statusClass,
-                            isSelectedDay
-                              ? 'border-[var(--color-primary)]'
-                              : 'border-transparent',
+                            isSelectedDay ? 'border-[var(--color-primary)]' : 'border-transparent',
                           )}
                           data-date={entry.date}
                           data-status={entry.status}

--- a/apps/web/src/features/dashboard/components/macro-rings.test.tsx
+++ b/apps/web/src/features/dashboard/components/macro-rings.test.tsx
@@ -78,9 +78,7 @@ describe('MacroRings', () => {
   it('renders four macro rings with distinct colors and eaten values', () => {
     const { container } = render(<MacroRings snapshot={snapshotFixture} />);
 
-    const grid = container.querySelector(
-      'div.grid.grid-cols-1.gap-4.sm\\:grid-cols-2.lg\\:grid-cols-4',
-    );
+    const grid = container.querySelector('div.grid.grid-cols-2.gap-2\\.5.lg\\:grid-cols-4');
     expect(grid).toBeInTheDocument();
     expect(screen.getAllByRole('progressbar')).toHaveLength(4);
 
@@ -93,6 +91,8 @@ describe('MacroRings', () => {
     expect(screen.getByText('145g')).toBeInTheDocument();
     expect(screen.getByText('200g')).toBeInTheDocument();
     expect(screen.getByText('65g')).toBeInTheDocument();
+    expect(screen.getByText('1850 / 2200 kcal')).toBeInTheDocument();
+    expect(screen.getByText('145g / 180g')).toBeInTheDocument();
 
     const caloriesRingIndicator = getMacroItem('Calories').querySelector(
       '[data-slot="progress-ring-indicator"]',
@@ -118,6 +118,7 @@ describe('MacroRings', () => {
 
     expect(screen.getByText('0 kcal')).toBeInTheDocument();
     expect(screen.getAllByText('0g')).toHaveLength(3);
+    expect(screen.getAllByText('No target')).toHaveLength(4);
   });
 
   it('toggles to remaining mode and shows inverse progress labels', () => {

--- a/apps/web/src/features/dashboard/components/macro-rings.tsx
+++ b/apps/web/src/features/dashboard/components/macro-rings.tsx
@@ -89,19 +89,32 @@ const getMacroStat = (snapshot: DashboardSnapshot | undefined, key: MacroKey): M
   };
 };
 
+const formatMacroSummary = (stat: MacroStat, unit: MacroConfig['unit']) => {
+  if (stat.target <= 0) {
+    return 'No target';
+  }
+
+  if (unit === 'kcal') {
+    return `${formatCalories(stat.actual)} / ${formatCalories(stat.target)} kcal`;
+  }
+
+  return `${formatGrams(stat.actual)} / ${formatGrams(stat.target)}`;
+};
+
 export function MacroRings({ snapshot }: MacroRingsProps) {
   const [mode, setMode] = useState<MacroMode>('eaten');
 
   return (
-    <section className="space-y-4">
+    <section className="space-y-2.5">
       <div className="flex items-center justify-end">
         <div
           aria-label="Macro display mode"
-          className="inline-flex rounded-lg border border-border bg-card p-1"
+          className="inline-flex rounded-lg border border-border bg-card p-0.5"
           role="group"
         >
           <Button
             aria-pressed={mode === 'eaten'}
+            className="px-2.5 text-xs"
             onClick={() => {
               setMode('eaten');
             }}
@@ -112,6 +125,7 @@ export function MacroRings({ snapshot }: MacroRingsProps) {
           </Button>
           <Button
             aria-pressed={mode === 'remaining'}
+            className="px-2.5 text-xs"
             onClick={() => {
               setMode('remaining');
             }}
@@ -123,31 +137,37 @@ export function MacroRings({ snapshot }: MacroRingsProps) {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-2 gap-2.5 lg:grid-cols-4">
         {MACRO_CONFIGS.map((macro) => {
-          const state = getMacroRingState(
-            getMacroStat(snapshot, macro.key),
-            mode,
-            macro.color,
-            macro.unit,
-          );
+          const stat = getMacroStat(snapshot, macro.key);
+          const state = getMacroRingState(stat, mode, macro.color, macro.unit);
 
           return (
             <div
-              className="flex flex-col items-center gap-2"
+              className="flex min-w-0 items-center gap-2.5 rounded-xl border border-border/70 bg-card/40 px-2.5 py-2"
               data-slot="macro-ring-item"
               key={macro.key}
             >
-              <div className="w-full max-w-[106px] px-1">
+              <div className="w-16 shrink-0">
                 <ProgressRing
                   aria-label={`${macro.label} progress`}
-                  className="h-auto w-full [&_span]:text-[11px] [&_span]:leading-tight [&_span]:text-center"
+                  className="h-auto w-full"
                   color={state.color}
                   label={state.valueLabel}
+                  labelClassName="text-[10px] leading-tight font-semibold"
+                  size={68}
+                  strokeWidth={7}
                   value={state.progress}
                 />
               </div>
-              <p className="text-sm font-medium text-muted">{macro.label}</p>
+              <div className="min-w-0 space-y-0.5">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                  {macro.label}
+                </p>
+                <p className="truncate text-[11px] text-muted-foreground">
+                  {formatMacroSummary(stat, macro.unit)}
+                </p>
+              </div>
             </div>
           );
         })}

--- a/apps/web/src/features/dashboard/components/recent-workouts.test.tsx
+++ b/apps/web/src/features/dashboard/components/recent-workouts.test.tsx
@@ -101,7 +101,9 @@ describe('RecentWorkouts', () => {
       expect(within(link).getByText(workout.name)).toBeInTheDocument();
       expect(within(link).getByText(`${workout.exerciseCount} exercises`)).toBeInTheDocument();
       expect(
-        within(link).getByText(workout.duration === null ? 'Duration n/a' : `${workout.duration} min`),
+        within(link).getByText(
+          workout.duration === null ? 'Duration n/a' : `${workout.duration} min`,
+        ),
       ).toBeInTheDocument();
     });
   });
@@ -121,13 +123,15 @@ describe('RecentWorkouts', () => {
     const cards = container.querySelectorAll('[data-slot="recent-workout-card"]');
     expect(cards.length).toBe(5);
     cards.forEach((card) => {
-      expect(card).toHaveClass('py-2');
+      expect(card).toHaveClass('py-2.5');
+      expect(card).toHaveClass('px-3');
       expect(card).toHaveClass('overflow-hidden');
     });
 
     const metadataPills = screen.getAllByText('6 exercises');
     metadataPills.forEach((pill) => {
       expect(pill).toHaveClass('rounded-full');
+      expect(pill).toHaveClass('px-2');
       expect(pill.parentElement).toHaveClass('text-xs');
     });
   });
@@ -189,7 +193,9 @@ describe('RecentWorkouts', () => {
       </MemoryRouter>,
     );
 
-    expect(container.querySelectorAll('[data-slot="recent-workout-card-skeleton"]')).toHaveLength(4);
+    expect(container.querySelectorAll('[data-slot="recent-workout-card-skeleton"]')).toHaveLength(
+      4,
+    );
   });
 
   it('renders an empty state when there are no completed sessions', () => {
@@ -205,7 +211,10 @@ describe('RecentWorkouts', () => {
     );
 
     expect(screen.getByText('No completed workouts yet')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Start a workout' })).toHaveAttribute('href', '/workouts');
+    expect(screen.getByRole('link', { name: 'Start a workout' })).toHaveAttribute(
+      'href',
+      '/workouts',
+    );
   });
 
   it('renders an error state when recent workouts query fails', () => {

--- a/apps/web/src/features/dashboard/components/recent-workouts.tsx
+++ b/apps/web/src/features/dashboard/components/recent-workouts.tsx
@@ -21,10 +21,13 @@ const formatWorkoutDate = (value: string): string => {
 
 function RecentWorkoutRowsSkeleton() {
   return (
-    <ul className="grid gap-3" data-slot="recent-workout-skeleton-list">
+    <ul className="grid gap-2.5" data-slot="recent-workout-skeleton-list">
       {Array.from({ length: WORKOUT_SKELETON_ROWS }).map((_, index) => (
         <li key={`workout-skeleton-${index}`}>
-          <Card className="h-full gap-3 overflow-hidden px-4 py-2" data-slot="recent-workout-card-skeleton">
+          <Card
+            className="h-full gap-2.5 overflow-hidden px-3 py-2.5"
+            data-slot="recent-workout-card-skeleton"
+          >
             <div className="space-y-2">
               <div className="flex items-start justify-between gap-2">
                 <div className="min-w-0 space-y-2">
@@ -49,25 +52,33 @@ export function RecentWorkouts() {
   const recentWorkoutsQuery = useRecentWorkouts(WORKOUTS_TO_SHOW);
 
   return (
-    <Card aria-labelledby="recent-workouts-heading">
-      <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
+    <Card aria-labelledby="recent-workouts-heading" className="gap-3 py-3 sm:py-3.5">
+      <CardHeader className="flex flex-row items-start justify-between gap-2.5 px-3 space-y-0 sm:px-4">
         <CardTitle>
-          <h2 className="text-xl font-semibold text-foreground md:text-2xl" id="recent-workouts-heading">
+          <h2
+            className="text-lg leading-tight font-semibold text-foreground md:text-xl"
+            id="recent-workouts-heading"
+          >
             Recent Workouts
           </h2>
         </CardTitle>
-        <Button asChild className="h-auto px-0 py-0 text-muted-foreground hover:text-foreground" size="sm" variant="link">
+        <Button
+          asChild
+          className="h-auto px-0 py-0 text-muted-foreground hover:text-foreground"
+          size="sm"
+          variant="link"
+        >
           <Link to="/workouts">View all</Link>
         </Button>
       </CardHeader>
 
-      <CardContent className="overflow-hidden">
+      <CardContent className="overflow-hidden px-3 sm:px-4">
         {recentWorkoutsQuery.isLoading ? (
           <RecentWorkoutRowsSkeleton />
         ) : recentWorkoutsQuery.isError ? (
           <p className="text-sm text-muted-foreground">Unable to load recent workouts.</p>
         ) : recentWorkoutsQuery.data && recentWorkoutsQuery.data.length > 0 ? (
-          <ul className="grid gap-3">
+          <ul className="grid gap-2.5">
             {recentWorkoutsQuery.data.map((workout) => (
               <li className="min-w-0" key={workout.id}>
                 <Link
@@ -76,28 +87,30 @@ export function RecentWorkouts() {
                   to={`/workouts/sessions/${workout.id}`}
                 >
                   <Card
-                    className="h-full gap-3 overflow-hidden px-4 py-2 transition-transform duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
+                    className="h-full gap-2.5 overflow-hidden px-3 py-2.5 transition-transform duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
                     data-slot="recent-workout-card"
                   >
                     <div className="space-y-2">
                       <div className="flex items-start justify-between gap-2">
                         <div className="min-w-0 space-y-1">
-                          <p className="text-base font-semibold leading-tight text-foreground">{workout.name}</p>
+                          <p className="text-sm font-semibold leading-tight text-foreground sm:text-base">
+                            {workout.name}
+                          </p>
                           <time className="text-sm text-muted" dateTime={workout.date}>
                             {formatWorkoutDate(workout.date)}
                           </time>
                         </div>
 
-                        <span className="shrink-0 rounded-full bg-[var(--color-accent-cream)] px-2.5 py-1 text-xs font-semibold text-on-cream dark:bg-amber-500/20 dark:text-amber-400">
+                        <span className="shrink-0 rounded-full bg-[var(--color-accent-cream)] px-2 py-1 text-[11px] font-semibold text-on-cream dark:bg-amber-500/20 dark:text-amber-400">
                           {formatRelativeWorkoutDate(workout.date)}
                         </span>
                       </div>
 
-                      <div className="flex min-w-0 flex-wrap gap-1.5 text-xs text-foreground sm:text-sm">
-                        <span className="rounded-full bg-secondary px-2.5 py-0.5">
+                      <div className="flex min-w-0 flex-wrap gap-1.5 text-xs text-foreground">
+                        <span className="rounded-full bg-secondary px-2 py-0.5">
                           {`${workout.exerciseCount} exercises`}
                         </span>
-                        <span className="rounded-full bg-secondary px-2.5 py-0.5">
+                        <span className="rounded-full bg-secondary px-2 py-0.5">
                           {workout.duration === null ? 'Duration n/a' : `${workout.duration} min`}
                         </span>
                       </div>
@@ -108,7 +121,7 @@ export function RecentWorkouts() {
             ))}
           </ul>
         ) : (
-          <div className="space-y-4" data-slot="recent-workout-empty-state">
+          <div className="space-y-2.5" data-slot="recent-workout-empty-state">
             <p className="text-sm text-muted">No completed workouts yet</p>
             <Button asChild size="sm">
               <Link to="/workouts">Start a workout</Link>

--- a/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
@@ -5,7 +5,6 @@ import { describe, expect, it } from 'vitest';
 
 import {
   calculateHabitCompletionPercent,
-  calculateWeightTrend,
   getSnapshotValueClassName,
   SnapshotCards,
 } from './snapshot-cards';
@@ -44,22 +43,6 @@ const snapshotFixture: DashboardSnapshot = {
     percentage: 75,
   },
 };
-
-describe('calculateWeightTrend', () => {
-  it('returns neutral when yesterday weight is not positive', () => {
-    expect(calculateWeightTrend(180, 0)).toEqual({ direction: 'neutral', value: 0 });
-    expect(calculateWeightTrend(180, -1)).toEqual({ direction: 'neutral', value: 0 });
-  });
-
-  it('returns neutral when there is no change', () => {
-    expect(calculateWeightTrend(180, 180)).toEqual({ direction: 'neutral', value: 0 });
-  });
-
-  it('returns up or down trend with rounded percent change', () => {
-    expect(calculateWeightTrend(182, 180)).toEqual({ direction: 'up', value: 1.1 });
-    expect(calculateWeightTrend(178, 180)).toEqual({ direction: 'down', value: 1.1 });
-  });
-});
 
 describe('calculateHabitCompletionPercent', () => {
   it('returns 0 when there are no active habits', () => {

--- a/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
@@ -110,7 +110,7 @@ describe('SnapshotCards', () => {
     );
   });
 
-  it('applies accent card backgrounds and neutral trends', () => {
+  it('applies accent card backgrounds and only shows a trend where the compact card meaningfully uses one', () => {
     render(
       <MemoryRouter>
         <SnapshotCards snapshot={snapshotFixture} />
@@ -133,8 +133,13 @@ describe('SnapshotCards', () => {
     expect(screen.getByText('Protein')).toHaveClass('text-on-mint');
     expect(screen.getByText('Habits')).toHaveClass('text-on-mint');
 
-    expect(within(weightCard as HTMLElement).getByLabelText('trend neutral')).toBeInTheDocument();
-    expect(within(weightCard as HTMLElement).getByText('0%')).toBeInTheDocument();
+    expect(within(weightCard as HTMLElement).queryByLabelText(/trend/i)).not.toBeInTheDocument();
+    expect(
+      within(caloriesCard as HTMLElement).queryByLabelText(/trend/i),
+    ).not.toBeInTheDocument();
+    expect(within(proteinCard as HTMLElement).queryByLabelText(/trend/i)).not.toBeInTheDocument();
+    expect(within(habitsCard as HTMLElement).getByLabelText('trend neutral')).toBeInTheDocument();
+    expect(within(habitsCard as HTMLElement).getByText('75%')).toBeInTheDocument();
     expect(screen.getByText('Completed')).toBeInTheDocument();
   });
 

--- a/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
@@ -74,11 +74,11 @@ describe('calculateHabitCompletionPercent', () => {
 
 describe('getSnapshotValueClassName', () => {
   it('returns larger text sizing for shorter values', () => {
-    expect(getSnapshotValueClassName('3/5')).toContain('text-2xl');
+    expect(getSnapshotValueClassName('3/5')).toContain('text-lg');
   });
 
   it('returns compact text sizing for longer values', () => {
-    expect(getSnapshotValueClassName('2,450 / 2,200')).toContain('text-lg');
+    expect(getSnapshotValueClassName('2,450 / 2,200')).toContain('text-sm');
   });
 });
 
@@ -90,11 +90,14 @@ describe('SnapshotCards', () => {
       </MemoryRouter>,
     );
 
-    const grid = container.querySelector('div.grid.grid-cols-1.sm\\:grid-cols-2');
+    const grid = container.querySelector('div.grid.grid-cols-2.gap-3');
     expect(grid).toBeInTheDocument();
 
     const cards = container.querySelectorAll('[data-slot="stat-card"]');
     expect(cards).toHaveLength(5);
+    cards.forEach((card) => {
+      expect(card).toHaveAttribute('data-density', 'compact');
+    });
 
     expect(screen.getByText('181.4 lbs')).toBeInTheDocument();
     expect(screen.getByText('1900 / 2300')).toBeInTheDocument();
@@ -277,6 +280,6 @@ describe('SnapshotCards', () => {
     );
 
     const caloriesValue = screen.getByText('12450 / 11200');
-    expect(caloriesValue).toHaveClass('text-lg', 'sm:text-xl', 'lg:text-2xl');
+    expect(caloriesValue).toHaveClass('text-sm', 'sm:text-base', 'lg:text-lg');
   });
 });

--- a/apps/web/src/features/dashboard/components/snapshot-cards.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.tsx
@@ -2,9 +2,9 @@
 import type { DashboardSnapshot, DashboardWorkoutSnapshot } from '@pulse/shared';
 import { Link } from 'react-router';
 
-import { StatCard, type StatTrend } from '@/components/ui/stat-card';
+import { StatCard } from '@/components/ui/stat-card';
 import { accentCardStyles } from '@/lib/accent-card-styles';
-import { formatCalories, formatGrams, formatTrendChange, formatWeight } from '@/lib/format-utils';
+import { formatCalories, formatGrams, formatWeight } from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
 
 type SnapshotCardsProps = {
@@ -27,25 +27,6 @@ const formatMacroProgressValue = (actual: number, target: number, mode: 'calorie
   }
 
   return `${formatCalories(actual)} / ${formatCalories(target)}`;
-};
-
-export const calculateWeightTrend = (weight: number, weightYesterday: number): StatTrend => {
-  if (weightYesterday <= 0) {
-    return { direction: 'neutral', value: 0 };
-  }
-
-  const change = weight - weightYesterday;
-
-  if (change === 0) {
-    return { direction: 'neutral', value: 0 };
-  }
-
-  const percent = Number(formatTrendChange((Math.abs(change) / weightYesterday) * 100));
-
-  return {
-    direction: change > 0 ? 'up' : 'down',
-    value: percent,
-  };
 };
 
 export const calculateHabitCompletionPercent = (

--- a/apps/web/src/features/dashboard/components/snapshot-cards.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.tsx
@@ -233,7 +233,6 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
         density="compact"
         data-stagger="0"
         label="Body Weight"
-        trend={snapshot && hasWeight ? { direction: 'neutral', value: 0 } : undefined}
         value={weightValue}
         valueClassName={getSnapshotValueClassName(weightValue)}
         valueTitle={weightValue}
@@ -249,7 +248,6 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
         density="compact"
         data-stagger="1"
         label="Calories"
-        trend={snapshot && hasCaloriesTarget ? { direction: 'neutral', value: 0 } : undefined}
         value={caloriesValue}
         valueClassName={getSnapshotValueClassName(caloriesValueText)}
         valueTitle={hasCaloriesTarget ? caloriesValueText : undefined}
@@ -265,7 +263,6 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
         density="compact"
         data-stagger="2"
         label="Protein"
-        trend={snapshot && hasProteinTarget ? { direction: 'neutral', value: 0 } : undefined}
         value={proteinValue}
         valueClassName={getSnapshotValueClassName(proteinValueText)}
         valueTitle={hasProteinTarget ? proteinValueText : undefined}

--- a/apps/web/src/features/dashboard/components/snapshot-cards.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.tsx
@@ -14,8 +14,8 @@ type SnapshotCardsProps = {
 const notConfiguredCardClassName =
   'border-dashed border-border/80 bg-muted/35 text-muted-foreground shadow-none';
 const notConfiguredAccentTextClassName = 'text-muted-foreground';
-const longValueClassName = 'text-lg sm:text-xl lg:text-2xl';
-const shortValueClassName = 'text-2xl sm:text-2xl lg:text-3xl';
+const longValueClassName = 'text-sm sm:text-base lg:text-lg';
+const shortValueClassName = 'text-lg sm:text-xl lg:text-2xl';
 
 export const getSnapshotValueClassName = (value: string) => {
   return value.length >= 13 ? longValueClassName : shortValueClassName;
@@ -193,11 +193,12 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
   const workoutCard = (
     <StatCard
       className={cn(
-        'border-primary/20 bg-secondary',
+        'col-span-2 border-primary/20 bg-secondary',
         workoutHref
           ? 'cursor-pointer transition-colors hover:border-primary/40 hover:bg-secondary/80'
           : undefined,
       )}
+      density="compact"
       data-stagger="4"
       icon={
         workoutStatusBadge ? (
@@ -223,12 +224,13 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
   );
 
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
+    <div className="grid grid-cols-2 gap-3">
       <StatCard
         accentTextClassName={
           snapshot && !hasWeight ? notConfiguredAccentTextClassName : 'text-on-cream'
         }
         className={snapshot && !hasWeight ? notConfiguredCardClassName : accentCardStyles.cream}
+        density="compact"
         data-stagger="0"
         label="Body Weight"
         trend={snapshot && hasWeight ? { direction: 'neutral', value: 0 } : undefined}
@@ -244,6 +246,7 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
         className={
           snapshot && !hasCaloriesTarget ? notConfiguredCardClassName : accentCardStyles.pink
         }
+        density="compact"
         data-stagger="1"
         label="Calories"
         trend={snapshot && hasCaloriesTarget ? { direction: 'neutral', value: 0 } : undefined}
@@ -259,6 +262,7 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
         className={
           snapshot && !hasProteinTarget ? notConfiguredCardClassName : accentCardStyles.mint
         }
+        density="compact"
         data-stagger="2"
         label="Protein"
         trend={snapshot && hasProteinTarget ? { direction: 'neutral', value: 0 } : undefined}
@@ -272,6 +276,7 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
           snapshot && !hasHabits ? notConfiguredAccentTextClassName : 'text-on-mint'
         }
         className={snapshot && !hasHabits ? notConfiguredCardClassName : accentCardStyles.mint}
+        density="compact"
         data-stagger="3"
         label="Habits"
         trend={
@@ -287,7 +292,7 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
       {workoutHref ? (
         <Link
           aria-label={`Open today's workout: ${snapshot?.workout?.name ?? 'workout'}`}
-          className="block rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="col-span-2 block rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           to={workoutHref}
         >
           {workoutCard}

--- a/apps/web/src/features/dashboard/components/trend-sparkline.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.tsx
@@ -134,11 +134,11 @@ export function TrendSparkline({
   const hasSingleDataPoint = plottedData.length === 1;
 
   return (
-    <div className={cn('flex h-full flex-col gap-4', className)} data-slot="trend-sparkline">
-      <div className="flex items-start justify-between gap-4">
+    <div className={cn('flex h-full flex-col gap-2.5', className)} data-slot="trend-sparkline">
+      <div className="flex items-start justify-between gap-2.5">
         <p
           className={cn(
-            'text-sm font-medium opacity-70 dark:text-muted dark:opacity-100',
+            'text-xs font-medium uppercase tracking-[0.14em] opacity-70 dark:text-muted dark:opacity-100',
             textClass,
           )}
         >
@@ -147,14 +147,17 @@ export function TrendSparkline({
 
         <div className="space-y-1 text-right">
           <p
-            className={cn('text-3xl font-semibold tracking-tight dark:text-foreground', textClass)}
+            className={cn(
+              'text-xl leading-tight font-semibold tracking-tight sm:text-2xl dark:text-foreground',
+              textClass,
+            )}
           >
             {currentValue}
           </p>
           <div
             aria-label={`trend ${direction}`}
             className={cn(
-              'flex items-center justify-end gap-1 text-sm font-medium opacity-80 dark:text-muted dark:opacity-100',
+              'flex items-center justify-end gap-1 text-xs font-medium opacity-80 dark:text-muted dark:opacity-100',
               textClass,
             )}
             data-slot="trend-sparkline-change"
@@ -167,7 +170,7 @@ export function TrendSparkline({
 
       {plottedData.length === 0 ? (
         <div
-          className="flex h-[60px] items-center justify-center rounded-md bg-muted/35"
+          className="flex h-[48px] items-center justify-center rounded-md bg-muted/35"
           data-slot="trend-sparkline-empty"
         >
           <p className="text-sm text-muted">{emptyMessage}</p>
@@ -175,7 +178,7 @@ export function TrendSparkline({
       ) : (
         <div
           aria-label={`${label} sparkline`}
-          className="h-[60px] w-full"
+          className="h-[48px] w-full"
           data-slot="trend-sparkline-chart"
           role="img"
         >
@@ -213,13 +216,13 @@ function TrendMetricCard({
   return (
     <Card
       className={cn(
-        'gap-0 border-transparent py-5 shadow-sm dark:text-foreground',
+        'gap-0 border-transparent py-3 shadow-sm dark:text-foreground',
         textClassName,
         className,
       )}
       data-slot="trend-sparkline-card"
     >
-      <CardContent className="h-full px-5">
+      <CardContent className="h-full px-3">
         <TrendSparkline
           changePercent={changePercent}
           color={color}
@@ -236,19 +239,19 @@ function TrendMetricCard({
 function TrendMetricCardSkeleton() {
   return (
     <Card
-      className="gap-0 border-transparent py-5 shadow-sm"
+      className="gap-0 border-transparent py-3 shadow-sm"
       data-slot="trend-sparkline-card-skeleton"
     >
-      <CardContent className="h-full px-5">
-        <div className="flex h-full flex-col gap-4" data-slot="trend-sparkline-skeleton">
-          <div className="flex items-start justify-between gap-4">
+      <CardContent className="h-full px-3">
+        <div className="flex h-full flex-col gap-2.5" data-slot="trend-sparkline-skeleton">
+          <div className="flex items-start justify-between gap-2.5">
             <div className="h-4 w-28 animate-pulse rounded bg-muted/50" />
             <div className="space-y-2">
-              <div className="ml-auto h-8 w-20 animate-pulse rounded bg-muted/50" />
+              <div className="ml-auto h-6 w-20 animate-pulse rounded bg-muted/50" />
               <div className="ml-auto h-4 w-14 animate-pulse rounded bg-muted/50" />
             </div>
           </div>
-          <div className="h-[60px] w-full animate-pulse rounded bg-muted/50" />
+          <div className="h-[48px] w-full animate-pulse rounded bg-muted/50" />
         </div>
       </CardContent>
     </Card>
@@ -266,7 +269,7 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
   if ((needsWeight && weightTrendQuery.isLoading) || (needsMacros && macroTrendQuery.isLoading)) {
     return (
       <section aria-label="Trend sparklines">
-        <div className="grid gap-4">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-1">
           <TrendMetricCardSkeleton />
           <TrendMetricCardSkeleton />
           <TrendMetricCardSkeleton />
@@ -279,7 +282,7 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
     return (
       <section aria-label="Trend sparklines">
         <Card className="gap-0 border-border/70 py-4 shadow-sm">
-          <CardContent className="px-5">
+          <CardContent className="px-3">
             <p className="text-sm text-muted-foreground">Unable to load trend data.</p>
           </CardContent>
         </Card>
@@ -360,7 +363,7 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
     return (
       <section aria-label="Trend sparklines">
         <Card className="gap-0 border-border/70 py-4 shadow-sm">
-          <CardContent className="px-5">
+          <CardContent className="px-3">
             <p className="text-sm text-muted-foreground">No trend metrics selected.</p>
           </CardContent>
         </Card>
@@ -370,7 +373,7 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
 
   return (
     <section aria-label="Trend sparklines">
-      <div className="grid gap-4">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-1">
         {configs.map((config) => (
           <TrendMetricCard key={config.label} {...config} />
         ))}

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.test.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createQueryClientWrapper } from '@/test/query-client';
@@ -65,6 +66,17 @@ const weightEntriesFixture = [
 describe('WeightTrendChart', () => {
   let mockFetch: ReturnType<typeof vi.fn>;
 
+  function renderChart() {
+    const { wrapper } = createQueryClientWrapper();
+
+    return render(
+      <MemoryRouter>
+        <WeightTrendChart />
+      </MemoryRouter>,
+      { wrapper },
+    );
+  }
+
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(new Date('2026-03-08T12:00:00'));
@@ -105,9 +117,7 @@ describe('WeightTrendChart', () => {
   });
 
   it('fetches 1M range by default and renders header + insight metrics', async () => {
-    const { wrapper } = createQueryClientWrapper();
-
-    const { container } = render(<WeightTrendChart />, { wrapper });
+    const { container } = renderChart();
 
     await waitFor(() => {
       expect(screen.getByRole('img', { name: 'Weight trend chart' })).toBeInTheDocument();
@@ -135,9 +145,7 @@ describe('WeightTrendChart', () => {
   });
 
   it('switches ranges and re-fetches weight entries with selected days', async () => {
-    const { wrapper } = createQueryClientWrapper();
-
-    render(<WeightTrendChart />, { wrapper });
+    renderChart();
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith('/api/v1/weight?days=30', expect.any(Object));
@@ -157,9 +165,7 @@ describe('WeightTrendChart', () => {
   });
 
   it('allows toggling each legend series', async () => {
-    const { wrapper } = createQueryClientWrapper();
-
-    render(<WeightTrendChart />, { wrapper });
+    renderChart();
 
     const scaleToggle = await screen.findByRole('button', { name: 'Scale Weight' });
     const trendToggle = screen.getByRole('button', { name: 'Trend Weight' });
@@ -206,13 +212,12 @@ describe('WeightTrendChart', () => {
       );
     });
 
-    const { wrapper } = createQueryClientWrapper();
-    render(<WeightTrendChart />, { wrapper });
+    renderChart();
 
     expect(await screen.findByText('Log your weight to see trends')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Go to weight entry' })).toHaveAttribute(
       'href',
-      '#dashboard-log-weight-card',
+      '/#dashboard-log-weight-card',
     );
   });
 });

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.test.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.test.tsx
@@ -107,7 +107,7 @@ describe('WeightTrendChart', () => {
   it('fetches 1M range by default and renders header + insight metrics', async () => {
     const { wrapper } = createQueryClientWrapper();
 
-    render(<WeightTrendChart />, { wrapper });
+    const { container } = render(<WeightTrendChart />, { wrapper });
 
     await waitFor(() => {
       expect(screen.getByRole('img', { name: 'Weight trend chart' })).toBeInTheDocument();
@@ -128,6 +128,10 @@ describe('WeightTrendChart', () => {
     expect(screen.getByText(/7-day change:/)).toBeInTheDocument();
     expect(screen.getByLabelText('3-day direction stable')).toBeInTheDocument();
     expect(screen.getByLabelText('7-day direction down')).toBeInTheDocument();
+
+    const chartCard = container.querySelector('[data-slot="weight-trend-chart"]');
+    expect(chartCard).toHaveClass('gap-3', 'py-3');
+    expect(container.querySelector('[data-slot="weight-trend-legend"]')).toHaveClass('gap-1.5');
   });
 
   it('switches ranges and re-fetches weight entries with selected days', async () => {

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
@@ -155,41 +155,50 @@ export function WeightTrendChart() {
   };
 
   return (
-    <Card aria-labelledby="weight-trend-chart-heading" data-slot="weight-trend-chart">
-      <CardHeader className="gap-4 border-b border-border/70 pb-5">
+    <Card
+      aria-labelledby="weight-trend-chart-heading"
+      className="gap-3 py-3 sm:py-4"
+      data-slot="weight-trend-chart"
+    >
+      <CardHeader className="gap-2.5 border-b border-border/70 px-3 pb-3 sm:px-4">
         <div className="space-y-1">
           <CardTitle>
             <h2
-              className="text-xl font-semibold text-foreground md:text-2xl"
+              className="text-lg leading-tight font-semibold text-foreground md:text-xl"
               id="weight-trend-chart-heading"
             >
               Weight Trend
             </h2>
           </CardTitle>
-          <p className="text-sm text-muted-foreground">Scale weight with EWMA smoothing.</p>
-          <a className="text-sm font-medium text-primary hover:underline" href="/weight/history">
+          <p className="text-xs text-muted-foreground sm:text-sm">
+            Scale weight with EWMA smoothing.
+          </p>
+          <a
+            className="text-xs font-medium text-primary hover:underline sm:text-sm"
+            href="/weight/history"
+          >
             View history
           </a>
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-2">
-          <div className="rounded-xl bg-secondary/45 px-4 py-3">
+        <div className="grid gap-2 sm:grid-cols-2">
+          <div className="rounded-xl bg-secondary/45 px-3 py-2.5">
             <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
               Current trend
             </p>
             <p
-              className="mt-1 text-2xl font-semibold text-foreground"
+              className="mt-1 text-lg font-semibold text-foreground sm:text-xl"
               data-slot="weight-trend-current-trend"
             >
               {chartData.length > 0 ? formatWeightLabel(headerInsights.currentTrend) : '--'}
             </p>
           </div>
-          <div className="rounded-xl bg-secondary/45 px-4 py-3">
+          <div className="rounded-xl bg-secondary/45 px-3 py-2.5">
             <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
               Period average
             </p>
             <p
-              className="mt-1 text-2xl font-semibold text-foreground"
+              className="mt-1 text-lg font-semibold text-foreground sm:text-xl"
               data-slot="weight-trend-period-average"
             >
               {chartData.length > 0 ? formatWeightLabel(headerInsights.avgWeight) : '--'}
@@ -199,13 +208,13 @@ export function WeightTrendChart() {
 
         <div
           aria-label="Weight trend range"
-          className="inline-flex w-full flex-wrap items-center gap-2 rounded-full border border-border bg-secondary/35 p-1"
+          className="inline-flex w-full flex-wrap items-center gap-1 rounded-full border border-border bg-secondary/35 p-0.5"
           role="group"
         >
           {RANGE_OPTIONS.map((option) => (
             <Button
               aria-pressed={selectedRange.value === option.value}
-              className="rounded-full"
+              className="rounded-full px-2.5 text-xs"
               key={option.value}
               onClick={() => setSelectedRange(option)}
               size="sm"
@@ -218,18 +227,18 @@ export function WeightTrendChart() {
         </div>
       </CardHeader>
 
-      <CardContent className="space-y-5 px-4 py-5 sm:px-6">
+      <CardContent className="space-y-3 px-3 py-3 sm:px-4">
         {weightEntriesQuery.isLoading ? (
           <div
-            className="h-[280px] w-full animate-pulse rounded-2xl bg-muted/50"
+            className="h-[220px] w-full animate-pulse rounded-2xl bg-muted/50 sm:h-[260px]"
             data-slot="weight-trend-loading"
           />
         ) : weightEntriesQuery.isError ? (
-          <div className="flex min-h-[220px] items-center justify-center rounded-2xl border border-border/70 bg-muted/20 px-6 text-center">
+          <div className="flex min-h-[180px] items-center justify-center rounded-2xl border border-border/70 bg-muted/20 px-4 text-center sm:min-h-[220px]">
             <p className="text-sm text-muted-foreground">Unable to load weight trend data.</p>
           </div>
         ) : chartData.length === 0 ? (
-          <div className="flex min-h-[220px] items-center justify-center rounded-2xl border border-dashed border-border bg-muted/15 px-6 text-center">
+          <div className="flex min-h-[180px] items-center justify-center rounded-2xl border border-dashed border-border bg-muted/15 px-4 text-center sm:min-h-[220px]">
             <div className="space-y-2">
               <p className="text-base font-semibold text-foreground">
                 Log your weight to see trends
@@ -245,23 +254,23 @@ export function WeightTrendChart() {
         ) : (
           <>
             {!visibleSeries.scale && !visibleSeries.trend ? (
-              <div className="flex h-[280px] items-center justify-center text-sm text-muted-foreground sm:h-[320px]">
+              <div className="flex h-[220px] items-center justify-center text-sm text-muted-foreground sm:h-[280px]">
                 Enable at least one series to display the chart.
               </div>
             ) : (
               <div
                 aria-label="Weight trend chart"
-                className="h-[280px] w-full sm:h-[320px]"
+                className="h-[220px] w-full sm:h-[280px]"
                 role="img"
               >
                 <ResponsiveContainer height="100%" width="100%">
-                  <LineChart data={chartData} margin={{ top: 12, right: 8, bottom: 6, left: 2 }}>
+                  <LineChart data={chartData} margin={{ top: 8, right: 4, bottom: 2, left: 0 }}>
                     <CartesianGrid stroke="var(--color-border)" strokeDasharray="3 3" />
                     <XAxis
                       axisLine={false}
                       dataKey="date"
-                      minTickGap={20}
-                      tick={{ fill: 'var(--color-muted)', fontSize: 12 }}
+                      minTickGap={16}
+                      tick={{ fill: 'var(--color-muted)', fontSize: 11 }}
                       tickFormatter={(value: string) =>
                         axisDateFormatter.format(new Date(`${value}T12:00:00`))
                       }
@@ -270,10 +279,10 @@ export function WeightTrendChart() {
                     <YAxis
                       axisLine={false}
                       domain={yDomain}
-                      tick={{ fill: 'var(--color-muted)', fontSize: 12 }}
+                      tick={{ fill: 'var(--color-muted)', fontSize: 11 }}
                       tickFormatter={(value: number) => formatTrendChange(value)}
                       tickLine={false}
-                      width={50}
+                      width={40}
                     />
                     <Tooltip
                       contentStyle={{
@@ -333,7 +342,7 @@ export function WeightTrendChart() {
               </div>
             )}
 
-            <div className="flex flex-wrap items-center gap-2" data-slot="weight-trend-legend">
+            <div className="flex flex-wrap items-center gap-1.5" data-slot="weight-trend-legend">
               <LegendToggle
                 active={visibleSeries.scale}
                 color={SERIES_COLORS.scale}
@@ -349,7 +358,7 @@ export function WeightTrendChart() {
             </div>
 
             <div
-              className="grid gap-2 rounded-xl border border-border/70 bg-secondary/25 px-4 py-3"
+              className="grid gap-1.5 rounded-xl border border-border/70 bg-secondary/25 px-3 py-2.5 sm:grid-cols-2"
               data-slot="weight-trend-insights"
             >
               <p className="text-sm text-foreground">
@@ -387,7 +396,7 @@ function LegendToggle({
     <button
       aria-pressed={active}
       className={cn(
-        'inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors',
+        'inline-flex min-h-11 items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
         active
           ? 'border-border bg-secondary/55 text-foreground'
           : 'border-border/70 bg-background text-muted-foreground',
@@ -395,11 +404,7 @@ function LegendToggle({
       onClick={onClick}
       type="button"
     >
-      <span
-        aria-hidden="true"
-        className="size-2.5 rounded-full"
-        style={{ backgroundColor: color }}
-      />
+      <span aria-hidden="true" className="size-2 rounded-full" style={{ backgroundColor: color }} />
       <span>{label}</span>
     </button>
   );

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { BodyWeightEntry } from '@pulse/shared';
 import { computeEWMA, computeWeightInsights } from '@pulse/shared';
+import { Link } from 'react-router';
 import {
   CartesianGrid,
   Line,
@@ -173,12 +174,12 @@ export function WeightTrendChart() {
           <p className="text-xs text-muted-foreground sm:text-sm">
             Scale weight with EWMA smoothing.
           </p>
-          <a
+          <Link
             className="text-xs font-medium text-primary hover:underline sm:text-sm"
-            href="/weight/history"
+            to="/weight/history"
           >
             View history
-          </a>
+          </Link>
         </div>
 
         <div className="grid gap-2 sm:grid-cols-2">
@@ -243,12 +244,12 @@ export function WeightTrendChart() {
               <p className="text-base font-semibold text-foreground">
                 Log your weight to see trends
               </p>
-              <a
+              <Link
                 className="text-sm font-medium text-primary hover:underline"
-                href="#dashboard-log-weight-card"
+                to="#dashboard-log-weight-card"
               >
                 Go to weight entry
-              </a>
+              </Link>
             </div>
           </div>
         ) : (

--- a/apps/web/src/features/habits/components/daily-habits.test.tsx
+++ b/apps/web/src/features/habits/components/daily-habits.test.tsx
@@ -176,7 +176,12 @@ describe('DailyHabits', () => {
   it('renders a menu trigger for every habit card', () => {
     render(<DailyHabits />);
 
-    expect(screen.getAllByRole('button', { name: /open habit actions for/i })).toHaveLength(3);
+    const menuButtons = screen.getAllByRole('button', { name: /open habit actions for/i });
+
+    expect(menuButtons).toHaveLength(3);
+    menuButtons.forEach((button) => {
+      expect(button).toHaveClass('size-11', 'min-h-11', 'min-w-11');
+    });
   });
 
   it('shows frequency subtitles and paused badge on cards', () => {

--- a/apps/web/src/features/habits/components/daily-habits.tsx
+++ b/apps/web/src/features/habits/components/daily-habits.tsx
@@ -282,20 +282,20 @@ function buildDailyHabits(
 
 function DailyHabitsLoadingState() {
   return (
-    <div aria-busy="true" aria-label="Loading daily habits" className="space-y-4">
+    <div aria-busy="true" aria-label="Loading daily habits" className="space-y-3">
       <Card className={accentCardStyles.pink}>
-        <CardHeader className="gap-3">
+        <CardHeader className="gap-2">
           <p className="text-xs font-semibold uppercase tracking-[0.28em] opacity-70 dark:text-muted dark:opacity-100">
             Daily habits
           </p>
-          <div className="space-y-3">
+          <div className="space-y-2.5">
             <Skeleton className="h-8 w-56 rounded-full bg-black/10 dark:bg-secondary" />
             <Skeleton className="h-4 w-full max-w-2xl rounded-full bg-black/10 dark:bg-secondary" />
           </div>
         </CardHeader>
       </Card>
 
-      <div className="grid gap-4">
+      <div className="grid gap-3">
         {Array.from({ length: 3 }).map((_, index) => (
           <HabitRowSkeleton key={index} />
         ))}
@@ -314,16 +314,16 @@ type DailyHabitsErrorStateProps = {
 
 function DailyHabitsErrorState({ titleDate, message, onRetry }: DailyHabitsErrorStateProps) {
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       <Card className={accentCardStyles.pink}>
-        <CardHeader className="gap-3">
+        <CardHeader className="gap-2">
           <p className="text-xs font-semibold uppercase tracking-[0.28em] opacity-70 dark:text-muted dark:opacity-100">
             Daily habits
           </p>
-          <div className="space-y-2">
+          <div className="space-y-1.5">
             <CardTitle
               aria-level={2}
-              className="text-3xl font-semibold tracking-tight"
+              className="text-2xl font-semibold tracking-tight sm:text-3xl"
               role="heading"
             >
               {todayFormatter.format(titleDate)}
@@ -336,7 +336,7 @@ function DailyHabitsErrorState({ titleDate, message, onRetry }: DailyHabitsError
       </Card>
 
       <Card className="border-dashed">
-        <CardContent className="flex flex-col gap-4 py-6 sm:flex-row sm:items-center sm:justify-between">
+        <CardContent className="flex flex-col gap-3 py-5 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-sm text-muted">{message}</p>
           <Button onClick={onRetry} type="button">
             Try again
@@ -456,17 +456,17 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       <Card className={accentCardStyles.pink}>
-        <CardHeader className="gap-3">
+        <CardHeader className="gap-2">
           <p className="text-xs font-semibold uppercase tracking-[0.28em] opacity-70 dark:text-muted dark:opacity-100">
             Daily habits
           </p>
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-            <div className="space-y-2">
+          <div className="flex flex-col gap-2.5 sm:flex-row sm:items-end sm:justify-between">
+            <div className="space-y-1.5">
               <CardTitle
                 aria-level={2}
-                className="text-3xl font-semibold tracking-tight"
+                className="text-2xl font-semibold tracking-tight sm:text-3xl"
                 role="heading"
               >
                 {todayFormatter.format(activeDate)}
@@ -477,7 +477,7 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
                   : 'Review and log habits for this day to keep your history accurate.'}
               </CardDescription>
             </div>
-            <div className="inline-flex min-h-14 self-start items-center justify-center rounded-full bg-black/10 px-4 py-2 dark:bg-secondary">
+            <div className="inline-flex min-h-11 self-start items-center justify-center rounded-full bg-black/10 px-3.5 py-1.5 dark:bg-secondary">
               <span className="text-center text-sm font-semibold leading-tight dark:text-foreground">
                 {completedCount} of {activeHabits.length} habits complete
               </span>
@@ -488,7 +488,7 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
 
       {activeHabits.length === 0 ? (
         <Card className="border-dashed">
-          <CardContent className="py-6">
+          <CardContent className="py-5">
             <p className="text-base font-medium text-foreground">
               No active habits configured yet.
             </p>
@@ -496,7 +496,7 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
               Add your first habit to start tracking progress.
             </p>
             <Button
-              className="mt-4"
+              className="mt-3"
               onClick={() => {
                 setEditingHabitId(null);
                 setIsFormDialogOpen(true);
@@ -510,7 +510,7 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
         </Card>
       ) : (
         <>
-          <div className="grid gap-3">
+          <div className="grid gap-2.5">
             {dailyHabits.map((habit) => {
               const frequencySummary = getFrequencySummary(habit.sourceHabit);
               const isPaused =
@@ -554,7 +554,7 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
                   )}
                 >
                   {/* Top row: emoji + name + badges + menu */}
-                  <div className="flex items-center gap-3 px-4 pt-4 pb-1 sm:px-5">
+                  <div className="flex items-center gap-2.5 px-4 pt-3.5 pb-1 sm:px-5">
                     <span
                       className={cn(
                         'flex size-10 shrink-0 items-center justify-center rounded-xl text-2xl',
@@ -634,10 +634,10 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
                   ) : null}
 
                   {/* Interaction area */}
-                  <div className="px-4 pt-1 pb-4 sm:px-5">
+                  <div className="px-4 pt-0.5 pb-3.5 sm:px-5">
                     {habit.trackingType === 'boolean' ? (
                       <label
-                        className="flex cursor-pointer items-center gap-3 rounded-lg px-1 py-2"
+                        className="flex cursor-pointer items-center gap-3 rounded-lg px-0.5 py-1.5"
                         htmlFor={`habit-${habit.id}`}
                       >
                         <Checkbox
@@ -741,7 +741,7 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
                     )}
 
                     {canResetToAuto ? (
-                      <div className="mt-2">
+                      <div className="mt-1.5">
                         <Button
                           className="h-auto px-0 text-xs"
                           disabled={isSavingValue || isSavingToggle}

--- a/apps/web/src/features/habits/components/habit-card-menu.tsx
+++ b/apps/web/src/features/habits/components/habit-card-menu.tsx
@@ -154,6 +154,7 @@ export function HabitCardMenu({ habit, habits, onEdit }: HabitCardMenuProps) {
         <DropdownMenuTrigger asChild>
           <Button
             aria-label={`Open habit actions for ${habit.name}`}
+            className="-mr-1 size-11 min-h-11 min-w-11"
             disabled={isPending}
             size="icon-sm"
             type="button"
@@ -219,7 +220,7 @@ export function HabitCardMenu({ habit, habits, onEdit }: HabitCardMenuProps) {
       </DropdownMenu>
 
       <Dialog onOpenChange={setIsPauseDialogOpen} open={isPauseDialogOpen}>
-        <DialogContent>
+        <DialogContent className="gap-4 sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Pause scheduling</DialogTitle>
             <DialogDescription>
@@ -228,7 +229,7 @@ export function HabitCardMenu({ habit, habits, onEdit }: HabitCardMenuProps) {
             </DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-3">
+          <div className="space-y-2.5">
             <div className="space-y-2">
               <Label htmlFor={`pause-until-${habit.id}`}>Pause until</Label>
               <Input
@@ -241,7 +242,7 @@ export function HabitCardMenu({ habit, habits, onEdit }: HabitCardMenuProps) {
             </div>
           </div>
 
-          <DialogFooter className="gap-2">
+          <DialogFooter className="gap-2 pt-1">
             <Button
               disabled={isPending}
               onClick={() => setIsPauseDialogOpen(false)}

--- a/apps/web/src/features/habits/components/habit-form-dialog.test.tsx
+++ b/apps/web/src/features/habits/components/habit-form-dialog.test.tsx
@@ -83,6 +83,14 @@ describe('HabitFormDialog', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it('uses the compact dialog and form spacing classes', () => {
+    render(<HabitFormDialog onOpenChange={vi.fn()} open />);
+
+    expect(screen.getByRole('dialog')).toHaveClass('gap-4', 'p-5');
+    expect(document.querySelector('form')).toHaveClass('space-y-4');
+    expect(document.querySelector('[data-slot="dialog-footer"]')).toHaveClass('pt-1');
+  });
+
   it('uses edit mode defaults and calls update mutation', async () => {
     const onOpenChange = vi.fn();
     const updateMutation = createMutationMock();

--- a/apps/web/src/features/habits/components/habit-form-dialog.tsx
+++ b/apps/web/src/features/habits/components/habit-form-dialog.tsx
@@ -153,7 +153,7 @@ export function HabitFormDialog({ open, onOpenChange, habit }: HabitFormDialogPr
       }}
       open={open}
     >
-      <DialogContent className="max-h-[calc(100vh-2rem)] overflow-y-auto sm:max-w-xl">
+      <DialogContent className="max-h-[calc(100vh-2rem)] gap-4 overflow-y-auto sm:max-w-xl">
         <DialogHeader>
           <DialogTitle>{modeTitle}</DialogTitle>
           <DialogDescription>
@@ -161,7 +161,7 @@ export function HabitFormDialog({ open, onOpenChange, habit }: HabitFormDialogPr
           </DialogDescription>
         </DialogHeader>
 
-        <form className="space-y-5" onSubmit={handleSubmit(onSubmit)}>
+        <form className="space-y-4" onSubmit={handleSubmit(onSubmit)}>
           <div className="space-y-2">
             <Label htmlFor="habit-name">Habit name</Label>
             <Input
@@ -205,7 +205,7 @@ export function HabitFormDialog({ open, onOpenChange, habit }: HabitFormDialogPr
             />
           </div>
 
-          <div className="space-y-3">
+          <div className="space-y-2.5">
             <div className="space-y-1">
               <p className="text-sm font-medium text-foreground">Emoji</p>
               <p className="text-sm text-muted">Choose a quick visual cue for the list.</p>
@@ -260,7 +260,7 @@ export function HabitFormDialog({ open, onOpenChange, habit }: HabitFormDialogPr
             </select>
           </div>
 
-          <div className="space-y-3">
+          <div className="space-y-2.5">
             <div className="space-y-1">
               <Label htmlFor="habit-frequency">Frequency</Label>
               <p className="text-sm text-muted">Choose how often this habit should be scheduled.</p>
@@ -363,7 +363,7 @@ export function HabitFormDialog({ open, onOpenChange, habit }: HabitFormDialogPr
           </div>
 
           {showTargetFields ? (
-            <div className="grid gap-4 sm:grid-cols-2">
+            <div className="grid gap-3 sm:grid-cols-2">
               <div className="space-y-2">
                 <Label htmlFor="habit-target">Target</Label>
                 <Controller
@@ -423,7 +423,7 @@ export function HabitFormDialog({ open, onOpenChange, habit }: HabitFormDialogPr
 
           <div
             className={cn(
-              'inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-semibold text-slate-950',
+              'inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-sm font-semibold text-slate-950',
               trackingSurfaceClasses[trackingType],
             )}
           >
@@ -437,7 +437,7 @@ export function HabitFormDialog({ open, onOpenChange, habit }: HabitFormDialogPr
             </p>
           ) : null}
 
-          <DialogFooter>
+          <DialogFooter className="pt-1">
             <Button
               disabled={isSaving}
               onClick={() => onOpenChange(false)}

--- a/apps/web/src/features/habits/components/habit-history.test.tsx
+++ b/apps/web/src/features/habits/components/habit-history.test.tsx
@@ -136,6 +136,8 @@ describe('HabitHistory', () => {
 
     const hydrateGrid = screen.getByTestId('habit-history-grid-hydrate');
     expect(hydrateGrid).toHaveClass('flex', 'flex-wrap', 'gap-1');
+    expect(screen.getByText('Boolean habits: gray or green')).toHaveClass('px-2.5', 'py-0.5');
+    expect(hydrateGrid.parentElement).toHaveClass('pb-3');
     expect(container.querySelector('.overflow-x-auto')).toBeNull();
     expect(container.querySelector('.min-w-max')).toBeNull();
   });

--- a/apps/web/src/features/habits/components/habit-history.tsx
+++ b/apps/web/src/features/habits/components/habit-history.tsx
@@ -264,8 +264,8 @@ export function HabitHistory() {
 
   if (habitsQuery.isLoading || habitEntriesQuery.isLoading) {
     return (
-      <Card className="gap-5 border-border/70 shadow-sm">
-        <CardHeader className="gap-3">
+      <Card className="gap-4 border-border/70 shadow-sm">
+        <CardHeader className="gap-2">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
             Habit history
           </p>
@@ -291,8 +291,8 @@ export function HabitHistory() {
           : 'Unable to load habit history.';
 
     return (
-      <Card className="gap-5 border-border/70 shadow-sm">
-        <CardHeader className="gap-3">
+      <Card className="gap-4 border-border/70 shadow-sm">
+        <CardHeader className="gap-2">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
             Habit history
           </p>
@@ -322,8 +322,8 @@ export function HabitHistory() {
 
   if (historyRows.length === 0) {
     return (
-      <Card className="gap-5 border-border/70 shadow-sm">
-        <CardHeader className="gap-3">
+      <Card className="gap-4 border-border/70 shadow-sm">
+        <CardHeader className="gap-2">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
             Habit history
           </p>
@@ -341,9 +341,9 @@ export function HabitHistory() {
   }
 
   return (
-    <Card className="gap-5 border-border/70 shadow-sm">
-      <CardHeader className="gap-3">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+    <Card className="gap-4 border-border/70 shadow-sm">
+      <CardHeader className="gap-2">
+        <div className="flex flex-col gap-2.5 lg:flex-row lg:items-end lg:justify-between">
           <div className="space-y-1">
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
               Habit history
@@ -361,24 +361,24 @@ export function HabitHistory() {
             </CardDescription>
           </div>
 
-          <div className="flex flex-wrap gap-2">
-            <span className="inline-flex rounded-full bg-[var(--color-accent-pink)] px-3 py-1 text-xs font-semibold text-on-pink dark:bg-pink-500/20 dark:text-pink-400">
+          <div className="flex flex-wrap gap-1.5">
+            <span className="inline-flex rounded-full bg-[var(--color-accent-pink)] px-2.5 py-0.5 text-xs font-semibold text-on-pink dark:bg-pink-500/20 dark:text-pink-400">
               Boolean habits: gray or green
             </span>
-            <span className="inline-flex rounded-full bg-[var(--color-accent-cream)] px-3 py-1 text-xs font-semibold text-on-cream dark:bg-amber-500/20 dark:text-amber-400">
+            <span className="inline-flex rounded-full bg-[var(--color-accent-cream)] px-2.5 py-0.5 text-xs font-semibold text-on-cream dark:bg-amber-500/20 dark:text-amber-400">
               Numeric/time habits: intensity by target %
             </span>
           </div>
         </div>
       </CardHeader>
 
-      <CardContent className="space-y-4">
-        <div className="rounded-3xl border border-border/70 bg-card/40 p-4">
+      <CardContent className="space-y-3">
+        <div className="rounded-2xl border border-border/70 bg-card/40 p-3">
           <TooltipProvider>
-            <div className="space-y-4">
+            <div className="space-y-3">
               {historyRows.map((habit) => (
                 <div
-                  className="grid gap-3 border-b border-border/70 pb-4 last:border-b-0 last:pb-0 md:grid-cols-[minmax(180px,220px)_1fr]"
+                  className="grid gap-2.5 border-b border-border/70 pb-3 last:border-b-0 last:pb-0 md:grid-cols-[minmax(160px,200px)_1fr]"
                   key={habit.id}
                 >
                   <div className="space-y-1 md:pt-1">

--- a/apps/web/src/features/nutrition/components/meal-card.test.tsx
+++ b/apps/web/src/features/nutrition/components/meal-card.test.tsx
@@ -49,71 +49,35 @@ const breakfastMeal = {
 };
 
 describe('MealCard', () => {
-  it('renders the meal summary collapsed by default', () => {
+  it('renders a compact meal header with visible food rows by default', () => {
     render(<MealCard meal={breakfastMeal} />);
-
-    const trigger = screen.getByRole('button', { name: /breakfast/i });
-
-    expect(trigger).toHaveAttribute('aria-expanded', 'false');
-    expect(screen.getByText('7:20 AM')).toBeInTheDocument();
-    expect(screen.getByText('Large Eggs, Whole Wheat Bread, Whey Protein')).toHaveClass('truncate');
-    expect(screen.getByText('535 cal')).toBeInTheDocument();
-    expect(screen.getByText('29g protein')).toBeInTheDocument();
-    expect(screen.queryByText('Large Eggs')).not.toBeInTheDocument();
-
-    const summaryContainer = screen.getByRole('heading', { name: 'Breakfast' }).parentElement;
-    expect(summaryContainer).toHaveClass('min-w-0');
-  });
-
-  it('does not render a summary line when summary is null', () => {
-    render(<MealCard meal={{ ...breakfastMeal, summary: null }} />);
 
     expect(screen.queryByText('Large Eggs, Whole Wheat Bread, Whey Protein')).not.toBeInTheDocument();
-  });
-
-  it('expands to show individual food items and per-item macros', () => {
-    render(<MealCard meal={breakfastMeal} />);
-
-    const trigger = screen.getByRole('button', { name: /breakfast/i });
-    fireEvent.click(trigger);
-
-    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('535cal · 29P · 72C · 17F')).toBeInTheDocument();
+    expect(screen.getByText('7:20 AM · 3 foods')).toBeInTheDocument();
     expect(screen.getByText('Large Eggs')).toBeInTheDocument();
     expect(screen.getByText('3 eggs')).toBeInTheDocument();
+    expect(screen.getByText('210cal · 18P · 1C · 15F')).toBeInTheDocument();
     expect(screen.getByText('5.5 oz')).toBeInTheDocument();
-    expect(screen.getByText('2 scoops')).toBeInTheDocument();
-    expect(screen.getByText('210 cal')).toBeInTheDocument();
-    expect(screen.getByText('18g')).toBeInTheDocument();
-    expect(screen.getByText('44g')).toBeInTheDocument();
-    expect(screen.getByText('15g')).toBeInTheDocument();
+    expect(screen.getByText('220cal · 10P · 44C · 2F')).toBeInTheDocument();
   });
 
-  it('collapses the item list when the header is clicked again', () => {
+  it('uses compact row styling while keeping meal headers and rows at a 44px touch target', () => {
     render(<MealCard meal={breakfastMeal} />);
 
-    const trigger = screen.getByRole('button', { name: /breakfast/i });
+    const mealCard = screen.getByRole('heading', { name: 'Breakfast' }).closest('[data-slot="card"]');
+    const mealHeader = mealCard?.firstElementChild;
+    const firstRow = screen.getByText('Large Eggs').closest('li');
 
-    fireEvent.click(trigger);
-    fireEvent.click(trigger);
-
-    expect(trigger).toHaveAttribute('aria-expanded', 'false');
-    expect(screen.queryByText('Large Eggs')).not.toBeInTheDocument();
+    expect(mealHeader).toHaveClass('min-h-11');
+    expect(firstRow).toHaveClass('min-h-11');
+    expect(screen.getByText('Large Eggs')).toHaveClass('truncate');
   });
 
-  it('keeps horizontal padding consistent between collapsed and expanded states', () => {
-    render(<MealCard meal={breakfastMeal} />);
+  it('shows fallback time copy when meal time is not set', () => {
+    render(<MealCard meal={{ ...breakfastMeal, time: null }} />);
 
-    const trigger = screen.getByRole('button', { name: /breakfast/i });
-    const summarySection = trigger.parentElement;
-
-    expect(summarySection).toHaveClass('px-4', 'sm:px-5');
-
-    fireEvent.click(trigger);
-
-    const detailsId = trigger.getAttribute('aria-controls');
-    const expandedSection = detailsId ? document.getElementById(detailsId) : null;
-
-    expect(expandedSection).toHaveClass('px-4', 'sm:px-5');
+    expect(screen.getByText('Time not set · 3 foods')).toBeInTheDocument();
   });
 
   it('calls onDelete with the meal id when delete is clicked', () => {

--- a/apps/web/src/features/nutrition/components/meal-card.tsx
+++ b/apps/web/src/features/nutrition/components/meal-card.tsx
@@ -77,7 +77,8 @@ export function MealCard({ meal, onDelete, isDeleting = false }: MealCardProps) 
             <li
               key={item.id}
               className={cn(
-                'min-h-11 px-4 py-2 sm:px-5',
+                CARD_HORIZONTAL_PADDING,
+                'min-h-11 py-2',
                 index > 0 && 'border-t border-border/60',
                 index % 2 === 1 && 'bg-secondary/15',
               )}
@@ -128,17 +129,9 @@ function formatMacroSummary(macros: {
   fat: number;
 }) {
   return [
-    formatCompactCalories(macros.calories),
-    formatCompactGrams(macros.protein, 'P'),
-    formatCompactGrams(macros.carbs, 'C'),
-    formatCompactGrams(macros.fat, 'F'),
+    formatCalories(macros.calories, { compact: true }),
+    formatGrams(macros.protein, { compact: true, suffix: 'P' }),
+    formatGrams(macros.carbs, { compact: true, suffix: 'C' }),
+    formatGrams(macros.fat, { compact: true, suffix: 'F' }),
   ].join(' · ');
-}
-
-function formatCompactCalories(value: number) {
-  return formatCalories(value).replace(' cal', 'cal');
-}
-
-function formatCompactGrams(value: number, suffix: string) {
-  return `${formatGrams(value).replace(/g$/, '')}${suffix}`;
 }

--- a/apps/web/src/features/nutrition/components/meal-card.tsx
+++ b/apps/web/src/features/nutrition/components/meal-card.tsx
@@ -1,5 +1,4 @@
-import { useId, useState } from 'react';
-import { ChevronDown, Trash2 } from 'lucide-react';
+import { Trash2 } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -36,130 +35,66 @@ type MealCardProps = {
   isDeleting?: boolean;
 };
 
-const ITEM_HEADER_LABELS = [
-  { key: 'calories', label: 'Calories' },
-  { key: 'protein', label: 'Protein' },
-  { key: 'carbs', label: 'Carbs' },
-  { key: 'fat', label: 'Fat' },
-] as const;
 const CARD_HORIZONTAL_PADDING = 'px-4 sm:px-5';
 
 export function MealCard({ meal, onDelete, isDeleting = false }: MealCardProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const contentId = useId();
   const totals = calculateMacroTotals(meal.items);
   const formattedTime = formatMealTime(meal.time);
   const canDelete = typeof onDelete === 'function';
+  const mealMetadata = [formattedTime, formatFoodCount(meal.items.length)].filter(Boolean).join(' · ');
 
   return (
-    <Card className="gap-0 overflow-hidden border-border bg-[var(--color-card)] py-0 shadow-none">
-      <div className={cn('flex items-start gap-3 py-4', CARD_HORIZONTAL_PADDING)}>
-        <button
-          aria-controls={contentId}
-          aria-expanded={isExpanded}
-          className="flex min-w-0 flex-1 cursor-pointer flex-col gap-4 text-left transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
-          type="button"
-          onClick={() => setIsExpanded((current) => !current)}
-        >
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0 space-y-1">
-              <h2 className="text-lg font-semibold text-foreground">{meal.name}</h2>
-              <p className="text-sm text-muted">{formattedTime}</p>
-              {!isExpanded && meal.summary ? (
-                <p className="truncate text-sm text-muted">{meal.summary}</p>
-              ) : null}
-            </div>
-            <ChevronDown
-              aria-hidden="true"
-              className={cn(
-                'mt-0.5 size-5 shrink-0 text-muted transition-transform duration-200',
-                isExpanded && 'rotate-180',
-              )}
-            />
+    <Card className="gap-0 overflow-hidden rounded-xl border-border/70 bg-[var(--color-card)] py-0 shadow-none">
+      <div className={cn('flex min-h-11 items-start gap-2 py-2.5', CARD_HORIZONTAL_PADDING)}>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+            <h2 className="text-base font-semibold text-foreground sm:text-[17px]">{meal.name}</h2>
+            <p className="text-[11px] font-medium tracking-tight text-muted sm:text-xs">
+              {formatMacroSummary(totals)}
+            </p>
           </div>
-
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
-            <span className="font-semibold tracking-tight text-foreground">
-              {formatCalories(totals.calories)}
-            </span>
-            <span className="text-muted">{formatGrams(totals.protein)} protein</span>
-            <span className="text-muted">{formatGrams(totals.carbs)} carbs</span>
-            <span className="text-muted">{formatGrams(totals.fat)} fat</span>
-          </div>
-        </button>
+          <p className="mt-0.5 text-[11px] text-muted sm:text-xs">{mealMetadata}</p>
+        </div>
 
         {canDelete ? (
           <Button
             aria-label={`Delete ${meal.name}`}
-            className="shrink-0"
+            className="shrink-0 px-2.5 text-muted hover:text-foreground"
             disabled={isDeleting}
             onClick={() => onDelete(meal.id)}
-            size="icon-sm"
+            size="sm"
             type="button"
             variant="ghost"
           >
-            <Trash2 />
+            <Trash2 className="size-4" />
           </Button>
         ) : null}
       </div>
 
-      {isExpanded ? (
-        <div
-          className={cn('border-t border-border/80 py-4', CARD_HORIZONTAL_PADDING)}
-          id={contentId}
-        >
-          <div className="hidden grid-cols-[minmax(0,1.8fr)_repeat(4,minmax(0,0.7fr))] gap-3 px-3 pb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted sm:grid">
-            <span>Food</span>
-            {ITEM_HEADER_LABELS.map((column) => (
-              <span key={column.key} className="text-right">
-                {column.label}
-              </span>
-            ))}
-          </div>
-
-          <ul className="overflow-hidden rounded-lg border border-border/70 bg-secondary/10">
-            {meal.items.map((item, index) => (
-              <li
-                key={item.id}
-                className={cn(
-                  'grid gap-3 px-3 py-3 sm:grid-cols-[minmax(0,1.8fr)_repeat(4,minmax(0,0.7fr))] sm:items-center',
-                  index > 0 && 'border-t border-border/70',
-                  index % 2 === 1 && 'bg-secondary/15',
-                )}
-              >
-                <div className="min-w-0">
-                  <p className="truncate font-medium text-foreground">{item.name}</p>
-                  <p className="text-sm text-muted">{formatDisplayServing(item)}</p>
-                </div>
-
-                <div className="grid grid-cols-2 gap-x-3 gap-y-2 text-sm sm:contents">
-                  <MacroCell label="Calories" value={formatCalories(item.calories)} />
-                  <MacroCell label="Protein" value={formatGrams(item.protein)} />
-                  <MacroCell label="Carbs" value={formatGrams(item.carbs)} />
-                  <MacroCell label="Fat" value={formatGrams(item.fat)} />
-                </div>
-              </li>
-            ))}
-          </ul>
-        </div>
+      {meal.items.length > 0 ? (
+        <ul className="border-t border-border/70 bg-secondary/10">
+          {meal.items.map((item, index) => (
+            <li
+              key={item.id}
+              className={cn(
+                'min-h-11 px-4 py-2 sm:px-5',
+                index > 0 && 'border-t border-border/60',
+                index % 2 === 1 && 'bg-secondary/15',
+              )}
+            >
+              <div className="min-w-0">
+                <p className="truncate text-[15px] font-medium text-foreground">{item.name}</p>
+                <p className="mt-0.5 flex flex-wrap items-center gap-x-1 text-[11px] text-muted sm:text-xs">
+                  <span>{formatDisplayServing(item)}</span>
+                  <span aria-hidden="true">·</span>
+                  <span>{formatMacroSummary(item)}</span>
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
       ) : null}
     </Card>
-  );
-}
-
-type MacroCellProps = {
-  label: string;
-  value: string;
-};
-
-function MacroCell({ label, value }: MacroCellProps) {
-  return (
-    <div className="sm:text-right">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted sm:hidden">
-        {label}
-      </p>
-      <p className="font-medium text-foreground">{value}</p>
-    </div>
   );
 }
 
@@ -180,4 +115,30 @@ function formatMealTime(time: string | null) {
   const normalizedHours = hours % 12 || 12;
 
   return `${normalizedHours}:${String(minutes).padStart(2, '0')} ${meridiem}`;
+}
+
+function formatFoodCount(count: number) {
+  return `${count} ${count === 1 ? 'food' : 'foods'}`;
+}
+
+function formatMacroSummary(macros: {
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+}) {
+  return [
+    formatCompactCalories(macros.calories),
+    formatCompactGrams(macros.protein, 'P'),
+    formatCompactGrams(macros.carbs, 'C'),
+    formatCompactGrams(macros.fat, 'F'),
+  ].join(' · ');
+}
+
+function formatCompactCalories(value: number) {
+  return formatCalories(value).replace(' cal', 'cal');
+}
+
+function formatCompactGrams(value: number, suffix: string) {
+  return `${formatGrams(value).replace(/g$/, '')}${suffix}`;
 }

--- a/apps/web/src/features/nutrition/lib/nutrition-utils.test.ts
+++ b/apps/web/src/features/nutrition/lib/nutrition-utils.test.ts
@@ -14,6 +14,7 @@ describe('macro formatting', () => {
     expect(formatCalories(535)).toBe('535 cal');
     expect(formatGrams(29, { compact: true, suffix: 'P' })).toBe('29P');
     expect(formatGrams(29)).toBe('29g');
+    expect(formatGrams(31.7, { compact: true })).toBe('32g');
   });
 });
 

--- a/apps/web/src/features/nutrition/lib/nutrition-utils.test.ts
+++ b/apps/web/src/features/nutrition/lib/nutrition-utils.test.ts
@@ -1,10 +1,21 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  formatCalories,
   formatDisplayServing,
+  formatGrams,
   sortMeals,
   toMealLoggedAtTimestamp,
 } from '@/features/nutrition/lib/nutrition-utils';
+
+describe('macro formatting', () => {
+  it('supports compact nutrition labels without string replacement at call sites', () => {
+    expect(formatCalories(535, { compact: true })).toBe('535cal');
+    expect(formatCalories(535)).toBe('535 cal');
+    expect(formatGrams(29, { compact: true, suffix: 'P' })).toBe('29P');
+    expect(formatGrams(29)).toBe('29g');
+  });
+});
 
 describe('formatDisplayServing', () => {
   it('prefers display quantity and unit when both are present', () => {

--- a/apps/web/src/features/nutrition/lib/nutrition-utils.ts
+++ b/apps/web/src/features/nutrition/lib/nutrition-utils.ts
@@ -24,6 +24,15 @@ type ServingSource = {
   displayUnit?: string | null;
 };
 
+type CaloriesFormatOptions = {
+  compact?: boolean;
+};
+
+type GramsFormatOptions = {
+  compact?: boolean;
+  suffix?: string;
+};
+
 const DEFAULT_TOTALS: MacroTotals = {
   calories: 0,
   protein: 0,
@@ -99,11 +108,19 @@ export function toMealLoggedAtTimestamp(
   return fallbackTimestamp;
 }
 
-export function formatCalories(value: number): string {
-  return `${formatCaloriesValue(value)} cal`;
+export function formatCalories(value: number, options: CaloriesFormatOptions = {}): string {
+  const rounded = formatCaloriesValue(value);
+
+  return options.compact ? `${rounded}cal` : `${rounded} cal`;
 }
 
-export function formatGrams(value: number): string {
+export function formatGrams(value: number, options: GramsFormatOptions = {}): string {
+  const rounded = formatCaloriesValue(value);
+
+  if (options.compact) {
+    return `${rounded}${options.suffix ?? 'g'}`;
+  }
+
   return formatGramsValue(value);
 }
 

--- a/apps/web/src/features/nutrition/lib/nutrition-utils.ts
+++ b/apps/web/src/features/nutrition/lib/nutrition-utils.ts
@@ -115,7 +115,7 @@ export function formatCalories(value: number, options: CaloriesFormatOptions = {
 }
 
 export function formatGrams(value: number, options: GramsFormatOptions = {}): string {
-  const rounded = formatCaloriesValue(value);
+  const rounded = Math.round(Number.isFinite(value) ? value : 0);
 
   if (options.compact) {
     return `${rounded}${options.suffix ?? 'g'}`;

--- a/apps/web/src/features/profile/components/profile-hub.tsx
+++ b/apps/web/src/features/profile/components/profile-hub.tsx
@@ -79,8 +79,8 @@ export function ProfileHub({ equipmentSummary }: ProfileHubProps) {
   ];
 
   return (
-    <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 pb-10">
-      <header className="space-y-2">
+    <section className="mx-auto flex w-full max-w-6xl flex-col gap-5 pb-8">
+      <header className="space-y-1.5">
         <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted">Profile hub</p>
         <h1 className="text-3xl font-semibold text-primary">Profile</h1>
         <p className="max-w-3xl text-sm text-muted">
@@ -90,9 +90,9 @@ export function ProfileHub({ equipmentSummary }: ProfileHubProps) {
       </header>
 
       <Card className="overflow-hidden border-border/70 bg-card/95 shadow-sm">
-        <CardContent className="flex flex-col gap-5 px-6 py-6 sm:flex-row sm:items-center sm:justify-between">
+        <CardContent className="flex flex-col gap-4 px-5 py-5 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-4">
-            <div className="flex size-16 items-center justify-center rounded-full bg-[var(--color-accent-mint)] text-2xl font-semibold text-on-mint shadow-sm">
+            <div className="flex size-14 items-center justify-center rounded-full bg-[var(--color-accent-mint)] text-xl font-semibold text-on-mint shadow-sm">
               {initials}
             </div>
             <div className="space-y-1">
@@ -106,7 +106,7 @@ export function ProfileHub({ equipmentSummary }: ProfileHubProps) {
         </CardContent>
       </Card>
 
-      <div className="space-y-3">
+      <div className="space-y-2.5">
         <div className="flex items-center justify-between gap-3">
           <div className="space-y-1">
             <h2 className="text-xl font-semibold text-foreground">Quick access</h2>
@@ -117,7 +117,7 @@ export function ProfileHub({ equipmentSummary }: ProfileHubProps) {
         </div>
 
         <div
-          className="grid grid-cols-2 gap-4 lg:grid-cols-4"
+          className="grid grid-cols-2 gap-3 lg:grid-cols-4"
           data-testid="profile-quick-access-grid"
         >
           {profileDestinations.map((destination) => {
@@ -127,13 +127,13 @@ export function ProfileHub({ equipmentSummary }: ProfileHubProps) {
               <Link className="block cursor-pointer" key={destination.href} to={destination.href}>
                 <Card
                   className={cn(
-                    'h-full gap-4 border-border/70 bg-card/90 transition-all duration-200 hover:-translate-y-1 hover:border-primary/45 hover:bg-secondary/40 hover:shadow-lg focus-within:border-primary/55 focus-within:ring-2 focus-within:ring-primary/20',
+                    'h-full gap-3 border-border/70 bg-card/90 transition-all duration-200 hover:-translate-y-1 hover:border-primary/45 hover:bg-secondary/40 hover:shadow-lg focus-within:border-primary/55 focus-within:ring-2 focus-within:ring-primary/20',
                     destination.accentClassName,
                   )}
                 >
-                  <CardHeader className="gap-4">
+                  <CardHeader className="gap-3">
                     <div className="flex items-start justify-between gap-3">
-                      <div className="flex size-12 items-center justify-center rounded-2xl bg-secondary text-primary">
+                      <div className="flex size-11 items-center justify-center rounded-2xl bg-secondary text-primary">
                         <Icon aria-hidden="true" className="size-5" />
                       </div>
                       <span className="rounded-full border border-border/70 px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-muted-foreground">

--- a/apps/web/src/features/settings/components/agent-tokens-card.tsx
+++ b/apps/web/src/features/settings/components/agent-tokens-card.tsx
@@ -51,7 +51,7 @@ function CopyableToken({ token }: { token: string }) {
     <div className="space-y-2">
       <Label className="text-sm font-medium text-foreground">Your token</Label>
       <div className="flex items-center gap-2">
-        <code className="flex-1 overflow-x-auto rounded-lg border border-border/80 bg-secondary/50 px-3 py-2 text-xs break-all font-mono text-foreground">
+        <code className="flex-1 overflow-x-auto rounded-lg border border-border/80 bg-secondary/50 px-2.5 py-1.5 text-xs break-all font-mono text-foreground">
           {token}
         </code>
         <Button
@@ -101,7 +101,7 @@ function CreateTokenDialog({
 
   return (
     <Dialog onOpenChange={handleClose} open={open}>
-      <DialogContent>
+      <DialogContent className="gap-4 sm:max-w-md">
         <DialogHeader>
           <DialogTitle>{revealedToken ? 'Token created' : 'Create agent token'}</DialogTitle>
           <DialogDescription>
@@ -114,7 +114,7 @@ function CreateTokenDialog({
         {revealedToken ? (
           <CopyableToken token={revealedToken} />
         ) : (
-          <div className="space-y-2">
+          <div className="space-y-1.5">
             <Label className="text-sm font-medium text-foreground" htmlFor="token-name">
               Token name
             </Label>
@@ -132,7 +132,7 @@ function CreateTokenDialog({
           </div>
         )}
 
-        <DialogFooter>
+        <DialogFooter className="pt-1">
           {revealedToken ? (
             <Button onClick={() => handleClose(false)} type="button">
               Done
@@ -181,7 +181,7 @@ function RegenerateTokenDialog({
 
   return (
     <Dialog onOpenChange={handleClose} open={open}>
-      <DialogContent>
+      <DialogContent className="gap-4 sm:max-w-md">
         <DialogHeader>
           <DialogTitle>
             {revealedToken ? 'Token regenerated' : `Regenerate "${token?.name}"?`}
@@ -195,7 +195,7 @@ function RegenerateTokenDialog({
 
         {revealedToken ? <CopyableToken token={revealedToken} /> : null}
 
-        <DialogFooter>
+        <DialogFooter className="pt-1">
           {revealedToken ? (
             <Button onClick={() => handleClose(false)} type="button">
               Done
@@ -231,7 +231,7 @@ function TokenRow({
   onDelete: (token: AgentTokenListItem) => void;
 }) {
   return (
-    <div className="flex flex-col gap-3 rounded-xl border border-border/80 p-4 sm:flex-row sm:items-center sm:justify-between">
+    <div className="flex flex-col gap-2.5 rounded-xl border border-border/80 p-3 sm:flex-row sm:items-center sm:justify-between">
       <div className="min-w-0 space-y-1">
         <div className="flex items-center gap-2">
           <KeyIcon className="size-4 shrink-0 text-muted-foreground" />
@@ -284,7 +284,7 @@ export function AgentTokensCard() {
   return (
     <>
       <Card className="gap-4 border-border/70 shadow-sm">
-        <CardHeader className="space-y-2">
+        <CardHeader className="space-y-1.5">
           <div className="flex items-start justify-between gap-4">
             <div className="space-y-2">
               <CardTitle>
@@ -316,7 +316,7 @@ export function AgentTokensCard() {
               ))}
             </div>
           ) : tokens.length === 0 ? (
-            <div className="rounded-xl border border-dashed border-border/80 px-4 py-8 text-center">
+            <div className="rounded-xl border border-dashed border-border/80 px-4 py-6 text-center">
               <KeyIcon className="mx-auto size-8 text-muted-foreground/60" />
               <p className="mt-2 text-sm font-medium text-foreground">No agent tokens yet</p>
               <p className="mt-1 text-sm text-muted-foreground">

--- a/apps/web/src/features/settings/components/trash-manager.tsx
+++ b/apps/web/src/features/settings/components/trash-manager.tsx
@@ -76,7 +76,7 @@ export function TrashManager() {
 
   return (
     <Card className="gap-4 border-border/70 shadow-sm">
-      <CardHeader className="space-y-2">
+      <CardHeader className="space-y-1.5">
         <CardTitle>
           <h2 className="text-xl font-semibold text-foreground">Trash</h2>
         </CardTitle>
@@ -89,7 +89,7 @@ export function TrashManager() {
         {isPending ? (
           <p className="text-sm text-muted-foreground">Loading trash...</p>
         ) : totalItems === 0 ? (
-          <p className="rounded-xl border border-dashed border-border/70 bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
+          <p className="rounded-xl border border-dashed border-border/70 bg-muted/20 px-3.5 py-2.5 text-sm text-muted-foreground">
             Trash is empty
           </p>
         ) : (
@@ -100,14 +100,14 @@ export function TrashManager() {
                 className="group rounded-xl border border-border/70 bg-muted/10"
                 open
               >
-                <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-foreground">
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3.5 py-2.5 text-sm font-medium text-foreground">
                   <span>
                     {group.label} ({group.items.length})
                   </span>
                   <ChevronDownIcon className="size-4 text-muted-foreground transition-transform duration-200 group-open:rotate-180" />
                 </summary>
 
-                <ul className="space-y-2 border-t border-border/60 p-3">
+                <ul className="space-y-2 border-t border-border/60 p-2.5">
                   {group.items.map((item) => {
                     const isRestoring =
                       restoreItemMutation.isPending && restoreTargetId !== null && restoreTargetId === item.id;
@@ -115,7 +115,7 @@ export function TrashManager() {
                     return (
                       <li
                         key={item.id}
-                        className="flex flex-col gap-3 rounded-lg border border-border/60 bg-background/80 p-3 sm:flex-row sm:items-center sm:justify-between"
+                        className="flex flex-col gap-2.5 rounded-lg border border-border/60 bg-background/80 p-2.5 sm:flex-row sm:items-center sm:justify-between"
                       >
                         <div className="space-y-1">
                           <p className="text-sm font-medium text-foreground">{item.name}</p>

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -122,6 +122,9 @@ describe('SessionDetail', () => {
     expect(screen.getByLabelText(/show comparison/i)).toBeInTheDocument();
     expect(screen.queryByText('Volume progression')).not.toBeInTheDocument();
     expect(screen.getAllByText(/Set 1:/i).length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole('button', { name: 'Open Incline Dumbbell Press trend chart' }),
+    ).toHaveClass('size-11', 'min-h-11', 'min-w-11');
     expect(screen.getByText('Great pacing and clean reps.')).toBeInTheDocument();
     expect(screen.getByText('Felt strong and stable today.')).toBeInTheDocument();
     expect(screen.getByText('Bench at setting 5; keep elbows tucked.')).toBeInTheDocument();

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -335,7 +335,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
         </div>
       ) : null}
 
-      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-2.5 sm:grid-cols-2 xl:grid-cols-4">
         <StatCard
           accentTextClassName="text-blue-900 dark:text-blue-200"
           className="border-blue-200/70 bg-blue-500/10 dark:border-blue-400/30 dark:bg-blue-500/15"
@@ -383,7 +383,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
       ) : null}
 
       <Card>
-        <CardContent className="flex flex-col gap-4 py-5 sm:flex-row sm:items-center sm:justify-between">
+        <CardContent className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-1">
             <h2 className="text-base font-semibold text-foreground">Session comparison</h2>
             <p className="text-sm text-muted">
@@ -413,7 +413,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
         />
       ) : null}
 
-      <div className="space-y-4">
+      <div className="space-y-3">
         <div className="space-y-1">
           <h2 className="text-xl font-semibold text-foreground">Section breakdown</h2>
           <p className="text-sm text-muted">Review each phase exactly as it was logged.</p>
@@ -432,7 +432,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
               section.exercises.some((exercise) => Boolean(exercise.notes))
             }
           >
-            <summary className="cursor-pointer list-none px-5 py-4 sm:px-6 sm:py-5">
+            <summary className="cursor-pointer list-none px-4 py-3 sm:px-5 sm:py-4">
               <div className="flex items-center justify-between gap-3">
                 <div className="space-y-1">
                   <h3 className="text-lg font-semibold text-foreground">
@@ -452,18 +452,18 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
               </div>
             </summary>
 
-            <div className="space-y-3 border-t border-border px-4 py-4 sm:px-6 sm:py-5">
+            <div className="space-y-2.5 border-t border-border px-3 py-3 sm:px-5 sm:py-4">
               {section.exercises.map((exercise) => (
                 <Card
                   className={cn(
-                    'gap-4 py-0',
+                    'gap-3 py-0',
                     isEditing &&
                       'border-[color-mix(in_srgb,var(--color-accent-mint)_55%,transparent)] bg-[color-mix(in_srgb,var(--color-accent-mint)_10%,transparent)]',
                   )}
                   key={`${section.type}-${exercise.exerciseId}`}
                 >
-                  <CardHeader className="gap-3 py-5">
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <CardHeader className="gap-2.5 py-3">
+                    <div className="flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between">
                       <div className="space-y-2">
                         <div className="flex flex-wrap items-center gap-2">
                           <CardTitle>{exercise.name}</CardTitle>
@@ -484,7 +484,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
 
                       <Button
                         aria-label={`Open ${exercise.name} trend chart`}
-                        className="self-start"
+                        className="size-11 min-h-11 min-w-11 self-start"
                         onClick={() => setSelectedExerciseId(exercise.exerciseId)}
                         size="icon-sm"
                         type="button"
@@ -495,9 +495,9 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
                     </div>
                   </CardHeader>
 
-                  <CardContent className="space-y-4 pb-5">
+                  <CardContent className="space-y-3 pb-3">
                     {isEditing ? (
-                      <div className="space-y-3 rounded-2xl border border-[color-mix(in_srgb,var(--color-accent-mint)_55%,transparent)] bg-[color-mix(in_srgb,var(--color-accent-mint)_10%,transparent)] p-3">
+                      <div className="space-y-2.5 rounded-2xl border border-[color-mix(in_srgb,var(--color-accent-mint)_55%,transparent)] bg-[color-mix(in_srgb,var(--color-accent-mint)_10%,transparent)] p-2.5">
                         {exercise.sets.map((set) => (
                           <SessionSetEditor
                             draft={setDrafts[set.id] ?? createSessionSetDraft(set)}
@@ -510,10 +510,10 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
                         ))}
                       </div>
                     ) : (
-                      <div className="flex flex-wrap gap-2">
+                      <div className="flex flex-wrap gap-1.5">
                         {exercise.sets.map((set) => (
                           <span
-                            className="inline-flex rounded-full border border-border bg-secondary/55 px-3 py-1.5 text-sm text-foreground"
+                            className="inline-flex rounded-full border border-border bg-secondary/55 px-2.5 py-1 text-[13px] text-foreground"
                             key={set.id}
                           >
                             {formatSetLabel(set, exercise.trackingType, weightUnit)}
@@ -533,7 +533,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
                     ) : null}
  
                     {exercise.notes ? (
-                      <div className="rounded-2xl border border-border bg-secondary/35 px-4 py-3 text-sm text-foreground">
+                      <div className="rounded-2xl border border-border bg-secondary/35 px-3 py-2.5 text-sm text-foreground">
                         <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
                           Exercise notes
                         </p>
@@ -649,7 +649,7 @@ function SessionSetEditor({
   const readOnlySummary = getReadOnlyCorrectionSummary(set, trackingType, weightUnit);
 
   return (
-    <div className="rounded-2xl border border-border/70 bg-background/70 p-3">
+    <div className="rounded-2xl border border-border/70 bg-background/70 p-2.5">
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div className="space-y-1">
           <p className="text-sm font-semibold text-foreground">{`Set ${set.setNumber}`}</p>
@@ -665,7 +665,7 @@ function SessionSetEditor({
       {fields.length > 0 ? (
         <div
           className={cn(
-            'mt-3 grid gap-3',
+            'mt-2.5 grid gap-2',
             fields.length === 1 ? 'sm:grid-cols-[minmax(0,11rem)]' : 'sm:grid-cols-2',
           )}
         >
@@ -703,10 +703,10 @@ function SessionSetEditor({
           })}
         </div>
       ) : (
-        <p className="mt-3 text-sm text-muted">No editable set values are available for this entry.</p>
+        <p className="mt-2.5 text-sm text-muted">No editable set values are available for this entry.</p>
       )}
 
-      {readOnlySummary ? <p className="mt-3 text-xs text-muted">{readOnlySummary}</p> : null}
+      {readOnlySummary ? <p className="mt-2.5 text-xs text-muted">{readOnlySummary}</p> : null}
     </div>
   );
 }

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -184,6 +184,16 @@ describe('WorkoutTemplateDetail', () => {
       .closest('[data-slot="card"]');
 
     expect(inclinePressCard).not.toBeNull();
+    expect(
+      within(inclinePressCard as HTMLElement).getByRole('button', {
+        name: 'Drag handle for Incline Dumbbell Press',
+      }),
+    ).toHaveClass('size-11', 'min-h-11', 'min-w-11');
+    expect(
+      within(inclinePressCard as HTMLElement).getByRole('button', {
+        name: 'Exercise actions for Incline Dumbbell Press',
+      }),
+    ).toHaveClass('size-11', 'min-h-11', 'min-w-11');
     expect(within(inclinePressCard as HTMLElement).getByText('3×8-10')).toBeInTheDocument();
     expect(within(inclinePressCard as HTMLElement).getByText('Tempo: 3-1-1-0')).toBeInTheDocument();
     expect(within(inclinePressCard as HTMLElement).getByText(/Rest: 90s/)).toBeInTheDocument();

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -454,7 +454,7 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
         </div>
       </Card>
 
-      <div className="space-y-4">
+      <div className="space-y-3">
         {template.sections.map((section) => (
           <details
             className={cn(
@@ -464,8 +464,8 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
             key={section.type}
             open={section.type === 'main'}
           >
-            <summary className="cursor-pointer list-outside px-5 py-4">
-              <div className="flex flex-col gap-2 pr-6 sm:flex-row sm:items-center sm:justify-between">
+            <summary className="cursor-pointer list-outside px-4 py-3">
+              <div className="flex flex-col gap-1.5 pr-6 sm:flex-row sm:items-center sm:justify-between">
                 <div className="space-y-1">
                   <h2 className="text-lg font-bold tracking-wide text-foreground">
                     {sectionLabels[section.type]}
@@ -480,7 +480,7 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
               </div>
             </summary>
 
-            <div className="space-y-2 border-t border-border/80 px-4 py-4 sm:px-5 sm:py-4">
+            <div className="space-y-1.5 border-t border-border/80 px-3 py-3 sm:px-4 sm:py-3">
               {section.exercises.length === 0 ? (
                 <Card>
                   <CardContent className="py-5">
@@ -584,7 +584,7 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
                       return (
                         <div
                           className={cn(
-                            'relative space-y-2 rounded-2xl border border-border/90 border-l-4 px-3 py-3',
+                            'relative space-y-1.5 rounded-2xl border border-border/90 border-l-4 px-2.5 py-2.5',
                             supersetAccentClass,
                           )}
                           data-testid={`superset-group-${group.groupId}`}
@@ -596,7 +596,7 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
                               {formatSupersetLabel(group.groupId)}
                             </p>
                           </div>
-                          <div className="space-y-2">
+                          <div className="space-y-1.5">
                             {group.exercises.map((exercise, exerciseIndex) => {
                               const index = group.startIndex + exerciseIndex;
                               return (
@@ -924,19 +924,19 @@ function TemplateExerciseCard({
 
   return (
     <Card
-      className="gap-2 py-0"
+      className="gap-1.5 py-0"
       ref={setNodeRef}
       style={{
         transform: CSS.Transform.toString(transform),
         transition,
       }}
     >
-      <CardHeader className="gap-2 py-3">
+      <CardHeader className="gap-1.5 py-2.5">
         <div className="flex items-start justify-between gap-2">
           <div className="flex min-w-0 items-start gap-1.5">
             <Button
               aria-label={`Drag handle for ${exercise.exerciseName}`}
-              className="mt-0.5 size-8 touch-none"
+              className="-ml-1 mt-0.5 size-11 min-h-11 min-w-11 touch-none"
               size="icon"
               type="button"
               variant="ghost"
@@ -972,6 +972,7 @@ function TemplateExerciseCard({
             <DropdownMenuTrigger asChild>
               <Button
                 aria-label={`Exercise actions for ${exercise.exerciseName}`}
+                className="-mr-1 size-11 min-h-11 min-w-11"
                 size="icon"
                 type="button"
                 variant="ghost"
@@ -995,10 +996,10 @@ function TemplateExerciseCard({
         </div>
       </CardHeader>
 
-      <CardContent className="space-y-2 pb-3">
+      <CardContent className="space-y-1.5 pb-2.5">
         <p className="text-[10px] font-semibold tracking-[0.14em] text-muted uppercase">{`Exercise #${index + 1}`}</p>
 
-        <div className="grid gap-2 sm:grid-cols-3 lg:grid-cols-4">
+        <div className="grid gap-1.5 sm:grid-cols-3 lg:grid-cols-4">
           <InlineEditField
             ariaLabel={`Sets for ${exercise.exerciseName}`}
             label="Sets"

--- a/apps/web/src/features/workouts/components/workout-calendar.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.test.tsx
@@ -118,7 +118,13 @@ describe('WorkoutCalendar', () => {
     expect(await screen.findByText('Workout Calendar')).toBeInTheDocument();
     expect((await screen.findAllByLabelText('In-progress workout')).length).toBeGreaterThan(0);
     expect((await screen.findAllByLabelText('Completed workout')).length).toBeGreaterThan(0);
-    expect(screen.getByText('+2')).toBeInTheDocument();
+    expect(screen.getByText('+2')).toHaveClass('hidden', 'sm:inline-flex');
+    expect(screen.getByRole('button', { name: 'Previous month' })).toHaveClass(
+      'size-11',
+      'min-h-11',
+      'min-w-11',
+    );
+    expect(getCalendarDayTile(sessionDate)).toHaveClass('overflow-hidden');
     expect(screen.getByRole('link', { name: 'Done' })).toHaveAttribute(
       'href',
       '/workouts/session/session-1',

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -202,7 +202,7 @@ export function WorkoutCalendar({
 
   return (
     <Card className="gap-0 overflow-hidden">
-      <CardHeader className="gap-4 border-b border-border pb-5">
+      <CardHeader className="gap-4 border-b border-border pb-4">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-1">
             <CardTitle>Workout Calendar</CardTitle>
@@ -214,6 +214,7 @@ export function WorkoutCalendar({
           <div className="flex items-center gap-2 self-start">
             <Button
               aria-label="Previous month"
+              className="size-11 min-h-11 min-w-11"
               onClick={() => handleMonthChange(-1)}
               size="icon-sm"
               type="button"
@@ -226,6 +227,7 @@ export function WorkoutCalendar({
             </p>
             <Button
               aria-label="Next month"
+              className="size-11 min-h-11 min-w-11"
               onClick={() => handleMonthChange(1)}
               size="icon-sm"
               type="button"
@@ -246,9 +248,9 @@ export function WorkoutCalendar({
         </div>
       </CardHeader>
 
-      <CardContent className="grid gap-6 px-4 py-4 lg:grid-cols-[minmax(0,1.7fr)_minmax(18rem,1fr)] lg:px-6 lg:py-6">
+      <CardContent className="grid gap-4 px-3 py-3 lg:grid-cols-[minmax(0,1.7fr)_minmax(18rem,1fr)] lg:px-6 lg:py-6">
         <section aria-label="Monthly workout calendar" className="space-y-3">
-          <div className="grid grid-cols-7 gap-2">
+          <div className="grid grid-cols-7 gap-1.5 sm:gap-2">
             {DAY_LABELS.map((day) => (
               <p
                 key={day}
@@ -259,7 +261,7 @@ export function WorkoutCalendar({
             ))}
           </div>
 
-          <div className="grid grid-cols-7 gap-2">
+          <div className="grid grid-cols-7 gap-1.5 sm:gap-2">
             {calendarDays.map((day) => {
               const dateKey = toDateKey(day);
               const details = getDayDetails(dateKey, lookupContext);
@@ -273,7 +275,7 @@ export function WorkoutCalendar({
                   aria-label={`${fullDateFormatter.format(day)}${isSelected ? ', selected' : ''}`}
                   aria-pressed={isSelected}
                   className={cn(
-                    'flex min-h-14 cursor-pointer flex-col rounded-xl border px-1.5 py-1.5 text-left transition-all duration-200 sm:min-h-28 sm:rounded-2xl sm:px-3 sm:py-3',
+                    'flex min-h-14 min-w-0 cursor-pointer flex-col overflow-hidden rounded-xl border px-1 py-1 text-left transition-all duration-200 sm:min-h-28 sm:rounded-2xl sm:px-3 sm:py-3',
                     isInMonth
                       ? 'bg-card hover:border-primary/40 hover:bg-secondary/50'
                       : 'bg-secondary/35 opacity-55',
@@ -292,7 +294,7 @@ export function WorkoutCalendar({
                   role="button"
                   tabIndex={0}
                 >
-                  <div className="flex items-start justify-between gap-0.5">
+                  <div className="flex min-w-0 items-start justify-between gap-0.5">
                     <span
                       className={cn(
                         'shrink-0 text-xs font-semibold sm:text-sm',
@@ -302,10 +304,10 @@ export function WorkoutCalendar({
                     >
                       {day.getDate()}
                     </span>
-                    <div className="flex items-center gap-1">
+                    <div className="flex min-w-0 items-center gap-1">
                       {details.completedSession ? (
                         <Link
-                          className="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[9px] font-bold uppercase leading-none tracking-wide text-emerald-700 hover:bg-emerald-500/25 dark:text-emerald-400"
+                          className="max-w-full rounded-full bg-emerald-500/15 px-1 py-0.5 text-[8px] font-bold uppercase leading-none tracking-wide text-emerald-700 hover:bg-emerald-500/25 dark:text-emerald-400 sm:px-1.5 sm:text-[9px]"
                           onClick={(event) => event.stopPropagation()}
                           to={
                             buildSessionHref?.(details.completedSession.id, details.completedSession.status) ??
@@ -340,7 +342,7 @@ export function WorkoutCalendar({
                     </p>
                   </div>
 
-                  <div className="mt-auto flex items-center gap-1 pt-1 sm:gap-1.5 sm:pt-3">
+                  <div className="mt-auto flex min-w-0 items-center gap-1 pt-1 sm:gap-1.5 sm:pt-3">
                     {getTileIndicators(details.workoutIndicators).map((indicator) => (
                       <span
                         aria-label={`${statusToLabel(indicator.status)} workout`}
@@ -352,7 +354,7 @@ export function WorkoutCalendar({
                       />
                     ))}
                     {details.workoutIndicators.length >= 3 ? (
-                      <span className="rounded-full border border-slate-500/70 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground">
+                      <span className="hidden rounded-full border border-slate-500/70 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground sm:inline-flex">
                         +{details.workoutIndicators.length - 2}
                       </span>
                     ) : null}
@@ -370,7 +372,7 @@ export function WorkoutCalendar({
 
         <aside
           className={cn(
-            'order-first flex min-h-0 flex-col gap-4 rounded-3xl border p-5 shadow-sm lg:order-none',
+            'order-first flex min-h-0 flex-col gap-4 rounded-3xl border p-4 shadow-sm lg:order-none lg:p-5',
             accentPanel,
           )}
           id="workout-day-details"
@@ -497,7 +499,7 @@ function DayWorkoutItemCard({
   }
 
   return (
-    <div className="rounded-2xl border border-border/70 bg-secondary/40 p-3">
+    <div className="rounded-2xl border border-border/70 bg-secondary/40 p-2.5">
       <div className="flex items-start justify-between gap-2">
         <p className="text-sm font-medium text-foreground">{workout.name}</p>
         <span

--- a/apps/web/src/features/workouts/components/workout-list.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.test.tsx
@@ -68,6 +68,7 @@ describe('WorkoutList', () => {
     expect(headings).toEqual(['In Progress', 'Scheduled', 'Completed']);
 
     const inProgressSection = getSectionByTitle('In Progress');
+    const scheduledSection = getSectionByTitle('Scheduled');
     expect(within(inProgressSection).getAllByRole('link', { name: 'Resume' }).length).toBeGreaterThan(
       0,
     );
@@ -77,6 +78,11 @@ describe('WorkoutList', () => {
     expect(within(inProgressSection).getAllByRole('button', { name: /Delete/i }).length).toBeGreaterThan(
       0,
     );
+    within(scheduledSection)
+      .getAllByRole('button', { name: 'Reschedule' })
+      .forEach((button) => {
+        expect(button).toHaveClass('hover:text-foreground', 'active:text-foreground');
+      });
   });
 
   it('shows unavailable state for soft-deleted scheduled templates and hides stale start actions', async () => {

--- a/apps/web/src/features/workouts/components/workout-list.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.tsx
@@ -174,7 +174,7 @@ export function WorkoutList({
         <SectionHeading count={scheduledItems.length} title="Scheduled" />
         {!hasPlannedWorkouts ? (
           <Card className="border-dashed">
-            <CardContent className="space-y-4 py-5">
+            <CardContent className="space-y-3 py-4">
               <div className="space-y-1">
                 <h3 className="text-base font-semibold">No workouts planned</h3>
                 <p className="text-sm text-muted">
@@ -270,13 +270,13 @@ function InProgressWorkoutCard({
   return (
     <Card
       className={cn(
-        'h-full gap-4 border-l-4 py-0 transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-md',
+        'h-full gap-2.5 border-l-4 py-0 transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-md',
         session.cardClass,
       )}
       style={{ borderLeftColor: session.accentColor }}
     >
-      <CardHeader className="gap-3 py-5">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <CardHeader className="gap-2.5 py-3">
+        <div className="flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-1">
             <CardTitle>{session.name}</CardTitle>
             <p className="text-sm text-muted">{sessionDateFormatter.format(session.date)}</p>
@@ -294,14 +294,14 @@ function InProgressWorkoutCard({
         </div>
       </CardHeader>
 
-      <CardContent className="space-y-4 pb-5">
-        <ul className="flex flex-wrap gap-3 text-sm text-muted">
+      <CardContent className="space-y-3 pb-3">
+        <ul className="flex flex-wrap gap-2 text-sm text-muted">
           {buildStatusStats(session).map((stat) => (
             <WorkoutStat icon={stat.icon} key={`${session.id}-${stat.label}`} label={stat.label} />
           ))}
         </ul>
 
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-1.5">
           <Button asChild size="sm">
             <Link to={buildSessionHref(session.id, session.status)}>Resume</Link>
           </Button>
@@ -403,7 +403,7 @@ function ScheduledWorkoutCard({
   return (
     <Card
       className={cn(
-        'gap-4 border-l-4 py-0',
+        'gap-2.5 border-l-4 py-0',
         scheduledWorkout.isUnavailable
           ? 'border-destructive/45 bg-destructive/5'
           : scheduledWorkout.isMissed
@@ -411,8 +411,8 @@ function ScheduledWorkoutCard({
             : 'border-slate-300/70 dark:border-slate-700/70',
       )}
     >
-      <CardHeader className="gap-3 py-5">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <CardHeader className="gap-2.5 py-3">
+        <div className="flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-1">
             <CardTitle>{scheduledWorkout.templateName ?? 'Workout unavailable'}</CardTitle>
             <p className="text-sm text-muted">
@@ -446,8 +446,8 @@ function ScheduledWorkoutCard({
         </div>
       </CardHeader>
 
-      <CardContent className="space-y-4 pb-5">
-        <ul className="flex flex-wrap gap-3 text-sm text-muted">
+      <CardContent className="space-y-3 pb-3">
+        <ul className="flex flex-wrap gap-2 text-sm text-muted">
           <WorkoutStat
             icon={CalendarPlus2}
             label={`Scheduled ${sessionDateFormatter.format(parseDateForDisplay(scheduledWorkout.date))}`}
@@ -461,7 +461,7 @@ function ScheduledWorkoutCard({
           ) : null}
         </ul>
 
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-1.5">
           <Button
             disabled={isStartDisabled}
             onClick={() => {
@@ -473,6 +473,7 @@ function ScheduledWorkoutCard({
             Start now
           </Button>
           <Button
+            className="hover:text-foreground active:text-foreground"
             disabled={isMutating || !isTemplateAvailable}
             onClick={() => setIsRescheduleDialogOpen(true)}
             size="sm"
@@ -549,13 +550,13 @@ function WorkoutListCard({
     >
       <Card
         className={cn(
-          'h-full gap-4 border-l-4 py-0 transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-md',
+          'h-full gap-2.5 border-l-4 py-0 transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-md',
           session.cardClass,
         )}
         style={{ borderLeftColor: session.accentColor }}
       >
-        <CardHeader className="gap-3 py-5">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <CardHeader className="gap-2.5 py-3">
+          <div className="flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between">
             <div className="space-y-1">
               <CardTitle>{session.name}</CardTitle>
               <p className="text-sm text-muted">{sessionDateFormatter.format(session.date)}</p>
@@ -573,8 +574,8 @@ function WorkoutListCard({
           </div>
         </CardHeader>
 
-        <CardContent className="pb-5">
-          <ul className="flex flex-wrap gap-3 text-sm text-muted">
+        <CardContent className="pb-3">
+          <ul className="flex flex-wrap gap-2 text-sm text-muted">
             {buildStatusStats(session).map((stat) => (
               <WorkoutStat
                 icon={stat.icon}
@@ -591,7 +592,7 @@ function WorkoutListCard({
 
 function WorkoutStat({ icon: Icon, label }: { icon: typeof CalendarDays; label: string }) {
   return (
-    <li className="inline-flex items-center gap-1.5 rounded-full bg-secondary/55 px-3 py-1.5">
+    <li className="inline-flex items-center gap-1.5 rounded-full bg-secondary/55 px-2.5 py-1">
       <Icon aria-hidden="true" className="size-3.5 text-primary" />
       <span>{label}</span>
     </li>

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -437,7 +437,9 @@ describe('DashboardPage', () => {
       expect.objectContaining({ method: 'GET' }),
     );
 
-    const bodyWeightCard = screen.getAllByText('Body Weight')[0]?.closest('[data-slot="stat-card"]');
+    const bodyWeightCard = screen
+      .getAllByText('Body Weight')[0]
+      ?.closest('[data-slot="stat-card"]');
     expect(bodyWeightCard).toBeInTheDocument();
     expect(
       within(bodyWeightCard as HTMLElement).getByText(formatWeight(181.4)),
@@ -456,11 +458,15 @@ describe('DashboardPage', () => {
     expect(screen.getByRole('heading', { name: 'Recent Workouts' })).toBeInTheDocument();
     expect(screen.getByText('Upper Push A (Completed)')).toBeInTheDocument();
     expect(screen.getByText('1900 / 2300')).toBeInTheDocument();
-    expect(screen.getByText('170g / 190g')).toBeInTheDocument();
+    const proteinCard = screen.getAllByText('Protein')[0]?.closest('[data-slot="stat-card"]');
+    expect(within(proteinCard as HTMLElement).getByText('170g / 190g')).toBeInTheDocument();
     expect(screen.getByText('1/1')).toBeInTheDocument();
     expect(screen.getByTestId('dashboard-log-weight-card')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'History' })).toHaveAttribute('href', '/weight/history');
+    expect(screen.getByRole('link', { name: 'History' })).toHaveAttribute(
+      'href',
+      '/weight/history',
+    );
     expect(screen.queryByTestId('dashboard-log-weight-form')).not.toBeInTheDocument();
 
     const layout = container.querySelector('[data-slot="dashboard-layout"]');
@@ -476,18 +482,21 @@ describe('DashboardPage', () => {
       'grid',
       'min-w-0',
       'grid-cols-1',
-      'gap-6',
+      'gap-3',
       'md:grid-cols-2',
-      'xl:grid-cols-[minmax(240px,280px)_minmax(0,1fr)_minmax(280px,320px)]',
+      'xl:grid-cols-[minmax(220px,248px)_minmax(0,1fr)_minmax(260px,300px)]',
     );
-    expect(mainColumn).toHaveClass('order-1', 'md:order-1', 'xl:order-2');
-    expect(sidebarColumn).toHaveClass('order-2', 'md:order-2', 'xl:order-1');
-    expect(container.querySelector('[data-qa="dashboard-log-weight-form"]')).not.toBeInTheDocument();
+    expect(mainColumn).toHaveClass('order-1', 'gap-3', 'md:order-1', 'xl:order-2');
+    expect(sidebarColumn).toHaveClass('order-2', 'gap-3', 'md:order-2', 'xl:order-1');
+    expect(
+      container.querySelector('[data-qa="dashboard-log-weight-form"]'),
+    ).not.toBeInTheDocument();
     expect(recentColumn).toHaveClass('order-3', 'md:col-span-2', 'xl:col-span-1', 'xl:col-start-3');
     expect(weightTrendRow).toHaveClass('order-4', 'md:col-span-2', 'xl:col-span-3');
     expect(calendarPanel).toHaveClass('order-1', 'md:order-3');
     expect(snapshotPanel).toHaveClass('order-2', 'md:order-1');
     expect(macroPanel).toHaveClass('order-3', 'md:order-2');
+    expect(screen.getByTestId('dashboard-log-weight-card')).toHaveClass('gap-3', 'py-3');
   });
 
   it('opens contextual dashboard help from the page header', async () => {
@@ -634,7 +643,9 @@ describe('DashboardPage', () => {
     await vi.runAllTimersAsync();
     await Promise.resolve();
 
-    const bodyWeightCard = screen.getAllByText('Body Weight')[0]?.closest('[data-slot="stat-card"]');
+    const bodyWeightCard = screen
+      .getAllByText('Body Weight')[0]
+      ?.closest('[data-slot="stat-card"]');
     const habitsCard = screen.getByText('Habits').closest('[data-slot="stat-card"]');
 
     expect(bodyWeightCard).toBeInTheDocument();

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -617,7 +617,9 @@ describe('DashboardPage', () => {
     );
 
     expect(screen.getByLabelText('Loading dashboard snapshots')).toBeInTheDocument();
-    expect(screen.getAllByTestId('stat-card-skeleton')).toHaveLength(5);
+    const skeletonCards = screen.getAllByTestId('stat-card-skeleton');
+    expect(skeletonCards).toHaveLength(5);
+    expect(skeletonCards[4]).toHaveClass('col-span-2');
 
     deferredSnapshot.resolve(
       new Response(JSON.stringify({ data: snapshotForToday }), {

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -378,7 +378,11 @@ export function DashboardPage() {
                           className="grid grid-cols-2 gap-3"
                         >
                           {Array.from({ length: 5 }).map((_, index) => (
-                            <StatCardSkeleton key={index} showTrend={index !== 4} />
+                            <StatCardSkeleton
+                              className={index === 4 ? 'col-span-2' : undefined}
+                              key={index}
+                              showTrend={index !== 4}
+                            />
                           ))}
                         </div>
                       ) : (

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -240,7 +240,7 @@ export function DashboardPage() {
     (recentWorkoutsQuery.data?.length ?? 0) === 0;
 
   return (
-    <main className="flex w-full flex-col gap-8 py-6">
+    <main className="flex w-full flex-col gap-6 py-5 sm:gap-7 sm:py-6">
       <header className="animate-fade-in space-y-2">
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted sm:text-sm">
           {greeting}
@@ -341,11 +341,11 @@ export function DashboardPage() {
         />
       ) : (
         <div
-          className="grid min-w-0 grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-[minmax(240px,280px)_minmax(0,1fr)_minmax(280px,320px)]"
+          className="grid min-w-0 grid-cols-1 gap-3 sm:gap-4 md:grid-cols-2 xl:grid-cols-[minmax(220px,248px)_minmax(0,1fr)_minmax(260px,300px)]"
           data-slot="dashboard-layout"
         >
           <div
-            className="order-1 flex min-w-0 flex-col gap-6 md:order-1 xl:order-2"
+            className="order-1 flex min-w-0 flex-col gap-3 sm:gap-4 md:order-1 xl:order-2"
             data-slot="dashboard-main-column"
           >
             {visibleWidgets.includes('calendar') ? (
@@ -365,7 +365,7 @@ export function DashboardPage() {
 
             {visibleWidgets.includes('snapshot-cards') || visibleWidgets.includes('log-weight') ? (
               <div className="order-2 md:order-1" data-slot="dashboard-snapshot-panel">
-                <div className="flex flex-col gap-6">
+                <div className="flex flex-col gap-3 sm:gap-4">
                   {visibleWidgets.includes('snapshot-cards') ? (
                     <DashboardWidgetFrame
                       isEditMode={isEditMode}
@@ -375,7 +375,7 @@ export function DashboardPage() {
                       {snapshotQuery.isLoading ? (
                         <div
                           aria-label="Loading dashboard snapshots"
-                          className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4"
+                          className="grid grid-cols-2 gap-3"
                         >
                           {Array.from({ length: 5 }).map((_, index) => (
                             <StatCardSkeleton key={index} showTrend={index !== 4} />
@@ -393,34 +393,35 @@ export function DashboardPage() {
                       widgetLabel={DASHBOARD_WIDGET_IDS['log-weight']}
                     >
                       <Card
+                        className="gap-3 py-3 sm:py-3.5"
                         data-qa="dashboard-log-weight-card"
                         data-testid="dashboard-log-weight-card"
                       >
-                        <CardHeader className="space-y-1">
+                        <CardHeader className="gap-1.5 px-3 sm:px-4">
                           <div className="flex items-center justify-between gap-3">
                             <div className="space-y-1">
-                              <CardTitle>Body Weight</CardTitle>
-                              <CardDescription>
+                              <CardTitle className="leading-tight">Body Weight</CardTitle>
+                              <CardDescription className="text-xs sm:text-sm">
                                 Track your body weight for the selected day.
                               </CardDescription>
                             </div>
                             <Link
-                              className="text-sm font-medium text-primary hover:underline"
+                              className="text-xs font-medium text-primary hover:underline sm:text-sm"
                               to="/weight/history"
                             >
                               History
                             </Link>
                           </div>
                         </CardHeader>
-                        <CardContent>
-                          <div className="space-y-4">
+                        <CardContent className="px-3 sm:px-4">
+                          <div className="space-y-2.5">
                             {hasWeightForSelectedDay ? (
-                              <div className="flex items-center justify-between gap-3 rounded-xl border border-border/80 bg-secondary/30 px-4 py-3">
+                              <div className="flex items-center justify-between gap-3 rounded-xl border border-border/80 bg-secondary/30 px-3 py-2.5">
                                 <div className="space-y-1">
                                   <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
                                     Logged
                                   </p>
-                                  <p className="text-2xl font-semibold text-foreground">
+                                  <p className="text-xl font-semibold text-foreground">
                                     {selectedWeight.value.toFixed(1)} lbs
                                   </p>
                                 </div>
@@ -458,7 +459,7 @@ export function DashboardPage() {
 
                             {isWeightEditorOpen ? (
                               <form
-                                className="space-y-3"
+                                className="space-y-2.5"
                                 data-qa="dashboard-log-weight-form"
                                 data-testid="dashboard-log-weight-form"
                                 onSubmit={handleWeightSubmit}
@@ -543,7 +544,7 @@ export function DashboardPage() {
           </div>
 
           <div
-            className="order-2 flex min-w-0 flex-col gap-6 md:order-2 xl:order-1"
+            className="order-2 flex min-w-0 flex-col gap-3 sm:gap-4 md:order-2 xl:order-1"
             data-slot="dashboard-sidebar-column"
           >
             {visibleWidgets.includes('habit-chain') ? (
@@ -610,10 +611,10 @@ export function DashboardPage() {
               {hiddenWidgets.map((widgetId) => (
                 <Card
                   key={widgetId}
-                  className="border-dashed border-border/80 bg-muted/30 py-4"
+                  className="border-dashed border-border/80 bg-muted/30 py-3"
                   data-slot={`dashboard-hidden-widget-${widgetId}`}
                 >
-                  <CardContent className="flex items-center justify-between gap-3">
+                  <CardContent className="flex items-center justify-between gap-3 px-3">
                     <div>
                       <p className="text-sm font-medium text-foreground">
                         {DASHBOARD_WIDGET_IDS[widgetId]}

--- a/apps/web/src/pages/habits.tsx
+++ b/apps/web/src/pages/habits.tsx
@@ -70,8 +70,8 @@ export function HabitsPage() {
   }
 
   return (
-    <section className="space-y-4">
-      <div className="flex items-center gap-2">
+    <section className="space-y-3">
+      <div className="flex items-center gap-1.5">
         <h1 className="text-3xl font-semibold text-primary">Habits</h1>
         <HelpIcon title="Habits help">
           <p>

--- a/apps/web/src/pages/nutrition.test.tsx
+++ b/apps/web/src/pages/nutrition.test.tsx
@@ -229,25 +229,19 @@ function createDeferredResponse() {
   return { promise, resolve };
 }
 
-function getMealToggleButton(mealName: string) {
-  const candidateButtons = screen.getAllByRole('button', {
-    name: new RegExp(mealName, 'i'),
+function getMealHeading(mealName: string) {
+  return screen.getByRole('heading', {
+    name: new RegExp(`^${mealName}$`, 'i'),
   });
-  const button = candidateButtons.find((candidate) => candidate.hasAttribute('aria-controls'));
-
-  if (!button) {
-    throw new Error(`Expected a meal toggle button for ${mealName}`);
-  }
-
-  return button;
 }
 
 function expectMealsInDisplayOrder(mealNames: string[]) {
-  const buttons = mealNames.map((mealName) => getMealToggleButton(mealName));
+  const headings = mealNames.map((mealName) => getMealHeading(mealName));
 
-  for (let index = 0; index < buttons.length - 1; index += 1) {
+  for (let index = 0; index < headings.length - 1; index += 1) {
     expect(
-      buttons[index].compareDocumentPosition(buttons[index + 1]) & Node.DOCUMENT_POSITION_FOLLOWING,
+      headings[index].compareDocumentPosition(headings[index + 1]) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   }
 }
@@ -467,7 +461,7 @@ describe('NutritionPage', () => {
     await Promise.resolve();
 
     expect(screen.getByText('Thursday, March 5')).toBeInTheDocument();
-    expect(getMealToggleButton('Breakfast')).toBeInTheDocument();
+    expect(getMealHeading('Breakfast')).toBeInTheDocument();
   });
 
   it('shows a non-blocking fallback message when week summary fails', async () => {
@@ -691,7 +685,7 @@ describe('NutritionPage', () => {
     expectMealsInDisplayOrder(['Dinner', 'Snacks', 'Lunch', 'Breakfast']);
   });
 
-  it('expands a meal and deletes it via the API mutation', async () => {
+  it('shows grouped food rows and deletes a meal via the API mutation', async () => {
     const { fetchMock } = createNutritionApiMock({
       '2026-03-06': {
         daily: null,
@@ -721,9 +715,10 @@ describe('NutritionPage', () => {
     await vi.runAllTimersAsync();
     await Promise.resolve();
 
-    fireEvent.click(getMealToggleButton('Breakfast'));
+    expect(getMealHeading('Breakfast')).toBeInTheDocument();
     expect(screen.getByText('Large Eggs')).toBeInTheDocument();
     expect(screen.getByText('3 eggs')).toBeInTheDocument();
+    expect(screen.getByText('210cal · 18P · 1C · 15F')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete Breakfast' }));
     const dialog = screen.getByRole('alertdialog');

--- a/apps/web/src/pages/nutrition.tsx
+++ b/apps/web/src/pages/nutrition.tsx
@@ -139,8 +139,8 @@ export function NutritionPage() {
   }
 
   return (
-    <section className="space-y-5">
-      <header className="space-y-2">
+    <section className="space-y-4 sm:space-y-5">
+      <header className="space-y-1.5">
         <div className="flex items-center gap-2">
           <h1 className="text-3xl font-semibold text-primary">Nutrition</h1>
           <HelpIcon title="Nutrition help">
@@ -210,7 +210,7 @@ export function NutritionPage() {
         <>
           <section
             aria-label="Daily macro totals"
-            className={cn('rounded-2xl border border-border/70 px-5 py-5', accentCardStyles.cream)}
+            className={cn('rounded-2xl border border-border/70 px-4 py-4', accentCardStyles.cream)}
           >
             <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
               <div>
@@ -227,7 +227,7 @@ export function NutritionPage() {
             {isLoadingDay ? (
               <NutritionTotalsSkeleton />
             ) : (
-              <div className="mt-5 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              <div className="mt-4 grid grid-cols-1 gap-2.5 sm:grid-cols-2 lg:grid-cols-4">
                 {MACRO_CONFIG.map((macro) => {
                   const actual = dailyTotals[macro.key];
                   const target = dailyTargets?.[macro.key] ?? null;
@@ -236,7 +236,7 @@ export function NutritionPage() {
                   return (
                     <div
                       key={macro.key}
-                      className="rounded-xl border border-black/8 bg-white/30 px-4 py-4 backdrop-blur-sm dark:border-border dark:bg-secondary/60"
+                      className="rounded-xl border border-black/8 bg-white/30 px-3.5 py-3 backdrop-blur-sm dark:border-border dark:bg-secondary/60"
                     >
                       <p className="text-xs font-semibold uppercase tracking-[0.18em] opacity-65 dark:text-muted dark:opacity-100">
                         {macro.label}
@@ -287,9 +287,9 @@ export function NutritionPage() {
             </p>
           ) : null}
 
-          <div className="space-y-3">
+          <div className="space-y-2">
             {isLoadingDay ? (
-              <div aria-label="Loading nutrition meals" className="space-y-3">
+              <div aria-label="Loading nutrition meals" className="space-y-2">
                 {Array.from({ length: 4 }).map((_, index) => (
                   <MealCardSkeleton key={index} />
                 ))}
@@ -332,7 +332,7 @@ export function NutritionPage() {
 
 function NutritionTargetsPlaceholder() {
   return (
-    <section className="rounded-2xl border border-dashed border-border/70 bg-card/70 px-6 py-8 text-center shadow-sm">
+    <section className="rounded-2xl border border-dashed border-border/70 bg-card/70 px-5 py-6 text-center shadow-sm">
       <h2 className="text-lg font-semibold text-foreground">Macro progress</h2>
       <p className="mt-2 text-sm text-muted">
         No daily macro target is set yet. Add one in settings to enable progress rings.
@@ -345,12 +345,12 @@ function NutritionTotalsSkeleton() {
   return (
     <div
       aria-label="Loading nutrition"
-      className="mt-5 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4"
+      className="mt-4 grid grid-cols-1 gap-2.5 sm:grid-cols-2 lg:grid-cols-4"
     >
       {Array.from({ length: 4 }).map((_, index) => (
         <Skeleton
           key={index}
-          className="h-20 rounded-xl border border-black/8 bg-white/30 dark:border-border dark:bg-secondary/60"
+          className="h-18 rounded-xl border border-black/8 bg-white/30 dark:border-border dark:bg-secondary/60"
         />
       ))}
     </div>

--- a/apps/web/src/pages/profile.test.tsx
+++ b/apps/web/src/pages/profile.test.tsx
@@ -112,9 +112,11 @@ describe('ProfilePage', () => {
   });
 
   it('uses the responsive quick access grid classes required by the prototype', () => {
-    renderProfilePage();
+    const { container } = renderProfilePage();
 
     expect(screen.getByTestId('profile-quick-access-grid')).toHaveClass('grid-cols-2');
+    expect(screen.getByTestId('profile-quick-access-grid')).toHaveClass('gap-3');
     expect(screen.getByTestId('profile-quick-access-grid')).toHaveClass('lg:grid-cols-4');
+    expect(container.querySelector('section')).toHaveClass('gap-5', 'pb-8');
   });
 });

--- a/apps/web/src/pages/settings.tsx
+++ b/apps/web/src/pages/settings.tsx
@@ -253,7 +253,7 @@ function ThemeOptionCard({
   return (
     <Label
       className={cn(
-        'grid cursor-pointer gap-4 rounded-2xl border p-4 transition-colors',
+        'grid cursor-pointer gap-3 rounded-2xl border p-3.5 transition-colors',
         checked
           ? 'border-primary bg-secondary/70 shadow-sm'
           : 'border-border hover:border-primary/40 hover:bg-secondary/40',
@@ -261,7 +261,7 @@ function ThemeOptionCard({
       htmlFor={id}
     >
       <div className="flex items-start justify-between gap-3">
-        <div className="space-y-2">
+        <div className="space-y-1.5">
           <div className="flex items-center gap-3">
             <RadioGroupItem checked={checked} id={id} value={value} />
             <span className="text-base font-semibold text-foreground">{label}</span>
@@ -488,10 +488,10 @@ export function SettingsPage() {
   }
 
   return (
-    <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 pb-10">
+    <section className="mx-auto flex w-full max-w-6xl flex-col gap-5 pb-8">
       <BackLink />
 
-      <header className="space-y-2">
+      <header className="space-y-1.5">
         <h1 className="text-3xl font-semibold text-primary">Settings</h1>
         <p className="max-w-3xl text-sm text-muted">
           Manage the profile and appearance details that shape the Pulse experience across devices.
@@ -499,13 +499,13 @@ export function SettingsPage() {
       </header>
 
       <Card className="gap-4 border-border/70 shadow-sm">
-        <CardHeader className="space-y-2">
+        <CardHeader className="space-y-1.5">
           <CardTitle>
             <h2 className="text-xl font-semibold text-foreground">Profile</h2>
           </CardTitle>
           <CardDescription>Update your display name and view account details.</CardDescription>
         </CardHeader>
-        <CardContent className="space-y-4">
+        <CardContent className="space-y-3">
           <div className="space-y-2">
             <Label className="text-sm font-medium text-foreground" htmlFor="display-name">
               Display name
@@ -554,14 +554,14 @@ export function SettingsPage() {
               value={weightUnit}
             >
               <Label
-                className="flex cursor-pointer items-center gap-2 rounded-xl border border-border/80 p-3"
+                className="flex cursor-pointer items-center gap-2 rounded-xl border border-border/80 p-2.5"
                 htmlFor="weight-unit-lbs"
               >
                 <RadioGroupItem id="weight-unit-lbs" value="lbs" />
                 <span className="text-sm text-foreground">lbs</span>
               </Label>
               <Label
-                className="flex cursor-pointer items-center gap-2 rounded-xl border border-border/80 p-3"
+                className="flex cursor-pointer items-center gap-2 rounded-xl border border-border/80 p-2.5"
                 htmlFor="weight-unit-kg"
               >
                 <RadioGroupItem id="weight-unit-kg" value="kg" />
@@ -570,7 +570,7 @@ export function SettingsPage() {
             </RadioGroup>
           </div>
 
-          <div className="flex flex-col gap-3 border-t border-border/80 pt-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-2.5 border-t border-border/80 pt-3 sm:flex-row sm:items-center sm:justify-between">
             <p aria-live="polite" className="text-sm text-muted-foreground">
               {profileMessage || '\u00A0'}
             </p>
@@ -588,7 +588,7 @@ export function SettingsPage() {
       <AgentTokensCard />
 
       <Card className="gap-4 border-border/70 shadow-sm">
-        <CardHeader className="space-y-2">
+        <CardHeader className="space-y-1.5">
           <CardTitle>
             <h2 className="text-xl font-semibold text-foreground">Theme</h2>
           </CardTitle>
@@ -596,7 +596,7 @@ export function SettingsPage() {
             Choose how Pulse looks. Changes apply immediately and stay saved on this device.
           </CardDescription>
         </CardHeader>
-        <CardContent className="space-y-4">
+        <CardContent className="space-y-3">
           <RadioGroup
             aria-label="Theme options"
             className="grid gap-3 lg:grid-cols-3"
@@ -614,7 +614,7 @@ export function SettingsPage() {
       </Card>
 
       <Card className="gap-4 border-border/70 shadow-sm">
-        <CardHeader className="space-y-2">
+        <CardHeader className="space-y-1.5">
           <CardTitle>
             <h2 className="text-xl font-semibold text-foreground">Nutrition Targets</h2>
           </CardTitle>
@@ -622,7 +622,7 @@ export function SettingsPage() {
             Set daily macro targets for the dashboard rings and nutrition summaries.
           </CardDescription>
         </CardHeader>
-        <CardContent className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <CardContent className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
           <div className="space-y-2">
             <Label className="text-sm font-medium text-foreground" htmlFor="target-calories">
               Daily calories
@@ -686,7 +686,7 @@ export function SettingsPage() {
       </Card>
 
       <Card className="gap-4 border-border/70 shadow-sm">
-        <CardHeader className="space-y-2">
+        <CardHeader className="space-y-1.5">
           <CardTitle>
             <h2 className="text-xl font-semibold text-foreground">Dashboard Configuration</h2>
           </CardTitle>
@@ -694,8 +694,8 @@ export function SettingsPage() {
             Choose which habit streaks and trend sparklines show up on the dashboard.
           </CardDescription>
         </CardHeader>
-        <CardContent className="space-y-6">
-          <div className="space-y-3">
+        <CardContent className="space-y-5">
+          <div className="space-y-2.5">
             <div className="space-y-1">
               <h3 className="text-base font-semibold text-foreground">Habit Chains</h3>
               <p className="text-sm text-muted-foreground">
@@ -714,7 +714,7 @@ export function SettingsPage() {
                   return (
                     <Label
                       key={habit.id}
-                      className="flex cursor-pointer items-start gap-3 rounded-xl border border-border/80 p-3"
+                      className="flex cursor-pointer items-start gap-3 rounded-xl border border-border/80 p-2.5"
                       htmlFor={checkboxId}
                     >
                       <Checkbox
@@ -735,7 +735,7 @@ export function SettingsPage() {
             )}
           </div>
 
-          <div className="space-y-3">
+          <div className="space-y-2.5">
             <div className="space-y-1">
               <h3 className="text-base font-semibold text-foreground">Trend Sparklines</h3>
               <p className="text-sm text-muted-foreground">
@@ -749,7 +749,7 @@ export function SettingsPage() {
                 return (
                   <Label
                     key={metric.id}
-                    className="flex cursor-pointer items-start gap-3 rounded-xl border border-border/80 p-3"
+                    className="flex cursor-pointer items-start gap-3 rounded-xl border border-border/80 p-2.5"
                     htmlFor={checkboxId}
                   >
                     <Checkbox
@@ -769,7 +769,7 @@ export function SettingsPage() {
             </div>
           </div>
 
-          <div className="space-y-3">
+          <div className="space-y-2.5">
             <div className="space-y-1">
               <h3 className="text-base font-semibold text-foreground">Widget Visibility</h3>
               <p className="text-sm text-muted-foreground">
@@ -783,7 +783,7 @@ export function SettingsPage() {
                 return (
                   <Label
                     key={widgetId}
-                    className="flex cursor-pointer items-start gap-3 rounded-xl border border-border/80 p-3"
+                    className="flex cursor-pointer items-start gap-3 rounded-xl border border-border/80 p-2.5"
                     htmlFor={checkboxId}
                   >
                     <Checkbox
@@ -805,7 +805,7 @@ export function SettingsPage() {
             </div>
           </div>
 
-          <div className="flex flex-col gap-3 border-t border-border/80 pt-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-2.5 border-t border-border/80 pt-3 sm:flex-row sm:items-center sm:justify-between">
             <p aria-live="polite" className="text-sm text-muted-foreground">
               {saveMessage || 'Save changes to sync these preferences to your account.'}
             </p>


### PR DESCRIPTION
## Summary

This PR completes an app-wide density pass across the web UI so key screens show more signal per viewport, especially on mobile, without collapsing touch targets or making controls harder to scan. The dashboard was rebalanced into a tighter multi-column layout with compact snapshot cards, denser macro and trend widgets, a smaller log-weight panel, and habit chains that fit seven columns on small screens while preserving selectable day targets. Nutrition shifts from expandable meal cards to always-visible grouped food rows with inline macro summaries, reducing taps and vertical churn in the food log. Workout list, calendar, template, and session detail views were also tightened so planning, reviewing, and correcting sessions takes less space while fixing calendar tile overflow and low-contrast reschedule actions.

## Key Changes

- Added a compact `StatCard` density mode and applied it to dashboard snapshot widgets, including a two-column snapshot grid with the workout card spanning both columns.
- Reworked dashboard widgets for higher density: macro rings now show compact actual/target summaries, recent workouts and weight trend cards use tighter headers/content spacing, and trend sparklines use shorter chart heights and denser metric cards.
- Updated habit chains to use a 7-column mobile grid with smaller card chrome while keeping each day control at a minimum touch target size.
- Replaced nutrition meal accordions and per-item macro tables with always-expanded grouped rows that show serving details and compact macro strings inline; meal headers now surface time, food count, and total macros at a glance.
- Tightened workout surfaces across list, calendar, template detail, and session detail views, including smaller chips/cards, overflow-safe calendar tiles, preserved 44px controls for navigation/drag handles/actions, and improved reschedule button contrast.
- Finished the density audit across shared UI and remaining pages by reducing default dialog/alert-dialog/empty-state spacing, trimming app layout gutters, and aligning habits, profile, settings, agent token, and trash views to the same compact spacing scale.
- Expanded tests around compact defaults and interaction safety, including dialog spacing, dashboard/habit chain layout expectations, nutrition row rendering, and preserved touch-target classes.

## Technical Notes

- The main reusable primitive change is the new `density="compact"` path on `StatCard`; reviewers should focus there first because it drives several dashboard layout changes.
- Nutrition intentionally trades the previous accordion/table structure for permanently visible, flatter meal rows. That simplifies scanning and lowers interaction cost, but it is a real UX behavior change worth reviewing closely.
- Compactness was deliberately constrained by minimum target sizes on interactive controls such as dialog close buttons, habit-chain days, calendar navigation, chart legend toggles, and template drag/action buttons.
- The workout calendar changes are partly defensive, not just visual: `min-w-0`, overflow handling, and smaller status pills were added to prevent tile content from spilling on narrow screens.

## Commits

- `c732553 feat(web): finish remaining density pass`
- `8b72b07 feat(web): compact workout views`
- `4939ea8 feat(web): compact nutrition food log rows`
- `d30db42 feat(web): compact dashboard widgets`

## Tasks

- **Redesign dashboard cards for compact high-signal density**: Reduce card padding, tighten grid layout, compact habit chains, macro rings, weight chart on dashboard
- **Compact mobile food log rows**: Tighten food log row height, inline macros, reduce meal group header padding while preserving groupings
- **Compact workout views — list, calendar, templates, receipt**: Tighten workout cards, fix reschedule button contrast, fix calendar overflow, compact templates and receipt
- **Global density pass — habits, modals, remaining views**: Complete density audit for habit views, modals/dialogs, settings, and ensure uniform compactness

## Diff Stats

```
apps/web/src/components/layout/app-layout.test.tsx |   2 +-
 apps/web/src/components/layout/app-layout.tsx      |   2 +-
 .../components/skeletons/habit-row-skeleton.tsx    |   6 +-
 .../components/skeletons/meal-card-skeleton.tsx    |  31 ++--
 apps/web/src/components/ui/alert-dialog.tsx        |   6 +-
 .../src/components/ui/confirmation-dialog.test.tsx |   2 +
 apps/web/src/components/ui/dialog.test.tsx         |  36 +++++
 apps/web/src/components/ui/dialog.tsx              |   8 +-
 apps/web/src/components/ui/empty-state.test.tsx    |   6 +-
 apps/web/src/components/ui/empty-state.tsx         |  10 +-
 apps/web/src/components/ui/stat-card.tsx           |  36 ++++-
 .../dashboard/components/habit-chain.test.tsx      |  13 ++
 .../features/dashboard/components/habit-chain.tsx  |  25 ++--
 .../dashboard/components/macro-rings.test.tsx      |   7 +-
 .../features/dashboard/components/macro-rings.tsx  |  46 ++++--
 .../dashboard/components/recent-workouts.test.tsx  |  17 ++-
 .../dashboard/components/recent-workouts.tsx       |  43 ++++--
 .../dashboard/components/snapshot-cards.test.tsx   |  11 +-
 .../dashboard/components/snapshot-cards.tsx        |  15 +-
 .../dashboard/components/trend-sparkline.tsx       |  41 ++---
 .../components/weight-trend-chart.test.tsx         |   6 +-
 .../dashboard/components/weight-trend-chart.tsx    |  67 +++++----
 .../habits/components/daily-habits.test.tsx        |   7 +-
 .../features/habits/components/daily-habits.tsx    |  44 +++---
 .../features/habits/components/habit-card-menu.tsx |   7 +-
 .../habits/components/habit-form-dialog.test.tsx   |   8 +
 .../habits/components/habit-form-dialog.tsx        |  14 +-
 .../habits/components/habit-history.test.tsx       |   2 +
 .../features/habits/components/habit-history.tsx   |  32 ++--
 .../nutrition/components/meal-card.test.tsx        |  66 ++-------
 .../features/nutrition/components/meal-card.tsx    | 165 ++++++++-------------
 .../features/profile/components/profile-hub.tsx    |  18 +--
 .../settings/components/agent-tokens-card.tsx      |  18 +--
 .../features/settings/components/trash-manager.tsx |  10 +-
 .../workouts/components/session-detail.test.tsx    |   3 +
 .../workouts/components/session-detail.tsx         |  36 ++---
 .../workouts/components/template-detail.test.tsx   |  10 ++
 .../workouts/components/template-detail.tsx        |  23 +--
 .../workouts/components/workout-calendar.test.tsx  |   8 +-
 .../workouts/components/workout-calendar.tsx       |  26 ++--
 .../workouts/components/workout-list.test.tsx      |   6 +
 .../features/workouts/components/workout-list.tsx  |  39 ++---
 apps/web/src/pages/dashboard.test.tsx              |  29 ++--
 apps/web/src/pages/dashboard.tsx                   |  35 ++---
 apps/web/src/pages/habits.tsx                      |   4 +-
 apps/web/src/pages/nutrition.test.tsx              |  27 ++--
 apps/web/src/pages/nutrition.tsx                   |  20 +--
 apps/web/src/pages/profile.test.tsx                |   4 +-
 apps/web/src/pages/settings.tsx                    |  44 +++---
 49 files changed, 630 insertions(+), 511 deletions(-)
```