### PR TITLE
feat(dashboard): add drill-down navigation and habit chain interactions

### DIFF
--- a/apps/web/src/features/dashboard/components/dashboard-drilldown-link.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-drilldown-link.tsx
@@ -1,0 +1,61 @@
+import { ChevronRight } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { Link } from 'react-router';
+
+import { cn } from '@/lib/utils';
+
+type DashboardDrilldownLinkProps = {
+  children: ReactNode;
+  className?: string;
+  indicatorClassName?: string;
+  indicatorLabel?: string;
+  to: string;
+  viewLabel: string;
+};
+
+export const dashboardDrilldownCardClassName =
+  'cursor-pointer transition-[transform,box-shadow,filter,border-color,background-color] duration-200 group-hover/drilldown:-translate-y-0.5 group-hover/drilldown:border-primary/35 group-hover/drilldown:shadow-md group-hover/drilldown:brightness-[0.98] group-focus-within/drilldown:-translate-y-0.5 group-focus-within/drilldown:border-primary/45 group-focus-within/drilldown:shadow-md group-focus-within/drilldown:brightness-[0.98] dark:group-hover/drilldown:brightness-[1.08] dark:group-focus-within/drilldown:brightness-[1.08]';
+
+export function DashboardDrilldownIndicator({
+  className,
+  label = 'View',
+}: {
+  className?: string;
+  label?: string;
+}) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        'pointer-events-none absolute right-3 bottom-3 z-20 inline-flex items-center gap-1 rounded-full border border-border/70 bg-background/85 px-2 py-1 text-[11px] font-medium text-muted-foreground shadow-sm backdrop-blur-sm transition-colors group-hover/drilldown:text-foreground group-hover/drilldown:border-primary/35 group-focus-within/drilldown:text-foreground group-focus-within/drilldown:border-primary/45',
+        className,
+      )}
+    >
+      {label ? <span>{label}</span> : null}
+      <ChevronRight className="size-3.5" />
+    </span>
+  );
+}
+
+export function DashboardDrilldownLink({
+  children,
+  className,
+  indicatorClassName,
+  indicatorLabel,
+  to,
+  viewLabel,
+}: DashboardDrilldownLinkProps) {
+  return (
+    <div className={cn('group/drilldown relative isolate rounded-[inherit]', className)}>
+      {children}
+      <Link
+        aria-label={viewLabel}
+        className="absolute inset-0 z-10 rounded-[inherit] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        to={to}
+      >
+        <span className="sr-only">{viewLabel}</span>
+      </Link>
+      <DashboardDrilldownIndicator className={indicatorClassName} label={indicatorLabel} />
+    </div>
+  );
+}

--- a/apps/web/src/features/dashboard/components/dashboard-drilldown-link.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-drilldown-link.tsx
@@ -52,9 +52,7 @@ export function DashboardDrilldownLink({
         aria-label={viewLabel}
         className="absolute inset-0 z-10 rounded-[inherit] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         to={to}
-      >
-        <span className="sr-only">{viewLabel}</span>
-      </Link>
+      />
       <DashboardDrilldownIndicator className={indicatorClassName} label={indicatorLabel} />
     </div>
   );

--- a/apps/web/src/features/dashboard/components/habit-chain.test.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.test.tsx
@@ -454,7 +454,8 @@ describe('HabitChain', () => {
     });
 
     const firstSquare = container.querySelector('[data-slot="habit-chain-day"]');
-    expect(firstSquare).toHaveClass('size-11', 'min-h-11', 'min-w-11');
+    // Mobile: size-8 prevents grid cell overflow on narrow screens; sm+: size-11 for full 44px touch target
+    expect(firstSquare).toHaveClass('size-8', 'min-h-8', 'min-w-8', 'sm:size-11', 'sm:min-h-11', 'sm:min-w-11');
 
     const grid = container.querySelector('[data-slot="habit-chain-grid"]');
     expect(grid).toHaveClass('grid-cols-7', 'gap-1.5', 'sm:grid-cols-10');

--- a/apps/web/src/features/dashboard/components/habit-chain.test.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.test.tsx
@@ -1,10 +1,13 @@
 import type { Habit, HabitEntry } from '@pulse/shared';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { mockHabits } from '@/lib/mock-data/dashboard';
 
 import { HabitChain } from './habit-chain';
+
+type HabitChainProps = Parameters<typeof HabitChain>[0];
 
 const formatDateLabel = (date: string): string => {
   return new Intl.DateTimeFormat('en-US', {
@@ -55,13 +58,21 @@ const habitEntryRecords: HabitEntry[] = mockHabits.flatMap((habit, habitIndex) =
   })),
 );
 
+function renderHabitChain(props: HabitChainProps = {}) {
+  return render(
+    <MemoryRouter>
+      <HabitChain {...props} />
+    </MemoryRouter>,
+  );
+}
+
 describe('HabitChain', () => {
   afterEach(() => {
     vi.useRealTimers();
   });
 
   it('renders an empty state when no habits are provided', () => {
-    const { container } = render(<HabitChain />);
+    const { container } = renderHabitChain();
 
     expect(screen.getByText('No matching habits.')).toBeInTheDocument();
     const allSquares = container.querySelectorAll('[data-slot="habit-chain-day"]');
@@ -69,7 +80,7 @@ describe('HabitChain', () => {
   });
 
   it('renders all habits with 30 day squares each when API data is provided', () => {
-    const { container } = render(<HabitChain habits={habitRecords} entries={habitEntryRecords} />);
+    const { container } = renderHabitChain({ habits: habitRecords, entries: habitEntryRecords });
 
     mockHabits.forEach((habit) => {
       expect(screen.getByRole('heading', { name: habit.name })).toBeInTheDocument();
@@ -77,6 +88,9 @@ describe('HabitChain', () => {
 
     const streakLabels = screen.getAllByText(/\d+ day streak/);
     expect(streakLabels).toHaveLength(mockHabits.length);
+    expect(screen.getAllByRole('link', { name: /view .* habit details/i })).toHaveLength(
+      mockHabits.length,
+    );
 
     const allSquares = container.querySelectorAll('[data-slot="habit-chain-day"]');
     expect(allSquares).toHaveLength(mockHabits.length * 30);
@@ -84,9 +98,11 @@ describe('HabitChain', () => {
 
   it('renders squares in oldest-to-newest order and highlights today', () => {
     const habit = getHabitByIndex(0);
-    const { container } = render(
-      <HabitChain entries={habitEntryRecords} habitIds={[habit.id]} habits={habitRecords} />,
-    );
+    const { container } = renderHabitChain({
+      entries: habitEntryRecords,
+      habitIds: [habit.id],
+      habits: habitRecords,
+    });
 
     const squares = container.querySelectorAll('[data-slot="habit-chain-day"]');
     const firstEntry = habit.entries[0];
@@ -115,14 +131,12 @@ describe('HabitChain', () => {
       throw new Error('Expected a valid end date in mock habit entries.');
     }
 
-    const { container } = render(
-      <HabitChain
-        endDate={endDate}
-        entries={habitEntryRecords}
-        habitIds={[habit.id]}
-        habits={habitRecords}
-      />,
-    );
+    const { container } = renderHabitChain({
+      endDate,
+      entries: habitEntryRecords,
+      habitIds: [habit.id],
+      habits: habitRecords,
+    });
 
     const squares = container.querySelectorAll('[data-slot="habit-chain-day"]');
     expect(squares).toHaveLength(30);
@@ -169,14 +183,12 @@ describe('HabitChain', () => {
       },
     ];
 
-    const { container } = render(
-      <HabitChain
-        endDate="2026-03-11"
-        entries={chainEntries}
-        habitIds={[habit.id]}
-        habits={[habit]}
-      />,
-    );
+    const { container } = renderHabitChain({
+      endDate: '2026-03-11',
+      entries: chainEntries,
+      habitIds: [habit.id],
+      habits: [habit],
+    });
 
     const completedSquare = container.querySelector(
       '[data-slot="habit-chain-day"][data-date="2026-03-09"]',
@@ -219,9 +231,12 @@ describe('HabitChain', () => {
       updatedAt: new Date('2026-02-01T00:00:00Z').getTime(),
     };
 
-    const { container } = render(
-      <HabitChain endDate="2026-03-10" entries={[]} habitIds={[habit.id]} habits={[habit]} />,
-    );
+    const { container } = renderHabitChain({
+      endDate: '2026-03-10',
+      entries: [],
+      habitIds: [habit.id],
+      habits: [habit],
+    });
 
     const todaySquare = container.querySelector(
       '[data-slot="habit-chain-day"][data-date="2026-03-10"]',
@@ -236,14 +251,12 @@ describe('HabitChain', () => {
     vi.setSystemTime(new Date('2026-03-10T12:00:00Z'));
 
     const habit = getHabitByIndex(0);
-    const { container } = render(
-      <HabitChain
-        endDate="2026-03-11"
-        entries={habitEntryRecords}
-        habitIds={[habit.id]}
-        habits={habitRecords}
-      />,
-    );
+    const { container } = renderHabitChain({
+      endDate: '2026-03-11',
+      entries: habitEntryRecords,
+      habitIds: [habit.id],
+      habits: habitRecords,
+    });
 
     const futureSquare = container.querySelector(
       '[data-slot="habit-chain-day"][data-date="2026-03-11"]',
@@ -305,9 +318,12 @@ describe('HabitChain', () => {
       },
     ];
 
-    render(
-      <HabitChain endDate="2026-03-13" entries={entries} habitIds={[habit.id]} habits={[habit]} />,
-    );
+    renderHabitChain({
+      endDate: '2026-03-13',
+      entries,
+      habitIds: [habit.id],
+      habits: [habit],
+    });
 
     expect(screen.getByText('3 day streak')).toBeInTheDocument();
   });
@@ -315,9 +331,11 @@ describe('HabitChain', () => {
   it('filters habits with habitIds', () => {
     const selectedHabits = [getHabitByIndex(1), getHabitByIndex(3)];
     const selectedHabitIds = selectedHabits.map((habit) => habit.id);
-    const { container } = render(
-      <HabitChain entries={habitEntryRecords} habitIds={selectedHabitIds} habits={habitRecords} />,
-    );
+    const { container } = renderHabitChain({
+      entries: habitEntryRecords,
+      habitIds: selectedHabitIds,
+      habits: habitRecords,
+    });
 
     expect(screen.getByRole('heading', { name: selectedHabits[0].name })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: selectedHabits[1].name })).toBeInTheDocument();
@@ -331,9 +349,11 @@ describe('HabitChain', () => {
 
   it('assigns a date tooltip label to each day square', () => {
     const habit = getHabitByIndex(0);
-    const { container } = render(
-      <HabitChain entries={habitEntryRecords} habitIds={[habit.id]} habits={habitRecords} />,
-    );
+    const { container } = renderHabitChain({
+      entries: habitEntryRecords,
+      habitIds: [habit.id],
+      habits: habitRecords,
+    });
 
     const firstSquare = container.querySelector('[data-slot="habit-chain-day"]');
     const date = firstSquare?.getAttribute('data-date');
@@ -351,9 +371,11 @@ describe('HabitChain', () => {
 
   it('keeps each day circle at the minimum touch target size', () => {
     const habit = getHabitByIndex(0);
-    const { container } = render(
-      <HabitChain entries={habitEntryRecords} habitIds={[habit.id]} habits={habitRecords} />,
-    );
+    const { container } = renderHabitChain({
+      entries: habitEntryRecords,
+      habitIds: [habit.id],
+      habits: habitRecords,
+    });
 
     const firstSquare = container.querySelector('[data-slot="habit-chain-day"]');
     expect(firstSquare).toHaveClass('size-11', 'min-h-11', 'min-w-11');
@@ -364,9 +386,11 @@ describe('HabitChain', () => {
 
   it('includes the status in square aria labels', () => {
     const habit = getHabitByIndex(0);
-    const { container } = render(
-      <HabitChain entries={habitEntryRecords} habitIds={[habit.id]} habits={habitRecords} />,
-    );
+    const { container } = renderHabitChain({
+      entries: habitEntryRecords,
+      habitIds: [habit.id],
+      habits: habitRecords,
+    });
 
     const square = container.querySelector(
       '[data-slot="habit-chain-day"][data-status="completed"]',
@@ -375,19 +399,17 @@ describe('HabitChain', () => {
   });
 
   it('renders an empty state when no habits match the filter', () => {
-    render(
-      <HabitChain
-        entries={habitEntryRecords}
-        habitIds={['habit-does-not-exist']}
-        habits={habitRecords}
-      />,
-    );
+    renderHabitChain({
+      entries: habitEntryRecords,
+      habitIds: ['habit-does-not-exist'],
+      habits: habitRecords,
+    });
 
     expect(screen.getByText('No matching habits.')).toBeInTheDocument();
   });
 
   it('renders an empty state when an explicit empty filter is provided', () => {
-    render(<HabitChain entries={habitEntryRecords} habitIds={[]} habits={habitRecords} />);
+    renderHabitChain({ entries: habitEntryRecords, habitIds: [], habits: habitRecords });
 
     expect(screen.getByText('No matching habits.')).toBeInTheDocument();
   });

--- a/apps/web/src/features/dashboard/components/habit-chain.test.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.test.tsx
@@ -1,13 +1,27 @@
 import type { Habit, HabitEntry } from '@pulse/shared';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { useUpdateHabitEntry } from '@/features/habits/api/habits';
 import { mockHabits } from '@/lib/mock-data/dashboard';
 
 import { HabitChain } from './habit-chain';
 
+vi.mock('@/features/habits/api/habits', () => ({
+  useUpdateHabitEntry: vi.fn(),
+}));
+
+const mockedUseUpdateHabitEntry = vi.mocked(useUpdateHabitEntry);
+
 type HabitChainProps = Parameters<typeof HabitChain>[0];
+
+function createMutationMock() {
+  return {
+    isPending: false,
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+  };
+}
 
 const formatDateLabel = (date: string): string => {
   return new Intl.DateTimeFormat('en-US', {
@@ -69,6 +83,7 @@ function renderHabitChain(props: HabitChainProps = {}) {
 describe('HabitChain', () => {
   afterEach(() => {
     vi.useRealTimers();
+    mockedUseUpdateHabitEntry.mockReset();
   });
 
   it('renders an empty state when no habits are provided', () => {
@@ -249,6 +264,9 @@ describe('HabitChain', () => {
   it('shows future days as not scheduled', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-10T12:00:00Z'));
+    mockedUseUpdateHabitEntry.mockReturnValue(
+      createMutationMock() as unknown as ReturnType<typeof useUpdateHabitEntry>,
+    );
 
     const habit = getHabitByIndex(0);
     const { container } = renderHabitChain({
@@ -264,6 +282,64 @@ describe('HabitChain', () => {
 
     expect(futureSquare).toHaveAttribute('data-status', 'not_scheduled');
     expect(futureSquare).toHaveClass('bg-[var(--color-muted)]/40');
+    expect(futureSquare).toBeDisabled();
+  });
+
+  it('opens the day detail modal when a habit circle is clicked', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-10T12:00:00Z'));
+    mockedUseUpdateHabitEntry.mockReturnValue(
+      createMutationMock() as unknown as ReturnType<typeof useUpdateHabitEntry>,
+    );
+
+    const habit: Habit = {
+      id: 'habit-modal',
+      userId: 'user-1',
+      name: 'Meditate',
+      description: null,
+      emoji: null,
+      trackingType: 'boolean',
+      target: null,
+      unit: null,
+      frequency: 'daily',
+      frequencyTarget: null,
+      scheduledDays: null,
+      pausedUntil: null,
+      referenceSource: null,
+      referenceConfig: null,
+      sortOrder: 0,
+      active: true,
+      createdAt: new Date('2026-02-01T00:00:00Z').getTime(),
+      updatedAt: new Date('2026-02-01T00:00:00Z').getTime(),
+    };
+    const entries: HabitEntry[] = [
+      {
+        id: 'entry-modal',
+        habitId: habit.id,
+        userId: 'user-1',
+        date: '2026-03-09',
+        completed: true,
+        value: null,
+        createdAt: new Date('2026-03-09T12:00:00Z').getTime(),
+      },
+    ];
+
+    renderHabitChain({
+      endDate: '2026-03-10',
+      entries,
+      habitIds: [habit.id],
+      habits: [habit],
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Meditate 2026-03-09 Completed' }),
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByText('Meditate')).toBeInTheDocument();
+    expect(within(dialog).getByText('March 9, 2026')).toBeInTheDocument();
+    expect(within(dialog).getByText('Status')).toBeInTheDocument();
   });
 
   it('counts streak across not scheduled gaps and breaks on missed days', () => {

--- a/apps/web/src/features/dashboard/components/habit-chain.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.tsx
@@ -154,6 +154,8 @@ const buildHabitChainHabits = (
           entry: existingEntry,
           isFutureDate: false,
           isScheduled,
+          // Scheduled-but-unlogged today stays neutral so the chain does not penalize the user
+          // before the day is over. Consumers can inspect isScheduled/isFutureDate for detail.
           status: 'not_scheduled' as const,
         };
       }

--- a/apps/web/src/features/dashboard/components/habit-chain.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.tsx
@@ -7,6 +7,10 @@ import { Flame } from 'lucide-react';
 
 import { Card, CardContent } from '@/components/ui/card';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import {
+  DashboardDrilldownLink,
+  dashboardDrilldownCardClassName,
+} from '@/features/dashboard/components/dashboard-drilldown-link';
 import { addDays, formatDateKey, getToday, toDateKey } from '@/lib/date';
 import { cn } from '@/lib/utils';
 
@@ -146,68 +150,77 @@ export function HabitChain({ habitIds, habits = [], entries = [], endDate }: Hab
     <section aria-label="Habit chains" className="space-y-2.5">
       <TooltipProvider>
         {visibleHabits.map((habit) => (
-          <Card className="gap-2 px-3 py-2.5" key={habit.id}>
-            <CardContent className="space-y-2 px-0">
-              <div className="flex items-start justify-between gap-3">
-                <h2 className="text-sm leading-tight font-semibold text-foreground">
-                  {habit.name}
-                </h2>
-                <p
-                  className="inline-flex items-center gap-1 text-xs font-semibold text-foreground sm:text-sm"
-                  data-slot="habit-chain-streak"
+          <DashboardDrilldownLink
+            indicatorClassName="right-3 bottom-3"
+            key={habit.id}
+            to="/habits"
+            viewLabel={`View ${habit.name} habit details`}
+          >
+            <Card className={cn('gap-2 px-3 py-2.5', dashboardDrilldownCardClassName)}>
+              <CardContent className="space-y-2 px-0">
+                <div className="flex items-start justify-between gap-3 pr-14">
+                  <h2 className="text-sm leading-tight font-semibold text-foreground">
+                    {habit.name}
+                  </h2>
+                  <p
+                    className="inline-flex items-center gap-1 text-xs font-semibold text-foreground sm:text-sm"
+                    data-slot="habit-chain-streak"
+                  >
+                    <Flame aria-hidden className="size-3.5 text-[var(--color-accent-pink)]" />
+                    <span className="text-sm leading-none sm:text-base">{`${habit.currentStreak} day streak`}</span>
+                  </p>
+                </div>
+
+                <div
+                  className="grid grid-cols-7 gap-1.5 pr-14 sm:grid-cols-10"
+                  data-slot="habit-chain-grid"
                 >
-                  <Flame aria-hidden className="size-3.5 text-[var(--color-accent-pink)]" />
-                  <span className="text-sm leading-none sm:text-base">{`${habit.currentStreak} day streak`}</span>
-                </p>
-              </div>
+                  {habit.entries.map((entry) => {
+                    const isSelectedDay = entry.date === selectedDateKey;
+                    const statusLabel =
+                      entry.status === 'completed'
+                        ? 'Completed'
+                        : entry.status === 'missed'
+                          ? 'Missed'
+                          : 'Not scheduled';
+                    const statusClass =
+                      entry.status === 'completed'
+                        ? 'bg-[var(--color-accent-mint)]'
+                        : entry.status === 'missed'
+                          ? 'bg-red-400/70 dark:bg-red-500/50'
+                          : 'bg-[var(--color-muted)]/40';
 
-              <div
-                className="grid grid-cols-7 gap-1.5 sm:grid-cols-10"
-                data-slot="habit-chain-grid"
-              >
-                {habit.entries.map((entry) => {
-                  const isSelectedDay = entry.date === selectedDateKey;
-                  const statusLabel =
-                    entry.status === 'completed'
-                      ? 'Completed'
-                      : entry.status === 'missed'
-                        ? 'Missed'
-                        : 'Not scheduled';
-                  const statusClass =
-                    entry.status === 'completed'
-                      ? 'bg-[var(--color-accent-mint)]'
-                      : entry.status === 'missed'
-                        ? 'bg-red-400/70 dark:bg-red-500/50'
-                        : 'bg-[var(--color-muted)]/40';
-
-                  return (
-                    <Tooltip key={`${habit.id}-${entry.date}`}>
-                      <TooltipTrigger asChild>
-                        <button
-                          aria-label={`${habit.name} ${entry.date} ${statusLabel}`}
-                          className={cn(
-                            'size-11 min-h-11 min-w-11 justify-self-center rounded-full border transition-colors',
-                            statusClass,
-                            isSelectedDay ? 'border-[var(--color-primary)]' : 'border-transparent',
-                          )}
-                          data-date={entry.date}
-                          data-status={entry.status}
-                          data-slot="habit-chain-day"
-                          data-today={isSelectedDay ? 'true' : 'false'}
-                          title={`${formatDateLabel(entry.date)} — ${statusLabel}`}
-                          type="button"
-                        />
-                      </TooltipTrigger>
-                      <TooltipContent side="top" sideOffset={6}>
-                        <p>{formatDateLabel(entry.date)}</p>
-                        <p className="text-xs text-muted-foreground">{statusLabel}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  );
-                })}
-              </div>
-            </CardContent>
-          </Card>
+                    return (
+                      <Tooltip key={`${habit.id}-${entry.date}`}>
+                        <TooltipTrigger asChild>
+                          <button
+                            aria-label={`${habit.name} ${entry.date} ${statusLabel}`}
+                            className={cn(
+                              'relative z-20 size-11 min-h-11 min-w-11 justify-self-center rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                              statusClass,
+                              isSelectedDay
+                                ? 'border-[var(--color-primary)]'
+                                : 'border-transparent',
+                            )}
+                            data-date={entry.date}
+                            data-status={entry.status}
+                            data-slot="habit-chain-day"
+                            data-today={isSelectedDay ? 'true' : 'false'}
+                            title={`${formatDateLabel(entry.date)} — ${statusLabel}`}
+                            type="button"
+                          />
+                        </TooltipTrigger>
+                        <TooltipContent side="top" sideOffset={6}>
+                          <p>{formatDateLabel(entry.date)}</p>
+                          <p className="text-xs text-muted-foreground">{statusLabel}</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    );
+                  })}
+                </div>
+              </CardContent>
+            </Card>
+          </DashboardDrilldownLink>
         ))}
       </TooltipProvider>
     </section>

--- a/apps/web/src/features/dashboard/components/habit-chain.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.tsx
@@ -245,7 +245,7 @@ export function HabitChain({ habitIds, habits = [], entries = [], endDate }: Hab
                             <button
                               aria-label={`${habit.name} ${entry.date} ${statusLabel}`}
                               className={cn(
-                                'relative z-20 size-11 min-h-11 min-w-11 justify-self-center rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-55',
+                                'relative z-20 size-8 min-h-8 min-w-8 justify-self-center rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-55 sm:size-11 sm:min-h-11 sm:min-w-11',
                                 statusClass,
                                 isSelectedDay
                                   ? 'border-[var(--color-primary)]'

--- a/apps/web/src/features/dashboard/components/habit-chain.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.tsx
@@ -3,6 +3,7 @@ import {
   type Habit as HabitRecord,
   type HabitEntry as HabitEntryRecord,
 } from '@pulse/shared';
+import { useState } from 'react';
 import { Flame } from 'lucide-react';
 
 import { Card, CardContent } from '@/components/ui/card';
@@ -11,6 +12,7 @@ import {
   DashboardDrilldownLink,
   dashboardDrilldownCardClassName,
 } from '@/features/dashboard/components/dashboard-drilldown-link';
+import { HabitDayModal } from '@/features/habits/components/habit-day-modal';
 import { addDays, formatDateKey, getToday, toDateKey } from '@/lib/date';
 import { cn } from '@/lib/utils';
 
@@ -23,12 +25,16 @@ type HabitChainProps = {
 
 type HabitChainEntry = {
   date: string;
+  entry: HabitEntryRecord | null;
+  isFutureDate: boolean;
+  isScheduled: boolean;
   status: 'completed' | 'missed' | 'not_scheduled';
 };
 
 type HabitChainHabit = {
   currentStreak: number;
   entries: HabitChainEntry[];
+  habit: HabitRecord;
   id: string;
   name: string;
 };
@@ -82,15 +88,16 @@ const buildHabitChainHabits = (
   endDate: string,
 ): HabitChainHabit[] => {
   const entriesByHabit = new Map<string, HabitEntryRecord[]>();
-  const entriesByHabitByDate = new Map<string, Map<string, boolean>>();
+  const entriesByHabitByDate = new Map<string, Map<string, HabitEntryRecord>>();
 
   entries.forEach((entry) => {
     const existingEntries = entriesByHabit.get(entry.habitId) ?? [];
     existingEntries.push(entry);
     entriesByHabit.set(entry.habitId, existingEntries);
 
-    const entriesByDate = entriesByHabitByDate.get(entry.habitId) ?? new Map<string, boolean>();
-    entriesByDate.set(entry.date, entry.completed);
+    const entriesByDate =
+      entriesByHabitByDate.get(entry.habitId) ?? new Map<string, HabitEntryRecord>();
+    entriesByDate.set(entry.date, entry);
     entriesByHabitByDate.set(entry.habitId, entriesByDate);
   });
 
@@ -101,36 +108,69 @@ const buildHabitChainHabits = (
   );
 
   return habits.map((habit) => {
-    const entriesByDate = entriesByHabitByDate.get(habit.id) ?? new Map<string, boolean>();
+    const entriesByDate =
+      entriesByHabitByDate.get(habit.id) ?? new Map<string, HabitEntryRecord>();
     const entriesForHabit = entriesByHabit.get(habit.id) ?? [];
     const createdAtDateKey = toDateKey(new Date(habit.createdAt));
     const chainEntries = dates.map((date) => {
       const isFutureDate = date > todayKey;
+      const existingEntry = entriesByDate.get(date) ?? null;
 
       if (date < createdAtDateKey || isFutureDate) {
-        return { date, status: 'not_scheduled' as const };
+        return {
+          date,
+          entry: existingEntry,
+          isFutureDate,
+          isScheduled: false,
+          status: 'not_scheduled' as const,
+        };
       }
 
       const isScheduled = isHabitScheduledForDate(habit, date, entriesForHabit);
 
       if (!isScheduled) {
-        return { date, status: 'not_scheduled' as const };
+        return {
+          date,
+          entry: existingEntry,
+          isFutureDate: false,
+          isScheduled,
+          status: 'not_scheduled' as const,
+        };
       }
 
-      if (entriesByDate.get(date) === true) {
-        return { date, status: 'completed' as const };
+      if (existingEntry?.completed === true) {
+        return {
+          date,
+          entry: existingEntry,
+          isFutureDate: false,
+          isScheduled,
+          status: 'completed' as const,
+        };
       }
 
       if (date === todayKey) {
-        return { date, status: 'not_scheduled' as const };
+        return {
+          date,
+          entry: existingEntry,
+          isFutureDate: false,
+          isScheduled,
+          status: 'not_scheduled' as const,
+        };
       }
 
-      return { date, status: 'missed' as const };
+      return {
+        date,
+        entry: existingEntry,
+        isFutureDate: false,
+        isScheduled,
+        status: 'missed' as const,
+      };
     });
 
     return {
       currentStreak: getCurrentStreak(chainEntries),
       entries: chainEntries,
+      habit,
       id: habit.id,
       name: habit.name,
     };
@@ -138,6 +178,10 @@ const buildHabitChainHabits = (
 };
 
 export function HabitChain({ habitIds, habits = [], entries = [], endDate }: HabitChainProps) {
+  const [selectedDay, setSelectedDay] = useState<{
+    entry: HabitChainEntry;
+    habit: HabitRecord;
+  } | null>(null);
   const selectedDateKey = endDate ?? formatDateKey(getToday());
   const resolvedHabits = buildHabitChainHabits(habits, entries, selectedDateKey);
   const visibleHabits = getVisibleHabits(resolvedHabits, habitIds);
@@ -147,82 +191,112 @@ export function HabitChain({ habitIds, habits = [], entries = [], endDate }: Hab
   }
 
   return (
-    <section aria-label="Habit chains" className="space-y-2.5">
-      <TooltipProvider>
-        {visibleHabits.map((habit) => (
-          <DashboardDrilldownLink
-            indicatorClassName="right-3 bottom-3"
-            key={habit.id}
-            to="/habits"
-            viewLabel={`View ${habit.name} habit details`}
-          >
-            <Card className={cn('gap-2 px-3 py-2.5', dashboardDrilldownCardClassName)}>
-              <CardContent className="space-y-2 px-0">
-                <div className="flex items-start justify-between gap-3 pr-14">
-                  <h2 className="text-sm leading-tight font-semibold text-foreground">
-                    {habit.name}
-                  </h2>
-                  <p
-                    className="inline-flex items-center gap-1 text-xs font-semibold text-foreground sm:text-sm"
-                    data-slot="habit-chain-streak"
+    <>
+      <section aria-label="Habit chains" className="space-y-2.5">
+        <TooltipProvider>
+          {visibleHabits.map((habit) => (
+            <DashboardDrilldownLink
+              indicatorClassName="right-3 bottom-3"
+              key={habit.id}
+              to="/habits"
+              viewLabel={`View ${habit.name} habit details`}
+            >
+              <Card className={cn('gap-2 px-3 py-2.5', dashboardDrilldownCardClassName)}>
+                <CardContent className="space-y-2 px-0">
+                  <div className="flex items-start justify-between gap-3 pr-14">
+                    <h2 className="text-sm leading-tight font-semibold text-foreground">
+                      {habit.name}
+                    </h2>
+                    <p
+                      className="inline-flex items-center gap-1 text-xs font-semibold text-foreground sm:text-sm"
+                      data-slot="habit-chain-streak"
+                    >
+                      <Flame aria-hidden className="size-3.5 text-[var(--color-accent-pink)]" />
+                      <span className="text-sm leading-none sm:text-base">{`${habit.currentStreak} day streak`}</span>
+                    </p>
+                  </div>
+
+                  <div
+                    className="grid grid-cols-7 gap-1.5 pr-14 sm:grid-cols-10"
+                    data-slot="habit-chain-grid"
                   >
-                    <Flame aria-hidden className="size-3.5 text-[var(--color-accent-pink)]" />
-                    <span className="text-sm leading-none sm:text-base">{`${habit.currentStreak} day streak`}</span>
-                  </p>
-                </div>
+                    {habit.entries.map((entry) => {
+                      const isSelectedDay = entry.date === selectedDateKey;
+                      const statusLabel =
+                        entry.status === 'completed'
+                          ? 'Completed'
+                          : entry.status === 'missed'
+                            ? 'Missed'
+                            : entry.isFutureDate
+                              ? 'Future'
+                              : entry.isScheduled
+                                ? 'Not tracked'
+                                : 'Not scheduled';
+                      const statusClass =
+                        entry.status === 'completed'
+                          ? 'bg-[var(--color-accent-mint)]'
+                          : entry.status === 'missed'
+                            ? 'bg-red-400/70 dark:bg-red-500/50'
+                            : 'bg-[var(--color-muted)]/40';
 
-                <div
-                  className="grid grid-cols-7 gap-1.5 pr-14 sm:grid-cols-10"
-                  data-slot="habit-chain-grid"
-                >
-                  {habit.entries.map((entry) => {
-                    const isSelectedDay = entry.date === selectedDateKey;
-                    const statusLabel =
-                      entry.status === 'completed'
-                        ? 'Completed'
-                        : entry.status === 'missed'
-                          ? 'Missed'
-                          : 'Not scheduled';
-                    const statusClass =
-                      entry.status === 'completed'
-                        ? 'bg-[var(--color-accent-mint)]'
-                        : entry.status === 'missed'
-                          ? 'bg-red-400/70 dark:bg-red-500/50'
-                          : 'bg-[var(--color-muted)]/40';
+                      return (
+                        <Tooltip key={`${habit.id}-${entry.date}`}>
+                          <TooltipTrigger asChild>
+                            <button
+                              aria-label={`${habit.name} ${entry.date} ${statusLabel}`}
+                              className={cn(
+                                'relative z-20 size-11 min-h-11 min-w-11 justify-self-center rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-55',
+                                statusClass,
+                                isSelectedDay
+                                  ? 'border-[var(--color-primary)]'
+                                  : 'border-transparent',
+                              )}
+                              data-date={entry.date}
+                              data-status={entry.status}
+                              data-slot="habit-chain-day"
+                              data-today={isSelectedDay ? 'true' : 'false'}
+                              disabled={entry.isFutureDate}
+                              onClick={() => {
+                                setSelectedDay({
+                                  entry,
+                                  habit: habit.habit,
+                                });
+                              }}
+                              title={`${formatDateLabel(entry.date)} — ${statusLabel}`}
+                              type="button"
+                            />
+                          </TooltipTrigger>
+                          <TooltipContent side="top" sideOffset={6}>
+                            <p>{formatDateLabel(entry.date)}</p>
+                            <p className="text-xs text-muted-foreground">{statusLabel}</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      );
+                    })}
+                  </div>
+                </CardContent>
+              </Card>
+            </DashboardDrilldownLink>
+          ))}
+        </TooltipProvider>
+      </section>
 
-                    return (
-                      <Tooltip key={`${habit.id}-${entry.date}`}>
-                        <TooltipTrigger asChild>
-                          <button
-                            aria-label={`${habit.name} ${entry.date} ${statusLabel}`}
-                            className={cn(
-                              'relative z-20 size-11 min-h-11 min-w-11 justify-self-center rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-                              statusClass,
-                              isSelectedDay
-                                ? 'border-[var(--color-primary)]'
-                                : 'border-transparent',
-                            )}
-                            data-date={entry.date}
-                            data-status={entry.status}
-                            data-slot="habit-chain-day"
-                            data-today={isSelectedDay ? 'true' : 'false'}
-                            title={`${formatDateLabel(entry.date)} — ${statusLabel}`}
-                            type="button"
-                          />
-                        </TooltipTrigger>
-                        <TooltipContent side="top" sideOffset={6}>
-                          <p>{formatDateLabel(entry.date)}</p>
-                          <p className="text-xs text-muted-foreground">{statusLabel}</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    );
-                  })}
-                </div>
-              </CardContent>
-            </Card>
-          </DashboardDrilldownLink>
-        ))}
-      </TooltipProvider>
-    </section>
+      {selectedDay ? (
+        <HabitDayModal
+          date={selectedDay.entry.date}
+          entry={selectedDay.entry.entry}
+          habit={selectedDay.habit}
+          isOpen
+          isScheduled={selectedDay.entry.isScheduled}
+          key={`${selectedDay.habit.id}-${selectedDay.entry.date}-${selectedDay.entry.entry?.id ?? 'new'}`}
+          onOpenChange={(open) => {
+            if (!open) {
+              setSelectedDay(null);
+            }
+          }}
+          status={selectedDay.entry.status}
+        />
+      ) : null}
+    </>
   );
 }

--- a/apps/web/src/features/dashboard/components/macro-rings.test.tsx
+++ b/apps/web/src/features/dashboard/components/macro-rings.test.tsx
@@ -1,5 +1,6 @@
 import type { DashboardSnapshot } from '@pulse/shared';
 import { fireEvent, render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
 import { getMacroRingState, MacroRings } from './macro-rings';
@@ -76,7 +77,11 @@ describe('getMacroRingState', () => {
 
 describe('MacroRings', () => {
   it('renders four macro rings with distinct colors and eaten values', () => {
-    const { container } = render(<MacroRings snapshot={snapshotFixture} />);
+    const { container } = render(
+      <MemoryRouter>
+        <MacroRings snapshot={snapshotFixture} />
+      </MemoryRouter>,
+    );
 
     const grid = container.querySelector('div.grid.grid-cols-2.gap-2\\.5.lg\\:grid-cols-4');
     expect(grid).toBeInTheDocument();
@@ -93,6 +98,7 @@ describe('MacroRings', () => {
     expect(screen.getByText('65g')).toBeInTheDocument();
     expect(screen.getByText('1850 / 2200 kcal')).toBeInTheDocument();
     expect(screen.getByText('145g / 180g')).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: /view nutrition details for/i })).toHaveLength(4);
 
     const caloriesRingIndicator = getMacroItem('Calories').querySelector(
       '[data-slot="progress-ring-indicator"]',
@@ -114,7 +120,11 @@ describe('MacroRings', () => {
   });
 
   it('shows zeroed values when snapshot data is unavailable', () => {
-    render(<MacroRings />);
+    render(
+      <MemoryRouter>
+        <MacroRings />
+      </MemoryRouter>,
+    );
 
     expect(screen.getByText('0 kcal')).toBeInTheDocument();
     expect(screen.getAllByText('0g')).toHaveLength(3);
@@ -122,7 +132,11 @@ describe('MacroRings', () => {
   });
 
   it('toggles to remaining mode and shows inverse progress labels', () => {
-    render(<MacroRings snapshot={snapshotFixture} />);
+    render(
+      <MemoryRouter>
+        <MacroRings snapshot={snapshotFixture} />
+      </MemoryRouter>,
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Remaining' }));
 
@@ -143,18 +157,20 @@ describe('MacroRings', () => {
 
   it('turns over-target macros red and shows overage text in remaining mode', () => {
     render(
-      <MacroRings
-        snapshot={{
-          ...snapshotFixture,
-          macros: {
-            ...snapshotFixture.macros,
-            actual: {
-              ...snapshotFixture.macros.actual,
-              protein: 200,
+      <MemoryRouter>
+        <MacroRings
+          snapshot={{
+            ...snapshotFixture,
+            macros: {
+              ...snapshotFixture.macros,
+              actual: {
+                ...snapshotFixture.macros.actual,
+                protein: 200,
+              },
             },
-          },
-        }}
-      />,
+          }}
+        />
+      </MemoryRouter>,
     );
 
     const proteinItem = getMacroItem('Protein');

--- a/apps/web/src/features/dashboard/components/macro-rings.tsx
+++ b/apps/web/src/features/dashboard/components/macro-rings.tsx
@@ -119,7 +119,7 @@ export function MacroRings({ snapshot }: MacroRingsProps) {
         >
           <Button
             aria-pressed={mode === 'eaten'}
-            className="relative z-20 px-2.5 text-xs"
+            className="px-2.5 text-xs"
             onClick={() => {
               setMode('eaten');
             }}
@@ -130,7 +130,7 @@ export function MacroRings({ snapshot }: MacroRingsProps) {
           </Button>
           <Button
             aria-pressed={mode === 'remaining'}
-            className="relative z-20 px-2.5 text-xs"
+            className="px-2.5 text-xs"
             onClick={() => {
               setMode('remaining');
             }}

--- a/apps/web/src/features/dashboard/components/macro-rings.tsx
+++ b/apps/web/src/features/dashboard/components/macro-rings.tsx
@@ -4,7 +4,12 @@ import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { ProgressRing } from '@/components/ui/progress-ring';
+import {
+  DashboardDrilldownLink,
+  dashboardDrilldownCardClassName,
+} from '@/features/dashboard/components/dashboard-drilldown-link';
 import { formatCalories, formatGrams } from '@/lib/format-utils';
+import { cn } from '@/lib/utils';
 
 type MacroRingsProps = {
   snapshot?: DashboardSnapshot;
@@ -114,7 +119,7 @@ export function MacroRings({ snapshot }: MacroRingsProps) {
         >
           <Button
             aria-pressed={mode === 'eaten'}
-            className="px-2.5 text-xs"
+            className="relative z-20 px-2.5 text-xs"
             onClick={() => {
               setMode('eaten');
             }}
@@ -125,7 +130,7 @@ export function MacroRings({ snapshot }: MacroRingsProps) {
           </Button>
           <Button
             aria-pressed={mode === 'remaining'}
-            className="px-2.5 text-xs"
+            className="relative z-20 px-2.5 text-xs"
             onClick={() => {
               setMode('remaining');
             }}
@@ -143,32 +148,42 @@ export function MacroRings({ snapshot }: MacroRingsProps) {
           const state = getMacroRingState(stat, mode, macro.color, macro.unit);
 
           return (
-            <div
-              className="flex min-w-0 items-center gap-2.5 rounded-xl border border-border/70 bg-card/40 px-2.5 py-2"
-              data-slot="macro-ring-item"
+            <DashboardDrilldownLink
+              indicatorClassName="top-2 right-2 bottom-auto px-1.5 py-0.5"
+              indicatorLabel=""
               key={macro.key}
+              to="/nutrition"
+              viewLabel={`View nutrition details for ${macro.label}`}
             >
-              <div className="w-16 shrink-0">
-                <ProgressRing
-                  aria-label={`${macro.label} progress`}
-                  className="h-auto w-full"
-                  color={state.color}
-                  label={state.valueLabel}
-                  labelClassName="text-[10px] leading-tight font-semibold"
-                  size={68}
-                  strokeWidth={7}
-                  value={state.progress}
-                />
+              <div
+                className={cn(
+                  'flex min-w-0 items-center gap-2.5 rounded-xl border border-border/70 bg-card/40 px-2.5 py-2',
+                  dashboardDrilldownCardClassName,
+                )}
+                data-slot="macro-ring-item"
+              >
+                <div className="w-16 shrink-0">
+                  <ProgressRing
+                    aria-label={`${macro.label} progress`}
+                    className="h-auto w-full"
+                    color={state.color}
+                    label={state.valueLabel}
+                    labelClassName="text-[10px] leading-tight font-semibold"
+                    size={68}
+                    strokeWidth={7}
+                    value={state.progress}
+                  />
+                </div>
+                <div className="min-w-0 space-y-0.5 pr-4">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                    {macro.label}
+                  </p>
+                  <p className="truncate text-[11px] text-muted-foreground">
+                    {formatMacroSummary(stat, macro.unit)}
+                  </p>
+                </div>
               </div>
-              <div className="min-w-0 space-y-0.5">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                  {macro.label}
-                </p>
-                <p className="truncate text-[11px] text-muted-foreground">
-                  {formatMacroSummary(stat, macro.unit)}
-                </p>
-              </div>
-            </div>
+            </DashboardDrilldownLink>
           );
         })}
       </div>

--- a/apps/web/src/features/dashboard/components/recent-workouts.tsx
+++ b/apps/web/src/features/dashboard/components/recent-workouts.tsx
@@ -1,3 +1,4 @@
+import { ChevronRight } from 'lucide-react';
 import { Link } from 'react-router';
 
 import { Button } from '@/components/ui/button';
@@ -106,12 +107,20 @@ export function RecentWorkouts() {
                         </span>
                       </div>
 
-                      <div className="flex min-w-0 flex-wrap gap-1.5 text-xs text-foreground">
-                        <span className="rounded-full bg-secondary px-2 py-0.5">
-                          {`${workout.exerciseCount} exercises`}
-                        </span>
-                        <span className="rounded-full bg-secondary px-2 py-0.5">
-                          {workout.duration === null ? 'Duration n/a' : `${workout.duration} min`}
+                      <div className="flex min-w-0 items-center justify-between gap-2">
+                        <div className="flex min-w-0 flex-wrap gap-1.5 text-xs text-foreground">
+                          <span className="rounded-full bg-secondary px-2 py-0.5">
+                            {`${workout.exerciseCount} exercises`}
+                          </span>
+                          <span className="rounded-full bg-secondary px-2 py-0.5">
+                            {workout.duration === null ? 'Duration n/a' : `${workout.duration} min`}
+                          </span>
+                        </div>
+                        <span
+                          aria-hidden="true"
+                          className="inline-flex shrink-0 items-center text-muted-foreground"
+                        >
+                          <ChevronRight className="size-4" />
                         </span>
                       </div>
                     </div>

--- a/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
@@ -87,6 +87,22 @@ describe('SnapshotCards', () => {
     expect(screen.getByText('170g / 190g')).toBeInTheDocument();
     expect(screen.getByText('3/4')).toBeInTheDocument();
     expect(screen.getByText('Upper Push A (Completed)')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View weight history' })).toHaveAttribute(
+      'href',
+      '/weight/history',
+    );
+    expect(screen.getByRole('link', { name: 'View nutrition details' })).toHaveAttribute(
+      'href',
+      '/nutrition',
+    );
+    expect(screen.getByRole('link', { name: 'View protein details' })).toHaveAttribute(
+      'href',
+      '/nutrition',
+    );
+    expect(screen.getByRole('link', { name: 'View habits details' })).toHaveAttribute(
+      'href',
+      '/habits',
+    );
     expect(screen.getByRole('link', { name: /open today's workout/i })).toHaveAttribute(
       'href',
       '/workouts/sessions/session-upper-push-a/summary',
@@ -117,9 +133,7 @@ describe('SnapshotCards', () => {
     expect(screen.getByText('Habits')).toHaveClass('text-on-mint');
 
     expect(within(weightCard as HTMLElement).queryByLabelText(/trend/i)).not.toBeInTheDocument();
-    expect(
-      within(caloriesCard as HTMLElement).queryByLabelText(/trend/i),
-    ).not.toBeInTheDocument();
+    expect(within(caloriesCard as HTMLElement).queryByLabelText(/trend/i)).not.toBeInTheDocument();
     expect(within(proteinCard as HTMLElement).queryByLabelText(/trend/i)).not.toBeInTheDocument();
     expect(within(habitsCard as HTMLElement).getByLabelText('trend neutral')).toBeInTheDocument();
     expect(within(habitsCard as HTMLElement).getByText('75%')).toBeInTheDocument();

--- a/apps/web/src/features/dashboard/components/snapshot-cards.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.tsx
@@ -3,6 +3,11 @@ import type { DashboardSnapshot, DashboardWorkoutSnapshot } from '@pulse/shared'
 import { Link } from 'react-router';
 
 import { StatCard } from '@/components/ui/stat-card';
+import {
+  DashboardDrilldownIndicator,
+  DashboardDrilldownLink,
+  dashboardDrilldownCardClassName,
+} from '@/features/dashboard/components/dashboard-drilldown-link';
 import { accentCardStyles } from '@/lib/accent-card-styles';
 import { formatCalories, formatGrams, formatWeight } from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
@@ -130,7 +135,11 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
       : [
           <span key="text">No targets set</span>,
           ' ',
-          <Link key="link" className="font-semibold underline underline-offset-2" to="/settings">
+          <Link
+            key="link"
+            className="relative z-20 font-semibold underline underline-offset-2"
+            to="/settings"
+          >
             Settings
           </Link>,
         ]
@@ -151,7 +160,11 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
       : [
           <span key="text">No targets set</span>,
           ' ',
-          <Link key="link" className="font-semibold underline underline-offset-2" to="/settings">
+          <Link
+            key="link"
+            className="relative z-20 font-semibold underline underline-offset-2"
+            to="/settings"
+          >
             Settings
           </Link>,
         ]
@@ -175,9 +188,7 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
     <StatCard
       className={cn(
         'col-span-2 border-primary/20 bg-secondary',
-        workoutHref
-          ? 'cursor-pointer transition-colors hover:border-primary/40 hover:bg-secondary/80'
-          : undefined,
+        workoutHref ? dashboardDrilldownCardClassName : undefined,
       )}
       density="compact"
       data-stagger="4"
@@ -206,74 +217,111 @@ export function SnapshotCards({ snapshot }: SnapshotCardsProps) {
 
   return (
     <div className="grid grid-cols-2 gap-3">
-      <StatCard
-        accentTextClassName={
-          snapshot && !hasWeight ? notConfiguredAccentTextClassName : 'text-on-cream'
-        }
-        className={snapshot && !hasWeight ? notConfiguredCardClassName : accentCardStyles.cream}
-        density="compact"
-        data-stagger="0"
-        label="Body Weight"
-        value={weightValue}
-        valueClassName={getSnapshotValueClassName(weightValue)}
-        valueTitle={weightValue}
-      />
+      <DashboardDrilldownLink
+        indicatorClassName="top-2.5 right-2.5 bottom-auto px-1.5 py-0.5"
+        indicatorLabel=""
+        to="/weight/history"
+        viewLabel="View weight history"
+      >
+        <StatCard
+          accentTextClassName={
+            snapshot && !hasWeight ? notConfiguredAccentTextClassName : 'text-on-cream'
+          }
+          className={cn(
+            snapshot && !hasWeight ? notConfiguredCardClassName : accentCardStyles.cream,
+            dashboardDrilldownCardClassName,
+          )}
+          density="compact"
+          data-stagger="0"
+          label="Body Weight"
+          value={weightValue}
+          valueClassName={getSnapshotValueClassName(weightValue)}
+          valueTitle={weightValue}
+        />
+      </DashboardDrilldownLink>
 
-      <StatCard
-        accentTextClassName={
-          snapshot && !hasCaloriesTarget ? notConfiguredAccentTextClassName : 'text-on-pink'
-        }
-        className={
-          snapshot && !hasCaloriesTarget ? notConfiguredCardClassName : accentCardStyles.pink
-        }
-        density="compact"
-        data-stagger="1"
-        label="Calories"
-        value={caloriesValue}
-        valueClassName={getSnapshotValueClassName(caloriesValueText)}
-        valueTitle={hasCaloriesTarget ? caloriesValueText : undefined}
-      />
+      <DashboardDrilldownLink
+        indicatorClassName="top-2.5 right-2.5 bottom-auto px-1.5 py-0.5"
+        indicatorLabel=""
+        to="/nutrition"
+        viewLabel="View nutrition details"
+      >
+        <StatCard
+          accentTextClassName={
+            snapshot && !hasCaloriesTarget ? notConfiguredAccentTextClassName : 'text-on-pink'
+          }
+          className={cn(
+            snapshot && !hasCaloriesTarget ? notConfiguredCardClassName : accentCardStyles.pink,
+            dashboardDrilldownCardClassName,
+          )}
+          density="compact"
+          data-stagger="1"
+          label="Calories"
+          value={caloriesValue}
+          valueClassName={getSnapshotValueClassName(caloriesValueText)}
+          valueTitle={hasCaloriesTarget ? caloriesValueText : undefined}
+        />
+      </DashboardDrilldownLink>
 
-      <StatCard
-        accentTextClassName={
-          snapshot && !hasProteinTarget ? notConfiguredAccentTextClassName : 'text-on-mint'
-        }
-        className={
-          snapshot && !hasProteinTarget ? notConfiguredCardClassName : accentCardStyles.mint
-        }
-        density="compact"
-        data-stagger="2"
-        label="Protein"
-        value={proteinValue}
-        valueClassName={getSnapshotValueClassName(proteinValueText)}
-        valueTitle={hasProteinTarget ? proteinValueText : undefined}
-      />
+      <DashboardDrilldownLink
+        indicatorClassName="top-2.5 right-2.5 bottom-auto px-1.5 py-0.5"
+        indicatorLabel=""
+        to="/nutrition"
+        viewLabel="View protein details"
+      >
+        <StatCard
+          accentTextClassName={
+            snapshot && !hasProteinTarget ? notConfiguredAccentTextClassName : 'text-on-mint'
+          }
+          className={cn(
+            snapshot && !hasProteinTarget ? notConfiguredCardClassName : accentCardStyles.mint,
+            dashboardDrilldownCardClassName,
+          )}
+          density="compact"
+          data-stagger="2"
+          label="Protein"
+          value={proteinValue}
+          valueClassName={getSnapshotValueClassName(proteinValueText)}
+          valueTitle={hasProteinTarget ? proteinValueText : undefined}
+        />
+      </DashboardDrilldownLink>
 
-      <StatCard
-        accentTextClassName={
-          snapshot && !hasHabits ? notConfiguredAccentTextClassName : 'text-on-mint'
-        }
-        className={snapshot && !hasHabits ? notConfiguredCardClassName : accentCardStyles.mint}
-        density="compact"
-        data-stagger="3"
-        label="Habits"
-        trend={
-          snapshot && hasHabits
-            ? { direction: 'neutral', value: habitCompletionPercent }
-            : undefined
-        }
-        value={habitsValueText}
-        valueClassName={getSnapshotValueClassName(habitsValueText)}
-        valueTitle={habitsValueText}
-      />
+      <DashboardDrilldownLink
+        indicatorClassName="top-2.5 right-2.5 bottom-auto px-1.5 py-0.5"
+        indicatorLabel=""
+        to="/habits"
+        viewLabel="View habits details"
+      >
+        <StatCard
+          accentTextClassName={
+            snapshot && !hasHabits ? notConfiguredAccentTextClassName : 'text-on-mint'
+          }
+          className={cn(
+            snapshot && !hasHabits ? notConfiguredCardClassName : accentCardStyles.mint,
+            dashboardDrilldownCardClassName,
+          )}
+          density="compact"
+          data-stagger="3"
+          label="Habits"
+          trend={
+            snapshot && hasHabits
+              ? { direction: 'neutral', value: habitCompletionPercent }
+              : undefined
+          }
+          value={habitsValueText}
+          valueClassName={getSnapshotValueClassName(habitsValueText)}
+          valueTitle={habitsValueText}
+        />
+      </DashboardDrilldownLink>
 
       {workoutHref ? (
         <Link
           aria-label={`Open today's workout: ${snapshot?.workout?.name ?? 'workout'}`}
-          className="col-span-2 block rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="group/drilldown relative col-span-2 block rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           to={workoutHref}
         >
           {workoutCard}
+          <DashboardDrilldownIndicator className="right-2.5 bottom-2.5 px-1.5 py-0.5" label="" />
         </Link>
       ) : (
         workoutCard

--- a/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { calculateTrendChangePercent } from '@/features/dashboard/lib/trend-sparklines';
@@ -150,7 +151,11 @@ describe('TrendSparklines', () => {
       isLoading: false,
     } as ReturnType<typeof useMacroTrend>);
 
-    const { container } = render(<TrendSparklines endDate="2026-03-07" />);
+    const { container } = render(
+      <MemoryRouter>
+        <TrendSparklines endDate="2026-03-07" />
+      </MemoryRouter>,
+    );
 
     const cards = container.querySelectorAll('[data-slot="trend-sparkline-card"]');
     expect(cards).toHaveLength(3);
@@ -158,6 +163,18 @@ describe('TrendSparklines', () => {
     expect(screen.getByText('Weight Trend')).toBeInTheDocument();
     expect(screen.getByText('Calorie Trend')).toBeInTheDocument();
     expect(screen.getByText('Protein Trend')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View weight trend details' })).toHaveAttribute(
+      'href',
+      '/weight/history',
+    );
+    expect(screen.getByRole('link', { name: 'View calorie trend details' })).toHaveAttribute(
+      'href',
+      '/nutrition',
+    );
+    expect(screen.getByRole('link', { name: 'View protein trend details' })).toHaveAttribute(
+      'href',
+      '/nutrition',
+    );
     expect(screen.getByText('175.2 lbs')).toBeInTheDocument();
     expect(screen.getByText('2050 kcal')).toBeInTheDocument();
     expect(screen.getByText('170g')).toBeInTheDocument();
@@ -203,7 +220,11 @@ describe('TrendSparklines', () => {
       isLoading: false,
     } as ReturnType<typeof useMacroTrend>);
 
-    const { container } = render(<TrendSparklines />);
+    const { container } = render(
+      <MemoryRouter>
+        <TrendSparklines />
+      </MemoryRouter>,
+    );
 
     expect(container.querySelectorAll('[data-slot="trend-sparkline-card-skeleton"]')).toHaveLength(
       3,
@@ -221,7 +242,11 @@ describe('TrendSparklines', () => {
       isLoading: false,
     } as ReturnType<typeof useMacroTrend>);
 
-    const { container } = render(<TrendSparklines endDate="2026-03-07" metrics={['protein']} />);
+    const { container } = render(
+      <MemoryRouter>
+        <TrendSparklines endDate="2026-03-07" metrics={['protein']} />
+      </MemoryRouter>,
+    );
 
     const cards = container.querySelectorAll('[data-slot="trend-sparkline-card"]');
     expect(cards).toHaveLength(1);
@@ -246,7 +271,11 @@ describe('TrendSparklines', () => {
       isLoading: false,
     } as ReturnType<typeof useMacroTrend>);
 
-    render(<TrendSparklines metrics={[]} />);
+    render(
+      <MemoryRouter>
+        <TrendSparklines metrics={[]} />
+      </MemoryRouter>,
+    );
 
     expect(screen.getByText('No trend metrics selected.')).toBeInTheDocument();
     expect(screen.queryByText('Weight Trend')).not.toBeInTheDocument();
@@ -270,7 +299,11 @@ describe('TrendSparklines', () => {
       isError: false,
     } as ReturnType<typeof useMacroTrend>);
 
-    render(<TrendSparklines metrics={['weight']} />);
+    render(
+      <MemoryRouter>
+        <TrendSparklines metrics={['weight']} />
+      </MemoryRouter>,
+    );
 
     expect(screen.getByText('Unable to load trend data.')).toBeInTheDocument();
     expect(screen.queryByText('Weight Trend')).not.toBeInTheDocument();
@@ -303,7 +336,11 @@ describe('TrendSparklines', () => {
       isError: false,
     } as ReturnType<typeof useMacroTrend>);
 
-    render(<TrendSparklines endDate="2026-03-07" />);
+    render(
+      <MemoryRouter>
+        <TrendSparklines endDate="2026-03-07" />
+      </MemoryRouter>,
+    );
 
     const calorieCard = screen
       .getByText('Calorie Trend')
@@ -338,7 +375,11 @@ describe('TrendSparklines', () => {
       isError: false,
     } as ReturnType<typeof useMacroTrend>);
 
-    render(<TrendSparklines endDate="2026-03-06" />);
+    render(
+      <MemoryRouter>
+        <TrendSparklines endDate="2026-03-06" />
+      </MemoryRouter>,
+    );
 
     const weightCard = screen
       .getByText('Weight Trend')
@@ -375,7 +416,11 @@ describe('TrendSparklines', () => {
       isError: false,
     } as ReturnType<typeof useMacroTrend>);
 
-    render(<TrendSparklines endDate="2026-03-07" metrics={['calories']} />);
+    render(
+      <MemoryRouter>
+        <TrendSparklines endDate="2026-03-07" metrics={['calories']} />
+      </MemoryRouter>,
+    );
 
     const calorieCard = screen
       .getByText('Calorie Trend')

--- a/apps/web/src/features/dashboard/components/trend-sparkline.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.tsx
@@ -3,6 +3,10 @@ import { Line, LineChart, ResponsiveContainer } from 'recharts';
 import type { DashboardTrendMetric } from '@pulse/shared';
 
 import { Card, CardContent } from '@/components/ui/card';
+import {
+  DashboardDrilldownLink,
+  dashboardDrilldownCardClassName,
+} from '@/features/dashboard/components/dashboard-drilldown-link';
 import { useMacroTrend } from '@/hooks/use-macro-trend';
 import { useWeightTrend } from '@/hooks/use-weight-trend';
 import { accentCardStyles } from '@/lib/accent-card-styles';
@@ -20,6 +24,7 @@ type TrendMetricCardProps = {
   changePercent: number;
   color: string;
   data: TrendSparklineRealDatum[];
+  to: string;
   className?: string;
   textClassName?: string;
 };
@@ -210,29 +215,38 @@ function TrendMetricCard({
   changePercent,
   color,
   data,
+  to,
   className,
   textClassName,
 }: TrendMetricCardProps) {
   return (
-    <Card
-      className={cn(
-        'gap-0 border-transparent py-3 shadow-sm dark:text-foreground',
-        textClassName,
-        className,
-      )}
-      data-slot="trend-sparkline-card"
+    <DashboardDrilldownLink
+      indicatorClassName="right-2.5 bottom-2.5 px-1.5 py-0.5"
+      indicatorLabel=""
+      to={to}
+      viewLabel={`View ${label.toLowerCase()} details`}
     >
-      <CardContent className="h-full px-3">
-        <TrendSparkline
-          changePercent={changePercent}
-          color={color}
-          currentValue={currentValue}
-          data={data}
-          label={label}
-          textClassName={textClassName}
-        />
-      </CardContent>
-    </Card>
+      <Card
+        className={cn(
+          'gap-0 border-transparent py-3 shadow-sm dark:text-foreground',
+          dashboardDrilldownCardClassName,
+          textClassName,
+          className,
+        )}
+        data-slot="trend-sparkline-card"
+      >
+        <CardContent className="h-full px-3 pr-8">
+          <TrendSparkline
+            changePercent={changePercent}
+            color={color}
+            currentValue={currentValue}
+            data={data}
+            label={label}
+            textClassName={textClassName}
+          />
+        </CardContent>
+      </Card>
+    </DashboardDrilldownLink>
   );
 }
 
@@ -315,6 +329,7 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
   const allConfigs = {
     weight: {
       label: 'Weight Trend',
+      to: '/weight/history',
       currentValue: hasSelectedWeightValue ? formatWeight(selectedWeightValue, 'lbs') : '--',
       changePercent:
         weightSeries.length > 1
@@ -327,6 +342,7 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
     },
     calories: {
       label: 'Calorie Trend',
+      to: '/nutrition',
       currentValue: hasSelectedCalorieValue ? `${formatCalories(selectedCalorieValue)} kcal` : '--',
       changePercent:
         calorieSeries.length > 1
@@ -342,6 +358,7 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
     },
     protein: {
       label: 'Protein Trend',
+      to: '/nutrition',
       currentValue: hasSelectedProteinValue ? formatGrams(selectedProteinValue) : '--',
       changePercent:
         proteinSeries.length > 1

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { BodyWeightEntry } from '@pulse/shared';
 import { computeEWMA, computeWeightInsights } from '@pulse/shared';
+import { ChevronRight } from 'lucide-react';
 import { Link } from 'react-router';
 import {
   CartesianGrid,
@@ -158,7 +159,7 @@ export function WeightTrendChart() {
   return (
     <Card
       aria-labelledby="weight-trend-chart-heading"
-      className="gap-3 py-3 sm:py-4"
+      className="gap-3 py-3 transition-[box-shadow,border-color,background-color] duration-200 hover:border-primary/35 hover:bg-card/80 hover:shadow-md focus-within:border-primary/45 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 sm:py-4"
       data-slot="weight-trend-chart"
     >
       <CardHeader className="gap-2.5 border-b border-border/70 px-3 pb-3 sm:px-4">
@@ -175,10 +176,11 @@ export function WeightTrendChart() {
             Scale weight with EWMA smoothing.
           </p>
           <Link
-            className="text-xs font-medium text-primary hover:underline sm:text-sm"
+            className="inline-flex items-center gap-1 text-xs font-medium text-primary transition-colors hover:text-primary/80 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:text-sm"
             to="/weight/history"
           >
-            View history
+            <span>View history</span>
+            <ChevronRight className="size-3.5" />
           </Link>
         </div>
 

--- a/apps/web/src/features/habits/api/habits.test.tsx
+++ b/apps/web/src/features/habits/api/habits.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { Habit, HabitEntry } from '@pulse/shared';
 import { type ReactNode } from 'react';
+import { toast } from 'sonner';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { dashboardSnapshotQueryKeys } from '@/hooks/use-dashboard-snapshot';
@@ -19,8 +20,20 @@ import {
 } from './habits';
 import { habitQueryKeys } from './keys';
 
+const { toastErrorMock, toastSuccessMock } = vi.hoisted(() => ({
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+}));
+
 vi.mock('@/lib/api-client', () => ({
   apiRequest: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+  },
 }));
 
 const mockedApiRequest = vi.mocked(apiRequest);
@@ -61,6 +74,8 @@ function createWrapper(queryClient: QueryClient) {
 
 afterEach(() => {
   mockedApiRequest.mockReset();
+  vi.mocked(toast.error).mockClear();
+  vi.mocked(toast.success).mockClear();
 });
 
 describe('habit api hooks', () => {
@@ -299,6 +314,60 @@ describe('habit api hooks', () => {
       expect(queryClient.getQueryData<HabitEntry[]>(queryKey)).toEqual([updatedEntry]);
       expect(queryClient.getQueryData<HabitEntry[]>(chainQueryKey)).toEqual([updatedEntry]);
     });
+  });
+
+  it('creates a missing habit entry through the shared update hook and shows configured toasts', async () => {
+    const queryClient = createAppQueryClient();
+    const wrapper = createWrapper(queryClient);
+    const queryKey = habitQueryKeys.entryList({ from: '2026-03-09', to: '2026-03-09' });
+    const chainQueryKey = habitChainQueryKeys.range('2026-02-08', '2026-03-09');
+    const createdEntry: HabitEntry = {
+      id: 'entry-created',
+      habitId: 'habit-5',
+      userId: 'user-1',
+      date: '2026-03-09',
+      completed: true,
+      value: 8,
+      createdAt: 5,
+    };
+
+    queryClient.setQueryData(queryKey, []);
+    queryClient.setQueryData(chainQueryKey, []);
+    mockedApiRequest.mockResolvedValueOnce(createdEntry);
+
+    const { result } = renderHook(
+      () =>
+        useUpdateHabitEntry({
+          errorMessage: 'Could not save habit entry',
+          successMessage: 'Saved from modal',
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        habitId: 'habit-5',
+        date: '2026-03-09',
+        completed: true,
+        value: 8,
+      });
+    });
+
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/api/v1/habits/habit-5/entries',
+      expect.objectContaining({
+        body: {
+          completed: true,
+          date: '2026-03-09',
+          value: 8,
+        },
+        method: 'POST',
+      }),
+    );
+    expect(queryClient.getQueryData<HabitEntry[]>(queryKey)).toEqual([createdEntry]);
+    expect(queryClient.getQueryData<HabitEntry[]>(chainQueryKey)).toEqual([createdEntry]);
+    expect(toast.success).toHaveBeenCalledWith('Saved from modal');
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it('invalidates dashboard snapshot and chain queries after a toggle succeeds', async () => {

--- a/apps/web/src/features/habits/api/habits.ts
+++ b/apps/web/src/features/habits/api/habits.ts
@@ -1,8 +1,10 @@
 import { useMutation, useQuery, useQueryClient, type QueryKey } from '@tanstack/react-query';
 import {
+  createHabitEntryInputSchema,
   createHabitInputSchema,
   habitEntrySchema,
   habitSchema,
+  updateHabitEntryInputSchema,
   reorderHabitsInputSchema,
   updateHabitInputSchema,
   type CreateHabitInput,
@@ -51,12 +53,17 @@ type ToggleHabitVariables = {
 };
 
 type UpdateHabitEntryVariables = {
-  id: string;
+  id?: string | null;
   habitId: string;
   date: string;
   completed?: boolean;
   value?: number;
   isOverride?: boolean;
+};
+
+type UseUpdateHabitEntryOptions = {
+  errorMessage?: string;
+  successMessage?: string;
 };
 
 type ReorderMutationContext = {
@@ -143,7 +150,7 @@ const applyHabitEntryToCache = (
 
 const findCachedHabitEntry = (
   queryClient: ReturnType<typeof useQueryClient>,
-  entryId: string,
+  variables: Pick<UpdateHabitEntryVariables, 'date' | 'habitId' | 'id'>,
 ): HabitEntry | undefined => {
   const snapshots = [
     ...queryClient.getQueriesData<HabitEntry[]>({
@@ -155,7 +162,13 @@ const findCachedHabitEntry = (
   ];
 
   for (const [, entries] of snapshots) {
-    const match = entries?.find((entry) => entry.id === entryId);
+    const match = entries?.find((entry) => {
+      if (variables.id && entry.id === variables.id) {
+        return true;
+      }
+
+      return entry.habitId === variables.habitId && entry.date === variables.date;
+    });
     if (match) {
       return match;
     }
@@ -390,30 +403,40 @@ export function useToggleHabit() {
   });
 }
 
-export function useUpdateHabitEntry() {
+export function useUpdateHabitEntry(options: UseUpdateHabitEntryOptions = {}) {
   return createOptimisticMutation<
     HabitEntry[],
     HabitEntry,
     UpdateHabitEntryVariables,
     { optimisticEntry: HabitEntry }
   >({
-    mutationFn: async ({ id, completed, value, isOverride }) => {
-      const entry = await apiRequest<HabitEntry>(`/api/v1/habit-entries/${id}`, {
-        body: {
-          ...(completed === undefined ? {} : { completed }),
-          ...(value === undefined ? {} : { value }),
-          ...(isOverride === undefined ? {} : { isOverride }),
-        },
-        method: 'PATCH',
-      });
+    mutationFn: async ({ id, habitId, date, completed, value, isOverride }) => {
+      const entry = id
+        ? await apiRequest<HabitEntry>(`/api/v1/habit-entries/${id}`, {
+            body: updateHabitEntryInputSchema.parse({
+              ...(completed === undefined ? {} : { completed }),
+              ...(value === undefined ? {} : { value }),
+              ...(isOverride === undefined ? {} : { isOverride }),
+            }),
+            method: 'PATCH',
+          })
+        : await apiRequest<HabitEntry>(`/api/v1/habits/${habitId}/entries`, {
+            body: createHabitEntryInputSchema.parse({
+              completed: completed ?? false,
+              date,
+              ...(value === undefined ? {} : { value }),
+              ...(isOverride === undefined ? {} : { isOverride }),
+            }),
+            method: 'POST',
+          });
 
       return habitEntrySchema.parse(entry);
     },
     getMeta: (variables, queryClient) => {
-      const existingEntry = findCachedHabitEntry(queryClient, variables.id);
+      const existingEntry = findCachedHabitEntry(queryClient, variables);
       return {
         optimisticEntry: {
-          id: variables.id,
+          id: variables.id ?? `optimistic-${variables.habitId}-${variables.date}`,
           habitId: variables.habitId,
           userId: existingEntry?.userId ?? 'optimistic',
           date: variables.date,
@@ -434,5 +457,15 @@ export function useUpdateHabitEntry() {
       applyHabitEntryToCache(current, entry, context.queryKey),
     updater: (current, _variables, context) =>
       applyHabitEntryToCache(current, context.meta.optimisticEntry, context.queryKey),
+    onError: () => {
+      if (options.errorMessage) {
+        toast.error(options.errorMessage);
+      }
+    },
+    onSuccess: () => {
+      if (options.successMessage) {
+        toast.success(options.successMessage);
+      }
+    },
   });
 }

--- a/apps/web/src/features/habits/components/habit-day-modal.test.tsx
+++ b/apps/web/src/features/habits/components/habit-day-modal.test.tsx
@@ -172,7 +172,7 @@ describe('HabitDayModal', () => {
     });
   });
 
-  it('shows a read-only message for unscheduled days without entries', () => {
+  it('shows status info and edit form for unscheduled past days', () => {
     const mutation = createMutationMock();
     mockedUseUpdateHabitEntry.mockReturnValue(
       mutation as unknown as ReturnType<typeof useUpdateHabitEntry>,
@@ -184,8 +184,8 @@ describe('HabitDayModal', () => {
     });
 
     expect(
-      screen.getByText('This habit was not scheduled for this day, so there is nothing to log here.'),
+      screen.getByText('This habit was not scheduled for this day. You can still log a retroactive entry below.'),
     ).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/habits/components/habit-day-modal.test.tsx
+++ b/apps/web/src/features/habits/components/habit-day-modal.test.tsx
@@ -130,6 +130,33 @@ describe('HabitDayModal', () => {
     });
   });
 
+  it('does not allow negative numeric values', () => {
+    const mutation = createMutationMock();
+    mockedUseUpdateHabitEntry.mockReturnValue(
+      mutation as unknown as ReturnType<typeof useUpdateHabitEntry>,
+    );
+    const habit: Habit = {
+      ...baseHabit,
+      name: 'Water',
+      trackingType: 'numeric',
+      target: 8,
+      unit: 'glasses',
+    };
+
+    renderHabitDayModal({
+      habit,
+      status: 'missed',
+    });
+
+    const dialog = screen.getByRole('dialog');
+    fireEvent.change(within(dialog).getByLabelText('Water (glasses)'), {
+      target: { value: '-5' },
+    });
+
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(mutation.mutateAsync).not.toHaveBeenCalled();
+  });
+
   it('renders duration inputs for time habits and converts them to stored hours', async () => {
     const mutation = createMutationMock();
     mockedUseUpdateHabitEntry.mockReturnValue(

--- a/apps/web/src/features/habits/components/habit-day-modal.test.tsx
+++ b/apps/web/src/features/habits/components/habit-day-modal.test.tsx
@@ -1,0 +1,191 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import type { Habit, HabitEntry } from '@pulse/shared';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useUpdateHabitEntry } from '@/features/habits/api/habits';
+
+import { HabitDayModal } from './habit-day-modal';
+
+vi.mock('@/features/habits/api/habits', () => ({
+  useUpdateHabitEntry: vi.fn(),
+}));
+
+const mockedUseUpdateHabitEntry = vi.mocked(useUpdateHabitEntry);
+
+function createMutationMock() {
+  return {
+    isPending: false,
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const baseHabit: Habit = {
+  id: 'habit-1',
+  userId: 'user-1',
+  name: 'Hydrate',
+  description: null,
+  emoji: '💧',
+  trackingType: 'boolean',
+  target: null,
+  unit: null,
+  frequency: 'daily',
+  frequencyTarget: null,
+  scheduledDays: null,
+  pausedUntil: null,
+  referenceSource: null,
+  referenceConfig: null,
+  sortOrder: 0,
+  active: true,
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+function renderHabitDayModal({
+  date = '2026-03-09',
+  entry = null,
+  habit = baseHabit,
+  isScheduled = true,
+  status = 'not_scheduled',
+}: {
+  date?: string;
+  entry?: HabitEntry | null;
+  habit?: Habit;
+  isScheduled?: boolean;
+  status?: 'completed' | 'missed' | 'not_scheduled';
+} = {}) {
+  return render(
+    <HabitDayModal
+      date={date}
+      entry={entry}
+      habit={habit}
+      isOpen
+      isScheduled={isScheduled}
+      onOpenChange={vi.fn()}
+      status={status}
+    />,
+  );
+}
+
+describe('HabitDayModal', () => {
+  it('saves boolean habits with the selected completion state', async () => {
+    const mutation = createMutationMock();
+    mockedUseUpdateHabitEntry.mockReturnValue(
+      mutation as unknown as ReturnType<typeof useUpdateHabitEntry>,
+    );
+    const entry: HabitEntry = {
+      id: 'entry-1',
+      habitId: 'habit-1',
+      userId: 'user-1',
+      date: '2026-03-09',
+      completed: true,
+      value: null,
+      createdAt: 1,
+    };
+
+    renderHabitDayModal({
+      entry,
+      status: 'completed',
+    });
+
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Not done' }));
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+    expect(mutation.mutateAsync).toHaveBeenCalledWith({
+      id: 'entry-1',
+      habitId: 'habit-1',
+      date: '2026-03-09',
+      completed: false,
+    });
+  });
+
+  it('renders numeric input controls and creates a missing numeric entry', async () => {
+    const mutation = createMutationMock();
+    mockedUseUpdateHabitEntry.mockReturnValue(
+      mutation as unknown as ReturnType<typeof useUpdateHabitEntry>,
+    );
+    const habit: Habit = {
+      ...baseHabit,
+      name: 'Water',
+      trackingType: 'numeric',
+      target: 8,
+      unit: 'glasses',
+    };
+
+    renderHabitDayModal({
+      habit,
+      status: 'missed',
+    });
+
+    const dialog = screen.getByRole('dialog');
+    const input = within(dialog).getByLabelText('Water (glasses)');
+    fireEvent.change(input, { target: { value: '8' } });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+    expect(mutation.mutateAsync).toHaveBeenCalledWith({
+      habitId: 'habit-1',
+      date: '2026-03-09',
+      completed: true,
+      value: 8,
+    });
+  });
+
+  it('renders duration inputs for time habits and converts them to stored hours', async () => {
+    const mutation = createMutationMock();
+    mockedUseUpdateHabitEntry.mockReturnValue(
+      mutation as unknown as ReturnType<typeof useUpdateHabitEntry>,
+    );
+    const habit: Habit = {
+      ...baseHabit,
+      name: 'Sleep',
+      trackingType: 'time',
+      target: 8,
+      unit: 'hours',
+    };
+    const entry: HabitEntry = {
+      id: 'entry-2',
+      habitId: 'habit-1',
+      userId: 'user-1',
+      date: '2026-03-09',
+      completed: false,
+      value: 7.5,
+      createdAt: 2,
+    };
+
+    renderHabitDayModal({
+      habit,
+      entry,
+      status: 'missed',
+    });
+
+    const dialog = screen.getByRole('dialog');
+    fireEvent.change(within(dialog).getByLabelText('Hours'), { target: { value: '8' } });
+    fireEvent.change(within(dialog).getByLabelText('Minutes'), { target: { value: '15' } });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+    expect(mutation.mutateAsync).toHaveBeenCalledWith({
+      id: 'entry-2',
+      habitId: 'habit-1',
+      date: '2026-03-09',
+      completed: true,
+      value: 8.25,
+    });
+  });
+
+  it('shows a read-only message for unscheduled days without entries', () => {
+    const mutation = createMutationMock();
+    mockedUseUpdateHabitEntry.mockReturnValue(
+      mutation as unknown as ReturnType<typeof useUpdateHabitEntry>,
+    );
+
+    renderHabitDayModal({
+      isScheduled: false,
+      status: 'not_scheduled',
+    });
+
+    expect(
+      screen.getByText('This habit was not scheduled for this day, so there is nothing to log here.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/habits/components/habit-day-modal.tsx
+++ b/apps/web/src/features/habits/components/habit-day-modal.tsx
@@ -203,7 +203,11 @@ export function HabitDayModal({
 
     if (habit.trackingType === 'numeric') {
       const parsedValue = Number(numericValue);
-      if (numericValue.trim().length === 0 || !Number.isFinite(parsedValue)) {
+      if (
+        numericValue.trim().length === 0 ||
+        !Number.isFinite(parsedValue) ||
+        parsedValue < 0
+      ) {
         return;
       }
 
@@ -239,7 +243,9 @@ export function HabitDayModal({
 
   const isNumericSaveDisabled =
     habit.trackingType === 'numeric' &&
-    (numericValue.trim().length === 0 || !Number.isFinite(Number(numericValue)));
+    (numericValue.trim().length === 0 ||
+      !Number.isFinite(Number(numericValue)) ||
+      Number(numericValue) < 0);
   const savedDurationValue = getSavedDurationValue(durationValue, habit.unit);
   const isTimeSaveDisabled =
     habit.trackingType === 'time' &&
@@ -317,6 +323,7 @@ export function HabitDayModal({
                   <Input
                     id={numberInputId}
                     inputMode="decimal"
+                    min="0"
                     onChange={(event) => setNumericValue(event.target.value)}
                     placeholder={habit.target != null ? `Target: ${formatServing(habit.target)}` : 'Enter value'}
                     step="0.1"

--- a/apps/web/src/features/habits/components/habit-day-modal.tsx
+++ b/apps/web/src/features/habits/components/habit-day-modal.tsx
@@ -1,0 +1,402 @@
+import { useId, useMemo, useState } from 'react';
+import type { Habit, HabitEntry } from '@pulse/shared';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useUpdateHabitEntry } from '@/features/habits/api/habits';
+import { getToday, toDateKey } from '@/lib/date';
+import { formatServing } from '@/lib/format-utils';
+import { cn } from '@/lib/utils';
+
+type HabitDayModalProps = {
+  date: string;
+  entry: HabitEntry | null;
+  habit: Habit;
+  isOpen: boolean;
+  isScheduled: boolean;
+  onOpenChange: (open: boolean) => void;
+  status: 'completed' | 'missed' | 'not_scheduled';
+};
+
+type DurationDraft = {
+  hours: string;
+  minutes: string;
+};
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+function formatDateLabel(date: string) {
+  return dateFormatter.format(new Date(`${date}T00:00:00`));
+}
+
+function normalizeUnit(unit: string | null) {
+  return unit?.trim().toLowerCase() ?? '';
+}
+
+function isHourUnit(unit: string | null) {
+  return ['h', 'hour', 'hours', 'hr', 'hrs'].includes(normalizeUnit(unit));
+}
+
+function isMinuteUnit(unit: string | null) {
+  return ['m', 'min', 'mins', 'minute', 'minutes'].includes(normalizeUnit(unit));
+}
+
+function getValueLabel(habit: Habit, value: number | null | undefined) {
+  if (typeof value !== 'number') {
+    return 'No value recorded';
+  }
+
+  if (!habit.unit) {
+    return formatServing(value);
+  }
+
+  if (isHourUnit(habit.unit)) {
+    return `${formatServing(value)} h`;
+  }
+
+  return `${formatServing(value)} ${habit.unit}`;
+}
+
+function getDurationDraft(value: number | null | undefined, unit: string | null): DurationDraft {
+  if (typeof value !== 'number') {
+    return { hours: '', minutes: '' };
+  }
+
+  const totalMinutes = isMinuteUnit(unit) ? Math.round(value) : Math.round(value * 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  return {
+    hours: `${hours}`,
+    minutes: `${minutes}`.padStart(2, '0'),
+  };
+}
+
+function getSavedDurationValue(draft: DurationDraft, unit: string | null) {
+  const hasHours = draft.hours.trim().length > 0;
+  const hasMinutes = draft.minutes.trim().length > 0;
+
+  if (!hasHours && !hasMinutes) {
+    return null;
+  }
+
+  const hours = Number(draft.hours || '0');
+  const minutes = Number(draft.minutes || '0');
+  if (
+    !Number.isFinite(hours) ||
+    !Number.isFinite(minutes) ||
+    hours < 0 ||
+    minutes < 0 ||
+    minutes > 59
+  ) {
+    return Number.NaN;
+  }
+
+  const totalMinutes = hours * 60 + minutes;
+  if (isMinuteUnit(unit)) {
+    return totalMinutes;
+  }
+
+  return Math.round((totalMinutes / 60) * 100) / 100;
+}
+
+function getStatusCopy({
+  date,
+  entry,
+  habit,
+  isScheduled,
+  status,
+}: Pick<HabitDayModalProps, 'date' | 'entry' | 'habit' | 'isScheduled' | 'status'>) {
+  const todayKey = toDateKey(getToday());
+  const isFutureDate = date > todayKey;
+
+  if (isFutureDate) {
+    return {
+      description: 'Future dates are read-only until that day arrives.',
+      title: 'Future',
+    };
+  }
+
+  if (!isScheduled && !entry) {
+    return {
+      description: 'This habit was not scheduled for this day, so there is nothing to log here.',
+      title: 'Not scheduled',
+    };
+  }
+
+  if (status === 'completed') {
+    return {
+      description:
+        habit.trackingType === 'boolean'
+          ? 'This day is marked complete.'
+          : `Logged value: ${getValueLabel(habit, entry?.value)}`,
+      title: 'Completed',
+    };
+  }
+
+  if (status === 'missed') {
+    return {
+      description:
+        habit.trackingType === 'boolean'
+          ? 'This day is currently incomplete.'
+          : entry?.value != null
+            ? `Logged value: ${getValueLabel(habit, entry.value)}`
+            : 'No value has been logged for this day yet.',
+      title: 'Missed',
+    };
+  }
+
+  return {
+    description:
+      entry?.value != null
+        ? `Logged value: ${getValueLabel(habit, entry.value)}`
+        : 'No value has been logged for this day yet.',
+    title: 'Not tracked',
+  };
+}
+
+export function HabitDayModal({
+  date,
+  entry,
+  habit,
+  isOpen,
+  isScheduled,
+  onOpenChange,
+  status,
+}: HabitDayModalProps) {
+  const numberInputId = useId();
+  const hoursInputId = useId();
+  const minutesInputId = useId();
+  const todayKey = useMemo(() => toDateKey(getToday()), []);
+  const isFutureDate = date > todayKey;
+  const isReadOnly = isFutureDate || (!isScheduled && entry === null);
+  const isReferential = habit.referenceSource !== null && habit.referenceSource !== undefined;
+  const [booleanValue, setBooleanValue] = useState(entry?.completed ?? false);
+  const [numericValue, setNumericValue] = useState(
+    entry?.value != null ? `${entry.value}` : '',
+  );
+  const [durationValue, setDurationValue] = useState<DurationDraft>(() =>
+    getDurationDraft(entry?.value, habit.unit),
+  );
+  const mutation = useUpdateHabitEntry({
+    errorMessage: 'Failed to save habit entry. Please try again.',
+    successMessage: 'Habit entry saved',
+  });
+  const statusCopy = getStatusCopy({ date, entry, habit, isScheduled, status });
+
+  async function handleSave() {
+    let completed = booleanValue;
+    let value: number | undefined;
+
+    if (habit.trackingType === 'numeric') {
+      const parsedValue = Number(numericValue);
+      if (numericValue.trim().length === 0 || !Number.isFinite(parsedValue)) {
+        return;
+      }
+
+      value = parsedValue;
+      completed = habit.target !== null ? parsedValue >= habit.target : parsedValue > 0;
+    }
+
+    if (habit.trackingType === 'time') {
+      const parsedValue = getSavedDurationValue(durationValue, habit.unit);
+      if (parsedValue === null || Number.isNaN(parsedValue)) {
+        return;
+      }
+
+      value = parsedValue;
+      completed = habit.target !== null ? parsedValue >= habit.target : parsedValue > 0;
+    }
+
+    try {
+      await mutation.mutateAsync({
+        id: entry?.id,
+        habitId: habit.id,
+        date,
+        completed,
+        ...(value === undefined ? {} : { value }),
+        ...(isReferential ? { isOverride: true } : {}),
+      });
+
+      onOpenChange(false);
+    } catch {
+      // Toast messaging is handled by the mutation hook options.
+    }
+  }
+
+  const isNumericSaveDisabled =
+    habit.trackingType === 'numeric' &&
+    (numericValue.trim().length === 0 || !Number.isFinite(Number(numericValue)));
+  const savedDurationValue = getSavedDurationValue(durationValue, habit.unit);
+  const isTimeSaveDisabled =
+    habit.trackingType === 'time' &&
+    (savedDurationValue === null || Number.isNaN(savedDurationValue));
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={isOpen}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{habit.name}</DialogTitle>
+          <DialogDescription>{formatDateLabel(date)}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="rounded-lg border border-border/70 bg-muted/35 p-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+              Status
+            </p>
+            <p
+              className={cn(
+                'mt-2 text-base font-semibold',
+                status === 'completed'
+                  ? 'text-emerald-600 dark:text-emerald-400'
+                  : status === 'missed'
+                    ? 'text-rose-600 dark:text-rose-400'
+                    : 'text-foreground',
+              )}
+            >
+              {statusCopy.title}
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">{statusCopy.description}</p>
+          </div>
+
+          {isReferential ? (
+            <p className="text-xs text-muted-foreground">
+              Saving here creates or updates a manual override for this habit on {formatDateLabel(date)}.
+            </p>
+          ) : null}
+
+          {!isReadOnly ? (
+            <form
+              className="space-y-4"
+              onSubmit={(event) => {
+                event.preventDefault();
+                void handleSave();
+              }}
+            >
+              {habit.trackingType === 'boolean' ? (
+                <div className="space-y-2">
+                  <Label>Completion</Label>
+                  <div className="grid grid-cols-2 gap-2">
+                    <Button
+                      onClick={() => setBooleanValue(true)}
+                      type="button"
+                      variant={booleanValue ? 'default' : 'outline'}
+                    >
+                      Done
+                    </Button>
+                    <Button
+                      onClick={() => setBooleanValue(false)}
+                      type="button"
+                      variant={!booleanValue ? 'default' : 'outline'}
+                    >
+                      Not done
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+
+              {habit.trackingType === 'numeric' ? (
+                <div className="space-y-2">
+                  <Label htmlFor={numberInputId}>
+                    {habit.unit ? `${habit.name} (${habit.unit})` : habit.name}
+                  </Label>
+                  <Input
+                    id={numberInputId}
+                    inputMode="decimal"
+                    onChange={(event) => setNumericValue(event.target.value)}
+                    placeholder={habit.target != null ? `Target: ${formatServing(habit.target)}` : 'Enter value'}
+                    step="0.1"
+                    type="number"
+                    value={numericValue}
+                  />
+                </div>
+              ) : null}
+
+              {habit.trackingType === 'time' ? (
+                <div className="space-y-2">
+                  <Label>Duration</Label>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className="space-y-1.5">
+                      <Label className="text-xs text-muted-foreground" htmlFor={hoursInputId}>
+                        Hours
+                      </Label>
+                      <Input
+                        id={hoursInputId}
+                        inputMode="numeric"
+                        min="0"
+                        onChange={(event) =>
+                          setDurationValue((currentValue) => ({
+                            ...currentValue,
+                            hours: event.target.value,
+                          }))
+                        }
+                        placeholder="0"
+                        type="number"
+                        value={durationValue.hours}
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label className="text-xs text-muted-foreground" htmlFor={minutesInputId}>
+                        Minutes
+                      </Label>
+                      <Input
+                        id={minutesInputId}
+                        inputMode="numeric"
+                        max="59"
+                        min="0"
+                        onChange={(event) =>
+                          setDurationValue((currentValue) => ({
+                            ...currentValue,
+                            minutes: event.target.value,
+                          }))
+                        }
+                        placeholder="00"
+                        type="number"
+                        value={durationValue.minutes}
+                      />
+                    </div>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Stored in {habit.unit ?? 'hours'}.
+                  </p>
+                </div>
+              ) : null}
+
+              <DialogFooter className="pt-2">
+                <Button onClick={() => onOpenChange(false)} type="button" variant="outline">
+                  Cancel
+                </Button>
+                <Button
+                  disabled={mutation.isPending || isNumericSaveDisabled || isTimeSaveDisabled}
+                  type="submit"
+                >
+                  {mutation.isPending ? 'Saving...' : 'Save'}
+                </Button>
+              </DialogFooter>
+            </form>
+          ) : (
+            <DialogFooter className="pt-0">
+              <Button onClick={() => onOpenChange(false)} type="button" variant="outline">
+                Close
+              </Button>
+            </DialogFooter>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/habits/components/habit-day-modal.tsx
+++ b/apps/web/src/features/habits/components/habit-day-modal.tsx
@@ -132,7 +132,7 @@ function getStatusCopy({
 
   if (!isScheduled && !entry) {
     return {
-      description: 'This habit was not scheduled for this day, so there is nothing to log here.',
+      description: 'This habit was not scheduled for this day. You can still log a retroactive entry below.',
       title: 'Not scheduled',
     };
   }
@@ -182,7 +182,7 @@ export function HabitDayModal({
   const minutesInputId = useId();
   const todayKey = useMemo(() => toDateKey(getToday()), []);
   const isFutureDate = date > todayKey;
-  const isReadOnly = isFutureDate || (!isScheduled && entry === null);
+  const isReadOnly = isFutureDate;
   const isReferential = habit.referenceSource !== null && habit.referenceSource !== undefined;
   const [booleanValue, setBooleanValue] = useState(entry?.completed ?? false);
   const [numericValue, setNumericValue] = useState(

--- a/apps/web/src/features/weight/api/weight.test.tsx
+++ b/apps/web/src/features/weight/api/weight.test.tsx
@@ -10,6 +10,8 @@ import { createQueryClientWrapper } from '@/test/query-client';
 
 import {
   useDeleteWeight,
+  usePaginatedWeightEntries,
+  useWeightEntries,
   useLatestWeight,
   useLogWeight,
   useUpdateWeight,
@@ -124,6 +126,78 @@ describe('weight api hooks', () => {
       '/api/v1/weight?from=2026-03-01&to=2026-03-07',
       expect.any(Object),
     );
+  });
+
+  it('loads weight entries with general list filters', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse([
+        {
+          id: 'weight-1',
+          date: '2026-03-07',
+          weight: 181.4,
+          notes: null,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ]),
+    );
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useWeightEntries({ days: 30 }), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toHaveLength(1);
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/weight?days=30', expect.any(Object));
+  });
+
+  it('loads paginated weight entries when page params are supplied', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              id: 'weight-1',
+              date: '2026-03-07',
+              weight: 181.4,
+              notes: null,
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          ],
+          meta: {
+            page: 2,
+            limit: 10,
+            total: 11,
+          },
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 200,
+        },
+      ),
+    );
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => usePaginatedWeightEntries({ page: 2, limit: 10 }), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.data).toHaveLength(1);
+    expect(result.current.data?.meta).toEqual({
+      page: 2,
+      limit: 10,
+      total: 11,
+    });
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/weight?page=2&limit=10', expect.any(Object));
   });
 
   it('optimistically logs a weight entry, updates dashboard caches, and invalidates weight queries', async () => {

--- a/apps/web/src/features/weight/api/weight.ts
+++ b/apps/web/src/features/weight/api/weight.ts
@@ -51,6 +51,8 @@ export const weightQueryKeys = {
   listRoot: () => ['weight', 'list'] as const,
   list: (filters: WeightListFilters = {}) =>
     ['weight', 'list', normalizeWeightListFilters(filters)] as const,
+  // trendRoot intentionally aliases listRoot because trend data is fetched from the same
+  // /weight endpoint and lives under the same list cache hierarchy.
   trendRoot: () => ['weight', 'list'] as const,
   trend: ({ from, to }: Pick<WeightListFilters, 'from' | 'to'> = {}) =>
     ['weight', 'list', normalizeWeightListFilters({ from, to })] as const,

--- a/apps/web/src/features/weight/api/weight.ts
+++ b/apps/web/src/features/weight/api/weight.ts
@@ -11,12 +11,16 @@ import { toast } from 'sonner';
 
 import { dashboardSnapshotQueryKeys } from '@/hooks/use-dashboard-snapshot';
 import { dashboardWeightTrendQueryKeys } from '@/hooks/use-weight-trend';
-import { apiRequest } from '@/lib/api-client';
+import { apiRequest, apiRequestWithMeta } from '@/lib/api-client';
+import { addDays, formatUtcDateKey, parseDateInput } from '@/lib/date';
 import { createOptimisticMutation } from '@/lib/optimistic';
 import { crossFeatureInvalidationMap, invalidateQueryKeys } from '@/lib/query-invalidation';
 
-type WeightTrendFilters = {
+type WeightListFilters = {
+  days?: number;
   from?: string;
+  limit?: number;
+  page?: number;
   to?: string;
 };
 
@@ -27,26 +31,53 @@ type LogWeightCache =
   | DashboardSnapshot
   | DashboardWeightTrendPoint[];
 
-const normalizeWeightTrendFilters = ({ from, to }: WeightTrendFilters = {}) => ({
+type PaginatedWeightListMeta = {
+  limit: number;
+  page: number;
+  total: number;
+};
+
+const normalizeWeightListFilters = ({ days, from, limit, page, to }: WeightListFilters = {}) => ({
+  days: days ?? null,
   from: from ?? null,
+  limit: limit ?? null,
+  page: page ?? null,
   to: to ?? null,
 });
 
 export const weightQueryKeys = {
   all: ['weight'] as const,
   latest: () => ['weight', 'latest'] as const,
-  trendRoot: () => ['weight', 'trend'] as const,
-  trend: ({ from, to }: WeightTrendFilters = {}) =>
-    ['weight', 'trend', normalizeWeightTrendFilters({ from, to })] as const,
+  listRoot: () => ['weight', 'list'] as const,
+  list: (filters: WeightListFilters = {}) =>
+    ['weight', 'list', normalizeWeightListFilters(filters)] as const,
+  trendRoot: () => ['weight', 'list'] as const,
+  trend: ({ from, to }: Pick<WeightListFilters, 'from' | 'to'> = {}) =>
+    ['weight', 'list', normalizeWeightListFilters({ from, to })] as const,
+  page: ({ days, from, limit, page, to }: Required<Pick<WeightListFilters, 'limit' | 'page'>> &
+    WeightListFilters) =>
+    ['weight', 'list', normalizeWeightListFilters({ days, from, limit, page, to })] as const,
 };
 
 export const weightKeys = weightQueryKeys;
 
-const buildWeightTrendPath = ({ from, to }: WeightTrendFilters = {}) => {
+const buildWeightEntriesPath = ({ days, from, limit, page, to }: WeightListFilters = {}) => {
   const searchParams = new URLSearchParams();
+
+  if (days !== undefined) {
+    searchParams.set('days', String(days));
+  }
 
   if (from) {
     searchParams.set('from', from);
+  }
+
+  if (page !== undefined) {
+    searchParams.set('page', String(page));
+  }
+
+  if (limit !== undefined) {
+    searchParams.set('limit', String(limit));
   }
 
   if (to) {
@@ -60,8 +91,12 @@ const buildWeightTrendPath = ({ from, to }: WeightTrendFilters = {}) => {
 
 const fetchLatestWeight = () => apiRequest<BodyWeightEntry | null>('/api/v1/weight/latest');
 
-const fetchWeightTrend = (filters: WeightTrendFilters) =>
-  apiRequest<BodyWeightEntry[]>(buildWeightTrendPath(filters));
+const fetchWeightEntries = (filters: WeightListFilters) =>
+  apiRequest<BodyWeightEntry[]>(buildWeightEntriesPath(filters));
+
+const fetchPaginatedWeightEntries = (filters: Required<Pick<WeightListFilters, 'limit' | 'page'>> &
+  WeightListFilters) =>
+  apiRequestWithMeta<BodyWeightEntry[], PaginatedWeightListMeta>(buildWeightEntriesPath(filters));
 
 const postWeightEntry = (input: CreateWeightInput) =>
   apiRequest<BodyWeightEntry>('/api/v1/weight', {
@@ -103,30 +138,53 @@ const upsertWeightEntry = (entries: BodyWeightEntry[] | undefined, nextEntry: Bo
   return nextEntries.sort(compareWeightEntries);
 };
 
-const getWeightTrendFiltersFromQueryKey = (queryKey: QueryKey) => {
+const getWeightListFiltersFromQueryKey = (queryKey: QueryKey) => {
   const maybeFilters = queryKey[2];
 
   if (
     typeof maybeFilters === 'object' &&
     maybeFilters !== null &&
+    'days' in maybeFilters &&
     'from' in maybeFilters &&
+    'limit' in maybeFilters &&
+    'page' in maybeFilters &&
     'to' in maybeFilters
   ) {
-    return maybeFilters as { from: string | null; to: string | null };
+    return maybeFilters as {
+      days: number | null;
+      from: string | null;
+      limit: number | null;
+      page: number | null;
+      to: string | null;
+    };
   }
 
   return null;
 };
 
-const applyWeightEntryToTrendCache = (
+const applyWeightEntryToListCache = (
   entries: BodyWeightEntry[] | undefined,
   nextEntry: BodyWeightEntry,
   queryKey: QueryKey,
 ) => {
-  const filters = getWeightTrendFiltersFromQueryKey(queryKey);
+  const filters = getWeightListFiltersFromQueryKey(queryKey);
 
   if (filters) {
-    if ((filters.from && nextEntry.date < filters.from) || (filters.to && nextEntry.date > filters.to)) {
+    if (filters.page !== null || filters.limit !== null) {
+      return entries;
+    }
+
+    const resolvedTo = filters.to ?? formatUtcDateKey(new Date());
+    const resolvedFrom =
+      filters.from ??
+      (filters.days !== null
+        ? formatUtcDateKey(addDays(parseDateInput(`${resolvedTo}T00:00:00`), -(filters.days - 1)))
+        : null);
+
+    if (
+      (resolvedFrom && nextEntry.date < resolvedFrom) ||
+      (resolvedTo && nextEntry.date > resolvedTo)
+    ) {
       return entries;
     }
   }
@@ -216,11 +274,11 @@ const isLatestWeightCache = (
     cache === null ||
     (typeof cache === 'object' && !Array.isArray(cache) && 'createdAt' in cache));
 
-const isWeightTrendCache = (
+const isWeightListCache = (
   cache: LogWeightCache | undefined,
   queryKey: QueryKey,
 ): cache is BodyWeightEntry[] | undefined =>
-  hasQueryKeyPrefix(queryKey, weightQueryKeys.trendRoot()) &&
+  hasQueryKeyPrefix(queryKey, weightQueryKeys.listRoot()) &&
   (cache === undefined ||
     (Array.isArray(cache) &&
       (cache.length === 0 || (typeof cache[0] === 'object' && cache[0] !== null && 'createdAt' in cache[0]))));
@@ -255,8 +313,8 @@ const updateLogWeightCache = (
     return applyWeightEntryToLatestCache(current, nextEntry);
   }
 
-  if (isWeightTrendCache(current, queryKey)) {
-    return applyWeightEntryToTrendCache(current, nextEntry, queryKey);
+  if (isWeightListCache(current, queryKey)) {
+    return applyWeightEntryToListCache(current, nextEntry, queryKey);
   }
 
   if (isDashboardSnapshotCache(current, queryKey)) {
@@ -276,11 +334,22 @@ export const useLatestWeight = () =>
     queryFn: fetchLatestWeight,
   });
 
-export const useWeightTrend = (from?: string, to?: string) =>
+export const useWeightEntries = (filters: WeightListFilters = {}) =>
   useQuery({
-    queryKey: weightQueryKeys.trend({ from, to }),
-    queryFn: () => fetchWeightTrend({ from, to }),
+    queryKey: weightQueryKeys.list(filters),
+    queryFn: () => fetchWeightEntries(filters),
   });
+
+export const usePaginatedWeightEntries = (
+  filters: Required<Pick<WeightListFilters, 'limit' | 'page'>> & WeightListFilters,
+) =>
+  useQuery({
+    queryKey: weightQueryKeys.page(filters),
+    queryFn: () => fetchPaginatedWeightEntries(filters),
+  });
+
+export const useWeightTrend = (from?: string, to?: string) =>
+  useWeightEntries({ from, to });
 
 export const useLogWeight = () => {
   return createOptimisticMutation<

--- a/apps/web/src/features/weight/components/weight-history.tsx
+++ b/apps/web/src/features/weight/components/weight-history.tsx
@@ -1,13 +1,39 @@
-import { Scale, Trash2 } from 'lucide-react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { computeEWMA, computeWeightInsights, createWeightInputSchema, type BodyWeightEntry, type CreateWeightInput } from '@pulse/shared';
+import { Area, AreaChart, CartesianGrid, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { PencilLine, Plus, Scale, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
 
 import { EmptyState } from '@/components/ui/empty-state';
 import { Button } from '@/components/ui/button';
 import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import { Input } from '@/components/ui/input';
-import { useDeleteWeight, useUpdateWeight, useWeightTrend } from '@/features/weight/api/weight';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  useDeleteWeight,
+  useLogWeight,
+  useUpdateWeight,
+  useWeightEntries,
+} from '@/features/weight/api/weight';
 import { useWeightUnit } from '@/hooks/use-weight-unit';
-import { parseDateInput } from '@/lib/date';
+import { addDays, formatUtcDateKey, parseDateInput } from '@/lib/date';
+
+type RangeOption = {
+  days: number | null;
+  label: string;
+  value: '30d' | '90d' | '180d' | '365d' | 'all';
+};
+
+const RANGE_OPTIONS: RangeOption[] = [
+  { value: '30d', label: '30D', days: 30 },
+  { value: '90d', label: '90D', days: 90 },
+  { value: '180d', label: '6M', days: 180 },
+  { value: '365d', label: '1Y', days: 365 },
+  { value: 'all', label: 'All', days: null },
+];
+
+const DEFAULT_RANGE = RANGE_OPTIONS[0];
 
 const entryDateFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'short',
@@ -15,27 +41,149 @@ const entryDateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
 });
 
+const axisDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+});
+
+const tooltipDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+const compareWeightEntries = (left: BodyWeightEntry, right: BodyWeightEntry) =>
+  left.date.localeCompare(right.date) ||
+  left.createdAt - right.createdAt ||
+  left.id.localeCompare(right.id);
+
 function formatEntryDate(dateKey: string) {
   return entryDateFormatter.format(parseDateInput(`${dateKey}T00:00:00`));
 }
 
+function filterEntriesByRange(entries: BodyWeightEntry[], days: number | null) {
+  if (days === null) {
+    return entries;
+  }
+
+  const rangeEnd = formatUtcDateKey(new Date());
+  const rangeStart = formatUtcDateKey(addDays(parseDateInput(`${rangeEnd}T00:00:00`), -(days - 1)));
+
+  return entries.filter((entry) => entry.date >= rangeStart && entry.date <= rangeEnd);
+}
+
+function computeYAxisDomain(points: Array<{ scale: number; trend: number }>): [number, number] {
+  if (points.length === 0) {
+    return [0, 1];
+  }
+
+  const values = points.flatMap((point) => [point.scale, point.trend]);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+
+  if (min === max) {
+    const padding = Math.max(1, min * 0.02);
+    return [min - padding, max + padding];
+  }
+
+  const padding = Math.max(0.5, (max - min) * 0.1);
+  return [Number((min - padding).toFixed(1)), Number((max + padding).toFixed(1))];
+}
+
+function formatSignedChange(value: number, formatWeightValue: (value: number) => string) {
+  const absolute = formatWeightValue(Math.abs(value));
+
+  if (Math.abs(value) < 0.1) {
+    return `${absolute} change`;
+  }
+
+  return `${value > 0 ? '+' : '-'}${absolute}`;
+}
+
+function getDefaultDate() {
+  return formatUtcDateKey(new Date());
+}
+
 export function WeightHistory() {
   const { confirm, dialog } = useConfirmation();
-  // Intentional for now: this view is a full history log. Add pagination/date bounds if dataset size becomes a UX issue.
-  const weightEntriesQuery = useWeightTrend();
+  const entriesQuery = useWeightEntries();
+  const logWeightMutation = useLogWeight();
   const deleteWeightMutation = useDeleteWeight();
   const updateWeightMutation = useUpdateWeight();
+  const [selectedRange, setSelectedRange] = useState<RangeOption>(DEFAULT_RANGE);
+  const [isAddFormOpen, setIsAddFormOpen] = useState(false);
+  const [addErrorMessage, setAddErrorMessage] = useState('');
   const [editingEntryId, setEditingEntryId] = useState<string | null>(null);
   const [editingWeight, setEditingWeight] = useState('');
+  const [editingNotes, setEditingNotes] = useState('');
   const [editingWeightError, setEditingWeightError] = useState('');
   const { formatWeight } = useWeightUnit();
-  const sortedWeightEntries = useMemo(
-    () =>
-      [...(weightEntriesQuery.data ?? [])].sort(
-        (left, right) => right.date.localeCompare(left.date) || right.createdAt - left.createdAt,
-      ),
-    [weightEntriesQuery.data],
+
+  const {
+    formState: { errors: addEntryErrors },
+    handleSubmit,
+    register,
+    reset,
+  } = useForm<CreateWeightInput>({
+    defaultValues: {
+      date: getDefaultDate(),
+      notes: undefined,
+    },
+    resolver: zodResolver(createWeightInputSchema),
+  });
+
+  const allWeightEntries = useMemo(
+    () => [...(entriesQuery.data ?? [])].sort(compareWeightEntries),
+    [entriesQuery.data],
   );
+  const chartEntries = useMemo(
+    () => filterEntriesByRange(allWeightEntries, selectedRange.days),
+    [allWeightEntries, selectedRange.days],
+  );
+  const sortedWeightEntries = useMemo(
+    () => [...allWeightEntries].sort((left, right) => compareWeightEntries(right, left)),
+    [allWeightEntries],
+  );
+  const chartData = useMemo(
+    () => computeEWMA(chartEntries.map((entry) => ({ date: entry.date, weight: entry.weight }))),
+    [chartEntries],
+  );
+  const summaryDays = selectedRange.days ?? Math.max(chartData.length, 1);
+  const rangeInsights = useMemo(
+    () => computeWeightInsights(chartData, summaryDays),
+    [chartData, summaryDays],
+  );
+  const yDomain = useMemo(() => computeYAxisDomain(chartData), [chartData]);
+  const latestEntry = sortedWeightEntries[0] ?? null;
+
+  async function onSubmitNewEntry(values: CreateWeightInput) {
+    setAddErrorMessage('');
+
+    try {
+      await logWeightMutation.mutateAsync(values);
+      reset({
+        date: getDefaultDate(),
+        notes: undefined,
+      });
+      setIsAddFormOpen(false);
+    } catch (error) {
+      setAddErrorMessage(error instanceof Error ? error.message : 'Weight entry could not be saved.');
+    }
+  }
+
+  function startEditing(entry: BodyWeightEntry) {
+    setEditingEntryId(entry.id);
+    setEditingWeight(entry.weight.toString());
+    setEditingNotes(entry.notes ?? '');
+    setEditingWeightError('');
+  }
+
+  function stopEditing() {
+    setEditingEntryId(null);
+    setEditingWeight('');
+    setEditingNotes('');
+    setEditingWeightError('');
+  }
 
   function handleDelete(entry: { date: string; id: string }) {
     confirm({
@@ -47,7 +195,6 @@ export function WeightHistory() {
         try {
           await deleteWeightMutation.mutateAsync(entry.id);
         } catch {
-          // Error feedback is handled by the mutation onError callback.
           return;
         }
       },
@@ -64,129 +211,425 @@ export function WeightHistory() {
     try {
       await updateWeightMutation.mutateAsync({
         id: entryId,
-        input: { weight: parsedWeight },
+        input: {
+          notes: editingNotes.trim().length > 0 ? editingNotes.trim() : null,
+          weight: parsedWeight,
+        },
       });
-      setEditingEntryId(null);
-      setEditingWeight('');
-      setEditingWeightError('');
+      stopEditing();
     } catch {
       return;
     }
   }
 
-  const isLoading = weightEntriesQuery.isLoading;
-  const isError = weightEntriesQuery.isError;
+  const isLoading = entriesQuery.isLoading;
+  const isError = entriesQuery.isError;
   const isEmpty = !isLoading && !isError && sortedWeightEntries.length === 0;
 
   return (
     <section className="space-y-6">
-      {isError ? (
-        <div className="rounded-2xl border border-dashed border-destructive/40 p-6">
-          <h2 className="text-lg font-semibold text-foreground">Unable to load weight history</h2>
-          <p className="mt-1 text-sm text-muted">
-            {weightEntriesQuery.error instanceof Error
-              ? weightEntriesQuery.error.message
-              : 'The weight history request failed.'}
+      <section className="rounded-3xl border border-border/70 bg-card/95 p-4 shadow-sm sm:p-5">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground">Log a new entry</h2>
+            <p className="text-sm text-muted">
+              Add today&apos;s weigh-in or backfill a missed day without leaving this page.
+            </p>
+          </div>
+          <Button
+            className="min-h-11 self-start"
+            onClick={() => {
+              setIsAddFormOpen((current) => !current);
+              setAddErrorMessage('');
+            }}
+            type="button"
+            variant={isAddFormOpen ? 'outline' : 'default'}
+          >
+            <Plus aria-hidden="true" className="mr-2 size-4" />
+            {isAddFormOpen ? 'Hide form' : 'Add entry'}
+          </Button>
+        </div>
+
+        {isAddFormOpen ? (
+          <form
+            aria-label="Add weight entry"
+            className="mt-4 grid gap-3 border-t border-border/70 pt-4 sm:grid-cols-2"
+            onSubmit={handleSubmit(onSubmitNewEntry)}
+          >
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground" htmlFor="weight-entry-date">
+                Date
+              </label>
+              <Input
+                id="weight-entry-date"
+                type="date"
+                aria-invalid={addEntryErrors.date ? true : undefined}
+                disabled={logWeightMutation.isPending}
+                {...register('date')}
+              />
+              {addEntryErrors.date?.message ? (
+                <p className="text-sm text-destructive">{addEntryErrors.date.message}</p>
+              ) : null}
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground" htmlFor="weight-entry-value">
+                Weight
+              </label>
+              <Input
+                id="weight-entry-value"
+                type="number"
+                step="0.1"
+                min="0.1"
+                inputMode="decimal"
+                aria-invalid={addEntryErrors.weight ? true : undefined}
+                disabled={logWeightMutation.isPending}
+                placeholder="181.4"
+                {...register('weight', { valueAsNumber: true })}
+              />
+              {addEntryErrors.weight?.message ? (
+                <p className="text-sm text-destructive">{addEntryErrors.weight.message}</p>
+              ) : null}
+            </div>
+
+            <div className="space-y-2 sm:col-span-2">
+              <label className="text-sm font-medium text-foreground" htmlFor="weight-entry-notes">
+                Notes
+              </label>
+              <Textarea
+                id="weight-entry-notes"
+                disabled={logWeightMutation.isPending}
+                placeholder="Optional context like fasted, after cardio, or travel day."
+                rows={3}
+                {...register('notes')}
+              />
+            </div>
+
+            {addErrorMessage ? (
+              <p className="text-sm text-destructive sm:col-span-2">{addErrorMessage}</p>
+            ) : null}
+
+            <div className="flex flex-wrap gap-2 sm:col-span-2">
+              <Button className="min-h-11" disabled={logWeightMutation.isPending} type="submit">
+                Save entry
+              </Button>
+              <Button
+                className="min-h-11"
+                onClick={() => {
+                  reset({
+                    date: getDefaultDate(),
+                    notes: undefined,
+                  });
+                  setAddErrorMessage('');
+                  setIsAddFormOpen(false);
+                }}
+                type="button"
+                variant="ghost"
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        ) : null}
+      </section>
+
+      <section className="rounded-3xl border border-border/70 bg-card/95 p-4 shadow-sm sm:p-5">
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold text-foreground">Trend chart</h2>
+              <p className="text-sm text-muted">
+                Logged weigh-ins with the dashboard&apos;s EWMA smoothing across your selected range.
+              </p>
+            </div>
+            <div
+              aria-label="Weight history range"
+              className="inline-flex w-full flex-wrap items-center gap-1 rounded-full border border-border bg-secondary/30 p-1 sm:w-auto"
+              role="group"
+            >
+              {RANGE_OPTIONS.map((option) => (
+                <Button
+                  aria-pressed={selectedRange.value === option.value}
+                  className="rounded-full px-3 text-xs"
+                  key={option.value}
+                  onClick={() => setSelectedRange(option)}
+                  size="sm"
+                  type="button"
+                  variant={selectedRange.value === option.value ? 'default' : 'ghost'}
+                >
+                  {option.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-2xl bg-secondary/40 px-4 py-3">
+              <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                Latest entry
+              </p>
+              <p className="mt-1 text-lg font-semibold text-foreground">
+                {latestEntry ? formatWeight(latestEntry.weight) : '--'}
+              </p>
+            </div>
+            <div className="rounded-2xl bg-secondary/40 px-4 py-3">
+              <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                Period average
+              </p>
+              <p className="mt-1 text-lg font-semibold text-foreground">
+                {chartData.length > 0 ? formatWeight(rangeInsights.avgWeight) : '--'}
+              </p>
+            </div>
+            <div className="rounded-2xl bg-secondary/40 px-4 py-3">
+              <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                Range change
+              </p>
+              <p className="mt-1 text-lg font-semibold text-foreground">
+                {chartData.length > 0 ? formatSignedChange(rangeInsights.periodChange, formatWeight) : '--'}
+              </p>
+            </div>
+          </div>
+
+          {isLoading ? (
+            <div className="h-[280px] w-full animate-pulse rounded-2xl bg-muted/50 sm:h-[360px]" />
+          ) : isError ? (
+            <div className="rounded-2xl border border-dashed border-destructive/40 p-6">
+              <h3 className="text-base font-semibold text-foreground">Unable to load weight history</h3>
+              <p className="mt-1 text-sm text-muted">
+                {entriesQuery.error instanceof Error
+                  ? entriesQuery.error.message
+                  : 'The weight history request failed.'}
+              </p>
+            </div>
+          ) : chartData.length === 0 ? (
+            <div className="flex min-h-[240px] items-center justify-center rounded-2xl border border-dashed border-border bg-muted/15 px-4 text-center sm:min-h-[320px]">
+              <div className="space-y-2">
+                <p className="text-base font-semibold text-foreground">
+                  {isEmpty ? 'Log your first weight entry to build a trend.' : 'No entries in this range yet.'}
+                </p>
+                <p className="text-sm text-muted">
+                  Try a wider date range or add a new weigh-in above.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div aria-label="Weight history trend chart" className="h-[280px] w-full sm:h-[360px]" role="img">
+              <ResponsiveContainer height="100%" width="100%">
+                <AreaChart data={chartData} margin={{ top: 8, right: 8, bottom: 2, left: 0 }}>
+                  <defs>
+                    <linearGradient id="weight-history-scale-fill" x1="0" x2="0" y1="0" y2="1">
+                      <stop offset="5%" stopColor="var(--color-primary)" stopOpacity={0.35} />
+                      <stop offset="95%" stopColor="var(--color-primary)" stopOpacity={0.04} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid stroke="var(--color-border)" strokeDasharray="3 3" />
+                  <XAxis
+                    axisLine={false}
+                    dataKey="date"
+                    minTickGap={16}
+                    tick={{ fill: 'var(--color-muted)', fontSize: 11 }}
+                    tickFormatter={(value: string) =>
+                      axisDateFormatter.format(parseDateInput(`${value}T12:00:00`))
+                    }
+                    tickLine={false}
+                  />
+                  <YAxis
+                    axisLine={false}
+                    domain={yDomain}
+                    tick={{ fill: 'var(--color-muted)', fontSize: 11 }}
+                    tickFormatter={(value: number) => value.toFixed(value % 1 === 0 ? 0 : 1)}
+                    tickLine={false}
+                    width={42}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: 'var(--color-card)',
+                      border: '1px solid var(--color-border)',
+                      borderRadius: '14px',
+                      color: 'var(--color-foreground)',
+                    }}
+                    formatter={(value: number | undefined, name: string | undefined) => {
+                      if (name === 'scale') {
+                        return [formatWeight(value ?? 0), 'Logged weight'];
+                      }
+
+                      return [formatWeight(value ?? 0), 'Trend weight'];
+                    }}
+                    labelFormatter={(label) =>
+                      typeof label === 'string'
+                        ? tooltipDateFormatter.format(parseDateInput(`${label}T12:00:00`))
+                        : ''
+                    }
+                    separator=": "
+                  />
+                  <Area
+                    dataKey="scale"
+                    fill="url(#weight-history-scale-fill)"
+                    isAnimationActive={false}
+                    name="scale"
+                    stroke="var(--color-primary)"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    type="monotone"
+                  />
+                  <Line
+                    dataKey="trend"
+                    dot={{ fill: 'var(--color-card)', r: 4, stroke: 'var(--color-accent-cream)', strokeWidth: 2 }}
+                    isAnimationActive={false}
+                    name="trend"
+                    stroke="var(--color-accent-cream)"
+                    strokeDasharray="6 4"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2.5}
+                    type="monotone"
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+
+          <div className="flex flex-wrap items-center gap-4 text-xs font-medium text-muted">
+            <span className="inline-flex items-center gap-2">
+              <span aria-hidden="true" className="size-2 rounded-full bg-primary" />
+              Logged weight
+            </span>
+            <span className="inline-flex items-center gap-2">
+              <span aria-hidden="true" className="size-2 rounded-full bg-[var(--color-accent-cream)]" />
+              EWMA trend
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-foreground">Entries</h2>
+          <p className="text-sm text-muted">
+            Review every weigh-in, update mistaken values or notes, and remove entries you no longer want.
           </p>
         </div>
-      ) : null}
 
-      {isLoading ? <p className="text-sm text-muted">Loading weight history...</p> : null}
+        {isEmpty ? (
+          <EmptyState
+            description="Use the Add entry button above to log your first weigh-in."
+            icon={Scale}
+            title="No weight entries yet"
+          />
+        ) : null}
 
-      {isEmpty ? (
-        <EmptyState
-          description="Log your weight from the dashboard to start building your trend history."
-          icon={Scale}
-          title="No weight entries yet"
-        />
-      ) : null}
+        {!isLoading && !isError && sortedWeightEntries.length > 0 ? (
+          <ul className="grid gap-3" aria-label="Weight history entries">
+            {sortedWeightEntries.map((entry) => {
+              const formattedDate = formatEntryDate(entry.date);
+              const isEditing = editingEntryId === entry.id;
 
-      {!isLoading && !isError && sortedWeightEntries.length > 0 ? (
-        <ul className="grid gap-3" aria-label="Weight history entries">
-          {sortedWeightEntries.map((entry) => {
-            const formattedDate = formatEntryDate(entry.date);
-
-            return (
-              <li
-                className="flex items-start justify-between gap-3 rounded-2xl border border-border/70 bg-card px-4 py-4 shadow-sm"
-                key={entry.id}
-              >
-                <div className="space-y-1">
-                  <p className="text-sm font-semibold text-foreground">{formattedDate}</p>
-                  {editingEntryId === entry.id ? (
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Input
-                        aria-label={`Weight value for ${formattedDate}`}
-                        className="h-9 w-32"
-                        inputMode="decimal"
-                        min="0.1"
-                        onChange={(event) => {
-                          setEditingWeight(event.currentTarget.value);
-                          setEditingWeightError('');
-                        }}
-                        step="0.1"
-                        type="number"
-                        value={editingWeight}
-                      />
-                      <Button
-                        className="h-9 px-3"
-                        disabled={updateWeightMutation.isPending}
-                        onClick={() => {
-                          void handleSaveEdit(entry.id);
-                        }}
-                        type="button"
-                      >
-                        Save
-                      </Button>
-                      <Button
-                        className="h-9 px-3"
-                        onClick={() => {
-                          setEditingEntryId(null);
-                          setEditingWeight('');
-                          setEditingWeightError('');
-                        }}
-                        type="button"
-                        variant="ghost"
-                      >
-                        Cancel
-                      </Button>
-                      {editingWeightError ? (
-                        <p className="text-sm text-destructive" role="status">
-                          {editingWeightError}
-                        </p>
-                      ) : null}
-                    </div>
-                  ) : (
-                    <button
-                      className="text-left text-lg font-semibold text-primary hover:underline"
-                      onClick={() => {
-                        setEditingEntryId(entry.id);
-                        setEditingWeight(entry.weight.toFixed(1));
-                        setEditingWeightError('');
-                      }}
-                      type="button"
-                    >
-                      {formatWeight(entry.weight)}
-                    </button>
-                  )}
-                  {entry.notes ? <p className="text-sm text-muted">{entry.notes}</p> : null}
-                </div>
-
-                <Button
-                  aria-label={`Delete weight entry from ${formattedDate}`}
-                  className="min-h-[44px] min-w-[44px]"
-                  onClick={() => handleDelete({ date: entry.date, id: entry.id })}
-                  size="icon"
-                  type="button"
-                  variant="ghost"
+              return (
+                <li
+                  className="rounded-2xl border border-border/70 bg-card px-4 py-4 shadow-sm"
+                  key={entry.id}
                 >
-                  <Trash2 aria-hidden="true" className="size-4" />
-                </Button>
-              </li>
-            );
-          })}
-        </ul>
-      ) : null}
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0 flex-1 space-y-1.5">
+                      <p className="text-sm font-semibold text-foreground">{formattedDate}</p>
+
+                      {isEditing ? (
+                        <div className="grid gap-3 sm:max-w-xl sm:grid-cols-2">
+                          <div className="space-y-2">
+                            <label className="text-sm font-medium text-foreground" htmlFor={`weight-edit-${entry.id}`}>
+                              Weight
+                            </label>
+                            <Input
+                              aria-label={`Weight value for ${formattedDate}`}
+                              className="h-10"
+                              id={`weight-edit-${entry.id}`}
+                              inputMode="decimal"
+                              min="0.1"
+                              onChange={(event) => {
+                                setEditingWeight(event.currentTarget.value);
+                                setEditingWeightError('');
+                              }}
+                              step="0.1"
+                              type="number"
+                              value={editingWeight}
+                            />
+                          </div>
+
+                          <div className="space-y-2 sm:col-span-2">
+                            <label className="text-sm font-medium text-foreground" htmlFor={`weight-notes-${entry.id}`}>
+                              Notes
+                            </label>
+                            <Textarea
+                              aria-label={`Notes for ${formattedDate}`}
+                              id={`weight-notes-${entry.id}`}
+                              onChange={(event) => setEditingNotes(event.currentTarget.value)}
+                              rows={3}
+                              value={editingNotes}
+                            />
+                          </div>
+
+                          {editingWeightError ? (
+                            <p className="text-sm text-destructive sm:col-span-2" role="status">
+                              {editingWeightError}
+                            </p>
+                          ) : null}
+
+                          <div className="flex flex-wrap gap-2 sm:col-span-2">
+                            <Button
+                              className="min-h-11"
+                              disabled={updateWeightMutation.isPending}
+                              onClick={() => {
+                                void handleSaveEdit(entry.id);
+                              }}
+                              type="button"
+                            >
+                              Save
+                            </Button>
+                            <Button className="min-h-11" onClick={stopEditing} type="button" variant="ghost">
+                              Cancel
+                            </Button>
+                          </div>
+                        </div>
+                      ) : (
+                        <>
+                          <p className="text-lg font-semibold text-primary">{formatWeight(entry.weight)}</p>
+                          {entry.notes ? <p className="break-words text-sm text-muted">{entry.notes}</p> : null}
+                        </>
+                      )}
+                    </div>
+
+                    {!isEditing ? (
+                      <div className="flex items-center gap-2 self-start">
+                        <Button
+                          className="min-h-11"
+                          onClick={() => startEditing(entry)}
+                          type="button"
+                          variant="outline"
+                        >
+                          <PencilLine aria-hidden="true" className="mr-2 size-4" />
+                          Edit
+                        </Button>
+                        <Button
+                          aria-label={`Delete weight entry from ${formattedDate}`}
+                          className="min-h-11 min-w-11"
+                          onClick={() => handleDelete({ date: entry.date, id: entry.id })}
+                          size="icon"
+                          type="button"
+                          variant="ghost"
+                        >
+                          <Trash2 aria-hidden="true" className="size-4" />
+                        </Button>
+                      </div>
+                    ) : null}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
+      </section>
+
       {dialog}
     </section>
   );

--- a/apps/web/src/features/weight/components/weight-history.tsx
+++ b/apps/web/src/features/weight/components/weight-history.tsx
@@ -195,6 +195,8 @@ export function WeightHistory() {
         try {
           await deleteWeightMutation.mutateAsync(entry.id);
         } catch {
+          // The mutation hook owns user-facing error handling; this avoids an unhandled rejection
+          // from the confirmation dialog callback.
           return;
         }
       },
@@ -218,6 +220,7 @@ export function WeightHistory() {
       });
       stopEditing();
     } catch {
+      // The mutation hook already reports errors via toast state.
       return;
     }
   }

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -463,9 +463,18 @@ describe('DashboardPage', () => {
     expect(screen.getByText('1/1')).toBeInTheDocument();
     expect(screen.getByTestId('dashboard-log-weight-card')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'History' })).toHaveAttribute(
+    expect(screen.getAllByRole('link', { name: 'View history' })).toHaveLength(2);
+    expect(screen.getByRole('link', { name: 'View weight history' })).toHaveAttribute(
       'href',
       '/weight/history',
+    );
+    expect(screen.getByRole('link', { name: 'View nutrition details' })).toHaveAttribute(
+      'href',
+      '/nutrition',
+    );
+    expect(screen.getByRole('link', { name: 'View habits details' })).toHaveAttribute(
+      'href',
+      '/habits',
     );
     expect(screen.queryByTestId('dashboard-log-weight-form')).not.toBeInTheDocument();
 

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -1,6 +1,6 @@
 import { DASHBOARD_WIDGET_IDS } from '@pulse/shared';
 import { useQueryClient } from '@tanstack/react-query';
-import { EyeOff, LayoutDashboard, Pencil, Plus } from 'lucide-react';
+import { ChevronRight, EyeOff, LayoutDashboard, Pencil, Plus } from 'lucide-react';
 import { type FormEvent, type ReactNode, useEffect, useState } from 'react';
 import { Link } from 'react-router';
 
@@ -397,7 +397,7 @@ export function DashboardPage() {
                       widgetLabel={DASHBOARD_WIDGET_IDS['log-weight']}
                     >
                       <Card
-                        className="gap-3 py-3 sm:py-3.5"
+                        className="gap-3 py-3 transition-[box-shadow,border-color,background-color] duration-200 hover:border-primary/35 hover:bg-card/80 hover:shadow-md focus-within:border-primary/45 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 sm:py-3.5"
                         data-qa="dashboard-log-weight-card"
                         data-testid="dashboard-log-weight-card"
                       >
@@ -410,10 +410,11 @@ export function DashboardPage() {
                               </CardDescription>
                             </div>
                             <Link
-                              className="text-xs font-medium text-primary hover:underline sm:text-sm"
+                              className="inline-flex items-center gap-1 text-xs font-medium text-primary transition-colors hover:text-primary/80 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:text-sm"
                               to="/weight/history"
                             >
-                              History
+                              <span>View history</span>
+                              <ChevronRight className="size-3.5" />
                             </Link>
                           </div>
                         </CardHeader>

--- a/apps/web/src/pages/habits.test.tsx
+++ b/apps/web/src/pages/habits.test.tsx
@@ -67,6 +67,7 @@ describe('HabitsPage', () => {
     );
 
     expect(await screen.findByText('No active habits configured yet.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '← Back to Dashboard' })).toHaveAttribute('href', '/');
     fireEvent.click(screen.getByRole('button', { name: 'Add Habit' }));
 
     expect(await screen.findByRole('heading', { name: 'Add habit' })).toBeInTheDocument();

--- a/apps/web/src/pages/habits.tsx
+++ b/apps/web/src/pages/habits.tsx
@@ -1,11 +1,22 @@
 import { useMemo, useState } from 'react';
 import type { Habit, HabitEntry } from '@pulse/shared';
 
+import { BackLink } from '@/components/layout/back-link';
 import { HelpIcon } from '@/components/ui/help-icon';
 import { useHabitEntries, useHabits } from '@/features/habits/api/habits';
 import { DailyHabits, HabitHistory } from '@/features/habits';
-import { WeeklyHabitDatePicker, type DayCompletion } from '@/features/habits/components/weekly-habit-date-picker';
-import { addDays, formatDateKey, getToday, getWeekStart, normalizeDate, toDateKey } from '@/lib/date';
+import {
+  WeeklyHabitDatePicker,
+  type DayCompletion,
+} from '@/features/habits/components/weekly-habit-date-picker';
+import {
+  addDays,
+  formatDateKey,
+  getToday,
+  getWeekStart,
+  normalizeDate,
+  toDateKey,
+} from '@/lib/date';
 
 function getHabitEntryCompleted(habit: Habit, entry: HabitEntry | undefined) {
   if (!entry) {
@@ -33,7 +44,9 @@ function buildWeekCompletionByDate(habits: Habit[], entries: HabitEntry[], weekS
     const day = addDays(weekStart, dayOffset);
     const dayKey = formatDateKey(day);
     const dayEntries = entriesByDate.get(dayKey);
-    const completedCount = habits.filter((habit) => getHabitEntryCompleted(habit, dayEntries?.get(habit.id))).length;
+    const completedCount = habits.filter((habit) =>
+      getHabitEntryCompleted(habit, dayEntries?.get(habit.id)),
+    ).length;
 
     completionByDate[dayKey] = {
       completedCount,
@@ -71,6 +84,7 @@ export function HabitsPage() {
 
   return (
     <section className="space-y-3">
+      <BackLink label="Back to Dashboard" to="/" />
       <div className="flex items-center gap-1.5">
         <h1 className="text-3xl font-semibold text-primary">Habits</h1>
         <HelpIcon title="Habits help">
@@ -81,8 +95,12 @@ export function HabitsPage() {
             <li>Boolean: mark done or not done for the day.</li>
             <li>Numeric: log a value and compare it against your target.</li>
             <li>Time-based: track duration-style habits over time.</li>
-            <li>Streaks power the dashboard&apos;s don&apos;t break the chain view for consistency.</li>
-            <li>Create, edit, reorder, or archive/delete habits from the habits controls and menus.</li>
+            <li>
+              Streaks power the dashboard&apos;s don&apos;t break the chain view for consistency.
+            </li>
+            <li>
+              Create, edit, reorder, or archive/delete habits from the habits controls and menus.
+            </li>
             <li>Your AI agent can also log or update habit entries for you.</li>
           </ul>
         </HelpIcon>

--- a/apps/web/src/pages/nutrition.test.tsx
+++ b/apps/web/src/pages/nutrition.test.tsx
@@ -1,5 +1,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import type { DailyNutrition, DailyNutritionMeal, NutritionMacroTotals } from '@pulse/shared';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { NutritionPage } from '@/pages/nutrition';
@@ -219,6 +221,18 @@ function createNutritionApiMock(initialState: Record<string, DateState>) {
   return { fetchMock };
 }
 
+function renderNutritionPage() {
+  const { wrapper: QueryClientWrapper } = createQueryClientWrapper();
+
+  return render(<NutritionPage />, {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <MemoryRouter>
+        <QueryClientWrapper>{children}</QueryClientWrapper>
+      </MemoryRouter>
+    ),
+  });
+}
+
 function createDeferredResponse() {
   let resolve: (value: Response) => void = () => {};
 
@@ -391,8 +405,7 @@ describe('NutritionPage', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const { wrapper } = createQueryClientWrapper();
-    render(<NutritionPage />, { wrapper });
+    renderNutritionPage();
 
     await vi.runAllTimersAsync();
     await Promise.resolve();
@@ -400,6 +413,7 @@ describe('NutritionPage', () => {
     const dailyTotals = screen.getByLabelText('Daily macro totals');
 
     expect(screen.getByRole('heading', { name: 'Nutrition' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '← Back to Dashboard' })).toHaveAttribute('href', '/');
     expect(screen.getByText('Friday, March 6')).toBeInTheDocument();
     expect(screen.getByText('Friday, Mar 6')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Go to next day' })).toBeDisabled();
@@ -445,16 +459,16 @@ describe('NutritionPage', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const { wrapper } = createQueryClientWrapper();
-    render(<NutritionPage />, { wrapper });
+    renderNutritionPage();
 
     await vi.runAllTimersAsync();
     await Promise.resolve();
 
     const strip = screen.getByRole('list', { name: 'Nutrition week summary' });
     const dateNavPreviousButton = screen.getByRole('button', { name: 'Go to previous day' });
-    expect(strip.compareDocumentPosition(dateNavPreviousButton) & Node.DOCUMENT_POSITION_FOLLOWING)
-      .toBeTruthy();
+    expect(
+      strip.compareDocumentPosition(dateNavPreviousButton) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Select 2026-03-05' }));
     await vi.runAllTimersAsync();
@@ -492,8 +506,7 @@ describe('NutritionPage', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const { wrapper } = createQueryClientWrapper();
-    render(<NutritionPage />, { wrapper });
+    renderNutritionPage();
 
     await vi.runAllTimersAsync();
     await Promise.resolve();
@@ -512,8 +525,7 @@ describe('NutritionPage', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const { wrapper } = createQueryClientWrapper();
-    render(<NutritionPage />, { wrapper });
+    renderNutritionPage();
 
     await vi.runAllTimersAsync();
     await Promise.resolve();
@@ -540,8 +552,7 @@ describe('NutritionPage', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const { wrapper } = createQueryClientWrapper();
-    render(<NutritionPage />, { wrapper });
+    renderNutritionPage();
 
     await vi.runAllTimersAsync();
     await Promise.resolve();
@@ -587,8 +598,7 @@ describe('NutritionPage', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const { wrapper } = createQueryClientWrapper();
-    render(<NutritionPage />, { wrapper });
+    renderNutritionPage();
 
     fireEvent.click(screen.getByRole('button', { name: 'Go to previous day' }));
     await vi.runAllTimersAsync();
@@ -622,8 +632,7 @@ describe('NutritionPage', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const { wrapper } = createQueryClientWrapper();
-    render(<NutritionPage />, { wrapper });
+    renderNutritionPage();
 
     fireEvent.click(screen.getByRole('button', { name: 'Go to previous day' }));
     await vi.runAllTimersAsync();
@@ -664,8 +673,7 @@ describe('NutritionPage', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const { wrapper } = createQueryClientWrapper();
-    render(<NutritionPage />, { wrapper });
+    renderNutritionPage();
 
     fireEvent.click(screen.getByRole('button', { name: 'Go to previous day' }));
     await vi.runAllTimersAsync();
@@ -708,8 +716,7 @@ describe('NutritionPage', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const { wrapper } = createQueryClientWrapper();
-    render(<NutritionPage />, { wrapper });
+    renderNutritionPage();
 
     fireEvent.click(screen.getByRole('button', { name: 'Go to previous day' }));
     await vi.runAllTimersAsync();
@@ -775,8 +782,7 @@ describe('NutritionPage', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const { wrapper } = createQueryClientWrapper();
-    render(<NutritionPage />, { wrapper });
+    renderNutritionPage();
 
     expect(screen.getByLabelText('Loading nutrition')).toBeInTheDocument();
     expect(screen.getByLabelText('Loading nutrition rings')).toBeInTheDocument();
@@ -794,8 +800,7 @@ describe('NutritionPage', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const { wrapper } = createQueryClientWrapper();
-    render(<NutritionPage />, { wrapper });
+    renderNutritionPage();
 
     await vi.runAllTimersAsync();
     await Promise.resolve();

--- a/apps/web/src/pages/nutrition.tsx
+++ b/apps/web/src/pages/nutrition.tsx
@@ -2,6 +2,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { ArrowDown, ArrowUp, UtensilsCrossed } from 'lucide-react';
 
+import { BackLink } from '@/components/layout/back-link';
 import { MealCardSkeleton } from '@/components/skeletons';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -140,6 +141,7 @@ export function NutritionPage() {
 
   return (
     <section className="space-y-4 sm:space-y-5">
+      <BackLink label="Back to Dashboard" to="/" />
       <header className="space-y-1.5">
         <div className="flex items-center gap-2">
           <h1 className="text-3xl font-semibold text-primary">Nutrition</h1>

--- a/apps/web/src/pages/weight-history.test.tsx
+++ b/apps/web/src/pages/weight-history.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -7,18 +7,62 @@ import { WeightHistoryPage } from '@/pages/weight-history';
 import { renderWithQueryClient } from '@/test/render-with-query-client';
 import { jsonResponse } from '@/test/test-utils';
 
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<typeof import('recharts')>('recharts');
+  const React = await vi.importActual<typeof import('react')>('react');
+
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="responsive-container">
+        {React.isValidElement(children)
+          ? React.cloneElement(
+              children as React.ReactElement<{ height?: number; width?: number }>,
+              {
+                height: 360,
+                width: 720,
+              },
+            )
+          : children}
+      </div>
+    ),
+  };
+});
+
+type WeightEntryFixture = {
+  createdAt: number;
+  date: string;
+  id: string;
+  notes: string | null;
+  updatedAt: number;
+  weight: number;
+};
+
+function renderPage() {
+  renderWithQueryClient(
+    <MemoryRouter initialEntries={['/weight/history']}>
+      <Routes>
+        <Route element={<WeightHistoryPage />} path="/weight/history" />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
 describe('WeightHistoryPage', () => {
   beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2026-03-08T12:00:00'));
     window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
   });
 
   afterEach(() => {
     window.localStorage.clear();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it('lists entries in reverse chronological order and deletes with confirmation', async () => {
-    let weights = [
+  it('shows the chart, lists entries in reverse chronological order, and deletes with confirmation', async () => {
+    let weights: WeightEntryFixture[] = [
       {
         id: 'weight-1',
         date: '2026-03-04',
@@ -66,11 +110,7 @@ describe('WeightHistoryPage', () => {
       }
 
       if (url.pathname === '/api/v1/weight' && method === 'GET') {
-        return Promise.resolve(
-          jsonResponse({
-            data: weights,
-          }),
-        );
+        return Promise.resolve(jsonResponse({ data: weights }));
       }
 
       if (url.pathname === '/api/v1/weight/weight-2' && method === 'DELETE') {
@@ -85,23 +125,19 @@ describe('WeightHistoryPage', () => {
       throw new Error(`Unhandled request: ${method} ${url.pathname}`);
     });
 
-    renderWithQueryClient(
-      <MemoryRouter initialEntries={['/weight/history']}>
-        <Routes>
-          <Route element={<WeightHistoryPage />} path="/weight/history" />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderPage();
 
     expect(await screen.findByRole('heading', { name: 'Weight History' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '← Back to Dashboard' })).toHaveAttribute('href', '/');
-    expect(await screen.findByText('181.4 lbs')).toBeInTheDocument();
-    expect(screen.getByText('181.2 lbs')).toBeInTheDocument();
-    expect(screen.getByText('181.8 lbs')).toBeInTheDocument();
-    expect(screen.getByText('After cardio')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Weight history trend chart' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '30D' })).toHaveAttribute('aria-pressed', 'true');
 
     const list = screen.getByRole('list', { name: 'Weight history entries' });
-    const weightsInOrder = Array.from(list.querySelectorAll('li button.text-lg')).map(
+    expect(within(list).getByText('181.4 lbs')).toBeInTheDocument();
+    expect(within(list).getByText('181.2 lbs')).toBeInTheDocument();
+    expect(within(list).getByText('181.8 lbs')).toBeInTheDocument();
+    expect(within(list).getByText('After cardio')).toBeInTheDocument();
+    const weightsInOrder = Array.from(list.querySelectorAll('li p.text-lg')).map(
       (element) => element.textContent,
     );
     expect(weightsInOrder).toEqual(['181.4 lbs', '181.2 lbs', '181.8 lbs']);
@@ -116,7 +152,18 @@ describe('WeightHistoryPage', () => {
     expect(screen.queryByText('After cardio')).not.toBeInTheDocument();
   });
 
-  it('closes the confirmation dialog when delete fails', async () => {
+  it('adds a new weight entry from the quick-add form', async () => {
+    let weights: WeightEntryFixture[] = [
+      {
+        id: 'weight-1',
+        date: '2026-03-06',
+        weight: 181.4,
+        notes: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+
     vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
       const rawUrl =
         typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
@@ -138,158 +185,56 @@ describe('WeightHistoryPage', () => {
       }
 
       if (url.pathname === '/api/v1/weight' && method === 'GET') {
-        return Promise.resolve(
-          jsonResponse({
-            data: [
-              {
-                id: 'weight-1',
-                date: '2026-03-06',
-                weight: 181.4,
-                notes: null,
-                createdAt: 1,
-                updatedAt: 1,
-              },
-            ],
-          }),
-        );
+        return Promise.resolve(jsonResponse({ data: weights }));
       }
 
-      if (url.pathname === '/api/v1/weight/weight-1' && method === 'DELETE') {
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              error: {
-                code: 'WEIGHT_NOT_FOUND',
-                message: 'Weight entry not found',
-              },
-            }),
-            {
-              headers: { 'Content-Type': 'application/json' },
-              status: 404,
-            },
-          ),
-        );
+      if (url.pathname === '/api/v1/weight' && method === 'POST') {
+        const payload =
+          typeof init?.body === 'string'
+            ? (JSON.parse(init.body) as { date: string; notes?: string; weight: number })
+            : null;
+
+        const nextEntry: WeightEntryFixture = {
+          id: 'weight-2',
+          date: payload?.date ?? '2026-03-07',
+          weight: payload?.weight ?? 180,
+          notes: payload?.notes ?? null,
+          createdAt: 2,
+          updatedAt: 2,
+        };
+        weights = [...weights, nextEntry];
+        return Promise.resolve(jsonResponse({ data: nextEntry }));
       }
 
       throw new Error(`Unhandled request: ${method} ${url.pathname}`);
     });
 
-    renderWithQueryClient(
-      <MemoryRouter initialEntries={['/weight/history']}>
-        <Routes>
-          <Route element={<WeightHistoryPage />} path="/weight/history" />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderPage();
 
-    expect(await screen.findByText('181.4 lbs')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /Delete weight entry from Mar 6, 2026/i }));
-    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    const list = await screen.findByRole('list', { name: 'Weight history entries' });
+    expect(within(list).getByText('181.4 lbs')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Add entry' }));
 
-    fireEvent.click(screen.getByRole('button', { name: 'Delete entry' }));
+    fireEvent.change(screen.getByLabelText('Date'), {
+      target: { value: '2026-03-07' },
+    });
+    fireEvent.change(screen.getByLabelText('Weight'), {
+      target: { value: '180.2' },
+    });
+    fireEvent.change(screen.getByLabelText('Notes'), {
+      target: { value: 'After travel' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save entry' }));
 
     await waitFor(() => {
-      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+      expect(within(screen.getByRole('list', { name: 'Weight history entries' })).getByText('180.2 lbs')).toBeInTheDocument();
     });
+    expect(within(screen.getByRole('list', { name: 'Weight history entries' })).getByText('After travel')).toBeInTheDocument();
+    expect(screen.queryByRole('form', { name: 'Add weight entry' })).not.toBeInTheDocument();
   });
 
-  it('shows empty state when no entries are available', async () => {
-    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
-      const rawUrl =
-        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
-      const url = new URL(rawUrl, 'https://pulse.test');
-      const method = init?.method ?? 'GET';
-
-      if (url.pathname === '/api/v1/users/me' && method === 'GET') {
-        return Promise.resolve(
-          jsonResponse({
-            data: {
-              id: 'user-1',
-              username: 'test-user',
-              name: 'Test User',
-              weightUnit: 'lbs',
-              createdAt: 1,
-            },
-          }),
-        );
-      }
-
-      if (url.pathname === '/api/v1/weight' && method === 'GET') {
-        return Promise.resolve(
-          jsonResponse({
-            data: [],
-          }),
-        );
-      }
-
-      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
-    });
-
-    renderWithQueryClient(
-      <MemoryRouter initialEntries={['/weight/history']}>
-        <Routes>
-          <Route element={<WeightHistoryPage />} path="/weight/history" />
-        </Routes>
-      </MemoryRouter>,
-    );
-
-    expect(await screen.findByRole('heading', { name: 'No weight entries yet' })).toBeInTheDocument();
-  });
-
-  it('formats entries with the user preferred metric unit', async () => {
-    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
-      const rawUrl =
-        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
-      const url = new URL(rawUrl, 'https://pulse.test');
-      const method = init?.method ?? 'GET';
-
-      if (url.pathname === '/api/v1/users/me' && method === 'GET') {
-        return Promise.resolve(
-          jsonResponse({
-            data: {
-              id: 'user-1',
-              username: 'test-user',
-              name: 'Test User',
-              weightUnit: 'kg',
-              createdAt: 1,
-            },
-          }),
-        );
-      }
-
-      if (url.pathname === '/api/v1/weight' && method === 'GET') {
-        return Promise.resolve(
-          jsonResponse({
-            data: [
-              {
-                id: 'weight-1',
-                date: '2026-03-06',
-                weight: 81.2,
-                notes: null,
-                createdAt: 1,
-                updatedAt: 1,
-              },
-            ],
-          }),
-        );
-      }
-
-      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
-    });
-
-    renderWithQueryClient(
-      <MemoryRouter initialEntries={['/weight/history']}>
-        <Routes>
-          <Route element={<WeightHistoryPage />} path="/weight/history" />
-        </Routes>
-      </MemoryRouter>,
-    );
-
-    expect(await screen.findByText('81.2 kg')).toBeInTheDocument();
-  });
-
-  it('supports inline editing of a weight value', async () => {
-    let weights = [
+  it('supports editing a weight value and note inline', async () => {
+    let weights: WeightEntryFixture[] = [
       {
         id: 'weight-1',
         date: '2026-03-06',
@@ -326,11 +271,19 @@ describe('WeightHistoryPage', () => {
 
       if (url.pathname === '/api/v1/weight/weight-1' && method === 'PATCH') {
         const payload =
-          typeof init?.body === 'string' ? (JSON.parse(init.body) as { weight: number }) : null;
-        const nextWeight = payload?.weight ?? weights[0]?.weight ?? 0;
+          typeof init?.body === 'string'
+            ? (JSON.parse(init.body) as { notes: string | null; weight: number })
+            : null;
 
         weights = weights.map((entry) =>
-          entry.id === 'weight-1' ? { ...entry, weight: nextWeight, updatedAt: entry.updatedAt + 1 } : entry,
+          entry.id === 'weight-1'
+            ? {
+                ...entry,
+                notes: payload?.notes ?? null,
+                updatedAt: entry.updatedAt + 1,
+                weight: payload?.weight ?? entry.weight,
+              }
+            : entry,
         );
 
         return Promise.resolve(jsonResponse({ data: weights[0] }));
@@ -339,24 +292,23 @@ describe('WeightHistoryPage', () => {
       throw new Error(`Unhandled request: ${method} ${url.pathname}`);
     });
 
-    renderWithQueryClient(
-      <MemoryRouter initialEntries={['/weight/history']}>
-        <Routes>
-          <Route element={<WeightHistoryPage />} path="/weight/history" />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderPage();
 
-    expect(await screen.findByText('181.4 lbs')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: '181.4 lbs' }));
+    const list = await screen.findByRole('list', { name: 'Weight history entries' });
+    expect(within(list).getByText('181.4 lbs')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
     fireEvent.change(screen.getByLabelText('Weight value for Mar 6, 2026'), {
       target: { value: '180.2' },
+    });
+    fireEvent.change(screen.getByLabelText('Notes for Mar 6, 2026'), {
+      target: { value: 'Adjusted after retest' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
-      expect(screen.getByText('180.2 lbs')).toBeInTheDocument();
+      expect(within(screen.getByRole('list', { name: 'Weight history entries' })).getByText('180.2 lbs')).toBeInTheDocument();
     });
+    expect(within(screen.getByRole('list', { name: 'Weight history entries' })).getByText('Adjusted after retest')).toBeInTheDocument();
   });
 
   it('shows validation feedback when saving an invalid inline weight edit', async () => {
@@ -404,23 +356,17 @@ describe('WeightHistoryPage', () => {
       throw new Error(`Unhandled request: ${method} ${url.pathname}`);
     });
 
-    renderWithQueryClient(
-      <MemoryRouter initialEntries={['/weight/history']}>
-        <Routes>
-          <Route element={<WeightHistoryPage />} path="/weight/history" />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderPage();
 
-    expect(await screen.findByText('181.4 lbs')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: '181.4 lbs' }));
+    const list = await screen.findByRole('list', { name: 'Weight history entries' });
+    expect(within(list).getByText('181.4 lbs')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
     fireEvent.change(screen.getByLabelText('Weight value for Mar 6, 2026'), {
       target: { value: '0' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(screen.getByText('Enter a valid weight above 0.')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
     const hasPatchToWeightEntry = fetchSpy.mock.calls.some((call) => {
       const input = call[0];
       const rawUrl =
@@ -431,6 +377,94 @@ describe('WeightHistoryPage', () => {
       return url.pathname === '/api/v1/weight/weight-1' && method === 'PATCH';
     });
     expect(hasPatchToWeightEntry).toBe(false);
+  });
+
+  it('shows a range empty state until the user expands to all history', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const rawUrl =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url = new URL(rawUrl, 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/users/me' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: 'user-1',
+              username: 'test-user',
+              name: 'Test User',
+              weightUnit: 'kg',
+              createdAt: 1,
+            },
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/weight' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'weight-1',
+                date: '2025-10-01',
+                weight: 81.2,
+                notes: null,
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            ],
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderPage();
+
+    const list = await screen.findByRole('list', { name: 'Weight history entries' });
+    expect(within(list).getByText('81.2 kg')).toBeInTheDocument();
+    expect(screen.getByText('No entries in this range yet.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('img', { name: 'Weight history trend chart' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when no entries are available', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const rawUrl =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url = new URL(rawUrl, 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/users/me' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: 'user-1',
+              username: 'test-user',
+              name: 'Test User',
+              weightUnit: 'lbs',
+              createdAt: 1,
+            },
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/weight' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole('heading', { name: 'No weight entries yet' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add entry' })).toBeInTheDocument();
   });
 
   it('shows contextual help for weight history', async () => {
@@ -455,23 +489,13 @@ describe('WeightHistoryPage', () => {
       }
 
       if (url.pathname === '/api/v1/weight' && method === 'GET') {
-        return Promise.resolve(
-          jsonResponse({
-            data: [],
-          }),
-        );
+        return Promise.resolve(jsonResponse({ data: [] }));
       }
 
       throw new Error(`Unhandled request: ${method} ${url.pathname}`);
     });
 
-    renderWithQueryClient(
-      <MemoryRouter initialEntries={['/weight/history']}>
-        <Routes>
-          <Route element={<WeightHistoryPage />} path="/weight/history" />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderPage();
 
     expect(await screen.findByRole('heading', { name: 'Weight History' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Help' }));
@@ -486,7 +510,10 @@ describe('WeightHistoryPage', () => {
       screen.getByText('The dashboard trend line uses an exponentially weighted moving average (EWMA).'),
     ).toBeInTheDocument();
     expect(
-      screen.getByText('Tap any logged value to edit it inline when an entry needs correction.'),
+      screen.getByText('Use the range selector to zoom from the last 30 days out to your full history.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Edit buttons let you correct a value or note without leaving the page.'),
     ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/weight-history.tsx
+++ b/apps/web/src/pages/weight-history.tsx
@@ -15,13 +15,14 @@ export function WeightHistoryPage() {
           </p>
           <ul className="list-disc space-y-1 pl-5">
             <li>The dashboard trend line uses an exponentially weighted moving average (EWMA).</li>
+            <li>Use the range selector to zoom from the last 30 days out to your full history.</li>
             <li>You can log weight manually in the app or ask your AI agent to log it.</li>
-            <li>Tap any logged value to edit it inline when an entry needs correction.</li>
+            <li>Edit buttons let you correct a value or note without leaving the page.</li>
           </ul>
         </HelpIcon>
       </div>
       <p className="max-w-2xl text-sm text-muted">
-        Review your full body weight log, update values inline, or remove entries you no longer want.
+        Review your full body weight log, inspect longer-term trends, add new entries, and clean up mistakes.
       </p>
       <WeightHistory />
     </main>

--- a/apps/web/src/pages/workouts.test.tsx
+++ b/apps/web/src/pages/workouts.test.tsx
@@ -281,6 +281,7 @@ describe('WorkoutsPage', () => {
     );
 
     expect(screen.getByRole('heading', { name: 'Workouts' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '← Back to Dashboard' })).toHaveAttribute('href', '/');
     expect(screen.getByRole('button', { name: 'Calendar' })).toHaveAttribute(
       'aria-pressed',
       'true',
@@ -336,17 +337,27 @@ describe('WorkoutsPage', () => {
       'aria-pressed',
       'true',
     );
-    const detailsLink = (await screen.findAllByRole('link')).find(
-      (link) => link.getAttribute('href') === '/workouts/session/session-1?view=list',
-    );
+    await waitFor(() => {
+      expect(
+        screen
+          .getAllByRole('link')
+          .some((link) => link.getAttribute('href') === '/workouts/session/session-1?view=list'),
+      ).toBe(true);
+    });
+
+    const detailsLink = screen
+      .getAllByRole('link')
+      .find((link) => link.getAttribute('href') === '/workouts/session/session-1?view=list');
     if (!detailsLink) {
       throw new Error('Expected session detail link with view=list query param');
     }
     expect(detailsLink).toHaveAttribute('href', '/workouts/session/session-1?view=list');
 
-    const activeSessionLink = (await screen.findAllByRole('link')).find(
-      (link) => link.getAttribute('href') === '/workouts/active?view=list&sessionId=session-2',
-    );
+    const activeSessionLink = screen
+      .getAllByRole('link')
+      .find(
+        (link) => link.getAttribute('href') === '/workouts/active?view=list&sessionId=session-2',
+      );
     if (!activeSessionLink) {
       throw new Error('Expected in-progress session link to the active workout route');
     }
@@ -355,9 +366,11 @@ describe('WorkoutsPage', () => {
       '/workouts/active?view=list&sessionId=session-2',
     );
 
-    const pausedSessionLink = (await screen.findAllByRole('link')).find(
-      (link) => link.getAttribute('href') === '/workouts/active?view=list&sessionId=session-4',
-    );
+    const pausedSessionLink = screen
+      .getAllByRole('link')
+      .find(
+        (link) => link.getAttribute('href') === '/workouts/active?view=list&sessionId=session-4',
+      );
     if (!pausedSessionLink) {
       throw new Error('Expected paused session link to the active workout route');
     }

--- a/apps/web/src/pages/workouts.tsx
+++ b/apps/web/src/pages/workouts.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { Dumbbell, X } from 'lucide-react';
 import { useSearchParams } from 'react-router';
 
+import { BackLink } from '@/components/layout/back-link';
 import { WorkoutCardSkeleton } from '@/components/skeletons';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -112,6 +113,7 @@ export function WorkoutsPage() {
 
   return (
     <section className="space-y-6">
+      <BackLink label="Back to Dashboard" to="/" />
       <div className="space-y-2">
         <div className="flex items-center gap-2">
           <h1 className="text-3xl font-semibold text-primary">Workouts</h1>
@@ -120,10 +122,18 @@ export function WorkoutsPage() {
               Pulse workouts follow a Templates {'>'} Sessions {'>'} Sets flow.
             </p>
             <ul className="list-disc space-y-1 pl-5">
-              <li>Start a workout from Templates, then log each exercise set during the session.</li>
-              <li>Active sessions are saved in localStorage so you can recover if the app closes.</li>
-              <li>Pause to stop active timing, resume when ready, or cancel if you need to end early.</li>
-              <li>Scheduled workouts appear in Calendar and can be used to plan upcoming sessions.</li>
+              <li>
+                Start a workout from Templates, then log each exercise set during the session.
+              </li>
+              <li>
+                Active sessions are saved in localStorage so you can recover if the app closes.
+              </li>
+              <li>
+                Pause to stop active timing, resume when ready, or cancel if you need to end early.
+              </li>
+              <li>
+                Scheduled workouts appear in Calendar and can be used to plan upcoming sessions.
+              </li>
             </ul>
           </HelpIcon>
         </div>


### PR DESCRIPTION
## Summary

This PR turns the dashboard into a set of actionable drill-down entry points instead of a read-only overview. Snapshot cards, trend sparklines, macro cards, the habit chain, and the weight card now route directly to the relevant detail pages, with consistent hover/focus treatment and visible navigation affordances. It also expands the weight history experience into a full management page with chart range controls, add/edit/delete flows, and inline corrections. On the habits side, chain-day circles now open a detail modal so users can inspect and update boolean, numeric, and time-based entries directly from the dashboard, including retroactive logging for unscheduled past dates.

## Key Changes

- Added a reusable `DashboardDrilldownLink` / indicator pattern and applied it across dashboard snapshot cards, trend cards, macro rings, habit chains, and workout/weight navigation affordances.
- Built out `/weight/history` into a richer detail page with:
  - add-entry form
  - selectable chart ranges (`30D`, `90D`, `6M`, `1Y`, `All`)
  - EWMA trend visualization and summary stats
  - inline edit/delete controls for existing weigh-ins
- Added `HabitDayModal` for habit-chain interactions, with form behavior tailored to boolean, numeric, and time-based habits.
- Updated habit entry mutations so the UI can either patch an existing entry or create a new one when a past day has no entry yet, enabling retroactive backfill from the modal.
- Added dashboard-to-detail backlinks on Habits, Nutrition, and Workouts pages to support the new navigation flow.
- Reduced habit-chain circle size on mobile to prevent grid-cell overflow while preserving larger targets on larger breakpoints.

## Technical Notes

- The drill-down pattern uses an absolute `Link` overlay plus a shared indicator component, while keeping inner interactive controls above the overlay with explicit `z-index` handling. Reviewers should pay attention to focus states and nested-interaction behavior in the dashboard widgets.
- Habit-chain entries now carry richer per-day metadata (`entry`, `isScheduled`, `isFutureDate`) so the UI can distinguish completed, missed, unscheduled, and future states and decide when editing is allowed.
- `useUpdateHabitEntry` now supports both create and patch paths behind one hook. That keeps the modal logic simple, but it means cache reconciliation now has to match entries by either `id` or `(habitId, date)`.
- Weight logging uses optimistic cache updates across latest-weight, weight-list, dashboard snapshot, and dashboard trend queries; weight edits/deletes still use invalidation rather than full optimistic reconciliation. That split keeps the common add flow snappy without taking on unnecessary complexity for destructive operations.

## Commits

- `7ee2f80 fix(habits): use responsive circle sizes to prevent grid cell overflow on mobile`
- `5b7ffc8 fix(habits): allow retroactive logging on unscheduled past dates`
- `adf793c feat(habits): add habit chain day detail modal`
- `3a366f1 feat(web): add weight history management page`
- `9dec2eb feat(web): add dashboard drilldown navigation`

## Tasks

- **Make dashboard cards clickable with drill-down navigation**: Wrap dashboard cards in Links to detail pages, add hover/focus states, add navigation affordances
- **Create weight history detail page with management**: Build /weight/history page with trend chart, entry list, add/edit/delete capabilities
- **Add habit chain circle click → day-detail modal**: Add onClick to habit chain circles, create HabitDayModal with type-appropriate edit forms, wire mutations

## Diff Stats

```
.../components/dashboard-drilldown-link.tsx        |  61 ++
 .../dashboard/components/habit-chain.test.tsx      | 213 +++++--
 .../features/dashboard/components/habit-chain.tsx  | 243 +++++---
 .../dashboard/components/macro-rings.test.tsx      |  44 +-
 .../features/dashboard/components/macro-rings.tsx  |  65 +-
 .../dashboard/components/recent-workouts.tsx       |  21 +-
 .../dashboard/components/snapshot-cards.test.tsx   |  20 +-
 .../dashboard/components/snapshot-cards.tsx        | 174 ++++--
 .../dashboard/components/trend-sparkline.test.tsx  |  61 +-
 .../dashboard/components/trend-sparkline.tsx       |  53 +-
 .../dashboard/components/weight-trend-chart.tsx    |   8 +-
 apps/web/src/features/habits/api/habits.test.tsx   |  69 +++
 apps/web/src/features/habits/api/habits.ts         |  63 +-
 .../habits/components/habit-day-modal.test.tsx     | 191 ++++++
 .../features/habits/components/habit-day-modal.tsx | 402 ++++++++++++
 apps/web/src/features/weight/api/weight.test.tsx   |  74 +++
 apps/web/src/features/weight/api/weight.ts         | 111 +++-
 .../features/weight/components/weight-history.tsx  | 677 +++++++++++++++++----
 apps/web/src/pages/dashboard.test.tsx              |  11 +-
 apps/web/src/pages/dashboard.tsx                   |   9 +-
 apps/web/src/pages/habits.test.tsx                 |   1 +
 apps/web/src/pages/habits.tsx                      |  28 +-
 apps/web/src/pages/nutrition.test.tsx              |  53 +-
 apps/web/src/pages/nutrition.tsx                   |   2 +
 apps/web/src/pages/weight-history.test.tsx         | 397 ++++++------
 apps/web/src/pages/weight-history.tsx              |   5 +-
 apps/web/src/pages/workouts.test.tsx               |  31 +-
 apps/web/src/pages/workouts.tsx                    |  18 +-
 28 files changed, 2443 insertions(+), 662 deletions(-)
```