### PR TITLE
fix(api): exercise persistence, food merge, and meal item addition

### DIFF
--- a/.agents/skills/pulse-app-usage/SKILL.md
+++ b/.agents/skills/pulse-app-usage/SKILL.md
@@ -66,6 +66,57 @@ Use this skill to operate the Pulse fitness app through its agent API. This cove
 - **Log ad-hoc (one-off):** restaurant estimates, custom recipes that will not be reused, temporary experiments, uncertain approximations.
 - If unsure, prefer ad-hoc first; promote to a saved food only after repeated use.
 
+### Food Merge Workflow
+
+Use this when duplicate foods exist and one canonical record should remain.
+
+**When to use:**
+
+- Same food was created twice (name/brand variants, spelling duplicates, accidental duplicate entries).
+- You want historical meal items and usage stats consolidated under one winner food.
+
+**Request format:**
+
+```json
+POST /api/v1/foods/:winnerId/merge
+{
+  "loserId": "<food-uuid>"
+}
+```
+
+**Behavior notes:**
+
+- `winnerId` (path) and `loserId` (body) must be different.
+- Meal-item references are re-linked automatically.
+- Loser food is soft-deleted; winner usage metadata is merged.
+
+### Meal Item Addition Workflow
+
+Use this to append items to an existing meal without recreating or replacing the meal.
+
+**When to use:**
+
+- User says "add this to lunch/breakfast/dinner" after the meal already exists.
+- You need to keep existing meal metadata (`name`, `time`, `notes`) and only append new rows.
+
+**Request format:**
+
+```json
+POST /api/v1/meals/:id/items
+{
+  "items": [
+    { "foodName": "Jasmine Rice", "quantity": 1.5 },
+    { "foodName": "Chicken Breast", "quantity": 1 }
+  ]
+}
+```
+
+**Behavior notes:**
+
+- Uses the same unified item schema as `POST /api/v1/meals/`.
+- Returns the full updated meal snapshot (all items), not only appended items.
+- If any food cannot be resolved, the route returns `422 UNRESOLVED_FOODS`.
+
 ### Hydration Tracking
 
 When a meal includes water or any water-based liquid (protein shakes, electrolyte drinks, plain water, etc.), automatically log the water volume to the "Water" habit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ pnpm --filter shared build  # Build shared package
 
 ## Key Domain Notes
 
-- **Nutrition**: Meals are entered by AI agents only — no manual entry UI. The frontend is read-only for meal data. Meal summaries can be overridden or cleared via meal PATCH routes by sending `summary` (string or `null`).
+- **Nutrition**: Meals are entered by AI agents only — no manual entry UI. The frontend is read-only for meal data. Meal summaries can be overridden or cleared via meal PATCH routes by sending `summary` (string or `null`). Foods can be deduplicated with `POST /api/v1/foods/:winnerId/merge`, and existing meals can be appended without recreation via `POST /api/v1/meals/:id/items`.
 - **Workouts**: The most complex UI domain. Templates → Sessions → Sets. Active session state is server-side. Completed sessions can be corrected via `PATCH /api/v1/workout-sessions/:id/corrections` — set values (weight, reps, rpe) can be updated without changing session status or timestamps.
 - **Habits**: User-configurable with boolean/numeric/time tracking types, plus referential habits (`weight`, `nutrition_daily`, `nutrition_meal`, `workout`) that auto-resolve completion from linked data unless manually overridden. Feed into dashboard "don't break the chain" widgets.
 - **Foods**: Per-user database. `lastUsedAt` and `usageCount` are automatically maintained by the meal store layer whenever saved-food meal items are created, updated, or deleted.

--- a/apps/api/src/__tests__/foods-nutrition.test.ts
+++ b/apps/api/src/__tests__/foods-nutrition.test.ts
@@ -165,6 +165,12 @@ const decrementFoodUsageInState = (foodId: string, userId: string) => {
 };
 
 vi.mock('../routes/foods/store.js', () => ({
+  FoodMergeSameIdError: class FoodMergeSameIdError extends Error {},
+  FoodMergeNotFoundError: class FoodMergeNotFoundError extends Error {
+    constructor(public readonly foodRole: 'winner' | 'loser') {
+      super(`Merge ${foodRole} food not found`);
+    }
+  },
   createFood: vi.fn(
     async (
       input: Omit<StoredFood, 'createdAt' | 'updatedAt' | 'lastUsedAt' | 'usageCount' | 'tags'> & {
@@ -231,6 +237,14 @@ vi.mock('../routes/foods/store.js', () => ({
       };
     },
   ),
+  findFoodById: vi.fn(async (id: string, userId: string) => {
+    const existing = testState.foods.get(id);
+    if (!existing || existing.userId !== userId) {
+      return undefined;
+    }
+
+    return existing;
+  }),
   updateFood: vi.fn(async (id: string, userId: string, updates: Partial<StoredFood>) => {
     const existing = testState.foods.get(id);
     if (!existing || existing.userId !== userId) {
@@ -262,6 +276,46 @@ vi.mock('../routes/foods/store.js', () => ({
 
     testState.foods.delete(id);
     return true;
+  }),
+  mergeFoods: vi.fn(async (userId: string, winnerId: string, loserId: string) => {
+    if (winnerId === loserId) {
+      throw new Error('winnerId and loserId must be different');
+    }
+
+    const winner = testState.foods.get(winnerId);
+    const loser = testState.foods.get(loserId);
+    if (!winner || winner.userId !== userId) {
+      throw new Error('Merge winner food not found');
+    }
+    if (!loser || loser.userId !== userId) {
+      throw new Error('Merge loser food not found');
+    }
+
+    for (const [id, item] of testState.mealItems.entries()) {
+      if (item.foodId === loserId) {
+        testState.mealItems.set(id, {
+          ...item,
+          foodId: winnerId,
+        });
+      }
+    }
+
+    const mergedWinner: StoredFood = {
+      ...winner,
+      usageCount: winner.usageCount + loser.usageCount,
+      lastUsedAt:
+        winner.lastUsedAt === null
+          ? loser.lastUsedAt
+          : loser.lastUsedAt === null
+            ? winner.lastUsedAt
+            : Math.max(winner.lastUsedAt, loser.lastUsedAt),
+      updatedAt: Date.now(),
+    };
+
+    testState.foods.set(winnerId, mergedWinner);
+    testState.foods.delete(loserId);
+
+    return mergedWinner;
   }),
   trackFoodUsage: vi.fn(async (foodId: string, userId: string, lastUsedAt = Date.now()) => {
     incrementFoodUsageInState(foodId, userId, lastUsedAt);

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -115,6 +115,18 @@ describe('OpenAPI docs', () => {
         security: [{ bearerAuth: [] }, { agentToken: [] }],
       });
       expect(body.paths?.['/api/v1/meals/']?.post.requestBody).toBeTruthy();
+      expect(body.paths?.['/api/v1/foods/{winnerId}/merge']?.post).toMatchObject({
+        summary: 'Merge one food into another',
+        tags: ['foods'],
+        security: [{ bearerAuth: [] }, { agentToken: [] }],
+      });
+      expect(body.paths?.['/api/v1/foods/{winnerId}/merge']?.post.requestBody).toBeTruthy();
+      expect(body.paths?.['/api/v1/meals/{id}/items']?.post).toMatchObject({
+        summary: 'Add items to an existing meal',
+        tags: ['nutrition'],
+        security: [{ bearerAuth: [] }, { agentToken: [] }],
+      });
+      expect(body.paths?.['/api/v1/meals/{id}/items']?.post.requestBody).toBeTruthy();
 
       expect(body.paths?.['/api/v1/nutrition/{date}/summary']?.get).toMatchObject({
         summary: 'Get daily nutrition summary',

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -1055,7 +1055,7 @@ describe('exercise routes', () => {
     );
     const response = await context.app.inject({
       method: 'GET',
-      url: '/api/v1/exercises?page=1&limit=20',
+      url: '/api/v1/exercises?page=1&limit=100',
       headers: createAuthorizationHeader(authToken),
     });
     const filtersResponse = await context.app.inject({
@@ -1072,7 +1072,7 @@ describe('exercise routes', () => {
       ],
       meta: {
         page: 1,
-        limit: 20,
+        limit: 100,
         total: 2,
       },
     });
@@ -1170,7 +1170,7 @@ describe('exercise routes', () => {
     );
     const response = await context.app.inject({
       method: 'GET',
-      url: '/api/v1/exercises?page=1&limit=20',
+      url: '/api/v1/exercises?page=1&limit=100',
       headers: createAuthorizationHeader(authToken),
     });
     const filtersResponse = await context.app.inject({
@@ -1184,7 +1184,7 @@ describe('exercise routes', () => {
       data: [],
       meta: {
         page: 1,
-        limit: 20,
+        limit: 100,
         total: 0,
       },
     });

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -1345,7 +1345,10 @@ describe('exercise routes', () => {
     });
   });
 
-  it('persists formCues, coachingNotes, and instructions across patch/put read-after-write flows', async () => {
+  const createSessionToken = () =>
+    context.app.jwt.sign({ sub: 'user-1', type: 'session', iss: 'pulse-api' }, { expiresIn: '7d' });
+
+  const seedMetadataExercise = () =>
     seedExercise({
       id: 'metadata-exercise',
       userId: 'user-1',
@@ -1358,10 +1361,39 @@ describe('exercise routes', () => {
       coachingNotes: null,
     });
 
-    const authToken = context.app.jwt.sign(
-      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
-      { expiresIn: '7d' },
-    );
+  const listMetadataExercise = async (authToken: string) => {
+    const listResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises?page=1&limit=100',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(listResponse.statusCode).toBe(200);
+
+    const listPayload = listResponse.json() as {
+      data: Array<{
+        id: string;
+        name: string;
+        formCues: string[];
+        coachingNotes: string | null;
+        instructions: string | null;
+      }>;
+    };
+
+    const metadataExercise = listPayload.data.find((exercise) => exercise.id === 'metadata-exercise');
+    expect(metadataExercise).toBeDefined();
+    if (!metadataExercise) {
+      throw new Error('Expected metadata-exercise to be returned from exercise list');
+    }
+
+    return metadataExercise;
+  };
+
+  // Regression note: commit-9 confirmed no active persistence bug; these tests lock the current
+  // metadata write behavior so schema/store regressions are caught early.
+  it('persists formCues, coachingNotes, and instructions on PATCH', async () => {
+    seedMetadataExercise();
+    const authToken = createSessionToken();
 
     const patchResponse = await context.app.inject({
       method: 'PATCH',
@@ -1383,29 +1415,36 @@ describe('exercise routes', () => {
         instructions: 'Stand with feet shoulder-width apart.',
       }),
     });
+  });
 
-    const listAfterPatchResponse = await context.app.inject({
-      method: 'GET',
-      url: '/api/v1/exercises?page=1&limit=20',
+  it('returns PATCHed metadata via GET list read-back', async () => {
+    seedMetadataExercise();
+    const authToken = createSessionToken();
+
+    await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/exercises/metadata-exercise',
       headers: createAuthorizationHeader(authToken),
+      payload: {
+        formCues: ['Keep elbows tucked'],
+        coachingNotes: 'Focus on form',
+        instructions: 'Stand with feet shoulder-width apart.',
+      },
     });
 
-    expect(listAfterPatchResponse.statusCode).toBe(200);
-    const listAfterPatch = listAfterPatchResponse.json() as {
-      data: Array<{
-        id: string;
-        formCues: string[];
-        coachingNotes: string | null;
-        instructions: string | null;
-      }>;
-    };
-    expect(listAfterPatch.data.find((exercise) => exercise.id === 'metadata-exercise')).toEqual(
+    const metadataExercise = await listMetadataExercise(authToken);
+    expect(metadataExercise).toEqual(
       expect.objectContaining({
         formCues: ['Keep elbows tucked'],
         coachingNotes: 'Focus on form',
         instructions: 'Stand with feet shoulder-width apart.',
       }),
     );
+  });
+
+  it('persists formCues, coachingNotes, and instructions on PUT', async () => {
+    seedMetadataExercise();
+    const authToken = createSessionToken();
 
     const putResponse = await context.app.inject({
       method: 'PUT',
@@ -1429,29 +1468,23 @@ describe('exercise routes', () => {
         instructions: 'Sit tall and pull the handle toward your lower ribs.',
       }),
     });
+  });
 
-    const listAfterPutResponse = await context.app.inject({
-      method: 'GET',
-      url: '/api/v1/exercises?page=1&limit=20',
+  it('preserves metadata on partial PATCH and persists it to GET list read-back', async () => {
+    seedMetadataExercise();
+    const authToken = createSessionToken();
+
+    await context.app.inject({
+      method: 'PUT',
+      url: '/api/v1/exercises/metadata-exercise',
       headers: createAuthorizationHeader(authToken),
-    });
-
-    expect(listAfterPutResponse.statusCode).toBe(200);
-    const listAfterPut = listAfterPutResponse.json() as {
-      data: Array<{
-        id: string;
-        formCues: string[];
-        coachingNotes: string | null;
-        instructions: string | null;
-      }>;
-    };
-    expect(listAfterPut.data.find((exercise) => exercise.id === 'metadata-exercise')).toEqual(
-      expect.objectContaining({
+      payload: {
+        name: 'Cable Row v2',
         formCues: ['Brace core and pull elbows back'],
         coachingNotes: 'Drive elbows behind your torso',
         instructions: 'Sit tall and pull the handle toward your lower ribs.',
-      }),
-    );
+      },
+    });
 
     const patchWithoutMetadataFields = await context.app.inject({
       method: 'PATCH',
@@ -1471,6 +1504,33 @@ describe('exercise routes', () => {
         coachingNotes: 'Drive elbows behind your torso',
         instructions: 'Sit tall and pull the handle toward your lower ribs.',
       }),
+    });
+
+    const metadataExercise = await listMetadataExercise(authToken);
+    expect(metadataExercise).toEqual(
+      expect.objectContaining({
+        name: 'Cable Row v3',
+        formCues: ['Brace core and pull elbows back'],
+        coachingNotes: 'Drive elbows behind your torso',
+        instructions: 'Sit tall and pull the handle toward your lower ribs.',
+      }),
+    );
+  });
+
+  it('handles PATCH null metadata values and preserves non-null formCues', async () => {
+    seedMetadataExercise();
+    const authToken = createSessionToken();
+
+    await context.app.inject({
+      method: 'PUT',
+      url: '/api/v1/exercises/metadata-exercise',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        name: 'Cable Row v2',
+        formCues: ['Brace core and pull elbows back'],
+        coachingNotes: 'Drive elbows behind your torso',
+        instructions: 'Sit tall and pull the handle toward your lower ribs.',
+      },
     });
 
     const patchNullMetadataResponse = await context.app.inject({
@@ -1493,28 +1553,52 @@ describe('exercise routes', () => {
       }),
     });
 
-    const listAfterNullPatchResponse = await context.app.inject({
-      method: 'GET',
-      url: '/api/v1/exercises?page=1&limit=20',
-      headers: createAuthorizationHeader(authToken),
-    });
-
-    expect(listAfterNullPatchResponse.statusCode).toBe(200);
-    const listAfterNullPatch = listAfterNullPatchResponse.json() as {
-      data: Array<{
-        id: string;
-        formCues: string[];
-        coachingNotes: string | null;
-        instructions: string | null;
-      }>;
-    };
-    expect(listAfterNullPatch.data.find((exercise) => exercise.id === 'metadata-exercise')).toEqual(
+    const metadataExercise = await listMetadataExercise(authToken);
+    expect(metadataExercise).toEqual(
       expect.objectContaining({
         formCues: ['Brace core and pull elbows back'],
         coachingNotes: null,
         instructions: null,
       }),
     );
+  });
+
+  it('persists final metadata state in the database after patch/put updates', async () => {
+    seedMetadataExercise();
+    const authToken = createSessionToken();
+
+    await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/exercises/metadata-exercise',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        formCues: ['Keep elbows tucked'],
+        coachingNotes: 'Focus on form',
+        instructions: 'Stand with feet shoulder-width apart.',
+      },
+    });
+
+    await context.app.inject({
+      method: 'PUT',
+      url: '/api/v1/exercises/metadata-exercise',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        name: 'Cable Row v2',
+        formCues: ['Brace core and pull elbows back'],
+        coachingNotes: 'Drive elbows behind your torso',
+        instructions: 'Sit tall and pull the handle toward your lower ribs.',
+      },
+    });
+
+    await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/exercises/metadata-exercise',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        coachingNotes: null,
+        instructions: null,
+      },
+    });
 
     const persistedMetadata = context.db
       .select({

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -1421,7 +1421,7 @@ describe('exercise routes', () => {
     seedMetadataExercise();
     const authToken = createSessionToken();
 
-    await context.app.inject({
+    const patchResponse = await context.app.inject({
       method: 'PATCH',
       url: '/api/v1/exercises/metadata-exercise',
       headers: createAuthorizationHeader(authToken),
@@ -1431,6 +1431,7 @@ describe('exercise routes', () => {
         instructions: 'Stand with feet shoulder-width apart.',
       },
     });
+    expect(patchResponse.statusCode).toBe(200);
 
     const metadataExercise = await listMetadataExercise(authToken);
     expect(metadataExercise).toEqual(
@@ -1474,7 +1475,7 @@ describe('exercise routes', () => {
     seedMetadataExercise();
     const authToken = createSessionToken();
 
-    await context.app.inject({
+    const putResponse = await context.app.inject({
       method: 'PUT',
       url: '/api/v1/exercises/metadata-exercise',
       headers: createAuthorizationHeader(authToken),
@@ -1485,6 +1486,7 @@ describe('exercise routes', () => {
         instructions: 'Sit tall and pull the handle toward your lower ribs.',
       },
     });
+    expect(putResponse.statusCode).toBe(200);
 
     const patchWithoutMetadataFields = await context.app.inject({
       method: 'PATCH',
@@ -1521,7 +1523,7 @@ describe('exercise routes', () => {
     seedMetadataExercise();
     const authToken = createSessionToken();
 
-    await context.app.inject({
+    const putResponse = await context.app.inject({
       method: 'PUT',
       url: '/api/v1/exercises/metadata-exercise',
       headers: createAuthorizationHeader(authToken),
@@ -1532,6 +1534,7 @@ describe('exercise routes', () => {
         instructions: 'Sit tall and pull the handle toward your lower ribs.',
       },
     });
+    expect(putResponse.statusCode).toBe(200);
 
     const patchNullMetadataResponse = await context.app.inject({
       method: 'PATCH',
@@ -1567,7 +1570,7 @@ describe('exercise routes', () => {
     seedMetadataExercise();
     const authToken = createSessionToken();
 
-    await context.app.inject({
+    const patchResponse = await context.app.inject({
       method: 'PATCH',
       url: '/api/v1/exercises/metadata-exercise',
       headers: createAuthorizationHeader(authToken),
@@ -1577,8 +1580,9 @@ describe('exercise routes', () => {
         instructions: 'Stand with feet shoulder-width apart.',
       },
     });
+    expect(patchResponse.statusCode).toBe(200);
 
-    await context.app.inject({
+    const putResponse = await context.app.inject({
       method: 'PUT',
       url: '/api/v1/exercises/metadata-exercise',
       headers: createAuthorizationHeader(authToken),
@@ -1589,8 +1593,9 @@ describe('exercise routes', () => {
         instructions: 'Sit tall and pull the handle toward your lower ribs.',
       },
     });
+    expect(putResponse.statusCode).toBe(200);
 
-    await context.app.inject({
+    const patchNullMetadataResponse = await context.app.inject({
       method: 'PATCH',
       url: '/api/v1/exercises/metadata-exercise',
       headers: createAuthorizationHeader(authToken),
@@ -1599,6 +1604,7 @@ describe('exercise routes', () => {
         instructions: null,
       },
     });
+    expect(patchNullMetadataResponse.statusCode).toBe(200);
 
     const persistedMetadata = context.db
       .select({

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -1345,6 +1345,194 @@ describe('exercise routes', () => {
     });
   });
 
+  it('persists formCues, coachingNotes, and instructions across patch/put read-after-write flows', async () => {
+    seedExercise({
+      id: 'metadata-exercise',
+      userId: 'user-1',
+      name: 'Cable Row',
+      muscleGroups: ['lats'],
+      equipment: 'cable',
+      category: 'compound',
+      formCues: [],
+      instructions: null,
+      coachingNotes: null,
+    });
+
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    const patchResponse = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/exercises/metadata-exercise',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        formCues: ['Keep elbows tucked'],
+        coachingNotes: 'Focus on form',
+        instructions: 'Stand with feet shoulder-width apart.',
+      },
+    });
+
+    expect(patchResponse.statusCode).toBe(200);
+    expect(patchResponse.json()).toEqual({
+      data: expect.objectContaining({
+        id: 'metadata-exercise',
+        formCues: ['Keep elbows tucked'],
+        coachingNotes: 'Focus on form',
+        instructions: 'Stand with feet shoulder-width apart.',
+      }),
+    });
+
+    const listAfterPatchResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises?page=1&limit=20',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(listAfterPatchResponse.statusCode).toBe(200);
+    const listAfterPatch = listAfterPatchResponse.json() as {
+      data: Array<{
+        id: string;
+        formCues: string[];
+        coachingNotes: string | null;
+        instructions: string | null;
+      }>;
+    };
+    expect(listAfterPatch.data.find((exercise) => exercise.id === 'metadata-exercise')).toEqual(
+      expect.objectContaining({
+        formCues: ['Keep elbows tucked'],
+        coachingNotes: 'Focus on form',
+        instructions: 'Stand with feet shoulder-width apart.',
+      }),
+    );
+
+    const putResponse = await context.app.inject({
+      method: 'PUT',
+      url: '/api/v1/exercises/metadata-exercise',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        name: 'Cable Row v2',
+        formCues: ['Brace core and pull elbows back'],
+        coachingNotes: 'Drive elbows behind your torso',
+        instructions: 'Sit tall and pull the handle toward your lower ribs.',
+      },
+    });
+
+    expect(putResponse.statusCode).toBe(200);
+    expect(putResponse.json()).toEqual({
+      data: expect.objectContaining({
+        id: 'metadata-exercise',
+        name: 'Cable Row v2',
+        formCues: ['Brace core and pull elbows back'],
+        coachingNotes: 'Drive elbows behind your torso',
+        instructions: 'Sit tall and pull the handle toward your lower ribs.',
+      }),
+    });
+
+    const listAfterPutResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises?page=1&limit=20',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(listAfterPutResponse.statusCode).toBe(200);
+    const listAfterPut = listAfterPutResponse.json() as {
+      data: Array<{
+        id: string;
+        formCues: string[];
+        coachingNotes: string | null;
+        instructions: string | null;
+      }>;
+    };
+    expect(listAfterPut.data.find((exercise) => exercise.id === 'metadata-exercise')).toEqual(
+      expect.objectContaining({
+        formCues: ['Brace core and pull elbows back'],
+        coachingNotes: 'Drive elbows behind your torso',
+        instructions: 'Sit tall and pull the handle toward your lower ribs.',
+      }),
+    );
+
+    const patchWithoutMetadataFields = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/exercises/metadata-exercise',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        name: 'Cable Row v3',
+      },
+    });
+
+    expect(patchWithoutMetadataFields.statusCode).toBe(200);
+    expect(patchWithoutMetadataFields.json()).toEqual({
+      data: expect.objectContaining({
+        id: 'metadata-exercise',
+        name: 'Cable Row v3',
+        formCues: ['Brace core and pull elbows back'],
+        coachingNotes: 'Drive elbows behind your torso',
+        instructions: 'Sit tall and pull the handle toward your lower ribs.',
+      }),
+    });
+
+    const patchNullMetadataResponse = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/exercises/metadata-exercise',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        coachingNotes: null,
+        instructions: null,
+      },
+    });
+
+    expect(patchNullMetadataResponse.statusCode).toBe(200);
+    expect(patchNullMetadataResponse.json()).toEqual({
+      data: expect.objectContaining({
+        id: 'metadata-exercise',
+        formCues: ['Brace core and pull elbows back'],
+        coachingNotes: null,
+        instructions: null,
+      }),
+    });
+
+    const listAfterNullPatchResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises?page=1&limit=20',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(listAfterNullPatchResponse.statusCode).toBe(200);
+    const listAfterNullPatch = listAfterNullPatchResponse.json() as {
+      data: Array<{
+        id: string;
+        formCues: string[];
+        coachingNotes: string | null;
+        instructions: string | null;
+      }>;
+    };
+    expect(listAfterNullPatch.data.find((exercise) => exercise.id === 'metadata-exercise')).toEqual(
+      expect.objectContaining({
+        formCues: ['Brace core and pull elbows back'],
+        coachingNotes: null,
+        instructions: null,
+      }),
+    );
+
+    const persistedMetadata = context.db
+      .select({
+        formCues: exercises.formCues,
+        coachingNotes: exercises.coachingNotes,
+        instructions: exercises.instructions,
+      })
+      .from(exercises)
+      .where(eq(exercises.id, 'metadata-exercise'))
+      .get();
+
+    expect(persistedMetadata).toEqual({
+      formCues: ['Brace core and pull elbows back'],
+      coachingNotes: null,
+      instructions: null,
+    });
+  });
+
   it('deletes only user-specific exercises and rejects global rows', async () => {
     seedExercise({
       id: 'user-exercise',

--- a/apps/api/src/routes/foods/index.test.ts
+++ b/apps/api/src/routes/foods/index.test.ts
@@ -6,13 +6,28 @@ import {
   findUserAuthById,
   updateAgentTokenLastUsedAt,
 } from '../../middleware/store.js';
-import { createFood, deleteFood, findFoodById, listFoods, updateFood } from './store.js';
+import {
+  createFood,
+  deleteFood,
+  findFoodById,
+  FoodMergeNotFoundError,
+  listFoods,
+  mergeFoods,
+  updateFood,
+} from './store.js';
 
 vi.mock('./store.js', () => ({
+  FoodMergeSameIdError: class FoodMergeSameIdError extends Error {},
+  FoodMergeNotFoundError: class FoodMergeNotFoundError extends Error {
+    constructor(public readonly foodRole: 'winner' | 'loser') {
+      super(`Merge ${foodRole} food not found`);
+    }
+  },
   createFood: vi.fn(),
   deleteFood: vi.fn(),
   findFoodById: vi.fn(),
   listFoods: vi.fn(),
+  mergeFoods: vi.fn(),
   updateFood: vi.fn(),
 }));
 
@@ -105,6 +120,7 @@ describe('foods routes', () => {
     vi.mocked(deleteFood).mockReset();
     vi.mocked(findFoodById).mockReset();
     vi.mocked(listFoods).mockReset();
+    vi.mocked(mergeFoods).mockReset();
     vi.mocked(updateFood).mockReset();
     vi.mocked(findAgentTokenByHash).mockReset();
     vi.mocked(findUserAuthById).mockReset();
@@ -400,6 +416,13 @@ describe('foods routes', () => {
             name: 'Updated',
           },
         }),
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/foods/11111111-1111-4111-8111-111111111111/merge',
+          payload: {
+            loserId: '22222222-2222-4222-8222-222222222222',
+          },
+        }),
       ]);
 
       for (const response of requests) {
@@ -411,6 +434,151 @@ describe('foods routes', () => {
           },
         });
       }
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('merges foods and returns the updated winner food', async () => {
+    vi.mocked(mergeFoods).mockResolvedValue(
+      buildFood({
+        id: '11111111-1111-4111-8111-111111111111',
+        usageCount: 14,
+        lastUsedAt: 1_700_000_100_000,
+      }),
+    );
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/v1/foods/11111111-1111-4111-8111-111111111111/merge',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          loserId: '22222222-2222-4222-8222-222222222222',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: buildFood({
+          id: '11111111-1111-4111-8111-111111111111',
+          usageCount: 14,
+          lastUsedAt: 1_700_000_100_000,
+        }),
+      });
+      expect(vi.mocked(mergeFoods)).toHaveBeenCalledWith(
+        'user-1',
+        '11111111-1111-4111-8111-111111111111',
+        '22222222-2222-4222-8222-222222222222',
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns 400 for invalid merge requests', async () => {
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
+
+      const [sameIdResponse, invalidBodyResponse] = await Promise.all([
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/foods/11111111-1111-4111-8111-111111111111/merge',
+          headers: createAuthorizationHeader(authToken),
+          payload: {
+            loserId: '11111111-1111-4111-8111-111111111111',
+          },
+        }),
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/foods/11111111-1111-4111-8111-111111111111/merge',
+          headers: createAuthorizationHeader(authToken),
+          payload: {
+            loserId: 'food-1',
+          },
+        }),
+      ]);
+
+      expect(sameIdResponse.statusCode).toBe(400);
+      expect(sameIdResponse.json()).toEqual({
+        error: {
+          code: 'INVALID_FOOD_MERGE',
+          message: 'winnerId and loserId must be different',
+        },
+      });
+      expect(vi.mocked(mergeFoods)).not.toHaveBeenCalled();
+
+      expect(invalidBodyResponse.statusCode).toBe(400);
+      expectValidationError(invalidBodyResponse.json(), {
+        method: 'POST',
+        url: '/api/v1/foods/11111111-1111-4111-8111-111111111111/merge',
+        instancePath: '/loserId',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns 404 when either merge food cannot be found', async () => {
+    vi.mocked(mergeFoods)
+      .mockRejectedValueOnce(new FoodMergeNotFoundError('loser'))
+      .mockRejectedValueOnce(new FoodMergeNotFoundError('winner'));
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const authToken = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
+
+      const loserMissingResponse = await app.inject({
+        method: 'POST',
+        url: '/api/v1/foods/11111111-1111-4111-8111-111111111111/merge',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          loserId: '22222222-2222-4222-8222-222222222222',
+        },
+      });
+
+      const winnerMissingResponse = await app.inject({
+        method: 'POST',
+        url: '/api/v1/foods/33333333-3333-4333-8333-333333333333/merge',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          loserId: '22222222-2222-4222-8222-222222222222',
+        },
+      });
+
+      expect(loserMissingResponse.statusCode).toBe(404);
+      expect(loserMissingResponse.json()).toEqual({
+        error: {
+          code: 'FOOD_NOT_FOUND',
+          message: 'Food not found',
+        },
+      });
+
+      expect(winnerMissingResponse.statusCode).toBe(404);
+      expect(winnerMissingResponse.json()).toEqual({
+        error: {
+          code: 'FOOD_NOT_FOUND',
+          message: 'Food not found',
+        },
+      });
     } finally {
       await app.close();
     }

--- a/apps/api/src/routes/foods/index.test.ts
+++ b/apps/api/src/routes/foods/index.test.ts
@@ -10,6 +10,7 @@ import {
   createFood,
   deleteFood,
   findFoodById,
+  FoodMergeSameIdError,
   FoodMergeNotFoundError,
   listFoods,
   mergeFoods,
@@ -17,7 +18,11 @@ import {
 } from './store.js';
 
 vi.mock('./store.js', () => ({
-  FoodMergeSameIdError: class FoodMergeSameIdError extends Error {},
+  FoodMergeSameIdError: class FoodMergeSameIdError extends Error {
+    constructor() {
+      super('winnerId and loserId must be different');
+    }
+  },
   FoodMergeNotFoundError: class FoodMergeNotFoundError extends Error {
     constructor(public readonly foodRole: 'winner' | 'loser') {
       super(`Merge ${foodRole} food not found`);
@@ -484,6 +489,8 @@ describe('foods routes', () => {
   });
 
   it('returns 400 for invalid merge requests', async () => {
+    vi.mocked(mergeFoods).mockRejectedValueOnce(new FoodMergeSameIdError());
+
     const app = buildServer();
 
     try {
@@ -519,7 +526,12 @@ describe('foods routes', () => {
           message: 'winnerId and loserId must be different',
         },
       });
-      expect(vi.mocked(mergeFoods)).not.toHaveBeenCalled();
+      expect(vi.mocked(mergeFoods)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(mergeFoods)).toHaveBeenCalledWith(
+        'user-1',
+        '11111111-1111-4111-8111-111111111111',
+        '11111111-1111-4111-8111-111111111111',
+      );
 
       expect(invalidBodyResponse.statusCode).toBe(400);
       expectValidationError(invalidBodyResponse.json(), {

--- a/apps/api/src/routes/foods/index.ts
+++ b/apps/api/src/routes/foods/index.ts
@@ -6,11 +6,13 @@ import {
   createFoodInputSchema,
   foodQueryParamsSchema,
   foodSchema,
+  mergeFoodInputSchema,
   patchFoodInputSchema,
   updateFoodInputSchema,
 } from '@pulse/shared';
 import type { FastifyPluginAsync } from 'fastify';
 import { type ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
 
 import { sendError } from '../../lib/reply.js';
 import { requireAuth } from '../../middleware/auth.js';
@@ -24,13 +26,25 @@ import {
   successFlagSchema,
 } from '../../openapi.js';
 
-import { createFood, deleteFood, findFoodById, listFoods, updateFood } from './store.js';
+import {
+  createFood,
+  deleteFood,
+  findFoodById,
+  FoodMergeNotFoundError,
+  FoodMergeSameIdError,
+  listFoods,
+  mergeFoods,
+  updateFood,
+} from './store.js';
 
 const createFoodResponseSchema = apiDataResponseSchema(foodSchema);
 
 const listFoodsResponseSchema = apiPaginatedResponseSchema(foodSchema);
 
 const successResponseSchema = apiDataResponseSchema(successFlagSchema);
+const mergeFoodParamsSchema = z.object({
+  winnerId: z.string().uuid(),
+});
 
 export const foodsRoutes: FastifyPluginAsync = async (app) => {
   app.addHook('onRequest', requireAuth);
@@ -164,6 +178,57 @@ export const foodsRoutes: FastifyPluginAsync = async (app) => {
       return reply.send({
         data: food,
       });
+    },
+  );
+
+  typedApp.post(
+    '/:winnerId/merge',
+    {
+      schema: {
+        params: mergeFoodParamsSchema,
+        body: mergeFoodInputSchema,
+        response: {
+          200: apiDataResponseSchema(foodSchema),
+          400: badRequestResponseSchema,
+          401: apiErrorResponseSchema,
+          404: apiErrorResponseSchema,
+        },
+        tags: ['foods'],
+        summary: 'Merge one food into another',
+        security: authSecurity,
+      },
+    },
+    async (request, reply) => {
+      if (request.params.winnerId === request.body.loserId) {
+        return sendError(
+          reply,
+          400,
+          'INVALID_FOOD_MERGE',
+          'winnerId and loserId must be different',
+        );
+      }
+
+      try {
+        const mergedFood = await mergeFoods(
+          request.userId,
+          request.params.winnerId,
+          request.body.loserId,
+        );
+
+        return reply.send({
+          data: mergedFood,
+        });
+      } catch (error) {
+        if (error instanceof FoodMergeSameIdError) {
+          return sendError(reply, 400, 'INVALID_FOOD_MERGE', error.message);
+        }
+
+        if (error instanceof FoodMergeNotFoundError) {
+          return sendError(reply, 404, 'FOOD_NOT_FOUND', 'Food not found');
+        }
+
+        throw error;
+      }
     },
   );
 

--- a/apps/api/src/routes/foods/index.ts
+++ b/apps/api/src/routes/foods/index.ts
@@ -199,15 +199,6 @@ export const foodsRoutes: FastifyPluginAsync = async (app) => {
       },
     },
     async (request, reply) => {
-      if (request.params.winnerId === request.body.loserId) {
-        return sendError(
-          reply,
-          400,
-          'INVALID_FOOD_MERGE',
-          'winnerId and loserId must be different',
-        );
-      }
-
       try {
         const mergedFood = await mergeFoods(
           request.userId,

--- a/apps/api/src/routes/foods/store.test.ts
+++ b/apps/api/src/routes/foods/store.test.ts
@@ -23,6 +23,7 @@ const dbState = vi.hoisted(() => ({
   insertRunResult: { changes: 1 },
   updateRunResult: { changes: 1 },
   deleteRunResult: { changes: 1 },
+  transaction: vi.fn(),
   reset() {
     this.selectResults = [];
     this.selectBuilders = [];
@@ -33,6 +34,7 @@ const dbState = vi.hoisted(() => ({
     this.insertRunResult = { changes: 1 };
     this.updateRunResult = { changes: 1 };
     this.deleteRunResult = { changes: 1 };
+    this.transaction.mockClear();
   },
 }));
 
@@ -92,43 +94,83 @@ const createSelectBuilder = (result: SelectResultConfig) => {
   return builder;
 };
 
+const buildStoredFood = (
+  overrides: Partial<{
+    id: string;
+    userId: string;
+    name: string;
+    usageCount: number;
+    lastUsedAt: number | null;
+    deletedAt: string | null;
+  }> = {},
+) => ({
+  id: '11111111-1111-4111-8111-111111111111',
+  userId: 'user-1',
+  name: 'Greek Yogurt',
+  brand: null,
+  servingSize: '170 g',
+  servingGrams: 170,
+  calories: 90,
+  protein: 18,
+  carbs: 5,
+  fat: 0,
+  fiber: null,
+  sugar: 5,
+  verified: true,
+  source: null,
+  notes: null,
+  usageCount: 4,
+  tags: [],
+  lastUsedAt: 1_700_000_000_000,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_001,
+  ...overrides,
+});
+
 vi.mock('../../db/index.js', () => ({
-  db: {
-    select: vi.fn(() => createSelectBuilder(dbState.selectResults.shift() ?? {})),
-    insert: vi.fn(() => ({
-      values: vi.fn((values: unknown) => {
-        dbState.insertValues.push(values);
+  db: (() => {
+    const db = {
+      transaction: dbState.transaction,
+      select: vi.fn(() => createSelectBuilder(dbState.selectResults.shift() ?? {})),
+      insert: vi.fn(() => ({
+        values: vi.fn((values: unknown) => {
+          dbState.insertValues.push(values);
 
-        return {
-          run: vi.fn(() => dbState.insertRunResult),
-        };
-      }),
-    })),
-    update: vi.fn(() => ({
-      set: vi.fn((values: unknown) => {
-        dbState.updateSets.push(values);
+          return {
+            run: vi.fn(() => dbState.insertRunResult),
+          };
+        }),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn((values: unknown) => {
+          dbState.updateSets.push(values);
 
-        return {
-          where: vi.fn((whereClause: unknown) => {
-            dbState.updateWhereCalls.push(whereClause);
+          return {
+            where: vi.fn((whereClause: unknown) => {
+              dbState.updateWhereCalls.push(whereClause);
 
-            return {
-              run: vi.fn(() => dbState.updateRunResult),
-            };
-          }),
-        };
-      }),
-    })),
-    delete: vi.fn(() => ({
-      where: vi.fn((whereClause: unknown) => {
-        dbState.deleteWhereCalls.push(whereClause);
+              return {
+                run: vi.fn(() => dbState.updateRunResult),
+              };
+            }),
+          };
+        }),
+      })),
+      delete: vi.fn(() => ({
+        where: vi.fn((whereClause: unknown) => {
+          dbState.deleteWhereCalls.push(whereClause);
 
-        return {
-          run: vi.fn(() => dbState.deleteRunResult),
-        };
-      }),
-    })),
-  },
+          return {
+            run: vi.fn(() => dbState.deleteRunResult),
+          };
+        }),
+      })),
+    };
+
+    dbState.transaction.mockImplementation((callback: (tx: typeof db) => unknown) => callback(db));
+
+    return db;
+  })(),
 }));
 
 describe('foods store', () => {
@@ -419,5 +461,135 @@ describe('foods store', () => {
     expect(flattenSql((dbState.updateSets.at(-1) as { usageCount: unknown }).usageCount)).toContain(
       'case when usage_count > 0 then usage_count - 1 else 0 end',
     );
+  });
+
+  it('merges foods transactionally by relinking meal items, combining usage stats, and soft-deleting the loser', async () => {
+    const winnerId = '11111111-1111-4111-8111-111111111111';
+    const loserId = '22222222-2222-4222-8222-222222222222';
+    dbState.selectResults.push(
+      {
+        get: buildStoredFood({
+          id: winnerId,
+          usageCount: 4,
+          lastUsedAt: 1_700_000_100_000,
+        }),
+      },
+      {
+        get: buildStoredFood({
+          id: loserId,
+          name: 'Skyr',
+          usageCount: 7,
+          lastUsedAt: 1_700_000_400_000,
+        }),
+      },
+      {
+        get: buildStoredFood({
+          id: winnerId,
+          usageCount: 11,
+          lastUsedAt: 1_700_000_400_000,
+        }),
+      },
+    );
+
+    const { mergeFoods } = await import('./store.js');
+    const mergedWinner = await mergeFoods('user-1', winnerId, loserId);
+
+    expect(dbState.transaction).toHaveBeenCalledOnce();
+    expect(mergedWinner).toEqual(
+      expect.objectContaining({
+        id: winnerId,
+        usageCount: 11,
+        lastUsedAt: 1_700_000_400_000,
+      }),
+    );
+    expect(dbState.updateSets).toHaveLength(3);
+    expect(dbState.updateSets[0]).toEqual({
+      foodId: winnerId,
+    });
+    expect(dbState.updateSets[1]).toMatchObject({
+      usageCount: 11,
+      lastUsedAt: 1_700_000_400_000,
+      updatedAt: expect.any(Number),
+    });
+    expect(dbState.updateSets[2]).toMatchObject({
+      deletedAt: expect.any(String),
+      updatedAt: expect.any(Number),
+    });
+
+    const relinkWhereText = flattenSql(dbState.updateWhereCalls[0]);
+    expect(relinkWhereText).toContain(`food_id = ${loserId}`);
+    const winnerWhereText = flattenSql(dbState.updateWhereCalls[1]);
+    expect(winnerWhereText).toContain(`id = ${winnerId}`);
+    expect(winnerWhereText).toContain('user_id = user-1');
+    const loserWhereText = flattenSql(dbState.updateWhereCalls[2]);
+    expect(loserWhereText).toContain(`id = ${loserId}`);
+    expect(loserWhereText).toContain('user_id = user-1');
+  });
+
+  it('uses the max available lastUsedAt when merging nullable timestamps', async () => {
+    const winnerId = '11111111-1111-4111-8111-111111111111';
+    const loserId = '22222222-2222-4222-8222-222222222222';
+    dbState.selectResults.push(
+      {
+        get: buildStoredFood({
+          id: winnerId,
+          usageCount: 2,
+          lastUsedAt: null,
+        }),
+      },
+      {
+        get: buildStoredFood({
+          id: loserId,
+          usageCount: 3,
+          lastUsedAt: 1_700_000_500_000,
+        }),
+      },
+      {
+        get: buildStoredFood({
+          id: winnerId,
+          usageCount: 5,
+          lastUsedAt: 1_700_000_500_000,
+        }),
+      },
+    );
+
+    const { mergeFoods } = await import('./store.js');
+    await mergeFoods('user-1', winnerId, loserId);
+
+    expect(dbState.updateSets[1]).toMatchObject({
+      lastUsedAt: 1_700_000_500_000,
+    });
+  });
+
+  it('rejects invalid merge combinations and missing scoped foods', async () => {
+    const winnerId = '11111111-1111-4111-8111-111111111111';
+    const loserId = '22222222-2222-4222-8222-222222222222';
+    const { FoodMergeSameIdError, mergeFoods } = await import('./store.js');
+
+    await expect(mergeFoods('user-1', winnerId, winnerId)).rejects.toBeInstanceOf(
+      FoodMergeSameIdError,
+    );
+    expect(dbState.transaction).not.toHaveBeenCalled();
+
+    dbState.selectResults.push({
+      get: undefined,
+    });
+    await expect(mergeFoods('user-1', winnerId, loserId)).rejects.toMatchObject({
+      foodRole: 'winner',
+    });
+
+    dbState.selectResults.push(
+      {
+        get: buildStoredFood({
+          id: winnerId,
+        }),
+      },
+      {
+        get: undefined,
+      },
+    );
+    await expect(mergeFoods('user-1', winnerId, loserId)).rejects.toMatchObject({
+      foodRole: 'loser',
+    });
   });
 });

--- a/apps/api/src/routes/foods/store.ts
+++ b/apps/api/src/routes/foods/store.ts
@@ -8,7 +8,7 @@ import type {
   UpdateFoodInput,
 } from '@pulse/shared';
 
-import { foods } from '../../db/schema/index.js';
+import { foods, mealItems } from '../../db/schema/index.js';
 
 export type FoodRecord = Food;
 
@@ -21,6 +21,20 @@ export type FoodListResult = {
   foods: FoodRecord[];
   total: number;
 };
+
+export class FoodMergeSameIdError extends Error {
+  constructor() {
+    super('winnerId and loserId must be different');
+    this.name = 'FoodMergeSameIdError';
+  }
+}
+
+export class FoodMergeNotFoundError extends Error {
+  constructor(public readonly foodRole: 'winner' | 'loser') {
+    super(`Merge ${foodRole} food not found`);
+    this.name = 'FoodMergeNotFoundError';
+  }
+}
 
 const foodSelection = {
   id: foods.id,
@@ -395,6 +409,100 @@ export const deleteFood = async (id: string, userId: string): Promise<boolean> =
     .run();
 
   return result.changes === 1;
+};
+
+const mergeLastUsedAt = (winnerLastUsedAt: number | null, loserLastUsedAt: number | null) => {
+  if (winnerLastUsedAt === null) {
+    return loserLastUsedAt;
+  }
+
+  if (loserLastUsedAt === null) {
+    return winnerLastUsedAt;
+  }
+
+  return Math.max(winnerLastUsedAt, loserLastUsedAt);
+};
+
+export const mergeFoods = async (
+  userId: string,
+  winnerId: string,
+  loserId: string,
+): Promise<FoodRecord> => {
+  if (winnerId === loserId) {
+    throw new FoodMergeSameIdError();
+  }
+
+  const { db } = await import('../../db/index.js');
+
+  return db.transaction((tx) => {
+    const winner = tx
+      .select(foodSelection)
+      .from(foods)
+      .where(and(eq(foods.id, winnerId), eq(foods.userId, userId), isNull(foods.deletedAt)))
+      .limit(1)
+      .get();
+
+    if (!winner) {
+      throw new FoodMergeNotFoundError('winner');
+    }
+
+    const loser = tx
+      .select(foodSelection)
+      .from(foods)
+      .where(and(eq(foods.id, loserId), eq(foods.userId, userId), isNull(foods.deletedAt)))
+      .limit(1)
+      .get();
+
+    if (!loser) {
+      throw new FoodMergeNotFoundError('loser');
+    }
+
+    tx.update(mealItems).set({ foodId: winnerId }).where(eq(mealItems.foodId, loserId)).run();
+
+    const now = Date.now();
+    const updatedWinnerUsageCount = winner.usageCount + loser.usageCount;
+    const updatedWinnerLastUsedAt = mergeLastUsedAt(winner.lastUsedAt, loser.lastUsedAt);
+
+    const winnerUpdateResult = tx
+      .update(foods)
+      .set({
+        usageCount: updatedWinnerUsageCount,
+        lastUsedAt: updatedWinnerLastUsedAt,
+        updatedAt: now,
+      })
+      .where(and(eq(foods.id, winnerId), eq(foods.userId, userId), isNull(foods.deletedAt)))
+      .run();
+
+    if (winnerUpdateResult.changes !== 1) {
+      throw new Error('Failed to update winner food during merge');
+    }
+
+    const loserDeleteResult = tx
+      .update(foods)
+      .set({
+        deletedAt: new Date(now).toISOString(),
+        updatedAt: now,
+      })
+      .where(and(eq(foods.id, loserId), eq(foods.userId, userId), isNull(foods.deletedAt)))
+      .run();
+
+    if (loserDeleteResult.changes !== 1) {
+      throw new Error('Failed to soft-delete loser food during merge');
+    }
+
+    const mergedWinner = tx
+      .select(foodSelection)
+      .from(foods)
+      .where(and(eq(foods.id, winnerId), eq(foods.userId, userId), isNull(foods.deletedAt)))
+      .limit(1)
+      .get();
+
+    if (!mergedWinner) {
+      throw new Error('Failed to load merged winner food');
+    }
+
+    return mergedWinner;
+  });
 };
 
 export const trackFoodUsage = async (

--- a/apps/api/src/routes/foods/store.ts
+++ b/apps/api/src/routes/foods/store.ts
@@ -457,6 +457,7 @@ export const mergeFoods = async (
       throw new FoodMergeNotFoundError('loser');
     }
 
+    // We scope winner/loser lookup by user first; UUID food IDs are globally unique, so this relink is user-safe.
     tx.update(mealItems).set({ foodId: winnerId }).where(eq(mealItems.foodId, loserId)).run();
 
     const now = Date.now();

--- a/apps/api/src/routes/meals/index.test.ts
+++ b/apps/api/src/routes/meals/index.test.ts
@@ -12,6 +12,7 @@ import {
   createMealForDate,
   findMealById,
   findMealItemById,
+  MealFoodOwnershipError,
   patchMealById,
   patchMealItemById,
 } from '../nutrition/store.js';
@@ -269,6 +270,52 @@ describe('meal routes', () => {
         },
       });
       expect(vi.mocked(createMealForDate)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns INVALID_MEAL_ITEMS when creating a meal references foods outside user scope', async () => {
+    vi.mocked(createMealForDate).mockRejectedValue(new MealFoodOwnershipError());
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const token = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/v1/meals',
+        headers: createAuthorizationHeader(token),
+        payload: {
+          date: '2026-03-09',
+          name: 'Lunch',
+          items: [
+            {
+              foodId: 'foreign-food-id',
+              name: 'Chicken',
+              amount: 1,
+              unit: 'serving',
+              calories: 300,
+              protein: 40,
+              carbs: 0,
+              fat: 10,
+            },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(422);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'INVALID_MEAL_ITEMS',
+          message: 'One or more meal items reference unavailable foods',
+        },
+      });
+      expect(vi.mocked(createMealForDate)).toHaveBeenCalledTimes(1);
     } finally {
       await app.close();
     }
@@ -773,7 +820,7 @@ describe('meal routes', () => {
         },
       });
 
-      expect(response.statusCode).toBe(200);
+      expect(response.statusCode).toBe(201);
       expect(response.json()).toEqual({
         data: {
           meal: expect.objectContaining({ id: 'meal-1', updatedAt: 2 }),
@@ -830,6 +877,23 @@ describe('meal routes', () => {
         updatedAt: 2,
       },
       items: [
+        {
+          id: 'item-0',
+          mealId: 'meal-1',
+          foodId: null,
+          name: 'Apple',
+          amount: 1,
+          unit: 'medium',
+          displayQuantity: null,
+          displayUnit: null,
+          calories: 95,
+          protein: 0.5,
+          carbs: 25,
+          fat: 0.3,
+          fiber: null,
+          sugar: null,
+          createdAt: 0,
+        },
         {
           id: 'item-1',
           mealId: 'meal-1',
@@ -895,33 +959,31 @@ describe('meal routes', () => {
         },
       });
 
-      expect(response.statusCode).toBe(200);
-      expect(response.json()).toMatchObject({
-        data: {
-          meal: {
-            id: 'meal-1',
-            name: 'Lunch',
-          },
-          items: [
-            {
-              id: 'item-1',
-              foodId: 'food-1',
-            },
-            {
-              id: 'item-2',
-              foodId: null,
-            },
-          ],
-        },
-        agent: {
+      expect(response.statusCode).toBe(201);
+      const body = response.json();
+      expect(body.data.meal).toMatchObject({
+        id: 'meal-1',
+        name: 'Lunch',
+      });
+      expect(body.data.items).toContainEqual(expect.objectContaining({ id: 'item-0', foodId: null }));
+      expect(body.data.items).toContainEqual(
+        expect.objectContaining({ id: 'item-1', foodId: 'food-1' }),
+      );
+      expect(body.data.items).toContainEqual(expect.objectContaining({ id: 'item-2', foodId: null }));
+      expect(body.agent).toEqual(
+        expect.objectContaining({
           hints: expect.any(Array),
           suggestedActions: expect.any(Array),
           relatedState: expect.objectContaining({
             mealName: 'Lunch',
             itemCount: 2,
           }),
-        },
-      });
+        }),
+      );
+      expect(body.agent.relatedState.mealMacros.calories).toBe(515);
+      expect(body.agent.relatedState.mealMacros.protein).toBe(31.5);
+      expect(body.agent.relatedState.mealMacros.carbs).toBe(85);
+      expect(body.agent.relatedState.mealMacros.fat).toBeCloseTo(4.3, 5);
       expect(vi.mocked(addItemsToMeal)).toHaveBeenCalledWith('user-1', 'meal-1', [
         expect.objectContaining({
           foodId: 'food-1',
@@ -984,6 +1046,50 @@ describe('meal routes', () => {
         },
       });
       expect(vi.mocked(addItemsToMeal)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns INVALID_MEAL_ITEMS when appended items reference foods outside user scope', async () => {
+    vi.mocked(addItemsToMeal).mockRejectedValue(new MealFoodOwnershipError());
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const token = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/v1/meals/meal-1/items',
+        headers: createAuthorizationHeader(token),
+        payload: {
+          items: [
+            {
+              foodId: 'foreign-food-id',
+              name: 'Olive Oil',
+              amount: 1,
+              unit: 'tbsp',
+              calories: 120,
+              protein: 0,
+              carbs: 0,
+              fat: 14,
+            },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(422);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'INVALID_MEAL_ITEMS',
+          message: 'One or more meal items reference unavailable foods',
+        },
+      });
+      expect(vi.mocked(addItemsToMeal)).toHaveBeenCalledTimes(1);
     } finally {
       await app.close();
     }

--- a/apps/api/src/routes/meals/index.test.ts
+++ b/apps/api/src/routes/meals/index.test.ts
@@ -820,7 +820,7 @@ describe('meal routes', () => {
         },
       });
 
-      expect(response.statusCode).toBe(201);
+      expect(response.statusCode).toBe(200);
       expect(response.json()).toEqual({
         data: {
           meal: expect.objectContaining({ id: 'meal-1', updatedAt: 2 }),
@@ -959,7 +959,7 @@ describe('meal routes', () => {
         },
       });
 
-      expect(response.statusCode).toBe(201);
+      expect(response.statusCode).toBe(200);
       const body = response.json();
       expect(body.data.meal).toMatchObject({
         id: 'meal-1',

--- a/apps/api/src/routes/meals/index.test.ts
+++ b/apps/api/src/routes/meals/index.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../../middleware/store.js';
 import { createFood, findFoodById, findFoodByName } from '../foods/store.js';
 import {
+  addItemsToMeal,
   createMealForDate,
   findMealById,
   findMealItemById,
@@ -32,6 +33,7 @@ vi.mock('../nutrition/store.js', async () => {
     await vi.importActual<typeof import('../nutrition/store.js')>('../nutrition/store.js');
   return {
     ...actual,
+    addItemsToMeal: vi.fn(),
     createMealForDate: vi.fn(),
     findMealById: vi.fn(),
     findMealItemById: vi.fn(),
@@ -78,6 +80,7 @@ describe('meal routes', () => {
     vi.mocked(findFoodById).mockReset();
     vi.mocked(findFoodByName).mockReset();
     vi.mocked(createMealForDate).mockReset();
+    vi.mocked(addItemsToMeal).mockReset();
     vi.mocked(findMealById).mockReset();
     vi.mocked(findMealItemById).mockReset();
     vi.mocked(patchMealById).mockReset();
@@ -688,6 +691,389 @@ describe('meal routes', () => {
           }),
         ],
       });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('adds a single item to an existing meal via JWT', async () => {
+    vi.mocked(addItemsToMeal).mockResolvedValue({
+      meal: {
+        id: 'meal-1',
+        nutritionLogId: 'log-1',
+        name: 'Lunch',
+        summary: 'Chicken, Rice',
+        time: '12:30',
+        notes: null,
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      items: [
+        {
+          id: 'item-1',
+          mealId: 'meal-1',
+          foodId: 'food-1',
+          name: 'Chicken',
+          amount: 1,
+          unit: 'serving',
+          displayQuantity: null,
+          displayUnit: null,
+          calories: 300,
+          protein: 40,
+          carbs: 0,
+          fat: 10,
+          fiber: null,
+          sugar: null,
+          createdAt: 1,
+        },
+        {
+          id: 'item-2',
+          mealId: 'meal-1',
+          foodId: null,
+          name: 'Olive Oil',
+          amount: 1,
+          unit: 'tbsp',
+          displayQuantity: null,
+          displayUnit: null,
+          calories: 120,
+          protein: 0,
+          carbs: 0,
+          fat: 14,
+          fiber: null,
+          sugar: null,
+          createdAt: 2,
+        },
+      ],
+    });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const token = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/v1/meals/meal-1/items',
+        headers: createAuthorizationHeader(token),
+        payload: {
+          items: [
+            {
+              name: 'Olive Oil',
+              amount: 1,
+              unit: 'tbsp',
+              calories: 120,
+              protein: 0,
+              carbs: 0,
+              fat: 14,
+            },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        data: {
+          meal: expect.objectContaining({ id: 'meal-1', updatedAt: 2 }),
+          items: expect.arrayContaining([
+            expect.objectContaining({ id: 'item-2', name: 'Olive Oil' }),
+          ]),
+        },
+      });
+      expect(vi.mocked(addItemsToMeal)).toHaveBeenCalledWith('user-1', 'meal-1', [
+        {
+          foodId: null,
+          name: 'Olive Oil',
+          amount: 1,
+          unit: 'tbsp',
+          displayQuantity: undefined,
+          displayUnit: undefined,
+          calories: 120,
+          protein: 0,
+          carbs: 0,
+          fat: 14,
+          fiber: undefined,
+          sugar: undefined,
+        },
+      ]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('adds multiple items for agent callers and returns enrichment', async () => {
+    vi.mocked(findAgentTokenByHash).mockResolvedValue({
+      id: 'agent-token-1',
+      userId: 'user-1',
+    });
+    vi.mocked(findFoodByName).mockResolvedValue({
+      id: 'food-1',
+      name: 'Chicken Breast',
+      brand: null,
+      servingSize: 'serving',
+      calories: 120,
+      protein: 25,
+      carbs: 0,
+      fat: 2,
+    });
+    vi.mocked(addItemsToMeal).mockResolvedValue({
+      meal: {
+        id: 'meal-1',
+        nutritionLogId: 'log-1',
+        name: 'Lunch',
+        summary: 'Chicken, Rice',
+        time: '12:30',
+        notes: null,
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      items: [
+        {
+          id: 'item-1',
+          mealId: 'meal-1',
+          foodId: 'food-1',
+          name: 'Chicken Breast',
+          amount: 1,
+          unit: 'serving',
+          displayQuantity: null,
+          displayUnit: null,
+          calories: 120,
+          protein: 25,
+          carbs: 0,
+          fat: 2,
+          fiber: null,
+          sugar: null,
+          createdAt: 1,
+        },
+        {
+          id: 'item-2',
+          mealId: 'meal-1',
+          foodId: null,
+          name: 'Rice Bowl',
+          amount: 1,
+          unit: 'bowl',
+          displayQuantity: null,
+          displayUnit: null,
+          calories: 300,
+          protein: 6,
+          carbs: 60,
+          fat: 2,
+          fiber: null,
+          sugar: null,
+          createdAt: 2,
+        },
+      ],
+    });
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/v1/meals/meal-1/items',
+        headers: createAuthorizationHeader('plain-agent-token', 'AgentToken'),
+        payload: {
+          items: [
+            {
+              foodName: 'Chicken Breast',
+              quantity: 1,
+            },
+            {
+              foodName: 'Rice Bowl',
+              quantity: 1,
+              unit: 'bowl',
+              adhoc: true,
+              calories: 300,
+              protein: 6,
+              carbs: 60,
+              fat: 2,
+            },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        data: {
+          meal: {
+            id: 'meal-1',
+            name: 'Lunch',
+          },
+          items: [
+            {
+              id: 'item-1',
+              foodId: 'food-1',
+            },
+            {
+              id: 'item-2',
+              foodId: null,
+            },
+          ],
+        },
+        agent: {
+          hints: expect.any(Array),
+          suggestedActions: expect.any(Array),
+          relatedState: expect.objectContaining({
+            mealName: 'Lunch',
+            itemCount: 2,
+          }),
+        },
+      });
+      expect(vi.mocked(addItemsToMeal)).toHaveBeenCalledWith('user-1', 'meal-1', [
+        expect.objectContaining({
+          foodId: 'food-1',
+          name: 'Chicken Breast',
+          amount: 1,
+          calories: 120,
+          protein: 25,
+          carbs: 0,
+          fat: 2,
+        }),
+        expect.objectContaining({
+          foodId: null,
+          name: 'Rice Bowl',
+          amount: 1,
+          unit: 'bowl',
+          calories: 300,
+          protein: 6,
+          carbs: 60,
+          fat: 2,
+        }),
+      ]);
+      expect(vi.mocked(updateAgentTokenLastUsedAt)).toHaveBeenCalledWith('agent-token-1');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns UNRESOLVED_FOODS when appended items cannot be resolved', async () => {
+    vi.mocked(findFoodById).mockResolvedValue(undefined);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const token = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/v1/meals/meal-1/items',
+        headers: createAuthorizationHeader(token),
+        payload: {
+          items: [
+            {
+              foodId: 'food-404',
+              name: 'Chicken breast (grilled)',
+              amount: 1,
+              unit: 'serving',
+            },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(422);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'UNRESOLVED_FOODS',
+          message: 'Could not find foods: Chicken breast (grilled)',
+        },
+      });
+      expect(vi.mocked(addItemsToMeal)).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns 404 when appending items to a missing meal', async () => {
+    vi.mocked(addItemsToMeal).mockResolvedValue(undefined);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const token = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/v1/meals/missing-meal/items',
+        headers: createAuthorizationHeader(token),
+        payload: {
+          items: [
+            {
+              name: 'Olive Oil',
+              amount: 1,
+              unit: 'tbsp',
+              calories: 120,
+              protein: 0,
+              carbs: 0,
+              fat: 14,
+            },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'MEAL_NOT_FOUND',
+          message: 'Meal not found',
+        },
+      });
+      expect(vi.mocked(addItemsToMeal)).toHaveBeenCalledWith(
+        'user-1',
+        'missing-meal',
+        expect.any(Array),
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns 404 when appending items to a meal owned by a different user', async () => {
+    vi.mocked(addItemsToMeal).mockResolvedValue(undefined);
+
+    const app = buildServer();
+
+    try {
+      await app.ready();
+      const token = app.jwt.sign(
+        { sub: 'user-2', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/v1/meals/meal-1/items',
+        headers: createAuthorizationHeader(token),
+        payload: {
+          items: [
+            {
+              name: 'Olive Oil',
+              amount: 1,
+              unit: 'tbsp',
+              calories: 120,
+              protein: 0,
+              carbs: 0,
+              fat: 14,
+            },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'MEAL_NOT_FOUND',
+          message: 'Meal not found',
+        },
+      });
+      expect(vi.mocked(addItemsToMeal)).toHaveBeenCalledWith('user-2', 'meal-1', expect.any(Array));
     } finally {
       await app.close();
     }

--- a/apps/api/src/routes/meals/index.ts
+++ b/apps/api/src/routes/meals/index.ts
@@ -257,7 +257,7 @@ export const mealRoutes: FastifyPluginAsync = async (app) => {
         params: idParamsSchema,
         body: addMealItemsInputSchema,
         response: {
-          201: apiDataResponseSchema(dailyNutritionMealSchema),
+          200: apiDataResponseSchema(dailyNutritionMealSchema),
           400: badRequestResponseSchema,
           401: apiErrorResponseSchema,
           404: apiErrorResponseSchema,
@@ -313,7 +313,7 @@ export const mealRoutes: FastifyPluginAsync = async (app) => {
         mealMacros,
       });
 
-      return reply.code(201).send({
+      return reply.code(200).send({
         data: updatedMeal,
       });
     },

--- a/apps/api/src/routes/meals/index.ts
+++ b/apps/api/src/routes/meals/index.ts
@@ -29,6 +29,7 @@ import {
   createMealForDate,
   findMealById,
   findMealItemById,
+  MealFoodOwnershipError,
   patchMealById,
   patchMealItemById,
 } from '../nutrition/store.js';
@@ -51,6 +52,20 @@ type PersistedMealCreateItem = {
 
 const MAX_MEAL_SUMMARY_LENGTH = 500;
 const SUMMARY_ELLIPSIS = '...';
+const INVALID_MEAL_ITEMS_MESSAGE = 'One or more meal items reference unavailable foods';
+
+const sumMealMacros = (
+  items: Array<{ calories: number; protein: number; carbs: number; fat: number }>,
+) =>
+  items.reduce(
+    (totals, item) => ({
+      calories: totals.calories + item.calories,
+      protein: totals.protein + item.protein,
+      carbs: totals.carbs + item.carbs,
+      fat: totals.fat + item.fat,
+    }),
+    { calories: 0, protein: 0, carbs: 0, fat: 0 },
+  );
 
 const buildMealSummary = (names: string[], maxLength: number) => {
   let summary = '';
@@ -200,23 +215,24 @@ export const mealRoutes: FastifyPluginAsync = async (app) => {
               )
             : undefined;
 
-      const created = await createMealForDate(request.userId, request.body.date, {
-        name: request.body.name,
-        summary,
-        time: request.body.time,
-        notes: request.body.notes,
-        items: resolvedItems,
-      });
+      let created: Awaited<ReturnType<typeof createMealForDate>>;
+      try {
+        created = await createMealForDate(request.userId, request.body.date, {
+          name: request.body.name,
+          summary,
+          time: request.body.time,
+          notes: request.body.notes,
+          items: resolvedItems,
+        });
+      } catch (error) {
+        if (error instanceof MealFoodOwnershipError) {
+          return sendError(reply, 422, 'INVALID_MEAL_ITEMS', INVALID_MEAL_ITEMS_MESSAGE);
+        }
 
-      const mealMacros = created.items.reduce(
-        (totals, item) => ({
-          calories: totals.calories + item.calories,
-          protein: totals.protein + item.protein,
-          carbs: totals.carbs + item.carbs,
-          fat: totals.fat + item.fat,
-        }),
-        { calories: 0, protein: 0, carbs: 0, fat: 0 },
-      );
+        throw error;
+      }
+
+      const mealMacros = sumMealMacros(created.items);
 
       setAgentEnrichmentContext(request, {
         endpoint: 'meal.create',
@@ -241,7 +257,7 @@ export const mealRoutes: FastifyPluginAsync = async (app) => {
         params: idParamsSchema,
         body: addMealItemsInputSchema,
         response: {
-          200: apiDataResponseSchema(dailyNutritionMealSchema),
+          201: apiDataResponseSchema(dailyNutritionMealSchema),
           400: badRequestResponseSchema,
           401: apiErrorResponseSchema,
           404: apiErrorResponseSchema,
@@ -273,29 +289,31 @@ export const mealRoutes: FastifyPluginAsync = async (app) => {
         .filter((result): result is { ok: true; item: PersistedMealCreateItem } => result.ok)
         .map((result) => result.item);
 
-      const updatedMeal = await addItemsToMeal(request.userId, request.params.id, resolvedItems);
+      let updatedMeal: Awaited<ReturnType<typeof addItemsToMeal>>;
+      try {
+        updatedMeal = await addItemsToMeal(request.userId, request.params.id, resolvedItems);
+      } catch (error) {
+        if (error instanceof MealFoodOwnershipError) {
+          return sendError(reply, 422, 'INVALID_MEAL_ITEMS', INVALID_MEAL_ITEMS_MESSAGE);
+        }
+
+        throw error;
+      }
+
       if (!updatedMeal) {
         return sendError(reply, 404, 'MEAL_NOT_FOUND', 'Meal not found');
       }
 
-      const addedItemMacros = resolvedItems.reduce(
-        (totals, item) => ({
-          calories: totals.calories + item.calories,
-          protein: totals.protein + item.protein,
-          carbs: totals.carbs + item.carbs,
-          fat: totals.fat + item.fat,
-        }),
-        { calories: 0, protein: 0, carbs: 0, fat: 0 },
-      );
+      const mealMacros = sumMealMacros(updatedMeal.items);
 
       setAgentEnrichmentContext(request, {
         endpoint: 'meal.update',
         mealName: updatedMeal.meal.name,
         itemCount: resolvedItems.length,
-        mealMacros: addedItemMacros,
+        mealMacros,
       });
 
-      return reply.send({
+      return reply.code(201).send({
         data: updatedMeal,
       });
     },

--- a/apps/api/src/routes/meals/index.ts
+++ b/apps/api/src/routes/meals/index.ts
@@ -1,4 +1,5 @@
 import {
+  addMealItemsInputSchema,
   apiDataResponseSchema,
   createMealForDateInputSchema,
   type CreateMealForDateInput,
@@ -24,6 +25,7 @@ import {
 } from '../../openapi.js';
 import { findFoodById } from '../foods/store.js';
 import {
+  addItemsToMeal,
   createMealForDate,
   findMealById,
   findMealItemById,
@@ -226,6 +228,75 @@ export const mealRoutes: FastifyPluginAsync = async (app) => {
 
       return reply.code(201).send({
         data: created,
+      });
+    },
+  );
+
+  typedApp.post(
+    '/:id/items',
+    {
+      preHandler: agentRequestTransform,
+      onSend: agentEnrichmentOnSend,
+      schema: {
+        params: idParamsSchema,
+        body: addMealItemsInputSchema,
+        response: {
+          200: apiDataResponseSchema(dailyNutritionMealSchema),
+          400: badRequestResponseSchema,
+          401: apiErrorResponseSchema,
+          404: apiErrorResponseSchema,
+          422: apiErrorResponseSchema,
+        },
+        tags: ['nutrition'],
+        summary: 'Add items to an existing meal',
+        security: authSecurity,
+      },
+    },
+    async (request, reply) => {
+      const normalizedItems = await Promise.all(
+        request.body.items.map((item) => normalizeMealItemForCreate(item, request.userId)),
+      );
+      const unresolvedFoods = normalizedItems
+        .filter((result): result is { ok: false; unresolvedName: string } => !result.ok)
+        .map((result) => result.unresolvedName);
+
+      if (unresolvedFoods.length > 0) {
+        return sendError(
+          reply,
+          422,
+          'UNRESOLVED_FOODS',
+          `Could not find foods: ${unresolvedFoods.join(', ')}`,
+        );
+      }
+
+      const resolvedItems = normalizedItems
+        .filter((result): result is { ok: true; item: PersistedMealCreateItem } => result.ok)
+        .map((result) => result.item);
+
+      const updatedMeal = await addItemsToMeal(request.userId, request.params.id, resolvedItems);
+      if (!updatedMeal) {
+        return sendError(reply, 404, 'MEAL_NOT_FOUND', 'Meal not found');
+      }
+
+      const addedItemMacros = resolvedItems.reduce(
+        (totals, item) => ({
+          calories: totals.calories + item.calories,
+          protein: totals.protein + item.protein,
+          carbs: totals.carbs + item.carbs,
+          fat: totals.fat + item.fat,
+        }),
+        { calories: 0, protein: 0, carbs: 0, fat: 0 },
+      );
+
+      setAgentEnrichmentContext(request, {
+        endpoint: 'meal.update',
+        mealName: updatedMeal.meal.name,
+        itemCount: resolvedItems.length,
+        mealMacros: addedItemMacros,
+      });
+
+      return reply.send({
+        data: updatedMeal,
       });
     },
   );

--- a/apps/api/src/routes/nutrition/store.food-usage.test.ts
+++ b/apps/api/src/routes/nutrition/store.food-usage.test.ts
@@ -122,6 +122,110 @@ const createTxForMealInsert = (returnedItems: Array<Record<string, unknown>>) =>
   };
 };
 
+const createTxForAddMealItems = (options: {
+  mealExists?: boolean;
+  insertedItems: Array<Record<string, unknown>>;
+  allMealItems: Array<Record<string, unknown>>;
+  updatedAt?: number;
+}) => {
+  const mealExists = options.mealExists ?? true;
+  const existingMeal = mealExists
+    ? {
+        id: 'meal-1',
+        nutritionLogId: 'log-1',
+        name: 'Lunch',
+        summary: null,
+        time: null,
+        notes: null,
+        createdAt: 2,
+        updatedAt: 2,
+      }
+    : undefined;
+  const ownedFoodsAll = vi.fn(() =>
+    options.insertedItems
+      .map((item) => item.foodId)
+      .filter((foodId): foodId is string => typeof foodId === 'string')
+      .filter((foodId, index, foodIds) => foodIds.indexOf(foodId) === index)
+      .map((id) => ({ id })),
+  );
+  const insertedMealItemsAll = vi.fn(() => options.insertedItems);
+  const allMealItemsAll = vi.fn(() => options.allMealItems);
+  const getUpdatedMeal = vi.fn(() =>
+    existingMeal
+      ? {
+          ...existingMeal,
+          updatedAt: options.updatedAt ?? 3,
+        }
+      : undefined,
+  );
+
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn((table) => {
+        if (getTableName(table) === 'meals') {
+          return {
+            innerJoin: vi.fn(() => ({
+              where: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  get: vi.fn(() => existingMeal),
+                })),
+              })),
+            })),
+          };
+        }
+
+        if (getTableName(table) === 'foods') {
+          return {
+            where: vi.fn(() => ({
+              all: ownedFoodsAll,
+            })),
+          };
+        }
+
+        if (getTableName(table) === 'meal_items') {
+          return {
+            where: vi.fn(() => ({
+              orderBy: vi.fn(() => ({
+                all: allMealItemsAll,
+              })),
+            })),
+          };
+        }
+
+        throw new Error(`Unexpected select table: ${String(table)}`);
+      }),
+    })),
+    insert: vi.fn((table) => {
+      if (getTableName(table) === 'meal_items') {
+        return {
+          values: vi.fn(() => ({
+            returning: vi.fn(() => ({
+              all: insertedMealItemsAll,
+            })),
+          })),
+        };
+      }
+
+      throw new Error(`Unexpected insert table: ${String(table)}`);
+    }),
+    update: vi.fn((table) => {
+      if (getTableName(table) === 'meals') {
+        return {
+          set: vi.fn(() => ({
+            where: vi.fn(() => ({
+              returning: vi.fn(() => ({
+                get: getUpdatedMeal,
+              })),
+            })),
+          })),
+        };
+      }
+
+      throw new Error(`Unexpected update table: ${String(table)}`);
+    }),
+  };
+};
+
 const createTxForMealDelete = (
   options: { exists?: boolean; foodIds?: Array<string | null> } = {},
 ) => {
@@ -342,6 +446,182 @@ describe('nutrition store food usage tracking', () => {
       ],
     });
 
+    expect(testState.trackFoodUsage).not.toHaveBeenCalled();
+    expect(testState.decrementFoodUsage).not.toHaveBeenCalled();
+  });
+
+  it('appends items to an existing meal, refreshes updatedAt, and tracks saved foods', async () => {
+    testState.db.transaction.mockImplementation(
+      (callback: (tx: ReturnType<typeof createTxForAddMealItems>) => unknown) =>
+        callback(
+          createTxForAddMealItems({
+            updatedAt: 10,
+            insertedItems: [
+              {
+                id: 'item-2',
+                mealId: 'meal-1',
+                foodId: 'food-2',
+                name: 'Rice',
+                amount: 1,
+                unit: 'cup',
+                displayQuantity: null,
+                displayUnit: null,
+                calories: 200,
+                protein: 4,
+                carbs: 45,
+                fat: 1,
+                fiber: null,
+                sugar: null,
+                createdAt: 4,
+              },
+              {
+                id: 'item-3',
+                mealId: 'meal-1',
+                foodId: null,
+                name: 'Olive Oil',
+                amount: 1,
+                unit: 'tbsp',
+                displayQuantity: null,
+                displayUnit: null,
+                calories: 120,
+                protein: 0,
+                carbs: 0,
+                fat: 14,
+                fiber: null,
+                sugar: null,
+                createdAt: 5,
+              },
+            ],
+            allMealItems: [
+              {
+                id: 'item-1',
+                mealId: 'meal-1',
+                foodId: 'food-1',
+                name: 'Chicken',
+                amount: 1,
+                unit: 'serving',
+                displayQuantity: null,
+                displayUnit: null,
+                calories: 300,
+                protein: 40,
+                carbs: 0,
+                fat: 10,
+                fiber: null,
+                sugar: null,
+                createdAt: 3,
+              },
+              {
+                id: 'item-2',
+                mealId: 'meal-1',
+                foodId: 'food-2',
+                name: 'Rice',
+                amount: 1,
+                unit: 'cup',
+                displayQuantity: null,
+                displayUnit: null,
+                calories: 200,
+                protein: 4,
+                carbs: 45,
+                fat: 1,
+                fiber: null,
+                sugar: null,
+                createdAt: 4,
+              },
+              {
+                id: 'item-3',
+                mealId: 'meal-1',
+                foodId: null,
+                name: 'Olive Oil',
+                amount: 1,
+                unit: 'tbsp',
+                displayQuantity: null,
+                displayUnit: null,
+                calories: 120,
+                protein: 0,
+                carbs: 0,
+                fat: 14,
+                fiber: null,
+                sugar: null,
+                createdAt: 5,
+              },
+            ],
+          }),
+        ),
+    );
+
+    const { addItemsToMeal } = await import('./store.js');
+    const updated = await addItemsToMeal('user-1', 'meal-1', [
+      {
+        foodId: 'food-2',
+        name: 'Rice',
+        amount: 1,
+        unit: 'cup',
+        calories: 200,
+        protein: 4,
+        carbs: 45,
+        fat: 1,
+      },
+      {
+        foodId: null,
+        name: 'Olive Oil',
+        amount: 1,
+        unit: 'tbsp',
+        calories: 120,
+        protein: 0,
+        carbs: 0,
+        fat: 14,
+      },
+    ]);
+
+    expect(updated).toBeDefined();
+    expect(updated?.meal.updatedAt).toBe(10);
+    expect(updated?.items).toHaveLength(3);
+    const macroTotals = updated?.items.reduce(
+      (totals, item) => ({
+        calories: totals.calories + item.calories,
+        protein: totals.protein + item.protein,
+        carbs: totals.carbs + item.carbs,
+        fat: totals.fat + item.fat,
+      }),
+      { calories: 0, protein: 0, carbs: 0, fat: 0 },
+    );
+    expect(macroTotals).toEqual({
+      calories: 620,
+      protein: 44,
+      carbs: 45,
+      fat: 25,
+    });
+    expect(testState.trackFoodUsage).toHaveBeenCalledTimes(1);
+    expect(testState.trackFoodUsage).toHaveBeenCalledWith('food-2', 'user-1');
+    expect(testState.decrementFoodUsage).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when appending items to a missing meal', async () => {
+    testState.db.transaction.mockImplementation(
+      (callback: (tx: ReturnType<typeof createTxForAddMealItems>) => unknown) =>
+        callback(
+          createTxForAddMealItems({
+            mealExists: false,
+            insertedItems: [],
+            allMealItems: [],
+          }),
+        ),
+    );
+
+    const { addItemsToMeal } = await import('./store.js');
+    const updated = await addItemsToMeal('user-1', 'missing-meal', [
+      {
+        name: 'Olive Oil',
+        amount: 1,
+        unit: 'tbsp',
+        calories: 120,
+        protein: 0,
+        carbs: 0,
+        fat: 14,
+      },
+    ]);
+
+    expect(updated).toBeUndefined();
     expect(testState.trackFoodUsage).not.toHaveBeenCalled();
     expect(testState.decrementFoodUsage).not.toHaveBeenCalled();
   });

--- a/apps/api/src/routes/nutrition/store.ts
+++ b/apps/api/src/routes/nutrition/store.ts
@@ -90,6 +90,13 @@ type MealInputItemWithMacros = CreateMealInput['items'][number] & {
   fat: number;
 };
 
+export class MealFoodOwnershipError extends Error {
+  constructor() {
+    super('One or more foodIds do not belong to this user');
+    this.name = 'MealFoodOwnershipError';
+  }
+}
+
 const nutritionLogSelection = {
   id: nutritionLogs.id,
   userId: nutritionLogs.userId,
@@ -312,7 +319,7 @@ export const createMealForDate = async (
         .all();
 
       if (ownedFoods.length !== foodIds.length) {
-        throw new Error('One or more foodIds do not belong to this user');
+        throw new MealFoodOwnershipError();
       }
     }
 
@@ -677,7 +684,7 @@ export const addItemsToMeal = async (
         .all();
 
       if (ownedFoods.length !== foodIds.length) {
-        throw new Error('One or more foodIds do not belong to this user');
+        throw new MealFoodOwnershipError();
       }
     }
 

--- a/apps/api/src/routes/nutrition/store.ts
+++ b/apps/api/src/routes/nutrition/store.ts
@@ -631,6 +631,118 @@ export const findMealById = async (
     .get();
 };
 
+export const addItemsToMeal = async (
+  userId: string,
+  mealId: string,
+  items: MealInputItemWithMacros[],
+): Promise<{ meal: MealRecord; items: MealItemRecord[] } | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  const now = Date.now();
+  const updated = db.transaction((tx) => {
+    const meal = tx
+      .select(mealSelection)
+      .from(meals)
+      .innerJoin(nutritionLogs, eq(nutritionLogs.id, meals.nutritionLogId))
+      .where(and(eq(meals.id, mealId), eq(nutritionLogs.userId, userId)))
+      .limit(1)
+      .get();
+
+    if (!meal) {
+      return undefined;
+    }
+
+    const itemValues = items.map((item) => ({
+      mealId: meal.id,
+      foodId: toNullable(item.foodId),
+      name: item.name,
+      amount: item.amount,
+      unit: item.unit,
+      displayQuantity: toNullable(item.displayQuantity),
+      displayUnit: toNullable(item.displayUnit),
+      calories: item.calories,
+      protein: item.protein,
+      carbs: item.carbs,
+      fat: item.fat,
+      fiber: toNullable(item.fiber),
+      sugar: toNullable(item.sugar),
+    }));
+
+    const foodIds = [...new Set(itemValues.map((item) => item.foodId).filter(isTrackedFoodId))];
+    if (foodIds.length > 0) {
+      const ownedFoods = tx
+        .select({ id: foods.id })
+        .from(foods)
+        .where(and(inArray(foods.id, foodIds), eq(foods.userId, userId)))
+        .all();
+
+      if (ownedFoods.length !== foodIds.length) {
+        throw new Error('One or more foodIds do not belong to this user');
+      }
+    }
+
+    const insertedItems = tx
+      .insert(mealItems)
+      .values(itemValues)
+      .returning(mealItemSelection)
+      .all();
+
+    if (insertedItems.length !== items.length) {
+      throw new Error('Failed to persist meal items');
+    }
+
+    const updatedMeal = tx
+      .update(meals)
+      .set({
+        updatedAt: now,
+      })
+      .where(eq(meals.id, meal.id))
+      .returning(mealSelection)
+      .get();
+
+    if (!updatedMeal) {
+      throw new Error('Failed to persist meal update');
+    }
+
+    const allItems = tx
+      .select(mealItemSelection)
+      .from(mealItems)
+      .where(eq(mealItems.mealId, meal.id))
+      .orderBy(asc(mealItems.createdAt))
+      .all();
+
+    return {
+      meal: updatedMeal,
+      items: allItems,
+      insertedItems,
+    };
+  });
+
+  if (!updated) {
+    return undefined;
+  }
+
+  await applyFoodUsageTrackingEffects(
+    userId,
+    updated.insertedItems.flatMap((item) =>
+      isTrackedFoodId(item.foodId)
+        ? [
+            {
+              action: 'increment' as const,
+              foodId: item.foodId,
+            },
+          ]
+        : [],
+    ),
+    'meal item append',
+  );
+
+  return {
+    meal: updated.meal,
+    items: updated.items,
+  };
+};
+
 export const patchMealById = async (
   userId: string,
   mealId: string,

--- a/apps/api/src/routes/nutrition/store.ts
+++ b/apps/api/src/routes/nutrition/store.ts
@@ -1,4 +1,4 @@
-import { and, asc, between, desc, eq, inArray, lte, sql } from 'drizzle-orm';
+import { and, asc, between, desc, eq, inArray, isNull, lte, sql } from 'drizzle-orm';
 
 import type {
   CreateMealInput,
@@ -315,7 +315,7 @@ export const createMealForDate = async (
       const ownedFoods = tx
         .select({ id: foods.id })
         .from(foods)
-        .where(and(inArray(foods.id, foodIds), eq(foods.userId, userId)))
+        .where(and(inArray(foods.id, foodIds), eq(foods.userId, userId), isNull(foods.deletedAt)))
         .all();
 
       if (ownedFoods.length !== foodIds.length) {
@@ -646,7 +646,16 @@ export const addItemsToMeal = async (
   const { db } = await import('../../db/index.js');
 
   const now = Date.now();
-  const updated = db.transaction((tx) => {
+  type AddItemsToMealTransactionResult =
+    | {
+        meal: MealRecord;
+        items: MealItemRecord[];
+        // Carry newly inserted items outside the transaction for usage tracking side effects.
+        insertedItems: MealItemRecord[];
+      }
+    | undefined;
+
+  const updated: AddItemsToMealTransactionResult = db.transaction((tx) => {
     const meal = tx
       .select(mealSelection)
       .from(meals)
@@ -680,7 +689,7 @@ export const addItemsToMeal = async (
       const ownedFoods = tx
         .select({ id: foods.id })
         .from(foods)
-        .where(and(inArray(foods.id, foodIds), eq(foods.userId, userId)))
+        .where(and(inArray(foods.id, foodIds), eq(foods.userId, userId), isNull(foods.deletedAt)))
         .all();
 
       if (ownedFoods.length !== foodIds.length) {

--- a/docs/conventions/agent-integration.md
+++ b/docs/conventions/agent-integration.md
@@ -180,6 +180,36 @@ Searches user foods by name or brand and returns the standard paginated envelope
 
 Creates a user-scoped food entry.
 
+#### `POST /api/v1/foods/:winnerId/merge`
+
+Merges a duplicate food into a keeper food. The API re-links historical meal items from `loserId` to `winnerId`, combines usage metadata, and soft-deletes the loser food.
+
+Request:
+
+```json
+{
+  "loserId": "22222222-2222-4222-8222-222222222222"
+}
+```
+
+Response (`200`):
+
+```json
+{
+  "data": {
+    "id": "11111111-1111-4111-8111-111111111111",
+    "name": "Chicken Breast",
+    "usageCount": 84,
+    "lastUsedAt": 1760000000000
+  }
+}
+```
+
+Error notes:
+
+- `400 INVALID_FOOD_MERGE` when `winnerId === loserId`
+- `404 FOOD_NOT_FOUND` when either food is missing or not user-accessible
+
 #### `POST /api/v1/meals`
 
 Logs a meal for a date from food-name references. Under AgentToken auth:
@@ -235,6 +265,50 @@ Response (`201`):
   }
 }
 ```
+
+#### `POST /api/v1/meals/:id/items`
+
+Appends one or more items to an existing meal without recreating the meal record. Item inputs follow the same unified schema used by meal creation (saved-food or ad-hoc modes).
+
+Request:
+
+```json
+{
+  "items": [{ "foodName": "Jasmine Rice", "quantity": 1.5 }]
+}
+```
+
+Response (`201`):
+
+```json
+{
+  "data": {
+    "meal": {
+      "id": "meal-1",
+      "name": "Lunch"
+    },
+    "items": [
+      {
+        "id": "item-1",
+        "name": "Chicken Breast",
+        "amount": 2,
+        "unit": "serving"
+      },
+      {
+        "id": "item-2",
+        "name": "Jasmine Rice",
+        "amount": 1.5,
+        "unit": "serving"
+      }
+    ]
+  }
+}
+```
+
+Notes:
+
+- Response includes the full updated meal snapshot (all meal items), not only newly appended items.
+- Returns `404 MEAL_NOT_FOUND` if the meal does not exist for the authenticated user.
 
 ### Exercises And Workouts
 

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from 'vitest';
 
-import { type User, userSchema } from "./index";
+import { addMealItemsInputSchema, mergeFoodInputSchema, type User, userSchema } from './index';
 
 describe("userSchema", () => {
   it("parses a valid user object", () => {
@@ -26,5 +26,37 @@ describe("userSchema", () => {
     };
 
     expect(user.name).toBe("Pulse");
+  });
+});
+
+describe('shared schema exports', () => {
+  it('exports mergeFoodInputSchema from package root', () => {
+    const payload = mergeFoodInputSchema.parse({
+      loserId: '22222222-2222-4222-8222-222222222222',
+    });
+
+    expect(payload.loserId).toBe('22222222-2222-4222-8222-222222222222');
+  });
+
+  it('exports addMealItemsInputSchema from package root', () => {
+    const payload = addMealItemsInputSchema.parse({
+      items: [
+        {
+          foodName: 'Chicken Breast',
+          quantity: 1,
+          calories: 165,
+          protein: 31,
+          carbs: 0,
+          fat: 3.6,
+        },
+      ],
+    });
+
+    expect(payload.items).toHaveLength(1);
+    expect(payload.items[0]).toMatchObject({
+      name: 'Chicken Breast',
+      amount: 1,
+      unit: 'serving',
+    });
   });
 });

--- a/packages/shared/src/schemas/foods.test.ts
+++ b/packages/shared/src/schemas/foods.test.ts
@@ -6,8 +6,10 @@ import {
   foodSchema,
   type Food,
   type FoodQueryParams,
+  type MergeFoodInput,
   type PatchFoodInput,
   type UpdateFoodInput,
+  mergeFoodInputSchema,
   patchFoodInputSchema,
   updateFoodInputSchema,
 } from './foods';
@@ -243,6 +245,26 @@ describe('foodQueryParamsSchema', () => {
       foodQueryParamsSchema.parse({
         sort: 'calories',
         page: '0',
+      }),
+    ).toThrow();
+  });
+});
+
+describe('mergeFoodInputSchema', () => {
+  it('accepts uuid loserId', () => {
+    const payload: MergeFoodInput = mergeFoodInputSchema.parse({
+      loserId: '11111111-1111-4111-8111-111111111111',
+    });
+
+    expect(payload).toEqual({
+      loserId: '11111111-1111-4111-8111-111111111111',
+    });
+  });
+
+  it('rejects invalid loserId values', () => {
+    expect(() =>
+      mergeFoodInputSchema.parse({
+        loserId: 'food-1',
       }),
     ).toThrow();
   });

--- a/packages/shared/src/schemas/foods.ts
+++ b/packages/shared/src/schemas/foods.ts
@@ -116,6 +116,10 @@ export const updateFoodInputSchema = foodMutationFieldsSchema
 
 export const patchFoodInputSchema = updateFoodInputSchema;
 
+export const mergeFoodInputSchema = z.object({
+  loserId: z.string().uuid(),
+});
+
 export const foodQueryParamsSchema = z.object({
   q: optionalQueryText,
   tags: optionalQueryTags,
@@ -129,4 +133,5 @@ export type FoodSort = z.infer<typeof foodSortSchema>;
 export type CreateFoodInput = z.infer<typeof createFoodInputSchema>;
 export type UpdateFoodInput = z.infer<typeof updateFoodInputSchema>;
 export type PatchFoodInput = z.infer<typeof patchFoodInputSchema>;
+export type MergeFoodInput = z.infer<typeof mergeFoodInputSchema>;
 export type FoodQueryParams = z.infer<typeof foodQueryParamsSchema>;

--- a/packages/shared/src/schemas/nutrition.test.ts
+++ b/packages/shared/src/schemas/nutrition.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  type AddMealItemsInput,
   type CreateMealInput,
   type CreateMealForDateInput,
   type DailyNutrition,
@@ -10,6 +11,7 @@ import {
   type PatchMealItemInput,
   type NutritionSummary,
   type NutritionWeekSummary,
+  addMealItemsInputSchema,
   createMealInputSchema,
   createMealForDateInputSchema,
   dailyNutritionSchema,
@@ -366,6 +368,46 @@ describe('createMealForDateInputSchema', () => {
             fat: 1,
           },
         ],
+      }),
+    ).toThrow();
+  });
+});
+
+describe('addMealItemsInputSchema', () => {
+  it('parses a valid add-items payload', () => {
+    const payload: AddMealItemsInput = addMealItemsInputSchema.parse({
+      items: [
+        {
+          foodName: 'Greek Yogurt',
+          quantity: 2,
+          calories: 120,
+          protein: 15,
+          carbs: 6,
+          fat: 3,
+        },
+      ],
+    });
+
+    expect(payload).toEqual({
+      items: [
+        {
+          foodName: 'Greek Yogurt',
+          name: 'Greek Yogurt',
+          amount: 2,
+          unit: 'serving',
+          calories: 120,
+          protein: 15,
+          carbs: 6,
+          fat: 3,
+        },
+      ],
+    });
+  });
+
+  it('requires at least one item', () => {
+    expect(() =>
+      addMealItemsInputSchema.parse({
+        items: [],
       }),
     ).toThrow();
   });

--- a/packages/shared/src/schemas/nutrition.ts
+++ b/packages/shared/src/schemas/nutrition.ts
@@ -185,6 +185,10 @@ export const createMealForDateInputSchema = createMealInputSchema.extend({
   date: dateSchema,
 });
 
+export const addMealItemsInputSchema = z.object({
+  items: z.array(mealItemInputSchema).min(1),
+});
+
 export const patchMealInputSchema = z
   .object({
     name: requiredText(120).optional(),
@@ -216,6 +220,7 @@ export const patchMealItemInputSchema = z
 export type MealItemInput = z.infer<typeof mealItemInputSchema>;
 export type CreateMealInput = z.infer<typeof createMealInputSchema>;
 export type CreateMealForDateInput = z.infer<typeof createMealForDateInputSchema>;
+export type AddMealItemsInput = z.infer<typeof addMealItemsInputSchema>;
 export type PatchMealInput = z.infer<typeof patchMealInputSchema>;
 export type PatchMealItemInput = z.infer<typeof patchMealItemInputSchema>;
 export type NutritionMacroTotals = z.infer<typeof nutritionMacroTotalsSchema>;

--- a/packages/shared/src/unified-api-docs.test.ts
+++ b/packages/shared/src/unified-api-docs.test.ts
@@ -39,6 +39,8 @@ describe('unified API documentation', () => {
     expect(agentConventionDoc).not.toContain('/api/agent/');
     expect(agentConventionDoc).toContain('GET /api/v1/context');
     expect(agentConventionDoc).toContain('GET /api/v1/foods?q=<term>&limit=<n>');
+    expect(agentConventionDoc).toContain('POST /api/v1/foods/:winnerId/merge');
+    expect(agentConventionDoc).toContain('POST /api/v1/meals/:id/items');
     expect(agentConventionDoc).toContain('GET /api/v1/exercises?q=<term>&limit=<n>');
     expect(agentConventionDoc).toContain('Authorization: AgentToken <token>');
     expect(agentConventionDoc).toContain('optional `agent` field');
@@ -54,6 +56,8 @@ describe('unified API documentation', () => {
     expect(skillDoc).toContain('POST /api/v1/workout-templates');
     expect(skillDoc).toContain('PATCH /api/v1/habits/:id/entries');
     expect(skillDoc).toContain('POST /api/v1/meals');
+    expect(skillDoc).toContain('POST /api/v1/foods/:winnerId/merge');
+    expect(skillDoc).toContain('POST /api/v1/meals/:id/items');
     expect(skillDoc).toContain('optional `agent` field');
   });
 });


### PR DESCRIPTION
## Summary
This PR adds two nutrition API capabilities and tightens regression coverage around exercise metadata persistence. On the foods side, it introduces `POST /api/v1/foods/:winnerId/merge` to consolidate duplicate foods by relinking meal items, merging usage metadata, and soft-deleting the loser record. On the meals side, it adds `POST /api/v1/meals/:id/items` so callers can append new items to an existing meal without recreating it, while preserving agent/JWT unified behavior and enrichment. It also standardizes meal-item ownership failures to a typed `MealFoodOwnershipError` so both meal creation and meal append return consistent `422 INVALID_MEAL_ITEMS` responses.

## Key Changes
- Added `POST /api/v1/foods/:winnerId/merge` route with validation and explicit error mapping:
  - `400 INVALID_FOOD_MERGE` for same winner/loser IDs
  - `404 FOOD_NOT_FOUND` when either record is missing/out of scope
- Implemented transactional `mergeFoods(...)` store logic:
  - verifies both foods are active and user-scoped
  - reassigns `meal_items.foodId` from loser to winner
  - updates winner `usageCount` and `lastUsedAt` (max/nullable merge behavior)
  - soft-deletes loser food
- Added `POST /api/v1/meals/:id/items` route using shared `addMealItemsInputSchema` and existing normalization flow.
- Implemented `addItemsToMeal(...)` in nutrition store:
  - verifies meal ownership
  - inserts appended items
  - bumps meal `updatedAt`
  - returns full updated meal snapshot (all items)
  - applies saved-food usage tracking effects for inserted tracked foods
- Expanded API/shared tests for:
  - new endpoint behavior and error cases (JWT + AgentToken)
  - OpenAPI path/schema presence
  - shared package exports for `mergeFoodInputSchema` and `addMealItemsInputSchema`
  - exercise PATCH/PUT metadata read-after-write regression coverage (`formCues`, `coachingNotes`, `instructions`)

## Technical Notes
- Merge and append flows use explicit domain errors (`FoodMerge*Error`, `MealFoodOwnershipError`) to keep route-level HTTP responses deterministic.
- `POST /meals/:id/items` computes enrichment macros from the full updated meal snapshot, while `itemCount` reflects only appended items.
- `addMealItemsInputSchema` reuses the same meal item schema shape as meal creation to keep agent/jwt input semantics aligned.
- Docs and agent integration references were updated so the new endpoints are represented in both human docs and OpenAPI validation tests.

## Commits

- `eeaf361 chore(pr-2): verify commit-13 integration gates`
- `45f1c64 test(api): verify new endpoint docs and shared exports`
- `8bd093c fix(api): align meal append enrichment semantics`
- `51e9ce0 feat(api): add endpoint to append items to existing meals`
- `3634dff feat(api): add food merge endpoint`
- `1fe96db test(api): increase exercise list readback limits in route tests`
- `79f9cad test(api): harden exercise metadata regression setup assertions`
- `4a3f9b4 test(api): split exercise metadata persistence regression cases`
- `71a5b36 test(exercises): add read-after-write persistence regression coverage`

## Tasks

- **Fix exercise PATCH/PUT persistence for formCues, coachingNotes, instructions**: Add failing test, investigate Zod response serialization / Drizzle JSON column / normalizeNullableString, fix root cause
- **Add food merge endpoint POST /foods/:winnerId/merge**: Transactional merge: re-link meal_items, merge usage counts, soft-delete loser food
- **Add POST /meals/:id/items endpoint to add items to existing meal**: Insert items, update meal updatedAt, track food usage, return updated meal
- **Schema exports and OpenAPI verification for new endpoints**: Ensure new schemas exported from shared package, verify OpenAPI spec includes new endpoints
- **PR 2 integration pass — full test suite**: Run full test suite, fix any regressions from commits 9-12

## Diff Stats

```
.agents/skills/pulse-app-usage/SKILL.md            |  51 +++
 AGENTS.md                                          |   2 +-
 apps/api/src/__tests__/foods-nutrition.test.ts     |  54 +++
 apps/api/src/index.test.ts                         |  12 +
 apps/api/src/routes/exercises/index.test.ts        | 286 +++++++++++-
 apps/api/src/routes/foods/index.test.ts            | 170 ++++++-
 apps/api/src/routes/foods/index.ts                 |  67 ++-
 apps/api/src/routes/foods/store.test.ts            | 244 ++++++++--
 apps/api/src/routes/foods/store.ts                 | 110 ++++-
 apps/api/src/routes/meals/index.test.ts            | 492 +++++++++++++++++++++
 apps/api/src/routes/meals/index.ts                 | 121 ++++-
 .../src/routes/nutrition/store.food-usage.test.ts  | 280 ++++++++++++
 apps/api/src/routes/nutrition/store.ts             | 121 ++++-
 docs/conventions/agent-integration.md              |  74 ++++
 packages/shared/src/index.test.ts                  |  36 +-
 packages/shared/src/schemas/foods.test.ts          |  22 +
 packages/shared/src/schemas/foods.ts               |   5 +
 packages/shared/src/schemas/nutrition.test.ts      |  42 ++
 packages/shared/src/schemas/nutrition.ts           |   5 +
 packages/shared/src/unified-api-docs.test.ts       |   4 +
 20 files changed, 2135 insertions(+), 63 deletions(-)
```