### PR TITLE
fix(workouts): session UX fixes — auto-complete, timer, sections, tracking types

### DIFF
--- a/apps/web/src/features/workouts/components/form-cue-chips.test.tsx
+++ b/apps/web/src/features/workouts/components/form-cue-chips.test.tsx
@@ -38,4 +38,23 @@ describe('FormCueChips', () => {
     expect(screen.getByText('Template programming notes')).toBeInTheDocument();
     expect(screen.getByText('Top set at RPE 8, then two back-off sets.')).toBeInTheDocument();
   });
+
+  it('renders markdown in coaching notes and escapes HTML', () => {
+    render(
+      <FormCueChips
+        exerciseCoachingNotes={
+          '## Focus\n- **Brace** first\n- Stay smooth\n\n<script>alert("xss")</script>'
+        }
+        exerciseCues={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show notes' }));
+
+    expect(screen.getByText('Focus').tagName).toBe('H2');
+    expect(screen.getByText('Brace').tagName).toBe('STRONG');
+    expect(screen.getByText('Stay smooth').closest('li')).toBeInTheDocument();
+    expect(screen.getByText('<script>alert("xss")</script>')).toBeInTheDocument();
+    expect(document.querySelector('script')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/workouts/components/form-cue-chips.tsx
+++ b/apps/web/src/features/workouts/components/form-cue-chips.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { MarkdownNote } from './markdown-note';
 
 type FormCueChipsProps = {
   exerciseCues: string[];
@@ -75,7 +76,7 @@ export function FormCueChips({
                   <p className="text-xs font-semibold tracking-[0.16em] text-muted uppercase">
                     Exercise coaching notes
                   </p>
-                  <p className="text-sm text-muted">{exerciseCoachingNotes}</p>
+                  <MarkdownNote className="text-sm text-muted" content={exerciseCoachingNotes} />
                 </div>
               ) : null}
               {templateProgrammingNotes ? (
@@ -83,7 +84,7 @@ export function FormCueChips({
                   <p className="text-xs font-semibold tracking-[0.16em] text-muted uppercase">
                     Template programming notes
                   </p>
-                  <p className="text-sm text-muted">{templateProgrammingNotes}</p>
+                  <MarkdownNote className="text-sm text-muted" content={templateProgrammingNotes} />
                 </div>
               ) : null}
             </div>

--- a/apps/web/src/features/workouts/components/markdown-note.tsx
+++ b/apps/web/src/features/workouts/components/markdown-note.tsx
@@ -1,0 +1,21 @@
+import { renderJournalMarkdown } from '@/features/journal/lib/markdown';
+import { cn } from '@/lib/utils';
+
+type MarkdownNoteProps = {
+  className?: string;
+  content: string;
+};
+
+export function MarkdownNote({ className, content }: MarkdownNoteProps) {
+  return (
+    <div
+      className={cn(
+        '[&_br]:block [&_br]:content-[""] [&_code]:rounded-sm [&_code]:bg-secondary/70 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.9em]',
+        '[&_em]:italic [&_h2]:mt-1 [&_h2]:text-base [&_h2]:font-semibold [&_h3]:mt-3 [&_h3]:text-sm [&_h3]:font-semibold',
+        '[&_li]:list-disc [&_li]:text-inherit [&_p]:text-inherit [&_p]:leading-6 [&_strong]:font-semibold [&_ul]:space-y-1 [&_ul]:pl-5',
+        className,
+      )}
+      dangerouslySetInnerHTML={{ __html: renderJournalMarkdown(content) }}
+    />
+  );
+}

--- a/apps/web/src/features/workouts/components/scheduled-workout-detail.tsx
+++ b/apps/web/src/features/workouts/components/scheduled-workout-detail.tsx
@@ -1,13 +1,18 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router';
 import { ArrowLeft, CalendarClock, Dumbbell, TriangleAlert } from 'lucide-react';
-import type { WorkoutTemplate } from '@pulse/shared';
+import type {
+  WorkoutTemplate,
+  WorkoutTemplateExercise,
+  WeightUnit,
+} from '@pulse/shared';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import { useStartSession } from '@/hooks/use-workout-session';
+import { useWeightUnit } from '@/hooks/use-weight-unit';
 import { toDateKey } from '@/lib/date-utils';
 import { cn } from '@/lib/utils';
 
@@ -17,6 +22,7 @@ import {
   useUnscheduleWorkout,
   useWorkoutSessions,
 } from '../api/workouts';
+import { getDistanceUnit } from '../lib/tracking';
 import { buildInitialSessionSets } from '../lib/workout-session-sets';
 import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
 
@@ -45,6 +51,7 @@ type ScheduledWorkoutDetailProps = {
 
 export function ScheduledWorkoutDetail({ id }: ScheduledWorkoutDetailProps) {
   const navigate = useNavigate();
+  const { weightUnit } = useWeightUnit();
   const { data: scheduledWorkout, isLoading, isError } = useScheduledWorkoutDetail(id);
   const startSessionMutation = useStartSession();
   const rescheduleWorkoutMutation = useRescheduleWorkout();
@@ -219,7 +226,7 @@ export function ScheduledWorkoutDetail({ id }: ScheduledWorkoutDetailProps) {
         </CardContent>
       </Card>
 
-      {template ? <TemplateSections template={template} /> : null}
+      {template ? <TemplateSections template={template} weightUnit={weightUnit} /> : null}
 
       {scheduledWorkout ? (
         <ScheduleWorkoutDialog
@@ -253,7 +260,13 @@ function BackLink() {
   );
 }
 
-function TemplateSections({ template }: { template: WorkoutTemplate }) {
+function TemplateSections({
+  template,
+  weightUnit,
+}: {
+  template: WorkoutTemplate;
+  weightUnit: WeightUnit;
+}) {
   const nonEmptySections = template.sections.filter((section) => section.exercises.length > 0);
 
   if (nonEmptySections.length === 0) {
@@ -293,15 +306,7 @@ function TemplateSections({ template }: { template: WorkoutTemplate }) {
                   <p className="truncate text-sm font-medium text-foreground">
                     {exercise.exerciseName}
                   </p>
-                  <p className="text-xs text-muted">
-                    {exercise.sets} set{exercise.sets === 1 ? '' : 's'}
-                    {exercise.repsMin != null && exercise.repsMax != null
-                      ? ` · ${exercise.repsMin}–${exercise.repsMax} reps`
-                      : exercise.repsMin != null
-                        ? ` · ${exercise.repsMin}+ reps`
-                        : ''}
-                    {exercise.restSeconds != null ? ` · ${exercise.restSeconds}s rest` : ''}
-                  </p>
+                  <p className="text-xs text-muted">{formatExerciseSummary(exercise, weightUnit)}</p>
                 </div>
                 {exercise.supersetGroup ? (
                   <Badge className="shrink-0" variant="secondary">
@@ -316,4 +321,106 @@ function TemplateSections({ template }: { template: WorkoutTemplate }) {
       ))}
     </div>
   );
+}
+
+function formatExerciseSummary(exercise: WorkoutTemplateExercise, weightUnit: WeightUnit) {
+  const segments = [
+    `${exercise.sets} set${exercise.sets === 1 ? '' : 's'}`,
+    formatExerciseTarget(exercise, weightUnit),
+    exercise.restSeconds != null ? `${exercise.restSeconds} sec rest` : null,
+  ].filter((segment): segment is string => segment != null && segment.length > 0);
+
+  return segments.join(' · ');
+}
+
+function formatExerciseTarget(exercise: WorkoutTemplateExercise, weightUnit: WeightUnit) {
+  const repsTarget = formatRepTarget(exercise.repsMin, exercise.repsMax);
+  const firstTarget = (exercise.setTargets ?? [])[0] ?? null;
+  const targetWeight =
+    firstTarget?.targetWeight != null
+      ? `${firstTarget.targetWeight} ${weightUnit}`
+      : firstTarget?.targetWeightMin != null && firstTarget?.targetWeightMax != null
+        ? `${firstTarget.targetWeightMin}-${firstTarget.targetWeightMax} ${weightUnit}`
+        : null;
+  const targetSeconds =
+    firstTarget?.targetSeconds != null ? `${firstTarget.targetSeconds} sec` : null;
+  const targetDistance =
+    firstTarget?.targetDistance != null
+      ? `${firstTarget.targetDistance} ${getDistanceUnit(weightUnit)}`
+      : null;
+
+  switch (exercise.trackingType) {
+    case 'weight_reps':
+      return targetWeight ?? withRepUnit(repsTarget);
+    case 'weight_seconds':
+      if (targetWeight && targetSeconds) {
+        return `${targetWeight} × ${targetSeconds}`;
+      }
+      return targetWeight ?? targetSeconds ?? withSecUnit(repsTarget);
+    case 'bodyweight_reps':
+    case 'reps_only':
+      return withRepUnit(repsTarget);
+    case 'reps_seconds':
+      if (repsTarget && targetSeconds) {
+        return `${withRepUnit(repsTarget)} × ${targetSeconds}`;
+      }
+      return targetSeconds ?? withSecUnit(repsTarget);
+    case 'seconds_only':
+      return targetSeconds ?? withSecUnit(repsTarget);
+    case 'distance':
+      return targetDistance ?? withDistanceUnit(repsTarget, weightUnit);
+    case 'cardio':
+      if (targetSeconds && targetDistance) {
+        return `${targetSeconds} + ${targetDistance}`;
+      }
+      return targetSeconds ?? targetDistance ?? withSecUnit(repsTarget);
+    default:
+      return withRepUnit(repsTarget);
+  }
+}
+
+function formatRepTarget(repsMin: number | null, repsMax: number | null) {
+  if (repsMin != null && repsMax != null) {
+    return repsMin === repsMax ? `${repsMin}` : `${repsMin}-${repsMax}`;
+  }
+
+  if (repsMin != null) {
+    return `${repsMin}+`;
+  }
+
+  if (repsMax != null) {
+    return `Up to ${repsMax}`;
+  }
+
+  return null;
+}
+
+function withRepUnit(value: string | null) {
+  if (!value) {
+    return null;
+  }
+
+  const lower = value.toLowerCase();
+  return lower.includes('rep') || lower.includes('sec') || lower.includes('min')
+    ? value
+    : `${value} reps`;
+}
+
+function withSecUnit(value: string | null) {
+  if (!value) {
+    return null;
+  }
+
+  const lower = value.toLowerCase();
+  return lower.includes('sec') || lower.includes('min') ? value : `${value} sec`;
+}
+
+function withDistanceUnit(value: string | null, weightUnit: WeightUnit) {
+  if (!value) {
+    return null;
+  }
+
+  const lower = value.toLowerCase();
+  const distanceUnit = getDistanceUnit(weightUnit);
+  return lower.includes('mi') || lower.includes('km') ? value : `${value} ${distanceUnit}`;
 }

--- a/apps/web/src/features/workouts/components/session-comparison.test.tsx
+++ b/apps/web/src/features/workouts/components/session-comparison.test.tsx
@@ -138,4 +138,22 @@ describe('SessionComparison', () => {
     expect(screen.getByText('2.5 mi')).toBeInTheDocument();
     expect(screen.getByText('1 mi')).toBeInTheDocument();
   });
+
+  it('shows mixed session volume as non-comparable', () => {
+    const previousSession = createSession({
+      id: 'previous-session',
+      startedAt: Date.parse('2026-02-20T18:00:00Z'),
+      sets: [createSet('distance-run', 1, 1.2), createSet('couch-stretch', 1, 60)],
+    });
+    const currentSession = createSession({
+      id: 'current-session',
+      sets: [createSet('distance-run', 1, 2.5), createSet('couch-stretch', 1, 90)],
+    });
+
+    render(<SessionComparison currentSession={currentSession} previousSession={previousSession} />);
+
+    expect(screen.getByText('Mixed progression')).toBeInTheDocument();
+    expect(screen.getAllByText('-').length).toBeGreaterThanOrEqual(3);
+    expect(screen.queryByText('+16%')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/workouts/components/session-comparison.test.tsx
+++ b/apps/web/src/features/workouts/components/session-comparison.test.tsx
@@ -120,4 +120,22 @@ describe('SessionComparison', () => {
     expect(screen.getByText('90 sec')).toBeInTheDocument();
     expect(screen.getByText('60 sec')).toBeInTheDocument();
   });
+
+  it('uses distance metric labels for distance-tracked sessions', () => {
+    const previousSession = createSession({
+      id: 'previous-session',
+      startedAt: Date.parse('2026-02-20T18:00:00Z'),
+      sets: [createSet('distance-run', 1, 1)],
+    });
+    const currentSession = createSession({
+      id: 'current-session',
+      sets: [createSet('distance-run', 1, 2.5)],
+    });
+
+    render(<SessionComparison currentSession={currentSession} previousSession={previousSession} />);
+
+    expect(screen.getByText('Distance progression')).toBeInTheDocument();
+    expect(screen.getByText('2.5 mi')).toBeInTheDocument();
+    expect(screen.getByText('1 mi')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/workouts/components/session-comparison.tsx
+++ b/apps/web/src/features/workouts/components/session-comparison.tsx
@@ -91,9 +91,11 @@ export function SessionComparison({
   const currentVolume = getSessionVolume(currentSession);
   const previousVolume = getSessionVolume(previousSession);
   const volumeDelta = currentVolume - previousVolume;
-  const percentChange =
-    previousVolume > 0 ? Math.round((volumeDelta / previousVolume) * 100) : null;
   const volumeLabel = getSessionVolumeLabel(currentSession);
+  const percentChange =
+    volumeLabel !== 'mixed' && previousVolume > 0
+      ? Math.round((volumeDelta / previousVolume) * 100)
+      : null;
 
   return (
     <Card className="border-transparent bg-[var(--color-accent-mint)] text-on-accent dark:bg-card dark:text-foreground">
@@ -128,7 +130,7 @@ export function SessionComparison({
           </p>
           <div className="mt-2 flex items-center gap-2">
             <DeltaIndicator
-              direction={getDirection(volumeDelta)}
+              direction={volumeLabel === 'mixed' ? 'flat' : getDirection(volumeDelta)}
               label={formatVolumeDelta(volumeDelta, volumeLabel, weightUnit)}
             />
             {percentChange != null ? (
@@ -416,7 +418,7 @@ function formatVolume(value: number, label: string, weightUnit: WeightUnit) {
   }
 
   if (label === 'mixed') {
-    return formatNumber(value);
+    return '-';
   }
 
   return `${formatNumber(value)} reps`;
@@ -436,7 +438,7 @@ function formatVolumeDelta(value: number, label: string, weightUnit: WeightUnit)
   }
 
   if (label === 'mixed') {
-    return formatSignedNumber(value);
+    return '-';
   }
 
   return `${formatSignedNumber(value)} reps`;

--- a/apps/web/src/features/workouts/components/session-comparison.tsx
+++ b/apps/web/src/features/workouts/components/session-comparison.tsx
@@ -16,8 +16,11 @@ import {
 import { cn } from '@/lib/utils';
 
 import {
+  getDistanceUnit,
+  getSetDistance,
   getSetSeconds,
-  getSetVolume,
+  getSetSummaryMetricValue,
+  getTrackingSummaryMetricLabel,
   getTrackingVolumeLabel,
   resolveTrackingType,
 } from '../lib/tracking';
@@ -337,12 +340,12 @@ function getSessionVolume(session: WorkoutSession) {
 
   return session.sets.reduce((total, set) => {
     const trackingType = trackingByExerciseId.get(set.exerciseId) ?? 'weight_reps';
-    return total + getSetVolume(trackingType, set);
+    return total + getSetSummaryMetricValue(trackingType, set);
   }, 0);
 }
 
 function getExerciseVolumeFromSets(sets: SessionSet[], trackingType: ExerciseTrackingType) {
-  return sets.reduce((total, set) => total + getSetVolume(trackingType, set), 0);
+  return sets.reduce((total, set) => total + getSetSummaryMetricValue(trackingType, set), 0);
 }
 
 function getPrimarySetMetric(set: SessionSet, trackingType: ExerciseTrackingType) {
@@ -352,7 +355,7 @@ function getPrimarySetMetric(set: SessionSet, trackingType: ExerciseTrackingType
     case 'cardio':
       return getSetSeconds(set) ?? 0;
     case 'distance':
-      return 0;
+      return getSetDistance(set) ?? 0;
     default:
       return set.reps ?? 0;
   }
@@ -393,10 +396,10 @@ function getSessionVolumeLabel(session: WorkoutSession) {
 
   if (trackingTypes.size === 1) {
     const only = [...trackingTypes][0];
-    return getTrackingVolumeLabel(only);
+    return getTrackingSummaryMetricLabel(only);
   }
 
-  return 'volume';
+  return 'mixed';
 }
 
 function formatVolume(value: number, label: string, weightUnit: WeightUnit) {
@@ -406,6 +409,14 @@ function formatVolume(value: number, label: string, weightUnit: WeightUnit) {
 
   if (label === 'seconds') {
     return `${formatNumber(value)} sec`;
+  }
+
+  if (label === 'distance') {
+    return `${formatNumber(value)} ${getDistanceUnit(weightUnit)}`;
+  }
+
+  if (label === 'mixed') {
+    return formatNumber(value);
   }
 
   return `${formatNumber(value)} reps`;
@@ -418,6 +429,14 @@ function formatVolumeDelta(value: number, label: string, weightUnit: WeightUnit)
 
   if (label === 'seconds') {
     return `${formatSignedNumber(value)} sec`;
+  }
+
+  if (label === 'distance') {
+    return `${formatSignedNumber(value)} ${getDistanceUnit(weightUnit)}`;
+  }
+
+  if (label === 'mixed') {
+    return formatSignedNumber(value);
   }
 
   return `${formatSignedNumber(value)} reps`;

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -188,6 +188,42 @@ describe('SessionDetail', () => {
     expect(screen.getByText('Felt strong overall.')).toBeInTheDocument();
   });
 
+  it('hides the reps stat card for time-only sessions', async () => {
+    const currentSession = createSession({
+      id: 'session-time-only',
+      templateId: 'template-upper-push',
+      sets: [
+        createSet({
+          id: 'set-stretch-1',
+          exerciseId: 'couch-stretch',
+          setNumber: 1,
+          reps: 90,
+          weight: null,
+          section: 'cooldown',
+        }),
+      ],
+    });
+
+    mockSessionDetailRequests({
+      sessionId: currentSession.id,
+      session: currentSession,
+      sessions: [
+        createSessionListItem({
+          id: currentSession.id,
+          templateId: currentSession.templateId,
+          templateName: 'Upper Push',
+          startedAt: currentSession.startedAt,
+        }),
+      ],
+    });
+
+    renderSessionDetail(currentSession.id);
+
+    expect(await screen.findByText('Workout receipt')).toBeInTheDocument();
+    expect(screen.getByText('Seconds')).toBeInTheDocument();
+    expect(screen.queryByText(/^Reps$/)).not.toBeInTheDocument();
+  });
+
   it('shows volume progression, deltas, and PR badges when comparison is enabled', async () => {
     const previousSession = createSession({
       id: 'session-previous',

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -130,6 +130,65 @@ describe('SessionDetail', () => {
     expect(screen.getByText('Bench at setting 5; keep elbows tucked.')).toBeInTheDocument();
   });
 
+  it('renders markdown in read-only notes and escapes unsafe HTML', async () => {
+    const currentSession = createSession({
+      id: 'session-markdown-notes',
+      templateId: 'template-upper-push',
+      notes:
+        '## Session focus\nLine one\nLine two\n\n- **Brace** before unrack\n- Keep a steady tempo\n\n<script>alert("xss")</script>',
+      feedback: {
+        energy: 4,
+        recovery: 4,
+        technique: 5,
+        notes: 'Reflection line one\nReflection line two',
+        responses: [
+          {
+            id: 'coach-note',
+            label: 'Coach note',
+            type: 'text',
+            value: 'Solid pace today.',
+            notes: 'Stay *conservative* on set 1.\n- Add a pause',
+          },
+        ],
+      },
+      sets: [
+        createSet({
+          id: 'set-markdown-note',
+          exerciseId: 'incline-dumbbell-press',
+          setNumber: 1,
+          notes: '- Bench at setting 5\n- Keep elbows tucked.',
+          reps: 8,
+          section: 'main',
+          weight: 50,
+        }),
+      ],
+    });
+
+    mockSessionDetailRequests({
+      sessionId: currentSession.id,
+      session: currentSession,
+      sessions: [
+        createSessionListItem({
+          id: currentSession.id,
+          templateId: currentSession.templateId,
+          templateName: 'Upper Push',
+          startedAt: currentSession.startedAt,
+        }),
+      ],
+    });
+
+    renderSessionDetail(currentSession.id);
+
+    expect(await screen.findByText('Workout receipt')).toBeInTheDocument();
+    expect(screen.getByText('Session focus').tagName).toBe('H2');
+    expect(screen.getByText('Brace').tagName).toBe('STRONG');
+    expect(screen.getByText('Keep elbows tucked.').closest('li')).toBeInTheDocument();
+    expect(screen.getByText('conservative').tagName).toBe('EM');
+    expect(screen.getByText('<script>alert("xss")</script>')).toBeInTheDocument();
+    expect(document.querySelectorAll('br').length).toBeGreaterThan(0);
+    expect(document.querySelector('script')).not.toBeInTheDocument();
+  });
+
   it('renders structured feedback responses when available', async () => {
     const currentSession = createSession({
       id: 'session-structured-feedback',

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -50,6 +50,7 @@ import {
 } from '../api/workouts';
 import { buildInitialSessionSets } from '../lib/workout-session-sets';
 import {
+  formatTrackingMetricBreakdown,
   formatSetSummary,
   getDistanceUnit,
   getSetDistance,
@@ -204,6 +205,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
 
   const sessionDate = new Date(session.startedAt);
   const summary = getSessionSummary(session, template ?? null);
+  const shouldShowRepsStat = summary.metricTotals.reps > 0 && summary.metricLabel !== 'reps';
   const sections = buildSections(session, template);
   const selectedExercise = sections
     .flatMap((section) => section.exercises)
@@ -349,7 +351,12 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
         </div>
       ) : null}
 
-      <div className="grid gap-2.5 sm:grid-cols-2 xl:grid-cols-4">
+      <div
+        className={cn(
+          'grid gap-2.5 sm:grid-cols-2',
+          shouldShowRepsStat ? 'xl:grid-cols-4' : 'xl:grid-cols-3',
+        )}
+      >
         <StatCard
           accentTextClassName="text-blue-900 dark:text-blue-200"
           className="border-blue-200/70 bg-blue-500/10 dark:border-blue-400/30 dark:bg-blue-500/15"
@@ -364,13 +371,15 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
           label="Sets"
           value={`${summary.totalSets}`}
         />
-        <StatCard
-          accentTextClassName="text-fuchsia-900 dark:text-fuchsia-200"
-          className="border-fuchsia-200/70 bg-fuchsia-500/10 dark:border-fuchsia-400/30 dark:bg-fuchsia-500/15"
-          icon={<Repeat2 aria-hidden="true" className="size-4" />}
-          label="Reps"
-          value={integerFormatter.format(summary.metricTotals.reps)}
-        />
+        {shouldShowRepsStat ? (
+          <StatCard
+            accentTextClassName="text-fuchsia-900 dark:text-fuchsia-200"
+            className="border-fuchsia-200/70 bg-fuchsia-500/10 dark:border-fuchsia-400/30 dark:bg-fuchsia-500/15"
+            icon={<Repeat2 aria-hidden="true" className="size-4" />}
+            label="Reps"
+            value={integerFormatter.format(summary.metricTotals.reps)}
+          />
+        ) : null}
         <StatCard
           accentTextClassName="text-emerald-900 dark:text-emerald-200"
           className="border-emerald-200/70 bg-emerald-500/10 dark:border-emerald-400/30 dark:bg-emerald-500/15"
@@ -1185,7 +1194,7 @@ function formatSummaryMetric(
     case 'distance':
       return `${formatServing(totals.distance)} ${getDistanceUnit(weightUnit)}`;
     case 'mixed':
-      return formatMixedMetricSummary(totals, weightUnit);
+      return formatTrackingMetricBreakdown(totals, weightUnit);
     default:
       return '-';
   }
@@ -1209,32 +1218,6 @@ function formatSummaryMetricLabel(label: SessionMetricLabel) {
   }
 
   return 'Volume';
-}
-
-function formatMixedMetricSummary(
-  totals: Record<TrackingSummaryMetricLabel, number>,
-  weightUnit: WeightUnit,
-) {
-  const segments: string[] = [];
-
-  if (totals.volume > 0) {
-    segments.push(`${formatWeightValue(totals.volume)} ${weightUnit}`);
-  }
-  if (totals.reps > 0) {
-    segments.push(`${integerFormatter.format(totals.reps)} reps`);
-  }
-  if (totals.seconds > 0) {
-    segments.push(`${formatServing(totals.seconds)} sec`);
-  }
-  if (totals.distance > 0) {
-    segments.push(`${formatServing(totals.distance)} ${getDistanceUnit(weightUnit)}`);
-  }
-
-  if (segments.length === 0) {
-    return '-';
-  }
-
-  return segments.join(' • ');
 }
 
 function formatLabel(value: string) {

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -64,6 +64,7 @@ import {
 import { findPreviousTemplateSession } from '../lib/session-comparison';
 import type { ActiveWorkoutExerciseHistoryPoint } from '../types';
 import { ExerciseTrendChart } from './exercise-trend-chart';
+import { MarkdownNote } from './markdown-note';
 import { SessionComparison, SessionExerciseComparison } from './session-comparison';
 
 type SessionDetailProps = {
@@ -398,9 +399,9 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="rounded-2xl border border-border bg-secondary/35 px-4 py-3 text-sm leading-6 text-foreground">
-              {session.notes}
-            </p>
+            <div className="rounded-2xl border border-border bg-secondary/35 px-4 py-3">
+              <MarkdownNote className="text-sm text-foreground" content={session.notes} />
+            </div>
           </CardContent>
         </Card>
       ) : null}
@@ -560,7 +561,10 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
                         <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
                           Exercise notes
                         </p>
-                        <p>{exercise.notes}</p>
+                        <MarkdownNote
+                          className="text-sm text-foreground"
+                          content={exercise.notes}
+                        />
                       </div>
                     ) : null}
                   </CardContent>
@@ -592,7 +596,10 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
                         {formatFeedbackResponseValue(response)}
                       </p>
                       {response.notes?.trim() ? (
-                        <p className="mt-2 text-sm text-muted">{response.notes.trim()}</p>
+                        <MarkdownNote
+                          className="mt-2 text-sm text-muted"
+                          content={response.notes.trim()}
+                        />
                       ) : null}
                     </div>
                   ))}
@@ -610,7 +617,10 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
                   <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
                     Reflection
                   </p>
-                  <p>{session.feedback.notes}</p>
+                  <MarkdownNote
+                    className="text-sm text-foreground"
+                    content={session.feedback.notes}
+                  />
                 </div>
               ) : null}
             </>
@@ -1011,7 +1021,9 @@ function getSessionSummary(session: WorkoutSession, template: WorkoutTemplate | 
       }
       metricLabels.add(metricLabel);
       summary.metricLabel =
-        metricLabels.size > 1 ? 'mixed' : (([...metricLabels][0] ?? 'volume') as SessionMetricLabel);
+        metricLabels.size > 1
+          ? 'mixed'
+          : (([...metricLabels][0] ?? 'volume') as SessionMetricLabel);
 
       return summary;
     },

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -50,11 +50,14 @@ import {
 } from '../api/workouts';
 import { buildInitialSessionSets } from '../lib/workout-session-sets';
 import {
+  formatSetSummary,
   getDistanceUnit,
   getSetDistance,
   getSetSeconds,
-  getSetVolume,
-  getTrackingVolumeLabel,
+  getSetSummaryMetricValue,
+  getTrackingSummaryMetricLabel,
+  isRepTrackingType,
+  type TrackingSummaryMetricLabel,
   resolveTrackingType,
 } from '../lib/tracking';
 import { findPreviousTemplateSession } from '../lib/session-comparison';
@@ -97,6 +100,8 @@ type SessionSetEditorField = {
   step: string;
   suffix?: string;
 };
+
+type SessionMetricLabel = TrackingSummaryMetricLabel | 'mixed';
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   weekday: 'long',
@@ -198,7 +203,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
   }
 
   const sessionDate = new Date(session.startedAt);
-  const summary = getSessionSummary(session);
+  const summary = getSessionSummary(session, template ?? null);
   const sections = buildSections(session, template);
   const selectedExercise = sections
     .flatMap((section) => section.exercises)
@@ -364,14 +369,14 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
           className="border-fuchsia-200/70 bg-fuchsia-500/10 dark:border-fuchsia-400/30 dark:bg-fuchsia-500/15"
           icon={<Repeat2 aria-hidden="true" className="size-4" />}
           label="Reps"
-          value={integerFormatter.format(summary.totalReps)}
+          value={integerFormatter.format(summary.metricTotals.reps)}
         />
         <StatCard
           accentTextClassName="text-emerald-900 dark:text-emerald-200"
           className="border-emerald-200/70 bg-emerald-500/10 dark:border-emerald-400/30 dark:bg-emerald-500/15"
           icon={<Scale aria-hidden="true" className="size-4" />}
-          label={formatLabel(summary.metricLabel)}
-          value={formatSummaryMetric(summary.totalVolume, summary.metricLabel, weightUnit)}
+          label={formatSummaryMetricLabel(summary.metricLabel)}
+          value={formatSummaryMetric(summary.metricTotals, summary.metricLabel, weightUnit)}
         />
       </div>
 
@@ -886,6 +891,7 @@ function buildSections(
 ): SessionDetailSection[] {
   const templateSectionByExerciseId = new Map<string, WorkoutTemplateSectionType>();
   const templateExerciseNameById = new Map<string, string>();
+  const templateTrackingTypeById = new Map<string, ExerciseTrackingType>();
   const sessionTrackingTypeById = new Map(
     (session.exercises ?? []).map((exercise) => [exercise.exerciseId, exercise.trackingType]),
   );
@@ -894,6 +900,9 @@ function buildSections(
     section.exercises.forEach((exercise) => {
       templateSectionByExerciseId.set(exercise.exerciseId, section.type);
       templateExerciseNameById.set(exercise.exerciseId, exercise.exerciseName);
+      if (exercise.trackingType) {
+        templateTrackingTypeById.set(exercise.exerciseId, exercise.trackingType);
+      }
     });
   });
 
@@ -930,7 +939,10 @@ function buildSections(
           phaseBadge: inferPhaseBadge(sectionType),
           sets: [...sets].sort((left, right) => left.setNumber - right.setNumber),
           trackingType: resolveTrackingType({
-            trackingType: sessionTrackingTypeById.get(exerciseId) ?? undefined,
+            trackingType:
+              sessionTrackingTypeById.get(exerciseId) ??
+              templateTrackingTypeById.get(exerciseId) ??
+              undefined,
             exerciseId,
             exerciseName: name,
           }),
@@ -954,57 +966,56 @@ function buildSectionSubtitle(sectionType: SessionDetailSectionType, count: numb
   return `${count} exercise${count === 1 ? '' : 's'} logged`;
 }
 
-function getSessionSummary(session: WorkoutSession) {
+function getSessionSummary(session: WorkoutSession, template: WorkoutTemplate | null) {
   const exerciseIds = new Set<string>();
-  const exerciseTrackingTypeById = new Map<string, ExerciseTrackingType>();
-  let hasVolume = false;
-  let hasReps = false;
-  let hasSeconds = false;
+  const sessionTrackingTypeById = new Map(
+    (session.exercises ?? []).map((exercise) => [exercise.exerciseId, exercise.trackingType]),
+  );
+  const templateTrackingTypeById = new Map<string, ExerciseTrackingType>();
+  template?.sections.forEach((section) => {
+    section.exercises.forEach((exercise) => {
+      if (exercise.trackingType) {
+        templateTrackingTypeById.set(exercise.exerciseId, exercise.trackingType);
+      }
+    });
+  });
+  const metricLabels = new Set<TrackingSummaryMetricLabel>();
 
   return session.sets.reduce(
     (summary, set) => {
       exerciseIds.add(set.exerciseId);
       summary.totalSets += 1;
       summary.totalExercises = exerciseIds.size;
-      const trackingType =
-        exerciseTrackingTypeById.get(set.exerciseId) ??
-        resolveTrackingType({ exerciseId: set.exerciseId });
-      exerciseTrackingTypeById.set(set.exerciseId, trackingType);
-
-      if (set.reps != null) {
-        summary.totalReps += set.reps;
+      const trackingType = resolveTrackingType({
+        trackingType:
+          sessionTrackingTypeById.get(set.exerciseId) ??
+          templateTrackingTypeById.get(set.exerciseId) ??
+          undefined,
+        exerciseId: set.exerciseId,
+      });
+      const metricLabel = getTrackingSummaryMetricLabel(trackingType);
+      if (metricLabel !== 'reps') {
+        summary.metricTotals[metricLabel] += getSetSummaryMetricValue(trackingType, set);
       }
-
-      summary.totalVolume += getSetVolume(trackingType, set);
-      const metricLabel = getTrackingVolumeLabel(trackingType);
-
-      if (metricLabel === 'volume') {
-        hasVolume = true;
+      if (isRepTrackingType(trackingType) && set.reps != null) {
+        summary.metricTotals.reps += set.reps;
       }
-      if (metricLabel === 'reps') {
-        hasReps = true;
-      }
-      if (metricLabel === 'seconds') {
-        hasSeconds = true;
-      }
-
+      metricLabels.add(metricLabel);
       summary.metricLabel =
-        hasVolume || (hasReps && hasSeconds)
-          ? 'volume'
-          : hasReps
-            ? 'reps'
-            : hasSeconds
-              ? 'seconds'
-              : 'volume';
+        metricLabels.size > 1 ? 'mixed' : (([...metricLabels][0] ?? 'volume') as SessionMetricLabel);
 
       return summary;
     },
     {
-      metricLabel: 'volume' as 'reps' | 'seconds' | 'volume',
+      metricLabel: 'volume' as SessionMetricLabel,
+      metricTotals: {
+        distance: 0,
+        reps: 0,
+        seconds: 0,
+        volume: 0,
+      },
       totalExercises: 0,
-      totalReps: 0,
       totalSets: 0,
-      totalVolume: 0,
     },
   );
 }
@@ -1153,49 +1164,77 @@ function formatSetLabel(
   trackingType: ExerciseTrackingType,
   weightUnit: WeightUnit,
 ) {
-  if (set.skipped) {
-    return `Set ${set.setNumber}: Skipped`;
-  }
-
-  const repsValue = set.reps != null ? integerFormatter.format(set.reps) : '0';
-  const secondsValue = integerFormatter.format(getSetSeconds(set) ?? 0);
-  const distanceUnit = getDistanceUnit(weightUnit);
-
-  if (trackingType === 'seconds_only') {
-    return `Set ${set.setNumber}: ${secondsValue} sec`;
-  }
-
-  if (trackingType === 'cardio') {
-    const distanceValue = formatNumber(getSetDistance(set) ?? 0);
-    return `Set ${set.setNumber}: ${secondsValue} sec / ${distanceValue} ${distanceUnit}`;
-  }
-
-  if (trackingType === 'weight_seconds') {
-    const weightLabel =
-      set.weight != null ? `${formatWeightValue(set.weight)} ${weightUnit} × ` : '';
-    return `Set ${set.setNumber}: ${weightLabel}${secondsValue} sec`;
-  }
-
-  const repsLabel = `${repsValue} reps`;
-  const weightLabel = set.weight != null ? `${formatWeightValue(set.weight)} ${weightUnit} × ` : '';
-
-  return `Set ${set.setNumber}: ${weightLabel}${repsLabel}`;
+  return formatSetSummary(set, trackingType, {
+    includeSetNumber: true,
+    weightUnit,
+  });
 }
 
 function formatSummaryMetric(
-  value: number,
-  label: 'reps' | 'seconds' | 'volume',
+  totals: Record<TrackingSummaryMetricLabel, number>,
+  label: SessionMetricLabel,
   weightUnit: WeightUnit,
 ) {
-  if (label === 'volume') {
-    return `${formatWeightValue(value)} ${weightUnit}`;
+  switch (label) {
+    case 'volume':
+      return `${formatWeightValue(totals.volume)} ${weightUnit}`;
+    case 'reps':
+      return integerFormatter.format(totals.reps);
+    case 'seconds':
+      return `${formatServing(totals.seconds)} sec`;
+    case 'distance':
+      return `${formatServing(totals.distance)} ${getDistanceUnit(weightUnit)}`;
+    case 'mixed':
+      return formatMixedMetricSummary(totals, weightUnit);
+    default:
+      return '-';
+  }
+}
+
+function formatSummaryMetricLabel(label: SessionMetricLabel) {
+  if (label === 'mixed') {
+    return 'Mixed metrics';
   }
 
   if (label === 'seconds') {
-    return `${formatServing(value)} sec`;
+    return 'Seconds';
   }
 
-  return integerFormatter.format(value);
+  if (label === 'distance') {
+    return 'Distance';
+  }
+
+  if (label === 'reps') {
+    return 'Reps';
+  }
+
+  return 'Volume';
+}
+
+function formatMixedMetricSummary(
+  totals: Record<TrackingSummaryMetricLabel, number>,
+  weightUnit: WeightUnit,
+) {
+  const segments: string[] = [];
+
+  if (totals.volume > 0) {
+    segments.push(`${formatWeightValue(totals.volume)} ${weightUnit}`);
+  }
+  if (totals.reps > 0) {
+    segments.push(`${integerFormatter.format(totals.reps)} reps`);
+  }
+  if (totals.seconds > 0) {
+    segments.push(`${formatServing(totals.seconds)} sec`);
+  }
+  if (totals.distance > 0) {
+    segments.push(`${formatServing(totals.distance)} ${getDistanceUnit(weightUnit)}`);
+  }
+
+  if (segments.length === 0) {
+    return '-';
+  }
+
+  return segments.join(' • ');
 }
 
 function formatLabel(value: string) {

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -130,8 +130,16 @@ describe('SessionExerciseList', () => {
       />,
     );
 
-    expect(screen.getByText('2/2 exercises done')).toBeInTheDocument();
-    expect(screen.getByText('0/4 exercises done')).toBeInTheDocument();
+    const warmupButton = screen.getByRole('button', { name: /Warmup/i });
+    const warmupBadge = within(warmupButton).getByText('2/2');
+    expect(warmupBadge).toHaveClass('bg-emerald-500/15');
+    expect(within(warmupBadge).getByText('Section complete')).toBeInTheDocument();
+
+    const mainButton = screen.getByRole('button', { name: /Main/i });
+    const mainBadge = within(mainButton).getByText('0/4');
+    expect(mainBadge).toHaveClass('bg-muted');
+    expect(screen.queryByText('2/2 exercises done')).not.toBeInTheDocument();
+    expect(screen.queryByText('0/4 exercises done')).not.toBeInTheDocument();
     expect(
       screen.getByRole('heading', { level: 2, name: /Main \d+-\d+ min/i }),
     ).toBeInTheDocument();
@@ -179,6 +187,51 @@ describe('SessionExerciseList', () => {
 
     expect(optionalCard).not.toBeNull();
     expect(within(optionalCard as HTMLElement).getByText('Optional')).toBeInTheDocument();
+  });
+
+  it('applies distinct section badge styles for complete, partial, and zero-complete sections', () => {
+    if (!activeTemplate) {
+      throw new Error('Expected upper-push template in mock data.');
+    }
+
+    const session = buildActiveWorkoutSession(
+      activeTemplate,
+      createInitialWorkoutSetDrafts(
+        activeTemplate,
+        new Set([
+          createWorkoutSetId('row-erg', 1),
+          createWorkoutSetId('banded-shoulder-external-rotation', 1),
+          createWorkoutSetId('banded-shoulder-external-rotation', 2),
+          createWorkoutSetId('rope-triceps-pushdown', 1),
+          createWorkoutSetId('rope-triceps-pushdown', 2),
+          createWorkoutSetId('rope-triceps-pushdown', 3),
+        ]),
+      ),
+    );
+
+    renderWithQueryClient(
+      <SessionExerciseList
+        onAddSet={vi.fn()}
+        onExerciseNotesChange={vi.fn()}
+        onRemoveSet={vi.fn()}
+        onSetUpdate={vi.fn()}
+        session={session}
+      />,
+    );
+
+    const warmupBadge = within(screen.getByRole('button', { name: /Warmup/i })).getByText('2/2');
+    expect(warmupBadge).toHaveClass('bg-emerald-500/15');
+    expect(within(warmupBadge).getByText('Section complete')).toBeInTheDocument();
+
+    const mainBadge = within(screen.getByRole('button', { name: /Main/i })).getByText('1/4');
+    expect(mainBadge).toHaveClass('bg-secondary');
+    expect(mainBadge).not.toHaveClass('bg-muted');
+
+    const cooldownBadge = within(screen.getByRole('button', { name: /Cooldown/i })).getByText(
+      '0/1',
+    );
+    expect(cooldownBadge).toHaveClass('bg-muted');
+    expect(cooldownBadge).not.toHaveClass('bg-secondary');
   });
 
   it('debounces exercise notes updates until typing pauses', async () => {

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -90,7 +90,7 @@ describe('SessionExerciseList', () => {
     );
 
     expect(screen.getByText('Target: 70-90 lbs')).toBeInTheDocument();
-    expect(screen.getByText('Target: 30s')).toBeInTheDocument();
+    expect(screen.getByText('Target: 30 sec')).toBeInTheDocument();
     expect(screen.getByText('Target: 40 mi')).toBeInTheDocument();
   });
 
@@ -1192,7 +1192,7 @@ describe('SessionExerciseList', () => {
     fireEvent.click(within(rowErgCard as HTMLElement).getByText('Related history'));
     const relatedExerciseLabel = within(rowErgCard as HTMLElement).getByText('Incline Bench Press');
     expect(relatedExerciseLabel).toBeVisible();
-    expect(relatedExerciseLabel.closest('div')).toHaveTextContent(/60x8/);
+    expect(relatedExerciseLabel.closest('div')).toHaveTextContent(/60 lbs × 8 reps/);
 
     useLastPerformanceSpy.mockRestore();
   });

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -718,6 +718,71 @@ describe('SessionExerciseList', () => {
     ).toHaveClass('line-through');
   });
 
+  it('keeps section open state manual when workout progress moves into the next section', () => {
+    if (!activeTemplate) {
+      throw new Error('Expected upper-push template in mock data.');
+    }
+
+    const initialSession = buildActiveWorkoutSession(
+      activeTemplate,
+      createInitialWorkoutSetDrafts(activeTemplate, new Set()),
+    );
+    const progressedSession = buildActiveWorkoutSession(
+      activeTemplate,
+      createInitialWorkoutSetDrafts(
+        activeTemplate,
+        new Set([
+          createWorkoutSetId('row-erg', 1),
+          createWorkoutSetId('banded-shoulder-external-rotation', 1),
+          createWorkoutSetId('banded-shoulder-external-rotation', 2),
+        ]),
+      ),
+    );
+
+    const queryClient = createAppQueryClient();
+    queryClient.clear();
+
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <SessionExerciseList
+          onAddSet={vi.fn()}
+          onExerciseNotesChange={vi.fn()}
+          onRemoveSet={vi.fn()}
+          onSetUpdate={vi.fn()}
+          session={initialSession}
+        />
+      </QueryClientProvider>,
+    );
+
+    const warmupButton = screen.getByRole('button', { name: /Warmup/i });
+    const mainButton = screen.getByRole('button', { name: /Main/i });
+
+    if (warmupButton.getAttribute('aria-expanded') === 'false') {
+      fireEvent.click(warmupButton);
+    }
+    if (mainButton.getAttribute('aria-expanded') === 'true') {
+      fireEvent.click(mainButton);
+    }
+
+    expect(warmupButton).toHaveAttribute('aria-expanded', 'true');
+    expect(mainButton).toHaveAttribute('aria-expanded', 'false');
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <SessionExerciseList
+          onAddSet={vi.fn()}
+          onExerciseNotesChange={vi.fn()}
+          onRemoveSet={vi.fn()}
+          onSetUpdate={vi.fn()}
+          session={progressedSession}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: /Warmup/i })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('button', { name: /Main/i })).toHaveAttribute('aria-expanded', 'false');
+  });
+
   it('collapses sections, toggles exercise details, and focuses the requested next set input', () => {
     if (!activeTemplate) {
       throw new Error('Expected upper-push template in mock data.');

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -214,12 +214,14 @@ export function SessionExerciseList({
         const completedExercises = section.exercises.filter(
           (exercise) => exercise.completedSets >= exercise.targetSets,
         ).length;
+        const totalExercises = section.exercises.length;
+        const isSectionCompleted = totalExercises > 0 && completedExercises === totalExercises;
+        const isSectionInProgress = completedExercises > 0 && !isSectionCompleted;
         const exerciseIndexById = new Map(
           section.exercises.map((exercise, index) => [exercise.id, index]),
         );
         const sectionLabel = sectionLabels[section.type];
         const sectionEstimate = formatEstimateMinuteRange(estimateSectionTime(section));
-        const sectionSummary = `${completedExercises}/${section.exercises.length} exercises done`;
         const isOpen =
           openSections[section.id] ?? isSectionInitiallyOpen(section, session.currentExerciseId);
         const reorderSectionExercises = (currentIndex: number, nextIndex: number) => {
@@ -262,20 +264,27 @@ export function SessionExerciseList({
               }
               type="button"
             >
-              <div className="space-y-1">
+              <div>
                 <h2 className="flex items-baseline gap-2 text-lg font-semibold text-foreground">
                   {sectionLabel}
                   <span className="text-xs font-medium text-muted">{sectionEstimate}</span>
                 </h2>
-                <p className="text-sm text-muted">{sectionSummary}</p>
               </div>
 
               <div className="flex items-center gap-3">
                 <Badge
-                  className="border-transparent bg-secondary text-secondary-foreground"
+                  className={cn(
+                    isSectionCompleted
+                      ? 'border-emerald-500/30 bg-emerald-500/15 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300'
+                      : isSectionInProgress
+                        ? 'border-transparent bg-secondary text-secondary-foreground'
+                        : 'border-border/70 bg-muted text-muted-foreground',
+                  )}
                   variant="outline"
                 >
-                  {`${completedExercises}/${section.exercises.length}`}
+                  {isSectionCompleted ? <Check aria-hidden="true" className="size-3.5" /> : null}
+                  {isSectionCompleted ? <span className="sr-only">Section complete</span> : null}
+                  {`${completedExercises}/${totalExercises}`}
                 </Badge>
                 <ChevronDown
                   aria-hidden="true"

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -67,7 +67,7 @@ import {
   formatRestDuration,
   formatTempo,
 } from '../lib/time-estimates';
-import { getDistanceUnit } from '../lib/tracking';
+import { formatSetSummary, getDistanceUnit } from '../lib/tracking';
 import { FormCueChips } from './form-cue-chips';
 import { RenameExerciseDialog } from './rename-exercise-dialog';
 import { SetRow, type SetRowUpdate } from './set-row';
@@ -976,27 +976,25 @@ function formatCompactPerformanceSetByTrackingType(
   prescribedReps: string,
   weightUnit: WeightUnit,
 ) {
-  const distanceUnit = getDistanceUnit(weightUnit);
-
-  switch (trackingType) {
-    case 'weight_reps':
-      return weight != null ? `${formatWeight(weight)}x${value}` : `${value}`;
-    case 'weight_seconds':
-      return weight != null ? `${formatWeight(weight)}x${value} sec` : `${value} sec`;
-    case 'bodyweight_reps':
-    case 'reps_only':
-      return formatPerformedReps(value, prescribedReps);
-    case 'seconds_only':
-      return `${value} sec`;
-    case 'reps_seconds':
-      return `${value} reps`;
-    case 'distance':
-      return `${value} ${distanceUnit}`;
-    case 'cardio':
-      return `${value} sec`;
-    default:
-      return weight != null ? `${formatWeight(weight)}x${value}` : `${value}`;
+  if (
+    (trackingType === 'bodyweight_reps' || trackingType === 'reps_only') &&
+    (prescribedReps.includes('min') || prescribedReps.includes('sec'))
+  ) {
+    return formatPerformedReps(value, prescribedReps);
   }
+
+  const setMetrics =
+    trackingType === 'distance'
+      ? { distance: value, weight }
+      : {
+          reps: value,
+          weight,
+        };
+
+  return formatSetSummary(setMetrics, trackingType, {
+    useLegacySecondsFallback: trackingType !== 'reps_seconds',
+    weightUnit,
+  });
 }
 
 function formatExerciseSubtitle({
@@ -1007,6 +1005,7 @@ function formatExerciseSubtitle({
   weightUnit: WeightUnit;
 }) {
   const repTarget = parsePrescribedRepTarget(exercise.prescribedReps);
+  const trackedTarget = formatTrackedRepTarget(repTarget, exercise.trackingType, weightUnit);
   const sets = exercise.prescribedSets;
   const hasWeightLadder =
     (exercise.trackingType === 'weight_reps' || exercise.trackingType === 'weight_seconds') &&
@@ -1022,7 +1021,7 @@ function formatExerciseSubtitle({
     const weightLadder = exercise.reversePyramid
       .map((target) => formatWeight(target.targetWeight))
       .join(' → ');
-    return `${sets} sets, ${repTarget} reps, ${weightLadder} ${weightUnit}`;
+    return `${sets} sets, ${trackedTarget}, ${weightLadder} ${weightUnit}`;
   }
 
   if (hasPerSetWeightTargets) {
@@ -1034,7 +1033,7 @@ function formatExerciseSubtitle({
 
     if (uniqueWeights.size === 1) {
       const weight = [...uniqueWeights][0] ?? 0;
-      return `${sets} sets, ${formatWeight(weight)} ${weightUnit} × ${repTarget}`;
+      return `${sets} sets, ${formatWeight(weight)} ${weightUnit} × ${trackedTarget}`;
     }
 
     if (uniqueWeights.size > 1) {
@@ -1045,23 +1044,25 @@ function formatExerciseSubtitle({
         )
         .map((set) => formatWeight(set.targetWeight))
         .join(' → ');
-      return `${sets} sets, ${repTarget} reps, ${weightLadder} ${weightUnit}`;
+      return `${sets} sets, ${trackedTarget}, ${weightLadder} ${weightUnit}`;
     }
 
     const firstRange = exercise.sets.find(
       (set) => set.targetWeightMin != null && set.targetWeightMax != null,
     );
     if (firstRange && firstRange.targetWeightMin != null && firstRange.targetWeightMax != null) {
-      return `${sets} sets, ${firstRange.targetWeightMin}-${firstRange.targetWeightMax} ${weightUnit} × ${repTarget}`;
+      return `${sets} sets, ${firstRange.targetWeightMin}-${firstRange.targetWeightMax} ${weightUnit} × ${trackedTarget}`;
     }
   }
 
-  const needsRepsSuffix =
-    !repTarget.toLowerCase().includes('rep') &&
-    !repTarget.toLowerCase().includes('sec') &&
-    !repTarget.toLowerCase().includes('min');
+  const hasExplicitUnit =
+    repTarget.toLowerCase().includes('rep') ||
+    repTarget.toLowerCase().includes('sec') ||
+    repTarget.toLowerCase().includes('min') ||
+    repTarget.toLowerCase().includes('mi') ||
+    repTarget.toLowerCase().includes('km');
 
-  return needsRepsSuffix ? `${sets} sets × ${repTarget} reps` : `${sets} × ${repTarget}`;
+  return hasExplicitUnit ? `${sets} × ${trackedTarget}` : `${sets} sets × ${trackedTarget}`;
 }
 
 function formatHistoryPreview({
@@ -1106,6 +1107,34 @@ function parsePrescribedRepTarget(prescribedReps: string) {
   return prescribedReps;
 }
 
+function formatTrackedRepTarget(
+  target: string,
+  trackingType: ExerciseTrackingType,
+  weightUnit: WeightUnit,
+) {
+  const lower = target.toLowerCase();
+
+  if (
+    trackingType === 'seconds_only' ||
+    trackingType === 'weight_seconds' ||
+    trackingType === 'cardio' ||
+    trackingType === 'reps_seconds'
+  ) {
+    return lower.includes('sec') || lower.includes('min') ? target : `${target} sec`;
+  }
+
+  if (trackingType === 'distance') {
+    const unit = getDistanceUnit(weightUnit);
+    return lower.includes('km') || lower.includes('mi') ? target : `${target} ${unit}`;
+  }
+
+  if (lower.includes('rep') || lower.includes('sec') || lower.includes('min')) {
+    return target;
+  }
+
+  return `${target} reps`;
+}
+
 function formatPerformedReps(reps: number, prescribedReps: string) {
   if (prescribedReps.includes('min')) {
     const minutes = Math.floor(reps / 60);
@@ -1119,7 +1148,7 @@ function formatPerformedReps(reps: number, prescribedReps: string) {
   }
 
   if (prescribedReps.includes('sec')) {
-    return `${reps}s`;
+    return `${reps} sec`;
   }
 
   return `${reps} reps`;

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -119,6 +119,22 @@ const supersetAccentStyles = [
   'border-l-rose-500 before:bg-rose-500',
 ] as const;
 
+function isSectionInitiallyOpen(
+  section: ActiveWorkoutSessionData['sections'][number],
+  currentExerciseId: string | null,
+) {
+  return section.exercises.some((exercise) => exercise.id === currentExerciseId);
+}
+
+function createInitialOpenSections(session: ActiveWorkoutSessionData) {
+  return Object.fromEntries(
+    session.sections.map((section) => [
+      section.id,
+      isSectionInitiallyOpen(section, session.currentExerciseId),
+    ]),
+  );
+}
+
 export function SessionExerciseList({
   enableApiLastPerformance = false,
   focusSetId = null,
@@ -134,7 +150,9 @@ export function SessionExerciseList({
   sessionCuesByExercise,
   weightUnit = 'lbs',
 }: SessionExerciseListProps) {
-  const [openSections, setOpenSections] = useState<Record<string, boolean>>({});
+  const [openSections, setOpenSections] = useState<Record<string, boolean>>(() =>
+    createInitialOpenSections(session),
+  );
   const [expandedExercises, setExpandedExercises] = useState<Record<string, boolean>>({});
   const [renameTarget, setRenameTarget] = useState<{
     exerciseId: string;
@@ -181,6 +199,7 @@ export function SessionExerciseList({
     const input = repsInputRefs.current[focusSetId];
 
     if (!input) {
+      onFocusSetHandled?.();
       return;
     }
 
@@ -202,10 +221,7 @@ export function SessionExerciseList({
         const sectionEstimate = formatEstimateMinuteRange(estimateSectionTime(section));
         const sectionSummary = `${completedExercises}/${section.exercises.length} exercises done`;
         const isOpen =
-          focusTarget?.sectionId === section.id
-            ? true
-            : (openSections[section.id] ??
-              section.exercises.some((exercise) => exercise.id === session.currentExerciseId));
+          openSections[section.id] ?? isSectionInitiallyOpen(section, session.currentExerciseId);
         const reorderSectionExercises = (currentIndex: number, nextIndex: number) => {
           if (!onReorderExercises) {
             return;
@@ -239,10 +255,9 @@ export function SessionExerciseList({
               onClick={() =>
                 setOpenSections((current) => ({
                   ...current,
-                  [section.id]: !(
-                    current[section.id] ??
-                    section.exercises.some((exercise) => exercise.id === session.currentExerciseId)
-                  ),
+                  [section.id]:
+                    !(current[section.id] ??
+                      isSectionInitiallyOpen(section, session.currentExerciseId)),
                 }))
               }
               type="button"

--- a/apps/web/src/features/workouts/components/session-summary.test.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.test.tsx
@@ -181,4 +181,36 @@ describe('SessionSummary', () => {
 
     expect(screen.getByText('Saved "Upper Push" to mock templates.')).toBeInTheDocument();
   });
+
+  it('renders tracking-aware summary labels for time-based and mixed sessions', () => {
+    renderWithQueryClient(
+      <SessionSummary
+        duration="12:00"
+        exerciseResults={[
+          {
+            id: 'plank',
+            metricLabel: 'seconds',
+            metricValue: 120,
+            name: 'Plank Hold',
+            reps: 0,
+            setsCompleted: 2,
+            totalSets: 2,
+          },
+        ]}
+        exercisesCompleted={1}
+        onDone={() => {}}
+        summaryMetricLabel="mixed"
+        summaryMetricMixedValue="120 sec • 0.5 mi"
+        totalReps={0}
+        totalSets={2}
+        totalVolume={0}
+        workoutName="Conditioning"
+      />,
+    );
+
+    expect(screen.getByText('Tracked metrics')).toBeInTheDocument();
+    expect(screen.getByText('120 sec • 0.5 mi')).toBeInTheDocument();
+    expect(screen.queryByTestId('summary-pill-count-reps')).not.toBeInTheDocument();
+    expect(screen.getByText('Seconds: 120 sec')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/workouts/components/session-summary.test.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.test.tsx
@@ -213,4 +213,44 @@ describe('SessionSummary', () => {
     expect(screen.queryByTestId('summary-pill-count-reps')).not.toBeInTheDocument();
     expect(screen.getByText('Seconds: 120 sec')).toBeInTheDocument();
   });
+
+  it('renders markdown in read-only exercise and feedback notes', () => {
+    renderWithQueryClient(
+      <SessionSummary
+        duration="15:24"
+        exerciseResults={[
+          {
+            id: 'incline-press',
+            name: 'Incline Dumbbell Press',
+            notes: '- **Brace** at lockout\n- Keep elbows stacked',
+            reps: 16,
+            setsCompleted: 2,
+            totalSets: 2,
+            volume: 880,
+          },
+        ]}
+        exercisesCompleted={1}
+        feedback={[
+          {
+            id: 'coach-note',
+            label: 'Coach note',
+            notes: 'Stay *conservative* early.\n\n<script>alert("xss")</script>',
+            type: 'text',
+            value: 'Solid pacing.',
+          },
+        ]}
+        onDone={() => {}}
+        totalReps={16}
+        totalSets={2}
+        totalVolume={880}
+        workoutName="Upper Push"
+      />,
+    );
+
+    expect(screen.getByText('Brace').tagName).toBe('STRONG');
+    expect(screen.getByText('Keep elbows stacked').closest('li')).toBeInTheDocument();
+    expect(screen.getByText('conservative').tagName).toBe('EM');
+    expect(screen.getByText('<script>alert("xss")</script>')).toBeInTheDocument();
+    expect(document.querySelector('script')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/workouts/components/session-summary.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
+import { formatServing } from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
 
 import {
@@ -26,6 +27,7 @@ import {
   TEMPLATE_TAG_LIMIT,
   TEMPLATE_TAG_SUGGESTIONS,
 } from '../lib/template-tags';
+import { getDistanceUnit, type TrackingSummaryMetricLabel } from '../lib/tracking';
 import type { ActiveWorkoutFeedbackDraft } from '../types';
 
 type SessionSummaryProps = {
@@ -40,6 +42,9 @@ type SessionSummaryProps = {
   onNotesChange?: (notes: string) => void;
   sessionNotes?: string;
   sessionId?: string | null;
+  summaryMetricLabel?: TrackingSummaryMetricLabel | 'mixed';
+  summaryMetricMixedValue?: string | null;
+  summaryMetricValue?: number | null;
   completedSets?: number;
   summarySaving?: boolean;
   totalVolume?: number;
@@ -51,12 +56,14 @@ type SessionSummaryProps = {
 
 export type SessionSummaryExerciseResult = {
   id: string;
+  metricLabel?: TrackingSummaryMetricLabel;
+  metricValue?: number;
   name: string;
   notes?: string | null;
   reps: number;
   setsCompleted: number;
   totalSets: number;
-  volume: number;
+  volume?: number;
 };
 
 export function SessionSummary({
@@ -71,6 +78,9 @@ export function SessionSummary({
   onNotesChange,
   sessionNotes: initialSessionNotes = '',
   sessionId = null,
+  summaryMetricLabel = 'volume',
+  summaryMetricMixedValue = null,
+  summaryMetricValue = null,
   completedSets,
   summarySaving = false,
   totalVolume = 0,
@@ -89,6 +99,15 @@ export function SessionSummary({
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
 
   const hasMaxTemplateTags = templateTags.length >= TEMPLATE_TAG_LIMIT;
+  const resolvedSummaryMetricValue = getSummaryMetricValue({
+    metricLabel: summaryMetricLabel,
+    metricMixedValue: summaryMetricMixedValue,
+    metricValue: summaryMetricValue,
+    totalVolume,
+    totalReps,
+    weightUnit,
+  });
+  const shouldShowRepsPill = totalReps > 0 && summaryMetricLabel !== 'reps';
   const normalizedTagQuery = templateTagInput.trim().toLowerCase();
   const suggestedTemplateTags = useMemo(
     () =>
@@ -149,9 +168,9 @@ export function SessionSummary({
           <div className="flex flex-wrap gap-2">
             <SummaryPill
               icon={Dumbbell}
-              label="Total volume"
-              tone="volume"
-              value={formatWeight(totalVolume, weightUnit)}
+              label={getSummaryMetricLabel(summaryMetricLabel)}
+              tone={getMetricTone(summaryMetricLabel)}
+              value={resolvedSummaryMetricValue}
             />
             <SummaryPill icon={Clock3} label="Duration" tone="time" value={duration} />
             <SummaryPill
@@ -160,7 +179,9 @@ export function SessionSummary({
               tone="count"
               value={completedSets === undefined ? `${totalSets}` : `${completedSets}/${totalSets}`}
             />
-            <SummaryPill icon={CheckCircle2} label="Reps" tone="count" value={`${totalReps}`} />
+            {shouldShowRepsPill ? (
+              <SummaryPill icon={CheckCircle2} label="Reps" tone="count" value={`${totalReps}`} />
+            ) : null}
           </div>
 
           {exerciseResults.length > 0 ? (
@@ -182,11 +203,17 @@ export function SessionSummary({
                     </div>
                     <div className="mt-1 flex flex-wrap gap-1.5">
                       <MetricChip
-                        label="Volume"
-                        tone="volume"
-                        value={formatWeight(exercise.volume, weightUnit)}
+                        label={getExerciseMetricLabel(exercise.metricLabel ?? 'volume')}
+                        tone={getMetricTone(exercise.metricLabel ?? 'volume')}
+                        value={formatSummaryMetricValue(
+                          exercise.metricValue ?? exercise.volume ?? 0,
+                          exercise.metricLabel ?? 'volume',
+                          weightUnit,
+                        )}
                       />
-                      <MetricChip label="Reps" tone="count" value={`${exercise.reps}`} />
+                      {exercise.reps > 0 && (exercise.metricLabel ?? 'volume') !== 'reps' ? (
+                        <MetricChip label="Reps" tone="count" value={`${exercise.reps}`} />
+                      ) : null}
                     </div>
                     {exercise.notes?.trim() ? (
                       <p className="mt-2 text-xs text-muted">{exercise.notes.trim()}</p>
@@ -464,6 +491,98 @@ function formatFeedbackFieldValue(field: ActiveWorkoutFeedbackDraft[number]) {
     default:
       return '-';
   }
+}
+
+function getSummaryMetricLabel(label: TrackingSummaryMetricLabel | 'mixed') {
+  switch (label) {
+    case 'reps':
+      return 'Total reps';
+    case 'seconds':
+      return 'Total time';
+    case 'distance':
+      return 'Total distance';
+    case 'mixed':
+      return 'Tracked metrics';
+    case 'volume':
+    default:
+      return 'Total volume';
+  }
+}
+
+function getExerciseMetricLabel(label: TrackingSummaryMetricLabel) {
+  switch (label) {
+    case 'reps':
+      return 'Reps';
+    case 'seconds':
+      return 'Seconds';
+    case 'distance':
+      return 'Distance';
+    case 'volume':
+    default:
+      return 'Volume';
+  }
+}
+
+function formatSummaryMetricValue(
+  value: number,
+  label: TrackingSummaryMetricLabel,
+  weightUnit: WeightUnit,
+) {
+  if (label === 'volume') {
+    return formatWeight(value, weightUnit);
+  }
+
+  if (label === 'reps') {
+    return `${Math.round(value)}`;
+  }
+
+  if (label === 'seconds') {
+    return `${formatServing(value)} sec`;
+  }
+
+  return `${formatServing(value)} ${getDistanceUnit(weightUnit)}`;
+}
+
+function getSummaryMetricValue({
+  metricLabel,
+  metricMixedValue,
+  metricValue,
+  totalReps,
+  totalVolume,
+  weightUnit,
+}: {
+  metricLabel: TrackingSummaryMetricLabel | 'mixed';
+  metricMixedValue: string | null;
+  metricValue: number | null;
+  totalReps: number;
+  totalVolume: number;
+  weightUnit: WeightUnit;
+}) {
+  if (metricLabel === 'mixed') {
+    return metricMixedValue ?? '-';
+  }
+
+  if (metricValue != null) {
+    return formatSummaryMetricValue(metricValue, metricLabel, weightUnit);
+  }
+
+  if (metricLabel === 'reps') {
+    return `${totalReps}`;
+  }
+
+  return formatSummaryMetricValue(totalVolume, metricLabel, weightUnit);
+}
+
+function getMetricTone(label: TrackingSummaryMetricLabel | 'mixed'): 'count' | 'time' | 'volume' {
+  if (label === 'seconds') {
+    return 'time';
+  }
+
+  if (label === 'volume') {
+    return 'volume';
+  }
+
+  return 'count';
 }
 
 function SummaryPill({

--- a/apps/web/src/features/workouts/components/session-summary.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.tsx
@@ -29,6 +29,7 @@ import {
 } from '../lib/template-tags';
 import { getDistanceUnit, type TrackingSummaryMetricLabel } from '../lib/tracking';
 import type { ActiveWorkoutFeedbackDraft } from '../types';
+import { MarkdownNote } from './markdown-note';
 
 type SessionSummaryProps = {
   className?: string;
@@ -216,7 +217,10 @@ export function SessionSummary({
                       ) : null}
                     </div>
                     {exercise.notes?.trim() ? (
-                      <p className="mt-2 text-xs text-muted">{exercise.notes.trim()}</p>
+                      <MarkdownNote
+                        className="mt-2 text-xs text-muted"
+                        content={exercise.notes.trim()}
+                      />
                     ) : null}
                   </article>
                 ))}
@@ -272,7 +276,10 @@ export function SessionSummary({
                       {formatFeedbackFieldValue(field)}
                     </p>
                     {field.notes?.trim() ? (
-                      <p className="mt-1.5 text-xs text-muted">{field.notes.trim()}</p>
+                      <MarkdownNote
+                        className="mt-1.5 text-xs text-muted"
+                        content={field.notes.trim()}
+                      />
                     ) : null}
                   </div>
                 ))}

--- a/apps/web/src/features/workouts/components/set-row.test.tsx
+++ b/apps/web/src/features/workouts/components/set-row.test.tsx
@@ -12,7 +12,7 @@ describe('SetRow', () => {
     vi.useRealTimers();
   });
 
-  it('renders compact inline inputs and auto-completes from field updates', () => {
+  it('renders compact inline inputs and sends value-only updates while typing', () => {
     const onUpdate = vi.fn();
 
     render(
@@ -43,7 +43,6 @@ describe('SetRow', () => {
 
     expect(onUpdate).toHaveBeenCalledTimes(1);
     expect(onUpdate).toHaveBeenCalledWith({
-      completed: true,
       distance: null,
       reps: 10,
       seconds: null,
@@ -51,7 +50,7 @@ describe('SetRow', () => {
     });
   });
 
-  it('applies completed styling and handles cleared numeric values', () => {
+  it('applies completed styling and keeps completion unchanged when editing values', () => {
     const onUpdate = vi.fn();
 
     render(<SetRow completed onUpdate={onUpdate} reps={13} setNumber={1} weight={50} />);
@@ -62,13 +61,40 @@ describe('SetRow', () => {
 
     expect(document.querySelector('[data-slot="set-row"]')).toHaveClass('bg-emerald-500/10');
     expect(onUpdate).toHaveBeenCalledWith({
-      completed: false,
       distance: null,
       reps: null,
       seconds: null,
       weight: 50,
     });
     expect(screen.queryByRole('button', { name: 'Add Set' })).not.toBeInTheDocument();
+  });
+
+  it('marks a set complete and incomplete through the explicit checkbox', () => {
+    const onUpdate = vi.fn();
+
+    const { rerender } = render(
+      <SetRow completed={false} onUpdate={onUpdate} reps={8} setNumber={2} weight={60} />,
+    );
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Complete set 2' }));
+    expect(onUpdate).toHaveBeenCalledWith({
+      completed: true,
+      distance: null,
+      reps: 8,
+      seconds: null,
+      weight: 60,
+    });
+
+    onUpdate.mockClear();
+    rerender(<SetRow completed onUpdate={onUpdate} reps={8} setNumber={2} weight={60} />);
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Complete set 2' }));
+    expect(onUpdate).toHaveBeenCalledWith({
+      completed: false,
+      distance: null,
+      reps: 8,
+      seconds: null,
+      weight: 60,
+    });
   });
 
   it('renders reps-only rows without weight input', () => {
@@ -86,7 +112,7 @@ describe('SetRow', () => {
     expect(screen.queryByLabelText('Weight for set 2')).not.toBeInTheDocument();
   });
 
-  it('auto-completes seconds-only rows from duration input', () => {
+  it('sends value-only updates for seconds-only rows', () => {
     const onUpdate = vi.fn();
 
     render(
@@ -104,7 +130,6 @@ describe('SetRow', () => {
     vi.advanceTimersByTime(500);
 
     expect(onUpdate).toHaveBeenCalledWith({
-      completed: true,
       distance: null,
       reps: null,
       seconds: 45,

--- a/apps/web/src/features/workouts/components/set-row.test.tsx
+++ b/apps/web/src/features/workouts/components/set-row.test.tsx
@@ -167,7 +167,7 @@ describe('SetRow', () => {
       />,
     );
 
-    expect(screen.getByText('Target: 135 lbs × 45s')).toBeInTheDocument();
+    expect(screen.getByText('Target: 135 lbs × 45 sec')).toBeInTheDocument();
   });
 
   it('prefixes cardio target hints when only one dimension exists', () => {
@@ -183,7 +183,7 @@ describe('SetRow', () => {
       />,
     );
 
-    expect(screen.getByText('Target: 45s')).toBeInTheDocument();
+    expect(screen.getByText('Target: 45 sec')).toBeInTheDocument();
   });
 
   it('renders weight ranges in target hints for weight-rep exercises', () => {
@@ -230,7 +230,7 @@ describe('SetRow', () => {
       />,
     );
 
-    expect(screen.getByText('Target: 45s')).toBeInTheDocument();
+    expect(screen.getByText('Target: 45 sec')).toBeInTheDocument();
   });
 
   it('does not render a target hint when no prescribed targets exist', () => {

--- a/apps/web/src/features/workouts/components/set-row.tsx
+++ b/apps/web/src/features/workouts/components/set-row.tsx
@@ -308,7 +308,7 @@ function formatTargetHint({
       : null;
   const weightValue =
     targetWeight !== null ? `${targetWeight} ${weightUnit}` : (weightRange ?? null);
-  const secondsValue = targetSeconds !== null ? `${targetSeconds}s` : null;
+  const secondsValue = targetSeconds !== null ? `${targetSeconds} sec` : null;
   const distanceValue =
     targetDistance !== null ? `${targetDistance} ${getDistanceUnit(weightUnit)}` : null;
 

--- a/apps/web/src/features/workouts/components/set-row.tsx
+++ b/apps/web/src/features/workouts/components/set-row.tsx
@@ -1,11 +1,12 @@
 import { forwardRef, useState } from 'react';
 import type { ExerciseTrackingType, WeightUnit } from '@pulse/shared';
 
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { useDebouncedCallback } from '@/lib/use-debounced-callback';
 import { cn } from '@/lib/utils';
 
-import { getDistanceUnit, isSetCompleteForTrackingType } from '../lib/tracking';
+import { getDistanceUnit } from '../lib/tracking';
 
 type SetRowUpdate = {
   completed?: boolean;
@@ -78,7 +79,7 @@ export const SetRow = forwardRef<HTMLInputElement, SetRowProps>(function SetRow(
   const debouncedOnUpdate = useDebouncedCallback((update: SetRowUpdate) => {
     onUpdate(update);
   });
-  const localCompleted = completed || isSetCompleteForTrackingType(trackingType, resolvedValues);
+  const localCompleted = completed;
   const targetHint = formatTargetHint({
     targetDistance,
     targetSeconds,
@@ -97,9 +98,23 @@ export const SetRow = forwardRef<HTMLInputElement, SetRowProps>(function SetRow(
       )}
       data-slot="set-row"
     >
-      <div className="shrink-0">
-        <span className="text-xs font-semibold text-muted">{`Set ${setNumber}`}</span>
-        {targetHint ? <p className="text-[10px] text-muted">{targetHint}</p> : null}
+      <div className="flex shrink-0 items-start gap-2">
+        <Checkbox
+          aria-label={`Complete set ${setNumber}`}
+          checked={completed}
+          className="mt-0.5 border-border bg-background"
+          onCheckedChange={(nextChecked) => {
+            debouncedOnUpdate.cancel();
+            onUpdate({
+              ...resolvedValues,
+              completed: nextChecked === true,
+            });
+          }}
+        />
+        <div>
+          <span className="text-xs font-semibold text-muted">{`Set ${setNumber}`}</span>
+          {targetHint ? <p className="text-[10px] text-muted">{targetHint}</p> : null}
+        </div>
       </div>
 
       <div
@@ -118,16 +133,12 @@ export const SetRow = forwardRef<HTMLInputElement, SetRowProps>(function SetRow(
                 ...resolvedValues,
                 [input.key]: value,
               };
-              const nextCompleted = isSetCompleteForTrackingType(trackingType, nextValues);
               setLocalOverrides((current) => ({
                 ...current,
                 [input.key]: value,
               }));
 
-              debouncedOnUpdate.run({
-                ...nextValues,
-                completed: nextCompleted,
-              });
+              debouncedOnUpdate.run(nextValues);
             }}
             onBlur={() => {
               debouncedOnUpdate.flush();

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -639,13 +639,13 @@ describe('WorkoutTemplateDetail', () => {
     );
 
     expect(await screen.findByText('2 x 15')).toBeInTheDocument();
-    expect(screen.getByText('2 x 45s')).toBeInTheDocument();
-    expect(screen.getByText('Set 1: 45s • Set 2: 60s')).toBeInTheDocument();
+    expect(screen.getByText('2 x 45 sec')).toBeInTheDocument();
+    expect(screen.getByText('Set 1: 45 sec • Set 2: 60 sec')).toBeInTheDocument();
     expect(screen.getByText('3 x 6-8 (bodyweight)')).toBeInTheDocument();
-    expect(screen.getByText('2 x 40 lbs x 30s')).toBeInTheDocument();
-    expect(screen.getByText('2 x 10-12 x 30s')).toBeInTheDocument();
+    expect(screen.getByText('2 x 40 lbs x 30 sec')).toBeInTheDocument();
+    expect(screen.getByText('2 x 10-12 x 30 sec')).toBeInTheDocument();
     expect(screen.getByText('3 x 0.25 mi')).toBeInTheDocument();
-    expect(screen.getByText('1 x 300s + 1 mi')).toBeInTheDocument();
+    expect(screen.getByText('1 x 300 sec + 1 mi')).toBeInTheDocument();
   });
 
   it('schedules a workout from the template detail view', async () => {

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -79,7 +79,7 @@ import {
   formatWorkoutConflictDescription,
   getDayWorkoutConflicts,
 } from '../lib/day-workout-conflicts';
-import { getDistanceUnit } from '../lib/tracking';
+import { formatSetSummary, getDistanceUnit } from '../lib/tracking';
 import { buildInitialSessionSets } from '../lib/workout-session-sets';
 import { FormCueChips } from './form-cue-chips';
 import { RenameExerciseDialog } from './rename-exercise-dialog';
@@ -1275,6 +1275,7 @@ function ExerciseDetailModal({
   onOpenChange: (open: boolean) => void;
   onSaveCoachingNotes: (exerciseId: string, coachingNotes: string | null) => Promise<unknown>;
 }) {
+  const { weightUnit } = useWeightUnit();
   const [activeTab, setActiveTab] = useState<'overview' | 'history' | 'related'>('overview');
   const [coachingNotes, setCoachingNotes] = useState(exercise.exercise?.coachingNotes ?? '');
   const [isSaving, setIsSaving] = useState(false);
@@ -1397,7 +1398,7 @@ function ExerciseDetailModal({
               <p className="text-sm text-muted">Loading recent performance...</p>
             ) : (
               <p className="text-sm text-foreground">
-                {formatLastPerformanceSummary(historyQuery.data?.history ?? null, trackingType)}
+                {formatLastPerformanceSummary(historyQuery.data?.history ?? null, trackingType, weightUnit)}
               </p>
             )}
           </div>
@@ -1423,6 +1424,7 @@ function ExerciseDetailModal({
                     {formatLastPerformanceSummary(
                       relatedExercise.history,
                       relatedExercise.trackingType,
+                      weightUnit,
                     )}
                   </p>
                 </div>
@@ -1730,25 +1732,25 @@ function formatTrackingTypeLabel(trackingType: ExerciseTrackingType) {
 function formatLastPerformanceSummary(
   history: { date: string; sets: Array<{ reps: number; weight: number | null }> } | null,
   trackingType: ExerciseTrackingType,
+  weightUnit: WeightUnit,
 ) {
   if (!history || history.sets.length === 0) {
     return 'No history yet.';
   }
 
   const setSummary = history.sets
-    .map((set) => {
-      switch (trackingType) {
-        case 'weight_reps':
-        case 'weight_seconds':
-          return set.weight != null ? `${set.weight} x ${set.reps}` : `${set.reps}`;
-        case 'seconds_only':
-          return `${set.reps}s`;
-        case 'distance':
-          return `${set.reps} distance`;
-        default:
-          return `${set.reps} reps`;
-      }
-    })
+    .map((set) =>
+      formatSetSummary(
+        trackingType === 'distance'
+          ? { distance: set.reps, weight: set.weight }
+          : { reps: set.reps, weight: set.weight },
+        trackingType,
+        {
+          useLegacySecondsFallback: trackingType !== 'reps_seconds',
+          weightUnit,
+        },
+      ),
+    )
     .join(', ');
 
   return `${historyDateFormatter.format(new Date(`${history.date}T12:00:00`))} • ${setSummary}`;
@@ -1778,10 +1780,10 @@ function formatPrescription(exercise: WorkoutTemplateExercise, weightUnit: Weigh
   if (exercise.trackingType === 'seconds_only') {
     if (repsTarget) {
       if (exercise.sets !== null) {
-        return `${exercise.sets} x ${repsTarget}s`;
+        return `${exercise.sets} x ${repsTarget} sec`;
       }
 
-      return `${repsTarget}s`;
+      return `${repsTarget} sec`;
     }
 
     if (exercise.sets !== null) {
@@ -1893,7 +1895,7 @@ function formatTargetByTrackingType(
   repsTarget: string | null,
 ) {
   const weightLabel = formatTargetWeight(target, weightUnit);
-  const secondsLabel = target?.targetSeconds != null ? `${target.targetSeconds}s` : null;
+  const secondsLabel = target?.targetSeconds != null ? `${target.targetSeconds} sec` : null;
   const distanceLabel =
     target?.targetDistance != null
       ? `${target.targetDistance} ${getDistanceUnit(weightUnit)}`

--- a/apps/web/src/features/workouts/lib/active-session.test.ts
+++ b/apps/web/src/features/workouts/lib/active-session.test.ts
@@ -211,4 +211,78 @@ describe('active-session helpers', () => {
 
     expect(firstMainExercise?.trackingType).toBe('seconds_only');
   });
+
+  it('honors explicit template tracking type for unknown exercises', () => {
+    if (!activeTemplate) {
+      throw new Error('Expected upper-push template in mock data.');
+    }
+
+    const unknownExerciseTemplate = structuredClone(activeTemplate);
+    const mainSection = unknownExerciseTemplate.sections[1];
+    const firstExercise = mainSection?.exercises[0];
+    if (!mainSection || !firstExercise) {
+      throw new Error('Expected main section with exercises in template.');
+    }
+
+    mainSection.exercises[0] = {
+      ...firstExercise,
+      exerciseId: 'dead-hang',
+      exerciseName: 'Dead Hang',
+      reps: '8',
+      trackingType: 'seconds_only',
+    };
+
+    const session = buildActiveWorkoutSession(
+      unknownExerciseTemplate,
+      createInitialWorkoutSetDrafts(
+        unknownExerciseTemplate,
+        new Set([createWorkoutSetId('dead-hang', 1)]),
+      ),
+    );
+    const firstMainExercise = session.sections.find((section) => section.type === 'main')
+      ?.exercises[0];
+    const firstSet = firstMainExercise?.sets[0];
+
+    expect(firstMainExercise?.trackingType).toBe('seconds_only');
+    expect(firstSet?.seconds).toBe(8);
+    expect(firstSet?.reps).toBeNull();
+    expect(firstSet?.weight).toBeNull();
+  });
+
+  it('honors explicit reps-only tracking type for unknown exercises', () => {
+    if (!activeTemplate) {
+      throw new Error('Expected upper-push template in mock data.');
+    }
+
+    const unknownExerciseTemplate = structuredClone(activeTemplate);
+    const mainSection = unknownExerciseTemplate.sections[1];
+    const firstExercise = mainSection?.exercises[0];
+    if (!mainSection || !firstExercise) {
+      throw new Error('Expected main section with exercises in template.');
+    }
+
+    mainSection.exercises[0] = {
+      ...firstExercise,
+      exerciseId: 'dead-bug',
+      exerciseName: 'Dead Bug',
+      reps: '12',
+      trackingType: 'reps_only',
+    };
+
+    const session = buildActiveWorkoutSession(
+      unknownExerciseTemplate,
+      createInitialWorkoutSetDrafts(
+        unknownExerciseTemplate,
+        new Set([createWorkoutSetId('dead-bug', 1)]),
+      ),
+    );
+    const firstMainExercise = session.sections.find((section) => section.type === 'main')
+      ?.exercises[0];
+    const firstSet = firstMainExercise?.sets[0];
+
+    expect(firstMainExercise?.trackingType).toBe('reps_only');
+    expect(firstSet?.reps).toBe(12);
+    expect(firstSet?.seconds).toBeNull();
+    expect(firstSet?.weight).toBeNull();
+  });
 });

--- a/apps/web/src/features/workouts/lib/active-session.ts
+++ b/apps/web/src/features/workouts/lib/active-session.ts
@@ -15,7 +15,11 @@ import type {
   ActiveWorkoutSet,
   ActiveWorkoutSetDrafts,
 } from '../types';
-import { parsePrescribedRepsValue, resolveTrackingType } from './tracking';
+import {
+  isWeightedTrackingType,
+  parsePrescribedRepsValue,
+  resolveTrackingType,
+} from './tracking';
 import { workoutEnhancedExercises } from './mock-data';
 
 const exerciseById = new Map(mockExercises.map((exercise) => [exercise.id, exercise]));
@@ -83,6 +87,7 @@ export function buildActiveWorkoutSession(
         exerciseId: templateExercise.exerciseId,
         exerciseName: exercise?.name ?? templateExercise.exerciseName,
         prescribedReps: templateExercise.reps,
+        trackingType: templateExercise.trackingType,
       });
       const sets = getWorkoutSets(templateExercise, setDrafts);
       const completedSets = sets.filter((set) => set.completed).length;
@@ -207,6 +212,7 @@ export function createWorkoutSetDraft(
     exerciseId,
     exerciseName: exercise?.name ?? templateExercise.exerciseName,
     prescribedReps: templateExercise.reps,
+    trackingType: templateExercise.trackingType,
   });
   const initialValue = completed ? parsePrescribedRepsValue(templateExercise.reps) : null;
 
@@ -222,7 +228,10 @@ export function createWorkoutSetDraft(
     targetWeight: null,
     targetWeightMax: null,
     targetWeightMin: null,
-    weight: completed ? (sampleWeightByExerciseId.get(exerciseId) ?? null) : null,
+    weight:
+      completed && isWeightedTrackingType(trackingType)
+        ? (sampleWeightByExerciseId.get(exerciseId) ?? null)
+        : null,
   };
 }
 

--- a/apps/web/src/features/workouts/lib/session-notes.ts
+++ b/apps/web/src/features/workouts/lib/session-notes.ts
@@ -7,6 +7,7 @@ import type {
 
 import type { ActiveWorkoutSetDrafts } from '@/features/workouts/types';
 import type { WorkoutTemplate as MockWorkoutTemplate } from '@/lib/mock-data/workouts';
+import { isTimeBasedTrackingType, isWeightedTrackingType } from './tracking';
 
 type TemplateExerciseLookup = Map<
   string,
@@ -55,11 +56,7 @@ export function buildSessionSetInputs(
     const templateExercise = templateExerciseById.get(exerciseId);
     const normalizedExerciseNote = normalizeExerciseNote(exerciseNotes[exerciseId]);
     const trackingType = templateExercise?.trackingType ?? 'weight_reps';
-    const isTimeBased =
-      trackingType === 'weight_seconds' ||
-      trackingType === 'reps_seconds' ||
-      trackingType === 'seconds_only' ||
-      trackingType === 'cardio';
+    const isTimeBased = isTimeBasedTrackingType(trackingType);
 
     for (const draftSet of [...draftSets].sort((left, right) => left.number - right.number)) {
       sessionSets.push({
@@ -76,7 +73,7 @@ export function buildSessionSetInputs(
         targetWeightMax: draftSet.targetWeightMax,
         targetSeconds: draftSet.targetSeconds,
         targetDistance: draftSet.targetDistance,
-        weight: draftSet.weight,
+        weight: isWeightedTrackingType(trackingType) ? draftSet.weight : null,
       });
     }
   }

--- a/apps/web/src/features/workouts/lib/tracking.test.ts
+++ b/apps/web/src/features/workouts/lib/tracking.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  formatMetricNumber,
   formatSetSummary,
+  formatTrackingMetricBreakdown,
   getSetSummaryMetricValue,
   getTrackingSummaryMetricLabel,
 } from './tracking';
@@ -74,5 +76,25 @@ describe('tracking format helpers', () => {
     expect(getTrackingSummaryMetricLabel('distance')).toBe('distance');
     expect(getSetSummaryMetricValue('weight_reps', { reps: 5, weight: 100 })).toBe(500);
     expect(getSetSummaryMetricValue('seconds_only', { reps: 40 })).toBe(40);
+  });
+
+  it('formats mixed metric breakdown values consistently', () => {
+    expect(
+      formatTrackingMetricBreakdown(
+        {
+          distance: 0.5,
+          reps: 12,
+          seconds: 120,
+          volume: 135,
+        },
+        'lbs',
+      ),
+    ).toBe('135 lbs • 12 reps • 120 sec • 0.5 mi');
+  });
+
+  it('formats metric numbers without trailing zeros', () => {
+    expect(formatMetricNumber(135)).toBe('135');
+    expect(formatMetricNumber(135.5)).toBe('135.5');
+    expect(formatMetricNumber(135.678)).toBe('135.68');
   });
 });

--- a/apps/web/src/features/workouts/lib/tracking.test.ts
+++ b/apps/web/src/features/workouts/lib/tracking.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatSetSummary,
+  getSetSummaryMetricValue,
+  getTrackingSummaryMetricLabel,
+} from './tracking';
+
+describe('tracking format helpers', () => {
+  it('formats weighted rep sets with units and set number', () => {
+    expect(
+      formatSetSummary(
+        {
+          reps: 8,
+          setNumber: 2,
+          weight: 135,
+        },
+        'weight_reps',
+        { includeSetNumber: true, weightUnit: 'lbs' },
+      ),
+    ).toBe('Set 2: 135 lbs × 8 reps');
+  });
+
+  it('formats seconds-only sets with sec suffix', () => {
+    expect(
+      formatSetSummary(
+        {
+          reps: 45,
+        },
+        'seconds_only',
+      ),
+    ).toBe('45 sec');
+  });
+
+  it('formats distance sets with configured distance unit', () => {
+    expect(
+      formatSetSummary(
+        {
+          distance: 2.5,
+        },
+        'distance',
+        { weightUnit: 'kg' },
+      ),
+    ).toBe('2.5 km');
+  });
+
+  it('formats cardio sets with time and distance', () => {
+    expect(
+      formatSetSummary(
+        {
+          reps: 300,
+          distance: 1.2,
+        },
+        'cardio',
+      ),
+    ).toBe('300 sec / 1.2 mi');
+  });
+
+  it('does not infer seconds from reps for reps-seconds history when fallback is disabled', () => {
+    expect(
+      formatSetSummary(
+        {
+          reps: 10,
+          seconds: null,
+        },
+        'reps_seconds',
+        { useLegacySecondsFallback: false },
+      ),
+    ).toBe('10 reps');
+  });
+
+  it('uses tracking-aware aggregate labels and values', () => {
+    expect(getTrackingSummaryMetricLabel('weight_seconds')).toBe('seconds');
+    expect(getTrackingSummaryMetricLabel('distance')).toBe('distance');
+    expect(getSetSummaryMetricValue('weight_reps', { reps: 5, weight: 100 })).toBe(500);
+    expect(getSetSummaryMetricValue('seconds_only', { reps: 40 })).toBe(40);
+  });
+});

--- a/apps/web/src/features/workouts/lib/tracking.ts
+++ b/apps/web/src/features/workouts/lib/tracking.ts
@@ -326,6 +326,32 @@ export function formatTrackingTypeSummary(trackingTypes: ExerciseTrackingType[])
   return uniqueTrackingTypes.map((trackingType) => getTrackingTypeLabel(trackingType)).join(' • ');
 }
 
+export function formatTrackingMetricBreakdown(
+  totals: Record<TrackingSummaryMetricLabel, number>,
+  weightUnit: WeightUnit,
+) {
+  const segments: string[] = [];
+
+  if (totals.volume > 0) {
+    segments.push(`${formatMetricNumber(totals.volume)} ${weightUnit}`);
+  }
+  if (totals.reps > 0) {
+    segments.push(`${formatMetricNumber(totals.reps)} reps`);
+  }
+  if (totals.seconds > 0) {
+    segments.push(`${formatMetricNumber(totals.seconds)} sec`);
+  }
+  if (totals.distance > 0) {
+    segments.push(`${formatMetricNumber(totals.distance)} ${getDistanceUnit(weightUnit)}`);
+  }
+
+  if (segments.length === 0) {
+    return '-';
+  }
+
+  return segments.join(' • ');
+}
+
 function joinSegments(
   left: string | null,
   right: string | null,
@@ -338,7 +364,7 @@ function joinSegments(
   return left ?? right ?? '-';
 }
 
-function formatMetricNumber(value: number) {
+export function formatMetricNumber(value: number) {
   const normalized = Math.round(value * 100) / 100;
   if (Number.isInteger(normalized)) {
     return integerFormatter.format(normalized);

--- a/apps/web/src/features/workouts/lib/tracking.ts
+++ b/apps/web/src/features/workouts/lib/tracking.ts
@@ -80,6 +80,19 @@ export function getDistanceUnit(weightUnit: WeightUnit) {
   return weightUnit === 'kg' ? 'km' : 'mi';
 }
 
+export function isWeightedTrackingType(trackingType: ExerciseTrackingType) {
+  return trackingType === 'weight_reps' || trackingType === 'weight_seconds';
+}
+
+export function isTimeBasedTrackingType(trackingType: ExerciseTrackingType) {
+  return (
+    trackingType === 'weight_seconds' ||
+    trackingType === 'reps_seconds' ||
+    trackingType === 'seconds_only' ||
+    trackingType === 'cardio'
+  );
+}
+
 export function getSetSeconds(set: SetMetrics) {
   if (set.seconds != null) {
     return set.seconds;

--- a/apps/web/src/features/workouts/lib/tracking.ts
+++ b/apps/web/src/features/workouts/lib/tracking.ts
@@ -3,6 +3,8 @@ import type { ExerciseTrackingType, WeightUnit } from '@pulse/shared';
 type SetMetrics = {
   distance?: number | null;
   reps?: number | null;
+  setNumber?: number | null;
+  skipped?: boolean;
   seconds?: number | null;
   weight?: number | null;
 };
@@ -26,6 +28,9 @@ const TRACKING_TYPE_ORDER: ExerciseTrackingType[] = [
   'distance',
   'cardio',
 ];
+const integerFormatter = new Intl.NumberFormat('en-US');
+
+export type TrackingSummaryMetricLabel = 'distance' | 'reps' | 'seconds' | 'volume';
 
 export function resolveTrackingType({
   category,
@@ -94,17 +99,63 @@ export function isTimeBasedTrackingType(trackingType: ExerciseTrackingType) {
 }
 
 export function getSetSeconds(set: SetMetrics) {
-  if (set.seconds != null) {
-    return set.seconds;
-  }
-
-  // Temporary bridge: persisted session sets still store time values in `reps`.
-  // Remove this fallback once session-set `seconds` is migrated end-to-end.
-  return set.reps;
+  return getSetSecondsValue(set, true);
 }
 
 export function getSetDistance(set: SetMetrics) {
   return set.distance ?? null;
+}
+
+export function formatSetSummary(
+  set: SetMetrics,
+  trackingType: ExerciseTrackingType,
+  {
+    includeSetNumber = false,
+    useLegacySecondsFallback = true,
+    weightUnit = 'lbs',
+  }: {
+    includeSetNumber?: boolean;
+    useLegacySecondsFallback?: boolean;
+    weightUnit?: WeightUnit;
+  } = {},
+) {
+  const prefix =
+    includeSetNumber && set.setNumber != null ? `Set ${set.setNumber}: ` : '';
+
+  if (set.skipped) {
+    return `${prefix}Skipped`;
+  }
+
+  const weightLabel = set.weight != null ? `${formatWeightNumber(set.weight)} ${weightUnit}` : null;
+  const repsLabel = set.reps != null ? `${formatMetricNumber(set.reps)} reps` : null;
+  const seconds = getSetSecondsValue(set, useLegacySecondsFallback);
+  const secondsLabel = seconds != null ? `${formatMetricNumber(seconds)} sec` : null;
+  const distance = getSetDistance(set);
+  const resolvedDistance = distance ?? (trackingType === 'distance' ? set.reps : null);
+  const distanceLabel =
+    resolvedDistance != null
+      ? `${formatMetricNumber(resolvedDistance)} ${getDistanceUnit(weightUnit)}`
+      : null;
+
+  switch (trackingType) {
+    case 'weight_reps':
+      return `${prefix}${joinSegments(weightLabel, repsLabel, ' × ')}`;
+    case 'weight_seconds':
+      return `${prefix}${joinSegments(weightLabel, secondsLabel, ' × ')}`;
+    case 'bodyweight_reps':
+    case 'reps_only':
+      return `${prefix}${repsLabel ?? '-'}`;
+    case 'reps_seconds':
+      return `${prefix}${joinSegments(repsLabel, secondsLabel, ' × ')}`;
+    case 'seconds_only':
+      return `${prefix}${secondsLabel ?? '-'}`;
+    case 'distance':
+      return `${prefix}${distanceLabel ?? '-'}`;
+    case 'cardio':
+      return `${prefix}${joinSegments(secondsLabel, distanceLabel, ' / ')}`;
+    default:
+      return `${prefix}${joinSegments(weightLabel, repsLabel, ' × ')}`;
+  }
 }
 
 export function isSetCompleteForTrackingType(trackingType: ExerciseTrackingType, set: SetMetrics) {
@@ -126,7 +177,7 @@ export function isSetCompleteForTrackingType(trackingType: ExerciseTrackingType,
     case 'seconds_only':
       return seconds > 0;
     case 'distance':
-      return distance > 0;
+      return (set.distance ?? set.reps ?? 0) > 0;
     case 'cardio':
       return seconds > 0 && distance > 0;
     default:
@@ -138,7 +189,6 @@ export function getSetVolume(trackingType: ExerciseTrackingType, set: SetMetrics
   const reps = set.reps ?? 0;
   const weight = set.weight ?? 0;
   const seconds = getSetSeconds(set) ?? 0;
-  const distance = getSetDistance(set) ?? 0;
 
   switch (trackingType) {
     case 'weight_reps':
@@ -153,12 +203,57 @@ export function getSetVolume(trackingType: ExerciseTrackingType, set: SetMetrics
     case 'seconds_only':
       return seconds;
     case 'distance':
-      return distance;
+      return set.distance ?? set.reps ?? 0;
     case 'cardio':
       return seconds;
     default:
       return 0;
   }
+}
+
+export function getTrackingSummaryMetricLabel(
+  trackingType: ExerciseTrackingType,
+): TrackingSummaryMetricLabel {
+  switch (trackingType) {
+    case 'weight_reps':
+      return 'volume';
+    case 'bodyweight_reps':
+    case 'reps_only':
+      return 'reps';
+    case 'weight_seconds':
+    case 'reps_seconds':
+    case 'seconds_only':
+    case 'cardio':
+      return 'seconds';
+    case 'distance':
+      return 'distance';
+    default:
+      return 'volume';
+  }
+}
+
+export function getSetSummaryMetricValue(trackingType: ExerciseTrackingType, set: SetMetrics) {
+  switch (getTrackingSummaryMetricLabel(trackingType)) {
+    case 'volume':
+      return getSetVolume(trackingType, set);
+    case 'reps':
+      return set.reps ?? 0;
+    case 'seconds':
+      return getSetSeconds(set) ?? 0;
+    case 'distance':
+      return getSetDistance(set) ?? set.reps ?? 0;
+    default:
+      return 0;
+  }
+}
+
+export function isRepTrackingType(trackingType: ExerciseTrackingType) {
+  return (
+    trackingType === 'weight_reps' ||
+    trackingType === 'bodyweight_reps' ||
+    trackingType === 'reps_only' ||
+    trackingType === 'reps_seconds'
+  );
 }
 
 export function getTrackingVolumeLabel(trackingType: ExerciseTrackingType) {
@@ -229,4 +324,48 @@ export function formatTrackingTypeSummary(trackingTypes: ExerciseTrackingType[])
   );
 
   return uniqueTrackingTypes.map((trackingType) => getTrackingTypeLabel(trackingType)).join(' • ');
+}
+
+function joinSegments(
+  left: string | null,
+  right: string | null,
+  separator: string,
+) {
+  if (left && right) {
+    return `${left}${separator}${right}`;
+  }
+
+  return left ?? right ?? '-';
+}
+
+function formatMetricNumber(value: number) {
+  const normalized = Math.round(value * 100) / 100;
+  if (Number.isInteger(normalized)) {
+    return integerFormatter.format(normalized);
+  }
+
+  return normalized.toFixed(2).replace(/\.?0+$/, '');
+}
+
+function formatWeightNumber(value: number) {
+  const normalized = Math.round(value * 10) / 10;
+  if (Number.isInteger(normalized)) {
+    return integerFormatter.format(normalized);
+  }
+
+  return normalized.toFixed(1);
+}
+
+function getSetSecondsValue(set: SetMetrics, useLegacyFallback: boolean) {
+  if (set.seconds != null) {
+    return set.seconds;
+  }
+
+  if (useLegacyFallback) {
+    // Temporary bridge: persisted session sets still store time values in `reps`.
+    // Remove this fallback once session-set `seconds` is migrated end-to-end.
+    return set.reps;
+  }
+
+  return null;
 }

--- a/apps/web/src/lib/mock-data/workouts.ts
+++ b/apps/web/src/lib/mock-data/workouts.ts
@@ -1,4 +1,5 @@
 import { addDays, startOfWeek, toDateKey } from '@/lib/date-utils';
+import type { ExerciseTrackingType } from '@pulse/shared';
 
 export type WorkoutExerciseCategory = 'compound' | 'isolation' | 'cardio' | 'mobility';
 
@@ -39,6 +40,7 @@ export interface WorkoutExercise {
 export interface WorkoutTemplateExercise {
   exerciseId: WorkoutExercise['id'];
   exerciseName?: string;
+  trackingType?: ExerciseTrackingType;
   sets: number;
   reps: string;
   tempo: string;

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -74,7 +74,7 @@ describe('ActiveWorkoutPage', () => {
     }
   });
 
-  it('renders the active workout UI and advances focus after the rest timer completes', () => {
+  it('renders the active workout UI and does not auto-focus a different section after rest timer completion', () => {
     renderActiveWorkoutPage();
 
     const heading = screen.getByRole('heading', { level: 1, name: 'Upper Push' });
@@ -126,7 +126,7 @@ describe('ActiveWorkoutPage', () => {
     });
 
     const nextExerciseCard = getExerciseCard('Row Erg');
-    expect(within(nextExerciseCard).getByLabelText('Seconds for set 1')).toHaveFocus();
+    expect(within(nextExerciseCard).getByLabelText('Seconds for set 1')).not.toHaveFocus();
     expect(screen.queryByText('After Incline Dumbbell Press set 3')).not.toBeInTheDocument();
 
     const optionalCard = getExerciseCard('Rope Triceps Pushdown');

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, screen, within } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { toast } from 'sonner';
@@ -1011,6 +1011,114 @@ describe('ActiveWorkoutPage', () => {
     expect(screen.getByText('Exercise 1 of 1')).toBeInTheDocument();
   });
 
+  it('renders reps_only and seconds_only inputs from API template tracking types', async () => {
+    vi.useRealTimers();
+    const templateId = '2679a7dd-4a40-4c3e-8bf6-7a70eb4ab5db';
+    const startedAt = Date.parse('2026-03-06T12:00:00.000Z');
+    const mockFetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.endsWith('/api/v1/auth/register')) {
+        return Promise.resolve(jsonResponse({ data: { token: 'dev-generated-token' } }));
+      }
+
+      if (url.endsWith(`/api/v1/workout-templates/${templateId}`)) {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: templateId,
+              userId: 'user-1',
+              name: 'Tracking QA',
+              description: null,
+              tags: [],
+              sections: [
+                {
+                  type: 'warmup',
+                  exercises: [],
+                },
+                {
+                  type: 'main',
+                  exercises: [
+                    {
+                      id: 'template-exercise-dead-bug',
+                      exerciseId: 'dead-bug',
+                      exerciseName: 'Dead Bug',
+                      trackingType: 'reps_only',
+                      sets: 1,
+                      repsMin: 12,
+                      repsMax: 12,
+                      tempo: '2111',
+                      restSeconds: 60,
+                      supersetGroup: null,
+                      notes: null,
+                      cues: [],
+                    },
+                  ],
+                },
+                {
+                  type: 'cooldown',
+                  exercises: [
+                    {
+                      id: 'template-exercise-dead-hang',
+                      exerciseId: 'dead-hang',
+                      exerciseName: 'Dead Hang',
+                      trackingType: 'seconds_only',
+                      sets: 1,
+                      repsMin: 30,
+                      repsMax: 30,
+                      tempo: '2111',
+                      restSeconds: 60,
+                      supersetGroup: null,
+                      notes: null,
+                      cues: [],
+                    },
+                    {
+                      id: 'template-exercise-couch-stretch',
+                      exerciseId: 'couch-stretch',
+                      exerciseName: 'Couch Stretch',
+                      trackingType: 'seconds_only',
+                      sets: 1,
+                      repsMin: 45,
+                      repsMax: 45,
+                      tempo: '2111',
+                      restSeconds: 60,
+                      supersetGroup: null,
+                      notes: null,
+                      cues: [],
+                    },
+                  ],
+                },
+              ],
+              createdAt: startedAt,
+              updatedAt: startedAt,
+            },
+          }),
+        );
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch request: ${url}`));
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    renderActiveWorkoutPage(`/workouts/active?template=${templateId}`);
+    await screen.findByRole('heading', { level: 1, name: 'Tracking QA' });
+    await waitFor(() => {
+      expect(screen.getByText('0/3 sets completed')).toBeInTheDocument();
+    });
+
+    const deadBugCard = getExerciseCard('Dead Bug');
+    expect(within(deadBugCard).getByLabelText('Reps for set 1')).toBeInTheDocument();
+    expect(within(deadBugCard).queryByLabelText('Weight for set 1')).not.toBeInTheDocument();
+
+    const deadHangCard = getExerciseCard('Dead Hang');
+    expect(within(deadHangCard).getByLabelText('Seconds for set 1')).toBeInTheDocument();
+    expect(within(deadHangCard).queryByLabelText('Reps for set 1')).not.toBeInTheDocument();
+    expect(within(deadHangCard).queryByLabelText('Weight for set 1')).not.toBeInTheDocument();
+
+    const couchStretchCard = getExerciseCard('Couch Stretch');
+    expect(within(couchStretchCard).getByLabelText('Seconds for set 1')).toBeInTheDocument();
+  });
+
   it('creates a completed session without a pre-stored token by using dev auto-session auth', async () => {
     vi.useRealTimers();
     window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
@@ -1188,6 +1296,99 @@ describe('ActiveWorkoutPage', () => {
         setNumber: 2,
         skipped: false,
         weight: 45,
+      },
+    ]);
+  });
+
+  it('forces weight to null for non-weighted tracking types in completion payloads', () => {
+    const payloadSets = buildSessionSetInputs(
+      {
+        'dead-bug': [
+          {
+            completed: true,
+            distance: null,
+            id: 'dead-bug-set-1',
+            number: 1,
+            reps: 12,
+            seconds: null,
+            weight: 0,
+          },
+        ],
+        'dead-hang': [
+          {
+            completed: true,
+            distance: null,
+            id: 'dead-hang-set-1',
+            number: 1,
+            reps: null,
+            seconds: 30,
+            weight: 0,
+          },
+        ],
+      },
+      new Map([
+        [
+          'dead-bug',
+          {
+            exercise: {
+              badges: ['mobility'],
+              exerciseId: 'dead-bug',
+              exerciseName: 'Dead Bug',
+              formCues: [],
+              reps: '12',
+              restSeconds: 45,
+              sets: 1,
+              tempo: '2111',
+              trackingType: 'reps_only',
+            },
+            section: 'main',
+            trackingType: 'reps_only',
+          },
+        ],
+        [
+          'dead-hang',
+          {
+            exercise: {
+              badges: ['mobility'],
+              exerciseId: 'dead-hang',
+              exerciseName: 'Dead Hang',
+              formCues: [],
+              reps: '30 sec',
+              restSeconds: 45,
+              sets: 1,
+              tempo: '2111',
+              trackingType: 'seconds_only',
+            },
+            section: 'cooldown',
+            trackingType: 'seconds_only',
+          },
+        ],
+      ]),
+      {},
+    );
+
+    expect(payloadSets).toEqual([
+      {
+        completed: true,
+        exerciseId: 'dead-bug',
+        notes: null,
+        orderIndex: 0,
+        reps: 12,
+        section: 'main',
+        setNumber: 1,
+        skipped: false,
+        weight: null,
+      },
+      {
+        completed: true,
+        exerciseId: 'dead-hang',
+        notes: null,
+        orderIndex: 0,
+        reps: 30,
+        section: 'cooldown',
+        setNumber: 1,
+        skipped: false,
+        weight: null,
       },
     ]);
   });

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -99,7 +99,9 @@ describe('ActiveWorkoutPage', () => {
     expect(
       screen.getByText("Some cards are in preview — sample data is shown and won't be saved."),
     ).toBeInTheDocument();
-    expect(screen.getByText(/\d+\/2 exercises done/)).toBeInTheDocument();
+    expect(
+      within(screen.getByRole('button', { name: /Warmup/i })).getByText('0/2'),
+    ).toBeInTheDocument();
     expect(screen.getByText('Superset')).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /Post-Workout Supplemental \(10-20 min\)/i }),

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -113,6 +113,7 @@ describe('ActiveWorkoutPage', () => {
     fireEvent.change(within(inclineCard).getByLabelText('Reps for set 3'), {
       target: { value: '9' },
     });
+    fireEvent.click(within(inclineCard).getByRole('checkbox', { name: 'Complete set 3' }));
 
     act(() => {
       vi.advanceTimersByTime(500);
@@ -146,6 +147,58 @@ describe('ActiveWorkoutPage', () => {
         name: 'Complete supplemental exercise Dead Bug Breathing',
       }),
     ).toBeChecked();
+  });
+
+  it('only updates the rest timer on explicit set completion toggles', () => {
+    renderActiveWorkoutPage();
+
+    const inclineCard = getExerciseCard('Incline Dumbbell Press');
+
+    fireEvent.change(within(inclineCard).getByLabelText('Weight for set 1'), {
+      target: { value: '50' },
+    });
+    fireEvent.change(within(inclineCard).getByLabelText('Reps for set 1'), {
+      target: { value: '8' },
+    });
+    fireEvent.click(within(inclineCard).getByRole('checkbox', { name: 'Complete set 1' }));
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByText('After Incline Dumbbell Press set 1')).toBeInTheDocument();
+
+    fireEvent.change(within(inclineCard).getByLabelText('Weight for set 2'), {
+      target: { value: '52.5' },
+    });
+    fireEvent.change(within(inclineCard).getByLabelText('Reps for set 2'), {
+      target: { value: '8' },
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByText('After Incline Dumbbell Press set 1')).toBeInTheDocument();
+    expect(screen.queryByText('After Incline Dumbbell Press set 2')).not.toBeInTheDocument();
+
+    fireEvent.click(within(inclineCard).getByRole('checkbox', { name: 'Complete set 2' }));
+    expect(screen.getByText('After Incline Dumbbell Press set 2')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(20_000);
+    });
+
+    fireEvent.change(within(inclineCard).getByLabelText('Reps for set 2'), {
+      target: { value: '9' },
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByText('After Incline Dumbbell Press set 2')).toBeInTheDocument();
+    expect(screen.queryByText('1:30')).not.toBeInTheDocument();
+
+    fireEvent.click(within(inclineCard).getByRole('checkbox', { name: 'Complete set 2' }));
+    expect(screen.queryByText('After Incline Dumbbell Press set 2')).not.toBeInTheDocument();
   });
 
   it('moves from session logging to feedback, summary, and back to workouts', async () => {
@@ -1209,8 +1262,9 @@ function completeSet(exerciseName: string, setNumber: number) {
       value: '1',
     },
   });
+  fireEvent.click(within(card).getByRole('checkbox', { name: `Complete set ${setNumber}` }));
 
-  const skipButton = screen.queryByRole('button', { name: 'Skip' });
+  const skipButton = screen.queryByRole('button', { name: /Skip rest timer/i });
 
   if (skipButton) {
     fireEvent.click(skipButton);

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -191,8 +191,8 @@ describe('ActiveWorkoutPage', () => {
       target: { value: '65' },
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Finish Workout' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Finish' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Complete Workout' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Complete' }));
 
     expect(
       screen.getByRole('heading', { level: 2, name: 'How did this session feel?' }),
@@ -754,21 +754,21 @@ describe('ActiveWorkoutPage', () => {
     vi.useRealTimers();
     renderActiveWorkoutPage();
 
-    const finishButton = screen.getByRole('button', { name: 'Finish Workout' });
-    const finishFooter = finishButton.closest('div');
-    expect(finishFooter).not.toBeNull();
+    const completeButton = screen.getByRole('button', { name: 'Complete Workout' });
+    const completeFooter = completeButton.closest('div');
+    expect(completeFooter).not.toBeNull();
     expect(
-      within(finishFooter as HTMLElement).getByText(/\d+\/\d+ sets completed/i),
+      within(completeFooter as HTMLElement).getByText(/\d+\/\d+ sets completed/i),
     ).toBeInTheDocument();
 
-    fireEvent.click(finishButton);
+    fireEvent.click(completeButton);
     expect(screen.getByText(/End workout with \d+ sets remaining\?/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(screen.queryByText(/End workout with \d+ sets remaining\?/i)).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Finish Workout' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Finish' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Complete Workout' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Complete' }));
 
     expect(
       screen.getByRole('heading', { level: 2, name: 'How did this session feel?' }),
@@ -813,11 +813,62 @@ describe('ActiveWorkoutPage', () => {
     expect(screen.getByTestId('summary-pill-count-sets')).toHaveTextContent(/\d+\/\d+/);
   });
 
+  it('keeps the session active after the last set until completion is explicitly confirmed', () => {
+    vi.useRealTimers();
+    renderActiveWorkoutPage();
+
+    completeSet('Row Erg', 1);
+    completeSet('Banded Shoulder External Rotation', 1);
+    completeSet('Banded Shoulder External Rotation', 2);
+    completeSet('Incline Dumbbell Press', 1);
+    completeSet('Incline Dumbbell Press', 2);
+    completeSet('Incline Dumbbell Press', 3);
+    completeSet('Seated Dumbbell Shoulder Press', 1);
+    completeSet('Seated Dumbbell Shoulder Press', 2);
+    completeSet('Seated Dumbbell Shoulder Press', 3);
+    completeSet('Cable Lateral Raise', 1);
+    completeSet('Cable Lateral Raise', 2);
+    completeSet('Cable Lateral Raise', 3);
+    completeSet('Rope Triceps Pushdown', 1);
+    completeSet('Rope Triceps Pushdown', 2);
+    completeSet('Rope Triceps Pushdown', 3);
+
+    if (!screen.queryByRole('heading', { level: 3, name: 'Couch Stretch' })) {
+      fireEvent.click(screen.getByRole('button', { name: /Cooldown/i }));
+    }
+
+    completeSet('Couch Stretch', 1);
+    completeSet('Couch Stretch', 2);
+
+    expect(screen.getByRole('button', { name: 'Complete Workout' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { level: 2, name: 'How did this session feel?' }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Complete Workout' }));
+    expect(screen.getByText('Complete this workout?')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { level: 2, name: 'How did this session feel?' }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByText('Complete this workout?')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { level: 2, name: 'How did this session feel?' }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Complete Workout' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Complete' }));
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'How did this session feel?' }),
+    ).toBeInTheDocument();
+  });
+
   it('shows standard feedback controls and requires pain details when pain is yes', () => {
     renderActiveWorkoutPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Finish Workout' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Finish' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Complete Workout' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Complete' }));
 
     const rpeGroup = screen.getByRole('group', { name: 'Session RPE rating' });
     expect(rpeGroup).toBeInTheDocument();
@@ -928,8 +979,8 @@ describe('ActiveWorkoutPage', () => {
 
     renderActiveWorkoutPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Finish Workout' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Finish' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Complete Workout' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Complete' }));
     fireEvent.click(
       within(screen.getByRole('group', { name: 'Session RPE rating' })).getByRole('button', {
         name: '7',

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -296,9 +296,9 @@ describe('ActiveWorkoutPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Finalize session' }));
 
     expect(await screen.findByRole('heading', { level: 1, name: 'Workout summary' })).toBeVisible();
-    expect(screen.getByText('Total volume')).toBeInTheDocument();
+    expect(screen.getByText(/Total volume|Tracked metrics/)).toBeInTheDocument();
     expect(screen.getByText('Sets')).toBeInTheDocument();
-    expect(screen.getByText('Reps')).toBeInTheDocument();
+    expect(screen.getAllByText(/Reps|Total reps/).length).toBeGreaterThan(0);
     expect(screen.getByText('Duration')).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 2, name: 'Exercise results' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 2, name: 'Session feedback' })).toBeInTheDocument();

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -63,6 +63,8 @@ import {
 } from '@/features/workouts/api/workouts';
 import {
   getSetVolume,
+  isTimeBasedTrackingType,
+  isWeightedTrackingType,
   resolveTrackingType,
 } from '@/features/workouts/lib/tracking';
 import { useCompleteSession } from '@/hooks/use-complete-session';
@@ -253,16 +255,6 @@ export function ActiveWorkoutPage() {
     });
   }, [activeWorkoutDraftId, navigate]);
 
-  const sessionTrackingTypeById = useMemo(
-    () =>
-      new Map(
-        (activeSession?.exercises ?? []).map((exercise) => [
-          exercise.exerciseId,
-          exercise.trackingType,
-        ]),
-      ),
-    [activeSession?.exercises],
-  );
   const templateExerciseById = useMemo(
     () =>
       new Map(
@@ -273,7 +265,7 @@ export function ActiveWorkoutPage() {
               exercise,
               section: section.type,
               trackingType: resolveTrackingType({
-                trackingType: sessionTrackingTypeById.get(exercise.exerciseId) ?? undefined,
+                trackingType: exercise.trackingType,
                 category: mockExerciseById.get(exercise.exerciseId)?.category,
                 exerciseId: exercise.exerciseId,
                 exerciseName: exercise.exerciseName,
@@ -283,7 +275,7 @@ export function ActiveWorkoutPage() {
           ]),
         ),
       ),
-    [template, sessionTrackingTypeById],
+    [template],
   );
   const exerciseOrderIndexById = useMemo(
     () => buildExerciseOrderIndexById(template, exerciseOrderBySection),
@@ -1059,12 +1051,16 @@ export function ActiveWorkoutPage() {
       return;
     }
 
-    const normalizedUpdate = update;
     const updatedSets = exerciseSets.map((set) =>
       set.id === setId
         ? {
-            ...set,
-            ...normalizedUpdate,
+            ...normalizeSetDraftForTrackingType(
+              {
+                ...set,
+                ...update,
+              },
+              templateExercise.trackingType,
+            ),
           }
         : set,
     );
@@ -1082,14 +1078,12 @@ export function ActiveWorkoutPage() {
 
     if (activeSessionId) {
       setSessionError(null);
-      const isTimeBased = ['weight_seconds', 'reps_seconds', 'seconds_only', 'cardio'].includes(
-        templateExercise.trackingType,
-      );
+      const isTimeBased = isTimeBasedTrackingType(templateExercise.trackingType);
       const persistedUpdate = {
         completed: updatedSet.completed,
         // Bridge for time-based exercises: store seconds in the `reps` column until DB support lands.
         reps: isTimeBased ? updatedSet.seconds : updatedSet.reps,
-        weight: updatedSet.weight,
+        weight: isWeightedTrackingType(templateExercise.trackingType) ? updatedSet.weight : null,
       };
       updateSetMutation.mutate(
         {
@@ -1109,14 +1103,14 @@ export function ActiveWorkoutPage() {
       );
     }
 
-    if (normalizedUpdate.completed === false) {
+    if (update.completed === false) {
       setRestTimer(null);
       setRestTimerTargetSetId(null);
       setFocusSetId(null);
       return;
     }
 
-    if (normalizedUpdate.completed !== true || previousSet.completed || !updatedSet.completed) {
+    if (update.completed !== true || previousSet.completed || !updatedSet.completed) {
       return;
     }
 
@@ -1381,20 +1375,9 @@ function createSessionSetDrafts(
   for (const sessionSet of sessionSets) {
     const trackingType =
       templateExerciseById.get(sessionSet.exerciseId)?.trackingType ?? 'weight_reps';
-    const nextSeconds =
-      trackingType === 'weight_seconds' ||
-      trackingType === 'reps_seconds' ||
-      trackingType === 'seconds_only' ||
-      trackingType === 'cardio'
-        ? sessionSet.reps
-        : null;
-    const nextReps =
-      trackingType === 'weight_seconds' ||
-      trackingType === 'reps_seconds' ||
-      trackingType === 'seconds_only' ||
-      trackingType === 'cardio'
-        ? null
-        : sessionSet.reps;
+    const isTimeBased = isTimeBasedTrackingType(trackingType);
+    const nextSeconds = isTimeBased ? sessionSet.reps : null;
+    const nextReps = isTimeBased ? null : sessionSet.reps;
     const nextSet = {
       completed: sessionSet.completed,
       distance: null,
@@ -1407,7 +1390,7 @@ function createSessionSetDrafts(
       targetWeight: sessionSet.targetWeight ?? null,
       targetWeightMax: sessionSet.targetWeightMax ?? null,
       targetWeightMin: sessionSet.targetWeightMin ?? null,
-      weight: sessionSet.weight,
+      weight: isWeightedTrackingType(trackingType) ? sessionSet.weight : null,
     };
     const existingSets = drafts[sessionSet.exerciseId] ?? [];
     const existingSetIndex = existingSets.findIndex((set) => set.number === sessionSet.setNumber);
@@ -1839,6 +1822,20 @@ function findSetSectionId(session: ReturnType<typeof buildActiveWorkoutSession>,
   return null;
 }
 
+function normalizeSetDraftForTrackingType<T extends { weight: number | null }>(
+  setDraft: T,
+  trackingType: ExerciseTrackingType,
+) {
+  if (!isWeightedTrackingType(trackingType)) {
+    return {
+      ...setDraft,
+      weight: null,
+    };
+  }
+
+  return setDraft;
+}
+
 function toDateTimeLocalValue(isoString: string) {
   const date = new Date(isoString);
 
@@ -1944,6 +1941,7 @@ function toMockWorkoutTemplate(template: ApiWorkoutTemplate): MockWorkoutTemplat
       exercises: section.exercises.map((exercise) => ({
         exerciseId: exercise.exerciseId,
         exerciseName: exercise.exerciseName,
+        trackingType: exercise.trackingType,
         sets: exercise.sets ?? 1,
         reps: formatTemplateExerciseReps(exercise.repsMin, exercise.repsMax),
         tempo: exercise.tempo ?? '2111',
@@ -2024,6 +2022,7 @@ function buildTemplateFromSession(
         sessionExercise.exerciseName ||
         fallbackExerciseNameById.get(sessionExercise.exerciseId) ||
         'Unknown Exercise',
+      trackingType: fallbackExercise?.trackingType ?? sessionExercise.trackingType ?? undefined,
       sets: Math.max(
         fallbackExercise?.sets ?? 0,
         sessionExercise.sets.reduce((maxValue, set) => Math.max(maxValue, set.setNumber), 0),
@@ -2077,6 +2076,7 @@ function buildSessionExercisesFromSets(session: ApiWorkoutSession) {
       exerciseId: string;
       exerciseName: string;
       orderIndex: number;
+      trackingType: ExerciseTrackingType | null;
       section: WorkoutTemplateSectionType | null;
       sets: SessionSet[];
     }
@@ -2094,6 +2094,7 @@ function buildSessionExercisesFromSets(session: ApiWorkoutSession) {
       exerciseId: set.exerciseId,
       exerciseName: namesById.get(set.exerciseId) ?? 'Unknown Exercise',
       orderIndex: set.orderIndex ?? 0,
+      trackingType: null,
       section: set.section,
       sets: [set],
     });

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -13,7 +13,6 @@ import {
   type WorkoutSession as ApiWorkoutSession,
   type SessionSet,
   type WorkoutSessionTimeSegment,
-  type WeightUnit,
   workoutSessionSchema,
   type WorkoutSessionFeedback,
   type WorkoutSessionFeedbackResponse,
@@ -62,7 +61,7 @@ import {
   useWorkoutTemplate,
 } from '@/features/workouts/api/workouts';
 import {
-  getDistanceUnit,
+  formatTrackingMetricBreakdown,
   getSetSummaryMetricValue,
   getTrackingSummaryMetricLabel,
   isRepTrackingType,
@@ -1922,41 +1921,6 @@ function parseEditableTimeSegments(timeSegments: WorkoutSessionTimeSegment[]) {
       error: 'Time segments must be ordered, non-overlapping, and each end must be after start.',
     };
   }
-}
-
-function formatTrackingMetricBreakdown(
-  totals: Record<TrackingSummaryMetricLabel, number>,
-  weightUnit: WeightUnit,
-) {
-  const segments: string[] = [];
-
-  if (totals.volume > 0) {
-    segments.push(`${formatMetricValue(totals.volume)} ${weightUnit}`);
-  }
-  if (totals.reps > 0) {
-    segments.push(`${formatMetricValue(totals.reps)} reps`);
-  }
-  if (totals.seconds > 0) {
-    segments.push(`${formatMetricValue(totals.seconds)} sec`);
-  }
-  if (totals.distance > 0) {
-    segments.push(`${formatMetricValue(totals.distance)} ${getDistanceUnit(weightUnit)}`);
-  }
-
-  if (segments.length === 0) {
-    return '-';
-  }
-
-  return segments.join(' • ');
-}
-
-function formatMetricValue(value: number) {
-  const rounded = Math.round(value * 100) / 100;
-  if (Number.isInteger(rounded)) {
-    return new Intl.NumberFormat('en-US').format(rounded);
-  }
-
-  return rounded.toFixed(2).replace(/\.?0+$/, '');
 }
 
 function buildActiveWorkoutSessionHref(sessionId: string, view: string | null) {

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -1135,6 +1135,13 @@ export function ActiveWorkoutPage() {
       return;
     }
 
+    const completedSetSectionId = findSetSectionId(updatedSession, updatedSet.id);
+    const nextSetSectionId = findSetSectionId(updatedSession, nextTargetSetId);
+    const shouldFocusNextSet =
+      completedSetSectionId !== null &&
+      nextSetSectionId !== null &&
+      completedSetSectionId === nextSetSectionId;
+
     restTimerTokenRef.current += 1;
     setRestTimer({
       duration: templateExercise.exercise.restSeconds,
@@ -1147,7 +1154,7 @@ export function ActiveWorkoutPage() {
       setNumber: updatedSet.number,
       token: restTimerTokenRef.current,
     });
-    setRestTimerTargetSetId(nextTargetSetId);
+    setRestTimerTargetSetId(shouldFocusNextSet ? nextTargetSetId : null);
     setFocusSetId(null);
   }
 
@@ -1813,6 +1820,18 @@ function findNextPendingSetId(session: ReturnType<typeof buildActiveWorkoutSessi
 
       if (nextSet) {
         return nextSet.id;
+      }
+    }
+  }
+
+  return null;
+}
+
+function findSetSectionId(session: ReturnType<typeof buildActiveWorkoutSession>, setId: string) {
+  for (const section of session.sections) {
+    for (const exercise of section.exercises) {
+      if (exercise.sets.some((set) => set.id === setId)) {
+        return section.id;
       }
     }
   }

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -695,8 +695,8 @@ export function ActiveWorkoutPage() {
           />
 
           <div className="pt-2">
-            <Button className="w-full sm:w-auto" onClick={handleFinishWorkout} type="button">
-              Finish Workout
+            <Button className="w-full sm:w-auto" onClick={handleCompleteWorkout} type="button">
+              Complete Workout
             </Button>
             <p className="mt-2 text-sm text-muted">{`${completedSetsSummary} sets completed`}</p>
           </div>
@@ -1137,11 +1137,6 @@ export function ActiveWorkoutPage() {
       sessionStartedAt: startTime,
     });
 
-    if (updatedSession.completedSets === updatedSession.totalSets) {
-      transitionToFeedbackStage();
-      return;
-    }
-
     const nextTargetSetId = findNextPendingSetId(updatedSession);
 
     if (!nextTargetSetId) {
@@ -1202,19 +1197,17 @@ export function ActiveWorkoutPage() {
     setRestTimerTargetSetId(null);
   }
 
-  function handleFinishWorkout() {
-    if (remainingSetCount > 0) {
-      confirm({
-        title: 'Finish workout early?',
-        description: `End workout with ${remainingSetCount} sets remaining?`,
-        confirmLabel: 'Finish',
-        onConfirm: transitionToFeedbackStage,
-        variant: 'default',
-      });
-      return;
-    }
-
-    transitionToFeedbackStage();
+  function handleCompleteWorkout() {
+    confirm({
+      title: 'Complete this workout?',
+      description:
+        remainingSetCount > 0
+          ? `End workout with ${remainingSetCount} sets remaining?`
+          : 'You can review, add notes, and enter feedback before finalizing.',
+      confirmLabel: 'Complete',
+      onConfirm: transitionToFeedbackStage,
+      variant: 'default',
+    });
   }
 
   function transitionToFeedbackStage() {

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -13,6 +13,7 @@ import {
   type WorkoutSession as ApiWorkoutSession,
   type SessionSet,
   type WorkoutSessionTimeSegment,
+  type WeightUnit,
   workoutSessionSchema,
   type WorkoutSessionFeedback,
   type WorkoutSessionFeedbackResponse,
@@ -28,7 +29,6 @@ import {
   SessionSummary,
   SupplementalMenu,
   buildActiveWorkoutSession,
-  countCompletedReps,
   createInitialWorkoutSetDrafts,
   createWorkoutSetDraft,
   workoutFeedbackFields,
@@ -62,10 +62,14 @@ import {
   useWorkoutTemplate,
 } from '@/features/workouts/api/workouts';
 import {
-  getSetVolume,
+  getDistanceUnit,
+  getSetSummaryMetricValue,
+  getTrackingSummaryMetricLabel,
+  isRepTrackingType,
   isTimeBasedTrackingType,
   isWeightedTrackingType,
   resolveTrackingType,
+  type TrackingSummaryMetricLabel,
 } from '@/features/workouts/lib/tracking';
 import { useCompleteSession } from '@/hooks/use-complete-session';
 import { useLogSet, useUpdateSet } from '@/hooks/use-session-sets';
@@ -421,31 +425,65 @@ export function ActiveWorkoutPage() {
     () => `${session.completedSets}/${session.totalSets}`,
     [session.completedSets, session.totalSets],
   );
-  const totalCompletedReps = useMemo(() => countCompletedReps(setDrafts), [setDrafts]);
   const summaryExerciseResults = useMemo(
     () =>
       session.sections.flatMap((section) =>
         section.exercises.map((exercise) => {
           const completedSets = exercise.sets.filter((set) => set.completed);
+          const metricLabel = getTrackingSummaryMetricLabel(exercise.trackingType);
           return {
             id: exercise.id,
-            name: exercise.name,
-            notes: exercise.notes,
-            reps: completedSets.reduce((total, set) => total + (set.reps ?? 0), 0),
-            setsCompleted: exercise.completedSets,
-            totalSets: exercise.targetSets,
-            volume: completedSets.reduce(
-              (total, set) => total + getSetVolume(exercise.trackingType, set),
+            metricLabel,
+            metricValue: completedSets.reduce(
+              (total, set) => total + getSetSummaryMetricValue(exercise.trackingType, set),
               0,
             ),
+            name: exercise.name,
+            notes: exercise.notes,
+            reps: isRepTrackingType(exercise.trackingType)
+              ? completedSets.reduce((total, set) => total + (set.reps ?? 0), 0)
+              : 0,
+            setsCompleted: exercise.completedSets,
+            totalSets: exercise.targetSets,
           };
         }),
       ),
     [session.sections],
   );
-  const totalSessionVolume = useMemo(
-    () => summaryExerciseResults.reduce((total, exercise) => total + exercise.volume, 0),
+  const totalCompletedReps = useMemo(
+    () => summaryExerciseResults.reduce((total, exercise) => total + exercise.reps, 0),
     [summaryExerciseResults],
+  );
+  const summaryMetrics = useMemo(() => {
+    const totals: Record<TrackingSummaryMetricLabel, number> = {
+      distance: 0,
+      reps: 0,
+      seconds: 0,
+      volume: 0,
+    };
+    const labels = new Set<TrackingSummaryMetricLabel>();
+
+    summaryExerciseResults.forEach((exercise) => {
+      totals[exercise.metricLabel] += exercise.metricValue;
+      labels.add(exercise.metricLabel);
+    });
+
+    return {
+      metricLabel: labels.size > 1 ? 'mixed' : (([...labels][0] ?? 'volume') as
+        | TrackingSummaryMetricLabel
+        | 'mixed'),
+      totals,
+    };
+  }, [summaryExerciseResults]);
+  const totalSessionVolume = useMemo(
+    () => summaryMetrics.totals.volume,
+    [summaryMetrics.totals.volume],
+  );
+  const summaryMetricValue =
+    summaryMetrics.metricLabel === 'mixed' ? null : summaryMetrics.totals[summaryMetrics.metricLabel];
+  const summaryMetricMixedValue = useMemo(
+    () => formatTrackingMetricBreakdown(summaryMetrics.totals, weightUnit),
+    [summaryMetrics.totals, weightUnit],
   );
   const estimatedTotalSeconds = useMemo(() => estimateTotalTime(session), [session]);
   const remainingEstimatedSeconds = useMemo(() => estimateRemainingTime(session), [session]);
@@ -832,6 +870,9 @@ export function ActiveWorkoutPage() {
           onNotesChange={setSessionNotes}
           sessionNotes={sessionNotes}
           sessionId={activeSessionId}
+          summaryMetricLabel={summaryMetrics.metricLabel}
+          summaryMetricMixedValue={summaryMetricMixedValue}
+          summaryMetricValue={summaryMetricValue}
           summarySaving={summarySaving}
           totalVolume={totalSessionVolume}
           totalReps={totalCompletedReps}
@@ -1881,6 +1922,41 @@ function parseEditableTimeSegments(timeSegments: WorkoutSessionTimeSegment[]) {
       error: 'Time segments must be ordered, non-overlapping, and each end must be after start.',
     };
   }
+}
+
+function formatTrackingMetricBreakdown(
+  totals: Record<TrackingSummaryMetricLabel, number>,
+  weightUnit: WeightUnit,
+) {
+  const segments: string[] = [];
+
+  if (totals.volume > 0) {
+    segments.push(`${formatMetricValue(totals.volume)} ${weightUnit}`);
+  }
+  if (totals.reps > 0) {
+    segments.push(`${formatMetricValue(totals.reps)} reps`);
+  }
+  if (totals.seconds > 0) {
+    segments.push(`${formatMetricValue(totals.seconds)} sec`);
+  }
+  if (totals.distance > 0) {
+    segments.push(`${formatMetricValue(totals.distance)} ${getDistanceUnit(weightUnit)}`);
+  }
+
+  if (segments.length === 0) {
+    return '-';
+  }
+
+  return segments.join(' • ');
+}
+
+function formatMetricValue(value: number) {
+  const rounded = Math.round(value * 100) / 100;
+  if (Number.isInteger(rounded)) {
+    return new Intl.NumberFormat('en-US').format(rounded);
+  }
+
+  return rounded.toFixed(2).replace(/\.?0+$/, '');
 }
 
 function buildActiveWorkoutSessionHref(sessionId: string, view: string | null) {

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -63,7 +63,6 @@ import {
 } from '@/features/workouts/api/workouts';
 import {
   getSetVolume,
-  isSetCompleteForTrackingType,
   resolveTrackingType,
 } from '@/features/workouts/lib/tracking';
 import { useCompleteSession } from '@/hooks/use-complete-session';
@@ -1060,17 +1059,7 @@ export function ActiveWorkoutPage() {
       return;
     }
 
-    const mergedSet = {
-      ...previousSet,
-      ...update,
-    };
-    const normalizedUpdate =
-      update.completed === undefined
-        ? {
-            ...update,
-            completed: isSetCompleteForTrackingType(templateExercise.trackingType, mergedSet),
-          }
-        : update;
+    const normalizedUpdate = update;
     const updatedSets = exerciseSets.map((set) =>
       set.id === setId
         ? {
@@ -1127,7 +1116,7 @@ export function ActiveWorkoutPage() {
       return;
     }
 
-    if (previousSet.completed || !updatedSet.completed) {
+    if (normalizedUpdate.completed !== true || previousSet.completed || !updatedSet.completed) {
       return;
     }
 


### PR DESCRIPTION
## Summary
This PR fixes several workout session UX regressions by removing implicit completion behavior and making completion actions explicit. Logging values in a set no longer auto-completes sets/sessions or resets rest timers; completion now happens via the set checkbox and a required workout completion confirmation dialog. It also standardizes tracking-type behavior (reps/seconds/distance/volume) across active workout, summary, detail, comparison, template, and scheduled-workout views, including proper handling of mixed-metric sessions. Finally, read-only workout notes now render markdown consistently (session notes, exercise notes, coaching/programming notes, and feedback notes), with coverage added for safe HTML handling.

## Key Changes
- Replaced implicit set completion with explicit checkbox completion in `SetRow`; value edits now send value-only updates.
- Removed auto-transition to feedback when the last set is completed; session completion now requires clicking `Complete Workout` and confirming.
- Rest timer reset/start logic now runs only on explicit completion toggles, not on reps/weight/seconds input changes.
- Removed automatic section boundary collapse/jump behavior; section open/closed state is now user-controlled after initial state.
- Added section completion badge states (complete/in-progress/not-started) and removed redundant section subtitle text.
- Fixed tracking type propagation so `reps_only`/`seconds_only` (and other types) render correct fields and payloads throughout session flows.
- Centralized metric formatting/computation with new tracking helpers (set summary formatting, metric labels/values, mixed-metric breakdowns).
- Applied tracking-aware unit labels and formatting across receipt/history/comparison/template/scheduled views, including distance units and consistent `sec` labeling.
- Added `MarkdownNote` component and switched read-only note surfaces to markdown rendering.
- Expanded tests across active workout, tracking utils, set row, session list/summary/detail/comparison, and template/form cue components.

## Technical Notes
- Session-set persistence still uses the existing bridge where time-based values are stored in `reps` until DB support for `seconds` is end-to-end; new helpers make fallback behavior explicit and opt-out where needed.
- Mixed tracking sessions are now treated as non-comparable for percent-delta displays in comparison UI (`-` instead of misleading math).
- Non-weighted tracking types now normalize `weight` to `null` in drafts and completion payloads to prevent invalid unit rendering/data carryover.
- Markdown rendering uses `renderJournalMarkdown` via `dangerouslySetInnerHTML`; tests were added to verify unsafe HTML is escaped in read-only contexts.

## Commits

- `684aea2 chore(workouts): verify pr-3 integration gates`
- `f76072e fix(workouts): render markdown in read-only workout notes`
- `d73b11d fix(workouts): unify mixed metric formatting and comparison output`
- `e9eee59 fix(workouts): enforce tracking-aware unit rendering across workout views`
- `bae2539 fix(workouts): resolve session tracking type rendering`
- `36bd1a4 fix(workouts): clean section headers and add completion badge states`
- `aa340fc fix(workouts): remove automatic section boundary collapse`
- `cc60313 fix(workouts): reset rest timer only on explicit set completion`
- `e242214 fix(web): require explicit workout completion confirmation`

## Tasks

- **Fix auto-complete bug — last set should not complete session**: Investigate handleSetUpdate in active-workout.tsx, remove auto-transition to feedback stage, add confirmation dialog
- **Fix rest timer reset on input — only reset on explicit completion**: Investigate timer clear logic, ensure timer only resets on set completion checkbox, not input changes
- **Remove section auto-collapse at boundaries**: Find and remove section-level auto-collapse/jump logic; user wants NO auto-collapse at any level
- **Section completed state indicator + remove redundant subtitle**: Add visual completed indicator to section headers, remove redundant 'X/X exercises done' text, keep badge
- **Fix reps_only/seconds_only tracking type rendering**: Fix trackingType propagation from exercise record to session UI; Dead Hang/Dead Bug should render correct input types
- **Units consistency audit across workout views**: Audit receipt, summary, template, planned session views for tracking-type-aware unit labels
- **Session notes markdown rendering in read-only contexts**: Apply existing renderJournalMarkdown() to session/exercise notes on receipt and history views
- **PR 3 integration pass — full test suite**: Run full test suite, fix any regressions from workout UX commits

## Diff Stats

```
.../workouts/components/form-cue-chips.test.tsx    |  19 ++
 .../workouts/components/form-cue-chips.tsx         |   5 +-
 .../features/workouts/components/markdown-note.tsx |  21 ++
 .../components/scheduled-workout-detail.tsx        | 131 +++++++-
 .../components/session-comparison.test.tsx         |  36 +++
 .../workouts/components/session-comparison.tsx     |  39 ++-
 .../workouts/components/session-detail.test.tsx    |  95 ++++++
 .../workouts/components/session-detail.tsx         | 208 ++++++------
 .../components/session-exercise-list.test.tsx      | 126 +++++++-
 .../workouts/components/session-exercise-list.tsx  | 143 ++++++---
 .../workouts/components/session-summary.test.tsx   |  72 +++++
 .../workouts/components/session-summary.tsx        | 148 ++++++++-
 .../features/workouts/components/set-row.test.tsx  |  43 ++-
 .../src/features/workouts/components/set-row.tsx   |  33 +-
 .../workouts/components/template-detail.test.tsx   |  10 +-
 .../workouts/components/template-detail.tsx        |  38 +--
 .../features/workouts/lib/active-session.test.ts   |  74 +++++
 .../src/features/workouts/lib/active-session.ts    |  13 +-
 .../web/src/features/workouts/lib/session-notes.ts |   9 +-
 .../web/src/features/workouts/lib/tracking.test.ts | 100 ++++++
 apps/web/src/features/workouts/lib/tracking.ts     | 198 +++++++++++-
 apps/web/src/lib/mock-data/workouts.ts             |   2 +
 apps/web/src/pages/active-workout.test.tsx         | 348 +++++++++++++++++++--
 apps/web/src/pages/active-workout.tsx              | 198 +++++++-----
 24 files changed, 1780 insertions(+), 329 deletions(-)
```