### PR TITLE
fix(dashboard): duration formatting, routing, habits, and daily status cards

### DIFF
--- a/apps/web/src/features/dashboard/components/habit-chain.test.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.test.tsx
@@ -248,6 +248,139 @@ describe('HabitChain', () => {
     expect(todaySquare).toHaveClass('bg-[var(--color-muted)]/40');
   });
 
+  it('renders a proportional progress ring for today numeric progress', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-10T12:00:00Z'));
+
+    const habit: Habit = {
+      id: 'habit-water-partial',
+      userId: 'user-1',
+      name: 'Water',
+      description: null,
+      emoji: null,
+      trackingType: 'numeric',
+      target: 100,
+      unit: 'oz',
+      frequency: 'daily',
+      frequencyTarget: null,
+      scheduledDays: null,
+      pausedUntil: null,
+      sortOrder: 0,
+      active: true,
+      createdAt: new Date('2026-02-01T00:00:00Z').getTime(),
+      updatedAt: new Date('2026-02-01T00:00:00Z').getTime(),
+    };
+    const entries: HabitEntry[] = [
+      {
+        id: 'entry-water-partial',
+        habitId: habit.id,
+        userId: habit.userId,
+        date: '2026-03-10',
+        completed: false,
+        value: 52,
+        createdAt: new Date('2026-03-10T12:00:00Z').getTime(),
+      },
+    ];
+
+    renderHabitChain({
+      endDate: '2026-03-10',
+      entries,
+      habitIds: [habit.id],
+      habits: [habit],
+    });
+
+    const todaySquare = screen.getByRole('button', { name: 'Water 2026-03-10 Not tracked' });
+    expect(todaySquare).toHaveClass('bg-transparent');
+
+    const progressCircle = todaySquare.querySelector('circle[stroke="var(--color-accent-mint)"]');
+    if (!progressCircle) {
+      throw new Error('Expected progress circle for partial numeric progress.');
+    }
+
+    const dashArray = Number.parseFloat(progressCircle.getAttribute('stroke-dasharray') ?? '0');
+    const dashOffset = Number.parseFloat(progressCircle.getAttribute('stroke-dashoffset') ?? '0');
+    expect(dashArray).toBeGreaterThan(0);
+    expect(dashOffset / dashArray).toBeCloseTo(0.48, 1);
+  });
+
+  it('keeps 0%, partial, and 100% numeric states visually distinct', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-10T12:00:00Z'));
+
+    const baseHabit = {
+      userId: 'user-1',
+      description: null,
+      emoji: null,
+      trackingType: 'numeric' as const,
+      target: 100,
+      unit: 'oz',
+      frequency: 'daily' as const,
+      frequencyTarget: null,
+      scheduledDays: null,
+      pausedUntil: null,
+      sortOrder: 0,
+      active: true,
+      createdAt: new Date('2026-02-01T00:00:00Z').getTime(),
+      updatedAt: new Date('2026-02-01T00:00:00Z').getTime(),
+    };
+
+    const habits: Habit[] = [
+      { ...baseHabit, id: 'habit-water-zero', name: 'Water Zero' },
+      { ...baseHabit, id: 'habit-water-partial', name: 'Water Partial' },
+      { ...baseHabit, id: 'habit-water-full', name: 'Water Full' },
+    ];
+    const entries: HabitEntry[] = [
+      {
+        id: 'entry-water-zero',
+        habitId: 'habit-water-zero',
+        userId: 'user-1',
+        date: '2026-03-10',
+        completed: false,
+        value: 0,
+        createdAt: new Date('2026-03-10T12:00:00Z').getTime(),
+      },
+      {
+        id: 'entry-water-partial',
+        habitId: 'habit-water-partial',
+        userId: 'user-1',
+        date: '2026-03-10',
+        completed: false,
+        value: 52,
+        createdAt: new Date('2026-03-10T12:00:00Z').getTime(),
+      },
+      {
+        id: 'entry-water-full',
+        habitId: 'habit-water-full',
+        userId: 'user-1',
+        date: '2026-03-10',
+        completed: true,
+        value: 100,
+        createdAt: new Date('2026-03-10T12:00:00Z').getTime(),
+      },
+    ];
+
+    renderHabitChain({
+      endDate: '2026-03-10',
+      entries,
+      habits,
+    });
+
+    const zeroSquare = screen.getByRole('button', { name: 'Water Zero 2026-03-10 Not tracked' });
+    const partialSquare = screen.getByRole('button', {
+      name: 'Water Partial 2026-03-10 Not tracked',
+    });
+    const fullSquare = screen.getByRole('button', { name: 'Water Full 2026-03-10 Completed' });
+
+    expect(zeroSquare).toHaveClass('bg-[var(--color-muted)]/40');
+    expect(zeroSquare.querySelector('svg')).toBeNull();
+
+    expect(partialSquare).toHaveClass('bg-transparent');
+    expect(partialSquare.querySelector('svg')).toBeInTheDocument();
+
+    expect(fullSquare).toHaveClass('bg-[var(--color-accent-mint)]');
+    expect(fullSquare.querySelector('svg')).toBeNull();
+  });
+
   it('shows future days as not scheduled', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-10T12:00:00Z'));

--- a/apps/web/src/features/dashboard/components/habit-daily-status-card.test.tsx
+++ b/apps/web/src/features/dashboard/components/habit-daily-status-card.test.tsx
@@ -1,5 +1,5 @@
 import type { Habit, HabitEntry } from '@pulse/shared';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -164,6 +164,44 @@ describe('HabitDailyStatusCard', () => {
     expect(screen.getByLabelText('Water daily progress')).toHaveAttribute('aria-valuenow', '52');
   });
 
+  it('keeps numeric progress visuals at 0 when target is not set', () => {
+    mockHabitHooks({
+      entries: [
+        {
+          completed: false,
+          createdAt: 7,
+          date: '2026-03-06',
+          habitId: 'habit-water',
+          id: 'entry-water',
+          userId: 'user-1',
+          value: 52,
+        },
+      ],
+      habits: [
+        {
+          ...habitsFixture[0],
+          id: 'habit-water',
+          name: 'Water',
+          target: null,
+        },
+      ],
+    });
+
+    render(<HabitDailyStatusCard habitId="habit-water" />);
+
+    expect(screen.getByText('52 oz')).toBeInTheDocument();
+    expect(screen.getByText('Target: Not set')).toBeInTheDocument();
+
+    const card = screen.getByTestId('habit-daily-status-card-habit-water');
+    const ring = within(card)
+      .getAllByRole('progressbar')
+      .find((node) => node.getAttribute('aria-valuemax') === '100');
+
+    expect(ring).toHaveAttribute('aria-valuenow', '0');
+    expect(screen.getByLabelText('Water daily progress')).toHaveAttribute('aria-valuenow', '0');
+    expect(screen.getByLabelText('Water daily progress')).toHaveAttribute('aria-valuemax', '1');
+  });
+
   it('renders boolean habit cards with checkbox state text', () => {
     mockHabitHooks({
       entries: [
@@ -218,6 +256,7 @@ describe('HabitDailyStatusCard', () => {
     const valueInput = screen.getByTestId('habit-daily-value-input-habit-water');
     fireEvent.change(valueInput, { target: { value: '67' } });
     fireEvent.keyDown(valueInput, { key: 'Escape' });
+    fireEvent.blur(valueInput);
 
     expect(screen.getByTestId('habit-daily-value-button-habit-water')).toBeInTheDocument();
     expect(screen.getByText('52 oz')).toBeInTheDocument();

--- a/apps/web/src/features/dashboard/components/habit-daily-status-card.test.tsx
+++ b/apps/web/src/features/dashboard/components/habit-daily-status-card.test.tsx
@@ -208,6 +208,22 @@ describe('HabitDailyStatusCard', () => {
     );
   });
 
+  it('cancels numeric inline edits when pressing Escape', () => {
+    const { mutate } = mockHabitHooks({});
+
+    render(<HabitDailyStatusCard habitId="habit-water" />);
+
+    fireEvent.click(screen.getByTestId('habit-daily-value-button-habit-water'));
+
+    const valueInput = screen.getByTestId('habit-daily-value-input-habit-water');
+    fireEvent.change(valueInput, { target: { value: '67' } });
+    fireEvent.keyDown(valueInput, { key: 'Escape' });
+
+    expect(screen.getByTestId('habit-daily-value-button-habit-water')).toBeInTheDocument();
+    expect(screen.getByText('52 oz')).toBeInTheDocument();
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
   it('toggles boolean habit completion and saves immediately', () => {
     const { mutate } = mockHabitHooks({
       entries: [

--- a/apps/web/src/features/dashboard/components/habit-daily-status-card.test.tsx
+++ b/apps/web/src/features/dashboard/components/habit-daily-status-card.test.tsx
@@ -1,0 +1,269 @@
+import type { Habit, HabitEntry } from '@pulse/shared';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useHabitEntries,
+  useHabits,
+  useToggleHabit,
+} from '@/features/habits/api/habits';
+
+import { HabitDailyStatusCard } from './habit-daily-status-card';
+
+vi.mock('@/features/habits/api/habits', () => ({
+  useHabitEntries: vi.fn(),
+  useHabits: vi.fn(),
+  useToggleHabit: vi.fn(),
+}));
+
+const mockedUseHabits = vi.mocked(useHabits);
+const mockedUseHabitEntries = vi.mocked(useHabitEntries);
+const mockedUseToggleHabit = vi.mocked(useToggleHabit);
+
+const habitsFixture: Habit[] = [
+  {
+    active: true,
+    createdAt: 1,
+    emoji: null,
+    id: 'habit-water',
+    name: 'Water',
+    description: null,
+    sortOrder: 0,
+    target: 100,
+    trackingType: 'numeric',
+    unit: 'oz',
+    frequency: 'daily',
+    frequencyTarget: null,
+    scheduledDays: null,
+    pausedUntil: null,
+    updatedAt: 1,
+    userId: 'user-1',
+  },
+  {
+    active: true,
+    createdAt: 2,
+    emoji: null,
+    id: 'habit-meditate',
+    name: 'Meditate',
+    description: null,
+    sortOrder: 1,
+    target: null,
+    trackingType: 'boolean',
+    unit: null,
+    frequency: 'daily',
+    frequencyTarget: null,
+    scheduledDays: null,
+    pausedUntil: null,
+    updatedAt: 2,
+    userId: 'user-1',
+  },
+  {
+    active: true,
+    createdAt: 3,
+    emoji: null,
+    id: 'habit-sleep',
+    name: 'Sleep',
+    description: null,
+    sortOrder: 2,
+    target: 8,
+    trackingType: 'numeric',
+    unit: 'h',
+    frequency: 'daily',
+    frequencyTarget: null,
+    scheduledDays: null,
+    pausedUntil: null,
+    updatedAt: 3,
+    userId: 'user-1',
+  },
+];
+
+const entriesFixture: HabitEntry[] = [
+  {
+    completed: false,
+    createdAt: 1,
+    date: '2026-03-06',
+    habitId: 'habit-water',
+    id: 'entry-water',
+    userId: 'user-1',
+    value: 52,
+  },
+  {
+    completed: false,
+    createdAt: 2,
+    date: '2026-03-06',
+    habitId: 'habit-meditate',
+    id: 'entry-meditate',
+    userId: 'user-1',
+    value: null,
+  },
+  {
+    completed: true,
+    createdAt: 3,
+    date: '2026-03-06',
+    habitId: 'habit-sleep',
+    id: 'entry-sleep',
+    userId: 'user-1',
+    value: 8,
+  },
+];
+
+function mockHabitHooks({
+  entries = entriesFixture,
+  habits = habitsFixture,
+  mutate = vi.fn(),
+}: {
+  entries?: HabitEntry[];
+  habits?: Habit[];
+  mutate?: ReturnType<typeof vi.fn>;
+}) {
+  mockedUseHabits.mockReturnValue({
+    data: habits,
+    error: null,
+    isError: false,
+    isLoading: false,
+  } as unknown as ReturnType<typeof useHabits>);
+
+  mockedUseHabitEntries.mockReturnValue({
+    data: entries,
+    error: null,
+    isError: false,
+    isLoading: false,
+  } as unknown as ReturnType<typeof useHabitEntries>);
+
+  mockedUseToggleHabit.mockReturnValue({
+    isPending: false,
+    mutate,
+    variables: undefined,
+  } as unknown as ReturnType<typeof useToggleHabit>);
+
+  return { mutate };
+}
+
+describe('HabitDailyStatusCard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-06T09:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    mockedUseHabits.mockReset();
+    mockedUseHabitEntries.mockReset();
+    mockedUseToggleHabit.mockReset();
+  });
+
+  it('renders numeric habit values and progress against target', () => {
+    mockHabitHooks({});
+
+    render(<HabitDailyStatusCard habitId="habit-water" />);
+
+    expect(screen.getByText('Water')).toBeInTheDocument();
+    expect(screen.getByText('52 oz')).toBeInTheDocument();
+    expect(screen.getByText('Target: 100 oz')).toBeInTheDocument();
+    expect(screen.getByText('52%')).toBeInTheDocument();
+    expect(screen.getByLabelText('Water daily progress')).toHaveAttribute('aria-valuenow', '52');
+  });
+
+  it('renders boolean habit cards with checkbox state text', () => {
+    mockHabitHooks({
+      entries: [
+        {
+          completed: true,
+          createdAt: 5,
+          date: '2026-03-06',
+          habitId: 'habit-meditate',
+          id: 'entry-meditate',
+          userId: 'user-1',
+          value: null,
+        },
+      ],
+    });
+
+    render(<HabitDailyStatusCard habitId="habit-meditate" />);
+
+    expect(screen.getByText('Meditate')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Meditate completion' })).toBeChecked();
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+
+  it('saves numeric inline edits on blur', () => {
+    const { mutate } = mockHabitHooks({});
+
+    render(<HabitDailyStatusCard habitId="habit-water" />);
+
+    fireEvent.click(screen.getByTestId('habit-daily-value-button-habit-water'));
+
+    const valueInput = screen.getByTestId('habit-daily-value-input-habit-water');
+    fireEvent.change(valueInput, { target: { value: '67' } });
+    fireEvent.blur(valueInput);
+
+    expect(mutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        completed: false,
+        date: '2026-03-06',
+        entryId: 'entry-water',
+        habitId: 'habit-water',
+        value: 67,
+      }),
+    );
+  });
+
+  it('toggles boolean habit completion and saves immediately', () => {
+    const { mutate } = mockHabitHooks({
+      entries: [
+        {
+          completed: false,
+          createdAt: 5,
+          date: '2026-03-06',
+          habitId: 'habit-meditate',
+          id: 'entry-meditate',
+          userId: 'user-1',
+          value: null,
+        },
+      ],
+    });
+
+    render(<HabitDailyStatusCard habitId="habit-meditate" />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Meditate completion' }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        completed: true,
+        date: '2026-03-06',
+        entryId: 'entry-meditate',
+        habitId: 'habit-meditate',
+      }),
+    );
+  });
+
+  it('renders multiple habit daily cards independently', () => {
+    const { mutate } = mockHabitHooks({});
+
+    render(
+      <>
+        <HabitDailyStatusCard habitId="habit-water" />
+        <HabitDailyStatusCard habitId="habit-sleep" />
+      </>,
+    );
+
+    expect(screen.getByTestId('habit-daily-status-card-habit-water')).toBeInTheDocument();
+    expect(screen.getByTestId('habit-daily-status-card-habit-sleep')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('habit-daily-value-button-habit-water'));
+    const waterInput = screen.getByTestId('habit-daily-value-input-habit-water');
+    fireEvent.change(waterInput, { target: { value: '60' } });
+    fireEvent.blur(waterInput);
+
+    expect(mutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        habitId: 'habit-water',
+      }),
+    );
+    expect(mutate).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        habitId: 'habit-sleep',
+      }),
+    );
+  });
+});

--- a/apps/web/src/features/dashboard/components/habit-daily-status-card.tsx
+++ b/apps/web/src/features/dashboard/components/habit-daily-status-card.tsx
@@ -1,0 +1,271 @@
+import { type Habit, type HabitEntry } from '@pulse/shared';
+import { Pencil } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { ProgressBar } from '@/components/ui/progress-bar';
+import { ProgressRing } from '@/components/ui/progress-ring';
+import {
+  useHabitEntries,
+  useHabits,
+  useToggleHabit,
+} from '@/features/habits/api/habits';
+import { getToday, toDateKey } from '@/lib/date';
+import { formatPercent, formatServing } from '@/lib/format-utils';
+
+type ResolvedTodayEntry = {
+  completed: boolean;
+  isOverride: boolean;
+  value: number | null;
+};
+
+type HabitWithTodayEntry = Habit & {
+  todayEntry?: ResolvedTodayEntry | null;
+};
+
+type HabitDailyStatusCardProps = {
+  habitId: string;
+  compact?: boolean;
+};
+
+function formatHabitValue(value: number, unit: string | null) {
+  const formattedValue = formatServing(value);
+  const normalizedUnit = unit?.trim();
+
+  if (!normalizedUnit) {
+    return formattedValue;
+  }
+
+  return `${formattedValue} ${normalizedUnit}`;
+}
+
+function getNumericCompletion(target: number | null, value: number | null) {
+  if (target == null || target <= 0 || value == null) {
+    return false;
+  }
+
+  return value >= target;
+}
+
+function getProgressPercent(target: number | null, value: number | null) {
+  if (target == null || target <= 0 || value == null) {
+    return 0;
+  }
+
+  return Math.min((value / target) * 100, 100);
+}
+
+function getEffectiveEntry(habit: HabitWithTodayEntry, entry: HabitEntry | undefined) {
+  const isReferential = habit.referenceSource !== null && habit.referenceSource !== undefined;
+  const useTodayEntry =
+    isReferential &&
+    habit.todayEntry !== undefined &&
+    habit.todayEntry !== null &&
+    (entry?.isOverride ?? false) !== true;
+
+  return {
+    completed: useTodayEntry ? (habit.todayEntry?.completed ?? false) : (entry?.completed ?? false),
+    isReferential,
+    value: useTodayEntry ? (habit.todayEntry?.value ?? null) : (entry?.value ?? null),
+  };
+}
+
+export function HabitDailyStatusCard({ habitId, compact = false }: HabitDailyStatusCardProps) {
+  const [isEditingNumericValue, setIsEditingNumericValue] = useState(false);
+  const [numericDraftValue, setNumericDraftValue] = useState('');
+
+  const todayKey = toDateKey(getToday());
+  const habitsQuery = useHabits();
+  const habitEntriesQuery = useHabitEntries(todayKey, todayKey);
+  const toggleHabitMutation = useToggleHabit();
+
+  const habit = useMemo(
+    () => (habitsQuery.data ?? []).find((item) => item.id === habitId),
+    [habitId, habitsQuery.data],
+  );
+  const todayEntry = useMemo(
+    () => (habitEntriesQuery.data ?? []).find((entry) => entry.habitId === habitId),
+    [habitEntriesQuery.data, habitId],
+  );
+
+  if (habitsQuery.isLoading || habitEntriesQuery.isLoading) {
+    return (
+      <Card className="gap-2 py-3">
+        <CardHeader className="px-3 sm:px-4">
+          <Skeleton className="h-4 w-40" />
+        </CardHeader>
+        <CardContent className="space-y-2 px-3 sm:px-4">
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-3 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (habitsQuery.isError || habitEntriesQuery.isError) {
+    return (
+      <Card className="gap-2 border-dashed py-3">
+        <CardHeader className="px-3 sm:px-4">
+          <CardTitle className="text-sm">Habit status unavailable</CardTitle>
+          <CardDescription className="text-xs">Unable to load today&apos;s habit data.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  if (!habit) {
+    return (
+      <Card className="gap-2 border-dashed py-3">
+        <CardHeader className="px-3 sm:px-4">
+          <CardTitle className="text-sm">Habit not found</CardTitle>
+          <CardDescription className="text-xs">This card references a missing habit.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const { completed, isReferential, value } = getEffectiveEntry(habit, todayEntry);
+  const isBooleanHabit = habit.trackingType === 'boolean';
+  const numericValue = typeof value === 'number' ? value : null;
+  const progressPercent = getProgressPercent(habit.target, numericValue);
+  const progressTarget =
+    habit.target != null && habit.target > 0 ? habit.target : Math.max(numericValue ?? 0, 1);
+  const isSaving = toggleHabitMutation.isPending && toggleHabitMutation.variables?.habitId === habit.id;
+
+  const saveHabitValue = (nextCompleted: boolean, nextNumericValue: number | null) => {
+    toggleHabitMutation.mutate({
+      habitId: habit.id,
+      entryId: todayEntry?.id,
+      date: todayKey,
+      completed: nextCompleted,
+      ...(isReferential ? { isOverride: true } : {}),
+      ...(nextNumericValue === null ? {} : { value: nextNumericValue }),
+    });
+  };
+
+  const commitNumericValue = () => {
+    const trimmedValue = numericDraftValue.trim();
+    const parsedValue = trimmedValue.length === 0 ? null : Number(trimmedValue);
+
+    setIsEditingNumericValue(false);
+
+    if (parsedValue !== null && (!Number.isFinite(parsedValue) || parsedValue < 0)) {
+      return;
+    }
+
+    if (parsedValue === numericValue) {
+      return;
+    }
+
+    saveHabitValue(getNumericCompletion(habit.target, parsedValue), parsedValue);
+  };
+
+  return (
+    <Card
+      className="gap-2 py-3"
+      data-slot="habit-daily-status-card"
+      data-testid={`habit-daily-status-card-${habit.id}`}
+    >
+      <CardHeader className="gap-1 px-3 sm:px-4">
+        <CardTitle className="text-base leading-tight">{habit.name}</CardTitle>
+        <CardDescription className="text-xs">Daily status</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3 px-3 sm:px-4">
+        {isBooleanHabit ? (
+          <div className="flex items-center justify-between gap-3 rounded-xl border border-border/70 bg-secondary/25 px-3 py-2.5">
+            <p className="text-sm text-muted-foreground">Today</p>
+            <label className="inline-flex items-center gap-2 text-sm font-medium text-foreground">
+              <Checkbox
+                aria-label={`${habit.name} completion`}
+                checked={completed}
+                disabled={isSaving}
+                onCheckedChange={(checked) => {
+                  const nextCompleted = checked === true;
+                  saveHabitValue(nextCompleted, null);
+                }}
+              />
+              <span>{completed ? 'Done' : 'Not done'}</span>
+            </label>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="flex items-center gap-3">
+              <ProgressRing
+                className="shrink-0"
+                color="var(--color-accent)"
+                label={formatPercent(progressPercent)}
+                size={compact ? 58 : 74}
+                strokeWidth={compact ? 6 : 7}
+                value={progressPercent}
+              />
+              <div className="min-w-0 space-y-1">
+                <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                  Today
+                </p>
+                {isEditingNumericValue ? (
+                  <Input
+                    aria-label={`${habit.name} value`}
+                    autoFocus
+                    className="h-8 w-28"
+                    data-testid={`habit-daily-value-input-${habit.id}`}
+                    inputMode="decimal"
+                    onBlur={commitNumericValue}
+                    onChange={(event) => {
+                      setNumericDraftValue(event.currentTarget.value);
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') {
+                        event.preventDefault();
+                        event.currentTarget.blur();
+                      }
+
+                      if (event.key === 'Escape') {
+                        setIsEditingNumericValue(false);
+                      }
+                    }}
+                    type="number"
+                    value={numericDraftValue}
+                  />
+                ) : (
+                  <Button
+                    className="h-auto p-0 text-left text-base font-semibold"
+                    data-testid={`habit-daily-value-button-${habit.id}`}
+                    disabled={isSaving}
+                    onClick={() => {
+                      setNumericDraftValue(numericValue == null ? '' : String(numericValue));
+                      setIsEditingNumericValue(true);
+                    }}
+                    type="button"
+                    variant="ghost"
+                  >
+                    {numericValue == null
+                      ? `0${habit.unit ? ` ${habit.unit}` : ''}`
+                      : formatHabitValue(numericValue, habit.unit)}
+                    <Pencil className="ml-1 size-3.5 text-muted-foreground" />
+                  </Button>
+                )}
+                <p className="text-xs text-muted-foreground">
+                  Target:{' '}
+                  {habit.target == null
+                    ? 'Not set'
+                    : formatHabitValue(habit.target, habit.unit)}
+                </p>
+              </div>
+            </div>
+            <ProgressBar
+              aria-label={`${habit.name} daily progress`}
+              color="var(--color-accent)"
+              max={progressTarget}
+              showValue={false}
+              value={numericValue ?? 0}
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/features/dashboard/components/habit-daily-status-card.tsx
+++ b/apps/web/src/features/dashboard/components/habit-daily-status-card.tsx
@@ -1,6 +1,6 @@
 import { type Habit, type HabitEntry } from '@pulse/shared';
 import { Pencil } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
@@ -60,24 +60,21 @@ function getProgressPercent(target: number | null, value: number | null) {
 }
 
 function getEffectiveEntry(habit: HabitWithTodayEntry, entry: HabitEntry | undefined) {
-  const isReferential = habit.referenceSource !== null && habit.referenceSource !== undefined;
+  const isReferential = habit.referenceSource != null;
   // For referential habits, use the aggregated `todayEntry` unless there is an explicit manual override.
-  const useTodayEntry =
-    isReferential &&
-    habit.todayEntry !== undefined &&
-    habit.todayEntry !== null &&
-    (entry?.isOverride ?? false) !== true;
+  const useTodayEntry = isReferential && habit.todayEntry != null && !entry?.isOverride;
 
   return {
-    completed: useTodayEntry ? (habit.todayEntry?.completed ?? false) : (entry?.completed ?? false),
+    completed: (useTodayEntry ? habit.todayEntry?.completed : entry?.completed) ?? false,
     isReferential,
-    value: useTodayEntry ? (habit.todayEntry?.value ?? null) : (entry?.value ?? null),
+    value: (useTodayEntry ? habit.todayEntry?.value : entry?.value) ?? null,
   };
 }
 
 export function HabitDailyStatusCard({ habitId, compact = false }: HabitDailyStatusCardProps) {
   const [isEditingNumericValue, setIsEditingNumericValue] = useState(false);
   const [numericDraftValue, setNumericDraftValue] = useState('');
+  const isCancellingNumericEditRef = useRef(false);
 
   const todayKey = toDateKey(getToday());
   const habitsQuery = useHabits();
@@ -132,9 +129,10 @@ export function HabitDailyStatusCard({ habitId, compact = false }: HabitDailySta
   const { completed, isReferential, value } = getEffectiveEntry(habit, todayEntry);
   const isBooleanHabit = habit.trackingType === 'boolean';
   const numericValue = typeof value === 'number' ? value : null;
+  const hasNumericTarget = habit.target != null && habit.target > 0;
   const progressPercent = getProgressPercent(habit.target, numericValue);
-  const progressTarget =
-    habit.target != null && habit.target > 0 ? habit.target : Math.max(numericValue ?? 0, 1);
+  const progressTarget = habit.target != null && habit.target > 0 ? habit.target : 1;
+  const progressValue = hasNumericTarget ? (numericValue ?? 0) : 0;
   const isSaving = toggleHabitMutation.isPending && toggleHabitMutation.variables?.habitId === habit.id;
 
   const saveHabitValue = (nextCompleted: boolean, nextNumericValue: number | null) => {
@@ -149,6 +147,11 @@ export function HabitDailyStatusCard({ habitId, compact = false }: HabitDailySta
   };
 
   const commitNumericValue = () => {
+    if (isCancellingNumericEditRef.current) {
+      isCancellingNumericEditRef.current = false;
+      return;
+    }
+
     const trimmedValue = numericDraftValue.trim();
     const parsedValue = trimmedValue.length === 0 ? null : Number(trimmedValue);
 
@@ -225,6 +228,7 @@ export function HabitDailyStatusCard({ habitId, compact = false }: HabitDailySta
                       }
 
                       if (event.key === 'Escape') {
+                        isCancellingNumericEditRef.current = true;
                         setNumericDraftValue(numericValue == null ? '' : String(numericValue));
                         setIsEditingNumericValue(false);
                       }
@@ -263,7 +267,7 @@ export function HabitDailyStatusCard({ habitId, compact = false }: HabitDailySta
               color="var(--color-accent)"
               max={progressTarget}
               showValue={false}
-              value={numericValue ?? 0}
+              value={progressValue}
             />
           </div>
         )}

--- a/apps/web/src/features/dashboard/components/habit-daily-status-card.tsx
+++ b/apps/web/src/features/dashboard/components/habit-daily-status-card.tsx
@@ -61,6 +61,7 @@ function getProgressPercent(target: number | null, value: number | null) {
 
 function getEffectiveEntry(habit: HabitWithTodayEntry, entry: HabitEntry | undefined) {
   const isReferential = habit.referenceSource !== null && habit.referenceSource !== undefined;
+  // For referential habits, use the aggregated `todayEntry` unless there is an explicit manual override.
   const useTodayEntry =
     isReferential &&
     habit.todayEntry !== undefined &&
@@ -94,7 +95,7 @@ export function HabitDailyStatusCard({ habitId, compact = false }: HabitDailySta
 
   if (habitsQuery.isLoading || habitEntriesQuery.isLoading) {
     return (
-      <Card className="gap-2 py-3">
+      <Card className="gap-2 py-3" data-testid={`habit-daily-status-card-loading-${habitId}`}>
         <CardHeader className="px-3 sm:px-4">
           <Skeleton className="h-4 w-40" />
         </CardHeader>
@@ -224,6 +225,7 @@ export function HabitDailyStatusCard({ habitId, compact = false }: HabitDailySta
                       }
 
                       if (event.key === 'Escape') {
+                        setNumericDraftValue(numericValue == null ? '' : String(numericValue));
                         setIsEditingNumericValue(false);
                       }
                     }}

--- a/apps/web/src/features/dashboard/components/recent-workouts.test.tsx
+++ b/apps/web/src/features/dashboard/components/recent-workouts.test.tsx
@@ -4,6 +4,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { formatRelativeWorkoutDate } from '@/features/dashboard/lib/recent-workouts';
 import { useRecentWorkouts } from '@/hooks/use-recent-workouts';
+import { formatDuration } from '@/lib/format-utils';
 
 import { RecentWorkouts } from './recent-workouts';
 
@@ -26,21 +27,21 @@ const recentWorkoutsFixture = [
     id: 'session-1',
     name: 'Upper Push A',
     date: '2026-03-05',
-    duration: 62,
+    duration: 3924,
     exerciseCount: 6,
   },
   {
     id: 'session-2',
     name: 'Lower Strength',
     date: '2026-03-03',
-    duration: 70,
+    duration: 3600,
     exerciseCount: 5,
   },
   {
     id: 'session-3',
     name: 'Upper Pull A',
     date: '2026-02-28',
-    duration: 58,
+    duration: 5400,
     exerciseCount: 7,
   },
   {
@@ -103,10 +104,9 @@ describe('RecentWorkouts', () => {
       expect(link).toHaveAttribute('href', `/workouts/sessions/${workout.id}`);
       expect(within(link).getByText(workout.name)).toBeInTheDocument();
       expect(within(link).getByText(`${workout.exerciseCount} exercises`)).toBeInTheDocument();
+      const durationLabel = formatDuration(workout.duration);
       expect(
-        within(link).getByText(
-          workout.duration === null ? 'Duration n/a' : `${workout.duration} min`,
-        ),
+        within(link).getByText(durationLabel === '-' ? 'Duration n/a' : durationLabel),
       ).toBeInTheDocument();
     });
   });

--- a/apps/web/src/features/dashboard/components/recent-workouts.tsx
+++ b/apps/web/src/features/dashboard/components/recent-workouts.tsx
@@ -7,6 +7,7 @@ import { DashboardCardHeaderLink } from '@/features/dashboard/components/dashboa
 import { formatRelativeWorkoutDate } from '@/features/dashboard/lib/recent-workouts';
 import { useRecentWorkouts } from '@/hooks/use-recent-workouts';
 import { parseDateInput } from '@/lib/date';
+import { formatDuration } from '@/lib/format-utils';
 
 const WORKOUTS_TO_SHOW = 5;
 const WORKOUT_SKELETON_ROWS = 4;
@@ -78,54 +79,58 @@ export function RecentWorkouts() {
           <p className="text-sm text-muted-foreground">Unable to load recent workouts.</p>
         ) : recentWorkoutsQuery.data && recentWorkoutsQuery.data.length > 0 ? (
           <ul className="grid gap-2.5 py-0.5">
-            {recentWorkoutsQuery.data.map((workout) => (
-              <li className="min-w-0" key={workout.id}>
-                <Link
-                  aria-label={`Open ${workout.name}`}
-                  className="block cursor-pointer rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-                  to={`/workouts/sessions/${workout.id}`}
-                >
-                  <Card
-                    className="h-full gap-2.5 overflow-hidden px-3 py-2.5 transition-transform duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
-                    data-slot="recent-workout-card"
+            {recentWorkoutsQuery.data.map((workout) => {
+              const durationLabel = formatDuration(workout.duration);
+
+              return (
+                <li className="min-w-0" key={workout.id}>
+                  <Link
+                    aria-label={`Open ${workout.name}`}
+                    className="block cursor-pointer rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                    to={`/workouts/sessions/${workout.id}`}
                   >
-                    <div className="space-y-2">
-                      <div className="flex items-start justify-between gap-2">
-                        <div className="min-w-0 space-y-1">
-                          <p className="text-sm font-semibold leading-tight text-foreground sm:text-base">
-                            {workout.name}
-                          </p>
-                          <time className="text-sm text-muted" dateTime={workout.date}>
-                            {formatWorkoutDate(workout.date)}
-                          </time>
-                        </div>
+                    <Card
+                      className="h-full gap-2.5 overflow-hidden px-3 py-2.5 transition-transform duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
+                      data-slot="recent-workout-card"
+                    >
+                      <div className="space-y-2">
+                        <div className="flex items-start justify-between gap-2">
+                          <div className="min-w-0 space-y-1">
+                            <p className="text-sm font-semibold leading-tight text-foreground sm:text-base">
+                              {workout.name}
+                            </p>
+                            <time className="text-sm text-muted" dateTime={workout.date}>
+                              {formatWorkoutDate(workout.date)}
+                            </time>
+                          </div>
 
-                        <span className="shrink-0 rounded-full bg-[var(--color-accent-cream)] px-2 py-1 text-[11px] font-semibold text-on-cream dark:bg-amber-500/20 dark:text-amber-400">
-                          {formatRelativeWorkoutDate(workout.date)}
-                        </span>
-                      </div>
-
-                      <div className="flex min-w-0 items-center justify-between gap-2">
-                        <div className="flex min-w-0 flex-wrap gap-1.5 text-xs text-foreground">
-                          <span className="rounded-full bg-secondary px-2 py-0.5">
-                            {`${workout.exerciseCount} exercises`}
-                          </span>
-                          <span className="rounded-full bg-secondary px-2 py-0.5">
-                            {workout.duration === null ? 'Duration n/a' : `${workout.duration} min`}
+                          <span className="shrink-0 rounded-full bg-[var(--color-accent-cream)] px-2 py-1 text-[11px] font-semibold text-on-cream dark:bg-amber-500/20 dark:text-amber-400">
+                            {formatRelativeWorkoutDate(workout.date)}
                           </span>
                         </div>
-                        <span
-                          aria-hidden="true"
-                          className="inline-flex shrink-0 items-center text-muted-foreground"
-                        >
-                          <ChevronRight className="size-4" />
-                        </span>
+
+                        <div className="flex min-w-0 items-center justify-between gap-2">
+                          <div className="flex min-w-0 flex-wrap gap-1.5 text-xs text-foreground">
+                            <span className="rounded-full bg-secondary px-2 py-0.5">
+                              {`${workout.exerciseCount} exercises`}
+                            </span>
+                            <span className="rounded-full bg-secondary px-2 py-0.5">
+                              {durationLabel === '-' ? 'Duration n/a' : durationLabel}
+                            </span>
+                          </div>
+                          <span
+                            aria-hidden="true"
+                            className="inline-flex shrink-0 items-center text-muted-foreground"
+                          >
+                            <ChevronRight className="size-4" />
+                          </span>
+                        </div>
                       </div>
-                    </div>
-                  </Card>
-                </Link>
-              </li>
-            ))}
+                    </Card>
+                  </Link>
+                </li>
+              );
+            })}
           </ul>
         ) : (
           <div className="space-y-2.5" data-slot="recent-workout-empty-state">

--- a/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.test.tsx
@@ -106,7 +106,7 @@ describe('SnapshotCards', () => {
     );
     expect(screen.getByRole('link', { name: /open today's workout/i })).toHaveAttribute(
       'href',
-      '/workouts/sessions/session-upper-push-a/summary',
+      '/workouts/sessions/session-upper-push-a',
     );
   });
 
@@ -257,7 +257,7 @@ describe('SnapshotCards', () => {
 
     expect(screen.getByRole('link', { name: /open today's workout/i })).toHaveAttribute(
       'href',
-      '/workouts/sessions/session-upper-pull',
+      '/workouts/active?sessionId=session-upper-pull',
     );
     expect(screen.getByText('In Progress')).toBeInTheDocument();
   });

--- a/apps/web/src/features/dashboard/components/snapshot-cards.tsx
+++ b/apps/web/src/features/dashboard/components/snapshot-cards.tsx
@@ -79,10 +79,10 @@ const getWorkoutHref = (workout: DashboardWorkoutSnapshot | null | undefined): s
   }
 
   if (workout.status === 'in_progress') {
-    return `/workouts/sessions/${workout.sessionId}`;
+    return `/workouts/active?sessionId=${encodeURIComponent(workout.sessionId)}`;
   }
 
-  return `/workouts/sessions/${workout.sessionId}/summary`;
+  return `/workouts/sessions/${workout.sessionId}`;
 };
 
 const getWorkoutStatusBadge = (status: DashboardWorkoutSnapshot['status']) => {

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.test.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.test.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { dashboardWeightTrendQueryKeys } from '@/hooks/use-weight-trend';
 import { createQueryClientWrapper } from '@/test/query-client';
 
 import { WeightTrendChart } from './weight-trend-chart';
@@ -67,14 +68,18 @@ describe('WeightTrendChart', () => {
   let mockFetch: ReturnType<typeof vi.fn>;
 
   function renderChart() {
-    const { wrapper } = createQueryClientWrapper();
-
-    return render(
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const renderResult = render(
       <MemoryRouter>
         <WeightTrendChart />
       </MemoryRouter>,
       { wrapper },
     );
+
+    return {
+      ...renderResult,
+      queryClient,
+    };
   }
 
   beforeEach(() => {
@@ -116,7 +121,7 @@ describe('WeightTrendChart', () => {
     vi.unstubAllGlobals();
   });
 
-  it('fetches 1M range by default and renders header + insight metrics', async () => {
+  it('fetches the default 1M range with today-inclusive from/to dates', async () => {
     const { container } = renderChart();
 
     await waitFor(() => {
@@ -124,7 +129,7 @@ describe('WeightTrendChart', () => {
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      '/api/v1/weight?days=30',
+      '/api/v1/weight?from=2026-02-07&to=2026-03-08',
       expect.objectContaining({ method: 'GET' }),
     );
     expect(screen.getByRole('heading', { name: 'Weight Trend' })).toBeInTheDocument();
@@ -144,23 +149,54 @@ describe('WeightTrendChart', () => {
     expect(container.querySelector('[data-slot="weight-trend-legend"]')).toHaveClass('gap-1.5');
   });
 
-  it('switches ranges and re-fetches weight entries with selected days', async () => {
+  it('switches ranges and re-fetches weight entries with selected from/to dates', async () => {
     renderChart();
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith('/api/v1/weight?days=30', expect.any(Object));
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v1/weight?from=2026-02-07&to=2026-03-08',
+        expect.any(Object),
+      );
     });
 
     fireEvent.click(screen.getByRole('button', { name: '1W' }));
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith('/api/v1/weight?days=7', expect.any(Object));
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v1/weight?from=2026-03-02&to=2026-03-08',
+        expect.any(Object),
+      );
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'All' }));
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith('/api/v1/weight', expect.any(Object));
+    });
+  });
+
+  it('refetches after dashboard weight trend invalidation', async () => {
+    const { queryClient } = renderChart();
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v1/weight?from=2026-02-07&to=2026-03-08',
+        expect.any(Object),
+      );
+    });
+
+    await act(async () => {
+      await queryClient.invalidateQueries({
+        queryKey: dashboardWeightTrendQueryKeys.all,
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        mockFetch.mock.calls.filter(
+          ([path]) => path === '/api/v1/weight?from=2026-02-07&to=2026-03-08',
+        ).length,
+      ).toBeGreaterThanOrEqual(2);
     });
   });
 

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
@@ -5,6 +5,7 @@ import { computeEWMA, computeWeightInsights } from '@pulse/shared';
 import { Link } from 'react-router';
 
 import { DashboardCardHeaderLink } from '@/features/dashboard/components/dashboard-drilldown-link';
+import { dashboardWeightTrendQueryKeys } from '@/hooks/use-weight-trend';
 import {
   CartesianGrid,
   Line,
@@ -18,6 +19,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { apiRequest } from '@/lib/api-client';
+import { addDays, getToday, toDateKey } from '@/lib/date';
 import { formatTrendChange, formatWeight } from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
 
@@ -31,6 +33,11 @@ type ChartPoint = {
   date: string;
   scale: number;
   trend: number;
+};
+
+type ResolvedRange = {
+  from: string | null;
+  to: string | null;
 };
 
 const RANGE_OPTIONS: RangeOption[] = [
@@ -59,11 +66,38 @@ const tooltipDateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
 });
 
-const fetchWeightEntries = async (days: number | null) => {
+const resolveRange = (days: number | null): ResolvedRange => {
+  if (days === null) {
+    return {
+      from: null,
+      to: null,
+    };
+  }
+
+  const today = getToday();
+  const to = toDateKey(today);
+  const from = toDateKey(addDays(today, -(days - 1)));
+
+  return { from, to };
+};
+
+const getQueryKeyForRange = ({ from, to }: ResolvedRange) => {
+  if (from && to) {
+    return dashboardWeightTrendQueryKeys.range(from, to);
+  }
+
+  return [...dashboardWeightTrendQueryKeys.all, 'all'] as const;
+};
+
+const fetchWeightEntries = async ({ from, to }: ResolvedRange) => {
   const params = new URLSearchParams();
 
-  if (days !== null) {
-    params.set('days', String(days));
+  if (from) {
+    params.set('from', from);
+  }
+
+  if (to) {
+    params.set('to', to);
   }
 
   const query = params.toString();
@@ -116,10 +150,11 @@ export function WeightTrendChart() {
     scale: true,
     trend: true,
   });
+  const resolvedRange = useMemo(() => resolveRange(selectedRange.days), [selectedRange.days]);
 
   const weightEntriesQuery = useQuery({
-    queryKey: ['dashboard', 'weight-trend-chart', selectedRange.value],
-    queryFn: () => fetchWeightEntries(selectedRange.days),
+    queryKey: getQueryKeyForRange(resolvedRange),
+    queryFn: () => fetchWeightEntries(resolvedRange),
   });
 
   const chartData = useMemo(() => {

--- a/apps/web/src/features/habits/components/habit-chain-dot.tsx
+++ b/apps/web/src/features/habits/components/habit-chain-dot.tsx
@@ -163,9 +163,15 @@ export function HabitChainDot({
   const statusLabel = getStatusLabel(entry);
   const details = formatValueDetails(entry, habit);
 
-  // Ring for quota habits with partial progress (not yet completed)
+  // Ring for quota habits with partial progress, including today's scheduled dot.
   const showRing =
-    quota && progress != null && progress > 0 && progress < 1 && entry.status === 'missed';
+    quota &&
+    progress != null &&
+    progress > 0 &&
+    progress < 1 &&
+    entry.isScheduled &&
+    !entry.isFutureDate &&
+    entry.status !== 'completed';
 
   const statusClass = showRing
     ? 'bg-transparent'

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -130,6 +130,33 @@ describe('SessionDetail', () => {
     expect(screen.getByText('Bench at setting 5; keep elbows tucked.')).toBeInTheDocument();
   });
 
+  it('formats receipt duration from seconds', async () => {
+    const currentSession = createSession({
+      id: 'session-duration-format',
+      templateId: 'template-upper-push',
+      duration: 5400,
+    });
+
+    mockSessionDetailRequests({
+      sessionId: currentSession.id,
+      session: currentSession,
+      sessions: [
+        createSessionListItem({
+          id: currentSession.id,
+          templateId: currentSession.templateId,
+          templateName: 'Upper Push',
+          startedAt: currentSession.startedAt,
+          duration: currentSession.duration,
+        }),
+      ],
+    });
+
+    renderSessionDetail(currentSession.id);
+
+    expect(await screen.findByText('Workout receipt')).toBeInTheDocument();
+    expect(screen.getByText(/1h 30m/)).toBeInTheDocument();
+  });
+
   it('renders markdown in read-only notes and escapes unsafe HTML', async () => {
     const currentSession = createSession({
       id: 'session-markdown-notes',

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -38,7 +38,11 @@ import { StatCard } from '@/components/ui/stat-card';
 import { useStartSession } from '@/hooks/use-workout-session';
 import { useWeightUnit } from '@/hooks/use-weight-unit';
 import { toDateKey } from '@/lib/date-utils';
-import { formatServing, formatWeight as formatWeightValue } from '@/lib/format-utils';
+import {
+  formatDuration,
+  formatServing,
+  formatWeight as formatWeightValue,
+} from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
 
 import {
@@ -205,6 +209,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
   }
 
   const sessionDate = new Date(session.startedAt);
+  const durationLabel = formatDuration(session.duration);
   const summary = getSessionSummary(session, template ?? null);
   const shouldShowRepsStat = summary.metricTotals.reps > 0 && summary.metricLabel !== 'reps';
   const sections = buildSections(session, template);
@@ -288,7 +293,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
               <p className="max-w-3xl text-sm opacity-80 sm:text-base dark:text-muted dark:opacity-100">
                 {dateFormatter.format(sessionDate)}
                 {' · '}
-                {session.duration != null ? `${session.duration} min` : 'Duration not tracked'}
+                {durationLabel === '-' ? 'Duration not tracked' : durationLabel}
                 {' · '}
                 {`Started ${timeFormatter.format(sessionDate)}`}
               </p>

--- a/apps/web/src/features/workouts/components/workout-list.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.test.tsx
@@ -277,6 +277,25 @@ describe('WorkoutList', () => {
 
     expect(within(completedSection).getByText('Completed 1')).toBeInTheDocument();
   });
+
+  it('formats completed workout durations from seconds', async () => {
+    renderWorkoutList(
+      [
+        createSession({
+          id: 'session-duration-seconds',
+          status: 'completed',
+          templateName: 'Duration Session',
+          duration: 5400,
+        }),
+      ],
+      [],
+    );
+
+    await screen.findByRole('heading', { level: 2, name: 'Completed' });
+    const completedSection = getSectionByTitle('Completed');
+
+    expect(within(completedSection).getByText('1h 30m')).toBeInTheDocument();
+  });
 });
 
 function getSectionByTitle(title: 'In Progress' | 'Scheduled' | 'Completed') {

--- a/apps/web/src/features/workouts/components/workout-list.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.tsx
@@ -24,6 +24,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import { useNavigate } from 'react-router';
 import { toDateKey } from '@/lib/date-utils';
+import { formatDuration } from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
 
 import {
@@ -685,9 +686,11 @@ function getWorkoutPresentation(status: WorkoutSessionStatus) {
 
 function buildStatusStats(session: WorkoutListViewItem) {
   if (session.status === 'completed') {
+    const durationLabel = formatDuration(session.duration);
+
     return [
       { icon: CalendarCheck2, label: sessionDateFormatter.format(session.date) },
-      { icon: Timer, label: session.duration != null ? `${session.duration} min` : 'Duration n/a' },
+      { icon: Timer, label: durationLabel === '-' ? 'Duration n/a' : durationLabel },
       { icon: Dumbbell, label: `${session.exerciseCount} exercises` },
     ];
   }

--- a/apps/web/src/lib/format-utils.test.ts
+++ b/apps/web/src/lib/format-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   formatCalories,
+  formatDuration,
   formatGrams,
   formatPercent,
   formatServing,
@@ -39,5 +40,15 @@ describe('format-utils', () => {
   it('formats serving values with up to two decimals', () => {
     expect(formatServing(1.5)).toBe('1.5');
     expect(formatServing(2.0)).toBe('2');
+  });
+
+  it('formats workout duration from seconds to human-readable labels', () => {
+    expect(formatDuration(3924)).toBe('65 min');
+    expect(formatDuration(3600)).toBe('60 min');
+    expect(formatDuration(5400)).toBe('1h 30m');
+    expect(formatDuration(45)).toBe('< 1 min');
+    expect(formatDuration(0)).toBe('0 min');
+    expect(formatDuration(null)).toBe('-');
+    expect(formatDuration(undefined)).toBe('-');
   });
 });

--- a/apps/web/src/lib/format-utils.ts
+++ b/apps/web/src/lib/format-utils.ts
@@ -1,6 +1,9 @@
 type CaloriesUnit = 'none' | 'cal' | 'kcal';
 type WeightUnit = 'none' | 'lbs';
 
+const SECONDS_PER_MINUTE = 60;
+const HOUR_DISPLAY_THRESHOLD_SECONDS = 90 * SECONDS_PER_MINUTE;
+
 function normalizeNumber(value: number): number {
   return Number.isFinite(value) ? value : 0;
 }
@@ -43,4 +46,28 @@ export function formatServing(value: number): string {
   return normalizeNumber(value)
     .toFixed(2)
     .replace(/\.?0+$/, '');
+}
+
+export function formatDuration(seconds: number | null | undefined): string {
+  if (seconds == null) {
+    return '-';
+  }
+
+  const normalizedSeconds = Math.max(0, Math.floor(normalizeNumber(seconds)));
+  if (normalizedSeconds === 0) {
+    return '0 min';
+  }
+
+  if (normalizedSeconds < SECONDS_PER_MINUTE) {
+    return '< 1 min';
+  }
+
+  const totalMinutes = Math.floor(normalizedSeconds / SECONDS_PER_MINUTE);
+  if (normalizedSeconds < HOUR_DISPLAY_THRESHOLD_SECONDS) {
+    return `${totalMinutes} min`;
+  }
+
+  const hours = Math.floor(totalMinutes / 60);
+  const remainingMinutes = totalMinutes % 60;
+  return `${hours}h ${remainingMinutes}m`;
 }

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -947,8 +947,11 @@ describe('DashboardPage', () => {
     await Promise.resolve();
 
     expect(screen.queryByTestId('habit-daily-status-card-habit-meditate')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Show Meditate daily status widget' }),
+    ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Add card' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show Meditate daily status widget' }));
 
     await vi.runAllTimersAsync();
     await Promise.resolve();
@@ -969,6 +972,45 @@ describe('DashboardPage', () => {
     expect(JSON.parse(String(saveRequest?.[1]?.body))).toMatchObject({
       visibleWidgets: expect.arrayContaining(['habit-daily:habit-meditate']),
     });
+  });
+
+  it('restores hidden persisted habit daily widgets when using show all', async () => {
+    dashboardConfig = {
+      habitChainIds: ['habit-meditate'],
+      trendMetrics: ['weight', 'calories', 'protein'],
+      visibleWidgets: [...DEFAULT_VISIBLE_WIDGETS, 'habit-daily:habit-meditate'],
+    };
+
+    const { wrapper } = createQueryClientWrapper();
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+      { wrapper },
+    );
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit dashboard widgets' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide Recent Workouts widget' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Hide Meditate daily status widget' }));
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(screen.queryByRole('heading', { name: 'Recent Workouts' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('habit-daily-status-card-habit-meditate')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show all' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show all' }));
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(screen.getByRole('heading', { name: 'Recent Workouts' })).toBeInTheDocument();
+    expect(screen.getByTestId('habit-daily-status-card-habit-meditate')).toBeInTheDocument();
   });
 
   it('hides grouped widgets individually and supports bulk restore in edit mode', async () => {

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -756,6 +756,29 @@ describe('DashboardPage', () => {
     expect(screen.getByText('No matching habits.')).toBeInTheDocument();
   });
 
+  it('renders habit daily cards from dashboard config and coexists with habit chains', async () => {
+    dashboardConfig = {
+      habitChainIds: ['habit-meditate'],
+      trendMetrics: ['weight', 'calories', 'protein'],
+      visibleWidgets: [...DEFAULT_VISIBLE_WIDGETS, 'habit-daily:habit-meditate'],
+    };
+
+    const { wrapper } = createQueryClientWrapper();
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+      { wrapper },
+    );
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(screen.getByTestId('habit-daily-status-card-habit-meditate')).toBeInTheDocument();
+    expect(screen.getByLabelText('Habit chains')).toBeInTheDocument();
+    expect(screen.getAllByText('Meditate').length).toBeGreaterThan(1);
+  });
+
   it('hides the weight trend widget when it is excluded from visible widgets', async () => {
     dashboardConfig = {
       habitChainIds: ['habit-meditate'],
@@ -831,6 +854,63 @@ describe('DashboardPage', () => {
     expect(saveRequest).toBeDefined();
     expect(JSON.parse(String(saveRequest?.[1]?.body))).toMatchObject({
       visibleWidgets: expect.not.arrayContaining(['recent-workouts']),
+    });
+  });
+
+  it('adds and hides habit daily cards directly from dashboard edit mode', async () => {
+    const { wrapper } = createQueryClientWrapper();
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+      { wrapper },
+    );
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit dashboard widgets' }));
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    const addCardButton = screen.getByRole('button', { name: 'Add card' });
+    expect(addCardButton).not.toBeDisabled();
+
+    fireEvent.click(addCardButton);
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(screen.getByTestId('habit-daily-status-card-habit-meditate')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide Meditate daily status widget' }));
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(screen.queryByTestId('habit-daily-status-card-habit-meditate')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add card' }));
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(screen.getByTestId('habit-daily-status-card-habit-meditate')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    const saveRequest = mockFetch.mock.calls.find(([url, init]) => {
+      const raw = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      return raw.includes('/api/v1/dashboard/config') && init?.method === 'PUT';
+    });
+
+    expect(saveRequest).toBeDefined();
+    expect(JSON.parse(String(saveRequest?.[1]?.body))).toMatchObject({
+      visibleWidgets: expect.arrayContaining(['habit-daily:habit-meditate']),
     });
   });
 

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -779,6 +779,63 @@ describe('DashboardPage', () => {
     expect(screen.getAllByText('Meditate').length).toBeGreaterThan(1);
   });
 
+  it('shows habit daily card loading state while habits are still loading', async () => {
+    dashboardConfig = {
+      habitChainIds: ['habit-meditate'],
+      trendMetrics: ['weight', 'calories', 'protein'],
+      visibleWidgets: [...DEFAULT_VISIBLE_WIDGETS, 'habit-daily:habit-meditate'],
+    };
+    const deferredHabits = createDeferredResponse();
+    const defaultFetchImplementation = mockFetch.getMockImplementation() as
+      | ((input: string | URL | Request, init?: RequestInit) => Promise<Response>)
+      | undefined;
+
+    mockFetch.mockImplementation((input: string | URL | Request, init?: RequestInit) => {
+      const rawUrl =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url = new URL(rawUrl, 'http://localhost');
+
+      if (url.pathname === '/api/v1/habits' && init?.method === 'GET') {
+        return deferredHabits.promise;
+      }
+
+      return (
+        defaultFetchImplementation?.(input, init) ??
+        Promise.resolve(
+          new Response(JSON.stringify({ error: { code: 'NOT_FOUND', message: 'Not found' } }), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 404,
+          }),
+        )
+      );
+    });
+
+    const { wrapper } = createQueryClientWrapper();
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+      { wrapper },
+    );
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(screen.getByTestId('habit-daily-status-card-loading-habit-meditate')).toBeInTheDocument();
+
+    deferredHabits.resolve(
+      new Response(JSON.stringify({ data: habits }), {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200,
+      }),
+    );
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(screen.getByTestId('habit-daily-status-card-habit-meditate')).toBeInTheDocument();
+  });
+
   it('hides the weight trend widget when it is excluded from visible widgets', async () => {
     dashboardConfig = {
       habitChainIds: ['habit-meditate'],

--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -804,7 +804,7 @@ describe('DashboardPage', () => {
     expect(screen.getByRole('heading', { name: 'Hidden widgets' })).toBeInTheDocument();
     expect(screen.getByText('Recent Workouts')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Show' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show Recent Workouts widget' }));
     await vi.runAllTimersAsync();
     await Promise.resolve();
     expect(screen.getByRole('heading', { name: 'Recent Workouts' })).toBeInTheDocument();
@@ -832,6 +832,54 @@ describe('DashboardPage', () => {
     expect(JSON.parse(String(saveRequest?.[1]?.body))).toMatchObject({
       visibleWidgets: expect.not.arrayContaining(['recent-workouts']),
     });
+  });
+
+  it('hides grouped widgets individually and supports bulk restore in edit mode', async () => {
+    const { wrapper } = createQueryClientWrapper();
+    const { container } = render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+      { wrapper },
+    );
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit dashboard widgets' }));
+
+    expect(screen.getByRole('button', { name: 'Hide Daily Snapshot widget' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Hide Log Weight widget' })).toBeInTheDocument();
+    expect(container.querySelector('[data-widget-label="Daily Snapshot"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-widget-label="Log Weight"]')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide Daily Snapshot widget' }));
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(container.querySelector('[data-widget-label="Daily Snapshot"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-widget-label="Log Weight"]')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show Daily Snapshot widget' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Show all' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide Log Weight widget' }));
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(container.querySelector('[data-widget-label="Log Weight"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-slot="dashboard-snapshot-panel"]')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show all' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show all' }));
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(container.querySelector('[data-widget-label="Daily Snapshot"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-widget-label="Log Weight"]')).toBeInTheDocument();
+    expect(screen.getByText('No hidden widgets.')).toBeInTheDocument();
   });
 
   it('stays in edit mode and shows an error when widget visibility save fails', async () => {

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -11,7 +11,6 @@ import { HelpIcon } from '@/components/ui/help-icon';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { Toggle } from '@/components/ui/toggle';
 import { CalendarPicker } from '@/features/dashboard/components/calendar-picker';
 import { DashboardCardHeaderLink } from '@/features/dashboard/components/dashboard-drilldown-link';
 import { HabitChain } from '@/features/dashboard/components/habit-chain';
@@ -52,20 +51,22 @@ function DashboardWidgetEditOverlay({
   widgetLabel: string;
 }) {
   return (
-    <div className="pointer-events-none absolute inset-0 rounded-2xl bg-background/60">
-      <div className="pointer-events-auto absolute top-3 right-3">
-        <Toggle
+    <div className="pointer-events-auto absolute inset-0 z-30 rounded-2xl border-2 border-dashed border-primary/45 bg-background/65 backdrop-blur-[1px]">
+      <p className="absolute top-3 left-3 rounded-full border border-border/80 bg-background/95 px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/90 shadow-sm">
+        Edit mode
+      </p>
+      <div className="absolute top-3 right-3 z-40">
+        <Button
           aria-label={`Hide ${widgetLabel} widget`}
-          onPressedChange={() => {
-            onHide();
-          }}
-          pressed={false}
+          className="rounded-full border-border/80 bg-background/95 px-3 text-xs font-semibold shadow-sm hover:bg-background"
+          onClick={onHide}
           size="sm"
+          type="button"
           variant="outline"
         >
-          <EyeOff />
+          <EyeOff className="size-4" />
           Hide
-        </Toggle>
+        </Button>
       </div>
     </div>
   );
@@ -163,6 +164,10 @@ export function DashboardPage() {
       const current = currentDraft ?? persistedVisibleWidgets;
       return current.filter((value) => value !== widgetId);
     });
+  }
+
+  function showAllWidgets() {
+    setVisibleWidgetsDraft([...DEFAULT_VISIBLE_WIDGETS]);
   }
 
   function handleStartEditMode() {
@@ -610,7 +615,17 @@ export function DashboardPage() {
 
       {isEditMode ? (
         <section className="space-y-3">
-          <h2 className="text-lg font-semibold text-foreground">Hidden widgets</h2>
+          <div className="flex items-center justify-between gap-2">
+            <h2 className="text-lg font-semibold text-foreground">Hidden widgets</h2>
+            {hiddenWidgets.length > 1 ? (
+              <Button onClick={showAllWidgets} size="sm" type="button" variant="outline">
+                Show all
+              </Button>
+            ) : null}
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Use Restore to add cards back before saving.
+          </p>
           {hiddenWidgets.length === 0 ? (
             <p className="text-sm text-muted-foreground">No hidden widgets.</p>
           ) : (
@@ -629,13 +644,14 @@ export function DashboardPage() {
                       <p className="text-xs text-muted-foreground">Currently hidden</p>
                     </div>
                     <Button
+                      aria-label={`Show ${DASHBOARD_WIDGET_IDS[widgetId]} widget`}
                       onClick={() => showWidget(widgetId)}
                       size="sm"
                       type="button"
                       variant="outline"
                     >
                       <Plus />
-                      Show
+                      Restore
                     </Button>
                   </CardContent>
                 </Card>

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -148,6 +148,9 @@ export function DashboardPage() {
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
   const [isEditMode, setIsEditMode] = useState(false);
   const [visibleWidgetsDraft, setVisibleWidgetsDraft] = useState<DashboardWidgetId[] | null>(null);
+  const [editSessionHabitDailyWidgets, setEditSessionHabitDailyWidgets] = useState<
+    HabitDailyWidgetId[]
+  >([]);
   const [selectedCardType, setSelectedCardType] = useState<DashboardCardTypeId>('habit-daily');
   const [selectedHabitDailyId, setSelectedHabitDailyId] = useState('');
   const [widgetVisibilityMessage, setWidgetVisibilityMessage] = useState('');
@@ -168,7 +171,11 @@ export function DashboardPage() {
   const persistedVisibleWidgets = getUniqueWidgetIds(
     dashboardConfigQuery.data?.visibleWidgets ?? DEFAULT_VISIBLE_WIDGETS
   ).filter(isDashboardWidgetId);
+  const persistedHabitDailyWidgets = persistedVisibleWidgets.filter(isHabitDailyWidgetId);
   const visibleWidgets = visibleWidgetsDraft ?? persistedVisibleWidgets;
+  const restorableHabitDailyWidgets = isEditMode
+    ? getUniqueWidgetIds([...persistedHabitDailyWidgets, ...editSessionHabitDailyWidgets])
+    : persistedHabitDailyWidgets;
   const visibleHabitDailyWidgets = visibleWidgets
     .filter(isHabitDailyWidgetId)
     .map((widgetId) => ({
@@ -186,9 +193,26 @@ export function DashboardPage() {
   )
     ? selectedHabitDailyId
     : (availableHabitDailyHabits[0]?.id ?? '');
-  const hiddenWidgets = DEFAULT_VISIBLE_WIDGETS.filter(
-    (widgetId) => !visibleWidgets.includes(widgetId),
-  );
+  const hiddenWidgets = getUniqueWidgetIds<DashboardWidgetId>([
+    ...DEFAULT_VISIBLE_WIDGETS,
+    ...restorableHabitDailyWidgets,
+  ])
+    .filter((widgetId) => !visibleWidgets.includes(widgetId))
+    .map((widgetId) => {
+      if (isHabitDailyWidgetId(widgetId)) {
+        const habitId = getHabitIdFromDailyWidgetId(widgetId);
+        const habitName = habitsQuery.data?.find((habit) => habit.id === habitId)?.name;
+        return {
+          widgetId,
+          widgetLabel: habitName ? `${habitName} daily status` : 'Habit daily status',
+        };
+      }
+
+      return {
+        widgetId,
+        widgetLabel: DASHBOARD_WIDGET_IDS[widgetId],
+      };
+    });
   const showWeightTrendChart = visibleWidgets.includes('weight-trend');
   const isSavingDashboardConfig = saveDashboardConfigMutation.isPending;
   const selectedWeight = snapshotQuery.data?.weight;
@@ -223,19 +247,24 @@ export function DashboardPage() {
   function showAllWidgets() {
     setVisibleWidgetsDraft((currentDraft) => {
       const current = currentDraft ?? persistedVisibleWidgets;
-      const habitDailyWidgets = current.filter(isHabitDailyWidgetId);
-      return [...DEFAULT_VISIBLE_WIDGETS, ...habitDailyWidgets];
+      const habitDailyWidgets = getUniqueWidgetIds([
+        ...current.filter(isHabitDailyWidgetId),
+        ...restorableHabitDailyWidgets,
+      ]);
+      return getUniqueWidgetIds([...DEFAULT_VISIBLE_WIDGETS, ...habitDailyWidgets]);
     });
   }
 
   function handleStartEditMode() {
     setVisibleWidgetsDraft(persistedVisibleWidgets);
+    setEditSessionHabitDailyWidgets(persistedHabitDailyWidgets);
     setWidgetVisibilityMessage('');
     setIsEditMode(true);
   }
 
   function handleCancelEditMode() {
     setVisibleWidgetsDraft(null);
+    setEditSessionHabitDailyWidgets([]);
     setSelectedHabitDailyId('');
     setWidgetVisibilityMessage('');
     setIsEditMode(false);
@@ -246,7 +275,9 @@ export function DashboardPage() {
       return;
     }
 
-    showWidget(toHabitDailyWidgetId(selectedHabitDailyCardId));
+    const widgetId = toHabitDailyWidgetId(selectedHabitDailyCardId);
+    setEditSessionHabitDailyWidgets((current) => getUniqueWidgetIds([...current, widgetId]));
+    showWidget(widgetId);
     setSelectedHabitDailyId('');
   }
 
@@ -259,6 +290,7 @@ export function DashboardPage() {
         visibleWidgets,
       });
       setVisibleWidgetsDraft(null);
+      setEditSessionHabitDailyWidgets([]);
       setSelectedHabitDailyId('');
       setWidgetVisibilityMessage('');
       setIsEditMode(false);
@@ -715,7 +747,7 @@ export function DashboardPage() {
               <p className="text-sm text-muted-foreground">No hidden widgets.</p>
             ) : (
               <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-                {hiddenWidgets.map((widgetId) => (
+                {hiddenWidgets.map(({ widgetId, widgetLabel }) => (
                   <Card
                     key={widgetId}
                     className="border-dashed border-border/80 bg-muted/30 py-3"
@@ -723,13 +755,11 @@ export function DashboardPage() {
                   >
                     <CardContent className="flex items-center justify-between gap-3 px-3">
                       <div>
-                        <p className="text-sm font-medium text-foreground">
-                          {DASHBOARD_WIDGET_IDS[widgetId]}
-                        </p>
+                        <p className="text-sm font-medium text-foreground">{widgetLabel}</p>
                         <p className="text-xs text-muted-foreground">Currently hidden</p>
                       </div>
                       <Button
-                        aria-label={`Show ${DASHBOARD_WIDGET_IDS[widgetId]} widget`}
+                        aria-label={`Show ${widgetLabel} widget`}
                         onClick={() => showWidget(widgetId)}
                         size="sm"
                         type="button"

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -11,8 +11,16 @@ import { HelpIcon } from '@/components/ui/help-icon';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { CalendarPicker } from '@/features/dashboard/components/calendar-picker';
 import { DashboardCardHeaderLink } from '@/features/dashboard/components/dashboard-drilldown-link';
+import { HabitDailyStatusCard } from '@/features/dashboard/components/habit-daily-status-card';
 import { HabitChain } from '@/features/dashboard/components/habit-chain';
 import { MacroRings } from '@/features/dashboard/components/macro-rings';
 import { RecentWorkouts } from '@/features/dashboard/components/recent-workouts';
@@ -35,8 +43,15 @@ const dashboardDateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
   year: 'numeric',
 });
-type DashboardWidgetId = keyof typeof DASHBOARD_WIDGET_IDS;
-const DEFAULT_VISIBLE_WIDGETS = Object.keys(DASHBOARD_WIDGET_IDS) as DashboardWidgetId[];
+const HABIT_DAILY_WIDGET_PREFIX = 'habit-daily:';
+const DASHBOARD_CARD_TYPES = {
+  'habit-daily': 'Habit Daily Status',
+} as const;
+type DashboardStaticWidgetId = keyof typeof DASHBOARD_WIDGET_IDS;
+type HabitDailyWidgetId = `${typeof HABIT_DAILY_WIDGET_PREFIX}${string}`;
+type DashboardCardTypeId = keyof typeof DASHBOARD_CARD_TYPES;
+type DashboardWidgetId = DashboardStaticWidgetId | HabitDailyWidgetId;
+const DEFAULT_VISIBLE_WIDGETS = Object.keys(DASHBOARD_WIDGET_IDS) as DashboardStaticWidgetId[];
 const DEFAULT_DASHBOARD_CONFIG = {
   habitChainIds: [],
   trendMetrics: ['weight', 'calories', 'protein'] as const,
@@ -72,8 +87,28 @@ function DashboardWidgetEditOverlay({
   );
 }
 
-function isDashboardWidgetId(value: string): value is DashboardWidgetId {
+function isDashboardStaticWidgetId(value: string): value is DashboardStaticWidgetId {
   return value in DASHBOARD_WIDGET_IDS;
+}
+
+function isHabitDailyWidgetId(value: string): value is HabitDailyWidgetId {
+  return value.startsWith(HABIT_DAILY_WIDGET_PREFIX) && value.length > HABIT_DAILY_WIDGET_PREFIX.length;
+}
+
+function isDashboardWidgetId(value: string): value is DashboardWidgetId {
+  return isDashboardStaticWidgetId(value) || isHabitDailyWidgetId(value);
+}
+
+function toHabitDailyWidgetId(habitId: string): HabitDailyWidgetId {
+  return `${HABIT_DAILY_WIDGET_PREFIX}${habitId}`;
+}
+
+function getHabitIdFromDailyWidgetId(widgetId: HabitDailyWidgetId) {
+  return widgetId.slice(HABIT_DAILY_WIDGET_PREFIX.length);
+}
+
+function getUniqueWidgetIds<TWidgetId extends string>(widgetIds: TWidgetId[]) {
+  return Array.from(new Set(widgetIds));
 }
 
 type DashboardWeightStatus = {
@@ -113,6 +148,8 @@ export function DashboardPage() {
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
   const [isEditMode, setIsEditMode] = useState(false);
   const [visibleWidgetsDraft, setVisibleWidgetsDraft] = useState<DashboardWidgetId[] | null>(null);
+  const [selectedCardType, setSelectedCardType] = useState<DashboardCardTypeId>('habit-daily');
+  const [selectedHabitDailyId, setSelectedHabitDailyId] = useState('');
   const [widgetVisibilityMessage, setWidgetVisibilityMessage] = useState('');
   const logWeightMutation = useLogWeight();
   const saveDashboardConfigMutation = useSaveDashboardConfig();
@@ -128,10 +165,27 @@ export function DashboardPage() {
   const habitsQuery = useHabits();
   const habitChainEntriesQuery = useHabitChains(habitRangeStart, selectedDateKey);
   const recentWorkoutsQuery = useRecentWorkouts();
-  const persistedVisibleWidgets = (
+  const persistedVisibleWidgets = getUniqueWidgetIds(
     dashboardConfigQuery.data?.visibleWidgets ?? DEFAULT_VISIBLE_WIDGETS
   ).filter(isDashboardWidgetId);
   const visibleWidgets = visibleWidgetsDraft ?? persistedVisibleWidgets;
+  const visibleHabitDailyWidgets = visibleWidgets
+    .filter(isHabitDailyWidgetId)
+    .map((widgetId) => ({
+      habitId: getHabitIdFromDailyWidgetId(widgetId),
+      widgetId,
+    }));
+  const visibleHabitDailyHabitIdSet = new Set(
+    visibleHabitDailyWidgets.map((widget) => widget.habitId),
+  );
+  const availableHabitDailyHabits = (habitsQuery.data ?? []).filter(
+    (habit) => !visibleHabitDailyHabitIdSet.has(habit.id),
+  );
+  const selectedHabitDailyCardId = availableHabitDailyHabits.some(
+    (habit) => habit.id === selectedHabitDailyId,
+  )
+    ? selectedHabitDailyId
+    : (availableHabitDailyHabits[0]?.id ?? '');
   const hiddenWidgets = DEFAULT_VISIBLE_WIDGETS.filter(
     (widgetId) => !visibleWidgets.includes(widgetId),
   );
@@ -147,7 +201,7 @@ export function DashboardPage() {
         return current;
       }
 
-      return [...current, widgetId];
+      return getUniqueWidgetIds([...current, widgetId]);
     });
   }
 
@@ -167,7 +221,11 @@ export function DashboardPage() {
   }
 
   function showAllWidgets() {
-    setVisibleWidgetsDraft([...DEFAULT_VISIBLE_WIDGETS]);
+    setVisibleWidgetsDraft((currentDraft) => {
+      const current = currentDraft ?? persistedVisibleWidgets;
+      const habitDailyWidgets = current.filter(isHabitDailyWidgetId);
+      return [...DEFAULT_VISIBLE_WIDGETS, ...habitDailyWidgets];
+    });
   }
 
   function handleStartEditMode() {
@@ -178,8 +236,18 @@ export function DashboardPage() {
 
   function handleCancelEditMode() {
     setVisibleWidgetsDraft(null);
+    setSelectedHabitDailyId('');
     setWidgetVisibilityMessage('');
     setIsEditMode(false);
+  }
+
+  function handleAddDashboardCard() {
+    if (selectedCardType !== 'habit-daily' || selectedHabitDailyCardId.length === 0) {
+      return;
+    }
+
+    showWidget(toHabitDailyWidgetId(selectedHabitDailyCardId));
+    setSelectedHabitDailyId('');
   }
 
   async function handleSaveWidgetVisibility() {
@@ -191,6 +259,7 @@ export function DashboardPage() {
         visibleWidgets,
       });
       setVisibleWidgetsDraft(null);
+      setSelectedHabitDailyId('');
       setWidgetVisibilityMessage('');
       setIsEditMode(false);
     } catch {
@@ -559,6 +628,25 @@ export function DashboardPage() {
             className="order-2 flex min-w-0 flex-col gap-3 sm:gap-4 md:order-2"
             data-slot="dashboard-sidebar-column"
           >
+            {visibleHabitDailyWidgets.map(({ habitId, widgetId }) => {
+              const habit = habitsQuery.data?.find((item) => item.id === habitId);
+
+              if (!habit) {
+                return null;
+              }
+
+              return (
+                <DashboardWidgetFrame
+                  key={widgetId}
+                  dataSlot={`dashboard-habit-daily-card-${habitId}`}
+                  isEditMode={isEditMode}
+                  onHide={() => hideWidget(widgetId)}
+                  widgetLabel={`${habit.name} daily status`}
+                >
+                  <HabitDailyStatusCard compact habitId={habitId} />
+                </DashboardWidgetFrame>
+              );
+            })}
             {visibleWidgets.includes('habit-chain') ? (
               <DashboardWidgetFrame
                 isEditMode={isEditMode}
@@ -614,50 +702,119 @@ export function DashboardPage() {
       )}
 
       {isEditMode ? (
-        <section className="space-y-3">
-          <div className="flex items-center justify-between gap-2">
-            <h2 className="text-lg font-semibold text-foreground">Hidden widgets</h2>
-            {hiddenWidgets.length > 1 ? (
-              <Button onClick={showAllWidgets} size="sm" type="button" variant="outline">
-                Show all
-              </Button>
+        <section className="space-y-4">
+          <div className="space-y-3">
+            <div className="flex items-center justify-between gap-2">
+              <h2 className="text-lg font-semibold text-foreground">Hidden widgets</h2>
+              {hiddenWidgets.length > 1 ? (
+                <Button onClick={showAllWidgets} size="sm" type="button" variant="outline">
+                  Show all
+                </Button>
+              ) : null}
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Use Restore to add cards back before saving.
+            </p>
+            {hiddenWidgets.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No hidden widgets.</p>
+            ) : (
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                {hiddenWidgets.map((widgetId) => (
+                  <Card
+                    key={widgetId}
+                    className="border-dashed border-border/80 bg-muted/30 py-3"
+                    data-slot={`dashboard-hidden-widget-${widgetId}`}
+                  >
+                    <CardContent className="flex items-center justify-between gap-3 px-3">
+                      <div>
+                        <p className="text-sm font-medium text-foreground">
+                          {DASHBOARD_WIDGET_IDS[widgetId]}
+                        </p>
+                        <p className="text-xs text-muted-foreground">Currently hidden</p>
+                      </div>
+                      <Button
+                        aria-label={`Show ${DASHBOARD_WIDGET_IDS[widgetId]} widget`}
+                        onClick={() => showWidget(widgetId)}
+                        size="sm"
+                        type="button"
+                        variant="outline"
+                      >
+                        <Plus />
+                        Restore
+                      </Button>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-3">
+            <h2 className="text-lg font-semibold text-foreground">Add cards</h2>
+            <Card className="border-border/80 bg-muted/20 py-3">
+              <CardContent className="grid gap-3 px-3 sm:grid-cols-[minmax(0,200px)_minmax(0,1fr)_auto] sm:items-end">
+                <div className="space-y-1.5">
+                  <Label htmlFor="dashboard-add-card-type">Card type</Label>
+                  <Select
+                    onValueChange={(value) => {
+                      if (value in DASHBOARD_CARD_TYPES) {
+                        setSelectedCardType(value as DashboardCardTypeId);
+                      }
+                    }}
+                    value={selectedCardType}
+                  >
+                    <SelectTrigger aria-label="Select card type" id="dashboard-add-card-type">
+                      <SelectValue placeholder="Select card type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {(Object.entries(DASHBOARD_CARD_TYPES) as Array<
+                        [DashboardCardTypeId, string]
+                      >).map(([typeId, label]) => (
+                        <SelectItem key={typeId} value={typeId}>
+                          {label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="dashboard-add-card-habit">Habit</Label>
+                  <Select
+                    disabled={availableHabitDailyHabits.length === 0}
+                    onValueChange={setSelectedHabitDailyId}
+                    value={selectedHabitDailyCardId}
+                  >
+                    <SelectTrigger aria-label="Select habit for daily status card" id="dashboard-add-card-habit">
+                      <SelectValue placeholder="Select a habit" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {availableHabitDailyHabits.map((habit) => (
+                        <SelectItem key={habit.id} value={habit.id}>
+                          {habit.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <Button
+                  disabled={selectedHabitDailyCardId.length === 0}
+                  onClick={handleAddDashboardCard}
+                  type="button"
+                  variant="outline"
+                >
+                  <Plus />
+                  Add card
+                </Button>
+              </CardContent>
+            </Card>
+            {availableHabitDailyHabits.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                All active habits already have a daily status card.
+              </p>
             ) : null}
           </div>
-          <p className="text-sm text-muted-foreground">
-            Use Restore to add cards back before saving.
-          </p>
-          {hiddenWidgets.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No hidden widgets.</p>
-          ) : (
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-              {hiddenWidgets.map((widgetId) => (
-                <Card
-                  key={widgetId}
-                  className="border-dashed border-border/80 bg-muted/30 py-3"
-                  data-slot={`dashboard-hidden-widget-${widgetId}`}
-                >
-                  <CardContent className="flex items-center justify-between gap-3 px-3">
-                    <div>
-                      <p className="text-sm font-medium text-foreground">
-                        {DASHBOARD_WIDGET_IDS[widgetId]}
-                      </p>
-                      <p className="text-xs text-muted-foreground">Currently hidden</p>
-                    </div>
-                    <Button
-                      aria-label={`Show ${DASHBOARD_WIDGET_IDS[widgetId]} widget`}
-                      onClick={() => showWidget(widgetId)}
-                      size="sm"
-                      type="button"
-                      variant="outline"
-                    >
-                      <Plus />
-                      Restore
-                    </Button>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          )}
         </section>
       ) : null}
     </main>

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -631,17 +631,13 @@ export function DashboardPage() {
             {visibleHabitDailyWidgets.map(({ habitId, widgetId }) => {
               const habit = habitsQuery.data?.find((item) => item.id === habitId);
 
-              if (!habit) {
-                return null;
-              }
-
               return (
                 <DashboardWidgetFrame
                   key={widgetId}
                   dataSlot={`dashboard-habit-daily-card-${habitId}`}
                   isEditMode={isEditMode}
                   onHide={() => hideWidget(widgetId)}
-                  widgetLabel={`${habit.name} daily status`}
+                  widgetLabel={habit ? `${habit.name} daily status` : 'Habit daily status'}
                 >
                   <HabitDailyStatusCard compact habitId={habitId} />
                 </DashboardWidgetFrame>


### PR DESCRIPTION
## Summary
This PR fixes a set of dashboard correctness issues and adds a new configurable habit daily status card experience. Workout durations are now consistently formatted from seconds across dashboard and workout detail/list surfaces, preventing values like seconds being mislabeled as minutes. Dashboard workout links now route in-progress sessions to the active session flow and simplify completed-session routing. It also resolves stale weight-trend rendering by aligning the chart’s query keys/range parameters with shared invalidation behavior, and improves habit progress visuals/edit-mode controls for clearer day-to-day tracking.

## Key Changes
- Added `formatDuration` in `apps/web/src/lib/format-utils.ts` and applied it across:
  - `recent-workouts.tsx`
  - `session-detail.tsx`
  - `workout-list.tsx`
- Fixed snapshot workout routing in `snapshot-cards.tsx`:
  - `in_progress` now links to `/workouts/active?sessionId=...`
  - non-in-progress links to `/workouts/sessions/:id`
- Updated `weight-trend-chart.tsx` to use resolved `from/to` ranges and query keys derived from `dashboardWeightTrendQueryKeys`, so dashboard invalidations trigger expected refetches.
- Fixed partial numeric habit ring rendering in `habit-chain-dot.tsx` so scheduled, non-future, non-completed partial progress shows as a ring.
- Added new `HabitDailyStatusCard` component with inline editing:
  - boolean habits: checkbox toggle
  - numeric habits: quick edit with progress ring/bar and target display
  - referential habits use aggregated `todayEntry` unless manually overridden
- Expanded dashboard widget edit UX in `dashboard.tsx`:
  - clearer per-card hide overlay/buttons
  - hidden widgets “Restore” and “Show all”
  - add-card flow for dynamic `habit-daily:<habitId>` widgets
  - deduped/validated widget IDs before persistence
- Added comprehensive test coverage for new behavior and regressions across dashboard, habit, workout, and formatting components.

## Technical Notes
- `formatDuration` now treats input as seconds, not minutes; formatting behavior is:
  - `null/undefined -> "-"`, `<60s -> "< 1 min"`, `0 -> "0 min"`, `<90m -> "N min"`, `>=90m -> "Xh Ym"`.
- Weight trend chart now fetches via explicit `from/to` query params and uses query keys compatible with existing `dashboardWeightTrendQueryKeys.all` invalidation paths.
- Dynamic dashboard cards are encoded in `visibleWidgets` using a prefix (`habit-daily:`), with helper guards/parsers and set-based deduplication to avoid duplicate persisted widgets.
- Inline numeric habit editing intentionally commits on blur/Enter and cancels on Escape without mutation, which hardens edit cancel behavior and avoids accidental writes.

## Commits

- `dec0494 chore(dashboard): verify PR 4 integration — all gates green`
- `5d44456 fix(dashboard): harden habit daily edit cancel behavior`
- `cc80a81 feat(dashboard): add habit daily status cards with inline editing`
- `f06105b fix(dashboard): improve per-card widget visibility controls`
- `d199566 fix(dashboard): render numeric habit partial progress rings`
- `2aa9c96 fix(dashboard): align weight trend chart cache invalidation`
- `8faebb8 fix(dashboard): route in-progress workouts to active session`
- `25a03ce fix(web): format workout durations from seconds`

## Tasks

- **Fix duration formatting — seconds displayed as min**: Create formatDuration utility, apply to recent-workouts.tsx, session-detail.tsx, workout-list.tsx, and all other duration surfaces
- **Fix dashboard workout click routing for in-progress sessions**: In-progress workouts should route to active session page, not receipt. Fix href in snapshot-cards.tsx
- **Fix weight trend chart not updating after logging weight**: Verify query key alignment with invalidation map, fix rendering/caching issue
- **Fix numeric habit progress display — show progress ring not grey**: Investigate habit progress ring rendering edge cases, fix partial progress visualization
- **Fix dashboard edit mode per-card visibility**: Investigate per-widget edit overlay, fix if broken or improve discoverability
- **Dashboard habit daily status cards with inline editing**: New HabitDailyStatusCard component: today's value, target, quick-edit for numeric and boolean habits
- **PR 4 integration pass — full test suite**: Run full test suite, fix any regressions from dashboard commits

## Diff Stats

```
.../dashboard/components/habit-chain.test.tsx      | 133 ++++++++++
 .../components/habit-daily-status-card.test.tsx    | 285 +++++++++++++++++++++
 .../components/habit-daily-status-card.tsx         | 273 ++++++++++++++++++++
 .../dashboard/components/recent-workouts.test.tsx  |  12 +-
 .../dashboard/components/recent-workouts.tsx       |  89 ++++---
 .../dashboard/components/snapshot-cards.test.tsx   |   4 +-
 .../dashboard/components/snapshot-cards.tsx        |   4 +-
 .../components/weight-trend-chart.test.tsx         |  54 +++-
 .../dashboard/components/weight-trend-chart.tsx    |  45 +++-
 .../features/habits/components/habit-chain-dot.tsx |  10 +-
 .../workouts/components/session-detail.test.tsx    |  27 ++
 .../workouts/components/session-detail.tsx         |   9 +-
 .../workouts/components/workout-list.test.tsx      |  19 ++
 .../features/workouts/components/workout-list.tsx  |   5 +-
 apps/web/src/lib/format-utils.test.ts              |  11 +
 apps/web/src/lib/format-utils.ts                   |  27 ++
 apps/web/src/pages/dashboard.test.tsx              | 187 +++++++++++++-
 apps/web/src/pages/dashboard.tsx                   | 263 +++++++++++++++----
 18 files changed, 1338 insertions(+), 119 deletions(-)
```