### PR TITLE
feat(web): meal rename, agent polling, localStorage persistence, exercise history

### DIFF
--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -217,7 +217,7 @@ describe('exercise routes', () => {
     seedUser('user-2', 'alex');
   });
 
-  it('requires auth for create, list, last-performance, update, and delete', async () => {
+  it('requires auth for create, list, history, last-performance, update, and delete', async () => {
     const responses = await Promise.all([
       context.app.inject({
         method: 'POST',
@@ -232,6 +232,10 @@ describe('exercise routes', () => {
       context.app.inject({
         method: 'GET',
         url: '/api/v1/exercises',
+      }),
+      context.app.inject({
+        method: 'GET',
+        url: '/api/v1/exercises/exercise-1/history',
       }),
       context.app.inject({
         method: 'GET',
@@ -346,6 +350,14 @@ describe('exercise routes', () => {
       reps: 9,
     });
     seedSessionSet({
+      id: 'set-latest-2',
+      sessionId: 'session-latest',
+      exerciseId: 'global-bench',
+      setNumber: 2,
+      weight: 100,
+      reps: 8,
+    });
+    seedSessionSet({
       id: 'set-in-progress',
       sessionId: 'session-in-progress',
       exerciseId: 'global-bench',
@@ -383,6 +395,11 @@ describe('exercise routes', () => {
             setNumber: 1,
             weight: 105,
             reps: 9,
+          },
+          {
+            setNumber: 2,
+            weight: 100,
+            reps: 8,
           },
         ],
       },
@@ -487,6 +504,130 @@ describe('exercise routes', () => {
     });
   });
 
+  it('returns recent completed exercise history with all sets for each session', async () => {
+    seedExercise({
+      id: 'global-bench',
+      userId: null,
+      name: 'Bench Press',
+      muscleGroups: ['chest'],
+      equipment: 'barbell',
+      category: 'compound',
+    });
+
+    seedWorkoutSession({
+      id: 'session-old',
+      userId: 'user-1',
+      name: 'Push Day',
+      date: '2026-03-01',
+      status: 'completed',
+      startedAt: Date.parse('2026-03-01T10:00:00.000Z'),
+      completedAt: Date.parse('2026-03-01T10:45:00.000Z'),
+    });
+    seedWorkoutSession({
+      id: 'session-latest',
+      userId: 'user-1',
+      name: 'Push Day 2',
+      date: '2026-03-08',
+      status: 'completed',
+      startedAt: Date.parse('2026-03-08T10:00:00.000Z'),
+      completedAt: Date.parse('2026-03-08T10:50:00.000Z'),
+    });
+    seedWorkoutSession({
+      id: 'session-in-progress',
+      userId: 'user-1',
+      name: 'Push Day Live',
+      date: '2026-03-10',
+      status: 'in-progress',
+      startedAt: Date.parse('2026-03-10T10:00:00.000Z'),
+      completedAt: null,
+    });
+
+    context.db
+      .update(workoutSessions)
+      .set({ notes: 'Felt stronger than last week.' })
+      .where(eq(workoutSessions.id, 'session-latest'))
+      .run();
+
+    seedSessionSet({
+      id: 'set-old-1',
+      sessionId: 'session-old',
+      exerciseId: 'global-bench',
+      setNumber: 1,
+      weight: 95,
+      reps: 10,
+    });
+    seedSessionSet({
+      id: 'set-latest-1',
+      sessionId: 'session-latest',
+      exerciseId: 'global-bench',
+      setNumber: 1,
+      weight: 105,
+      reps: 8,
+    });
+    seedSessionSet({
+      id: 'set-latest-2',
+      sessionId: 'session-latest',
+      exerciseId: 'global-bench',
+      setNumber: 2,
+      weight: 100,
+      reps: 8,
+    });
+    seedSessionSet({
+      id: 'set-in-progress-1',
+      sessionId: 'session-in-progress',
+      exerciseId: 'global-bench',
+      setNumber: 1,
+      weight: 110,
+      reps: 6,
+    });
+
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    const response = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises/global-bench/history?limit=2',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: [
+        {
+          sessionId: 'session-latest',
+          date: '2026-03-08',
+          notes: 'Felt stronger than last week.',
+          sets: [
+            {
+              setNumber: 1,
+              weight: 105,
+              reps: 8,
+            },
+            {
+              setNumber: 2,
+              weight: 100,
+              reps: 8,
+            },
+          ],
+        },
+        {
+          sessionId: 'session-old',
+          date: '2026-03-01',
+          notes: null,
+          sets: [
+            {
+              setNumber: 1,
+              weight: 95,
+              reps: 10,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it('returns exact and related history when includeRelated=true', async () => {
     seedExercise({
       id: 'flat-bench',
@@ -542,6 +683,14 @@ describe('exercise routes', () => {
       reps: 5,
     });
     seedSessionSet({
+      id: 'set-flat-2',
+      sessionId: 'session-flat',
+      exerciseId: 'flat-bench',
+      setNumber: 2,
+      weight: 195,
+      reps: 6,
+    });
+    seedSessionSet({
       id: 'set-incline-1',
       sessionId: 'session-incline',
       exerciseId: 'incline-bench',
@@ -572,6 +721,11 @@ describe('exercise routes', () => {
               setNumber: 1,
               weight: 205,
               reps: 5,
+            },
+            {
+              setNumber: 2,
+              weight: 195,
+              reps: 6,
             },
           ],
         },

--- a/apps/api/src/routes/exercises/index.ts
+++ b/apps/api/src/routes/exercises/index.ts
@@ -315,6 +315,8 @@ export const exerciseRoutes: FastifyPluginAsync = async (app) => {
         limit: request.query.limit,
       });
 
+      reply.header('Cache-Control', 'private, no-cache');
+
       return reply.send({
         data: history,
       });

--- a/apps/api/src/routes/exercises/index.ts
+++ b/apps/api/src/routes/exercises/index.ts
@@ -8,6 +8,8 @@ import {
   exerciseHistoryWithRelatedSchema,
   exerciseLastPerformanceQuerySchema,
   exerciseLastPerformanceSchema,
+  exercisePerformanceHistoryQuerySchema,
+  exercisePerformanceHistorySchema,
   exerciseQueryParamsSchema,
   exerciseSchema,
   updateExerciseInputSchema,
@@ -35,6 +37,7 @@ import {
   findExerciseDedupCandidates,
   findExerciseHistoryWithRelated,
   findExerciseLastPerformance,
+  findExercisePerformanceHistory,
   findExerciseOwnership,
   findVisibleExerciseById,
   listExerciseFilters,
@@ -271,6 +274,49 @@ export const exerciseRoutes: FastifyPluginAsync = async (app) => {
 
       return reply.send({
         data: filters,
+      });
+    },
+  );
+
+  typedApp.get(
+    '/:id/history',
+    {
+      schema: {
+        params: idParamsSchema,
+        querystring: exercisePerformanceHistoryQuerySchema,
+        response: {
+          200: apiDataResponseSchema(exercisePerformanceHistorySchema),
+          400: badRequestResponseSchema,
+          401: apiErrorResponseSchema,
+          404: apiErrorResponseSchema,
+        },
+        tags: ['exercises'],
+        summary: 'Get recent completed session history for an exercise',
+        security: authSecurity,
+      },
+    },
+    async (request, reply) => {
+      const exercise = await findVisibleExerciseById({
+        id: request.params.id,
+        userId: request.userId,
+      });
+      if (!exercise) {
+        return sendError(
+          reply,
+          404,
+          EXERCISE_NOT_FOUND_RESPONSE.code,
+          EXERCISE_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      const history = await findExercisePerformanceHistory({
+        exerciseId: request.params.id,
+        userId: request.userId,
+        limit: request.query.limit,
+      });
+
+      return reply.send({
+        data: history,
       });
     },
   );

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -5,6 +5,7 @@ import type {
   ExerciseCategory,
   ExerciseHistoryWithRelated,
   ExerciseLastPerformance,
+  ExercisePerformanceHistory,
   ExerciseTrackingType,
   RelatedExerciseLastPerformance,
   UpdateExerciseInput,
@@ -618,6 +619,101 @@ export const findExerciseLastPerformance = async ({
       reps: set.reps,
     })),
   };
+};
+
+export const findExercisePerformanceHistory = async ({
+  exerciseId,
+  userId,
+  limit,
+}: {
+  exerciseId: string;
+  userId: string;
+  limit: number;
+}): Promise<ExercisePerformanceHistory> => {
+  const { db } = await import('../../db/index.js');
+
+  const sessions = await db
+    .select({
+      sessionId: workoutSessions.id,
+      date: workoutSessions.date,
+      notes: workoutSessions.notes,
+      completedAt: workoutSessions.completedAt,
+      startedAt: workoutSessions.startedAt,
+      createdAt: workoutSessions.createdAt,
+    })
+    .from(sessionSets)
+    .innerJoin(workoutSessions, eq(workoutSessions.id, sessionSets.sessionId))
+    .where(
+      and(
+        eq(sessionSets.exerciseId, exerciseId),
+        eq(workoutSessions.userId, userId),
+        isNull(workoutSessions.deletedAt),
+        eq(workoutSessions.status, 'completed'),
+      ),
+    )
+    .groupBy(
+      workoutSessions.id,
+      workoutSessions.date,
+      workoutSessions.notes,
+      workoutSessions.completedAt,
+      workoutSessions.startedAt,
+      workoutSessions.createdAt,
+    )
+    .orderBy(
+      desc(workoutSessions.completedAt),
+      desc(workoutSessions.startedAt),
+      desc(workoutSessions.createdAt),
+    )
+    .limit(limit)
+    .all();
+
+  if (sessions.length === 0) {
+    return [];
+  }
+
+  const sessionIds = sessions.map((session) => session.sessionId);
+  const completedSets = await db
+    .select({
+      sessionId: sessionSets.sessionId,
+      setNumber: sessionSets.setNumber,
+      weight: sessionSets.weight,
+      reps: sessionSets.reps,
+      createdAt: sessionSets.createdAt,
+    })
+    .from(sessionSets)
+    .where(and(inArray(sessionSets.sessionId, sessionIds), eq(sessionSets.exerciseId, exerciseId)))
+    .orderBy(asc(sessionSets.sessionId), asc(sessionSets.setNumber), asc(sessionSets.createdAt))
+    .all();
+
+  const setsBySessionId = new Map<
+    string,
+    Array<{ setNumber: number; weight: number | null; reps: number | null }>
+  >();
+  for (const set of completedSets) {
+    const currentSets = setsBySessionId.get(set.sessionId) ?? [];
+    currentSets.push({
+      setNumber: set.setNumber,
+      weight: set.weight,
+      reps: set.reps,
+    });
+    setsBySessionId.set(set.sessionId, currentSets);
+  }
+
+  return sessions.flatMap((session) => {
+    const sets = setsBySessionId.get(session.sessionId);
+    if (!sets || sets.length === 0) {
+      return [];
+    }
+
+    return [
+      {
+        sessionId: session.sessionId,
+        date: session.date,
+        notes: session.notes,
+        sets,
+      },
+    ];
+  });
 };
 
 const findExercisesLastPerformanceById = async ({

--- a/apps/web/src/features/dashboard/components/habit-daily-status-card.tsx
+++ b/apps/web/src/features/dashboard/components/habit-daily-status-card.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/features/habits/api/habits';
 import { getToday, toDateKey } from '@/lib/date';
 import { formatPercent, formatServing } from '@/lib/format-utils';
+import { HABIT_ENTRIES_POLL_INTERVAL_MS, getForegroundPollingInterval } from '@/lib/query-polling';
 
 type ResolvedTodayEntry = {
   completed: boolean;
@@ -77,8 +78,12 @@ export function HabitDailyStatusCard({ habitId, compact = false }: HabitDailySta
   const isCancellingNumericEditRef = useRef(false);
 
   const todayKey = toDateKey(getToday());
-  const habitsQuery = useHabits();
-  const habitEntriesQuery = useHabitEntries(todayKey, todayKey);
+  const habitsQuery = useHabits({
+    refetchIntervalMs: getForegroundPollingInterval(HABIT_ENTRIES_POLL_INTERVAL_MS),
+  });
+  const habitEntriesQuery = useHabitEntries(todayKey, todayKey, {
+    refetchIntervalMs: getForegroundPollingInterval(HABIT_ENTRIES_POLL_INTERVAL_MS),
+  });
   const toggleHabitMutation = useToggleHabit();
 
   const habit = useMemo(

--- a/apps/web/src/features/dashboard/components/trend-sparkline.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.tsx
@@ -6,6 +6,7 @@ import { computeEWMA, type DashboardTrendMetric } from '@pulse/shared';
 import { Card, CardContent } from '@/components/ui/card';
 import { useMacroTrend } from '@/hooks/use-macro-trend';
 import { useWeightTrend } from '@/hooks/use-weight-trend';
+import { WEIGHT_TREND_POLL_INTERVAL_MS, getForegroundPollingInterval } from '@/lib/query-polling';
 import { accentCardStyles } from '@/lib/accent-card-styles';
 import { addDays, parseDateInput, toDateKey } from '@/lib/date';
 import { formatCalories, formatGrams, formatTrendChange, formatWeight } from '@/lib/format-utils';
@@ -333,7 +334,10 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
   const needsWeight = resolvedMetrics.includes('weight');
   const needsMacros = resolvedMetrics.includes('calories') || resolvedMetrics.includes('protein');
   const range = resolveTrendRange(endDate);
-  const weightTrendQuery = useWeightTrend(range.from, range.to, { enabled: needsWeight });
+  const weightTrendQuery = useWeightTrend(range.from, range.to, {
+    enabled: needsWeight,
+    refetchIntervalMs: getForegroundPollingInterval(WEIGHT_TREND_POLL_INTERVAL_MS),
+  });
   const macroTrendQuery = useMacroTrend(range.from, range.to, { enabled: needsMacros });
 
   if ((needsWeight && weightTrendQuery.isLoading) || (needsMacros && macroTrendQuery.isLoading)) {

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
@@ -21,6 +21,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { apiRequest } from '@/lib/api-client';
 import { addDays, getToday, toDateKey } from '@/lib/date';
 import { formatTrendChange, formatWeight } from '@/lib/format-utils';
+import { WEIGHT_TREND_POLL_INTERVAL_MS, getForegroundPollingInterval } from '@/lib/query-polling';
 import { cn } from '@/lib/utils';
 
 type RangeOption = {
@@ -155,6 +156,8 @@ export function WeightTrendChart() {
   const weightEntriesQuery = useQuery({
     queryKey: getQueryKeyForRange(resolvedRange),
     queryFn: () => fetchWeightEntries(resolvedRange),
+    refetchInterval: getForegroundPollingInterval(WEIGHT_TREND_POLL_INTERVAL_MS) ?? false,
+    refetchIntervalInBackground: false,
   });
 
   const chartData = useMemo(() => {

--- a/apps/web/src/features/habits/api/habits.test.tsx
+++ b/apps/web/src/features/habits/api/habits.test.tsx
@@ -13,6 +13,7 @@ import { createAppQueryClient } from '@/lib/query-client';
 import {
   useCreateHabit,
   useDeleteHabit,
+  useHabitEntries,
   useHabits,
   useToggleHabit,
   useUpdateHabit,
@@ -143,6 +144,93 @@ describe('habit api hooks', () => {
       }),
     );
     expect(result.current.data).toEqual([habits[0]]);
+  });
+
+  it('configures foreground polling for habits and habit entries when intervals are provided', async () => {
+    const queryClient = createAppQueryClient();
+    const wrapper = createWrapper(queryClient);
+
+    const habitsResponse: Habit[] = [
+      {
+        id: 'habit-active',
+        userId: 'user-1',
+        name: 'Hydrate',
+        description: null,
+        emoji: '💧',
+        trackingType: 'numeric',
+        target: 8,
+        unit: 'glasses',
+        frequency: 'daily',
+        frequencyTarget: null,
+        scheduledDays: null,
+        pausedUntil: null,
+        sortOrder: 0,
+        active: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    const entriesResponse: HabitEntry[] = [
+      {
+        id: 'entry-1',
+        habitId: 'habit-active',
+        userId: 'user-1',
+        date: '2026-03-07',
+        completed: true,
+        value: 8,
+        createdAt: 1,
+      },
+    ];
+
+    mockedApiRequest.mockImplementation(async (path) => {
+      if (path === '/api/v1/habits') {
+        return habitsResponse;
+      }
+
+      if (path === '/api/v1/habit-entries?from=2026-03-07&to=2026-03-07') {
+        return entriesResponse;
+      }
+
+      throw new Error(`Unexpected path: ${String(path)}`);
+    });
+
+    const habitsHook = renderHook(() => useHabits({ refetchIntervalMs: 30_000 }), { wrapper });
+    const entriesHook = renderHook(
+      () =>
+        useHabitEntries('2026-03-07', '2026-03-07', {
+          refetchIntervalMs: 30_000,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(habitsHook.result.current.isSuccess).toBe(true);
+      expect(entriesHook.result.current.isSuccess).toBe(true);
+    });
+
+    const habitsQuery = queryClient.getQueryCache().find({
+      queryKey: habitQueryKeys.habits(),
+    });
+    const entriesQuery = queryClient.getQueryCache().find({
+      queryKey: habitQueryKeys.entries({ from: '2026-03-07', to: '2026-03-07' }),
+    });
+    const habitsQueryOptions = habitsQuery?.options as
+      | {
+          refetchInterval?: number | false;
+          refetchIntervalInBackground?: boolean;
+        }
+      | undefined;
+    const entriesQueryOptions = entriesQuery?.options as
+      | {
+          refetchInterval?: number | false;
+          refetchIntervalInBackground?: boolean;
+        }
+      | undefined;
+
+    expect(habitsQueryOptions?.refetchInterval).toBe(30_000);
+    expect(entriesQueryOptions?.refetchInterval).toBe(30_000);
+    expect(habitsQueryOptions?.refetchIntervalInBackground).toBe(false);
+    expect(entriesQueryOptions?.refetchIntervalInBackground).toBe(false);
   });
 
   it('optimistically updates and rolls back a toggled habit entry on failure', async () => {

--- a/apps/web/src/features/habits/api/habits.ts
+++ b/apps/web/src/features/habits/api/habits.ts
@@ -66,6 +66,11 @@ type UseUpdateHabitEntryOptions = {
   successMessage?: string;
 };
 
+type HabitQueryOptions = {
+  enabled?: boolean;
+  refetchIntervalMs?: number;
+};
+
 type ReorderMutationContext = {
   previousHabits: Habit[] | undefined;
 };
@@ -206,8 +211,9 @@ const reorderCachedHabits = (habits: Habit[] | undefined, items: ReorderHabitsIn
     .sort(compareHabits);
 };
 
-export function useHabits() {
+export function useHabits(options: HabitQueryOptions = {}) {
   return useQuery({
+    enabled: options.enabled ?? true,
     queryFn: async ({ signal }) => {
       const habits = await apiRequest<Habit[]>('/api/v1/habits', {
         method: 'GET',
@@ -217,11 +223,14 @@ export function useHabits() {
       return habitsWithTodayEntrySchema.parse(habits).filter((habit) => habit.active);
     },
     queryKey: habitQueryKeys.habits(),
+    refetchInterval: options.refetchIntervalMs ?? false,
+    refetchIntervalInBackground: false,
   });
 }
 
-export function useHabitEntries(from: string, to: string) {
+export function useHabitEntries(from: string, to: string, options: HabitQueryOptions = {}) {
   return useQuery({
+    enabled: (options.enabled ?? true) && from.length > 0 && to.length > 0,
     queryFn: async ({ signal }) => {
       const entries = await apiRequest<HabitEntry[]>(
         `/api/v1/habit-entries?from=${from}&to=${to}`,
@@ -234,6 +243,8 @@ export function useHabitEntries(from: string, to: string) {
       return habitEntriesSchema.parse(entries);
     },
     queryKey: habitQueryKeys.entries({ from, to }),
+    refetchInterval: options.refetchIntervalMs ?? false,
+    refetchIntervalInBackground: false,
   });
 }
 

--- a/apps/web/src/features/habits/components/daily-habits.test.tsx
+++ b/apps/web/src/features/habits/components/daily-habits.test.tsx
@@ -231,7 +231,13 @@ describe('DailyHabits', () => {
 
     render(<DailyHabits selectedDate={selectedDate} />);
 
-    expect(mockedUseHabitEntries).toHaveBeenCalledWith('2026-03-04', '2026-03-04');
+    expect(mockedUseHabitEntries).toHaveBeenCalledWith(
+      '2026-03-04',
+      '2026-03-04',
+      expect.objectContaining({
+        refetchIntervalMs: undefined,
+      }),
+    );
     const hydrateInput = screen.getByRole('spinbutton', { name: 'Hydrate' });
     fireEvent.change(hydrateInput, { target: { value: '9' } });
     fireEvent.blur(hydrateInput);

--- a/apps/web/src/features/habits/components/daily-habits.tsx
+++ b/apps/web/src/features/habits/components/daily-habits.tsx
@@ -24,6 +24,7 @@ import type { HabitConfig } from '@/features/habits/types';
 import { accentCardStyles } from '@/lib/accent-card-styles';
 import { getToday, isSameDay, normalizeDate, toDateKey } from '@/lib/date';
 import { formatPercent, formatServing } from '@/lib/format-utils';
+import { HABIT_ENTRIES_POLL_INTERVAL_MS, getForegroundPollingInterval } from '@/lib/query-polling';
 import { cn } from '@/lib/utils';
 
 import { HabitCardMenu } from './habit-card-menu';
@@ -360,8 +361,12 @@ export function DailyHabits({ selectedDate }: DailyHabitsProps) {
   const [isFormDialogOpen, setIsFormDialogOpen] = useState(false);
   const [editingHabitId, setEditingHabitId] = useState<string | null>(null);
 
-  const habitsQuery = useHabits();
-  const habitEntriesQuery = useHabitEntries(activeDateKey, activeDateKey);
+  const habitsQuery = useHabits({
+    refetchIntervalMs: getForegroundPollingInterval(HABIT_ENTRIES_POLL_INTERVAL_MS),
+  });
+  const habitEntriesQuery = useHabitEntries(activeDateKey, activeDateKey, {
+    refetchIntervalMs: getForegroundPollingInterval(HABIT_ENTRIES_POLL_INTERVAL_MS),
+  });
   const toggleHabitMutation = useToggleHabit();
   const updateHabitEntryMutation = useUpdateHabitEntry();
 

--- a/apps/web/src/features/habits/components/habit-history.test.tsx
+++ b/apps/web/src/features/habits/components/habit-history.test.tsx
@@ -143,7 +143,13 @@ describe('HabitHistory', () => {
   it('loads a 90-day range from API hooks and renders history grids', () => {
     render(<HabitHistory />);
 
-    expect(mockedUseHabitEntries).toHaveBeenCalledWith('2025-12-11', '2026-03-10');
+    expect(mockedUseHabitEntries).toHaveBeenCalledWith(
+      '2025-12-11',
+      '2026-03-10',
+      expect.objectContaining({
+        refetchIntervalMs: undefined,
+      }),
+    );
     expect(screen.getByText('Last 90 days')).toBeInTheDocument();
 
     const hydrateGrid = screen.getByTestId('habit-history-grid-hydrate');

--- a/apps/web/src/features/habits/components/habit-history.tsx
+++ b/apps/web/src/features/habits/components/habit-history.tsx
@@ -7,6 +7,7 @@ import { useHabitEntries, useHabits } from '@/features/habits/api/habits';
 import { HabitChainDot, type HabitDotEntry } from '@/features/habits/components/habit-chain-dot';
 import { addDays, getToday, toDateKey } from '@/lib/date';
 import { formatPercent } from '@/lib/format-utils';
+import { HABIT_ENTRIES_POLL_INTERVAL_MS, getForegroundPollingInterval } from '@/lib/query-polling';
 
 const HISTORY_DAYS = 90;
 
@@ -176,8 +177,12 @@ function getHistoryWindow(todayKey: string) {
 export function HabitHistory() {
   const todayKey = useTodayKey();
   const { dates, from, to } = useMemo(() => getHistoryWindow(todayKey), [todayKey]);
-  const habitsQuery = useHabits();
-  const habitEntriesQuery = useHabitEntries(from, to);
+  const habitsQuery = useHabits({
+    refetchIntervalMs: getForegroundPollingInterval(HABIT_ENTRIES_POLL_INTERVAL_MS),
+  });
+  const habitEntriesQuery = useHabitEntries(from, to, {
+    refetchIntervalMs: getForegroundPollingInterval(HABIT_ENTRIES_POLL_INTERVAL_MS),
+  });
 
   const historyRows = useMemo(
     () =>

--- a/apps/web/src/features/nutrition/api/nutrition.test.tsx
+++ b/apps/web/src/features/nutrition/api/nutrition.test.tsx
@@ -11,6 +11,7 @@ import { nutritionQueryKeys } from './keys';
 import {
   useDailyNutrition,
   useDeleteMeal,
+  useRenameMeal,
   useNutritionSummary,
   useNutritionWeekSummary,
 } from './nutrition';
@@ -216,5 +217,118 @@ describe('nutrition api hooks', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: habitChainQueryKeys.all,
     });
+  });
+
+  it('renames a meal and invalidates daily + summary + week-summary cache for that date', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        id: 'meal-1',
+        nutritionLogId: 'log-1',
+        name: 'Brunch',
+        summary: null,
+        time: '07:20',
+        notes: null,
+        createdAt: 1,
+        updatedAt: 2,
+      }),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useRenameMeal(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        date: '2026-03-09',
+        mealId: 'meal-1',
+        name: 'Brunch',
+      });
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/nutrition/2026-03-09/meals/meal-1',
+      expect.objectContaining({
+        body: JSON.stringify({ name: 'Brunch' }),
+        method: 'PATCH',
+      }),
+    );
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: nutritionQueryKeys.day('2026-03-09'),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: nutritionQueryKeys.summary('2026-03-09'),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: nutritionQueryKeys.weekSummary('2026-03-09'),
+    });
+  });
+
+  it('optimistically updates meal name and rolls back when rename fails', async () => {
+    let rejectRenameRequest: (error: Error) => void = () => {};
+    mockFetch.mockImplementationOnce(
+      () =>
+        new Promise<Response>((_resolve, reject) => {
+          rejectRenameRequest = reject;
+        }),
+    );
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setQueryData(nutritionQueryKeys.day('2026-03-09'), {
+      log: {
+        id: 'log-1',
+        userId: 'user-1',
+        date: '2026-03-09',
+        notes: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      meals: [
+        {
+          meal: {
+            id: 'meal-1',
+            nutritionLogId: 'log-1',
+            name: 'Breakfast',
+            summary: null,
+            time: '07:20',
+            notes: null,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          items: [],
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useRenameMeal(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        date: '2026-03-09',
+        mealId: 'meal-1',
+        name: 'Brunch',
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<{
+          meals: Array<{ meal: { name: string } }>;
+        }>(nutritionQueryKeys.day('2026-03-09'))?.meals[0]?.meal.name,
+      ).toBe('Brunch');
+    });
+
+    act(() => {
+      rejectRenameRequest(new Error('rename failed'));
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(
+      queryClient.getQueryData<{
+        meals: Array<{ meal: { name: string } }>;
+      }>(nutritionQueryKeys.day('2026-03-09'))?.meals[0]?.meal.name,
+    ).toBe('Breakfast');
   });
 });

--- a/apps/web/src/features/nutrition/api/nutrition.test.tsx
+++ b/apps/web/src/features/nutrition/api/nutrition.test.tsx
@@ -173,6 +173,82 @@ describe('nutrition api hooks', () => {
     );
   });
 
+  it('configures foreground polling when nutrition refetch intervals are provided', async () => {
+    mockFetch
+      .mockResolvedValueOnce(createJsonResponse(null))
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          date: '2026-03-09',
+          meals: 0,
+          actual: { calories: 0, protein: 0, carbs: 0, fat: 0 },
+          target: null,
+        }),
+      )
+      .mockResolvedValueOnce(createJsonResponse([]));
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+
+    const dayHook = renderHook(
+      () => useDailyNutrition('2026-03-09', { refetchIntervalMs: 20_000 }),
+      {
+        wrapper,
+      },
+    );
+    const summaryHook = renderHook(
+      () => useNutritionSummary('2026-03-09', { refetchIntervalMs: 20_000 }),
+      {
+        wrapper,
+      },
+    );
+    const weekSummaryHook = renderHook(
+      () => useNutritionWeekSummary('2026-03-09', { refetchIntervalMs: 30_000 }),
+      {
+        wrapper,
+      },
+    );
+
+    await waitFor(() => {
+      expect(dayHook.result.current.isSuccess).toBe(true);
+      expect(summaryHook.result.current.isSuccess).toBe(true);
+      expect(weekSummaryHook.result.current.isSuccess).toBe(true);
+    });
+
+    const dayQuery = queryClient.getQueryCache().find({
+      queryKey: nutritionQueryKeys.day('2026-03-09'),
+    });
+    const summaryQuery = queryClient.getQueryCache().find({
+      queryKey: nutritionQueryKeys.summary('2026-03-09'),
+    });
+    const weekSummaryQuery = queryClient.getQueryCache().find({
+      queryKey: nutritionQueryKeys.weekSummary('2026-03-09'),
+    });
+    const dayQueryOptions = dayQuery?.options as
+      | {
+          refetchInterval?: number | false;
+          refetchIntervalInBackground?: boolean;
+        }
+      | undefined;
+    const summaryQueryOptions = summaryQuery?.options as
+      | {
+          refetchInterval?: number | false;
+          refetchIntervalInBackground?: boolean;
+        }
+      | undefined;
+    const weekSummaryQueryOptions = weekSummaryQuery?.options as
+      | {
+          refetchInterval?: number | false;
+          refetchIntervalInBackground?: boolean;
+        }
+      | undefined;
+
+    expect(dayQueryOptions?.refetchInterval).toBe(20_000);
+    expect(summaryQueryOptions?.refetchInterval).toBe(20_000);
+    expect(weekSummaryQueryOptions?.refetchInterval).toBe(30_000);
+    expect(dayQueryOptions?.refetchIntervalInBackground).toBe(false);
+    expect(summaryQueryOptions?.refetchIntervalInBackground).toBe(false);
+    expect(weekSummaryQueryOptions?.refetchIntervalInBackground).toBe(false);
+  });
+
   it('deletes a meal and invalidates daily + summary + week-summary cache for that date', async () => {
     mockFetch.mockResolvedValueOnce(createJsonResponse({ success: true }));
 

--- a/apps/web/src/features/nutrition/api/nutrition.ts
+++ b/apps/web/src/features/nutrition/api/nutrition.ts
@@ -28,6 +28,11 @@ type RenameMealMutationContext = {
   previousDailyNutrition: DailyNutrition | null | undefined;
 };
 
+type NutritionQueryOptions = {
+  enabled?: boolean;
+  refetchIntervalMs?: number;
+};
+
 const fetchDailyNutrition = (date: string, signal?: AbortSignal) =>
   apiRequest<DailyNutrition>(`/api/v1/nutrition/${date}`, {
     method: 'GET',
@@ -90,22 +95,31 @@ const renameMealInDailyNutrition = (
   };
 };
 
-export const useDailyNutrition = (date: string) =>
+export const useDailyNutrition = (date: string, options: NutritionQueryOptions = {}) =>
   useQuery({
+    enabled: (options.enabled ?? true) && date.length > 0,
     queryKey: nutritionQueryKeys.day(date),
     queryFn: ({ signal }) => fetchDailyNutrition(date, signal),
+    refetchInterval: options.refetchIntervalMs ?? false,
+    refetchIntervalInBackground: false,
   });
 
-export const useNutritionSummary = (date: string) =>
+export const useNutritionSummary = (date: string, options: NutritionQueryOptions = {}) =>
   useQuery({
+    enabled: (options.enabled ?? true) && date.length > 0,
     queryKey: nutritionQueryKeys.summary(date),
     queryFn: ({ signal }) => fetchNutritionSummary(date, signal),
+    refetchInterval: options.refetchIntervalMs ?? false,
+    refetchIntervalInBackground: false,
   });
 
-export const useNutritionWeekSummary = (date: string) =>
+export const useNutritionWeekSummary = (date: string, options: NutritionQueryOptions = {}) =>
   useQuery({
+    enabled: (options.enabled ?? true) && date.length > 0,
     queryKey: nutritionQueryKeys.weekSummary(date),
     queryFn: ({ signal }) => fetchNutritionWeekSummary(date, signal),
+    refetchInterval: options.refetchIntervalMs ?? false,
+    refetchIntervalInBackground: false,
   });
 
 export const prefetchNutritionDay = async (queryClient: QueryClient, date: string) => {

--- a/apps/web/src/features/nutrition/api/nutrition.ts
+++ b/apps/web/src/features/nutrition/api/nutrition.ts
@@ -2,6 +2,7 @@ import { type QueryClient, useMutation, useQuery, useQueryClient } from '@tansta
 import type {
   DailyNutrition,
   DeleteMealResult,
+  NutritionMeal,
   NutritionSummary,
   NutritionWeekSummary,
 } from '@pulse/shared';
@@ -15,6 +16,16 @@ import { nutritionQueryKeys } from './keys';
 export type DeleteMealInput = {
   date: string;
   mealId: string;
+};
+
+export type RenameMealInput = {
+  date: string;
+  mealId: string;
+  name: string;
+};
+
+type RenameMealMutationContext = {
+  previousDailyNutrition: DailyNutrition | null | undefined;
 };
 
 const fetchDailyNutrition = (date: string, signal?: AbortSignal) =>
@@ -45,6 +56,39 @@ const deleteMeal = ({ date, mealId }: DeleteMealInput) =>
   apiRequest<DeleteMealResult>(`/api/v1/nutrition/${date}/meals/${mealId}`, {
     method: 'DELETE',
   });
+
+const renameMeal = ({ date, mealId, name }: RenameMealInput) =>
+  apiRequest<NutritionMeal>(`/api/v1/nutrition/${date}/meals/${mealId}`, {
+    body: {
+      name,
+    },
+    method: 'PATCH',
+  });
+
+const renameMealInDailyNutrition = (
+  dailyNutrition: DailyNutrition | null | undefined,
+  mealId: string,
+  name: string,
+): DailyNutrition | null | undefined => {
+  if (!dailyNutrition) {
+    return dailyNutrition;
+  }
+
+  return {
+    ...dailyNutrition,
+    meals: dailyNutrition.meals.map((entry) =>
+      entry.meal.id === mealId
+        ? {
+            ...entry,
+            meal: {
+              ...entry.meal,
+              name,
+            },
+          }
+        : entry,
+    ),
+  };
+};
 
 export const useDailyNutrition = (date: string) =>
   useQuery({
@@ -96,6 +140,55 @@ export const useDeleteMeal = () => {
         invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.mealMutation()),
       ]);
       toast.success('Meal deleted');
+    },
+  });
+};
+
+export const useRenameMeal = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: renameMeal,
+    onMutate: async (variables): Promise<RenameMealMutationContext> => {
+      await queryClient.cancelQueries({
+        queryKey: nutritionQueryKeys.day(variables.date),
+      });
+
+      const previousDailyNutrition = queryClient.getQueryData<DailyNutrition | null>(
+        nutritionQueryKeys.day(variables.date),
+      );
+
+      queryClient.setQueryData<DailyNutrition | null>(
+        nutritionQueryKeys.day(variables.date),
+        (currentDailyNutrition) =>
+          renameMealInDailyNutrition(currentDailyNutrition, variables.mealId, variables.name) ??
+          null,
+      );
+
+      return {
+        previousDailyNutrition,
+      };
+    },
+    onError: (_error, variables, context) => {
+      queryClient.setQueryData(
+        nutritionQueryKeys.day(variables.date),
+        context?.previousDailyNutrition,
+      );
+    },
+    onSuccess: async (_result, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: nutritionQueryKeys.day(variables.date),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: nutritionQueryKeys.summary(variables.date),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: nutritionQueryKeys.weekSummary(variables.date),
+        }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.mealMutation()),
+      ]);
+      toast.success('Meal renamed');
     },
   });
 };

--- a/apps/web/src/features/nutrition/components/meal-card.test.tsx
+++ b/apps/web/src/features/nutrition/components/meal-card.test.tsx
@@ -58,7 +58,7 @@ describe('MealCard', () => {
     expect(screen.getByText('7:20 AM')).toBeInTheDocument();
     expect(screen.queryByText('Large Eggs', { selector: 'li p' })).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Breakfast/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Expand Breakfast' }));
 
     expect(screen.getByText('Large Eggs')).toBeInTheDocument();
     expect(screen.getByText('3 eggs')).toBeInTheDocument();
@@ -81,7 +81,7 @@ describe('MealCard', () => {
   it('uses compact row styling with truncated item names after expanding', () => {
     render(<MealCard meal={breakfastMeal} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /Breakfast/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Expand Breakfast' }));
 
     expect(screen.getByText('Large Eggs')).toHaveClass('truncate');
   });
@@ -99,5 +99,79 @@ describe('MealCard', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete Breakfast' }));
 
     expect(onDelete).toHaveBeenCalledWith('meal-breakfast');
+  });
+
+  it('opens inline name editing when meal name is clicked', () => {
+    const onRename = vi.fn();
+
+    render(<MealCard meal={breakfastMeal} onRename={onRename} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Breakfast' }));
+
+    expect(screen.getByRole('textbox', { name: 'Meal name for Breakfast' })).toHaveValue(
+      'Breakfast',
+    );
+  });
+
+  it('submits the trimmed name on enter', () => {
+    const onRename = vi.fn();
+
+    render(<MealCard meal={breakfastMeal} onRename={onRename} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Breakfast' }));
+
+    const input = screen.getByRole('textbox', { name: 'Meal name for Breakfast' });
+    fireEvent.change(input, { target: { value: '  Late Breakfast  ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRename).toHaveBeenCalledWith('meal-breakfast', 'Late Breakfast');
+  });
+
+  it('submits a changed name on blur', () => {
+    const onRename = vi.fn();
+
+    render(<MealCard meal={breakfastMeal} onRename={onRename} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Breakfast' }));
+
+    const input = screen.getByRole('textbox', { name: 'Meal name for Breakfast' });
+    fireEvent.change(input, { target: { value: 'Brunch' } });
+    fireEvent.blur(input);
+
+    expect(onRename).toHaveBeenCalledWith('meal-breakfast', 'Brunch');
+  });
+
+  it('cancels rename on escape without firing mutation', () => {
+    const onRename = vi.fn();
+
+    render(<MealCard meal={breakfastMeal} onRename={onRename} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Breakfast' }));
+
+    const input = screen.getByRole('textbox', { name: 'Meal name for Breakfast' });
+    fireEvent.change(input, { target: { value: 'Brunch' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(onRename).not.toHaveBeenCalled();
+  });
+
+  it('does not fire mutation when blur has no changes', () => {
+    const onRename = vi.fn();
+
+    render(<MealCard meal={breakfastMeal} onRename={onRename} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Breakfast' }));
+    fireEvent.blur(screen.getByRole('textbox', { name: 'Meal name for Breakfast' }));
+
+    expect(onRename).not.toHaveBeenCalled();
+  });
+
+  it('prevents saving empty names', () => {
+    const onRename = vi.fn();
+
+    render(<MealCard meal={breakfastMeal} onRename={onRename} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Breakfast' }));
+
+    const input = screen.getByRole('textbox', { name: 'Meal name for Breakfast' });
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.getByText('Meal name is required')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/nutrition/components/meal-card.tsx
+++ b/apps/web/src/features/nutrition/components/meal-card.tsx
@@ -1,8 +1,9 @@
-import { useId, useState } from 'react';
+import { useId, useRef, useState } from 'react';
 import { ChevronDown, Trash2 } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 import {
   formatCalories,
@@ -32,46 +33,154 @@ export type MealCardMeal = {
 type MealCardProps = {
   meal: MealCardMeal;
   onDelete?: (mealId: string) => void;
+  onRename?: (mealId: string, name: string) => void;
   isDeleting?: boolean;
+  isRenaming?: boolean;
 };
 
 const CARD_HORIZONTAL_PADDING = 'px-4 sm:px-5';
 
-export function MealCard({ meal, onDelete, isDeleting = false }: MealCardProps) {
+export function MealCard({
+  meal,
+  onDelete,
+  onRename,
+  isDeleting = false,
+  isRenaming = false,
+}: MealCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [nameDraft, setNameDraft] = useState(meal.name);
+  const [nameError, setNameError] = useState<string | null>(null);
   const contentId = useId();
+  const skipBlurCommitRef = useRef(false);
   const formattedTime = formatMealTime(meal.time);
   const collapsedSummary = formatCollapsedSummary(meal);
   const canDelete = typeof onDelete === 'function';
+  const canRename = typeof onRename === 'function';
+
+  function beginNameEdit() {
+    if (!canRename || isRenaming) {
+      return;
+    }
+
+    setIsEditingName(true);
+    setNameDraft(meal.name);
+    setNameError(null);
+  }
+
+  function cancelNameEdit() {
+    setIsEditingName(false);
+    setNameDraft(meal.name);
+    setNameError(null);
+  }
+
+  function commitNameEdit() {
+    const nextName = nameDraft.trim();
+    const currentName = meal.name.trim();
+
+    if (!nextName) {
+      setNameError('Meal name is required');
+      return false;
+    }
+
+    if (nextName === currentName) {
+      cancelNameEdit();
+      return true;
+    }
+
+    onRename?.(meal.id, nextName);
+    setIsEditingName(false);
+    setNameError(null);
+    return true;
+  }
 
   return (
     <Card className="gap-0 overflow-hidden rounded-xl border-border/70 bg-[var(--color-card)] py-0 shadow-none">
-      <button
-        aria-controls={contentId}
-        aria-expanded={isExpanded}
-        className={cn(
-          'flex w-full cursor-pointer items-center gap-2 py-3 text-left transition-colors hover:bg-secondary/30',
-          CARD_HORIZONTAL_PADDING,
-        )}
-        onClick={() => setIsExpanded((prev) => !prev)}
-        type="button"
-      >
+      <div className={cn('flex items-start gap-2 py-3', CARD_HORIZONTAL_PADDING)}>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <h2 className="truncate text-sm font-semibold text-foreground">{meal.name}</h2>
+            <h2 className="min-w-0 truncate text-sm font-semibold text-foreground">
+              {isEditingName ? (
+                <Input
+                  aria-invalid={Boolean(nameError)}
+                  aria-label={`Meal name for ${meal.name}`}
+                  autoFocus
+                  className="h-8 max-w-56 text-sm sm:max-w-64"
+                  disabled={isRenaming}
+                  onBlur={() => {
+                    if (skipBlurCommitRef.current) {
+                      skipBlurCommitRef.current = false;
+                      return;
+                    }
+
+                    commitNameEdit();
+                  }}
+                  onChange={(event) => {
+                    setNameDraft(event.target.value);
+                    if (nameError) {
+                      setNameError(null);
+                    }
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Escape') {
+                      skipBlurCommitRef.current = true;
+                      event.preventDefault();
+                      cancelNameEdit();
+                      return;
+                    }
+
+                    if (event.key === 'Enter') {
+                      skipBlurCommitRef.current = true;
+                      event.preventDefault();
+                      commitNameEdit();
+                    }
+                  }}
+                  readOnly={isRenaming}
+                  value={nameDraft}
+                />
+              ) : (
+                <button
+                  aria-label={`Rename ${meal.name}`}
+                  className="max-w-full cursor-text truncate text-left transition-colors hover:text-primary"
+                  disabled={!canRename || isRenaming}
+                  onClick={beginNameEdit}
+                  type="button"
+                >
+                  {meal.name}
+                </button>
+              )}
+            </h2>
             <span className="shrink-0 text-[11px] text-muted">{formattedTime}</span>
           </div>
+          {nameError ? <p className="mt-1 text-xs text-destructive">{nameError}</p> : null}
           <p className="mt-0.5 truncate text-xs text-muted">{collapsedSummary}</p>
         </div>
 
         <div className="flex shrink-0 items-center gap-1">
+          <Button
+            aria-controls={contentId}
+            aria-expanded={isExpanded}
+            aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${meal.name}`}
+            className="shrink-0 px-2.5 text-muted hover:text-foreground"
+            onClick={() => setIsExpanded((prev) => !prev)}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            <ChevronDown
+              aria-hidden="true"
+              className={cn(
+                'size-4 text-muted transition-transform duration-200',
+                isExpanded && 'rotate-180',
+              )}
+            />
+          </Button>
           {canDelete ? (
             <Button
               aria-label={`Delete ${meal.name}`}
               className="shrink-0 px-2.5 text-muted hover:text-foreground"
               disabled={isDeleting}
-              onClick={(e) => {
-                e.stopPropagation();
+              onClick={() => {
                 onDelete(meal.id);
               }}
               size="sm"
@@ -81,15 +190,8 @@ export function MealCard({ meal, onDelete, isDeleting = false }: MealCardProps) 
               <Trash2 className="size-4" />
             </Button>
           ) : null}
-          <ChevronDown
-            aria-hidden="true"
-            className={cn(
-              'size-4 text-muted transition-transform duration-200',
-              isExpanded && 'rotate-180',
-            )}
-          />
         </div>
-      </button>
+      </div>
 
       {isExpanded ? (
         <div

--- a/apps/web/src/features/workouts/components/exercise-history-modal.tsx
+++ b/apps/web/src/features/workouts/components/exercise-history-modal.tsx
@@ -51,7 +51,7 @@ export function ExerciseHistoryModal({
           <DialogDescription>{`Last ${limit} completed sessions`}</DialogDescription>
         </DialogHeader>
 
-        <div className="max-h-[55vh] space-y-2 overflow-y-auto pr-1">
+        <div className="space-y-2 pr-1">
           {historyQuery.isPending ? (
             <p className="text-sm text-muted">Loading exercise history...</p>
           ) : null}

--- a/apps/web/src/features/workouts/components/exercise-history-modal.tsx
+++ b/apps/web/src/features/workouts/components/exercise-history-modal.tsx
@@ -1,0 +1,100 @@
+import type { ExerciseTrackingType, WeightUnit } from '@pulse/shared';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useExerciseHistory } from '@/hooks/use-exercise-history';
+
+import { formatSetSummary } from '../lib/tracking';
+
+const historyDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+type ExerciseHistoryModalProps = {
+  exerciseId: string;
+  exerciseName: string;
+  limit?: number;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  trackingType: ExerciseTrackingType;
+  weightUnit?: WeightUnit;
+};
+
+export function ExerciseHistoryModal({
+  exerciseId,
+  exerciseName,
+  limit = 10,
+  onOpenChange,
+  open,
+  trackingType,
+  weightUnit = 'lbs',
+}: ExerciseHistoryModalProps) {
+  const historyQuery = useExerciseHistory(exerciseId, {
+    enabled: open,
+    limit,
+  });
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{`${exerciseName} history`}</DialogTitle>
+          <DialogDescription>{`Last ${limit} completed sessions`}</DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-[55vh] space-y-2 overflow-y-auto pr-1">
+          {historyQuery.isPending ? (
+            <p className="text-sm text-muted">Loading exercise history...</p>
+          ) : null}
+
+          {!historyQuery.isPending && (historyQuery.data?.length ?? 0) === 0 ? (
+            <p className="text-sm text-muted">No completed history yet.</p>
+          ) : null}
+
+          {historyQuery.data?.map((session) => {
+            const setSummary = session.sets
+              .map((set) =>
+                formatSetSummary(
+                  trackingType === 'distance'
+                    ? { distance: set.reps, weight: set.weight }
+                    : { reps: set.reps, weight: set.weight },
+                  trackingType,
+                  {
+                    useLegacySecondsFallback: trackingType !== 'reps_seconds',
+                    weightUnit,
+                  },
+                ),
+              )
+              .join(', ');
+
+            return (
+              <div className="rounded-lg border border-border bg-card px-3 py-2.5" key={session.sessionId}>
+                <p className="text-sm font-semibold text-foreground">
+                  {`${historyDateFormatter.format(new Date(`${session.date}T12:00:00`))} - ${setSummary}`}
+                </p>
+                {session.notes?.trim() ? (
+                  <p className="mt-1 text-xs text-muted">{`Notes: ${session.notes.trim()}`}</p>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+
+        <DialogFooter>
+          <Button onClick={() => onOpenChange(false)} type="button" variant="outline">
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/workouts/components/exercise-library.test.tsx
+++ b/apps/web/src/features/workouts/components/exercise-library.test.tsx
@@ -281,6 +281,18 @@ describe('ExerciseLibrary', () => {
     expect(within(pressCard as HTMLElement).getByText('Push')).toBeInTheDocument();
   });
 
+  it('loads trend data from the exercise history API', async () => {
+    mockExerciseRequests();
+
+    renderExerciseLibrary();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Incline Dumbbell Press' }));
+
+    expect(await screen.findByText('Incline Dumbbell Press trends')).toBeInTheDocument();
+    expect((await screen.findAllByText(/Latest/)).length).toBeGreaterThan(0);
+    expect(screen.queryByText('No history yet')).not.toBeInTheDocument();
+  });
+
   it('renames an exercise from the card actions menu', async () => {
     mockExerciseRequests();
 
@@ -388,6 +400,25 @@ function renderExerciseLibrary() {
 
 function mockExerciseRequests() {
   const mockExercises = exerciseFixtures.map((exercise) => ({ ...exercise }));
+  const historyByExerciseId: Record<string, unknown[]> = {
+    'incline-dumbbell-press': [
+      {
+        sessionId: 'session-1',
+        date: '2026-03-08',
+        notes: null,
+        sets: [
+          { setNumber: 1, reps: 10, weight: 70 },
+          { setNumber: 2, reps: 9, weight: 70 },
+        ],
+      },
+      {
+        sessionId: 'session-2',
+        date: '2026-03-04',
+        notes: null,
+        sets: [{ setNumber: 1, reps: 8, weight: 65 }],
+      },
+    ],
+  };
 
   return vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
     const url = new URL(String(input), 'https://pulse.test');
@@ -432,6 +463,16 @@ function mockExerciseRequests() {
       return Promise.resolve(
         jsonResponse({
           data: exercise,
+        }),
+      );
+    }
+
+    if (url.pathname.startsWith('/api/v1/exercises/') && url.pathname.endsWith('/history')) {
+      const exerciseId = url.pathname.split('/')[4] ?? '';
+
+      return Promise.resolve(
+        jsonResponse({
+          data: historyByExerciseId[exerciseId] ?? [],
         }),
       );
     }

--- a/apps/web/src/features/workouts/components/exercise-library.tsx
+++ b/apps/web/src/features/workouts/components/exercise-library.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useSearchParams } from 'react-router';
 import { MoreVertical } from 'lucide-react';
-import type { Exercise } from '@pulse/shared';
+import type { Exercise, ExerciseTrackingType } from '@pulse/shared';
 import { toast } from 'sonner';
 
 import { Badge } from '@/components/ui/badge';
@@ -21,11 +21,16 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { useExerciseHistory } from '@/hooks/use-exercise-history';
+import { useWeightUnit } from '@/hooks/use-weight-unit';
 import { ApiError } from '@/lib/api-client';
 import { cn } from '@/lib/utils';
 
 import { useExerciseFilters, useExercises, useRenameExercise } from '../api/workouts';
-import { workoutExerciseHistory } from '../lib/mock-data';
+import type {
+  ActiveWorkoutExerciseHistoryPoint,
+  ActiveWorkoutPerformanceHistorySession,
+} from '../types';
 import { ExerciseTrendChart } from './exercise-trend-chart';
 import { RenameExerciseDialog } from './rename-exercise-dialog';
 import { TagChips } from './tag-chips';
@@ -49,6 +54,7 @@ type ExerciseLibraryProps = {
 };
 
 export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
+  const { weightUnit } = useWeightUnit();
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchTerm, setSearchTerm] = useState(searchParams.get('q') ?? '');
   const [selectedExerciseId, setSelectedExerciseId] = useState<string | null>(null);
@@ -111,6 +117,17 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
 
   const selectedExercise =
     filteredExercises.find((exercise) => exercise.id === selectedExerciseId) ?? null;
+  const selectedExerciseHistoryQuery = useExerciseHistory(selectedExercise?.id ?? '', {
+    enabled: selectedExercise != null,
+    limit: 30,
+  });
+  const selectedExerciseTrendHistory = useMemo(() => {
+    if (!selectedExercise) {
+      return [];
+    }
+
+    return toExerciseTrendHistory(selectedExerciseHistoryQuery.data ?? [], selectedExercise.trackingType);
+  }, [selectedExercise, selectedExerciseHistoryQuery.data]);
 
   return (
     <section className={cn('space-y-4', className)}>
@@ -313,10 +330,14 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
                     <p className="mt-1 text-sm text-muted">{selectedExercise.instructions}</p>
                   </div>
                 ) : null}
+                {selectedExerciseHistoryQuery.isPending ? (
+                  <p className="text-sm text-muted">Loading exercise history...</p>
+                ) : null}
                 <ExerciseTrendChart
                   exerciseName={selectedExercise.name}
-                  // TODO: Replace mock history with a real session-history query when workout history APIs land.
-                  history={workoutExerciseHistory[selectedExercise.id] ?? []}
+                  history={selectedExerciseTrendHistory}
+                  trackingType={selectedExercise.trackingType}
+                  weightUnit={weightUnit}
                 />
               </div>
             </div>
@@ -481,4 +502,76 @@ function formatLabel(value: string) {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
+}
+
+function toExerciseTrendHistory(
+  sessions: ActiveWorkoutPerformanceHistorySession[],
+  trackingType: ExerciseTrackingType,
+): ActiveWorkoutExerciseHistoryPoint[] {
+  return sessions.flatMap((session) => {
+    const topSet = pickTopSessionSet(session.sets, trackingType);
+
+    if (!topSet || topSet.reps == null) {
+      return [];
+    }
+
+    return [
+      {
+        date: session.date,
+        distance: trackingType === 'distance' ? topSet.reps : null,
+        reps: topSet.reps,
+        seconds:
+          trackingType === 'seconds_only' ||
+          trackingType === 'cardio' ||
+          trackingType === 'weight_seconds'
+            ? topSet.reps
+            : null,
+        trackingType,
+        weight: topSet.weight ?? 0,
+      },
+    ];
+  });
+}
+
+function pickTopSessionSet(
+  sets: ActiveWorkoutPerformanceHistorySession['sets'],
+  trackingType: ExerciseTrackingType,
+) {
+  const [firstSet, ...remainingSets] = sets;
+  if (!firstSet) {
+    return null;
+  }
+
+  return remainingSets.reduce((bestSet, currentSet) => {
+    if (currentSet.reps == null) {
+      return bestSet;
+    }
+
+    if (bestSet.reps == null) {
+      return currentSet;
+    }
+
+    if (
+      trackingType === 'seconds_only' ||
+      trackingType === 'cardio' ||
+      trackingType === 'weight_seconds' ||
+      trackingType === 'distance' ||
+      trackingType === 'reps_only' ||
+      trackingType === 'bodyweight_reps'
+    ) {
+      return currentSet.reps > bestSet.reps ? currentSet : bestSet;
+    }
+
+    const currentWeight = currentSet.weight ?? 0;
+    const bestWeight = bestSet.weight ?? 0;
+    if (currentWeight > bestWeight) {
+      return currentSet;
+    }
+
+    if (currentWeight === bestWeight && currentSet.reps > bestSet.reps) {
+      return currentSet;
+    }
+
+    return bestSet;
+  }, firstSet);
 }

--- a/apps/web/src/features/workouts/components/scheduled-workout-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/scheduled-workout-detail.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
+import { renderWithQueryClient } from '@/test/render-with-query-client';
+import { jsonResponse } from '@/test/test-utils';
+
+import { ScheduledWorkoutDetail } from './scheduled-workout-detail';
+
+beforeEach(() => {
+  window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
+});
+
+afterEach(() => {
+  window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
+  vi.restoreAllMocks();
+});
+
+describe('ScheduledWorkoutDetail', () => {
+  it('opens and closes exercise history modal from planned workout rows', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: 'scheduled-1',
+              userId: 'user-1',
+              templateId: 'template-1',
+              date: '2026-03-18',
+              sessionId: null,
+              createdAt: 1,
+              updatedAt: 1,
+              template: {
+                id: 'template-1',
+                userId: 'user-1',
+                name: 'Upper Push',
+                description: null,
+                tags: ['push'],
+                sections: [
+                  {
+                    type: 'warmup',
+                    exercises: [],
+                  },
+                  {
+                    type: 'main',
+                    exercises: [
+                      {
+                        id: 'template-exercise-1',
+                        exerciseId: 'incline-dumbbell-press',
+                        exerciseName: 'Incline Dumbbell Press',
+                        trackingType: 'weight_reps',
+                        sets: 3,
+                        repsMin: 8,
+                        repsMax: 10,
+                        tempo: null,
+                        restSeconds: 90,
+                        supersetGroup: null,
+                        notes: null,
+                        cues: [],
+                      },
+                    ],
+                  },
+                  {
+                    type: 'cooldown',
+                    exercises: [],
+                  },
+                ],
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            },
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [],
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/exercises/incline-dumbbell-press/history') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                sessionId: 'session-1',
+                date: '2026-03-12',
+                notes: null,
+                sets: [
+                  { setNumber: 1, reps: 10, weight: 70 },
+                  { setNumber: 2, reps: 9, weight: 70 },
+                ],
+              },
+            ],
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <ScheduledWorkoutDetail id="scheduled-1" />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Upper Push')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Incline Dumbbell Press history' }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('Incline Dumbbell Press history')).toBeInTheDocument();
+    expect(within(dialog).getByText('Last 10 completed sessions')).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getAllByRole('button', { name: 'Close' })[0] as HTMLElement);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Incline Dumbbell Press history')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/features/workouts/components/scheduled-workout-detail.tsx
+++ b/apps/web/src/features/workouts/components/scheduled-workout-detail.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router';
-import { ArrowLeft, CalendarClock, Dumbbell, TriangleAlert } from 'lucide-react';
+import { ArrowLeft, CalendarClock, Dumbbell, History, TriangleAlert } from 'lucide-react';
 import type {
+  ExerciseTrackingType,
   WorkoutTemplate,
   WorkoutTemplateExercise,
   WeightUnit,
@@ -24,6 +25,7 @@ import {
 } from '../api/workouts';
 import { getDistanceUnit } from '../lib/tracking';
 import { buildInitialSessionSets } from '../lib/workout-session-sets';
+import { ExerciseHistoryModal } from './exercise-history-modal';
 import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
@@ -59,6 +61,11 @@ export function ScheduledWorkoutDetail({ id }: ScheduledWorkoutDetailProps) {
   const { confirm, dialog: confirmDialog } = useConfirmation();
   const activeSessionsQuery = useWorkoutSessions({ status: ['in-progress', 'paused'] });
   const [isRescheduleDialogOpen, setIsRescheduleDialogOpen] = useState(false);
+  const [historyTarget, setHistoryTarget] = useState<{
+    exerciseId: string;
+    exerciseName: string;
+    trackingType: ExerciseTrackingType;
+  } | null>(null);
 
   const template = scheduledWorkout?.template ?? null;
   const isTemplateAvailable = template !== null;
@@ -226,7 +233,19 @@ export function ScheduledWorkoutDetail({ id }: ScheduledWorkoutDetailProps) {
         </CardContent>
       </Card>
 
-      {template ? <TemplateSections template={template} weightUnit={weightUnit} /> : null}
+      {template ? (
+        <TemplateSections
+          onOpenHistory={(exercise) =>
+            setHistoryTarget({
+              exerciseId: exercise.exerciseId,
+              exerciseName: exercise.exerciseName,
+              trackingType: exercise.trackingType,
+            })
+          }
+          template={template}
+          weightUnit={weightUnit}
+        />
+      ) : null}
 
       {scheduledWorkout ? (
         <ScheduleWorkoutDialog
@@ -241,6 +260,20 @@ export function ScheduledWorkoutDetail({ id }: ScheduledWorkoutDetailProps) {
           disallowDateMessage="Pick a different date to reschedule."
           submitLabel="Save"
           title="Reschedule workout"
+        />
+      ) : null}
+      {historyTarget ? (
+        <ExerciseHistoryModal
+          exerciseId={historyTarget.exerciseId}
+          exerciseName={historyTarget.exerciseName}
+          onOpenChange={(open) => {
+            if (!open) {
+              setHistoryTarget(null);
+            }
+          }}
+          open={historyTarget != null}
+          trackingType={historyTarget.trackingType}
+          weightUnit={weightUnit}
         />
       ) : null}
       {confirmDialog}
@@ -261,9 +294,11 @@ function BackLink() {
 }
 
 function TemplateSections({
+  onOpenHistory,
   template,
   weightUnit,
 }: {
+  onOpenHistory: (exercise: WorkoutTemplateExercise) => void;
   template: WorkoutTemplate;
   weightUnit: WeightUnit;
 }) {
@@ -313,6 +348,16 @@ function TemplateSections({
                     {exercise.supersetGroup}
                   </Badge>
                 ) : null}
+                <Button
+                  aria-label={`Open ${exercise.exerciseName} history`}
+                  className="size-8 min-h-8 min-w-8"
+                  onClick={() => onOpenHistory(exercise)}
+                  size="icon-sm"
+                  type="button"
+                  variant="ghost"
+                >
+                  <History aria-hidden="true" className="size-4 shrink-0 text-muted" />
+                </Button>
                 <Dumbbell aria-hidden="true" className="size-4 shrink-0 text-muted" />
               </div>
             ))}

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -123,7 +123,7 @@ describe('SessionDetail', () => {
     expect(screen.queryByText('Volume progression')).not.toBeInTheDocument();
     expect(screen.getAllByText(/Set 1:/i).length).toBeGreaterThan(0);
     expect(
-      screen.getByRole('button', { name: 'Open Incline Dumbbell Press trend chart' }),
+      screen.getByRole('button', { name: 'Open Incline Dumbbell Press history' }),
     ).toHaveClass('size-11', 'min-h-11', 'min-w-11');
     expect(screen.getByText('Great pacing and clean reps.')).toBeInTheDocument();
     expect(screen.getByText('Felt strong and stable today.')).toBeInTheDocument();
@@ -408,7 +408,7 @@ describe('SessionDetail', () => {
     expect(await screen.findByText('First session — no comparison available')).toBeInTheDocument();
   });
 
-  it('opens an exercise trend chart from the session detail exercise action', async () => {
+  it('opens full exercise history from the session detail exercise action', async () => {
     const currentSession = createSession({
       id: 'session-current',
       templateId: 'template-upper-push',
@@ -441,12 +441,13 @@ describe('SessionDetail', () => {
     await screen.findByText('Workout receipt');
 
     fireEvent.click(
-      screen.getByRole('button', { name: /open incline dumbbell press trend chart/i }),
+      screen.getByRole('button', { name: /open incline dumbbell press history/i }),
     );
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
-    expect(screen.getByText('Incline Dumbbell Press trends')).toBeInTheDocument();
-    expect(screen.getByLabelText('Incline Dumbbell Press trend chart')).toBeInTheDocument();
+    expect(screen.getByText('Incline Dumbbell Press history')).toBeInTheDocument();
+    expect(await screen.findByText(/Mar 1, 2026 -/)).toBeInTheDocument();
+    expect(screen.getByText(/8 reps/)).toBeInTheDocument();
   });
 
   it('supports inline correction editing and only submits changed values', async () => {
@@ -730,6 +731,24 @@ function mockSessionDetailRequests({
             createdAt: 1,
             updatedAt: 1,
           },
+        }),
+      );
+    }
+
+    if (url.includes('/api/v1/exercises/incline-dumbbell-press/history')) {
+      return Promise.resolve(
+        jsonResponse({
+          data: [
+            {
+              sessionId: 'session-last',
+              date: '2026-03-01',
+              notes: null,
+              sets: [
+                { setNumber: 1, reps: 8, weight: 105 },
+                { setNumber: 2, reps: 8, weight: 100 },
+              ],
+            },
+          ],
         }),
       );
     }

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -4,11 +4,11 @@ import {
   ArrowLeft,
   ChevronDown,
   Dumbbell,
+  History,
   ListChecks,
   NotebookPen,
   Repeat2,
   Scale,
-  TrendingUp,
 } from 'lucide-react';
 import {
   type ExerciseTrackingType,
@@ -25,13 +25,6 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { useConfirmation } from '@/components/ui/confirmation-dialog';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { StatCard } from '@/components/ui/stat-card';
@@ -58,7 +51,6 @@ import {
   formatSetSummary,
   getDistanceUnit,
   getSetDistance,
-  getSetSeconds,
   getSetSummaryMetricValue,
   getTrackingSummaryMetricLabel,
   isRepTrackingType,
@@ -66,8 +58,7 @@ import {
   resolveTrackingType,
 } from '../lib/tracking';
 import { findPreviousTemplateSession } from '../lib/session-comparison';
-import type { ActiveWorkoutExerciseHistoryPoint } from '../types';
-import { ExerciseTrendChart } from './exercise-trend-chart';
+import { ExerciseHistoryModal } from './exercise-history-modal';
 import { MarkdownNote } from './markdown-note';
 import { SessionComparison, SessionExerciseComparison } from './session-comparison';
 
@@ -216,15 +207,6 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
   const selectedExercise = sections
     .flatMap((section) => section.exercises)
     .find((exercise) => exercise.exerciseId === selectedExerciseId);
-  const selectedExerciseHistory =
-    selectedExercise != null
-      ? buildExerciseHistory({
-          currentSession: session,
-          exerciseId: selectedExercise.exerciseId,
-          previousSession,
-          trackingType: selectedExercise.trackingType,
-        })
-      : [];
 
   const startEditing = () => {
     setSetDrafts(buildSessionSetDrafts(session.sets));
@@ -512,14 +494,14 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
                       </div>
 
                       <Button
-                        aria-label={`Open ${exercise.name} trend chart`}
+                        aria-label={`Open ${exercise.name} history`}
                         className="size-11 min-h-11 min-w-11 self-start"
                         onClick={() => setSelectedExerciseId(exercise.exerciseId)}
                         size="icon-sm"
                         type="button"
                         variant="outline"
                       >
-                        <TrendingUp aria-hidden="true" className="size-4" />
+                        <History aria-hidden="true" className="size-4" />
                       </Button>
                     </div>
                   </CardHeader>
@@ -647,31 +629,16 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
         </Button>
       ) : null}
 
-      <Dialog
-        onOpenChange={(open) => (!open ? setSelectedExerciseId(null) : null)}
-        open={selectedExercise != null}
-      >
-        <DialogContent className="max-h-[90vh] overflow-y-auto rounded-t-3xl border-border p-0 sm:max-w-4xl sm:rounded-3xl">
-          {selectedExercise ? (
-            <div className="space-y-0">
-              <DialogHeader className="px-6 pt-6">
-                <DialogTitle>{`${selectedExercise.name} trends`}</DialogTitle>
-                <DialogDescription>
-                  Review weight and rep progression for this exercise.
-                </DialogDescription>
-              </DialogHeader>
-              <div className="px-4 pb-4 pt-2 sm:px-6 sm:pb-6">
-                <ExerciseTrendChart
-                  exerciseName={selectedExercise.name}
-                  history={selectedExerciseHistory}
-                  trackingType={selectedExercise.trackingType}
-                  weightUnit={weightUnit}
-                />
-              </div>
-            </div>
-          ) : null}
-        </DialogContent>
-      </Dialog>
+      {selectedExercise ? (
+        <ExerciseHistoryModal
+          exerciseId={selectedExercise.exerciseId}
+          exerciseName={selectedExercise.name}
+          onOpenChange={(open) => (!open ? setSelectedExerciseId(null) : null)}
+          open={selectedExercise != null}
+          trackingType={selectedExercise.trackingType}
+          weightUnit={weightUnit}
+        />
+      ) : null}
       {confirmDialog}
     </section>
   );
@@ -1093,96 +1060,6 @@ function inferPhaseBadge(
     default:
       return 'moderate';
   }
-}
-
-function buildExerciseHistory({
-  currentSession,
-  exerciseId,
-  previousSession,
-  trackingType,
-}: {
-  currentSession: WorkoutSession;
-  exerciseId: string;
-  previousSession: WorkoutSession | null;
-  trackingType: ExerciseTrackingType;
-}): ActiveWorkoutExerciseHistoryPoint[] {
-  const history: ActiveWorkoutExerciseHistoryPoint[] = [];
-
-  const previousPoint =
-    previousSession != null ? buildHistoryPoint(previousSession, exerciseId, trackingType) : null;
-  const currentPoint = buildHistoryPoint(currentSession, exerciseId, trackingType);
-
-  if (previousPoint) {
-    history.push(previousPoint);
-  }
-
-  if (currentPoint) {
-    history.push(currentPoint);
-  }
-
-  return history;
-}
-
-function buildHistoryPoint(
-  session: WorkoutSession,
-  exerciseId: string,
-  trackingType: ExerciseTrackingType,
-): ActiveWorkoutExerciseHistoryPoint | null {
-  const sets = session.sets.filter((set) => {
-    if (set.exerciseId !== exerciseId) {
-      return false;
-    }
-
-    if (
-      trackingType === 'seconds_only' ||
-      trackingType === 'cardio' ||
-      trackingType === 'weight_seconds'
-    ) {
-      // Time-based sets currently come back via `reps` until session-set seconds persistence lands.
-      return getSetSeconds(set) != null;
-    }
-
-    return set.reps != null;
-  });
-
-  if (sets.length === 0) {
-    return null;
-  }
-
-  const topSet = sets.reduce<SessionSet>((best, current) => {
-    if (
-      trackingType === 'seconds_only' ||
-      trackingType === 'cardio' ||
-      trackingType === 'weight_seconds'
-    ) {
-      return (getSetSeconds(current) ?? 0) > (getSetSeconds(best) ?? 0) ? current : best;
-    }
-
-    if (trackingType === 'bodyweight_reps' || trackingType === 'reps_only') {
-      return (current.reps ?? 0) > (best.reps ?? 0) ? current : best;
-    }
-
-    const bestWeight = best.weight ?? 0;
-    const currentWeight = current.weight ?? 0;
-
-    if (currentWeight > bestWeight) {
-      return current;
-    }
-
-    if (currentWeight === bestWeight && (current.reps ?? 0) > (best.reps ?? 0)) {
-      return current;
-    }
-
-    return best;
-  }, sets[0]);
-
-  return {
-    date: session.date,
-    reps: topSet.reps ?? 0,
-    seconds: getSetSeconds(topSet),
-    trackingType,
-    weight: topSet.weight ?? 0,
-  };
 }
 
 function formatSetLabel(

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -1266,6 +1266,141 @@ describe('SessionExerciseList', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('shows all sets in the inline history preview for the latest session', () => {
+    const session: ActiveWorkoutSessionData = {
+      completedSets: 0,
+      currentExercise: 1,
+      currentExerciseId: 'incline-dumbbell-press',
+      sections: [
+        {
+          exercises: [
+            {
+              badges: ['compound'],
+              category: 'compound',
+              completedSets: 0,
+              formCues: [],
+              id: 'incline-dumbbell-press',
+              injuryCues: [],
+              lastPerformance: {
+                date: '2026-03-13',
+                sessionId: 'session-last',
+                sets: [
+                  { completed: true, reps: 12, setNumber: 1, weight: 25 },
+                  { completed: true, reps: 12, setNumber: 2, weight: 25 },
+                ],
+              },
+              name: 'Incline Dumbbell Press',
+              notes: '',
+              phaseBadge: 'moderate',
+              prescribedSets: 2,
+              prescribedReps: '10-12',
+              priority: 'required',
+              restSeconds: 90,
+              reversePyramid: [],
+              sets: [
+                {
+                  completed: false,
+                  distance: null,
+                  id: 'incline-set-1',
+                  number: 1,
+                  reps: null,
+                  seconds: null,
+                  weight: null,
+                },
+              ],
+              supersetGroup: null,
+              templateCues: [],
+              tempo: null,
+              targetSets: 1,
+              trackingType: 'weight_reps',
+            },
+          ],
+          id: 'main',
+          title: 'Main',
+          type: 'main',
+        },
+      ],
+      totalExercises: 1,
+      totalSets: 1,
+      workoutName: 'History Preview Session',
+    };
+
+    renderWithQueryClient(
+      <SessionExerciseList
+        onAddSet={vi.fn()}
+        onExerciseNotesChange={vi.fn()}
+        onRemoveSet={vi.fn()}
+        onSetUpdate={vi.fn()}
+        session={session}
+      />,
+    );
+
+    const card = screen
+      .getByRole('heading', { level: 3, name: 'Incline Dumbbell Press' })
+      .closest('[data-slot="card"]');
+    expect(card).not.toBeNull();
+    expect(
+      within(card as HTMLElement).getByText(/Mar 13 - 25 lbs × 12 reps, 25 lbs × 12 reps/),
+    ).toBeInTheDocument();
+  });
+
+  it('opens and closes full history modal from active workout exercise rows', async () => {
+    if (!activeTemplate) {
+      throw new Error('Expected upper-push template in mock data.');
+    }
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/exercises/row-erg/history') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                sessionId: 'session-1',
+                date: '2026-03-17',
+                notes: null,
+                sets: [
+                  { setNumber: 1, reps: 15, weight: 25 },
+                  { setNumber: 2, reps: 12, weight: 25 },
+                ],
+              },
+            ],
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    const session = buildActiveWorkoutSession(
+      activeTemplate,
+      createInitialWorkoutSetDrafts(activeTemplate, new Set()),
+    );
+
+    renderWithQueryClient(
+      <SessionExerciseList
+        onAddSet={vi.fn()}
+        onExerciseNotesChange={vi.fn()}
+        onRemoveSet={vi.fn()}
+        onSetUpdate={vi.fn()}
+        session={session}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Row Erg history' }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('Row Erg history')).toBeInTheDocument();
+    expect(within(dialog).getByText('Last 10 completed sessions')).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getAllByRole('button', { name: 'Close' })[0] as HTMLElement);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Row Erg history')).not.toBeInTheDocument();
+    });
+  });
+
   it('renders related history collapsed by default and expands on demand', () => {
     if (!activeTemplate) {
       throw new Error('Expected upper-push template in mock data.');

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -15,6 +15,10 @@ import {
   createInitialWorkoutSetDrafts,
   createWorkoutSetId,
 } from '../lib/active-session';
+import {
+  getWorkoutExerciseStorageKey,
+  getWorkoutSectionStorageKey,
+} from '../lib/session-persistence';
 import type { ActiveWorkoutSessionData } from '../types';
 import { SessionExerciseList } from './session-exercise-list';
 
@@ -39,6 +43,26 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
 
 const activeTemplate = mockTemplates.find((template) => template.id === 'upper-push');
 const lowerTemplate = mockTemplates.find((template) => template.id === 'lower-quad-dominant');
+
+function getExercisePanelToggle(exerciseName: string, exerciseId: string) {
+  const card = screen
+    .getByRole('heading', { level: 3, name: exerciseName })
+    .closest('[data-slot="card"]');
+
+  if (!card) {
+    throw new Error(`Expected ${exerciseName} card.`);
+  }
+
+  const toggle = within(card as HTMLElement)
+    .getAllByRole('button')
+    .find((button) => button.getAttribute('aria-controls') === `exercise-panel-${exerciseId}`);
+
+  if (!toggle) {
+    throw new Error(`Expected ${exerciseName} toggle button.`);
+  }
+
+  return toggle;
+}
 
 describe('SessionExerciseList', () => {
   it('renders prescribed set targets from session set data', () => {
@@ -834,6 +858,111 @@ describe('SessionExerciseList', () => {
 
     expect(screen.getByRole('button', { name: /Warmup/i })).toHaveAttribute('aria-expanded', 'true');
     expect(screen.getByRole('button', { name: /Main/i })).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('persists section and exercise collapse state across remounts for the same session id', () => {
+    vi.useFakeTimers();
+
+    try {
+    if (!activeTemplate) {
+      throw new Error('Expected upper-push template in mock data.');
+    }
+
+    const session = buildActiveWorkoutSession(
+      activeTemplate,
+      createInitialWorkoutSetDrafts(activeTemplate, new Set()),
+    );
+    const sectionKey = getWorkoutSectionStorageKey('session-persist-a');
+    const exerciseKey = getWorkoutExerciseStorageKey('session-persist-a');
+
+    if (!sectionKey || !exerciseKey) {
+      throw new Error('Expected workout storage keys.');
+    }
+
+    const firstRender = renderWithQueryClient(
+      <SessionExerciseList
+        onAddSet={vi.fn()}
+        onExerciseNotesChange={vi.fn()}
+        onRemoveSet={vi.fn()}
+        onSetUpdate={vi.fn()}
+        session={session}
+        sessionId="session-persist-a"
+      />,
+    );
+
+    fireEvent.click(getExercisePanelToggle('Row Erg', 'row-erg'));
+    fireEvent.click(screen.getByRole('button', { name: /Warmup/i }));
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    firstRender.unmount();
+
+    const storedSections = window.localStorage.getItem(sectionKey);
+    const storedExercises = window.localStorage.getItem(exerciseKey);
+
+    expect(storedSections).not.toBeNull();
+    expect(storedExercises).not.toBeNull();
+    expect(JSON.parse(storedSections ?? '{}')).toMatchObject({ warmup: false });
+    expect(JSON.parse(storedExercises ?? '{}')).toMatchObject({ 'row-erg': false });
+
+    renderWithQueryClient(
+      <SessionExerciseList
+        onAddSet={vi.fn()}
+        onExerciseNotesChange={vi.fn()}
+        onRemoveSet={vi.fn()}
+        onSetUpdate={vi.fn()}
+        session={session}
+        sessionId="session-persist-a"
+      />,
+    );
+
+    const warmupButton = screen.getByRole('button', { name: /Warmup/i });
+    expect(warmupButton).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(warmupButton);
+
+    expect(getExercisePanelToggle('Row Erg', 'row-erg')).toHaveAttribute('aria-expanded', 'false');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('scopes persisted section state by session id', () => {
+    if (!activeTemplate) {
+      throw new Error('Expected upper-push template in mock data.');
+    }
+
+    const session = buildActiveWorkoutSession(
+      activeTemplate,
+      createInitialWorkoutSetDrafts(activeTemplate, new Set()),
+    );
+
+    const firstRender = renderWithQueryClient(
+      <SessionExerciseList
+        onAddSet={vi.fn()}
+        onExerciseNotesChange={vi.fn()}
+        onRemoveSet={vi.fn()}
+        onSetUpdate={vi.fn()}
+        session={session}
+        sessionId="session-scope-a"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Warmup/i }));
+    firstRender.unmount();
+
+    renderWithQueryClient(
+      <SessionExerciseList
+        onAddSet={vi.fn()}
+        onExerciseNotesChange={vi.fn()}
+        onRemoveSet={vi.fn()}
+        onSetUpdate={vi.fn()}
+        session={session}
+        sessionId="session-scope-b"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /Warmup/i })).toHaveAttribute('aria-expanded', 'true');
   });
 
   it('collapses sections, toggles exercise details, and focuses the requested next set input', () => {

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -33,6 +33,7 @@ import {
   Circle,
   Dot,
   GripVertical,
+  History,
   MoreVertical,
 } from 'lucide-react';
 import type { ExerciseTrackingType, WeightUnit } from '@pulse/shared';
@@ -75,6 +76,7 @@ import {
 } from '../lib/time-estimates';
 import { formatSetSummary, getDistanceUnit } from '../lib/tracking';
 import { FormCueChips } from './form-cue-chips';
+import { ExerciseHistoryModal } from './exercise-history-modal';
 import { RenameExerciseDialog } from './rename-exercise-dialog';
 import { SetRow, type SetRowUpdate } from './set-row';
 import { SwapExerciseDialog } from './swap-exercise-dialog';
@@ -179,6 +181,11 @@ export function SessionExerciseList({
   const [swapTarget, setSwapTarget] = useState<{
     exerciseId: string;
     exerciseName: string;
+  } | null>(null);
+  const [historyTarget, setHistoryTarget] = useState<{
+    exerciseId: string;
+    exerciseName: string;
+    trackingType: ExerciseTrackingType;
   } | null>(null);
   const repsInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
   const focusTarget = focusSetId ? findSetContext(session, focusSetId) : null;
@@ -360,6 +367,13 @@ export function SessionExerciseList({
                                 exerciseName: item.exercise.name,
                               })
                             }
+                            onOpenHistory={() =>
+                              setHistoryTarget({
+                                exerciseId: item.exercise.id,
+                                exerciseName: item.exercise.name,
+                                trackingType: item.exercise.trackingType,
+                              })
+                            }
                             onSwapExercise={() =>
                               setSwapTarget({
                                 exerciseId: item.exercise.id,
@@ -440,6 +454,13 @@ export function SessionExerciseList({
                                       setRenameTarget({
                                         exerciseId: exercise.id,
                                         exerciseName: exercise.name,
+                                      })
+                                    }
+                                    onOpenHistory={() =>
+                                      setHistoryTarget({
+                                        exerciseId: exercise.id,
+                                        exerciseName: exercise.name,
+                                        trackingType: exercise.trackingType,
                                       })
                                     }
                                     onSwapExercise={() =>
@@ -523,6 +544,20 @@ export function SessionExerciseList({
           sourceLabel="this workout"
         />
       ) : null}
+      {historyTarget ? (
+        <ExerciseHistoryModal
+          exerciseId={historyTarget.exerciseId}
+          exerciseName={historyTarget.exerciseName}
+          onOpenChange={(open) => {
+            if (!open) {
+              setHistoryTarget(null);
+            }
+          }}
+          open={historyTarget != null}
+          trackingType={historyTarget.trackingType}
+          weightUnit={weightUnit}
+        />
+      ) : null}
     </div>
   );
 }
@@ -539,6 +574,7 @@ type ExerciseCardItemProps = {
   onExerciseNotesChange: (exerciseId: string, notes: string) => void;
   onMoveDown: () => void;
   onMoveUp: () => void;
+  onOpenHistory: () => void;
   onRenameExercise: () => void;
   onSwapExercise: () => void;
   onRemoveSet: (exerciseId: string) => void;
@@ -563,6 +599,7 @@ function ExerciseCardItem({
   onExerciseNotesChange,
   onMoveDown,
   onMoveUp,
+  onOpenHistory,
   onRenameExercise,
   onSwapExercise,
   onRemoveSet,
@@ -671,6 +708,17 @@ function ExerciseCardItem({
             />
           </div>
         </button>
+
+        <Button
+          aria-label={`Open ${exercise.name} history`}
+          className="mt-0.5 size-8 shrink-0"
+          onClick={onOpenHistory}
+          size="icon"
+          type="button"
+          variant="ghost"
+        >
+          <History aria-hidden="true" className="size-4" />
+        </Button>
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
@@ -1112,7 +1160,7 @@ function formatHistoryPreview({
     )
     .join(', ');
 
-  return `${historyDateFormatter.format(new Date(`${history.date}T12:00:00`))} • ${setSummary}`;
+  return `${historyDateFormatter.format(new Date(`${history.date}T12:00:00`))} - ${setSummary}`;
 }
 
 function parsePrescribedRepTarget(prescribedReps: string) {

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -1,6 +1,7 @@
 import {
   Fragment,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type Dispatch,
@@ -48,12 +49,17 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Textarea } from '@/components/ui/textarea';
 import { useLastPerformance } from '@/hooks/use-last-performance';
+import { usePersistedState } from '@/hooks/usePersistedState';
 import { ApiError } from '@/lib/api-client';
 import { useDebouncedCallback } from '@/lib/use-debounced-callback';
 import { formatWeight as formatWeightValue } from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
 
 import { useRenameExercise } from '../api/workouts';
+import {
+  getWorkoutExerciseStorageKey,
+  getWorkoutSectionStorageKey,
+} from '../lib/session-persistence';
 import type {
   ActiveWorkoutExercise,
   ActiveWorkoutExerciseHistorySummary,
@@ -150,10 +156,22 @@ export function SessionExerciseList({
   sessionCuesByExercise,
   weightUnit = 'lbs',
 }: SessionExerciseListProps) {
-  const [openSections, setOpenSections] = useState<Record<string, boolean>>(() =>
-    createInitialOpenSections(session),
+  const sectionStorageKey = useMemo(
+    () => (sessionId ? (getWorkoutSectionStorageKey(sessionId) ?? '') : ''),
+    [sessionId],
   );
-  const [expandedExercises, setExpandedExercises] = useState<Record<string, boolean>>({});
+  const exerciseStorageKey = useMemo(
+    () => (sessionId ? (getWorkoutExerciseStorageKey(sessionId) ?? '') : ''),
+    [sessionId],
+  );
+  const [openSections, setOpenSections] = usePersistedState<Record<string, boolean>>(
+    sectionStorageKey,
+    () => createInitialOpenSections(session),
+  );
+  const [expandedExercises, setExpandedExercises] = usePersistedState<Record<string, boolean>>(
+    exerciseStorageKey,
+    {},
+  );
   const [renameTarget, setRenameTarget] = useState<{
     exerciseId: string;
     exerciseName: string;

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -1180,6 +1180,53 @@ describe('WorkoutTemplateDetail', () => {
     expect(await screen.findByText('Superset A')).toBeInTheDocument();
   });
 
+  it('opens exercise history modal from template exercise rows', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/workout-templates/upper-push') {
+        return Promise.resolve(jsonResponse(templatePayload));
+      }
+
+      if (url.pathname === '/api/v1/exercises/incline-dumbbell-press/history') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                sessionId: 'session-1',
+                date: '2026-03-06',
+                notes: 'Strong session',
+                sets: [
+                  { setNumber: 1, reps: 10, weight: 70 },
+                  { setNumber: 2, reps: 9, weight: 70 },
+                ],
+              },
+            ],
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutTemplateDetail templateId="upper-push" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open Incline Dumbbell Press history' }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('Incline Dumbbell Press history')).toBeInTheDocument();
+    expect(within(dialog).getByText('Last 10 completed sessions')).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getAllByRole('button', { name: 'Close' })[0] as HTMLElement);
+    await waitFor(() => {
+      expect(screen.queryByText('Incline Dumbbell Press history')).not.toBeInTheDocument();
+    });
+  });
+
   it('opens exercise detail modal with overview, history, and related data and saves coaching notes', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
       const url = new URL(String(input), 'https://pulse.test');

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -21,6 +21,7 @@ import {
   ArrowUp,
   Braces,
   GripVertical,
+  History,
   Link2Off,
   MoreVertical,
   Plus,
@@ -82,6 +83,7 @@ import {
 import { formatSetSummary, getDistanceUnit } from '../lib/tracking';
 import { buildInitialSessionSets } from '../lib/workout-session-sets';
 import { FormCueChips } from './form-cue-chips';
+import { ExerciseHistoryModal } from './exercise-history-modal';
 import { RenameExerciseDialog } from './rename-exercise-dialog';
 import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
 import { SwapExerciseDialog } from './swap-exercise-dialog';
@@ -151,6 +153,11 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
   const [exerciseDetailTarget, setExerciseDetailTarget] = useState<{
     exerciseId: string;
     templateExerciseId: string;
+  } | null>(null);
+  const [historyTarget, setHistoryTarget] = useState<{
+    exerciseId: string;
+    exerciseName: string;
+    trackingType: ExerciseTrackingType;
   } | null>(null);
   const [isScheduleDialogOpen, setIsScheduleDialogOpen] = useState(false);
 
@@ -559,6 +566,13 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
                                 templateExerciseId: exercise.id,
                               })
                             }
+                            onOpenHistory={() =>
+                              setHistoryTarget({
+                                exerciseId: exercise.exerciseId,
+                                exerciseName: exercise.exerciseName,
+                                trackingType: exercise.trackingType,
+                              })
+                            }
                             onRename={() =>
                               setRenameTarget({
                                 exerciseId: exercise.exerciseId,
@@ -634,6 +648,13 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
                                     setExerciseDetailTarget({
                                       exerciseId: exercise.exerciseId,
                                       templateExerciseId: exercise.id,
+                                    })
+                                  }
+                                  onOpenHistory={() =>
+                                    setHistoryTarget({
+                                      exerciseId: exercise.exerciseId,
+                                      exerciseName: exercise.exerciseName,
+                                      trackingType: exercise.trackingType,
                                     })
                                   }
                                   onRename={() =>
@@ -792,6 +813,20 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
           }
         />
       ) : null}
+      {historyTarget ? (
+        <ExerciseHistoryModal
+          exerciseId={historyTarget.exerciseId}
+          exerciseName={historyTarget.exerciseName}
+          onOpenChange={(open) => {
+            if (!open) {
+              setHistoryTarget(null);
+            }
+          }}
+          open={historyTarget != null}
+          trackingType={historyTarget.trackingType}
+          weightUnit={weightUnit}
+        />
+      ) : null}
 
       <div className="space-y-2">
         <div className="flex flex-wrap gap-2">
@@ -874,6 +909,7 @@ function TemplateExerciseCard({
   index,
   isMoveDownDisabled,
   isMoveUpDisabled,
+  onOpenHistory,
   onMoveDown,
   onMoveUp,
   onOpenDetails,
@@ -886,6 +922,7 @@ function TemplateExerciseCard({
   index: number;
   isMoveDownDisabled: boolean;
   isMoveUpDisabled: boolean;
+  onOpenHistory: () => void;
   onMoveDown: () => void;
   onMoveUp: () => void;
   onOpenDetails: () => void;
@@ -968,31 +1005,44 @@ function TemplateExerciseCard({
               ) : null}
             </div>
           </div>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                aria-label={`Exercise actions for ${exercise.exerciseName}`}
-                className="-mr-1 size-11 min-h-11 min-w-11"
-                size="icon"
-                type="button"
-                variant="ghost"
-              >
-                <MoreVertical aria-hidden="true" className="size-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={onSwap}>Swap exercise</DropdownMenuItem>
-              <DropdownMenuItem disabled={isMoveUpDisabled} onClick={onMoveUp}>
-                <ArrowUp aria-hidden="true" className="size-4" />
-                Move up
-              </DropdownMenuItem>
-              <DropdownMenuItem disabled={isMoveDownDisabled} onClick={onMoveDown}>
-                <ArrowDown aria-hidden="true" className="size-4" />
-                Move down
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={onRename}>Rename exercise</DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <div className="flex items-center gap-1">
+            <Button
+              aria-label={`Open ${exercise.exerciseName} history`}
+              className="size-11 min-h-11 min-w-11"
+              onClick={onOpenHistory}
+              size="icon"
+              type="button"
+              variant="ghost"
+            >
+              <History aria-hidden="true" className="size-4" />
+            </Button>
+
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  aria-label={`Exercise actions for ${exercise.exerciseName}`}
+                  className="-mr-1 size-11 min-h-11 min-w-11"
+                  size="icon"
+                  type="button"
+                  variant="ghost"
+                >
+                  <MoreVertical aria-hidden="true" className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={onSwap}>Swap exercise</DropdownMenuItem>
+                <DropdownMenuItem disabled={isMoveUpDisabled} onClick={onMoveUp}>
+                  <ArrowUp aria-hidden="true" className="size-4" />
+                  Move up
+                </DropdownMenuItem>
+                <DropdownMenuItem disabled={isMoveDownDisabled} onClick={onMoveDown}>
+                  <ArrowDown aria-hidden="true" className="size-4" />
+                  Move down
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={onRename}>Rename exercise</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
       </CardHeader>
 

--- a/apps/web/src/features/workouts/lib/session-persistence.test.ts
+++ b/apps/web/src/features/workouts/lib/session-persistence.test.ts
@@ -4,9 +4,14 @@ import type { ActiveWorkoutSetDrafts } from '../types';
 import {
   ACTIVE_WORKOUT_DRAFT_STORAGE_PREFIX,
   ACTIVE_WORKOUT_SESSION_STORAGE_KEY,
+  WORKOUT_EXERCISES_STORAGE_PREFIX,
+  WORKOUT_SECTIONS_STORAGE_PREFIX,
   clearStoredActiveWorkoutDraft,
   clearStoredActiveWorkoutSessionId,
+  clearStoredWorkoutSessionUiState,
   getActiveWorkoutDraftStorageKey,
+  getWorkoutExerciseStorageKey,
+  getWorkoutSectionStorageKey,
   getStoredActiveWorkoutDraft,
   setStoredActiveWorkoutDraft,
   setStoredActiveWorkoutSessionId,
@@ -85,5 +90,32 @@ describe('session-persistence', () => {
   it('returns null for blank draft ids', () => {
     expect(getActiveWorkoutDraftStorageKey('  ')).toBeNull();
     expect(getStoredActiveWorkoutDraft('  ')).toBeNull();
+  });
+
+  it('builds scoped storage keys for workout section and exercise UI state', () => {
+    expect(getWorkoutSectionStorageKey('session-a')).toBe(
+      `${WORKOUT_SECTIONS_STORAGE_PREFIX}:session-a`,
+    );
+    expect(getWorkoutExerciseStorageKey('session-a')).toBe(
+      `${WORKOUT_EXERCISES_STORAGE_PREFIX}:session-a`,
+    );
+    expect(getWorkoutSectionStorageKey('  ')).toBeNull();
+    expect(getWorkoutExerciseStorageKey('  ')).toBeNull();
+  });
+
+  it('clears persisted workout section and exercise UI state by session id', () => {
+    window.localStorage.setItem(
+      `${WORKOUT_SECTIONS_STORAGE_PREFIX}:session-a`,
+      JSON.stringify({ warmup: false }),
+    );
+    window.localStorage.setItem(
+      `${WORKOUT_EXERCISES_STORAGE_PREFIX}:session-a`,
+      JSON.stringify({ 'row-erg': false }),
+    );
+
+    clearStoredWorkoutSessionUiState('session-a');
+
+    expect(window.localStorage.getItem(`${WORKOUT_SECTIONS_STORAGE_PREFIX}:session-a`)).toBeNull();
+    expect(window.localStorage.getItem(`${WORKOUT_EXERCISES_STORAGE_PREFIX}:session-a`)).toBeNull();
   });
 });

--- a/apps/web/src/features/workouts/lib/session-persistence.ts
+++ b/apps/web/src/features/workouts/lib/session-persistence.ts
@@ -2,6 +2,8 @@ import type { ActiveWorkoutSetDrafts } from '@/features/workouts/types';
 
 export const ACTIVE_WORKOUT_SESSION_STORAGE_KEY = 'pulse.active-workout-session-id';
 export const ACTIVE_WORKOUT_DRAFT_STORAGE_PREFIX = 'pulse.active-workout-draft';
+export const WORKOUT_SECTIONS_STORAGE_PREFIX = 'pulse.workout-sections';
+export const WORKOUT_EXERCISES_STORAGE_PREFIX = 'pulse.workout-exercises';
 export const WORKOUT_SESSION_NOTICE_QUERY_KEY = 'sessionNotice';
 export const WORKOUT_SESSION_COMPLETED_NOTICE = 'completed';
 
@@ -13,6 +15,16 @@ type ActiveWorkoutDraft = {
 
 function canUseLocalStorage() {
   return typeof window !== 'undefined';
+}
+
+function getSessionScopedStorageKey(prefix: string, id: string) {
+  const normalizedId = id.trim();
+
+  if (!normalizedId) {
+    return null;
+  }
+
+  return `${prefix}:${normalizedId}`;
 }
 
 export function getStoredActiveWorkoutSessionId() {
@@ -47,13 +59,15 @@ export function clearStoredActiveWorkoutSessionId() {
 }
 
 export function getActiveWorkoutDraftStorageKey(id: string) {
-  const normalizedId = id.trim();
+  return getSessionScopedStorageKey(ACTIVE_WORKOUT_DRAFT_STORAGE_PREFIX, id);
+}
 
-  if (!normalizedId) {
-    return null;
-  }
+export function getWorkoutSectionStorageKey(id: string) {
+  return getSessionScopedStorageKey(WORKOUT_SECTIONS_STORAGE_PREFIX, id);
+}
 
-  return `${ACTIVE_WORKOUT_DRAFT_STORAGE_PREFIX}:${normalizedId}`;
+export function getWorkoutExerciseStorageKey(id: string) {
+  return getSessionScopedStorageKey(WORKOUT_EXERCISES_STORAGE_PREFIX, id);
 }
 
 export function getStoredActiveWorkoutDraft(id: string): ActiveWorkoutDraft | null {
@@ -111,4 +125,21 @@ export function clearStoredActiveWorkoutDraft(id: string) {
   }
 
   window.localStorage.removeItem(key);
+}
+
+export function clearStoredWorkoutSessionUiState(id: string) {
+  if (!canUseLocalStorage()) {
+    return;
+  }
+
+  const sectionKey = getWorkoutSectionStorageKey(id);
+  const exerciseKey = getWorkoutExerciseStorageKey(id);
+
+  if (sectionKey) {
+    window.localStorage.removeItem(sectionKey);
+  }
+
+  if (exerciseKey) {
+    window.localStorage.removeItem(exerciseKey);
+  }
 }

--- a/apps/web/src/features/workouts/types.ts
+++ b/apps/web/src/features/workouts/types.ts
@@ -38,6 +38,19 @@ export type ActiveWorkoutLastPerformance = {
   sets: ActiveWorkoutLastPerformanceSet[];
 };
 
+export type ActiveWorkoutPerformanceHistorySet = {
+  reps: number | null;
+  setNumber: number;
+  weight: number | null;
+};
+
+export type ActiveWorkoutPerformanceHistorySession = {
+  date: string;
+  notes: string | null;
+  sessionId: string;
+  sets: ActiveWorkoutPerformanceHistorySet[];
+};
+
 export type ActiveWorkoutRelatedLastPerformance = {
   exerciseId: string;
   exerciseName: string;

--- a/apps/web/src/hooks/use-dashboard-snapshot.test.tsx
+++ b/apps/web/src/hooks/use-dashboard-snapshot.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createQueryClientWrapper } from '@/test/query-client';
 
-import { useDashboardSnapshot } from './use-dashboard-snapshot';
+import { dashboardSnapshotQueryKeys, useDashboardSnapshot } from './use-dashboard-snapshot';
 
 const mockFetch = vi.fn();
 
@@ -111,5 +111,32 @@ describe('useDashboardSnapshot', () => {
     await waitFor(() => {
       expect(result.current.isError).toBe(true);
     });
+  });
+
+  it('configures foreground polling when a refetch interval is provided', async () => {
+    mockFetch.mockResolvedValue(createJsonResponse(snapshotFixture));
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(
+      () => useDashboardSnapshot('2026-03-06', { refetchIntervalMs: 20_000 }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const query = queryClient.getQueryCache().find({
+      queryKey: dashboardSnapshotQueryKeys.detail('2026-03-06'),
+    });
+    const queryOptions = query?.options as
+      | {
+          refetchInterval?: number | false;
+          refetchIntervalInBackground?: boolean;
+        }
+      | undefined;
+
+    expect(queryOptions?.refetchInterval).toBe(20_000);
+    expect(queryOptions?.refetchIntervalInBackground).toBe(false);
   });
 });

--- a/apps/web/src/hooks/use-dashboard-snapshot.ts
+++ b/apps/web/src/hooks/use-dashboard-snapshot.ts
@@ -8,6 +8,11 @@ export const dashboardSnapshotQueryKeys = {
   detail: (date: string) => [...dashboardSnapshotQueryKeys.all, date] as const,
 };
 
+type DashboardSnapshotQueryOptions = {
+  enabled?: boolean;
+  refetchIntervalMs?: number;
+};
+
 const fetchDashboardSnapshot = async (
   date: string,
   signal?: AbortSignal,
@@ -23,11 +28,13 @@ const fetchDashboardSnapshot = async (
   return dashboardSnapshotSchema.parse(snapshot);
 };
 
-export const useDashboardSnapshot = (date: string) =>
+export const useDashboardSnapshot = (date: string, options: DashboardSnapshotQueryOptions = {}) =>
   useQuery({
-    enabled: date.length > 0,
+    enabled: (options.enabled ?? true) && date.length > 0,
     queryFn: ({ signal }) => fetchDashboardSnapshot(date, signal),
     queryKey: dashboardSnapshotQueryKeys.detail(date),
+    refetchInterval: options.refetchIntervalMs ?? false,
+    refetchIntervalInBackground: false,
   });
 
 export const prefetchDashboardSnapshot = (queryClient: QueryClient, date: string) =>

--- a/apps/web/src/hooks/use-exercise-history.test.tsx
+++ b/apps/web/src/hooks/use-exercise-history.test.tsx
@@ -1,0 +1,126 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryClientWrapper } from '@/test/query-client';
+
+import { useExerciseHistory } from './use-exercise-history';
+
+const mockFetch = vi.fn();
+
+const createJsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify({ data }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+
+describe('use-exercise-history hook', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  it('loads and maps recent completed sessions with all sets', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse([
+        {
+          sessionId: 'session-2',
+          date: '2026-03-08',
+          notes: 'Felt strong.',
+          sets: [
+            { setNumber: 1, weight: 105, reps: 9 },
+            { setNumber: 2, weight: 100, reps: 8 },
+          ],
+        },
+      ]),
+    );
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useExerciseHistory('global-bench-press'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual([
+      {
+        sessionId: 'session-2',
+        date: '2026-03-08',
+        notes: 'Felt strong.',
+        sets: [
+          { setNumber: 1, weight: 105, reps: 9 },
+          { setNumber: 2, weight: 100, reps: 8 },
+        ],
+      },
+    ]);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/exercises/global-bench-press/history?limit=10'),
+      expect.any(Object),
+    );
+  });
+
+  it('returns an empty history list for not-found exercises', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 'EXERCISE_NOT_FOUND',
+            message: 'Exercise not found',
+          },
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 404,
+        },
+      ),
+    );
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useExerciseHistory('missing-exercise'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('does not fetch when disabled', () => {
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(
+      () =>
+        useExerciseHistory('global-bench-press', {
+          enabled: false,
+        }),
+      { wrapper },
+    );
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('uses the caller-provided session limit', async () => {
+    mockFetch.mockResolvedValueOnce(createJsonResponse([]));
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(
+      () =>
+        useExerciseHistory('global-bench-press', {
+          limit: 5,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/exercises/global-bench-press/history?limit=5'),
+      expect.any(Object),
+    );
+  });
+});

--- a/apps/web/src/hooks/use-exercise-history.ts
+++ b/apps/web/src/hooks/use-exercise-history.ts
@@ -1,0 +1,63 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  exercisePerformanceHistoryQuerySchema,
+  exercisePerformanceHistorySchema,
+} from '@pulse/shared';
+
+import type { ActiveWorkoutPerformanceHistorySession } from '@/features/workouts/types';
+import { ApiError, apiRequest } from '@/lib/api-client';
+
+const exerciseHistoryQueryKeys = {
+  all: ['exercise-history'] as const,
+  detail: (exerciseId: string, limit: number) =>
+    ['exercise-history', exerciseId, { limit }] as const,
+};
+
+async function getExerciseHistory(
+  exerciseId: string,
+  limit: number,
+): Promise<ActiveWorkoutPerformanceHistorySession[]> {
+  try {
+    const data = await apiRequest<unknown>(`/api/v1/exercises/${exerciseId}/history?limit=${limit}`);
+    const payload = exercisePerformanceHistorySchema.parse(data);
+
+    return payload.map((session) => ({
+      date: session.date,
+      notes: session.notes,
+      sessionId: session.sessionId,
+      sets: session.sets.map((set) => ({
+        reps: set.reps,
+        setNumber: set.setNumber,
+        weight: set.weight,
+      })),
+    }));
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404 && error.code === 'EXERCISE_NOT_FOUND') {
+      return [];
+    }
+
+    throw error;
+  }
+}
+
+export function useExerciseHistory(
+  exerciseId: string,
+  options?: {
+    enabled?: boolean;
+    limit?: number;
+  },
+) {
+  const normalizedExerciseId = exerciseId.trim();
+  const enabled = options?.enabled ?? true;
+  const { limit } = exercisePerformanceHistoryQuerySchema.parse({
+    limit: options?.limit ?? 10,
+  });
+
+  return useQuery<ActiveWorkoutPerformanceHistorySession[]>({
+    enabled: enabled && normalizedExerciseId.length > 0,
+    queryFn: () => getExerciseHistory(normalizedExerciseId, limit),
+    queryKey: exerciseHistoryQueryKeys.detail(normalizedExerciseId, limit),
+  });
+}
+
+export { exerciseHistoryQueryKeys };

--- a/apps/web/src/hooks/use-habit-chains.test.tsx
+++ b/apps/web/src/hooks/use-habit-chains.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createQueryClientWrapper } from '@/test/query-client';
 
-import { useHabitChains } from './use-habit-chains';
+import { habitChainQueryKeys, useHabitChains } from './use-habit-chains';
 
 const mockFetch = vi.fn();
 
@@ -77,5 +77,35 @@ describe('useHabitChains', () => {
     await waitFor(() => {
       expect(result.current.isError).toBe(true);
     });
+  });
+
+  it('configures foreground polling when a refetch interval is provided', async () => {
+    mockFetch.mockResolvedValue(createJsonResponse(entriesFixture));
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(
+      () =>
+        useHabitChains('2026-03-01', '2026-03-06', {
+          refetchIntervalMs: 30_000,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const query = queryClient.getQueryCache().find({
+      queryKey: habitChainQueryKeys.range('2026-03-01', '2026-03-06'),
+    });
+    const queryOptions = query?.options as
+      | {
+          refetchInterval?: number | false;
+          refetchIntervalInBackground?: boolean;
+        }
+      | undefined;
+
+    expect(queryOptions?.refetchInterval).toBe(30_000);
+    expect(queryOptions?.refetchIntervalInBackground).toBe(false);
   });
 });

--- a/apps/web/src/hooks/use-habit-chains.ts
+++ b/apps/web/src/hooks/use-habit-chains.ts
@@ -11,6 +11,11 @@ export const habitChainQueryKeys = {
   range: (from: string, to: string) => [...habitChainQueryKeys.all, from, to] as const,
 };
 
+type HabitChainsQueryOptions = {
+  enabled?: boolean;
+  refetchIntervalMs?: number;
+};
+
 const fetchHabitChains = async (
   from: string,
   to: string,
@@ -27,9 +32,15 @@ const fetchHabitChains = async (
   return habitEntriesSchema.parse(entries);
 };
 
-export const useHabitChains = (from: string, to: string) =>
+export const useHabitChains = (
+  from: string,
+  to: string,
+  options: HabitChainsQueryOptions = {},
+) =>
   useQuery({
-    enabled: from.length > 0 && to.length > 0,
+    enabled: (options.enabled ?? true) && from.length > 0 && to.length > 0,
     queryFn: ({ signal }) => fetchHabitChains(from, to, signal),
     queryKey: habitChainQueryKeys.range(from, to),
+    refetchInterval: options.refetchIntervalMs ?? false,
+    refetchIntervalInBackground: false,
   });

--- a/apps/web/src/hooks/use-weight-trend.test.tsx
+++ b/apps/web/src/hooks/use-weight-trend.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createQueryClientWrapper } from '@/test/query-client';
 
-import { useWeightTrend } from './use-weight-trend';
+import { dashboardWeightTrendQueryKeys, useWeightTrend } from './use-weight-trend';
 
 const mockFetch = vi.fn();
 
@@ -100,5 +100,35 @@ describe('useWeightTrend', () => {
     });
 
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('configures foreground polling when a refetch interval is provided', async () => {
+    mockFetch.mockResolvedValueOnce(createJsonResponse([]));
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(
+      () =>
+        useWeightTrend('2026-03-04', '2026-03-05', {
+          refetchIntervalMs: 30_000,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const query = queryClient.getQueryCache().find({
+      queryKey: dashboardWeightTrendQueryKeys.range('2026-03-04', '2026-03-05'),
+    });
+    const queryOptions = query?.options as
+      | {
+          refetchInterval?: number | false;
+          refetchIntervalInBackground?: boolean;
+        }
+      | undefined;
+
+    expect(queryOptions?.refetchInterval).toBe(30_000);
+    expect(queryOptions?.refetchIntervalInBackground).toBe(false);
   });
 });

--- a/apps/web/src/hooks/use-weight-trend.ts
+++ b/apps/web/src/hooks/use-weight-trend.ts
@@ -40,7 +40,16 @@ const fetchWeightTrend = async (
   return dashboardWeightTrendSchema.parse(trend);
 };
 
-export const useWeightTrend = (from?: string, to?: string, options: { enabled?: boolean } = {}) => {
+type WeightTrendQueryOptions = {
+  enabled?: boolean;
+  refetchIntervalMs?: number;
+};
+
+export const useWeightTrend = (
+  from?: string,
+  to?: string,
+  options: WeightTrendQueryOptions = {},
+) => {
   const range = resolveDateRange(from, to);
   const enabled = options.enabled ?? DEFAULT_QUERY_ENABLED;
 
@@ -48,5 +57,7 @@ export const useWeightTrend = (from?: string, to?: string, options: { enabled?: 
     enabled,
     queryFn: ({ signal }) => fetchWeightTrend(range.from, range.to, signal),
     queryKey: dashboardWeightTrendQueryKeys.range(range.from, range.to),
+    refetchInterval: options.refetchIntervalMs ?? false,
+    refetchIntervalInBackground: false,
   });
 };

--- a/apps/web/src/hooks/usePersistedState.test.tsx
+++ b/apps/web/src/hooks/usePersistedState.test.tsx
@@ -1,0 +1,96 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { usePersistedState } from './usePersistedState';
+
+describe('usePersistedState', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('hydrates from localStorage when a stored value exists', () => {
+    window.localStorage.setItem('persisted-key', JSON.stringify({ open: false }));
+
+    const { result } = renderHook(() =>
+      usePersistedState('persisted-key', {
+        open: true,
+      }),
+    );
+
+    expect(result.current[0]).toEqual({ open: false });
+  });
+
+  it('falls back to default value when localStorage contains invalid JSON', () => {
+    window.localStorage.setItem('persisted-key', '{bad-json');
+
+    const { result } = renderHook(() => usePersistedState('persisted-key', { open: true }));
+
+    expect(result.current[0]).toEqual({ open: true });
+  });
+
+  it('persists updates with debounce', () => {
+    const { result } = renderHook(() => usePersistedState('persisted-key', { open: true }));
+
+    act(() => {
+      result.current[1]({ open: false });
+    });
+
+    expect(window.localStorage.getItem('persisted-key')).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(window.localStorage.getItem('persisted-key')).toBe(JSON.stringify({ open: false }));
+  });
+
+  it('scopes state by key and reloads when key changes', () => {
+    window.localStorage.setItem('state-a', JSON.stringify({ open: false }));
+    window.localStorage.setItem('state-b', JSON.stringify({ open: true }));
+
+    const { result, rerender } = renderHook(
+      ({ storageKey }) => usePersistedState(storageKey, { open: true }),
+      {
+        initialProps: {
+          storageKey: 'state-a',
+        },
+      },
+    );
+
+    expect(result.current[0]).toEqual({ open: false });
+
+    rerender({
+      storageKey: 'state-b',
+    });
+
+    expect(result.current[0]).toEqual({ open: true });
+  });
+
+  it('does not throw when localStorage read/write fails', () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('read blocked');
+    });
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('write blocked');
+    });
+
+    const { result } = renderHook(() => usePersistedState('persisted-key', { open: true }));
+    expect(result.current[0]).toEqual({ open: true });
+
+    act(() => {
+      result.current[1]({ open: false });
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(getItemSpy).toHaveBeenCalled();
+    expect(setItemSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/usePersistedState.ts
+++ b/apps/web/src/hooks/usePersistedState.ts
@@ -1,0 +1,75 @@
+import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+
+import { useDebouncedCallback } from '@/lib/use-debounced-callback';
+
+const PERSIST_DELAY_MS = 200;
+
+type Initializer<T> = T | (() => T);
+
+function canUseLocalStorage() {
+  return typeof window !== 'undefined';
+}
+
+function resolveInitializerValue<T>(value: Initializer<T>): T {
+  return typeof value === 'function' ? (value as () => T)() : value;
+}
+
+function readStoredValue<T>(key: string, fallback: T) {
+  if (!canUseLocalStorage() || !key) {
+    return fallback;
+  }
+
+  try {
+    const rawValue = window.localStorage.getItem(key);
+
+    if (!rawValue) {
+      return fallback;
+    }
+
+    return JSON.parse(rawValue) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function usePersistedState<T>(
+  key: string,
+  defaultValue: Initializer<T>,
+): [T, Dispatch<SetStateAction<T>>] {
+  const normalizedKey = key.trim();
+  const defaultValueRef = useRef(defaultValue);
+  const [value, setValue] = useState<T>(() =>
+    readStoredValue(normalizedKey, resolveInitializerValue(defaultValue)),
+  );
+  const persistValue = useDebouncedCallback((nextKey: string, nextValue: T) => {
+    if (!canUseLocalStorage() || !nextKey) {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(nextKey, JSON.stringify(nextValue));
+    } catch {
+      // Ignore persistence failures to keep state updates responsive.
+    }
+  }, PERSIST_DELAY_MS);
+
+  useEffect(() => {
+    defaultValueRef.current = defaultValue;
+  }, [defaultValue]);
+
+  useEffect(() => {
+    setValue(readStoredValue(normalizedKey, resolveInitializerValue(defaultValueRef.current)));
+  }, [normalizedKey]);
+
+  useEffect(() => {
+    persistValue.run(normalizedKey, value);
+  }, [normalizedKey, persistValue, value]);
+
+  useEffect(() => {
+    return () => {
+      persistValue.flush();
+    };
+  }, [persistValue]);
+
+  return [value, setValue];
+}

--- a/apps/web/src/lib/query-polling.ts
+++ b/apps/web/src/lib/query-polling.ts
@@ -1,0 +1,15 @@
+export const DASHBOARD_SNAPSHOT_POLL_INTERVAL_MS = 20_000;
+export const NUTRITION_POLL_INTERVAL_MS = 20_000;
+export const NUTRITION_WEEK_SUMMARY_POLL_INTERVAL_MS = 30_000;
+export const HABIT_ENTRIES_POLL_INTERVAL_MS = 30_000;
+export const WEIGHT_TREND_POLL_INTERVAL_MS = 30_000;
+
+const isVitestRuntime = import.meta.env.MODE === 'test';
+
+export const getForegroundPollingInterval = (intervalMs: number): number | undefined => {
+  if (isVitestRuntime) {
+    return undefined;
+  }
+
+  return intervalMs;
+};

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -7,7 +7,11 @@ import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
 import { renderWithQueryClient } from '@/test/render-with-query-client';
 import { jsonResponse } from '@/test/test-utils';
 import { buildSessionSetInputs, extractExerciseNotes } from '@/features/workouts/lib/session-notes';
-import { ACTIVE_WORKOUT_SESSION_STORAGE_KEY } from '@/features/workouts/lib/session-persistence';
+import {
+  ACTIVE_WORKOUT_SESSION_STORAGE_KEY,
+  WORKOUT_EXERCISES_STORAGE_PREFIX,
+  WORKOUT_SECTIONS_STORAGE_PREFIX,
+} from '@/features/workouts/lib/session-persistence';
 
 import { ActiveWorkoutPage } from './active-workout';
 
@@ -62,10 +66,15 @@ describe('ActiveWorkoutPage', () => {
     vi.restoreAllMocks();
     window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
     window.localStorage.removeItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY);
+    const cleanupPrefixes = [
+      'pulse.active-workout-draft:',
+      `${WORKOUT_SECTIONS_STORAGE_PREFIX}:`,
+      `${WORKOUT_EXERCISES_STORAGE_PREFIX}:`,
+    ];
     const draftKeys: string[] = [];
     for (let index = 0; index < window.localStorage.length; index += 1) {
       const key = window.localStorage.key(index);
-      if (key?.startsWith('pulse.active-workout-draft:')) {
+      if (key && cleanupPrefixes.some((prefix) => key.startsWith(prefix))) {
         draftKeys.push(key);
       }
     }
@@ -314,6 +323,62 @@ describe('ActiveWorkoutPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Done' }));
     expect(await screen.findByRole('heading', { level: 1, name: 'Workouts' })).toBeVisible();
   }, 15_000);
+
+  it('clears persisted section/exercise ui state when a session is already completed', async () => {
+    vi.useRealTimers();
+    const sessionId = 'session-completed-1';
+    const sectionStateKey = `${WORKOUT_SECTIONS_STORAGE_PREFIX}:${sessionId}`;
+    const exerciseStateKey = `${WORKOUT_EXERCISES_STORAGE_PREFIX}:${sessionId}`;
+    window.localStorage.setItem(sectionStateKey, JSON.stringify({ warmup: false }));
+    window.localStorage.setItem(exerciseStateKey, JSON.stringify({ 'row-erg': false }));
+
+    const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.endsWith('/api/v1/auth/register')) {
+        return Promise.resolve(jsonResponse({ data: { token: 'dev-generated-token' } }));
+      }
+
+      if (url.includes('/api/v1/workout-sessions?status=completed&limit=3')) {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (url.includes('/api/v1/workout-sessions?status=in-progress&status=paused')) {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (
+        url.endsWith(`/api/v1/workout-sessions/${sessionId}`) &&
+        (!init?.method || init.method === 'GET')
+      ) {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              ...buildInProgressSessionResponse(sessionId),
+              completedAt: Date.parse('2026-03-06T12:45:00.000Z'),
+              duration: 45,
+              status: 'completed',
+              timeSegments: [
+                {
+                  start: '2026-03-06T12:00:00.000Z',
+                  end: '2026-03-06T12:45:00.000Z',
+                },
+              ],
+            },
+          }),
+        );
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch request: ${url}`));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderActiveWorkoutPage(`/workouts/active?sessionId=${sessionId}`);
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Workouts' })).toBeVisible();
+    expect(window.localStorage.getItem(sectionStateKey)).toBeNull();
+    expect(window.localStorage.getItem(exerciseStateKey)).toBeNull();
+  });
 
   it('uses the selected template from the route query string', () => {
     renderActiveWorkoutPage('/workouts/active?template=lower-quad-dominant');

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -87,6 +87,7 @@ import {
   WORKOUT_SESSION_NOTICE_QUERY_KEY,
   clearStoredActiveWorkoutDraft,
   clearStoredActiveWorkoutSessionId,
+  clearStoredWorkoutSessionUiState,
   getStoredActiveWorkoutDraft,
   setStoredActiveWorkoutSessionId,
   setStoredActiveWorkoutDraft,
@@ -252,11 +253,14 @@ export function ActiveWorkoutPage() {
   }, [completedSessionsQuery.data]);
   const redirectToCompletedSessionNotice = useCallback(() => {
     clearStoredActiveWorkoutDraft(activeWorkoutDraftId);
+    if (activeSessionId) {
+      clearStoredWorkoutSessionUiState(activeSessionId);
+    }
     clearStoredActiveWorkoutSessionId();
     navigate(`/workouts?${WORKOUT_SESSION_NOTICE_QUERY_KEY}=${WORKOUT_SESSION_COMPLETED_NOTICE}`, {
       replace: true,
     });
-  }, [activeWorkoutDraftId, navigate]);
+  }, [activeSessionId, activeWorkoutDraftId, navigate]);
 
   const templateExerciseById = useMemo(
     () =>
@@ -781,6 +785,9 @@ export function ActiveWorkoutPage() {
               ]);
 
               clearStoredActiveWorkoutDraft(activeWorkoutDraftId);
+              if (activeSessionId) {
+                clearStoredWorkoutSessionUiState(activeSessionId);
+              }
               setSessionFeedback(feedback);
               setSessionCompletedAt(completedAtIso);
               setStage('summary');
@@ -864,6 +871,9 @@ export function ActiveWorkoutPage() {
             }
 
             clearStoredActiveWorkoutDraft(activeWorkoutDraftId);
+            if (persistedSessionId) {
+              clearStoredWorkoutSessionUiState(persistedSessionId);
+            }
             navigate('/workouts');
           }}
           onNotesChange={setSessionNotes}
@@ -1312,6 +1322,7 @@ export function ActiveWorkoutPage() {
       },
       onSuccess: () => {
         clearStoredActiveWorkoutDraft(activeWorkoutDraftId);
+        clearStoredWorkoutSessionUiState(activeSessionId);
         clearStoredActiveWorkoutSessionId();
         navigate('/workouts', { replace: true });
       },

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -34,6 +34,11 @@ import { useLogWeight } from '@/features/weight/api/weight';
 import { prefetchDashboardSnapshot, useDashboardSnapshot } from '@/hooks/use-dashboard-snapshot';
 import { useDashboardConfig, useSaveDashboardConfig } from '@/hooks/use-dashboard-config';
 import { useHabitChains } from '@/hooks/use-habit-chains';
+import {
+  DASHBOARD_SNAPSHOT_POLL_INTERVAL_MS,
+  HABIT_ENTRIES_POLL_INTERVAL_MS,
+  getForegroundPollingInterval,
+} from '@/lib/query-polling';
 import { addDays, getToday, isSameDay, toDateKey } from '@/lib/date';
 import { cn } from '@/lib/utils';
 
@@ -162,11 +167,17 @@ export function DashboardPage() {
   const isViewingToday = isSameDay(selectedDate, getToday());
   const greeting = getDashboardGreeting();
 
-  const snapshotQuery = useDashboardSnapshot(selectedDateKey);
+  const snapshotQuery = useDashboardSnapshot(selectedDateKey, {
+    refetchIntervalMs: getForegroundPollingInterval(DASHBOARD_SNAPSHOT_POLL_INTERVAL_MS),
+  });
   // TODO: apply widgetOrder to section layout once ordering UI is added.
   const dashboardConfigQuery = useDashboardConfig();
-  const habitsQuery = useHabits();
-  const habitChainEntriesQuery = useHabitChains(habitRangeStart, selectedDateKey);
+  const habitsQuery = useHabits({
+    refetchIntervalMs: getForegroundPollingInterval(HABIT_ENTRIES_POLL_INTERVAL_MS),
+  });
+  const habitChainEntriesQuery = useHabitChains(habitRangeStart, selectedDateKey, {
+    refetchIntervalMs: getForegroundPollingInterval(HABIT_ENTRIES_POLL_INTERVAL_MS),
+  });
   const recentWorkoutsQuery = useRecentWorkouts();
   const persistedVisibleWidgets = getUniqueWidgetIds(
     dashboardConfigQuery.data?.visibleWidgets ?? DEFAULT_VISIBLE_WIDGETS

--- a/apps/web/src/pages/habits.tsx
+++ b/apps/web/src/pages/habits.tsx
@@ -16,6 +16,7 @@ import {
   normalizeDate,
   toDateKey,
 } from '@/lib/date';
+import { HABIT_ENTRIES_POLL_INTERVAL_MS, getForegroundPollingInterval } from '@/lib/query-polling';
 
 function getHabitEntryCompleted(habit: Habit, entry: HabitEntry | undefined) {
   if (!entry) {
@@ -62,8 +63,12 @@ export function HabitsPage() {
   const normalizedSelectedDate = useMemo(() => normalizeDate(selectedDate), [selectedDate]);
   const weekEnd = useMemo(() => addDays(visibleWeekStart, 6), [visibleWeekStart]);
 
-  const habitsQuery = useHabits();
-  const weekEntriesQuery = useHabitEntries(toDateKey(visibleWeekStart), toDateKey(weekEnd));
+  const habitsQuery = useHabits({
+    refetchIntervalMs: getForegroundPollingInterval(HABIT_ENTRIES_POLL_INTERVAL_MS),
+  });
+  const weekEntriesQuery = useHabitEntries(toDateKey(visibleWeekStart), toDateKey(weekEnd), {
+    refetchIntervalMs: getForegroundPollingInterval(HABIT_ENTRIES_POLL_INTERVAL_MS),
+  });
 
   const weekCompletionByDate = useMemo(
     () =>

--- a/apps/web/src/pages/nutrition.test.tsx
+++ b/apps/web/src/pages/nutrition.test.tsx
@@ -188,6 +188,66 @@ function createNutritionApiMock(initialState: Record<string, DateState>) {
       });
     }
 
+    if (method === 'PATCH' && pathParts.length === 6 && pathParts[4] === 'meals') {
+      if (!dateState.daily) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: 'MEAL_NOT_FOUND',
+              message: 'Meal not found',
+            },
+          }),
+          {
+            headers: { 'Content-Type': 'application/json' },
+            status: 404,
+          },
+        );
+      }
+
+      const mealId = pathParts[5];
+      const rawBody =
+        typeof init?.body === 'string'
+          ? (JSON.parse(init.body) as { name?: string })
+          : ((init?.body ?? {}) as { name?: string });
+      const nextName = rawBody.name?.trim();
+
+      if (!nextName) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: 'Meal name is required',
+            },
+          }),
+          {
+            headers: { 'Content-Type': 'application/json' },
+            status: 400,
+          },
+        );
+      }
+
+      const mealEntry = dateState.daily.meals.find((entry) => entry.meal.id === mealId);
+      if (!mealEntry) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: 'MEAL_NOT_FOUND',
+              message: 'Meal not found',
+            },
+          }),
+          {
+            headers: { 'Content-Type': 'application/json' },
+            status: 404,
+          },
+        );
+      }
+
+      mealEntry.meal.name = nextName;
+      state.set(date, dateState);
+
+      return createJsonResponse(mealEntry.meal);
+    }
+
     if (method === 'DELETE' && pathParts.length === 6 && pathParts[4] === 'meals') {
       const mealId = pathParts[5];
 
@@ -734,9 +794,7 @@ describe('NutritionPage', () => {
 
     expect(getMealHeading('Breakfast')).toBeInTheDocument();
 
-    const breakfastHeading = getMealHeading('Breakfast');
-    const expandButton = breakfastHeading.closest('button[aria-expanded]');
-    if (!expandButton) throw new Error('Expected expand button for Breakfast meal');
+    const expandButton = screen.getByRole('button', { name: 'Expand Breakfast' });
     fireEvent.click(expandButton);
 
     expect(screen.getByText('Large Eggs')).toBeInTheDocument();
@@ -763,6 +821,121 @@ describe('NutritionPage', () => {
       );
     });
     expect(didDeleteMeal).toBe(true);
+  });
+
+  it('renames a meal inline and keeps the updated name after reloading the page', async () => {
+    const { fetchMock } = createNutritionApiMock({
+      '2026-03-06': {
+        daily: null,
+        target: TARGETS,
+      },
+      '2026-03-05': {
+        daily: {
+          log: {
+            id: 'log-2026-03-05',
+            userId: 'user-1',
+            date: '2026-03-05',
+            notes: null,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          meals: previousDayMeals,
+        },
+        target: TARGETS,
+      },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const view = renderNutritionPage();
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select 2026-03-05' }));
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Breakfast' }));
+    const input = screen.getByRole('textbox', { name: 'Meal name for Breakfast' });
+    expect(input).toHaveValue('Breakfast');
+    fireEvent.change(input, { target: { value: 'Early Meal' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    await vi.advanceTimersByTimeAsync(500);
+    await Promise.resolve();
+
+    expect(getMealHeading('Early Meal')).toBeInTheDocument();
+    const didRenameMeal = fetchMock.mock.calls.some(([inputArg, init]) => {
+      const url = new URL(String(inputArg), 'http://localhost');
+      return (
+        url.pathname === '/api/v1/nutrition/2026-03-05/meals/meal-breakfast' &&
+        init?.method === 'PATCH'
+      );
+    });
+    expect(didRenameMeal).toBe(true);
+
+    view.unmount();
+    renderNutritionPage();
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select 2026-03-05' }));
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(getMealHeading('Early Meal')).toBeInTheDocument();
+  });
+
+  it('does not call rename mutation when editing is cancelled or name is empty', async () => {
+    const { fetchMock } = createNutritionApiMock({
+      '2026-03-06': {
+        daily: null,
+        target: TARGETS,
+      },
+      '2026-03-05': {
+        daily: {
+          log: {
+            id: 'log-2026-03-05',
+            userId: 'user-1',
+            date: '2026-03-05',
+            notes: null,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          meals: previousDayMeals,
+        },
+        target: TARGETS,
+      },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderNutritionPage();
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select 2026-03-05' }));
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Breakfast' }));
+    fireEvent.blur(screen.getByRole('textbox', { name: 'Meal name for Breakfast' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Breakfast' }));
+    const input = screen.getByRole('textbox', { name: 'Meal name for Breakfast' });
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(screen.getByText('Meal name is required')).toBeInTheDocument();
+
+    const renameCalls = fetchMock.mock.calls.filter(([inputArg, init]) => {
+      const url = new URL(String(inputArg), 'http://localhost');
+      return (
+        url.pathname === '/api/v1/nutrition/2026-03-05/meals/meal-breakfast' &&
+        init?.method === 'PATCH'
+      );
+    });
+    expect(renameCalls).toHaveLength(0);
   });
 
   it('shows loading skeletons while daily + summary queries are pending', () => {

--- a/apps/web/src/pages/nutrition.tsx
+++ b/apps/web/src/pages/nutrition.tsx
@@ -13,6 +13,7 @@ import {
   prefetchNutritionDay,
   useDailyNutrition,
   useDeleteMeal,
+  useRenameMeal,
   useNutritionSummary,
   useNutritionWeekSummary,
 } from '@/features/nutrition/api/nutrition';
@@ -38,6 +39,7 @@ export function NutritionPage() {
   const dailySummaryQuery = useNutritionSummary(dateKey);
   const weekSummaryQuery = useNutritionWeekSummary(dateKey);
   const deleteMealMutation = useDeleteMeal();
+  const renameMealMutation = useRenameMeal();
 
   const selectedMeals = sortMeals(
     (dailyNutritionQuery.data?.meals ?? []).map(({ meal, items }) => ({
@@ -76,6 +78,10 @@ export function NutritionPage() {
     deleteMealMutation.isError && deleteMealMutation.error instanceof Error
       ? deleteMealMutation.error.message
       : null;
+  const renameErrorMessage =
+    renameMealMutation.isError && renameMealMutation.error instanceof Error
+      ? renameMealMutation.error.message
+      : null;
 
   useEffect(() => {
     const previousDateKey = formatDateKey(addDays(selectedDate, -1));
@@ -107,6 +113,14 @@ export function NutritionPage() {
           return;
         }
       },
+    });
+  }
+
+  function handleRenameMeal(mealId: string, name: string) {
+    renameMealMutation.mutate({
+      date: dateKey,
+      mealId,
+      name,
     });
   }
 
@@ -183,6 +197,11 @@ export function NutritionPage() {
               {deleteErrorMessage}
             </p>
           ) : null}
+          {renameErrorMessage ? (
+            <p className="text-sm text-destructive" role="alert">
+              {renameErrorMessage}
+            </p>
+          ) : null}
 
           <div className="space-y-2" aria-label="Meals logged section">
             <div className="flex items-center justify-between gap-2">
@@ -221,8 +240,12 @@ export function NutritionPage() {
                   isDeleting={
                     deleteMealMutation.isPending && deleteMealMutation.variables?.mealId === meal.id
                   }
+                  isRenaming={
+                    renameMealMutation.isPending && renameMealMutation.variables?.mealId === meal.id
+                  }
                   meal={meal}
                   onDelete={handleDeleteMeal}
+                  onRename={handleRenameMeal}
                 />
               ))
             ) : (

--- a/apps/web/src/pages/nutrition.tsx
+++ b/apps/web/src/pages/nutrition.tsx
@@ -18,6 +18,11 @@ import {
   useNutritionWeekSummary,
 } from '@/features/nutrition/api/nutrition';
 import {
+  NUTRITION_POLL_INTERVAL_MS,
+  NUTRITION_WEEK_SUMMARY_POLL_INTERVAL_MS,
+  getForegroundPollingInterval,
+} from '@/lib/query-polling';
+import {
   formatDateKey,
   formatDayLabel,
   isSameDay,
@@ -35,9 +40,15 @@ export function NutritionPage() {
   const { confirm, dialog } = useConfirmation();
   const dateKey = formatDateKey(selectedDate);
 
-  const dailyNutritionQuery = useDailyNutrition(dateKey);
-  const dailySummaryQuery = useNutritionSummary(dateKey);
-  const weekSummaryQuery = useNutritionWeekSummary(dateKey);
+  const dailyNutritionQuery = useDailyNutrition(dateKey, {
+    refetchIntervalMs: getForegroundPollingInterval(NUTRITION_POLL_INTERVAL_MS),
+  });
+  const dailySummaryQuery = useNutritionSummary(dateKey, {
+    refetchIntervalMs: getForegroundPollingInterval(NUTRITION_POLL_INTERVAL_MS),
+  });
+  const weekSummaryQuery = useNutritionWeekSummary(dateKey, {
+    refetchIntervalMs: getForegroundPollingInterval(NUTRITION_WEEK_SUMMARY_POLL_INTERVAL_MS),
+  });
   const deleteMealMutation = useDeleteMeal();
   const renameMealMutation = useRenameMeal();
 

--- a/packages/shared/src/schemas/exercises.ts
+++ b/packages/shared/src/schemas/exercises.ts
@@ -136,6 +136,10 @@ export const exerciseLastPerformanceQuerySchema = z.object({
   includeRelated: z.coerce.boolean().optional().default(false),
 });
 
+export const exercisePerformanceHistoryQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(50).default(10),
+});
+
 export const exerciseLastPerformanceSetSchema = z.object({
   setNumber: z.number().int().min(1),
   weight: z.number().min(0).nullable(),
@@ -160,6 +164,17 @@ export const exerciseHistoryWithRelatedSchema = z.object({
   related: z.array(relatedExerciseLastPerformanceSchema).max(20),
 });
 
+export const exercisePerformanceHistorySessionSchema = z.object({
+  sessionId: z.string(),
+  date: dateSchema,
+  notes: z.string().nullable(),
+  sets: z.array(exerciseLastPerformanceSetSchema).max(100),
+});
+
+export const exercisePerformanceHistorySchema = z
+  .array(exercisePerformanceHistorySessionSchema)
+  .max(50);
+
 export type ExerciseCategory = z.infer<typeof exerciseCategorySchema>;
 export type ExerciseTrackingType = z.infer<typeof exerciseTrackingTypeSchema>;
 export type Exercise = z.infer<typeof exerciseSchema>;
@@ -167,7 +182,10 @@ export type CreateExerciseInput = z.infer<typeof createExerciseInputSchema>;
 export type UpdateExerciseInput = z.infer<typeof updateExerciseInputSchema>;
 export type ExerciseQueryParams = z.infer<typeof exerciseQueryParamsSchema>;
 export type ExerciseLastPerformanceQuery = z.infer<typeof exerciseLastPerformanceQuerySchema>;
+export type ExercisePerformanceHistoryQuery = z.infer<typeof exercisePerformanceHistoryQuerySchema>;
 export type ExerciseLastPerformance = z.infer<typeof exerciseLastPerformanceSchema>;
 export type ExerciseLastPerformanceSet = z.infer<typeof exerciseLastPerformanceSetSchema>;
 export type RelatedExerciseLastPerformance = z.infer<typeof relatedExerciseLastPerformanceSchema>;
 export type ExerciseHistoryWithRelated = z.infer<typeof exerciseHistoryWithRelatedSchema>;
+export type ExercisePerformanceHistorySession = z.infer<typeof exercisePerformanceHistorySessionSchema>;
+export type ExercisePerformanceHistory = z.infer<typeof exercisePerformanceHistorySchema>;


### PR DESCRIPTION
## Summary
This PR improves nutrition editing, workout history visibility, and real-time UI freshness for agent-driven updates. Nutrition now supports inline meal renaming with optimistic cache updates, rollback on failure, and client-side validation/error surfacing. Across dashboard, nutrition, habits, and weight views, key queries now use foreground polling so agent writes appear automatically without manual refresh. Workout history is unified behind a new exercise history endpoint and reusable modal used across active workouts, session detail, template detail, scheduled workouts, and exercise library, while active-session expand/collapse UI state is now persisted per session in `localStorage`.

## Key Changes
- Added `GET /api/v1/exercises/:id/history` with shared Zod schemas (`limit` 1-50, default 10), returning recent completed sessions with `notes` and all sets.
- Added `findExercisePerformanceHistory` store query (completed sessions only, user-scoped, ordered by recency, grouped sets per session).
- Added `useExerciseHistory` hook with typed parsing and graceful `EXERCISE_NOT_FOUND` handling (`[]`).
- Introduced `ExerciseHistoryModal` and wired history entry points across:
  - active workout exercise rows
  - session detail
  - workout template detail
  - scheduled workout detail
  - exercise library
- Replaced exercise library mock trend data with real history API data and mapping logic.
- Added `usePersistedState` hook (debounced persistence) and applied it to active workout section/exercise collapse state, keyed by session ID.
- Added session-scoped storage key helpers and cleanup (`clearStoredWorkoutSessionUiState`) when sessions complete/redirect/end.
- Added inline meal rename UX in `MealCard` and `NutritionPage`:
  - click-to-edit name
  - Enter/blur commit
  - Escape cancel
  - empty-name validation
  - per-meal pending state
- Added `useRenameMeal` mutation with optimistic update + rollback + invalidation of day/summary/week + cross-feature invalidations.
- Added centralized polling config (`query-polling.ts`) and optional `refetchIntervalMs` support for dashboard/nutrition/habit/weight hooks, always with `refetchIntervalInBackground: false`.

## Technical Notes
- Polling is intentionally foreground-only; intervals are centralized and disabled in Vitest via `getForegroundPollingInterval` to keep tests deterministic.
- Exercise history API excludes in-progress/deleted sessions and drops sessions with zero matching sets, so modal/chart views only show meaningful completed data.
- History payload uses the shared set shape (`weight`, `reps`); time/distance display remains normalized in client formatting/mapping utilities.
- Test coverage was expanded across API routes, hooks, and UI flows for rename behavior, polling options, modal history access, session-scoped persistence, and cleanup on completed sessions.

## Commits

- `249b33a chore(pr-5): verify commit-34 integration gates`
- `49f1af2 feat(workouts): add unified exercise history modal and endpoint`
- `0ea8618 feat(workouts): persist active session collapse state`
- `43970cc feat(web): add foreground polling for agent-driven data refresh`
- `7097a10 feat(nutrition): add inline meal renaming with optimistic updates`

## Tasks

- **Meal renaming UI — inline rename from nutrition view**: Add inline rename or modal for meal names, wire to existing PATCH /meals/:id endpoint
- **Cache invalidation for agent writes — add polling**: Add refetchInterval to key queries (dashboard, nutrition, habits) so agent changes appear without manual refresh
- **UI state persistence via localStorage for expand/collapse**: Create usePersistedState hook, apply to active workout section/exercise collapse state, scoped by session ID
- **Exercise history audit — fix broken history and add full history modal**: Fix exercise page no-history, workout view single-set display, add history modal accessible from all workout contexts
- **PR 5 integration pass — full test suite**: Run full test suite, fix any regressions from cross-cutting commits

## Diff Stats

```
apps/api/src/routes/exercises/index.test.ts        | 156 +++++++++++-
 apps/api/src/routes/exercises/index.ts             |  46 ++++
 apps/api/src/routes/exercises/store.ts             |  96 ++++++++
 .../components/habit-daily-status-card.tsx         |   9 +-
 .../dashboard/components/trend-sparkline.tsx       |   6 +-
 .../dashboard/components/weight-trend-chart.tsx    |   3 +
 apps/web/src/features/habits/api/habits.test.tsx   |  88 +++++++
 apps/web/src/features/habits/api/habits.ts         |  15 +-
 .../habits/components/daily-habits.test.tsx        |   8 +-
 .../features/habits/components/daily-habits.tsx    |   9 +-
 .../habits/components/habit-history.test.tsx       |   8 +-
 .../features/habits/components/habit-history.tsx   |   9 +-
 .../src/features/nutrition/api/nutrition.test.tsx  | 190 +++++++++++++++
 apps/web/src/features/nutrition/api/nutrition.ts   | 113 ++++++++-
 .../nutrition/components/meal-card.test.tsx        |  78 +++++-
 .../features/nutrition/components/meal-card.tsx    | 148 ++++++++++--
 .../workouts/components/exercise-history-modal.tsx | 100 ++++++++
 .../workouts/components/exercise-library.test.tsx  |  41 ++++
 .../workouts/components/exercise-library.tsx       | 101 +++++++-
 .../components/scheduled-workout-detail.test.tsx   | 128 ++++++++++
 .../components/scheduled-workout-detail.tsx        |  49 +++-
 .../workouts/components/session-detail.test.tsx    |  29 ++-
 .../workouts/components/session-detail.tsx         | 151 ++----------
 .../components/session-exercise-list.test.tsx      | 264 +++++++++++++++++++++
 .../workouts/components/session-exercise-list.tsx  |  74 +++++-
 .../workouts/components/template-detail.test.tsx   |  47 ++++
 .../workouts/components/template-detail.tsx        | 100 ++++++--
 .../workouts/lib/session-persistence.test.ts       |  32 +++
 .../features/workouts/lib/session-persistence.ts   |  41 +++-
 apps/web/src/features/workouts/types.ts            |  13 +
 apps/web/src/hooks/use-dashboard-snapshot.test.tsx |  29 ++-
 apps/web/src/hooks/use-dashboard-snapshot.ts       |  11 +-
 apps/web/src/hooks/use-exercise-history.test.tsx   | 126 ++++++++++
 apps/web/src/hooks/use-exercise-history.ts         |  63 +++++
 apps/web/src/hooks/use-habit-chains.test.tsx       |  32 ++-
 apps/web/src/hooks/use-habit-chains.ts             |  15 +-
 apps/web/src/hooks/use-weight-trend.test.tsx       |  32 ++-
 apps/web/src/hooks/use-weight-trend.ts             |  13 +-
 apps/web/src/hooks/usePersistedState.test.tsx      |  96 ++++++++
 apps/web/src/hooks/usePersistedState.ts            |  75 ++++++
 apps/web/src/lib/query-polling.ts                  |  15 ++
 apps/web/src/pages/active-workout.test.tsx         |  69 +++++-
 apps/web/src/pages/active-workout.tsx              |  13 +-
 apps/web/src/pages/dashboard.tsx                   |  17 +-
 apps/web/src/pages/habits.tsx                      |   9 +-
 apps/web/src/pages/nutrition.test.tsx              | 179 +++++++++++++-
 apps/web/src/pages/nutrition.tsx                   |  40 +++-
 packages/shared/src/schemas/exercises.ts           |  18 ++
 48 files changed, 2760 insertions(+), 244 deletions(-)
```