### PR TITLE
fix(web,api): foundation fixes and quick wins (8.2, 8.12, 8.22, 8.23, 8.25, 8.29, 8.21)

### DIFF
--- a/apps/api/src/routes/v1/dashboard-store.test.ts
+++ b/apps/api/src/routes/v1/dashboard-store.test.ts
@@ -325,7 +325,7 @@ describe('dashboard store', () => {
     expect(testState.select).toHaveBeenCalledTimes(1);
   });
 
-  it('fills missing macro trend days with zero totals', async () => {
+  it('returns macro trend points only for days with logged meal data', async () => {
     testState.selectAllResults.push([
       {
         date: '2026-03-07',
@@ -353,13 +353,6 @@ describe('dashboard store', () => {
         protein: 170,
         carbs: 230,
         fat: 68,
-      },
-      {
-        date: '2026-03-08',
-        calories: 0,
-        protein: 0,
-        carbs: 0,
-        fat: 0,
       },
       {
         date: '2026-03-09',

--- a/apps/api/src/routes/v1/dashboard-store.ts
+++ b/apps/api/src/routes/v1/dashboard-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, between, desc, eq, inArray, isNull, lte, sql } from 'drizzle-orm';
+import { and, asc, between, desc, eq, inArray, isNotNull, isNull, lte, sql } from 'drizzle-orm';
 
 import type {
   DashboardConfig,
@@ -523,24 +523,18 @@ export const getDashboardMacrosTrend = async (
     .from(nutritionLogs)
     .leftJoin(meals, eq(meals.nutritionLogId, nutritionLogs.id))
     .leftJoin(mealItems, eq(mealItems.mealId, meals.id))
-    .where(and(eq(nutritionLogs.userId, userId), between(nutritionLogs.date, from, to)))
+    .where(
+      and(
+        eq(nutritionLogs.userId, userId),
+        between(nutritionLogs.date, from, to),
+        isNotNull(meals.id),
+      ),
+    )
     .groupBy(nutritionLogs.date)
     .orderBy(asc(nutritionLogs.date))
     .all();
 
-  const rowsByDate = new Map(
-    rows.map((row) => [
-      row.date,
-      {
-        calories: row.calories,
-        protein: row.protein,
-        carbs: row.carbs,
-        fat: row.fat,
-      },
-    ]),
-  );
-
-  return getDatesInRange(from, to).map((date) => toMacroTrendPoint(date, rowsByDate.get(date)));
+  return rows.map((row) => toMacroTrendPoint(row.date, row));
 };
 
 export const getDashboardConsistencyTrend = async (

--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -41,14 +41,16 @@ function AlertDialogContent({
   return (
     <AlertDialogPortal>
       <AlertDialogOverlay />
-      <AlertDialogPrimitive.Content
-        data-slot="alert-dialog-content"
-        className={cn(
-          'fixed top-[50%] left-[50%] z-50 mx-4 grid w-[calc(100%-2rem)] max-w-full translate-x-[-50%] translate-y-[-50%] gap-3 rounded-lg border bg-background p-5 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:mx-0 sm:w-full sm:max-w-lg',
-          className,
-        )}
-        {...props}
-      />
+      <div className="fixed inset-0 z-50 flex items-center justify-center">
+        <AlertDialogPrimitive.Content
+          data-slot="alert-dialog-content"
+          className={cn(
+            'max-h-[calc(100dvh-2rem)] overflow-y-auto mx-4 grid w-[calc(100%-2rem)] max-w-full gap-3 rounded-lg border bg-background p-5 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:mx-0 sm:w-full sm:max-w-lg',
+            className,
+          )}
+          {...props}
+        />
+      </div>
     </AlertDialogPortal>
   );
 }

--- a/apps/web/src/components/ui/confirmation-dialog.test.tsx
+++ b/apps/web/src/components/ui/confirmation-dialog.test.tsx
@@ -17,7 +17,11 @@ describe('ConfirmationDialog', () => {
 
     expect(screen.getByText('Delete template?')).toBeInTheDocument();
     expect(screen.getByText('This action cannot be undone.')).toBeInTheDocument();
-    expect(screen.getByRole('alertdialog')).toHaveClass('gap-3', 'p-5');
+    const alertDialog = screen.getByRole('alertdialog');
+
+    expect(alertDialog.parentElement).toHaveClass('fixed', 'inset-0', 'flex', 'items-center', 'justify-center');
+    expect(alertDialog).toHaveClass('gap-3', 'p-5', 'max-h-[calc(100dvh-2rem)]', 'overflow-y-auto');
+    expect(alertDialog).not.toHaveClass('translate-x-[-50%]', 'translate-y-[-50%]');
     expect(document.querySelector('[data-slot="alert-dialog-footer"]')).toHaveClass('pt-1');
   });
 

--- a/apps/web/src/components/ui/dialog.test.tsx
+++ b/apps/web/src/components/ui/dialog.test.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/ui/dialog';
 
 describe('Dialog', () => {
-  it('uses compact default spacing while keeping the close button touch target', () => {
+  it('uses flex wrapper centering with scroll-safe content defaults', () => {
     render(
       <Dialog open>
         <DialogContent>
@@ -25,7 +25,11 @@ describe('Dialog', () => {
       </Dialog>,
     );
 
-    expect(screen.getByRole('dialog')).toHaveClass('gap-3', 'p-5');
+    const dialog = screen.getByRole('dialog');
+
+    expect(dialog.parentElement).toHaveClass('fixed', 'inset-0', 'flex', 'items-center', 'justify-center');
+    expect(dialog).toHaveClass('gap-3', 'p-5', 'max-h-[calc(100dvh-2rem)]', 'overflow-y-auto');
+    expect(dialog).not.toHaveClass('translate-x-[-50%]', 'translate-y-[-50%]');
     expect(screen.getByTestId('dialog-header')).toHaveClass('gap-1.5');
     expect(screen.getByTestId('dialog-footer')).toHaveClass('pt-1');
     expect(screen.getByRole('button', { name: 'Close' })).toHaveClass(

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -48,25 +48,27 @@ function DialogContent({
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
-      <DialogPrimitive.Content
-        data-slot="dialog-content"
-        className={cn(
-          'fixed top-[50%] left-[50%] z-50 mx-4 grid w-[calc(100%-2rem)] max-w-full translate-x-[-50%] translate-y-[-50%] gap-3 rounded-lg border bg-background p-5 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:mx-0 sm:w-full sm:max-w-lg',
-          className,
-        )}
-        {...props}
-      >
-        {children}
-        {showCloseButton && (
-          <DialogPrimitive.Close
-            data-slot="dialog-close"
-            className="absolute top-2.5 right-2.5 flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded-md opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
-          >
-            <XIcon />
-            <span className="sr-only">Close</span>
-          </DialogPrimitive.Close>
-        )}
-      </DialogPrimitive.Content>
+      <div className="fixed inset-0 z-50 flex items-center justify-center">
+        <DialogPrimitive.Content
+          data-slot="dialog-content"
+          className={cn(
+            'max-h-[calc(100dvh-2rem)] overflow-y-auto mx-4 grid w-[calc(100%-2rem)] max-w-full gap-3 rounded-lg border bg-background p-5 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:mx-0 sm:w-full sm:max-w-lg',
+            className,
+          )}
+          {...props}
+        >
+          {children}
+          {showCloseButton && (
+            <DialogPrimitive.Close
+              data-slot="dialog-close"
+              className="absolute top-2.5 right-2.5 flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded-md opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            >
+              <XIcon />
+              <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+          )}
+        </DialogPrimitive.Content>
+      </div>
     </DialogPortal>
   );
 }

--- a/apps/web/src/features/dashboard/components/recent-workouts.test.tsx
+++ b/apps/web/src/features/dashboard/components/recent-workouts.test.tsx
@@ -182,6 +182,12 @@ describe('RecentWorkouts', () => {
     expect(screen.getByText('6 days ago')).toBeInTheDocument();
     expect(screen.getByText('1 week ago')).toBeInTheDocument();
     expect(screen.getByText('2 weeks ago')).toBeInTheDocument();
+
+    const relativeDateBadge = screen.getByText('Yesterday');
+    expect(relativeDateBadge).toHaveClass('bg-emerald-500/15');
+    expect(relativeDateBadge).toHaveClass('text-emerald-700');
+    expect(relativeDateBadge).toHaveClass('dark:bg-emerald-500/15');
+    expect(relativeDateBadge).toHaveClass('dark:text-emerald-400');
   });
 
   it('renders skeleton rows while loading', () => {

--- a/apps/web/src/features/dashboard/components/recent-workouts.tsx
+++ b/apps/web/src/features/dashboard/components/recent-workouts.tsx
@@ -104,7 +104,7 @@ export function RecentWorkouts() {
                             </time>
                           </div>
 
-                          <span className="shrink-0 rounded-full bg-[var(--color-accent-cream)] px-2 py-1 text-[11px] font-semibold text-on-cream dark:bg-amber-500/20 dark:text-amber-400">
+                          <span className="shrink-0 rounded-full bg-emerald-500/15 px-2 py-1 text-[11px] font-semibold text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400">
                             {formatRelativeWorkoutDate(workout.date)}
                           </span>
                         </div>

--- a/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.test.tsx
@@ -145,6 +145,7 @@ describe('TrendSparklines', () => {
     expect(screen.getByText('Weight Trend')).toBeInTheDocument();
     expect(screen.getByText('Calorie Trend')).toBeInTheDocument();
     expect(screen.getByText('Protein Trend')).toBeInTheDocument();
+    expect(screen.getAllByText('2-day avg')).toHaveLength(3);
 
     // "View details" links navigate to correct routes
     const links = screen.getAllByRole('link', { name: /view .+ details/i });
@@ -291,6 +292,7 @@ describe('TrendSparklines', () => {
       .closest('[data-slot="trend-sparkline-card"]') as HTMLElement;
 
     expect(within(calorieCard).getByText('--')).toBeInTheDocument();
+    expect(within(calorieCard).getByText('0-day avg')).toBeInTheDocument();
     expect(within(calorieCard).getByText('No data')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/dashboard/components/trend-sparkline.tsx
+++ b/apps/web/src/features/dashboard/components/trend-sparkline.tsx
@@ -123,6 +123,8 @@ const getChangeDirection = (changePercent: number): ChangeDirection => {
   return 'neutral';
 };
 
+const formatLookbackLabel = (days: number): string => `${days}-day avg`;
+
 const resolveTrendRange = (endDate?: string) => {
   const resolvedEndDate = endDate ?? toDateKey(new Date());
   const startDate = toDateKey(addDays(parseDateInput(resolvedEndDate), -(TREND_DAYS - 1)));
@@ -379,11 +381,13 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
   const latestWeight = getLatestTrend(weightSeries, 0);
   const latestCalories = getLatestTrend(calorieSeries, 0);
   const latestProtein = getLatestTrend(proteinSeries, 0);
-  const lookbackLabel = `${TREND_DAYS}d avg`;
+  const weightLookbackLabel = formatLookbackLabel(weightSeries.length);
+  const calorieLookbackLabel = formatLookbackLabel(calorieSeries.length);
+  const proteinLookbackLabel = formatLookbackLabel(proteinSeries.length);
   const allConfigs = {
     weight: {
       label: 'Weight Trend',
-      subtitle: lookbackLabel,
+      subtitle: weightLookbackLabel,
       to: '/weight/history',
       currentValue: weightSeries.length > 0 ? formatWeight(latestWeight, 'lbs') : '--',
       changePercent:
@@ -398,7 +402,7 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
     },
     calories: {
       label: 'Calorie Trend',
-      subtitle: lookbackLabel,
+      subtitle: calorieLookbackLabel,
       to: '/nutrition',
       currentValue: calorieSeries.length > 0 ? `${formatCalories(latestCalories)} kcal` : '--',
       changePercent:
@@ -416,7 +420,7 @@ export function TrendSparklines({ endDate, metrics }: TrendSparklinesProps) {
     },
     protein: {
       label: 'Protein Trend',
-      subtitle: lookbackLabel,
+      subtitle: proteinLookbackLabel,
       to: '/nutrition',
       currentValue: proteinSeries.length > 0 ? formatGrams(latestProtein) : '--',
       changePercent:

--- a/apps/web/src/features/workouts/components/session-feedback.tsx
+++ b/apps/web/src/features/workouts/components/session-feedback.tsx
@@ -574,7 +574,7 @@ function RpeScaleHelp() {
             <CircleHelp className="size-4" />
           </Button>
         </DialogTrigger>
-        <DialogContent className="top-auto bottom-0 translate-y-0 rounded-t-2xl rounded-b-none border-b-0 p-5 sm:top-[50%] sm:bottom-auto sm:translate-y-[-50%] sm:rounded-lg sm:border-b sm:p-6">
+        <DialogContent className="self-end rounded-t-2xl rounded-b-none border-b-0 p-5 sm:self-center sm:rounded-lg sm:border-b sm:p-6">
           <DialogHeader>
             <DialogTitle>Session RPE Guide</DialogTitle>
             <DialogDescription className="sr-only">

--- a/apps/web/src/features/workouts/components/session-header.test.tsx
+++ b/apps/web/src/features/workouts/components/session-header.test.tsx
@@ -2,7 +2,17 @@ import { useState } from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { formatElapsedTime } from '../lib/elapsed-time';
 import { SessionHeader } from './session-header';
+
+describe('formatElapsedTime', () => {
+  it('formats elapsed seconds as zero-padded mm:ss', () => {
+    expect(formatElapsedTime(0)).toBe('00:00');
+    expect(formatElapsedTime(9)).toBe('00:09');
+    expect(formatElapsedTime(65)).toBe('01:05');
+    expect(formatElapsedTime(3605)).toBe('60:05');
+  });
+});
 
 describe('SessionHeader', () => {
   beforeEach(() => {

--- a/apps/web/src/features/workouts/components/session-header.tsx
+++ b/apps/web/src/features/workouts/components/session-header.tsx
@@ -9,6 +9,7 @@ import { ProgressBar } from '@/components/ui/progress-bar';
 import { accentCardStyles } from '@/lib/accent-card-styles';
 import { cn } from '@/lib/utils';
 
+import { formatElapsedTime } from '../lib/elapsed-time';
 import { formatEstimateMinutes } from '../lib/time-estimates';
 import { StickyRestTimerBar } from './sticky-rest-timer-bar';
 
@@ -266,13 +267,6 @@ function getActiveElapsedSeconds(timeSegments: WorkoutSessionTimeSegment[], curr
 
     return total + Math.floor((endedAt - startedAt) / 1000);
   }, 0);
-}
-
-function formatElapsedTime(totalSeconds: number) {
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-
-  return `${`${minutes}`.padStart(2, '0')}:${`${seconds}`.padStart(2, '0')}`;
 }
 
 function formatStartTime(startTime: Date | string) {

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -231,6 +231,46 @@ describe('WorkoutTemplateDetail', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders supplemental section label and accent styling', async () => {
+    const templateWithSupplemental = {
+      data: {
+        ...templatePayload.data,
+        sections: [
+          ...templatePayload.data.sections,
+          {
+            type: 'supplemental',
+            exercises: [],
+          },
+        ],
+      },
+    };
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = String(input);
+
+      if (url.endsWith('/api/v1/workout-templates/upper-push')) {
+        return Promise.resolve(jsonResponse(templateWithSupplemental));
+      }
+
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutTemplateDetail templateId="upper-push" />
+      </MemoryRouter>,
+    );
+
+    const supplementalHeading = await screen.findByRole('heading', {
+      level: 2,
+      name: 'Supplemental',
+    });
+    const supplementalSection = supplementalHeading.closest('details');
+
+    expect(supplementalSection).not.toBeNull();
+    expect(supplementalSection).toHaveClass('border-l-[var(--color-accent-cream)]');
+  });
+
   it('saves inline sets, reps, rest, and notes on blur with debounce', async () => {
     const mutableTemplate = structuredClone(templatePayload);
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
@@ -1215,7 +1255,9 @@ describe('WorkoutTemplateDetail', () => {
       </MemoryRouter>,
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Open Incline Dumbbell Press history' }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Open Incline Dumbbell Press history' }),
+    );
 
     const dialog = await screen.findByRole('dialog');
     expect(within(dialog).getByText('Incline Dumbbell Press history')).toBeInTheDocument();

--- a/apps/web/src/features/workouts/components/workout-calendar.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.test.tsx
@@ -119,11 +119,23 @@ describe('WorkoutCalendar', () => {
     expect((await screen.findAllByLabelText('Completed workout')).length).toBeGreaterThan(0);
     expect(screen.getByText('+2')).toHaveClass('hidden', 'sm:inline-flex');
     expect(screen.getByRole('button', { name: 'Previous month' })).toHaveClass('size-8');
-    expect(getCalendarDayTile(sessionDate)).toHaveClass('overflow-hidden');
-    expect(screen.getByRole('link', { name: 'Done' })).toHaveAttribute(
+    const calendarDayTile = getCalendarDayTile(sessionDate);
+    expect(calendarDayTile).toHaveClass('overflow-hidden');
+    expect(calendarDayTile).toHaveClass('text-center', 'sm:text-left');
+    expect(calendarDayTile.querySelector('div')).toHaveClass(
+      'items-center',
+      'justify-center',
+      'sm:justify-between',
+    );
+    expect(calendarDayTile.querySelector('.mt-auto')).toHaveClass('justify-center', 'sm:justify-start');
+
+    const doneLink = screen.getByRole('link', { name: 'Done' });
+    expect(doneLink).toHaveClass('h-2', 'w-2', 'sm:h-auto', 'sm:w-auto');
+    expect(doneLink).toHaveAttribute(
       'href',
       '/workouts/session/session-1',
     );
+    expect(within(doneLink).getByText('Done')).toHaveClass('hidden', 'sm:inline');
   });
 
   it('shows selected-day workouts with status-aware actions', async () => {

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -268,7 +268,7 @@ export function WorkoutCalendar({
                   aria-label={`${fullDateFormatter.format(day)}${isSelected ? ', selected' : ''}`}
                   aria-pressed={isSelected}
                   className={cn(
-                    'flex min-h-14 min-w-0 cursor-pointer flex-col overflow-hidden rounded-xl border px-1 py-1 text-left transition-all duration-200 sm:min-h-28 sm:rounded-2xl sm:px-3 sm:py-3',
+                    'flex min-h-14 min-w-0 cursor-pointer flex-col overflow-hidden rounded-xl border px-1 py-1 text-center transition-all duration-200 sm:min-h-28 sm:rounded-2xl sm:px-3 sm:py-3 sm:text-left',
                     isInMonth
                       ? 'bg-card hover:border-primary/40 hover:bg-secondary/50'
                       : 'bg-secondary/35 opacity-55',
@@ -287,10 +287,10 @@ export function WorkoutCalendar({
                   role="button"
                   tabIndex={0}
                 >
-                  <div className="flex min-w-0 items-start justify-between gap-0.5">
+                  <div className="flex min-w-0 items-center justify-center gap-1 sm:items-start sm:justify-between sm:gap-0.5">
                     <span
                       className={cn(
-                        'shrink-0 text-xs font-semibold sm:text-sm',
+                        'shrink-0 text-center text-xs font-semibold sm:text-sm',
                         isToday ? 'text-primary' : 'text-foreground',
                         !isInMonth && 'text-muted',
                       )}
@@ -300,7 +300,8 @@ export function WorkoutCalendar({
                     <div className="flex min-w-0 items-center gap-1">
                       {details.completedSession ? (
                         <Link
-                          className="max-w-full rounded-full bg-emerald-500/15 px-1 py-0.5 text-[8px] font-bold uppercase leading-none tracking-wide text-emerald-700 hover:bg-emerald-500/25 dark:text-emerald-400 sm:px-1.5 sm:text-[9px]"
+                          aria-label="Done"
+                          className="inline-flex h-2 w-2 shrink-0 items-center justify-center rounded-full bg-emerald-500/15 p-0 text-[8px] font-bold uppercase leading-none tracking-wide text-emerald-700 hover:bg-emerald-500/25 dark:text-emerald-400 sm:h-auto sm:w-auto sm:px-1.5 sm:py-0.5 sm:text-[9px]"
                           onClick={(event) => event.stopPropagation()}
                           to={
                             buildSessionHref?.(
@@ -309,7 +310,7 @@ export function WorkoutCalendar({
                             ) ?? `/workouts/session/${details.completedSession.id}`
                           }
                         >
-                          Done
+                          <span className="hidden sm:inline">Done</span>
                         </Link>
                       ) : null}
                       {details.workouts.some((workout) => workout.isUnavailable) ? (
@@ -337,7 +338,7 @@ export function WorkoutCalendar({
                     </p>
                   </div>
 
-                  <div className="mt-auto flex min-w-0 items-center gap-1 pt-1 sm:gap-1.5 sm:pt-3">
+                  <div className="mt-auto flex min-w-0 items-center justify-center gap-1 pt-1 sm:justify-start sm:gap-1.5 sm:pt-3">
                     {getTileIndicators(details.workoutIndicators).map((indicator) => (
                       <span
                         aria-label={`${statusToLabel(indicator.status)} workout`}

--- a/apps/web/src/features/workouts/lib/elapsed-time.ts
+++ b/apps/web/src/features/workouts/lib/elapsed-time.ts
@@ -1,0 +1,6 @@
+export function formatElapsedTime(totalSeconds: number) {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  return `${`${minutes}`.padStart(2, '0')}:${`${seconds}`.padStart(2, '0')}`;
+}

--- a/apps/web/src/hooks/use-pull-to-refresh.test.tsx
+++ b/apps/web/src/hooks/use-pull-to-refresh.test.tsx
@@ -32,7 +32,7 @@ const createTouchEvent = (type: string, y?: number) => {
   return event;
 };
 
-const dispatchTouch = (type: 'touchstart' | 'touchmove' | 'touchend', y?: number) => {
+const dispatchTouch = (type: 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel', y?: number) => {
   const event = createTouchEvent(type, y);
   window.dispatchEvent(event);
   return event;
@@ -158,5 +158,70 @@ describe('usePullToRefresh', () => {
     await waitFor(() => {
       expect(result.current.refreshing).toBe(false);
     });
+  });
+
+  it('vibrates once when pull distance crosses the threshold during touch move', async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const vibrateMock = vi.fn();
+    Object.defineProperty(window.navigator, 'vibrate', {
+      configurable: true,
+      value: vibrateMock,
+      writable: true,
+    });
+
+    renderHook(() => usePullToRefresh({ onRefresh, threshold: 80 }));
+
+    act(() => {
+      dispatchTouch('touchstart', 0);
+      dispatchTouch('touchmove', 50);
+      dispatchTouch('touchmove', 85);
+      dispatchTouch('touchmove', 120);
+    });
+
+    expect(vibrateMock).toHaveBeenCalledTimes(1);
+    expect(vibrateMock).toHaveBeenCalledWith(10);
+
+    act(() => {
+      dispatchTouch('touchend');
+    });
+
+    await waitFor(() => {
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+    expect(vibrateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets threshold haptic state after touchcancel so the next gesture can vibrate again', async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const vibrateMock = vi.fn();
+    Object.defineProperty(window.navigator, 'vibrate', {
+      configurable: true,
+      value: vibrateMock,
+      writable: true,
+    });
+
+    renderHook(() => usePullToRefresh({ onRefresh, threshold: 80 }));
+
+    act(() => {
+      dispatchTouch('touchstart', 0);
+      dispatchTouch('touchmove', 100);
+      dispatchTouch('touchcancel');
+    });
+
+    await waitFor(() => {
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+    expect(vibrateMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      dispatchTouch('touchstart', 0);
+      dispatchTouch('touchmove', 100);
+      dispatchTouch('touchend');
+    });
+
+    await waitFor(() => {
+      expect(onRefresh).toHaveBeenCalledTimes(2);
+    });
+    expect(vibrateMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/src/hooks/use-pull-to-refresh.ts
+++ b/apps/web/src/hooks/use-pull-to-refresh.ts
@@ -56,6 +56,7 @@ export function usePullToRefresh({
   const canPullRef = useRef(false);
   const pullDistanceRef = useRef(0);
   const refreshingRef = useRef(false);
+  const hapticFiredRef = useRef(false);
 
   const updatePullDistance = useCallback((nextDistance: number) => {
     pullDistanceRef.current = nextDistance;
@@ -100,6 +101,7 @@ export function usePullToRefresh({
     const resetPullState = () => {
       isTouchActiveRef.current = false;
       canPullRef.current = false;
+      hapticFiredRef.current = false;
       setPulling(false);
       updatePullDistance(0);
     };
@@ -116,6 +118,7 @@ export function usePullToRefresh({
 
       isTouchActiveRef.current = true;
       canPullRef.current = isAtTop();
+      hapticFiredRef.current = false;
       touchStartYRef.current = touch.clientY;
     };
 
@@ -140,6 +143,12 @@ export function usePullToRefresh({
       const nextDistance = Math.min(deltaY, maxPullDistance);
       setPulling(true);
       updatePullDistance(nextDistance);
+
+      if (nextDistance >= threshold && !hapticFiredRef.current) {
+        hapticFiredRef.current = true;
+        window.navigator.vibrate?.(10);
+      }
+
       event.preventDefault();
     };
 

--- a/packages/shared/src/schemas/workout-templates.test.ts
+++ b/packages/shared/src/schemas/workout-templates.test.ts
@@ -149,6 +149,46 @@ describe('workoutTemplateSchema', () => {
       }),
     ).toThrow();
   });
+
+  it('accepts all four section types and rejects payloads with a fifth section', () => {
+    const fourSectionPayload = {
+      id: 'template-1',
+      userId: 'user-1',
+      name: 'Full Session',
+      description: null,
+      tags: [],
+      sections: [
+        { type: 'warmup', exercises: [] },
+        { type: 'main', exercises: [] },
+        { type: 'cooldown', exercises: [] },
+        { type: 'supplemental', exercises: [] },
+      ],
+      createdAt: 1,
+      updatedAt: 1,
+    } as const;
+
+    const parsed = workoutTemplateSchema.parse(fourSectionPayload);
+    expect(parsed.sections.map((section) => section.type)).toEqual([
+      'warmup',
+      'main',
+      'cooldown',
+      'supplemental',
+    ]);
+
+    const fiveSectionResult = workoutTemplateSchema.safeParse({
+      ...fourSectionPayload,
+      sections: [...fourSectionPayload.sections, { type: 'supplemental', exercises: [] }],
+    });
+
+    expect(fiveSectionResult.success).toBe(false);
+    if (!fiveSectionResult.success) {
+      expect(
+        fiveSectionResult.error.issues.some(
+          (issue) => issue.path.join('.') === 'sections' && issue.code === 'too_big',
+        ),
+      ).toBe(true);
+    }
+  });
 });
 
 describe('createWorkoutTemplateInputSchema', () => {


### PR DESCRIPTION
## Summary
This PR bundles a set of foundation-level bug fixes and UI polish updates across the web and API layers, with targeted test coverage to lock behavior in. Macro trend generation now returns only dates with actual meal data instead of injecting zero-filled days, which prevents misleading flat spots in dashboard nutrition trends. Dialog and alert-dialog positioning was refactored from transform-based centering to a fixed flex wrapper with scroll-safe content, improving reliability on iOS Safari and small viewports. The PR also includes quick wins for dashboard/workout UX (badge color update, tighter mobile calendar status UI, pull-to-refresh haptic feedback) and explicit tests for supplemental workout sections and elapsed timer formatting.

## Key Changes
- Updated `getDashboardMacrosTrend` to filter out nutrition-log dates without meals and removed range-based zero-fill mapping.
- Refined dashboard sparkline subtitle logic to reflect actual data length (`N-day avg`) rather than a fixed lookback label.
- Reworked `DialogContent` and `AlertDialogContent` centering to use `fixed inset-0 flex items-center justify-center`, plus `max-h` + `overflow-y-auto`.
- Adjusted mobile workout calendar day tile layout and changed the “Done” badge to a dot on small screens (text shown at `sm+` only).
- Changed recent workout relative-date badge styling from amber/cream to emerald tones.
- Added pull-to-refresh threshold haptics (`navigator.vibrate?.(10)`) with one-fire-per-gesture behavior and reset handling on `touchcancel`.
- Added/expanded tests for supplemental template sections, elapsed timer formatting extraction, dialog centering behavior, sparkline subtitle behavior, and pull-to-refresh haptics.

## Technical Notes
- API response shape for macro trends is unchanged, but series density is now sparse by design (only logged-meal dates); reviewers should confirm this matches product expectations for trend interpretation.
- The sparkline subtitle now derives from each metric’s series length, so empty data intentionally renders `0-day avg` instead of implying a full-window average.
- Because dialog centering now depends on wrapper flex alignment, sheet-style variants were updated to use alignment classes (`self-end`/`sm:self-center`) instead of positional transforms.
- Elapsed-time formatting was extracted to a shared workout utility for direct unit validation and reuse consistency.

## Commits

- `4b67ee7 fix(dashboard): exclude zero-meal days from macro trends`
- `8715e91 fix(web): polish badges, calendar mobile layout, and refresh haptics`
- `fba3988 fix(web): center dialogs with flex wrapper`
- `8746316 test: verify supplemental sections and elapsed timer`

## Tasks

- **Verify supplemental section support and session elapsed timer**: Verify issues 8.2 and 8.29 are already implemented. Write validation tests if missing.
- **Fix modal centering on mobile**: Replace transform-based centering in dialog.tsx with flexbox centering for iOS Safari compatibility.
- **Badge color, calendar mobile, haptic feedback**: Three small fixes: amber->emerald badges, hide 'Done' text on mobile calendar, add pull-to-refresh haptic.
- **Trend sparklines exclude zero-meal days**: Remove getDatesInRange zero-fill from getDashboardMacrosTrend. Only return dates with actual meal data.

## Diff Stats

```
apps/api/src/routes/v1/dashboard-store.test.ts     |  9 +--
 apps/api/src/routes/v1/dashboard-store.ts          | 24 +++-----
 apps/web/src/components/ui/alert-dialog.tsx        | 18 +++---
 .../src/components/ui/confirmation-dialog.test.tsx |  6 +-
 apps/web/src/components/ui/dialog.test.tsx         |  8 ++-
 apps/web/src/components/ui/dialog.tsx              | 40 +++++++------
 .../dashboard/components/recent-workouts.test.tsx  |  6 ++
 .../dashboard/components/recent-workouts.tsx       |  2 +-
 .../dashboard/components/trend-sparkline.test.tsx  |  2 +
 .../dashboard/components/trend-sparkline.tsx       | 12 ++--
 .../workouts/components/session-feedback.tsx       |  2 +-
 .../workouts/components/session-header.test.tsx    | 10 ++++
 .../workouts/components/session-header.tsx         |  8 +--
 .../workouts/components/template-detail.test.tsx   | 44 +++++++++++++-
 .../workouts/components/workout-calendar.test.tsx  | 16 +++++-
 .../workouts/components/workout-calendar.tsx       | 13 +++--
 apps/web/src/features/workouts/lib/elapsed-time.ts |  6 ++
 apps/web/src/hooks/use-pull-to-refresh.test.tsx    | 67 +++++++++++++++++++++-
 apps/web/src/hooks/use-pull-to-refresh.ts          |  9 +++
 .../shared/src/schemas/workout-templates.test.ts   | 40 +++++++++++++
 20 files changed, 266 insertions(+), 76 deletions(-)
```