### PR TITLE
fix(workouts): workout bugs and exercise improvements (8.31, 8.17, 8.30, 8.27, 8.15, 8.4, 8.20)

### DIFF
--- a/.agents/skills/pulse-app-usage/SKILL.md
+++ b/.agents/skills/pulse-app-usage/SKILL.md
@@ -155,6 +155,11 @@ Meals support editing via PATCH:
 - `DELETE /api/v1/nutrition/:date/meals/:mealId` — delete a meal entirely
 - Meal-level PATCH supports `summary`: send text to override, send `null` to clear, omit to leave unchanged.
 
+### Maintenance (JWT-only)
+
+- `POST /api/v1/admin/reconcile-food-usage` recomputes each food's `usageCount` from actual `meal_items` references and resets unreferenced foods to `usageCount: 0`.
+- This endpoint is JWT-only and is intended for maintenance/admin sessions, not AgentToken calls.
+
 ### Nutrition Summaries
 
 - `GET /api/v1/nutrition/:date/summary` — macro totals/targets summary for a date (with optional agent guidance)

--- a/apps/api/src/__tests__/food-usage-reconciliation.test.ts
+++ b/apps/api/src/__tests__/food-usage-reconciliation.test.ts
@@ -258,6 +258,44 @@ describe('food usage reconciliation endpoint', () => {
     });
   });
 
+  it('counts rows as updated when only lastUsedAt changes', async () => {
+    seedFood({
+      id: 'food-timestamp',
+      userId: 'user-1',
+      usageCount: 1,
+      lastUsedAt: 1_800_000_001_000,
+    });
+    seedMeal({ id: 'meal-1', userId: 'user-1', date: '2026-03-20' });
+    seedMealItem({
+      id: 'meal-item-1',
+      mealId: 'meal-1',
+      foodId: 'food-timestamp',
+      createdAt: 1_800_000_090_000,
+    });
+
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/reconcile-food-usage',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: {
+        reconciled: 1,
+        updated: 1,
+      },
+    });
+    expect(getFoodUsage('food-timestamp')).toEqual({
+      usageCount: 1,
+      lastUsedAt: 1_800_000_090_000,
+    });
+  });
+
   it('sets usageCount to 0 and clears lastUsedAt for foods with no references', async () => {
     seedFood({ id: 'food-unused', userId: 'user-1', usageCount: 5, lastUsedAt: 1_800_000_020_000 });
     seedFood({ id: 'food-used', userId: 'user-1', usageCount: 1, lastUsedAt: 1_800_000_030_000 });

--- a/apps/api/src/__tests__/food-usage-reconciliation.test.ts
+++ b/apps/api/src/__tests__/food-usage-reconciliation.test.ts
@@ -1,0 +1,326 @@
+import { createHash } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { eq } from 'drizzle-orm';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import type { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { agentTokens, foods, mealItems, meals, nutritionLogs, users } from '../db/schema/index.js';
+
+type DatabaseModule = typeof import('../db/index.js');
+
+type TestContext = {
+  app: FastifyInstance;
+  db: DatabaseModule['db'];
+  sqlite: DatabaseModule['sqlite'];
+  tempDir: string;
+};
+
+let context: TestContext;
+
+const createAuthorizationHeader = (token: string, scheme: 'Bearer' | 'AgentToken' = 'Bearer') => ({
+  authorization: `${scheme} ${token}`,
+});
+
+const seedUser = (id: string, username: string) =>
+  context.db
+    .insert(users)
+    .values({
+      id,
+      username,
+      name: username,
+      passwordHash: 'not-used-in-this-suite',
+    })
+    .run();
+
+const seedFood = (values: {
+  id: string;
+  userId: string;
+  usageCount?: number;
+  lastUsedAt?: number | null;
+}) =>
+  context.db
+    .insert(foods)
+    .values({
+      id: values.id,
+      userId: values.userId,
+      name: values.id,
+      calories: 100,
+      protein: 10,
+      carbs: 10,
+      fat: 5,
+      verified: true,
+      usageCount: values.usageCount ?? 0,
+      lastUsedAt: values.lastUsedAt ?? null,
+      tags: [],
+    })
+    .run();
+
+const seedMeal = (values: { id: string; userId: string; date: string }) => {
+  const logId = `log-${values.userId}-${values.date}`;
+
+  context.db
+    .insert(nutritionLogs)
+    .values({
+      id: logId,
+      userId: values.userId,
+      date: values.date,
+    })
+    .onConflictDoNothing({
+      target: [nutritionLogs.userId, nutritionLogs.date],
+    })
+    .run();
+
+  context.db
+    .insert(meals)
+    .values({
+      id: values.id,
+      nutritionLogId: logId,
+      name: values.id,
+    })
+    .run();
+};
+
+const seedMealItem = (values: {
+  id: string;
+  mealId: string;
+  foodId: string | null;
+  createdAt: number;
+}) =>
+  context.db
+    .insert(mealItems)
+    .values({
+      id: values.id,
+      mealId: values.mealId,
+      foodId: values.foodId,
+      name: values.id,
+      amount: 1,
+      unit: 'serving',
+      calories: 100,
+      protein: 10,
+      carbs: 10,
+      fat: 5,
+      createdAt: values.createdAt,
+    })
+    .run();
+
+const getFoodUsage = (foodId: string) =>
+  context.db
+    .select({
+      usageCount: foods.usageCount,
+      lastUsedAt: foods.lastUsedAt,
+    })
+    .from(foods)
+    .where(eq(foods.id, foodId))
+    .limit(1)
+    .get();
+
+describe('food usage reconciliation endpoint', () => {
+  beforeAll(async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'pulse-food-usage-reconcile-'));
+
+    process.env.JWT_SECRET = 'test-food-usage-reconcile-secret';
+    process.env.DATABASE_URL = join(tempDir, 'test.db');
+    vi.resetModules();
+
+    const [{ buildServer }, dbModule] = await Promise.all([
+      import('../index.js'),
+      import('../db/index.js'),
+    ]);
+
+    migrate(dbModule.db, {
+      migrationsFolder: fileURLToPath(new URL('../../drizzle', import.meta.url)),
+    });
+
+    const app = buildServer();
+    await app.ready();
+
+    context = {
+      app,
+      db: dbModule.db,
+      sqlite: dbModule.sqlite,
+      tempDir,
+    };
+  });
+
+  afterAll(async () => {
+    if (context) {
+      await context.app.close();
+      context.sqlite.close();
+      rmSync(context.tempDir, { recursive: true, force: true });
+    }
+
+    delete process.env.JWT_SECRET;
+    delete process.env.DATABASE_URL;
+    vi.resetModules();
+  });
+
+  beforeEach(() => {
+    context.db.delete(mealItems).run();
+    context.db.delete(meals).run();
+    context.db.delete(nutritionLogs).run();
+    context.db.delete(agentTokens).run();
+    context.db.delete(foods).run();
+    context.db.delete(users).run();
+
+    seedUser('user-1', 'derek');
+    seedUser('user-2', 'alex');
+  });
+
+  it('recomputes usage counts and lastUsedAt from meal item references', async () => {
+    seedFood({ id: 'food-a', userId: 'user-1', usageCount: 7, lastUsedAt: 111 });
+    seedFood({ id: 'food-b', userId: 'user-1', usageCount: 0, lastUsedAt: null });
+
+    seedMeal({ id: 'meal-1', userId: 'user-1', date: '2026-03-18' });
+    seedMeal({ id: 'meal-2', userId: 'user-1', date: '2026-03-19' });
+
+    seedMealItem({
+      id: 'meal-item-1',
+      mealId: 'meal-1',
+      foodId: 'food-a',
+      createdAt: 1_800_000_001_000,
+    });
+    seedMealItem({
+      id: 'meal-item-2',
+      mealId: 'meal-1',
+      foodId: 'food-b',
+      createdAt: 1_800_000_002_000,
+    });
+    seedMealItem({
+      id: 'meal-item-3',
+      mealId: 'meal-2',
+      foodId: 'food-a',
+      createdAt: 1_800_000_003_000,
+    });
+
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/reconcile-food-usage',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: {
+        reconciled: 2,
+        updated: 2,
+      },
+    });
+
+    expect(getFoodUsage('food-a')).toEqual({
+      usageCount: 2,
+      lastUsedAt: 1_800_000_003_000,
+    });
+    expect(getFoodUsage('food-b')).toEqual({
+      usageCount: 1,
+      lastUsedAt: 1_800_000_002_000,
+    });
+  });
+
+  it('corrects stale usageCount values to the true meal item count', async () => {
+    seedFood({ id: 'food-stale', userId: 'user-1', usageCount: 99, lastUsedAt: 123 });
+    seedMeal({ id: 'meal-1', userId: 'user-1', date: '2026-03-20' });
+    seedMealItem({
+      id: 'meal-item-1',
+      mealId: 'meal-1',
+      foodId: 'food-stale',
+      createdAt: 1_800_000_010_000,
+    });
+
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/reconcile-food-usage',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: {
+        reconciled: 1,
+        updated: 1,
+      },
+    });
+    expect(getFoodUsage('food-stale')).toEqual({
+      usageCount: 1,
+      lastUsedAt: 1_800_000_010_000,
+    });
+  });
+
+  it('sets usageCount to 0 and clears lastUsedAt for foods with no references', async () => {
+    seedFood({ id: 'food-unused', userId: 'user-1', usageCount: 5, lastUsedAt: 1_800_000_020_000 });
+    seedFood({ id: 'food-used', userId: 'user-1', usageCount: 1, lastUsedAt: 1_800_000_030_000 });
+    seedMeal({ id: 'meal-1', userId: 'user-1', date: '2026-03-20' });
+    seedMealItem({
+      id: 'meal-item-1',
+      mealId: 'meal-1',
+      foodId: 'food-used',
+      createdAt: 1_800_000_030_000,
+    });
+
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/reconcile-food-usage',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: {
+        reconciled: 2,
+        updated: 1,
+      },
+    });
+    expect(getFoodUsage('food-unused')).toEqual({
+      usageCount: 0,
+      lastUsedAt: null,
+    });
+    expect(getFoodUsage('food-used')).toEqual({
+      usageCount: 1,
+      lastUsedAt: 1_800_000_030_000,
+    });
+  });
+
+  it('rejects agent token callers because reconciliation is JWT-only', async () => {
+    seedFood({ id: 'food-a', userId: 'user-1' });
+    const token = 'plain-agent-token';
+    context.db
+      .insert(agentTokens)
+      .values({
+        id: 'agent-token-1',
+        userId: 'user-1',
+        name: 'maintenance',
+        tokenHash: createHash('sha256').update(token).digest('hex'),
+      })
+      .run();
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/reconcile-food-usage',
+      headers: createAuthorizationHeader(token, 'AgentToken'),
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'FORBIDDEN',
+        message: 'JWT authentication required',
+      },
+    });
+  });
+});

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -138,7 +138,7 @@ describe('OpenAPI docs', () => {
       );
 
       expect(body.paths?.['/api/v1/exercises/{id}/last-performance']?.get).toMatchObject({
-        summary: 'Get the latest completed performance for an exercise',
+        summary: 'Get recent completed performances for an exercise',
         tags: ['exercises'],
         security: [{ bearerAuth: [] }, { agentToken: [] }],
       });
@@ -146,6 +146,7 @@ describe('OpenAPI docs', () => {
         expect.arrayContaining([
           expect.objectContaining({ name: 'id', in: 'path' }),
           expect.objectContaining({ name: 'includeRelated', in: 'query' }),
+          expect.objectContaining({ name: 'limit', in: 'query' }),
         ]),
       );
 
@@ -211,7 +212,10 @@ describe('OpenAPI docs', () => {
       expect(response.statusCode).toBe(200);
 
       const body = response.json() as {
-        paths: Record<string, Partial<Record<(typeof HTTP_METHODS)[number], Record<string, unknown>>>>;
+        paths: Record<
+          string,
+          Partial<Record<(typeof HTTP_METHODS)[number], Record<string, unknown>>>
+        >;
       };
 
       const operationsWithRequestBody = Object.entries(body.paths).flatMap(([routePath, methods]) =>
@@ -288,7 +292,10 @@ describe('OpenAPI docs', () => {
       expect(response.statusCode).toBe(200);
 
       const body = response.json() as {
-        paths: Record<string, Partial<Record<(typeof HTTP_METHODS)[number], Record<string, unknown>>>>;
+        paths: Record<
+          string,
+          Partial<Record<(typeof HTTP_METHODS)[number], Record<string, unknown>>>
+        >;
       };
 
       const versionedOperations = Object.entries(body.paths)
@@ -311,7 +318,10 @@ describe('OpenAPI docs', () => {
           continue;
         }
 
-        if (routePath.startsWith('/api/v1/users/') || routePath.startsWith('/api/v1/agent-tokens/')) {
+        if (
+          routePath.startsWith('/api/v1/users/') ||
+          routePath.startsWith('/api/v1/agent-tokens/')
+        ) {
           expect(operation.security).toEqual([{ bearerAuth: [] }]);
           continue;
         }
@@ -375,8 +385,12 @@ describe('OpenAPI docs', () => {
       readFile(PULSE_APP_USAGE_SKILL, 'utf8'),
     ]);
 
-    expect(agentsDoc).toContain('API documentation: OpenAPI spec at `GET /api/docs/json`, Swagger UI at `/api/docs`');
-    expect(agentsDoc).toContain('Request and response schemas are auto-generated from Zod schemas into the OpenAPI spec');
+    expect(agentsDoc).toContain(
+      'API documentation: OpenAPI spec at `GET /api/docs/json`, Swagger UI at `/api/docs`',
+    );
+    expect(agentsDoc).toContain(
+      'Request and response schemas are auto-generated from Zod schemas into the OpenAPI spec',
+    );
     expect(agentsDoc).toContain(
       'OpenAPI-generated clients using the `agentToken` security scheme must still send the full header value as `Authorization: AgentToken <token>`; the prefix is not implied automatically.',
     );
@@ -384,7 +398,9 @@ describe('OpenAPI docs', () => {
     expect(readme).toContain(
       'API documentation available at `/api/docs` (Swagger UI) and `/api/docs/json` (OpenAPI 3.1 spec).',
     );
-    expect(readme).toContain('Response schemas are Zod-validated and documented in the OpenAPI spec.');
+    expect(readme).toContain(
+      'Response schemas are Zod-validated and documented in the OpenAPI spec.',
+    );
     expect(readme).toContain(
       'OpenAPI-generated clients using the `agentToken` security scheme must still prefix the header value manually as `AgentToken <token>`.',
     );

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -2010,6 +2010,132 @@ describe('exercise routes', () => {
     });
   });
 
+  it('deletes an unreferenced user exercise with 200', async () => {
+    seedExercise({
+      id: 'unreferenced-exercise',
+      userId: 'user-1',
+      name: 'Landmine Press',
+      muscleGroups: ['shoulders', 'upper chest'],
+      equipment: 'barbell',
+      category: 'compound',
+    });
+
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    const response = await context.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/exercises/unreferenced-exercise',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: {
+        success: true,
+      },
+    });
+
+    const persistedExercise = context.db
+      .select({ deletedAt: exercises.deletedAt })
+      .from(exercises)
+      .where(eq(exercises.id, 'unreferenced-exercise'))
+      .get();
+
+    expect(persistedExercise).toEqual({
+      deletedAt: expect.any(String),
+    });
+  });
+
+  it('ignores references from deleted templates and sessions when deleting an exercise', async () => {
+    seedExercise({
+      id: 'soft-deleted-reference-exercise',
+      userId: 'user-1',
+      name: 'Paused Lunge',
+      muscleGroups: ['quads', 'glutes'],
+      equipment: 'bodyweight',
+      category: 'isolation',
+    });
+
+    context.db
+      .insert(workoutTemplates)
+      .values({
+        id: 'deleted-template-reference',
+        userId: 'user-1',
+        name: 'Archived Lower Body',
+        description: null,
+        tags: [],
+      })
+      .run();
+    context.db
+      .insert(templateExercises)
+      .values({
+        id: 'deleted-template-reference-exercise',
+        templateId: 'deleted-template-reference',
+        exerciseId: 'soft-deleted-reference-exercise',
+        orderIndex: 0,
+        section: 'main',
+      })
+      .run();
+    context.db
+      .update(workoutTemplates)
+      .set({ deletedAt: '2026-03-01T00:00:00.000Z' })
+      .where(eq(workoutTemplates.id, 'deleted-template-reference'))
+      .run();
+
+    seedWorkoutSession({
+      id: 'deleted-session-reference',
+      userId: 'user-1',
+      name: 'Archived Session',
+      date: '2026-03-01',
+      startedAt: Date.parse('2026-03-01T08:00:00.000Z'),
+      status: 'completed',
+      completedAt: Date.parse('2026-03-01T08:30:00.000Z'),
+    });
+    seedSessionSet({
+      id: 'deleted-session-reference-set',
+      sessionId: 'deleted-session-reference',
+      exerciseId: 'soft-deleted-reference-exercise',
+      setNumber: 1,
+      reps: 12,
+    });
+    context.db
+      .update(workoutSessions)
+      .set({ deletedAt: '2026-03-02T00:00:00.000Z' })
+      .where(eq(workoutSessions.id, 'deleted-session-reference'))
+      .run();
+
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    const response = await context.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/exercises/soft-deleted-reference-exercise',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: {
+        success: true,
+      },
+    });
+
+    const persistedExercise = context.db
+      .select({ deletedAt: exercises.deletedAt })
+      .from(exercises)
+      .where(eq(exercises.id, 'soft-deleted-reference-exercise'))
+      .get();
+
+    expect(persistedExercise).toEqual({
+      deletedAt: expect.any(String),
+    });
+  });
+
   it('returns 409 when deleting an exercise referenced by a workout template', async () => {
     seedExercise({
       id: 'referenced-exercise',

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -2010,6 +2010,69 @@ describe('exercise routes', () => {
     });
   });
 
+  it('returns 409 when deleting an exercise referenced by a workout template', async () => {
+    seedExercise({
+      id: 'referenced-exercise',
+      userId: 'user-1',
+      name: 'Bulgarian Split Squat',
+      muscleGroups: ['quads', 'glutes'],
+      equipment: 'dumbbell',
+      category: 'compound',
+    });
+
+    context.db
+      .insert(workoutTemplates)
+      .values({
+        id: 'template-1',
+        userId: 'user-1',
+        name: 'Lower Body',
+        description: null,
+        tags: [],
+      })
+      .run();
+
+    context.db
+      .insert(templateExercises)
+      .values({
+        id: 'template-exercise-1',
+        templateId: 'template-1',
+        exerciseId: 'referenced-exercise',
+        orderIndex: 0,
+        section: 'main',
+      })
+      .run();
+
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    const response = await context.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/exercises/referenced-exercise',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'EXERCISE_IN_USE',
+        message:
+          'This exercise is referenced by workout templates or sessions. Remove it from all templates first.',
+      },
+    });
+
+    const persistedExercise = context.db
+      .select({ deletedAt: exercises.deletedAt })
+      .from(exercises)
+      .where(eq(exercises.id, 'referenced-exercise'))
+      .get();
+
+    expect(persistedExercise).toEqual({
+      deletedAt: null,
+    });
+  });
+
   it('returns validation errors for invalid create payloads and query params', async () => {
     const authToken = context.app.jwt.sign(
       { sub: 'user-1', type: 'session', iss: 'pulse-api' },

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -329,7 +329,7 @@ describe('exercise routes', () => {
     });
   });
 
-  it('returns most recent completed last performance for a visible exercise', async () => {
+  it('returns up to 3 most recent completed performances for a visible exercise by default', async () => {
     seedExercise({
       id: 'global-bench',
       userId: null,
@@ -356,6 +356,15 @@ describe('exercise routes', () => {
     });
 
     seedWorkoutSession({
+      id: 'session-oldest',
+      userId: 'user-1',
+      name: 'Upper Push',
+      date: '2026-02-20',
+      status: 'completed',
+      startedAt: 1_699_000_000_000,
+      completedAt: 1_699_000_003_000,
+    });
+    seedWorkoutSession({
       id: 'session-old',
       userId: 'user-1',
       name: 'Upper Push',
@@ -372,6 +381,15 @@ describe('exercise routes', () => {
       status: 'completed',
       startedAt: 1_700_000_010_000,
       completedAt: 1_700_000_015_000,
+    });
+    seedWorkoutSession({
+      id: 'session-newest',
+      userId: 'user-1',
+      name: 'Upper Push',
+      date: '2026-03-10',
+      status: 'completed',
+      startedAt: 1_700_000_030_000,
+      completedAt: 1_700_000_035_000,
     });
     seedWorkoutSession({
       id: 'session-in-progress',
@@ -391,6 +409,14 @@ describe('exercise routes', () => {
       completedAt: 1_700_000_025_000,
     });
 
+    seedSessionSet({
+      id: 'set-oldest-1',
+      sessionId: 'session-oldest',
+      exerciseId: 'global-bench',
+      setNumber: 1,
+      weight: 95,
+      reps: 10,
+    });
     seedSessionSet({
       id: 'set-old-1',
       sessionId: 'session-old',
@@ -424,6 +450,14 @@ describe('exercise routes', () => {
       reps: 8,
     });
     seedSessionSet({
+      id: 'set-newest-1',
+      sessionId: 'session-newest',
+      exerciseId: 'global-bench',
+      setNumber: 1,
+      weight: 110,
+      reps: 6,
+    });
+    seedSessionSet({
       id: 'set-in-progress',
       sessionId: 'session-in-progress',
       exerciseId: 'global-bench',
@@ -453,22 +487,51 @@ describe('exercise routes', () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
-      data: {
-        sessionId: 'session-latest',
-        date: '2026-03-08',
-        sets: [
-          {
-            setNumber: 1,
-            weight: 105,
-            reps: 9,
-          },
-          {
-            setNumber: 2,
-            weight: 100,
-            reps: 8,
-          },
-        ],
-      },
+      data: [
+        {
+          sessionId: 'session-newest',
+          date: '2026-03-10',
+          sets: [
+            {
+              setNumber: 1,
+              weight: 110,
+              reps: 6,
+            },
+          ],
+        },
+        {
+          sessionId: 'session-latest',
+          date: '2026-03-08',
+          sets: [
+            {
+              setNumber: 1,
+              weight: 105,
+              reps: 9,
+            },
+            {
+              setNumber: 2,
+              weight: 100,
+              reps: 8,
+            },
+          ],
+        },
+        {
+          sessionId: 'session-old',
+          date: '2026-03-01',
+          sets: [
+            {
+              setNumber: 1,
+              weight: 100,
+              reps: 8,
+            },
+            {
+              setNumber: 2,
+              weight: 100,
+              reps: 7,
+            },
+          ],
+        },
+      ],
     });
 
     const noDataResponse = await context.app.inject({
@@ -479,7 +542,7 @@ describe('exercise routes', () => {
 
     expect(noDataResponse.statusCode).toBe(200);
     expect(noDataResponse.json()).toEqual({
-      data: null,
+      data: [],
     });
 
     const privateExerciseResponse = await context.app.inject({
@@ -497,7 +560,7 @@ describe('exercise routes', () => {
     });
   });
 
-  it('returns the newest same-day completed performance for history lookups', async () => {
+  it('returns up to requested limit of completed performances in descending order', async () => {
     seedExercise({
       id: 'global-squat',
       userId: null,
@@ -525,6 +588,15 @@ describe('exercise routes', () => {
       startedAt: Date.parse('2026-03-12T17:00:00.000Z'),
       completedAt: Date.parse('2026-03-12T17:42:00.000Z'),
     });
+    seedWorkoutSession({
+      id: 'session-older',
+      userId: 'user-1',
+      name: 'Lower Body Previous',
+      date: '2026-03-09',
+      status: 'completed',
+      startedAt: Date.parse('2026-03-09T08:00:00.000Z'),
+      completedAt: Date.parse('2026-03-09T08:44:00.000Z'),
+    });
 
     seedSessionSet({
       id: 'set-early',
@@ -542,6 +614,14 @@ describe('exercise routes', () => {
       weight: 235,
       reps: 4,
     });
+    seedSessionSet({
+      id: 'set-older',
+      sessionId: 'session-older',
+      exerciseId: 'global-squat',
+      setNumber: 1,
+      weight: 215,
+      reps: 6,
+    });
 
     const authToken = context.app.jwt.sign(
       { sub: 'user-1', type: 'session', iss: 'pulse-api' },
@@ -550,23 +630,47 @@ describe('exercise routes', () => {
 
     const response = await context.app.inject({
       method: 'GET',
-      url: '/api/v1/exercises/global-squat/last-performance',
+      url: '/api/v1/exercises/global-squat/last-performance?limit=3',
       headers: createAuthorizationHeader(authToken),
     });
 
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
-      data: {
-        sessionId: 'session-late',
-        date: '2026-03-12',
-        sets: [
-          {
-            setNumber: 1,
-            weight: 235,
-            reps: 4,
-          },
-        ],
-      },
+      data: [
+        {
+          sessionId: 'session-late',
+          date: '2026-03-12',
+          sets: [
+            {
+              setNumber: 1,
+              weight: 235,
+              reps: 4,
+            },
+          ],
+        },
+        {
+          sessionId: 'session-early',
+          date: '2026-03-12',
+          sets: [
+            {
+              setNumber: 1,
+              weight: 225,
+              reps: 5,
+            },
+          ],
+        },
+        {
+          sessionId: 'session-older',
+          date: '2026-03-09',
+          sets: [
+            {
+              setNumber: 1,
+              weight: 215,
+              reps: 6,
+            },
+          ],
+        },
+      ],
     });
   });
 

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -217,7 +217,7 @@ describe('exercise routes', () => {
     seedUser('user-2', 'alex');
   });
 
-  it('requires auth for create, list, history, last-performance, update, and delete', async () => {
+  it('requires auth for create, list, read, history, last-performance, update, and delete', async () => {
     const responses = await Promise.all([
       context.app.inject({
         method: 'POST',
@@ -232,6 +232,10 @@ describe('exercise routes', () => {
       context.app.inject({
         method: 'GET',
         url: '/api/v1/exercises',
+      }),
+      context.app.inject({
+        method: 'GET',
+        url: '/api/v1/exercises/exercise-1',
       }),
       context.app.inject({
         method: 'GET',
@@ -261,6 +265,68 @@ describe('exercise routes', () => {
         },
       });
     }
+  });
+
+  it('returns a visible exercise by id', async () => {
+    seedExercise({
+      id: 'global-bench',
+      userId: null,
+      name: 'Bench Press',
+      muscleGroups: ['chest'],
+      equipment: 'barbell',
+      category: 'compound',
+      tags: ['strength'],
+      formCues: ['Brace and drive'],
+      instructions: 'Lower to sternum, press to lockout.',
+      coachingNotes: 'Keep elbows 45 degrees.',
+      relatedExerciseIds: [],
+    });
+    seedExercise({
+      id: 'private-exercise',
+      userId: 'user-2',
+      name: 'Private Exercise',
+      muscleGroups: ['back'],
+      equipment: 'cable',
+      category: 'compound',
+    });
+
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    const response = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises/global-bench',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      data: {
+        id: 'global-bench',
+        userId: null,
+        name: 'Bench Press',
+        muscleGroups: ['chest'],
+        equipment: 'barbell',
+        category: 'compound',
+        trackingType: 'weight_reps',
+      },
+    });
+
+    const notFoundResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/exercises/private-exercise',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(notFoundResponse.statusCode).toBe(404);
+    expect(notFoundResponse.json()).toEqual({
+      error: {
+        code: 'EXERCISE_NOT_FOUND',
+        message: 'Exercise not found',
+      },
+    });
   });
 
   it('returns most recent completed last performance for a visible exercise', async () => {
@@ -1534,7 +1600,9 @@ describe('exercise routes', () => {
       }>;
     };
 
-    const metadataExercise = listPayload.data.find((exercise) => exercise.id === 'metadata-exercise');
+    const metadataExercise = listPayload.data.find(
+      (exercise) => exercise.id === 'metadata-exercise',
+    );
     expect(metadataExercise).toBeDefined();
     if (!metadataExercise) {
       throw new Error('Expected metadata-exercise to be returned from exercise list');

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -302,6 +302,7 @@ describe('exercise routes', () => {
     });
 
     expect(response.statusCode).toBe(200);
+    expect(response.headers['cache-control']).toBe('private, no-cache');
     expect(response.json()).toMatchObject({
       data: {
         id: 'global-bench',
@@ -2184,7 +2185,7 @@ describe('exercise routes', () => {
       error: {
         code: 'EXERCISE_IN_USE',
         message:
-          'This exercise is referenced by workout templates or sessions. Remove it from all templates first.',
+          'This exercise is referenced by active workout templates or sessions and cannot be deleted.',
       },
     });
 

--- a/apps/api/src/routes/exercises/index.ts
+++ b/apps/api/src/routes/exercises/index.ts
@@ -41,6 +41,7 @@ import {
   findExerciseOwnership,
   findVisibleExerciseDetailsById,
   findVisibleExerciseById,
+  isExerciseInUse,
   listExerciseFilters,
   listExercises,
   updateOwnedExercise,
@@ -60,6 +61,20 @@ const INVALID_RELATED_EXERCISES_RESPONSE = {
   code: 'VALIDATION_ERROR',
   message: 'relatedExerciseIds must reference existing user-owned exercises',
 } as const;
+
+const EXERCISE_IN_USE_RESPONSE = {
+  code: 'EXERCISE_IN_USE',
+  message:
+    'This exercise is referenced by workout templates or sessions. Remove it from all templates first.',
+} as const;
+
+const isSqliteForeignKeyConstraintError = (error: unknown): error is { code: string } => {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  return (error as { code?: unknown }).code === 'SQLITE_CONSTRAINT_FOREIGNKEY';
+};
 
 const exerciseCreateDedupResponseSchema = z.object({
   created: z.literal(false),
@@ -470,6 +485,7 @@ export const exerciseRoutes: FastifyPluginAsync = async (app) => {
           401: apiErrorResponseSchema,
           403: apiErrorResponseSchema,
           404: apiErrorResponseSchema,
+          409: apiErrorResponseSchema,
         },
         tags: ['exercises'],
         summary: 'Delete an exercise',
@@ -486,7 +502,32 @@ export const exerciseRoutes: FastifyPluginAsync = async (app) => {
         return reply;
       }
 
-      const deleted = await deleteOwnedExercise(request.params.id, request.userId);
+      const inUse = await isExerciseInUse(request.params.id);
+      if (inUse) {
+        return sendError(
+          reply,
+          409,
+          EXERCISE_IN_USE_RESPONSE.code,
+          EXERCISE_IN_USE_RESPONSE.message,
+        );
+      }
+
+      let deleted: boolean;
+      try {
+        deleted = await deleteOwnedExercise(request.params.id, request.userId);
+      } catch (error) {
+        if (isSqliteForeignKeyConstraintError(error)) {
+          return sendError(
+            reply,
+            409,
+            EXERCISE_IN_USE_RESPONSE.code,
+            EXERCISE_IN_USE_RESPONSE.message,
+          );
+        }
+
+        throw error;
+      }
+
       if (!deleted) {
         return sendError(
           reply,

--- a/apps/api/src/routes/exercises/index.ts
+++ b/apps/api/src/routes/exercises/index.ts
@@ -39,6 +39,7 @@ import {
   findExerciseLastPerformance,
   findExercisePerformanceHistory,
   findExerciseOwnership,
+  findVisibleExerciseDetailsById,
   findVisibleExerciseById,
   listExerciseFilters,
   listExercises,
@@ -274,6 +275,41 @@ export const exerciseRoutes: FastifyPluginAsync = async (app) => {
 
       return reply.send({
         data: filters,
+      });
+    },
+  );
+
+  typedApp.get(
+    '/:id',
+    {
+      schema: {
+        params: idParamsSchema,
+        response: {
+          200: apiDataResponseSchema(exerciseSchema),
+          401: apiErrorResponseSchema,
+          404: apiErrorResponseSchema,
+        },
+        tags: ['exercises'],
+        summary: 'Get a visible exercise by id',
+        security: authSecurity,
+      },
+    },
+    async (request, reply) => {
+      const exercise = await findVisibleExerciseDetailsById({
+        id: request.params.id,
+        userId: request.userId,
+      });
+      if (!exercise) {
+        return sendError(
+          reply,
+          404,
+          EXERCISE_NOT_FOUND_RESPONSE.code,
+          EXERCISE_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      return reply.send({
+        data: exercise,
       });
     },
   );

--- a/apps/api/src/routes/exercises/index.ts
+++ b/apps/api/src/routes/exercises/index.ts
@@ -393,6 +393,8 @@ export const exerciseRoutes: FastifyPluginAsync = async (app) => {
       }
 
       if (request.query.includeRelated) {
+        // `limit` applies only to the non-related array response shape.
+        // The related-history branch always returns one latest entry per exercise.
         const historyWithRelated = await findExerciseHistoryWithRelated({
           exerciseId: request.params.id,
           relatedExerciseIds: exercise.relatedExerciseIds,

--- a/apps/api/src/routes/exercises/index.ts
+++ b/apps/api/src/routes/exercises/index.ts
@@ -65,7 +65,7 @@ const INVALID_RELATED_EXERCISES_RESPONSE = {
 const EXERCISE_IN_USE_RESPONSE = {
   code: 'EXERCISE_IN_USE',
   message:
-    'This exercise is referenced by workout templates or sessions. Remove it from all templates first.',
+    'This exercise is referenced by active workout templates or sessions and cannot be deleted.',
 } as const;
 
 const isSqliteForeignKeyConstraintError = (error: unknown): error is { code: string } => {
@@ -322,6 +322,8 @@ export const exerciseRoutes: FastifyPluginAsync = async (app) => {
           EXERCISE_NOT_FOUND_RESPONSE.message,
         );
       }
+
+      reply.header('Cache-Control', 'private, no-cache');
 
       return reply.send({
         data: exercise,

--- a/apps/api/src/routes/exercises/index.ts
+++ b/apps/api/src/routes/exercises/index.ts
@@ -7,7 +7,7 @@ import {
   createExerciseInputSchema,
   exerciseHistoryWithRelatedSchema,
   exerciseLastPerformanceQuerySchema,
-  exerciseLastPerformanceSchema,
+  exerciseLastPerformancesSchema,
   exercisePerformanceHistoryQuerySchema,
   exercisePerformanceHistorySchema,
   exerciseQueryParamsSchema,
@@ -367,14 +367,14 @@ export const exerciseRoutes: FastifyPluginAsync = async (app) => {
         querystring: exerciseLastPerformanceQuerySchema,
         response: {
           200: apiDataResponseSchema(
-            z.union([exerciseLastPerformanceSchema.nullable(), exerciseHistoryWithRelatedSchema]),
+            z.union([exerciseLastPerformancesSchema, exerciseHistoryWithRelatedSchema]),
           ),
           400: badRequestResponseSchema,
           401: apiErrorResponseSchema,
           404: apiErrorResponseSchema,
         },
         tags: ['exercises'],
-        summary: 'Get the latest completed performance for an exercise',
+        summary: 'Get recent completed performances for an exercise',
         security: authSecurity,
       },
     },
@@ -404,11 +404,11 @@ export const exerciseRoutes: FastifyPluginAsync = async (app) => {
         });
       }
 
-      const lastPerformance =
-        (await findExerciseLastPerformance({
-          exerciseId: request.params.id,
-          userId: request.userId,
-        })) ?? null;
+      const lastPerformance = await findExerciseLastPerformance({
+        exerciseId: request.params.id,
+        limit: request.query.limit,
+        userId: request.userId,
+      });
 
       return reply.send({
         data: lastPerformance,

--- a/apps/api/src/routes/exercises/index.ts
+++ b/apps/api/src/routes/exercises/index.ts
@@ -502,7 +502,10 @@ export const exerciseRoutes: FastifyPluginAsync = async (app) => {
         return reply;
       }
 
-      const inUse = await isExerciseInUse(request.params.id);
+      const inUse = await isExerciseInUse({
+        exerciseId: request.params.id,
+        userId: request.userId,
+      });
       if (inUse) {
         return sendError(
           reply,

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -5,6 +5,7 @@ import type {
   ExerciseCategory,
   ExerciseHistoryWithRelated,
   ExerciseLastPerformance,
+  ExerciseLastPerformances,
   ExercisePerformanceHistory,
   ExerciseTrackingType,
   RelatedExerciseLastPerformance,
@@ -572,71 +573,91 @@ export const findExerciseDedupCandidates = async ({
 
 export const findExerciseLastPerformance = async ({
   exerciseId,
+  limit,
   userId,
 }: {
   exerciseId: string;
+  limit: number;
   userId: string;
-}): Promise<ExerciseLastPerformance | undefined> => {
+}): Promise<ExerciseLastPerformances> => {
   const { db } = await import('../../db/index.js');
 
-  const latestSession = db
+  const recentSessions = await db
     .select({
-      id: workoutSessions.id,
+      sessionId: workoutSessions.id,
       date: workoutSessions.date,
+      completedAt: workoutSessions.completedAt,
+      startedAt: workoutSessions.startedAt,
+      createdAt: workoutSessions.createdAt,
     })
-    .from(workoutSessions)
+    .from(sessionSets)
+    .innerJoin(workoutSessions, eq(workoutSessions.id, sessionSets.sessionId))
     .where(
       and(
         eq(workoutSessions.userId, userId),
         isNull(workoutSessions.deletedAt),
         eq(workoutSessions.status, 'completed'),
-        sql`exists (
-          select 1
-          from ${sessionSets}
-          where ${sessionSets.sessionId} = ${workoutSessions.id}
-            and ${sessionSets.exerciseId} = ${exerciseId}
-        )`,
+        eq(sessionSets.exerciseId, exerciseId),
       ),
+    )
+    .groupBy(
+      workoutSessions.id,
+      workoutSessions.date,
+      workoutSessions.completedAt,
+      workoutSessions.startedAt,
+      workoutSessions.createdAt,
     )
     .orderBy(
       desc(workoutSessions.completedAt),
       desc(workoutSessions.startedAt),
       desc(workoutSessions.createdAt),
     )
-    .limit(1)
-    .as('latest_session');
+    .limit(limit)
+    .all();
 
-  const latestSets = db
+  if (recentSessions.length === 0) {
+    return [];
+  }
+
+  const sessionIds = recentSessions.map((session) => session.sessionId);
+  const recentSets = await db
     .select({
-      sessionId: latestSession.id,
-      date: latestSession.date,
+      sessionId: sessionSets.sessionId,
       setNumber: sessionSets.setNumber,
       weight: sessionSets.weight,
       reps: sessionSets.reps,
+      createdAt: sessionSets.createdAt,
     })
-    .from(latestSession)
-    .innerJoin(
-      sessionSets,
-      and(eq(sessionSets.sessionId, latestSession.id), eq(sessionSets.exerciseId, exerciseId)),
-    )
-    .orderBy(asc(sessionSets.setNumber), asc(sessionSets.createdAt))
+    .from(sessionSets)
+    .where(and(inArray(sessionSets.sessionId, sessionIds), eq(sessionSets.exerciseId, exerciseId)))
+    .orderBy(asc(sessionSets.sessionId), asc(sessionSets.setNumber), asc(sessionSets.createdAt))
     .all();
 
-  if (latestSets.length === 0) {
-    return undefined;
-  }
-
-  const [{ sessionId, date }] = latestSets;
-
-  return {
-    sessionId,
-    date,
-    sets: latestSets.map((set) => ({
+  const setsBySessionId = new Map<string, ExerciseLastPerformance['sets']>();
+  for (const set of recentSets) {
+    const currentSets = setsBySessionId.get(set.sessionId) ?? [];
+    currentSets.push({
       setNumber: set.setNumber,
       weight: set.weight,
       reps: set.reps,
-    })),
-  };
+    });
+    setsBySessionId.set(set.sessionId, currentSets);
+  }
+
+  return recentSessions.flatMap((session) => {
+    const sets = setsBySessionId.get(session.sessionId);
+    if (!sets || sets.length === 0) {
+      return [];
+    }
+
+    return [
+      {
+        sessionId: session.sessionId,
+        date: session.date,
+        sets,
+      },
+    ];
+  });
 };
 
 export const findExercisePerformanceHistory = async ({

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -311,6 +311,29 @@ export const deleteOwnedExercise = async (id: string, userId: string): Promise<b
   return result.changes === 1;
 };
 
+export const isExerciseInUse = async (exerciseId: string): Promise<boolean> => {
+  const { db } = await import('../../db/index.js');
+
+  const templateReference = db
+    .select({ id: templateExercises.id })
+    .from(templateExercises)
+    .where(eq(templateExercises.exerciseId, exerciseId))
+    .limit(1)
+    .get();
+  if (templateReference) {
+    return true;
+  }
+
+  const sessionReference = db
+    .select({ id: sessionSets.id })
+    .from(sessionSets)
+    .where(eq(sessionSets.exerciseId, exerciseId))
+    .limit(1)
+    .get();
+
+  return Boolean(sessionReference);
+};
+
 export const findVisibleExerciseById = async ({
   id,
   userId,

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -320,35 +320,39 @@ export const isExerciseInUse = async ({
 }): Promise<boolean> => {
   const { db } = await import('../../db/index.js');
 
-  const result = db
-    .select({
-      inUse: sql<number>`(
-        exists (
-          select 1
-          from template_exercises
-          inner join workout_templates
-            on workout_templates.id = template_exercises.template_id
-          where template_exercises.exercise_id = ${exerciseId}
-            and workout_templates.user_id = ${userId}
-            and workout_templates.deleted_at is null
-        )
-        or exists (
-          select 1
-          from session_sets
-          inner join workout_sessions
-            on workout_sessions.id = session_sets.session_id
-          where session_sets.exercise_id = ${exerciseId}
-            and workout_sessions.user_id = ${userId}
-            and workout_sessions.deleted_at is null
-        )
-      )`,
-    })
-    .from(exercises)
-    .where(eq(exercises.id, exerciseId))
+  const templateReference = db
+    .select({ id: templateExercises.id })
+    .from(templateExercises)
+    .innerJoin(workoutTemplates, eq(workoutTemplates.id, templateExercises.templateId))
+    .where(
+      and(
+        eq(templateExercises.exerciseId, exerciseId),
+        eq(workoutTemplates.userId, userId),
+        isNull(workoutTemplates.deletedAt),
+      ),
+    )
     .limit(1)
     .get();
 
-  return Boolean(result?.inUse);
+  if (templateReference) {
+    return true;
+  }
+
+  const sessionReference = db
+    .select({ id: sessionSets.id })
+    .from(sessionSets)
+    .innerJoin(workoutSessions, eq(workoutSessions.id, sessionSets.sessionId))
+    .where(
+      and(
+        eq(sessionSets.exerciseId, exerciseId),
+        eq(workoutSessions.userId, userId),
+        isNull(workoutSessions.deletedAt),
+      ),
+    )
+    .limit(1)
+    .get();
+
+  return Boolean(sessionReference);
 };
 
 export const findVisibleExerciseById = async ({

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -120,6 +120,15 @@ const buildListWhereClause = ({
     category ? eq(exercises.category, category) : undefined,
   );
 
+const buildVisibleByIdWhereClause = ({ id, userId }: { id: string; userId: string }) =>
+  and(
+    eq(exercises.id, id),
+    or(
+      and(isNull(exercises.userId), isNull(exercises.deletedAt)),
+      and(eq(exercises.userId, userId), isNull(exercises.deletedAt)),
+    ),
+  );
+
 export const createExercise = async ({
   id,
   userId,
@@ -317,15 +326,24 @@ export const findVisibleExerciseById = async ({
       relatedExerciseIds: exercises.relatedExerciseIds,
     })
     .from(exercises)
-    .where(
-      and(
-        eq(exercises.id, id),
-        or(
-          isNull(exercises.userId),
-          and(eq(exercises.userId, userId), isNull(exercises.deletedAt)),
-        ),
-      ),
-    )
+    .where(buildVisibleByIdWhereClause({ id, userId }))
+    .limit(1)
+    .get();
+};
+
+export const findVisibleExerciseDetailsById = async ({
+  id,
+  userId,
+}: {
+  id: string;
+  userId: string;
+}): Promise<Exercise | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  return db
+    .select(exerciseSelection)
+    .from(exercises)
+    .where(buildVisibleByIdWhereClause({ id, userId }))
     .limit(1)
     .get();
 };
@@ -777,7 +795,9 @@ const findExercisesLastPerformanceById = async ({
     }
   }
 
-  const latestSessionIds = [...new Set([...latestSessionByExerciseId.values()].map((row) => row.sessionId))];
+  const latestSessionIds = [
+    ...new Set([...latestSessionByExerciseId.values()].map((row) => row.sessionId)),
+  ];
   if (latestSessionIds.length === 0) {
     return new Map();
   }
@@ -914,12 +934,14 @@ export const findExerciseHistoryWithRelated = async ({
   });
 
   const history = historiesByExerciseId.get(exerciseId) ?? null;
-  const relatedHistory: RelatedExerciseLastPerformance[] = orderedRelated.map((relatedExercise) => ({
-    exerciseId: relatedExercise.id,
-    exerciseName: relatedExercise.name,
-    trackingType: relatedExercise.trackingType,
-    history: historiesByExerciseId.get(relatedExercise.id) ?? null,
-  }));
+  const relatedHistory: RelatedExerciseLastPerformance[] = orderedRelated.map(
+    (relatedExercise) => ({
+      exerciseId: relatedExercise.id,
+      exerciseName: relatedExercise.name,
+      trackingType: relatedExercise.trackingType,
+      history: historiesByExerciseId.get(relatedExercise.id) ?? null,
+    }),
+  );
 
   return {
     history,

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -311,27 +311,44 @@ export const deleteOwnedExercise = async (id: string, userId: string): Promise<b
   return result.changes === 1;
 };
 
-export const isExerciseInUse = async (exerciseId: string): Promise<boolean> => {
+export const isExerciseInUse = async ({
+  exerciseId,
+  userId,
+}: {
+  exerciseId: string;
+  userId: string;
+}): Promise<boolean> => {
   const { db } = await import('../../db/index.js');
 
-  const templateReference = db
-    .select({ id: templateExercises.id })
-    .from(templateExercises)
-    .where(eq(templateExercises.exerciseId, exerciseId))
+  const result = db
+    .select({
+      inUse: sql<number>`(
+        exists (
+          select 1
+          from template_exercises
+          inner join workout_templates
+            on workout_templates.id = template_exercises.template_id
+          where template_exercises.exercise_id = ${exerciseId}
+            and workout_templates.user_id = ${userId}
+            and workout_templates.deleted_at is null
+        )
+        or exists (
+          select 1
+          from session_sets
+          inner join workout_sessions
+            on workout_sessions.id = session_sets.session_id
+          where session_sets.exercise_id = ${exerciseId}
+            and workout_sessions.user_id = ${userId}
+            and workout_sessions.deleted_at is null
+        )
+      )`,
+    })
+    .from(exercises)
+    .where(eq(exercises.id, exerciseId))
     .limit(1)
     .get();
-  if (templateReference) {
-    return true;
-  }
 
-  const sessionReference = db
-    .select({ id: sessionSets.id })
-    .from(sessionSets)
-    .where(eq(sessionSets.exerciseId, exerciseId))
-    .limit(1)
-    .get();
-
-  return Boolean(sessionReference);
+  return Boolean(result?.inUse);
 };
 
 export const findVisibleExerciseById = async ({

--- a/apps/api/src/routes/foods/store.ts
+++ b/apps/api/src/routes/foods/store.ts
@@ -594,7 +594,7 @@ export const reconcileFoodUsage = async (
         continue;
       }
 
-      if (usageChanged) {
+      if (usageChanged || lastUsedAtChanged) {
         updated += 1;
       }
 

--- a/apps/api/src/routes/foods/store.ts
+++ b/apps/api/src/routes/foods/store.ts
@@ -530,11 +530,87 @@ export const trackFoodUsage = async (
 export const decrementFoodUsage = async (foodId: string, userId: string): Promise<void> => {
   const { db } = await import('../../db/index.js');
 
-  db
-    .update(foods)
+  db.update(foods)
     .set({
       usageCount: sql`case when usage_count > 0 then usage_count - 1 else 0 end`,
     })
     .where(and(eq(foods.id, foodId), eq(foods.userId, userId)))
     .run();
+};
+
+export const reconcileFoodUsage = async (
+  userId: string,
+): Promise<{ reconciled: number; updated: number }> => {
+  const { db } = await import('../../db/index.js');
+
+  return db.transaction((tx) => {
+    const foodsForUser = tx
+      .select({
+        id: foods.id,
+        usageCount: foods.usageCount,
+        lastUsedAt: foods.lastUsedAt,
+      })
+      .from(foods)
+      .where(and(eq(foods.userId, userId), isNull(foods.deletedAt)))
+      .all();
+
+    if (foodsForUser.length === 0) {
+      return { reconciled: 0, updated: 0 };
+    }
+
+    const usageRows = tx
+      .select({
+        foodId: mealItems.foodId,
+        usageCount: sql<number>`cast(count(*) as integer)`,
+        lastUsedAt: sql<number | null>`max(${mealItems.createdAt})`,
+      })
+      .from(mealItems)
+      .innerJoin(foods, eq(foods.id, mealItems.foodId))
+      .where(and(eq(foods.userId, userId), isNull(foods.deletedAt)))
+      .groupBy(mealItems.foodId)
+      .all();
+
+    const usageByFoodId = new Map<string, { usageCount: number; lastUsedAt: number | null }>();
+    for (const row of usageRows) {
+      if (typeof row.foodId !== 'string') {
+        continue;
+      }
+
+      usageByFoodId.set(row.foodId, {
+        usageCount: Number(row.usageCount ?? 0),
+        lastUsedAt: row.lastUsedAt === null ? null : Number(row.lastUsedAt),
+      });
+    }
+
+    let updated = 0;
+    const now = Date.now();
+
+    for (const food of foodsForUser) {
+      const nextUsage = usageByFoodId.get(food.id) ?? { usageCount: 0, lastUsedAt: null };
+      const usageChanged = food.usageCount !== nextUsage.usageCount;
+      const lastUsedAtChanged = food.lastUsedAt !== nextUsage.lastUsedAt;
+
+      if (!usageChanged && !lastUsedAtChanged) {
+        continue;
+      }
+
+      if (usageChanged) {
+        updated += 1;
+      }
+
+      tx.update(foods)
+        .set({
+          usageCount: nextUsage.usageCount,
+          lastUsedAt: nextUsage.lastUsedAt,
+          updatedAt: now,
+        })
+        .where(and(eq(foods.id, food.id), eq(foods.userId, userId), isNull(foods.deletedAt)))
+        .run();
+    }
+
+    return {
+      reconciled: foodsForUser.length,
+      updated,
+    };
+  });
 };

--- a/apps/api/src/routes/v1/index.ts
+++ b/apps/api/src/routes/v1/index.ts
@@ -3,8 +3,9 @@ import type { FastifyPluginAsync } from 'fastify';
 import { type ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 
-import { requireAuth } from '../../middleware/auth.js';
-import { apiErrorResponseSchema, authSecurity } from '../../openapi.js';
+import { requireAuth, requireJwtOnly } from '../../middleware/auth.js';
+import { apiErrorResponseSchema, authSecurity, jwtSecurity } from '../../openapi.js';
+import { reconcileFoodUsage } from '../foods/store.js';
 import { usersRoutes } from '../users/index.js';
 
 import { contextRoutes } from './context.js';
@@ -12,6 +13,11 @@ import { dashboardRoutes } from './dashboard.js';
 
 const pingResponseSchema = z.object({
   userId: z.string(),
+});
+
+const reconcileFoodUsageResponseSchema = z.object({
+  reconciled: z.number().int().nonnegative(),
+  updated: z.number().int().nonnegative(),
 });
 
 export const v1Routes: FastifyPluginAsync = async (app) => {
@@ -36,6 +42,27 @@ export const v1Routes: FastifyPluginAsync = async (app) => {
         userId: request.userId,
       },
     }),
+  );
+
+  typedApp.post(
+    '/admin/reconcile-food-usage',
+    {
+      onRequest: [requireAuth, requireJwtOnly],
+      schema: {
+        response: {
+          200: apiDataResponseSchema(reconcileFoodUsageResponseSchema),
+          401: apiErrorResponseSchema,
+          403: apiErrorResponseSchema,
+        },
+        tags: ['admin'],
+        summary: 'Reconcile food usage metadata from meal item references',
+        security: jwtSecurity,
+      },
+    },
+    async (request, reply) => {
+      const result = await reconcileFoodUsage(request.userId);
+      return reply.send({ data: result });
+    },
   );
 
   app.register(contextRoutes, { prefix: '/context' });

--- a/apps/web/e2e/habits.spec.ts
+++ b/apps/web/e2e/habits.spec.ts
@@ -1,7 +1,7 @@
 import { expect, request, test, type Page } from '@playwright/test';
+import { apiBaseURL } from './test-env';
 
 const authTokenStorageKey = 'pulse-auth-token';
-const apiBaseURL = process.env.API_BASE_URL ?? 'http://127.0.0.1:3001';
 
 const testUsername = `habits-e2e-${Date.now()}`;
 const testPassword = 'super-secret-password';
@@ -48,9 +48,9 @@ test.describe.serial('habits flow', () => {
 
   test('creates a boolean habit from settings', async ({ page }) => {
     await authenticatePage(page);
-    await page.goto('/settings');
+    await page.goto('/habits');
 
-    await page.getByRole('button', { name: 'Add habit' }).first().click();
+    await page.getByRole('button', { name: 'Add Habit' }).first().click();
     await page.getByLabel('Habit name').fill('Meditate');
     await page.getByLabel('Tracking type').selectOption('boolean');
     await page.getByRole('button', { exact: true, name: 'Save' }).click();
@@ -72,15 +72,15 @@ test.describe.serial('habits flow', () => {
     await expect(reloadedMeditateCheckbox).toHaveAttribute('data-state', 'checked');
 
     await page.goto('/');
-    await expect(page.getByText(/[1-9]\d* \/ \d+ complete/)).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: 'Dashboard' })).toBeVisible();
     await expect(page.getByLabel(/Meditate \d{4}-\d{2}-\d{2} Completed/)).toBeVisible();
   });
 
   test('creates and tracks a numeric habit', async ({ page }) => {
     await authenticatePage(page);
-    await page.goto('/settings');
+    await page.goto('/habits');
 
-    await page.getByRole('button', { name: 'Add habit' }).first().click();
+    await page.getByRole('button', { name: 'Add Habit' }).first().click();
     await page.getByLabel('Habit name').fill('Water (glasses)');
     await page.getByLabel('Tracking type').selectOption('numeric');
     await page.getByLabel('Target').fill('8');
@@ -96,7 +96,7 @@ test.describe.serial('habits flow', () => {
     await waterInput.fill('6');
     await waterInput.blur();
 
-    await expect(page.getByText('6 / 8 glasses', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('6 glasses / 8 glasses', { exact: true }).first()).toBeVisible();
     await expect(page.getByText('75%', { exact: true }).first()).toBeVisible();
   });
 });

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -1,7 +1,7 @@
 import { expect, request, test, type Page } from '@playwright/test';
+import { apiBaseURL } from './test-env';
 
 const authTokenStorageKey = 'pulse-auth-token';
-const apiBaseURL = process.env.API_BASE_URL ?? 'http://127.0.0.1:3001';
 const testUsername = `smoke-e2e-${Date.now()}`;
 const testPassword = 'super-secret-password';
 

--- a/apps/web/e2e/test-env.ts
+++ b/apps/web/e2e/test-env.ts
@@ -1,0 +1,3 @@
+const apiPort = process.env.API_PORT ?? process.env.VITE_API_PORT ?? process.env.PORT ?? '3101';
+
+export const apiBaseURL = process.env.API_BASE_URL ?? `http://127.0.0.1:${apiPort}`;

--- a/apps/web/e2e/workout-scheduling.spec.ts
+++ b/apps/web/e2e/workout-scheduling.spec.ts
@@ -1,7 +1,7 @@
 import { expect, request, test, type APIRequestContext, type Page } from '@playwright/test';
+import { apiBaseURL } from './test-env';
 
 const authTokenStorageKey = 'pulse-auth-token';
-const apiBaseURL = process.env.API_BASE_URL ?? 'http://127.0.0.1:3001';
 const seedSuffix = Date.now();
 
 const testUser = {
@@ -232,8 +232,9 @@ test.describe.serial('workout scheduling flow', () => {
     const scheduledCard = getScheduledCard(page);
     await expect(scheduledCard).toBeVisible();
 
-    await scheduledCard.getByRole('button', { name: 'Remove from schedule' }).click();
-    await page.getByRole('button', { name: 'Remove' }).click();
+    await scheduledCard.getByRole('button', { name: 'Reschedule' }).click();
+    await page.getByRole('dialog').getByRole('button', { name: 'Remove from schedule' }).click();
+    await page.getByRole('button', { name: 'Remove', exact: true }).click();
     await expect(getScheduledCard(page)).toHaveCount(0);
 
     const apiContext = await createAuthorizedApiContext();
@@ -246,7 +247,7 @@ test.describe.serial('workout scheduling flow', () => {
     }
   });
 
-  test('starts now from a scheduled workout and links schedule to session', async ({ page }) => {
+  test('starts a scheduled workout and removes it from the schedule list', async ({ page }) => {
     test.setTimeout(90_000);
 
     const today = toDateKey(new Date());
@@ -260,7 +261,7 @@ test.describe.serial('workout scheduling flow', () => {
     await page.getByRole('button', { exact: true, name: 'List' }).click();
     const startCard = getScheduledCard(page);
     await expect(startCard).toBeVisible();
-    await startCard.getByRole('button', { name: 'Start now' }).click();
+    await startCard.getByRole('button', { name: 'Start' }).click();
     await expect(page).toHaveURL(/\/workouts\/active\?/);
 
     const sessionId = new URL(page.url()).searchParams.get('sessionId');
@@ -272,7 +273,7 @@ test.describe.serial('workout scheduling flow', () => {
       const linkedRow = postStartRows.find(
         (row) => row.templateId === seededTemplateId && row.date === today,
       );
-      expect(linkedRow?.sessionId).toBe(sessionId);
+      expect(linkedRow).toBeUndefined();
     } finally {
       await apiContext.dispose();
     }

--- a/apps/web/e2e/workout-scheduling.spec.ts
+++ b/apps/web/e2e/workout-scheduling.spec.ts
@@ -177,7 +177,9 @@ test.describe.serial('workout scheduling flow', () => {
     }
   });
 
-  test('schedules a workout from template actions and renders in calendar/list', async ({ page }) => {
+  test('schedules a workout from template actions and renders in calendar/list', async ({
+    page,
+  }) => {
     test.setTimeout(90_000);
 
     await authenticatePage(page);
@@ -210,11 +212,19 @@ test.describe.serial('workout scheduling flow', () => {
 
     const apiContext = await createAuthorizedApiContext();
     try {
-      const scheduledRows = await fetchScheduledWorkouts(apiContext, range.from, range.to);
-      const targetSchedule = scheduledRows.find(
-        (row) => row.templateId === seededTemplateId && row.date === secondDate,
-      );
-      expect(targetSchedule).toBeTruthy();
+      await expect
+        .poll(
+          async () => {
+            const scheduledRows = await fetchScheduledWorkouts(apiContext, range.from, range.to);
+            return scheduledRows.some(
+              (row) => row.templateId === seededTemplateId && row.date === secondDate,
+            );
+          },
+          {
+            timeout: 15_000,
+          },
+        )
+        .toBeTruthy();
     } finally {
       await apiContext.dispose();
     }

--- a/apps/web/e2e/workout-session.spec.ts
+++ b/apps/web/e2e/workout-session.spec.ts
@@ -1,7 +1,7 @@
 import { expect, request, test, type Page } from '@playwright/test';
+import { apiBaseURL } from './test-env';
 
 const authTokenStorageKey = 'pulse-auth-token';
-const apiBaseURL = process.env.API_BASE_URL ?? 'http://127.0.0.1:3001';
 const seedSuffix = Date.now();
 
 const testUser = {
@@ -83,7 +83,7 @@ async function ensureSectionIsExpanded(page: Page, sectionName: 'Warmup' | 'Main
 }
 
 async function ensureAllExercisePanelsExpanded(page: Page) {
-  const exerciseButtons = page.locator('button[aria-controls^="exercise-panel-"]');
+  const exerciseButtons = page.locator('button[aria-controls^="exercise-panel-"]:visible');
   const exerciseButtonCount = await exerciseButtons.count();
 
   for (let index = 0; index < exerciseButtonCount; index += 1) {
@@ -220,7 +220,7 @@ test.describe.serial('workout session flow', () => {
     await authenticatePage(page);
     await page.goto('/workouts');
 
-    await page.getByRole('button', { name: 'Templates' }).click();
+    await page.getByRole('button', { exact: true, name: 'Templates' }).click();
     await page.getByRole('link', { name: seededTemplate.name }).click();
 
     await expect(page.getByRole('heading', { level: 1, name: seededTemplate.name })).toBeVisible();
@@ -231,6 +231,7 @@ test.describe.serial('workout session flow', () => {
     await ensureSectionIsExpanded(page, 'Warmup');
     await ensureSectionIsExpanded(page, 'Main');
     await ensureSectionIsExpanded(page, 'Cooldown');
+    await ensureAllExercisePanelsExpanded(page);
 
     await expect(page.getByRole('heading', { level: 3 }).first()).toBeVisible();
 
@@ -239,24 +240,6 @@ test.describe.serial('workout session flow', () => {
     await page.waitForTimeout(1200);
     const elapsedNext = await elapsedTimeText.innerText();
     expect(toElapsedSeconds(elapsedNext)).toBeGreaterThan(toElapsedSeconds(elapsedStart));
-
-    const firstSetWeight = page.getByLabel('Weight for set 1').first();
-    const firstSetReps = page.getByLabel('Reps for set 1').first();
-    const firstSetComplete = page.getByLabel('Complete set 1').first();
-
-    await firstSetWeight.fill('135');
-    await firstSetReps.fill('10');
-    await firstSetComplete.check();
-    await expect(firstSetComplete).toBeChecked();
-
-    const secondSetWeight = page.getByLabel('Weight for set 2').first();
-    const secondSetReps = page.getByLabel('Reps for set 2').first();
-    const secondSetComplete = page.getByLabel('Complete set 2').first();
-
-    await secondSetWeight.fill('140');
-    await secondSetReps.fill('8');
-    await secondSetComplete.check();
-    await expect(secondSetComplete).toBeChecked();
 
     await ensureAllExercisePanelsExpanded(page);
     const feedbackHeading = page.getByRole('heading', { name: 'How did this session feel?' });
@@ -288,9 +271,32 @@ test.describe.serial('workout session flow', () => {
       }
     }
 
+    await page.getByRole('button', { name: 'Complete Workout' }).click();
+    await page.getByRole('button', { name: 'Complete', exact: true }).click();
     await expect(feedbackHeading).toBeVisible({ timeout: 15_000 });
 
-    await page.getByRole('button', { name: 'Finalize session' }).click();
+    await page
+      .getByRole('group', { name: 'Session RPE rating' })
+      .getByRole('button', { name: '8', exact: true })
+      .click();
+    await page
+      .getByRole('group', { name: 'Shoulder feel rating' })
+      .getByRole('button', { name: '4', exact: true })
+      .click();
+    await page
+      .getByRole('group', { name: 'Energy post workout options' })
+      .getByRole('button')
+      .nth(3)
+      .click();
+    await page
+      .getByRole('group', { name: 'Any pain or discomfort? response' })
+      .getByRole('button')
+      .nth(1)
+      .click();
+
+    const finalizeButton = page.getByRole('button', { name: 'Finalize session' });
+    await expect(finalizeButton).toBeEnabled({ timeout: 15_000 });
+    await finalizeButton.click();
     await expect(page.getByRole('heading', { name: 'Workout summary' })).toBeVisible();
     await expect(page.getByText('Duration')).toBeVisible();
 
@@ -366,13 +372,7 @@ test.describe.serial('workout session flow', () => {
     test.setTimeout(60_000);
 
     await authenticatePage(page);
-    await page.goto('/workouts');
-
-    await page.getByRole('button', { name: 'Templates' }).click();
-    await page.getByRole('link', { name: seededTemplate.name }).first().click();
-    await expect(page.getByRole('heading', { level: 1, name: seededTemplate.name })).toBeVisible();
-
-    await page.getByRole('button', { name: 'Start Workout' }).click();
+    await page.goto(`/workouts/active?template=${seededTemplateId}`);
     await expect(page).toHaveURL(/\/workouts\/active\?/);
 
     await ensureSectionIsExpanded(page, 'Warmup');
@@ -386,8 +386,8 @@ test.describe.serial('workout session flow', () => {
     await expect(benchHeading).toBeVisible();
     const benchCard = benchHeading.locator('xpath=ancestor::*[@data-slot="card"][1]');
 
-    await benchCard.getByLabel('Weight for set 1').fill('135');
-    await benchCard.getByLabel('Reps for set 1').fill('8');
+    await benchCard.locator('input[aria-label="Reps for set 1"]:visible').first().fill('8');
+    await benchCard.getByLabel('Complete set 1').check();
 
     const restTimer = page.getByRole('timer', { name: 'Rest timer' });
     await expect(restTimer).toBeVisible({ timeout: 5_000 });
@@ -395,7 +395,7 @@ test.describe.serial('workout session flow', () => {
     const countdownBeforeInput = toRestTimerSeconds(await restTimer.innerText());
     await page.waitForTimeout(1_200);
 
-    await benchCard.getByLabel('Weight for set 2').fill('140');
+    await benchCard.locator('input[aria-label="Reps for set 2"]:visible').first().fill('6');
     await page.waitForTimeout(400);
 
     await expect(restTimer).toBeVisible();

--- a/apps/web/e2e/workout-session.spec.ts
+++ b/apps/web/e2e/workout-session.spec.ts
@@ -52,6 +52,21 @@ function toElapsedSeconds(value: string) {
   return minutes * 60 + seconds;
 }
 
+function toRestTimerSeconds(timerText: string) {
+  const minuteSecondMatch = timerText.match(/(\d+):(\d{2})/);
+  if (minuteSecondMatch) {
+    const [, minutes, seconds] = minuteSecondMatch;
+    return Number(minutes) * 60 + Number(seconds);
+  }
+
+  const secondsMatch = timerText.match(/(\d+)s/);
+  if (secondsMatch) {
+    return Number(secondsMatch[1]);
+  }
+
+  throw new Error(`Unable to parse rest timer text: ${timerText}`);
+}
+
 async function ensureSectionIsExpanded(page: Page, sectionName: 'Warmup' | 'Main' | 'Cooldown') {
   const sectionButton = page.getByRole('button', { name: new RegExp(sectionName, 'i') }).first();
   const sectionButtonCount = await sectionButton.count();
@@ -345,5 +360,50 @@ test.describe.serial('workout session flow', () => {
     } finally {
       await apiContext.dispose();
     }
+  });
+
+  test('keeps sticky rest timer running while entering data in another set', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    await authenticatePage(page);
+    await page.goto('/workouts');
+
+    await page.getByRole('button', { name: 'Templates' }).click();
+    await page.getByRole('link', { name: seededTemplate.name }).first().click();
+    await expect(page.getByRole('heading', { level: 1, name: seededTemplate.name })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Start Workout' }).click();
+    await expect(page).toHaveURL(/\/workouts\/active\?/);
+
+    await ensureSectionIsExpanded(page, 'Warmup');
+    await ensureSectionIsExpanded(page, 'Main');
+    await ensureAllExercisePanelsExpanded(page);
+
+    const benchHeading = page.getByRole('heading', {
+      level: 3,
+      name: seededExercises[1].name,
+    });
+    await expect(benchHeading).toBeVisible();
+    const benchCard = benchHeading.locator('xpath=ancestor::*[@data-slot="card"][1]');
+
+    await benchCard.getByLabel('Weight for set 1').fill('135');
+    await benchCard.getByLabel('Reps for set 1').fill('8');
+
+    const restTimer = page.getByRole('timer', { name: 'Rest timer' });
+    await expect(restTimer).toBeVisible({ timeout: 5_000 });
+
+    const countdownBeforeInput = toRestTimerSeconds(await restTimer.innerText());
+    await page.waitForTimeout(1_200);
+
+    await benchCard.getByLabel('Weight for set 2').fill('140');
+    await page.waitForTimeout(400);
+
+    await expect(restTimer).toBeVisible();
+    const countdownAfterInput = toRestTimerSeconds(await restTimer.innerText());
+    expect(countdownAfterInput).toBeLessThanOrEqual(countdownBeforeInput);
+
+    await page.waitForTimeout(1_200);
+    const countdownAfterTick = toRestTimerSeconds(await restTimer.innerText());
+    expect(countdownAfterTick).toBeLessThan(countdownAfterInput);
   });
 });

--- a/apps/web/e2e/workout-session.spec.ts
+++ b/apps/web/e2e/workout-session.spec.ts
@@ -379,15 +379,25 @@ test.describe.serial('workout session flow', () => {
     await ensureSectionIsExpanded(page, 'Main');
     await ensureAllExercisePanelsExpanded(page);
 
-    const benchHeading = page.getByRole('heading', {
-      level: 3,
-      name: seededExercises[1].name,
-    });
-    await expect(benchHeading).toBeVisible();
-    const benchCard = benchHeading.locator('xpath=ancestor::*[@data-slot="card"][1]');
+    const benchToggle = page
+      .getByRole('button')
+      .filter({ has: page.getByRole('heading', { level: 3, name: seededExercises[1].name }) })
+      .first();
+    await expect(benchToggle).toBeVisible();
+    if ((await benchToggle.getAttribute('aria-expanded')) !== 'true') {
+      await benchToggle.click();
+    }
 
-    await benchCard.locator('input[aria-label="Reps for set 1"]:visible').first().fill('8');
-    await benchCard.getByLabel('Complete set 1').check();
+    const benchPanelId = await benchToggle.getAttribute('aria-controls');
+    expect(benchPanelId).toBeTruthy();
+    const benchPanel = page.locator(`#${benchPanelId}`);
+    await expect(benchPanel).toBeVisible();
+
+    const benchWeightInputs = benchPanel.locator('input[aria-label^="Weight for set "]:visible');
+    const benchRepsInputs = benchPanel.locator('input[aria-label^="Reps for set "]:visible');
+    await benchWeightInputs.first().fill('135');
+    await benchRepsInputs.first().fill('8');
+    await benchRepsInputs.first().blur();
 
     const restTimer = page.getByRole('timer', { name: 'Rest timer' });
     await expect(restTimer).toBeVisible({ timeout: 5_000 });
@@ -395,7 +405,7 @@ test.describe.serial('workout session flow', () => {
     const countdownBeforeInput = toRestTimerSeconds(await restTimer.innerText());
     await page.waitForTimeout(1_200);
 
-    await benchCard.locator('input[aria-label="Reps for set 2"]:visible').first().fill('6');
+    await benchRepsInputs.nth(1).fill('6');
     await page.waitForTimeout(400);
 
     await expect(restTimer).toBeVisible();

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { defineConfig, devices } from '@playwright/test';
 
-const apiPort = process.env.API_PORT || '3001';
+const apiPort = process.env.API_PORT || process.env.VITE_API_PORT || process.env.PORT || '3101';
 const e2ePort = process.env.E2E_PORT || '4173';
 const baseURL = process.env.BASE_URL || `http://127.0.0.1:${e2ePort}`;
 const apiBaseURL = process.env.API_BASE_URL || `http://127.0.0.1:${apiPort}`;
@@ -24,13 +24,13 @@ export default defineConfig({
   ],
   webServer: [
     {
-      command: `DATABASE_URL=${e2eDatabasePath} pnpm --filter api dev`,
+      command: `PORT=${apiPort} DATABASE_URL=${e2eDatabasePath} pnpm --filter api dev`,
       cwd: path.resolve(__dirname, '../..'),
       reuseExistingServer: !process.env.CI,
       url: `${apiBaseURL}/health`,
     },
     {
-      command: `pnpm dev --host 127.0.0.1 --port ${e2ePort}`,
+      command: `VITE_API_PORT=${apiPort} pnpm dev --host 127.0.0.1 --port ${e2ePort}`,
       cwd: __dirname,
       reuseExistingServer: !process.env.CI,
       url: baseURL,

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -41,7 +41,7 @@ import {
 import { toast } from 'sonner';
 import { z } from 'zod';
 
-import { apiRequest, apiRequestWithMeta } from '@/lib/api-client';
+import { ApiError, apiRequest, apiRequestWithMeta } from '@/lib/api-client';
 import { createOptimisticMutation } from '@/lib/optimistic';
 import { crossFeatureInvalidationMap, invalidateQueryKeys } from '@/lib/query-invalidation';
 
@@ -590,14 +590,22 @@ async function getExercises(params: ExerciseQueryParams) {
   return exercisesResponseSchema.parse(payload);
 }
 
-async function getExercise(id: string, signal?: AbortSignal) {
-  const data = await apiRequest<unknown>(`/api/v1/exercises/${id}`, {
-    method: 'GET',
-    signal,
-  });
-  const payload = z.object({ data: exerciseSchema }).parse({ data });
+async function getExercise(id: string, signal?: AbortSignal): Promise<Exercise | null> {
+  try {
+    const data = await apiRequest<unknown>(`/api/v1/exercises/${id}`, {
+      method: 'GET',
+      signal,
+    });
+    const payload = z.object({ data: exerciseSchema }).parse({ data });
 
-  return payload.data;
+    return payload.data;
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      return null;
+    }
+
+    throw error;
+  }
 }
 
 async function getExerciseFilters() {
@@ -860,7 +868,7 @@ export function useExercises(params: ExerciseQueryParams, options?: { enabled?: 
 }
 
 export function useExercise(id: string, options?: { enabled?: boolean }) {
-  return useQuery<Exercise>({
+  return useQuery<Exercise | null>({
     enabled: (options?.enabled ?? true) && id.trim().length > 0,
     queryFn: ({ signal }) => getExercise(id, signal),
     queryKey: workoutQueryKeys.exercise(id),

--- a/apps/web/src/features/workouts/components/exercise-history-modal.tsx
+++ b/apps/web/src/features/workouts/components/exercise-history-modal.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/ui/dialog';
 import { useExerciseHistory } from '@/hooks/use-exercise-history';
 
-import { formatSetSummary } from '../lib/tracking';
+import { formatCompactSets } from '../lib/tracking';
 
 const historyDateFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'short',
@@ -36,7 +36,6 @@ export function ExerciseHistoryModal({
   onOpenChange,
   open,
   trackingType,
-  weightUnit = 'lbs',
 }: ExerciseHistoryModalProps) {
   const historyQuery = useExerciseHistory(exerciseId, {
     enabled: open,
@@ -61,21 +60,17 @@ export function ExerciseHistoryModal({
           ) : null}
 
           {historyQuery.data?.map((session) => {
-            const setSummary = session.sets
-              .map((set) =>
-                formatSetSummary(
-                  trackingType === 'distance'
-                    ? { distance: set.reps, weight: set.weight }
-                    : { reps: set.reps, weight: set.weight },
-                  trackingType,
-                  {
-                    compact: true,
-                    useLegacySecondsFallback: trackingType !== 'reps_seconds',
-                    weightUnit,
-                  },
-                ),
-              )
-              .join(', ');
+            const setSummary = formatCompactSets(
+              session.sets.map((set) =>
+                trackingType === 'distance'
+                  ? { distance: set.reps, weight: set.weight }
+                  : { reps: set.reps, weight: set.weight },
+              ),
+              trackingType,
+              {
+                useLegacySecondsFallback: trackingType !== 'reps_seconds',
+              },
+            );
 
             return (
               <div
@@ -83,7 +78,7 @@ export function ExerciseHistoryModal({
                 key={session.sessionId}
               >
                 <p className="text-sm font-semibold text-foreground">
-                  {`${historyDateFormatter.format(new Date(`${session.date}T12:00:00`))} - ${setSummary}`}
+                  {`${historyDateFormatter.format(new Date(`${session.date}T12:00:00`))} · ${setSummary}`}
                 </p>
                 {session.notes?.trim() ? (
                   <p className="mt-1 text-xs text-muted">{`Notes: ${session.notes.trim()}`}</p>

--- a/apps/web/src/features/workouts/components/exercise-history-modal.tsx
+++ b/apps/web/src/features/workouts/components/exercise-history-modal.tsx
@@ -36,6 +36,7 @@ export function ExerciseHistoryModal({
   onOpenChange,
   open,
   trackingType,
+  weightUnit = 'lbs',
 }: ExerciseHistoryModalProps) {
   const historyQuery = useExerciseHistory(exerciseId, {
     enabled: open,
@@ -69,6 +70,7 @@ export function ExerciseHistoryModal({
               trackingType,
               {
                 useLegacySecondsFallback: trackingType !== 'reps_seconds',
+                weightUnit,
               },
             );
 

--- a/apps/web/src/features/workouts/components/exercise-library.test.tsx
+++ b/apps/web/src/features/workouts/components/exercise-library.test.tsx
@@ -327,6 +327,31 @@ describe('ExerciseLibrary', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('opens the trend dialog from the exercise name button in table view', async () => {
+    mockExerciseRequests();
+
+    renderExerciseLibrary();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Table view' }));
+    await screen.findByRole('table', { name: 'Exercise library table view' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Air Bike' }));
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Air Bike trends')).toBeInTheDocument();
+  });
+
+  it('does not write the initial view preference to localStorage on mount', async () => {
+    mockExerciseRequests();
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+
+    renderExerciseLibrary();
+    await screen.findByRole('heading', { level: 3, name: 'Air Bike' });
+
+    expect(setItemSpy).not.toHaveBeenCalledWith(EXERCISE_LIBRARY_VIEW_STORAGE_KEY, 'card');
+    expect(setItemSpy).not.toHaveBeenCalledWith(EXERCISE_LIBRARY_VIEW_STORAGE_KEY, 'table');
+  });
+
   it('persists the selected view in localStorage', async () => {
     mockExerciseRequests();
 

--- a/apps/web/src/features/workouts/components/exercise-library.test.tsx
+++ b/apps/web/src/features/workouts/components/exercise-library.test.tsx
@@ -9,6 +9,8 @@ import { jsonResponse } from '@/test/test-utils';
 
 import { ExerciseLibrary } from './exercise-library';
 
+const EXERCISE_LIBRARY_VIEW_STORAGE_KEY = 'exercise-library-view';
+
 vi.mock('@/components/ui/dropdown-menu', () => ({
   DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -50,7 +52,7 @@ vi.mock('recharts', async () => {
   };
 });
 
-const exerciseFixtures = [
+const baseExerciseFixtures = [
   {
     id: 'air-bike',
     userId: null,
@@ -58,6 +60,7 @@ const exerciseFixtures = [
     muscleGroups: ['conditioning'],
     equipment: 'bike',
     category: 'cardio',
+    trackingType: 'cardio',
     tags: ['conditioning', 'intervals'],
     instructions: null,
     createdAt: 1,
@@ -70,6 +73,7 @@ const exerciseFixtures = [
     muscleGroups: ['rear delts', 'rotator cuff'],
     equipment: 'resistance band',
     category: 'mobility',
+    trackingType: 'weight_reps',
     tags: ['prehab'],
     instructions: 'Keep your elbow pinned and move slowly.',
     createdAt: 1,
@@ -82,6 +86,7 @@ const exerciseFixtures = [
     muscleGroups: ['chest', 'triceps'],
     equipment: 'barbell',
     category: 'compound',
+    trackingType: 'weight_reps',
     tags: ['pressing'],
     instructions: null,
     createdAt: 1,
@@ -94,6 +99,7 @@ const exerciseFixtures = [
     muscleGroups: ['lats', 'upper back'],
     equipment: 'machine',
     category: 'compound',
+    trackingType: 'weight_reps',
     tags: ['back'],
     instructions: null,
     createdAt: 1,
@@ -106,6 +112,7 @@ const exerciseFixtures = [
     muscleGroups: ['hip flexors', 'quads'],
     equipment: 'bodyweight',
     category: 'mobility',
+    trackingType: 'weight_reps',
     tags: ['recovery'],
     instructions: null,
     createdAt: 1,
@@ -118,6 +125,7 @@ const exerciseFixtures = [
     muscleGroups: ['quads', 'glutes'],
     equipment: 'dumbbell',
     category: 'compound',
+    trackingType: 'weight_reps',
     tags: ['legs'],
     instructions: null,
     createdAt: 1,
@@ -130,6 +138,7 @@ const exerciseFixtures = [
     muscleGroups: ['upper chest', 'front delts', 'triceps'],
     equipment: 'dumbbells',
     category: 'compound',
+    trackingType: 'weight_reps',
     tags: ['upper body', 'push'],
     instructions: 'Drive feet into the floor and keep wrists stacked.',
     createdAt: 1,
@@ -142,6 +151,7 @@ const exerciseFixtures = [
     muscleGroups: ['lats', 'upper back'],
     equipment: 'cable machine',
     category: 'compound',
+    trackingType: 'weight_reps',
     tags: ['pull'],
     instructions: null,
     createdAt: 1,
@@ -154,6 +164,7 @@ const exerciseFixtures = [
     muscleGroups: ['quads'],
     equipment: 'machine',
     category: 'isolation',
+    trackingType: 'weight_reps',
     tags: ['accessory'],
     instructions: null,
     createdAt: 1,
@@ -166,12 +177,29 @@ const exerciseFixtures = [
     muscleGroups: ['conditioning', 'upper back'],
     equipment: 'rower',
     category: 'cardio',
+    trackingType: 'cardio',
     tags: ['conditioning'],
     instructions: null,
     createdAt: 1,
     updatedAt: 1,
   },
 ];
+
+const generatedExerciseFixtures = Array.from({ length: 20 }, (_, index) => ({
+  id: `zz-generated-${index + 1}`,
+  userId: null,
+  name: `ZZ Generated Exercise ${String(index + 1).padStart(2, '0')}`,
+  muscleGroups: ['full body'],
+  equipment: 'machine',
+  category: 'compound',
+  trackingType: 'weight_reps',
+  tags: [],
+  instructions: null,
+  createdAt: 1,
+  updatedAt: 1,
+}));
+
+const exerciseFixtures = [...baseExerciseFixtures, ...generatedExerciseFixtures];
 
 beforeEach(() => {
   window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
@@ -180,6 +208,7 @@ beforeEach(() => {
 
 afterEach(() => {
   window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
+  window.localStorage.removeItem(EXERCISE_LIBRARY_VIEW_STORAGE_KEY);
   vi.restoreAllMocks();
   vi.useRealTimers();
 });
@@ -202,7 +231,9 @@ describe('ExerciseLibrary', () => {
     expect(
       screen.getByRole('heading', { level: 3, name: 'Chest Supported Row' }),
     ).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { level: 3, name: 'Air Bike' })).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { level: 3, name: 'Air Bike' })).not.toBeInTheDocument();
+    });
   });
 
   it('filters exercises by muscle group, equipment, and category together', async () => {
@@ -252,7 +283,9 @@ describe('ExerciseLibrary', () => {
 
     renderExerciseLibrary();
 
-    expect(await screen.findByText('10 exercises shown')).toBeInTheDocument();
+    expect(
+      await screen.findByText(`${exerciseFixtures.length} exercises shown`),
+    ).toBeInTheDocument();
     expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Next' }));
@@ -262,8 +295,58 @@ describe('ExerciseLibrary', () => {
     });
 
     expect(await screen.findByText('Page 2 of 2')).toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 3, name: 'Row Erg' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'ZZ Generated Exercise 20' }),
+    ).toBeInTheDocument();
     expect(screen.queryByRole('heading', { level: 3, name: 'Air Bike' })).not.toBeInTheDocument();
+  });
+
+  it('toggles between card and table layouts', async () => {
+    mockExerciseRequests();
+
+    renderExerciseLibrary();
+
+    expect(await screen.findByRole('heading', { level: 3, name: 'Air Bike' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('table', { name: 'Exercise library table view' }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Table view' }));
+
+    expect(
+      await screen.findByRole('table', { name: 'Exercise library table view' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Tracking Type' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 3, name: 'Air Bike' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Card view' }));
+
+    expect(await screen.findByRole('heading', { level: 3, name: 'Air Bike' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('table', { name: 'Exercise library table view' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('persists the selected view in localStorage', async () => {
+    mockExerciseRequests();
+
+    const firstRender = renderExerciseLibrary();
+    await screen.findByRole('heading', { level: 3, name: 'Air Bike' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Table view' }));
+
+    expect(
+      await screen.findByRole('table', { name: 'Exercise library table view' }),
+    ).toBeInTheDocument();
+    expect(window.localStorage.getItem(EXERCISE_LIBRARY_VIEW_STORAGE_KEY)).toBe('table');
+
+    firstRender.unmount();
+
+    renderExerciseLibrary();
+
+    expect(
+      await screen.findByRole('table', { name: 'Exercise library table view' }),
+    ).toBeInTheDocument();
   });
 
   it('renders exercise tags as muted chips in the library cards', async () => {
@@ -271,10 +354,12 @@ describe('ExerciseLibrary', () => {
 
     renderExerciseLibrary();
 
-    const pressCard = (await screen.findByRole('heading', {
-      level: 3,
-      name: 'Incline Dumbbell Press',
-    })).closest('[data-slot="card"]');
+    const pressCard = (
+      await screen.findByRole('heading', {
+        level: 3,
+        name: 'Incline Dumbbell Press',
+      })
+    ).closest('[data-slot="card"]');
 
     expect(pressCard).not.toBeNull();
     expect(within(pressCard as HTMLElement).getByText('Upper Body')).toBeInTheDocument();
@@ -298,13 +383,15 @@ describe('ExerciseLibrary', () => {
 
     renderExerciseLibrary();
 
-    const airBikeCard = (await screen.findByRole('heading', { level: 3, name: 'Air Bike' })).closest(
-      '[data-slot="card"]',
-    );
+    const airBikeCard = (
+      await screen.findByRole('heading', { level: 3, name: 'Air Bike' })
+    ).closest('[data-slot="card"]');
     expect(airBikeCard).not.toBeNull();
 
     fireEvent.click(
-      within(airBikeCard as HTMLElement).getByRole('button', { name: 'Exercise actions for Air Bike' }),
+      within(airBikeCard as HTMLElement).getByRole('button', {
+        name: 'Exercise actions for Air Bike',
+      }),
     );
     fireEvent.click(within(airBikeCard as HTMLElement).getByRole('button', { name: 'Rename' }));
 
@@ -315,7 +402,9 @@ describe('ExerciseLibrary', () => {
     fireEvent.change(input, { target: { value: 'Assault Bike' } });
     fireEvent.click(within(dialog).getByRole('button', { name: 'Rename' }));
 
-    expect(await screen.findByRole('heading', { level: 3, name: 'Assault Bike' })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { level: 3, name: 'Assault Bike' }),
+    ).toBeInTheDocument();
     expect(screen.queryByRole('heading', { level: 3, name: 'Air Bike' })).not.toBeInTheDocument();
   });
 
@@ -486,7 +575,7 @@ function mockExerciseRequests() {
     const equipment = url.searchParams.get('equipment')?.toLowerCase();
     const category = url.searchParams.get('category');
     const page = Number(url.searchParams.get('page') ?? '1');
-    const limit = Number(url.searchParams.get('limit') ?? '20');
+    const limit = Number(url.searchParams.get('limit') ?? '25');
 
     const filteredExercises = [...mockExercises]
       .filter((exercise) => (q ? exercise.name.toLowerCase().includes(q) : true))

--- a/apps/web/src/features/workouts/components/exercise-library.test.tsx
+++ b/apps/web/src/features/workouts/components/exercise-library.test.tsx
@@ -327,6 +327,38 @@ describe('ExerciseLibrary', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('renders a table skeleton while loading when table view is selected', async () => {
+    window.localStorage.setItem(EXERCISE_LIBRARY_VIEW_STORAGE_KEY, 'table');
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/exercises/filters') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              equipment: [],
+              muscleGroups: [],
+            },
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/exercises') {
+        return new Promise(() => {
+          // Keep the request pending to assert loading state.
+        });
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    renderExerciseLibrary();
+
+    expect(await screen.findByLabelText('Loading exercises table view')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Tracking Type' })).toBeInTheDocument();
+  });
+
   it('opens the trend dialog from the exercise name button in table view', async () => {
     mockExerciseRequests();
 

--- a/apps/web/src/features/workouts/components/exercise-library.tsx
+++ b/apps/web/src/features/workouts/components/exercise-library.tsx
@@ -294,7 +294,7 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
       </div>
 
       {exercisesQuery.isPending ? (
-        <ExerciseLibrarySkeleton />
+        <ExerciseLibrarySkeleton view={view} />
       ) : filteredExercises.length === 0 ? (
         <Card>
           <CardContent className="py-6">
@@ -523,7 +523,48 @@ function ExerciseTable({
   );
 }
 
-function ExerciseLibrarySkeleton() {
+function ExerciseLibrarySkeleton({ view }: { view: ExerciseLibraryView }) {
+  if (view === 'table') {
+    return (
+      <Card aria-label="Loading exercises table view" className="gap-0 py-0">
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-border text-muted">
+                <th className="px-4 py-3 font-medium">Name</th>
+                <th className="px-4 py-3 font-medium">Category</th>
+                <th className="px-4 py-3 font-medium">Muscle Group</th>
+                <th className="px-4 py-3 font-medium">Equipment</th>
+                <th className="px-4 py-3 font-medium">Tracking Type</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Array.from({ length: 6 }).map((_, index) => (
+                <tr className="border-b border-border/70" key={index}>
+                  <td className="px-4 py-3">
+                    <div className="h-4 w-40 animate-pulse rounded-full bg-secondary" />
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="h-4 w-24 animate-pulse rounded-full bg-secondary" />
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="h-4 w-32 animate-pulse rounded-full bg-secondary" />
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="h-4 w-24 animate-pulse rounded-full bg-secondary" />
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="h-4 w-28 animate-pulse rounded-full bg-secondary" />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+    );
+  }
+
   return (
     <div aria-label="Loading exercises" className="grid gap-4 xl:grid-cols-2">
       {Array.from({ length: 4 }).map((_, index) => (

--- a/apps/web/src/features/workouts/components/exercise-library.tsx
+++ b/apps/web/src/features/workouts/components/exercise-library.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useSearchParams } from 'react-router';
 import { LayoutGrid, List, MoreVertical } from 'lucide-react';
 import type { Exercise, ExerciseTrackingType } from '@pulse/shared';
@@ -63,6 +63,7 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
   const [selectedExerciseId, setSelectedExerciseId] = useState<string | null>(null);
   const [renameTarget, setRenameTarget] = useState<Exercise | null>(null);
   const [view, setView] = useState<ExerciseLibraryView>(() => loadExerciseLibraryViewPreference());
+  const initialViewRef = useRef(view);
 
   const currentQuery = searchParams.get('q') ?? '';
   const muscleGroup = searchParams.get('muscleGroup') ?? 'all';
@@ -96,6 +97,10 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
   }, [currentQuery, searchTerm, setSearchParams]);
 
   useEffect(() => {
+    if (view === initialViewRef.current) {
+      return;
+    }
+
     window.localStorage.setItem(EXERCISE_LIBRARY_VIEW_STORAGE_KEY, view);
   }, [view]);
 
@@ -491,19 +496,18 @@ function ExerciseTable({
           <tbody>
             {exercises.map((exercise) => (
               <tr
-                className="cursor-pointer border-b border-border/70 transition-colors hover:bg-secondary/35 focus-within:bg-secondary/35"
+                className="border-b border-border/70 transition-colors hover:bg-secondary/35 focus-within:bg-secondary/35"
                 key={exercise.id}
-                onClick={() => onSelectTrend(exercise.id)}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter' || event.key === ' ') {
-                    event.preventDefault();
-                    onSelectTrend(exercise.id);
-                  }
-                }}
-                role="button"
-                tabIndex={0}
               >
-                <td className="px-4 py-3 font-medium text-foreground">{exercise.name}</td>
+                <td className="px-4 py-3 font-medium text-foreground">
+                  <button
+                    className="cursor-pointer text-left underline-offset-4 transition hover:text-primary hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    onClick={() => onSelectTrend(exercise.id)}
+                    type="button"
+                  >
+                    {exercise.name}
+                  </button>
+                </td>
                 <td className="px-4 py-3 text-muted">{formatLabel(exercise.category)}</td>
                 <td className="px-4 py-3 text-muted">
                   {exercise.muscleGroups.map((group) => formatLabel(group)).join(', ')}

--- a/apps/web/src/features/workouts/components/exercise-library.tsx
+++ b/apps/web/src/features/workouts/components/exercise-library.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useSearchParams } from 'react-router';
-import { MoreVertical } from 'lucide-react';
+import { LayoutGrid, List, MoreVertical } from 'lucide-react';
 import type { Exercise, ExerciseTrackingType } from '@pulse/shared';
 import { toast } from 'sonner';
 
@@ -47,7 +47,10 @@ const categoryBadgeStyles = {
 } as const;
 
 const categoryOptions = ['compound', 'isolation', 'cardio', 'mobility'] as const;
-const PAGE_SIZE = 8;
+const PAGE_SIZE = 25;
+const EXERCISE_LIBRARY_VIEW_STORAGE_KEY = 'exercise-library-view';
+
+type ExerciseLibraryView = 'card' | 'table';
 
 type ExerciseLibraryProps = {
   className?: string;
@@ -59,6 +62,7 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
   const [searchTerm, setSearchTerm] = useState(searchParams.get('q') ?? '');
   const [selectedExerciseId, setSelectedExerciseId] = useState<string | null>(null);
   const [renameTarget, setRenameTarget] = useState<Exercise | null>(null);
+  const [view, setView] = useState<ExerciseLibraryView>(() => loadExerciseLibraryViewPreference());
 
   const currentQuery = searchParams.get('q') ?? '';
   const muscleGroup = searchParams.get('muscleGroup') ?? 'all';
@@ -90,6 +94,10 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
 
     return () => window.clearTimeout(timeoutId);
   }, [currentQuery, searchTerm, setSearchParams]);
+
+  useEffect(() => {
+    window.localStorage.setItem(EXERCISE_LIBRARY_VIEW_STORAGE_KEY, view);
+  }, [view]);
 
   const exercisesQuery = useExercises({
     category: parseCategory(category),
@@ -126,7 +134,10 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
       return [];
     }
 
-    return toExerciseTrendHistory(selectedExerciseHistoryQuery.data ?? [], selectedExercise.trackingType);
+    return toExerciseTrendHistory(
+      selectedExerciseHistoryQuery.data ?? [],
+      selectedExercise.trackingType,
+    );
   }, [selectedExercise, selectedExerciseHistoryQuery.data]);
 
   return (
@@ -140,7 +151,7 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
       </div>
 
       <Card className="gap-4 py-0">
-        <CardContent className="grid gap-4 py-5 md:grid-cols-2 xl:grid-cols-4">
+        <CardContent className="grid gap-4 py-5 md:grid-cols-2 xl:grid-cols-5">
           <FilterField label="Search by name">
             <Input
               aria-label="Search exercises"
@@ -209,6 +220,37 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
               ))}
             </select>
           </FilterField>
+
+          <FilterField label="View">
+            <div
+              aria-label="Exercise library view"
+              className="inline-flex min-h-[44px] w-fit items-center gap-1 rounded-full border border-border bg-card p-1"
+              role="group"
+            >
+              <Button
+                aria-label="Card view"
+                aria-pressed={view === 'card'}
+                className="h-8 w-8 rounded-full p-0"
+                onClick={() => setView('card')}
+                size="sm"
+                type="button"
+                variant={view === 'card' ? 'default' : 'ghost'}
+              >
+                <LayoutGrid aria-hidden="true" className="size-4" />
+              </Button>
+              <Button
+                aria-label="Table view"
+                aria-pressed={view === 'table'}
+                className="h-8 w-8 rounded-full p-0"
+                onClick={() => setView('table')}
+                size="sm"
+                type="button"
+                variant={view === 'table' ? 'default' : 'ghost'}
+              >
+                <List aria-hidden="true" className="size-4" />
+              </Button>
+            </div>
+          </FilterField>
         </CardContent>
       </Card>
 
@@ -256,6 +298,8 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
             </p>
           </CardContent>
         </Card>
+      ) : view === 'table' ? (
+        <ExerciseTable exercises={filteredExercises} onSelectTrend={setSelectedExerciseId} />
       ) : (
         <div className="grid gap-4 xl:grid-cols-2">
           {filteredExercises.map((exercise) => (
@@ -424,6 +468,57 @@ function ExerciseCard({
   );
 }
 
+function ExerciseTable({
+  exercises,
+  onSelectTrend,
+}: {
+  exercises: Exercise[];
+  onSelectTrend: (exerciseId: string) => void;
+}) {
+  return (
+    <Card className="gap-0 py-0">
+      <div className="overflow-x-auto">
+        <table aria-label="Exercise library table view" className="min-w-full text-left text-sm">
+          <thead>
+            <tr className="border-b border-border text-muted">
+              <th className="px-4 py-3 font-medium">Name</th>
+              <th className="px-4 py-3 font-medium">Category</th>
+              <th className="px-4 py-3 font-medium">Muscle Group</th>
+              <th className="px-4 py-3 font-medium">Equipment</th>
+              <th className="px-4 py-3 font-medium">Tracking Type</th>
+            </tr>
+          </thead>
+          <tbody>
+            {exercises.map((exercise) => (
+              <tr
+                className="cursor-pointer border-b border-border/70 transition-colors hover:bg-secondary/35 focus-within:bg-secondary/35"
+                key={exercise.id}
+                onClick={() => onSelectTrend(exercise.id)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    onSelectTrend(exercise.id);
+                  }
+                }}
+                role="button"
+                tabIndex={0}
+              >
+                <td className="px-4 py-3 font-medium text-foreground">{exercise.name}</td>
+                <td className="px-4 py-3 text-muted">{formatLabel(exercise.category)}</td>
+                <td className="px-4 py-3 text-muted">
+                  {exercise.muscleGroups.map((group) => formatLabel(group)).join(', ')}
+                </td>
+                <td className="px-4 py-3 text-muted">{formatLabel(exercise.equipment)}</td>
+                <td className="px-4 py-3 text-muted">{formatLabel(exercise.trackingType)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  );
+}
+
 function ExerciseLibrarySkeleton() {
   return (
     <div aria-label="Loading exercises" className="grid gap-4 xl:grid-cols-2">
@@ -496,9 +591,19 @@ function parsePage(value: string | null) {
   return Number.isNaN(page) || page < 1 ? 1 : page;
 }
 
+function loadExerciseLibraryViewPreference(): ExerciseLibraryView {
+  const storedValue = window.localStorage.getItem(EXERCISE_LIBRARY_VIEW_STORAGE_KEY);
+
+  if (storedValue === 'table') {
+    return 'table';
+  }
+
+  return 'card';
+}
+
 function formatLabel(value: string) {
   return value
-    .split(/[- ]+/)
+    .split(/[-_ ]+/)
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -444,7 +444,7 @@ describe('SessionDetail', () => {
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('Incline Dumbbell Press history')).toBeInTheDocument();
-    expect(await screen.findByText(/Mar 1, 2026 - 105x8/)).toBeInTheDocument();
+    expect(await screen.findByText(/Mar 1, 2026 · 105x8/)).toBeInTheDocument();
   });
 
   it('supports inline correction editing and only submits changed values', async () => {

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -1562,6 +1562,15 @@ describe('SessionExerciseList', () => {
       />,
     );
 
+    expect(
+      useLastPerformanceSpy.mock.calls.some(
+        ([exerciseId, options]) =>
+          exerciseId === 'row-erg' &&
+          options?.enabled === true &&
+          options?.includeRelated !== false,
+      ),
+    ).toBe(true);
+
     const rowErgCard = screen
       .getByRole('heading', { level: 3, name: 'Row Erg' })
       .closest('[data-slot="card"]');

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -1606,27 +1606,49 @@ describe('SessionExerciseList', () => {
     }
 
     const useLastPerformanceSpy = vi.spyOn(lastPerformanceHooks, 'useLastPerformance');
-    useLastPerformanceSpy.mockReturnValue({
-      data: {
-        history: {
-          date: '2026-03-12',
-          sessionId: 'session-10',
-          sets: [{ completed: true, reps: 10, setNumber: 1, weight: 55 }],
-        },
-        related: [
-          {
-            exerciseId: 'incline-bench',
-            exerciseName: 'Incline Bench Press',
-            trackingType: 'weight_reps',
+    useLastPerformanceSpy.mockImplementation((_, options) => {
+      if (options?.includeRelated === false) {
+        return {
+          data: {
             history: {
-              date: '2026-03-08',
-              sessionId: 'session-8',
-              sets: [{ completed: true, reps: 8, setNumber: 1, weight: 60 }],
+              date: '2026-03-12',
+              sessionId: 'session-10',
+              sets: [{ completed: true, reps: 10, setNumber: 1, weight: 55 }],
             },
+            historyEntries: [
+              {
+                date: '2026-03-12',
+                sessionId: 'session-10',
+                sets: [{ completed: true, reps: 10, setNumber: 1, weight: 55 }],
+              },
+            ],
+            related: [],
           },
-        ],
-      },
-    } as unknown as ReturnType<typeof lastPerformanceHooks.useLastPerformance>);
+        } as unknown as ReturnType<typeof lastPerformanceHooks.useLastPerformance>;
+      }
+
+      return {
+        data: {
+          history: null,
+          historyEntries: [],
+          related:
+            options?.enabled === true
+              ? [
+                  {
+                    exerciseId: 'incline-bench',
+                    exerciseName: 'Incline Bench Press',
+                    trackingType: 'weight_reps',
+                    history: {
+                      date: '2026-03-08',
+                      sessionId: 'session-8',
+                      sets: [{ completed: true, reps: 8, setNumber: 1, weight: 60 }],
+                    },
+                  },
+                ]
+              : [],
+        },
+      } as unknown as ReturnType<typeof lastPerformanceHooks.useLastPerformance>;
+    });
 
     const session = buildActiveWorkoutSession(
       activeTemplate,
@@ -1657,9 +1679,8 @@ describe('SessionExerciseList', () => {
       useLastPerformanceSpy.mock.calls.some(
         ([exerciseId, options]) =>
           exerciseId === 'row-erg' &&
-          options?.enabled === true &&
-          options?.includeRelated === true &&
-          options?.limit === 1,
+          options?.enabled === false &&
+          options?.includeRelated === true,
       ),
     ).toBe(true);
 
@@ -1669,6 +1690,12 @@ describe('SessionExerciseList', () => {
     expect(rowErgCard).not.toBeNull();
 
     fireEvent.click(getExercisePanelToggle('Row Erg', 'row-erg'));
+    expect(
+      useLastPerformanceSpy.mock.calls.some(
+        ([exerciseId, options]) =>
+          exerciseId === 'row-erg' && options?.enabled === true && options?.includeRelated === true,
+      ),
+    ).toBe(true);
     expect(within(rowErgCard as HTMLElement).getByText('History')).toBeInTheDocument();
     expect(within(rowErgCard as HTMLElement).getByText('Related history')).toBeInTheDocument();
     expect(within(rowErgCard as HTMLElement).getByText('Incline Bench Press')).not.toBeVisible();
@@ -1690,6 +1717,7 @@ describe('SessionExerciseList', () => {
     useLastPerformanceSpy.mockReturnValue({
       data: {
         history: null,
+        historyEntries: [],
         related: [],
       },
     } as unknown as ReturnType<typeof lastPerformanceHooks.useLastPerformance>);

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -1452,7 +1452,89 @@ describe('SessionExerciseList', () => {
       .getByRole('heading', { level: 3, name: 'Incline Dumbbell Press' })
       .closest('[data-slot="card"]');
     expect(card).not.toBeNull();
-    expect(within(card as HTMLElement).getByText(/Mar 13 - 25x12, 25x12/)).toBeInTheDocument();
+    expect(within(card as HTMLElement).getByText(/Mar 13 · 25x12, 25x12/)).toBeInTheDocument();
+  });
+
+  it('renders up to 3 inline history entries when API history is enabled', () => {
+    if (!activeTemplate) {
+      throw new Error('Expected upper-push template in mock data.');
+    }
+
+    const useLastPerformanceSpy = vi.spyOn(lastPerformanceHooks, 'useLastPerformance');
+    useLastPerformanceSpy.mockImplementation((_, options) => {
+      if (options?.includeRelated === false) {
+        return {
+          data: {
+            history: {
+              date: '2026-03-20',
+              sessionId: 'session-4',
+              sets: [{ completed: true, reps: 6, setNumber: 1, weight: 75 }],
+            },
+            historyEntries: [
+              {
+                date: '2026-03-20',
+                sessionId: 'session-4',
+                sets: [{ completed: true, reps: 6, setNumber: 1, weight: 75 }],
+              },
+              {
+                date: '2026-03-18',
+                sessionId: 'session-3',
+                sets: [{ completed: true, reps: 8, setNumber: 1, weight: 70 }],
+              },
+              {
+                date: '2026-03-15',
+                sessionId: 'session-2',
+                sets: [{ completed: true, reps: 10, setNumber: 1, weight: 65 }],
+              },
+              {
+                date: '2026-03-10',
+                sessionId: 'session-1',
+                sets: [{ completed: true, reps: 12, setNumber: 1, weight: 60 }],
+              },
+            ],
+            related: [],
+          },
+        } as unknown as ReturnType<typeof lastPerformanceHooks.useLastPerformance>;
+      }
+
+      return {
+        data: {
+          history: null,
+          historyEntries: [],
+          related: [],
+        },
+      } as unknown as ReturnType<typeof lastPerformanceHooks.useLastPerformance>;
+    });
+
+    const session = buildActiveWorkoutSession(
+      activeTemplate,
+      createInitialWorkoutSetDrafts(activeTemplate, new Set()),
+    );
+
+    renderWithQueryClient(
+      <SessionExerciseList
+        enableApiLastPerformance
+        onAddSet={vi.fn()}
+        onExerciseNotesChange={vi.fn()}
+        onRemoveSet={vi.fn()}
+        onSetUpdate={vi.fn()}
+        session={session}
+      />,
+    );
+
+    const card = screen
+      .getByRole('heading', { level: 3, name: 'Incline Dumbbell Press' })
+      .closest('[data-slot="card"]');
+    expect(card).not.toBeNull();
+
+    fireEvent.click(getExercisePanelToggle('Incline Dumbbell Press', 'incline-dumbbell-press'));
+
+    expect(within(card as HTMLElement).getByText(/Mar 20 · 75x6/)).toBeInTheDocument();
+    expect(within(card as HTMLElement).getByText(/Mar 18 · 70x8/)).toBeInTheDocument();
+    expect(within(card as HTMLElement).getByText(/Mar 15 · 65x10/)).toBeInTheDocument();
+    expect(within(card as HTMLElement).queryByText(/Mar 10 · 60x12/)).not.toBeInTheDocument();
+
+    useLastPerformanceSpy.mockRestore();
   });
 
   it('opens and closes full history modal from active workout exercise rows', async () => {
@@ -1567,7 +1649,17 @@ describe('SessionExerciseList', () => {
         ([exerciseId, options]) =>
           exerciseId === 'row-erg' &&
           options?.enabled === true &&
-          options?.includeRelated !== false,
+          options?.includeRelated === false &&
+          options?.limit === 3,
+      ),
+    ).toBe(true);
+    expect(
+      useLastPerformanceSpy.mock.calls.some(
+        ([exerciseId, options]) =>
+          exerciseId === 'row-erg' &&
+          options?.enabled === true &&
+          options?.includeRelated === true &&
+          options?.limit === 1,
       ),
     ).toBe(true);
 

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -694,6 +694,11 @@ function ExerciseCardItem({
     (notes: string) => onExerciseNotesChange(exercise.id, notes),
     500,
   );
+  const resolvedCollapseKey = collapseKey ?? exercise.id;
+  const isExpanded =
+    forceExpanded ||
+    focusTargetExerciseId === exercise.id ||
+    (expandedExercises[resolvedCollapseKey] ?? false);
 
   const historyEntriesQuery = useLastPerformance(exercise.id, {
     enabled: enableApiLastPerformance,
@@ -701,9 +706,8 @@ function ExerciseCardItem({
     limit: 3,
   });
   const relatedHistoryQuery = useLastPerformance(exercise.id, {
-    enabled: enableApiLastPerformance,
+    enabled: enableApiLastPerformance && isExpanded,
     includeRelated: true,
-    limit: 1,
   });
   const historySummary: ActiveWorkoutExerciseHistorySummary = enableApiLastPerformance
     ? {
@@ -718,11 +722,6 @@ function ExerciseCardItem({
       };
   const state = getExerciseState(exercise, sessionCurrentExerciseId);
   const isExerciseComplete = state === 'completed';
-  const resolvedCollapseKey = collapseKey ?? exercise.id;
-  const isExpanded =
-    forceExpanded ||
-    focusTargetExerciseId === exercise.id ||
-    (expandedExercises[resolvedCollapseKey] ?? false);
   const formCues = exercise.formCues;
   const templateCues = exercise.templateCues;
   const hasInjuryCues = exercise.injuryCues.length > 0;

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -87,7 +87,7 @@ import {
   formatTempo,
 } from '../lib/time-estimates';
 import { getSupersetAccentClass } from '../lib/superset-utils';
-import { formatSetSummary, getDistanceUnit } from '../lib/tracking';
+import { formatCompactSets, getDistanceUnit } from '../lib/tracking';
 import { FormCueChips } from './form-cue-chips';
 import { ExerciseHistoryModal } from './exercise-history-modal';
 import { RenameExerciseDialog } from './rename-exercise-dialog';
@@ -695,13 +695,27 @@ function ExerciseCardItem({
     500,
   );
 
-  const lastPerformanceQuery = useLastPerformance(exercise.id, {
+  const historyEntriesQuery = useLastPerformance(exercise.id, {
     enabled: enableApiLastPerformance,
+    includeRelated: false,
+    limit: 3,
+  });
+  const relatedHistoryQuery = useLastPerformance(exercise.id, {
+    enabled: enableApiLastPerformance,
+    includeRelated: true,
+    limit: 1,
   });
   const historySummary: ActiveWorkoutExerciseHistorySummary = enableApiLastPerformance
-    ? (lastPerformanceQuery.data ?? { history: null, related: [] })
-    : { history: exercise.lastPerformance, related: [] };
-  const lastPerformance = historySummary.history;
+    ? {
+        history: historyEntriesQuery.data?.history ?? null,
+        historyEntries: historyEntriesQuery.data?.historyEntries ?? [],
+        related: relatedHistoryQuery.data?.related ?? [],
+      }
+    : {
+        history: exercise.lastPerformance,
+        historyEntries: exercise.lastPerformance ? [exercise.lastPerformance] : [],
+        related: [],
+      };
   const state = getExerciseState(exercise, sessionCurrentExerciseId);
   const isExerciseComplete = state === 'completed';
   const resolvedCollapseKey = collapseKey ?? exercise.id;
@@ -881,14 +895,26 @@ function ExerciseCardItem({
                     View all
                   </button>
                 </div>
-                <p className="text-sm text-foreground">
-                  {formatHistoryPreview({
-                    history: lastPerformance,
-                    prescribedReps: exercise.prescribedReps,
+                {(() => {
+                  const previewEntries = formatHistoryPreviewEntries({
+                    historyEntries: historySummary.historyEntries,
                     trackingType: exercise.trackingType,
-                    weightUnit,
-                  })}
-                </p>
+                  });
+
+                  if (previewEntries.length === 0) {
+                    return <p className="text-sm text-foreground">No completed history yet.</p>;
+                  }
+
+                  return (
+                    <div className="space-y-1">
+                      {previewEntries.map((entry) => (
+                        <p className="text-sm text-foreground" key={entry.key}>
+                          {entry.text}
+                        </p>
+                      ))}
+                    </div>
+                  );
+                })()}
               </div>
 
               <div className="rounded-2xl border border-border bg-background/80 p-4 sm:flex-1">
@@ -927,13 +953,21 @@ function ExerciseCardItem({
                         {relatedExercise.exerciseName}
                       </p>
                       <p className="mt-1 text-sm text-foreground">
-                        {formatHistoryPreview({
-                          history: relatedExercise.history,
-                          prescribedReps: '',
-                          trackingType: relatedExercise.trackingType,
-                          weightUnit,
-                          emptyLabel: 'No completed sets yet.',
-                        })}
+                        {(() => {
+                          const previewEntries = formatHistoryPreviewEntries({
+                            historyEntries: relatedExercise.history
+                              ? [relatedExercise.history]
+                              : [],
+                            maxEntries: 1,
+                            trackingType: relatedExercise.trackingType,
+                          });
+
+                          if (previewEntries.length === 0) {
+                            return 'No completed sets yet.';
+                          }
+
+                          return previewEntries[0]?.text;
+                        })()}
                       </p>
                     </div>
                   ))}
@@ -1124,35 +1158,6 @@ function findSetContext(session: ActiveWorkoutSessionData, setId: string) {
   return null;
 }
 
-function formatCompactPerformanceSetByTrackingType(
-  trackingType: ExerciseTrackingType,
-  weight: number | null,
-  value: number,
-  prescribedReps: string,
-  weightUnit: WeightUnit,
-) {
-  if (
-    (trackingType === 'bodyweight_reps' || trackingType === 'reps_only') &&
-    (prescribedReps.includes('min') || prescribedReps.includes('sec'))
-  ) {
-    return formatPerformedReps(value, prescribedReps);
-  }
-
-  const setMetrics =
-    trackingType === 'distance'
-      ? { distance: value, weight }
-      : {
-          reps: value,
-          weight,
-        };
-
-  return formatSetSummary(setMetrics, trackingType, {
-    compact: true,
-    useLegacySecondsFallback: trackingType !== 'reps_seconds',
-    weightUnit,
-  });
-}
-
 function formatExerciseSubtitle({
   exercise,
   weightUnit,
@@ -1221,36 +1226,37 @@ function formatExerciseSubtitle({
   return hasExplicitUnit ? `${sets} × ${trackedTarget}` : `${sets} sets × ${trackedTarget}`;
 }
 
-function formatHistoryPreview({
-  history,
-  prescribedReps,
+function formatHistoryPreviewEntries({
+  historyEntries,
+  maxEntries = 3,
   trackingType,
-  weightUnit,
-  emptyLabel = 'No completed history yet.',
 }: {
-  history: ActiveWorkoutExercise['lastPerformance'];
-  prescribedReps: string;
+  historyEntries: ActiveWorkoutExerciseHistorySummary['historyEntries'];
+  maxEntries?: number;
   trackingType: ExerciseTrackingType;
-  weightUnit: WeightUnit;
-  emptyLabel?: string;
 }) {
-  if (!history || history.sets.length === 0) {
-    return emptyLabel;
+  if (historyEntries.length === 0) {
+    return [];
   }
 
-  const setSummary = history.sets
-    .map((set) =>
-      formatCompactPerformanceSetByTrackingType(
-        trackingType,
-        set.weight,
-        set.reps,
-        prescribedReps,
-        weightUnit,
+  return historyEntries.slice(0, maxEntries).map((history) => {
+    const setSummary = formatCompactSets(
+      history.sets.map((set) =>
+        trackingType === 'distance'
+          ? { distance: set.reps, weight: set.weight }
+          : { reps: set.reps, weight: set.weight },
       ),
-    )
-    .join(', ');
+      trackingType,
+      {
+        useLegacySecondsFallback: trackingType !== 'reps_seconds',
+      },
+    );
 
-  return `${historyDateFormatter.format(new Date(`${history.date}T12:00:00`))} - ${setSummary}`;
+    return {
+      key: history.sessionId,
+      text: `${historyDateFormatter.format(new Date(`${history.date}T12:00:00`))} · ${setSummary}`,
+    };
+  });
 }
 
 function parsePrescribedRepTarget(prescribedReps: string) {
@@ -1289,25 +1295,6 @@ function formatTrackedRepTarget(
   }
 
   return `${target} reps`;
-}
-
-function formatPerformedReps(reps: number, prescribedReps: string) {
-  if (prescribedReps.includes('min')) {
-    const minutes = Math.floor(reps / 60);
-    const seconds = reps % 60;
-
-    if (seconds === 0) {
-      return `${minutes} min`;
-    }
-
-    return `${minutes}:${`${seconds}`.padStart(2, '0')}`;
-  }
-
-  if (prescribedReps.includes('sec')) {
-    return `${reps} sec`;
-  }
-
-  return `${reps} reps`;
 }
 
 function formatWeight(weight: number) {

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -898,6 +898,7 @@ function ExerciseCardItem({
                   const previewEntries = formatHistoryPreviewEntries({
                     historyEntries: historySummary.historyEntries,
                     trackingType: exercise.trackingType,
+                    weightUnit,
                   });
 
                   if (previewEntries.length === 0) {
@@ -959,6 +960,7 @@ function ExerciseCardItem({
                               : [],
                             maxEntries: 1,
                             trackingType: relatedExercise.trackingType,
+                            weightUnit,
                           });
 
                           if (previewEntries.length === 0) {
@@ -1229,10 +1231,12 @@ function formatHistoryPreviewEntries({
   historyEntries,
   maxEntries = 3,
   trackingType,
+  weightUnit,
 }: {
   historyEntries: ActiveWorkoutExerciseHistorySummary['historyEntries'];
   maxEntries?: number;
   trackingType: ExerciseTrackingType;
+  weightUnit: WeightUnit;
 }) {
   if (historyEntries.length === 0) {
     return [];
@@ -1248,6 +1252,7 @@ function formatHistoryPreviewEntries({
       trackingType,
       {
         useLegacySecondsFallback: trackingType !== 'reps_seconds',
+        weightUnit,
       },
     );
 

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -1395,6 +1395,76 @@ describe('WorkoutTemplateDetail', () => {
     });
   });
 
+  it('hydrates coaching notes from the exercise lookup when template notes are missing', async () => {
+    const templateWithoutEmbeddedNotes = structuredClone(templatePayload);
+    const inclineExercise = templateWithoutEmbeddedNotes.data.sections[1]
+      .exercises[0] as MutableTemplateExercise;
+    inclineExercise.exercise = {
+      formCues: inclineExercise.exercise?.formCues ?? [],
+      coachingNotes: null,
+      instructions: null,
+    };
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/workout-templates/upper-push') {
+        return Promise.resolve(jsonResponse(templateWithoutEmbeddedNotes));
+      }
+
+      if (url.pathname === '/api/v1/exercises/incline-dumbbell-press' && init?.method !== 'PATCH') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: 'incline-dumbbell-press',
+              userId: 'user-1',
+              name: 'Incline Dumbbell Press',
+              muscleGroups: ['upper chest', 'triceps'],
+              equipment: 'Dumbbells',
+              category: 'compound',
+              trackingType: 'weight_reps',
+              tags: [],
+              formCues: ['Tuck shoulder blades', 'Drive elbows 45°'],
+              instructions: 'Lower dumbbells with control, then drive up.',
+              coachingNotes: 'Keep your upper back pinned to the bench.',
+              relatedExerciseIds: ['seated-dumbbell-shoulder-press'],
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/exercises/incline-dumbbell-press/last-performance') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              history: null,
+              related: [],
+            },
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutTemplateDetail templateId="upper-push" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Incline Dumbbell Press' }));
+    const dialog = await screen.findByRole('dialog');
+
+    await waitFor(() => {
+      expect(within(dialog).getByLabelText('Coaching notes')).toHaveValue(
+        'Keep your upper back pinned to the bench.',
+      );
+    });
+  });
+
   it('shows history fallback without error toast when exercise detail queries return 404', async () => {
     const toastErrorSpy = vi.spyOn(toast, 'error').mockImplementation(() => '');
 

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import type { MouseEvent, ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
+import { toast } from 'sonner';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
@@ -1391,6 +1392,61 @@ describe('WorkoutTemplateDetail', () => {
         ),
       ).toBe(true);
     });
+  });
+
+  it('shows history fallback without error toast when exercise detail queries return 404', async () => {
+    const toastErrorSpy = vi.spyOn(toast, 'error').mockImplementation(() => '');
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/workout-templates/upper-push') {
+        return Promise.resolve(jsonResponse(templatePayload));
+      }
+
+      if (url.pathname === '/api/v1/exercises/incline-dumbbell-press') {
+        return Promise.resolve(
+          jsonResponse(
+            {
+              error: {
+                code: 'EXERCISE_NOT_FOUND',
+                message: 'Exercise not found',
+              },
+            },
+            { status: 404 },
+          ),
+        );
+      }
+
+      if (url.pathname === '/api/v1/exercises/incline-dumbbell-press/last-performance') {
+        return Promise.resolve(
+          jsonResponse(
+            {
+              error: {
+                code: 'EXERCISE_NOT_FOUND',
+                message: 'Exercise not found',
+              },
+            },
+            { status: 404 },
+          ),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutTemplateDetail templateId="upper-push" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Incline Dumbbell Press' }));
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'History' }));
+
+    expect(await within(dialog).findByText('No history available.')).toBeInTheDocument();
+    expect(toastErrorSpy).not.toHaveBeenCalled();
   });
 
   it('renders a fallback state when the template request returns 404', async () => {

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -1370,6 +1370,7 @@ describe('WorkoutTemplateDetail', () => {
 
     fireEvent.click(within(dialog).getByRole('button', { name: 'History' }));
     expect(await within(dialog).findByText(/Mar/i)).toBeInTheDocument();
+    expect(within(dialog).getByText('Mar 6, 2026 · 70x10, 70x9')).toBeInTheDocument();
 
     fireEvent.click(within(dialog).getByRole('button', { name: 'Related' }));
     expect(await within(dialog).findByText('Seated Dumbbell Shoulder Press')).toBeInTheDocument();

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -1815,7 +1815,7 @@ function formatLastPerformanceSummary(
     },
   );
 
-  return `${historyDateFormatter.format(new Date(`${history.date}T12:00:00`))} • ${setSummary}`;
+  return `${historyDateFormatter.format(new Date(`${history.date}T12:00:00`))} · ${setSummary}`;
 }
 
 function formatLabel(value: string) {

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -81,7 +81,7 @@ import {
   getDayWorkoutConflicts,
 } from '../lib/day-workout-conflicts';
 import { getSupersetAccentClass } from '../lib/superset-utils';
-import { formatSetSummary, getDistanceUnit } from '../lib/tracking';
+import { formatCompactSets, getDistanceUnit } from '../lib/tracking';
 import { buildInitialSessionSets } from '../lib/workout-session-sets';
 import { FormCueChips } from './form-cue-chips';
 import { ExerciseHistoryModal } from './exercise-history-modal';
@@ -1342,7 +1342,6 @@ function ExerciseDetailModal({
   onOpenChange: (open: boolean) => void;
   onSaveCoachingNotes: (exerciseId: string, coachingNotes: string | null) => Promise<unknown>;
 }) {
-  const { weightUnit } = useWeightUnit();
   const [activeTab, setActiveTab] = useState<'overview' | 'history' | 'related'>('overview');
   const [coachingNotes, setCoachingNotes] = useState(exercise.exercise?.coachingNotes ?? '');
   const [isSaving, setIsSaving] = useState(false);
@@ -1467,11 +1466,7 @@ function ExerciseDetailModal({
             ) : (
               <p className="text-sm text-foreground">
                 {historyQuery.data?.history
-                  ? formatLastPerformanceSummary(
-                      historyQuery.data.history,
-                      trackingType,
-                      weightUnit,
-                    )
+                  ? formatLastPerformanceSummary(historyQuery.data.history, trackingType)
                   : 'No history available.'}
               </p>
             )}
@@ -1498,7 +1493,6 @@ function ExerciseDetailModal({
                     {formatLastPerformanceSummary(
                       relatedExercise.history,
                       relatedExercise.trackingType,
-                      weightUnit,
                     )}
                   </p>
                 </div>
@@ -1804,26 +1798,22 @@ function formatTrackingTypeLabel(trackingType: ExerciseTrackingType) {
 function formatLastPerformanceSummary(
   history: { date: string; sets: Array<{ reps: number; weight: number | null }> } | null,
   trackingType: ExerciseTrackingType,
-  weightUnit: WeightUnit,
 ) {
   if (!history || history.sets.length === 0) {
     return 'No history yet.';
   }
 
-  const setSummary = history.sets
-    .map((set) =>
-      formatSetSummary(
-        trackingType === 'distance'
-          ? { distance: set.reps, weight: set.weight }
-          : { reps: set.reps, weight: set.weight },
-        trackingType,
-        {
-          useLegacySecondsFallback: trackingType !== 'reps_seconds',
-          weightUnit,
-        },
-      ),
-    )
-    .join(', ');
+  const setSummary = formatCompactSets(
+    history.sets.map((set) =>
+      trackingType === 'distance'
+        ? { distance: set.reps, weight: set.weight }
+        : { reps: set.reps, weight: set.weight },
+    ),
+    trackingType,
+    {
+      useLegacySecondsFallback: trackingType !== 'reps_seconds',
+    },
+  );
 
   return `${historyDateFormatter.format(new Date(`${history.date}T12:00:00`))} • ${setSummary}`;
 }

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -826,6 +826,7 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
               },
             })
           }
+          weightUnit={weightUnit}
         />
       ) : null}
       {historyTarget ? (
@@ -1336,14 +1337,16 @@ function ExerciseDetailModal({
   isPending,
   onOpenChange,
   onSaveCoachingNotes,
+  weightUnit,
 }: {
   exercise: WorkoutTemplateExercise;
   isPending: boolean;
   onOpenChange: (open: boolean) => void;
   onSaveCoachingNotes: (exerciseId: string, coachingNotes: string | null) => Promise<unknown>;
+  weightUnit: WeightUnit;
 }) {
   const [activeTab, setActiveTab] = useState<'overview' | 'history' | 'related'>('overview');
-  const [coachingNotes, setCoachingNotes] = useState(exercise.exercise?.coachingNotes ?? '');
+  const [coachingNotesDraft, setCoachingNotesDraft] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
 
   const exerciseQuery = useExercise(exercise.exerciseId, { enabled: true });
@@ -1353,6 +1356,8 @@ function ExerciseDetailModal({
   });
 
   const matchedExercise = exerciseQuery.data ?? null;
+  const coachingNotes =
+    coachingNotesDraft ?? matchedExercise?.coachingNotes ?? exercise.exercise?.coachingNotes ?? '';
 
   const formCues =
     matchedExercise?.formCues ?? exercise.exercise?.formCues ?? exercise.formCues ?? [];
@@ -1430,7 +1435,7 @@ function ExerciseDetailModal({
               </p>
               <Textarea
                 aria-label="Coaching notes"
-                onChange={(event) => setCoachingNotes(event.currentTarget.value)}
+                onChange={(event) => setCoachingNotesDraft(event.currentTarget.value)}
                 rows={4}
                 value={coachingNotes}
               />
@@ -1466,7 +1471,11 @@ function ExerciseDetailModal({
             ) : (
               <p className="text-sm text-foreground">
                 {historyQuery.data?.history
-                  ? formatLastPerformanceSummary(historyQuery.data.history, trackingType)
+                  ? formatLastPerformanceSummary(
+                      historyQuery.data.history,
+                      trackingType,
+                      weightUnit,
+                    )
                   : 'No history available.'}
               </p>
             )}
@@ -1493,6 +1502,7 @@ function ExerciseDetailModal({
                     {formatLastPerformanceSummary(
                       relatedExercise.history,
                       relatedExercise.trackingType,
+                      weightUnit,
                     )}
                   </p>
                 </div>
@@ -1798,6 +1808,7 @@ function formatTrackingTypeLabel(trackingType: ExerciseTrackingType) {
 function formatLastPerformanceSummary(
   history: { date: string; sets: Array<{ reps: number; weight: number | null }> } | null,
   trackingType: ExerciseTrackingType,
+  weightUnit: WeightUnit,
 ) {
   if (!history || history.sets.length === 0) {
     return 'No history yet.';
@@ -1812,6 +1823,7 @@ function formatLastPerformanceSummary(
     trackingType,
     {
       useLegacySecondsFallback: trackingType !== 'reps_seconds',
+      weightUnit,
     },
   );
 

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -1466,11 +1466,13 @@ function ExerciseDetailModal({
               <p className="text-sm text-muted">Loading recent performance...</p>
             ) : (
               <p className="text-sm text-foreground">
-                {formatLastPerformanceSummary(
-                  historyQuery.data?.history ?? null,
-                  trackingType,
-                  weightUnit,
-                )}
+                {historyQuery.data?.history
+                  ? formatLastPerformanceSummary(
+                      historyQuery.data.history,
+                      trackingType,
+                      weightUnit,
+                    )
+                  : 'No history available.'}
               </p>
             )}
           </div>

--- a/apps/web/src/features/workouts/lib/tracking.test.ts
+++ b/apps/web/src/features/workouts/lib/tracking.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  formatCompactSets,
   formatMetricNumber,
   formatSetSummary,
   formatTrackingMetricBreakdown,
@@ -96,5 +97,33 @@ describe('tracking format helpers', () => {
     expect(formatMetricNumber(135)).toBe('135');
     expect(formatMetricNumber(135.5)).toBe('135.5');
     expect(formatMetricNumber(135.678)).toBe('135.68');
+  });
+
+  it('formats compact weighted sets as weight x reps', () => {
+    expect(
+      formatCompactSets(
+        [
+          { reps: 12, weight: 60 },
+          { reps: 8, weight: 60 },
+        ],
+        'weight_reps',
+      ),
+    ).toBe('60x12, 60x8');
+  });
+
+  it('formats compact reps-only sets as rep counts', () => {
+    expect(formatCompactSets([{ reps: 10 }, { reps: 8 }, { reps: 8 }], 'reps_only')).toBe(
+      '10, 8, 8',
+    );
+  });
+
+  it('formats compact time sets with seconds suffix', () => {
+    expect(formatCompactSets([{ reps: 60 }, { reps: 45 }], 'seconds_only')).toBe('60s, 45s');
+  });
+
+  it('formats compact distance sets with meter suffix', () => {
+    expect(formatCompactSets([{ distance: 400 }, { distance: 400 }], 'distance')).toBe(
+      '400m, 400m',
+    );
   });
 });

--- a/apps/web/src/features/workouts/lib/tracking.test.ts
+++ b/apps/web/src/features/workouts/lib/tracking.test.ts
@@ -121,9 +121,11 @@ describe('tracking format helpers', () => {
     expect(formatCompactSets([{ reps: 60 }, { reps: 45 }], 'seconds_only')).toBe('60s, 45s');
   });
 
-  it('formats compact distance sets with meter suffix', () => {
-    expect(formatCompactSets([{ distance: 400 }, { distance: 400 }], 'distance')).toBe(
-      '400m, 400m',
-    );
+  it('formats compact distance sets with configured distance units', () => {
+    expect(
+      formatCompactSets([{ distance: 4 }, { distance: 2.5 }], 'distance', {
+        weightUnit: 'kg',
+      }),
+    ).toBe('4km, 2.5km');
   });
 });

--- a/apps/web/src/features/workouts/lib/tracking.ts
+++ b/apps/web/src/features/workouts/lib/tracking.ts
@@ -168,8 +168,10 @@ export function formatCompactSets(
   trackingType: ExerciseTrackingType,
   {
     useLegacySecondsFallback = true,
+    weightUnit = 'lbs',
   }: {
     useLegacySecondsFallback?: boolean;
+    weightUnit?: WeightUnit;
   } = {},
 ) {
   if (sets.length === 0) {
@@ -177,7 +179,7 @@ export function formatCompactSets(
   }
 
   return sets
-    .map((set) => formatCompactHistorySet(set, trackingType, useLegacySecondsFallback))
+    .map((set) => formatCompactHistorySet(set, trackingType, useLegacySecondsFallback, weightUnit))
     .join(', ');
 }
 
@@ -220,13 +222,15 @@ function formatCompactHistorySet(
   set: SetMetrics,
   trackingType: ExerciseTrackingType,
   useLegacySecondsFallback: boolean,
+  weightUnit: WeightUnit,
 ) {
   const w = set.weight != null ? formatWeightNumber(set.weight) : null;
   const r = set.reps != null ? formatMetricNumber(set.reps) : null;
   const seconds = getSetSecondsValue(set, useLegacySecondsFallback);
   const s = seconds != null ? `${formatMetricNumber(seconds)}s` : null;
   const distance = getSetDistance(set) ?? (trackingType === 'distance' ? set.reps : null);
-  const d = distance != null ? `${formatMetricNumber(distance)}m` : null;
+  const d =
+    distance != null ? `${formatMetricNumber(distance)}${getDistanceUnit(weightUnit)}` : null;
 
   switch (trackingType) {
     case 'weight_reps':

--- a/apps/web/src/features/workouts/lib/tracking.ts
+++ b/apps/web/src/features/workouts/lib/tracking.ts
@@ -163,6 +163,24 @@ export function formatSetSummary(
   }
 }
 
+export function formatCompactSets(
+  sets: SetMetrics[],
+  trackingType: ExerciseTrackingType,
+  {
+    useLegacySecondsFallback = true,
+  }: {
+    useLegacySecondsFallback?: boolean;
+  } = {},
+) {
+  if (sets.length === 0) {
+    return '-';
+  }
+
+  return sets
+    .map((set) => formatCompactHistorySet(set, trackingType, useLegacySecondsFallback))
+    .join(', ');
+}
+
 function formatSetCompact(
   set: SetMetrics,
   trackingType: ExerciseTrackingType,
@@ -176,6 +194,39 @@ function formatSetCompact(
   const distance = getSetDistance(set) ?? (trackingType === 'distance' ? set.reps : null);
   const d =
     distance != null ? `${formatMetricNumber(distance)}${getDistanceUnit(weightUnit)}` : null;
+
+  switch (trackingType) {
+    case 'weight_reps':
+      return w != null && r != null ? `${w}x${r}` : (w ?? r ?? '-');
+    case 'weight_seconds':
+      return w != null && s != null ? `${w}x${s}` : (w ?? s ?? '-');
+    case 'bodyweight_reps':
+    case 'reps_only':
+      return r ?? '-';
+    case 'reps_seconds':
+      return r != null && s != null ? `${r}x${s}` : (r ?? s ?? '-');
+    case 'seconds_only':
+      return s ?? '-';
+    case 'distance':
+      return d ?? '-';
+    case 'cardio':
+      return s != null && d != null ? `${s}/${d}` : (s ?? d ?? '-');
+    default:
+      return w != null && r != null ? `${w}x${r}` : (w ?? r ?? '-');
+  }
+}
+
+function formatCompactHistorySet(
+  set: SetMetrics,
+  trackingType: ExerciseTrackingType,
+  useLegacySecondsFallback: boolean,
+) {
+  const w = set.weight != null ? formatWeightNumber(set.weight) : null;
+  const r = set.reps != null ? formatMetricNumber(set.reps) : null;
+  const seconds = getSetSecondsValue(set, useLegacySecondsFallback);
+  const s = seconds != null ? `${formatMetricNumber(seconds)}s` : null;
+  const distance = getSetDistance(set) ?? (trackingType === 'distance' ? set.reps : null);
+  const d = distance != null ? `${formatMetricNumber(distance)}m` : null;
 
   switch (trackingType) {
     case 'weight_reps':

--- a/apps/web/src/features/workouts/types.ts
+++ b/apps/web/src/features/workouts/types.ts
@@ -60,6 +60,7 @@ export type ActiveWorkoutRelatedLastPerformance = {
 
 export type ActiveWorkoutExerciseHistorySummary = {
   history: ActiveWorkoutLastPerformance | null;
+  historyEntries: ActiveWorkoutLastPerformance[];
   related: ActiveWorkoutRelatedLastPerformance[];
 };
 

--- a/apps/web/src/hooks/use-last-performance.test.tsx
+++ b/apps/web/src/hooks/use-last-performance.test.tsx
@@ -21,10 +21,10 @@ describe('use-last-performance hook', () => {
     vi.stubGlobal('fetch', mockFetch);
   });
 
-  it('loads and maps exact history data for an exercise', async () => {
+  it('loads and maps exact history data for an exercise by default', async () => {
     mockFetch.mockResolvedValueOnce(
-      createJsonResponse({
-        history: {
+      createJsonResponse([
+        {
           sessionId: 'session-2',
           date: '2026-03-08',
           sets: [
@@ -40,8 +40,7 @@ describe('use-last-performance hook', () => {
             },
           ],
         },
-        related: [],
-      }),
+      ]),
     );
 
     const { wrapper } = createQueryClientWrapper();
@@ -96,7 +95,7 @@ describe('use-last-performance hook', () => {
       expect.stringContaining('/api/v1/exercises/global-bench-press/last-performance?'),
       expect.any(Object),
     );
-    expect(mockFetch).toHaveBeenCalledWith(
+    expect(mockFetch).not.toHaveBeenCalledWith(
       expect.stringContaining('includeRelated=true'),
       expect.any(Object),
     );
@@ -129,7 +128,13 @@ describe('use-last-performance hook', () => {
     );
 
     const { wrapper } = createQueryClientWrapper();
-    const { result } = renderHook(() => useLastPerformance('global-bench-press'), { wrapper });
+    const { result } = renderHook(
+      () =>
+        useLastPerformance('global-bench-press', {
+          includeRelated: true,
+        }),
+      { wrapper },
+    );
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
@@ -158,6 +163,10 @@ describe('use-last-performance hook', () => {
         },
       ],
     });
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('includeRelated=true'),
+      expect.any(Object),
+    );
   });
 
   it('returns null for not-found exercises', async () => {

--- a/apps/web/src/hooks/use-last-performance.test.tsx
+++ b/apps/web/src/hooks/use-last-performance.test.tsx
@@ -70,12 +70,37 @@ describe('use-last-performance hook', () => {
           },
         ],
       },
+      historyEntries: [
+        {
+          sessionId: 'session-2',
+          date: '2026-03-08',
+          sets: [
+            {
+              completed: true,
+              setNumber: 1,
+              weight: 105,
+              reps: 9,
+            },
+            {
+              completed: true,
+              setNumber: 2,
+              weight: 100,
+              reps: 8,
+            },
+          ],
+        },
+      ],
       related: [],
     });
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining('/api/v1/exercises/global-bench-press/last-performance?includeRelated=true'),
+      expect.stringContaining('/api/v1/exercises/global-bench-press/last-performance?'),
       expect.any(Object),
     );
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('includeRelated=true'),
+      expect.any(Object),
+    );
+    expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('limit=3'), expect.any(Object));
   });
 
   it('maps related history entries', async () => {
@@ -112,6 +137,7 @@ describe('use-last-performance hook', () => {
 
     expect(result.current.data).toEqual({
       history: null,
+      historyEntries: [],
       related: [
         {
           exerciseId: 'incline-bench',
@@ -178,17 +204,30 @@ describe('use-last-performance hook', () => {
 
   it('allows callers to disable related history payloads', async () => {
     mockFetch.mockResolvedValueOnce(
-      createJsonResponse({
-        sessionId: 'session-2',
-        date: '2026-03-08',
-        sets: [
-          {
-            setNumber: 1,
-            weight: 105,
-            reps: 9,
-          },
-        ],
-      }),
+      createJsonResponse([
+        {
+          sessionId: 'session-2',
+          date: '2026-03-08',
+          sets: [
+            {
+              setNumber: 1,
+              weight: 105,
+              reps: 9,
+            },
+          ],
+        },
+        {
+          sessionId: 'session-1',
+          date: '2026-03-01',
+          sets: [
+            {
+              setNumber: 1,
+              weight: 100,
+              reps: 8,
+            },
+          ],
+        },
+      ]),
     );
 
     const { wrapper } = createQueryClientWrapper();
@@ -211,20 +250,112 @@ describe('use-last-performance hook', () => {
         sets: [
           {
             completed: true,
+            setNumber: 1,
+            weight: 105,
+            reps: 9,
+          },
+        ],
+      },
+      historyEntries: [
+        {
+          sessionId: 'session-2',
+          date: '2026-03-08',
+          sets: [
+            {
+              completed: true,
+              reps: 9,
+              setNumber: 1,
+              weight: 105,
+            },
+          ],
+        },
+        {
+          sessionId: 'session-1',
+          date: '2026-03-01',
+          sets: [
+            {
+              completed: true,
+              reps: 8,
+              setNumber: 1,
+              weight: 100,
+            },
+          ],
+        },
+      ],
+      related: [],
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/exercises/global-bench-press/last-performance?limit=3'),
+      expect.any(Object),
+    );
+    expect(mockFetch).not.toHaveBeenCalledWith(
+      expect.stringContaining('includeRelated=true'),
+      expect.any(Object),
+    );
+  });
+
+  it('supports overriding the history limit', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse([
+        {
+          sessionId: 'session-2',
+          date: '2026-03-08',
+          sets: [
+            {
+              setNumber: 1,
+              weight: 105,
+              reps: 9,
+            },
+          ],
+        },
+      ]),
+    );
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(
+      () =>
+        useLastPerformance('global-bench-press', {
+          includeRelated: false,
+          limit: 5,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual({
+      history: {
+        sessionId: 'session-2',
+        date: '2026-03-08',
+        sets: [
+          {
+            completed: true,
             reps: 9,
             setNumber: 1,
             weight: 105,
           },
         ],
       },
+      historyEntries: [
+        {
+          sessionId: 'session-2',
+          date: '2026-03-08',
+          sets: [
+            {
+              completed: true,
+              reps: 9,
+              setNumber: 1,
+              weight: 105,
+            },
+          ],
+        },
+      ],
       related: [],
     });
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining('/api/v1/exercises/global-bench-press/last-performance'),
-      expect.any(Object),
-    );
-    expect(mockFetch).not.toHaveBeenCalledWith(
-      expect.stringContaining('/api/v1/exercises/global-bench-press/last-performance?includeRelated=true'),
+      expect.stringContaining('/api/v1/exercises/global-bench-press/last-performance?limit=5'),
       expect.any(Object),
     );
   });

--- a/apps/web/src/hooks/use-last-performance.ts
+++ b/apps/web/src/hooks/use-last-performance.ts
@@ -112,7 +112,7 @@ export function useLastPerformance(
   const normalizedExerciseId = exerciseId.trim();
   const enabled = options?.enabled ?? true;
   const { includeRelated, limit } = exerciseLastPerformanceQuerySchema.parse({
-    includeRelated: options?.includeRelated ?? true,
+    includeRelated: options?.includeRelated ?? false,
     limit: options?.limit,
   });
 

--- a/apps/web/src/hooks/use-last-performance.ts
+++ b/apps/web/src/hooks/use-last-performance.ts
@@ -1,7 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import {
   exerciseHistoryWithRelatedSchema,
-  exerciseLastPerformanceSchema,
+  exerciseLastPerformanceQuerySchema,
+  exerciseLastPerformancesSchema,
   type ExerciseLastPerformance,
 } from '@pulse/shared';
 
@@ -13,8 +14,8 @@ import { ApiError, apiRequest } from '@/lib/api-client';
 
 const lastPerformanceQueryKeys = {
   all: ['exercise-last-performance'] as const,
-  detail: (exerciseId: string, includeRelated: boolean) =>
-    ['exercise-last-performance', exerciseId, { includeRelated }] as const,
+  detail: (exerciseId: string, includeRelated: boolean, limit: number) =>
+    ['exercise-last-performance', exerciseId, { includeRelated, limit }] as const,
 };
 
 function mapLastPerformance(
@@ -47,10 +48,18 @@ function mapLastPerformance(
 async function getLastPerformance(
   exerciseId: string,
   includeRelated: boolean,
+  limit: number,
 ): Promise<ActiveWorkoutExerciseHistorySummary | null> {
+  const query = new URLSearchParams({
+    limit: String(limit),
+  });
+  if (includeRelated) {
+    query.set('includeRelated', 'true');
+  }
+
   try {
     const data = await apiRequest<unknown>(
-      `/api/v1/exercises/${exerciseId}/last-performance${includeRelated ? '?includeRelated=true' : ''}`,
+      `/api/v1/exercises/${exerciseId}/last-performance?${query}`,
     );
 
     if (data == null) {
@@ -58,17 +67,24 @@ async function getLastPerformance(
     }
 
     if (!includeRelated) {
-      const payload = exerciseLastPerformanceSchema.parse(data);
+      const payload = exerciseLastPerformancesSchema.parse(data);
+      const historyEntries = payload
+        .map((entry) => mapLastPerformance(entry))
+        .filter((entry): entry is ActiveWorkoutLastPerformance => entry != null);
+
       return {
-        history: mapLastPerformance(payload),
+        history: historyEntries[0] ?? null,
+        historyEntries,
         related: [],
       };
     }
 
     const payload = exerciseHistoryWithRelatedSchema.parse(data);
+    const history = mapLastPerformance(payload.history);
 
     return {
-      history: mapLastPerformance(payload.history),
+      history,
+      historyEntries: history ? [history] : [],
       related: payload.related.map((relatedExercise) => ({
         exerciseId: relatedExercise.exerciseId,
         exerciseName: relatedExercise.exerciseName,
@@ -90,16 +106,20 @@ export function useLastPerformance(
   options?: {
     enabled?: boolean;
     includeRelated?: boolean;
+    limit?: number;
   },
 ) {
   const normalizedExerciseId = exerciseId.trim();
   const enabled = options?.enabled ?? true;
-  const includeRelated = options?.includeRelated ?? true;
+  const { includeRelated, limit } = exerciseLastPerformanceQuerySchema.parse({
+    includeRelated: options?.includeRelated ?? true,
+    limit: options?.limit,
+  });
 
   return useQuery<ActiveWorkoutExerciseHistorySummary | null>({
     enabled: enabled && normalizedExerciseId.length > 0,
-    queryFn: () => getLastPerformance(normalizedExerciseId, includeRelated),
-    queryKey: lastPerformanceQueryKeys.detail(normalizedExerciseId, includeRelated),
+    queryFn: () => getLastPerformance(normalizedExerciseId, includeRelated, limit),
+    queryKey: lastPerformanceQueryKeys.detail(normalizedExerciseId, includeRelated, limit),
   });
 }
 

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -1096,9 +1096,8 @@ describe('ActiveWorkoutPage', () => {
       }
 
       if (
-        url.includes(
-          '/api/v1/exercises/incline-dumbbell-press/last-performance?includeRelated=true',
-        )
+        url.includes('/api/v1/exercises/incline-dumbbell-press/last-performance') &&
+        url.includes('includeRelated=true')
       ) {
         return Promise.resolve(
           jsonResponse({
@@ -1114,6 +1113,23 @@ describe('ActiveWorkoutPage', () => {
         );
       }
 
+      if (
+        url.includes('/api/v1/exercises/incline-dumbbell-press/last-performance') &&
+        !url.includes('includeRelated=true')
+      ) {
+        return Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                sessionId: 'session-1',
+                date: '2026-03-08',
+                sets: [{ setNumber: 1, weight: 70, reps: 10 }],
+              },
+            ],
+          }),
+        );
+      }
+
       return Promise.reject(new Error(`Unexpected fetch request: ${url}`));
     });
     vi.stubGlobal('fetch', mockFetch);
@@ -1125,12 +1141,29 @@ describe('ActiveWorkoutPage', () => {
     await waitFor(() => {
       expect(
         mockFetch.mock.calls.some(([url]) =>
-          String(url).includes(
-            '/api/v1/exercises/incline-dumbbell-press/last-performance?includeRelated=true',
-          ),
+          String(url).includes('/api/v1/exercises/incline-dumbbell-press/last-performance'),
         ),
       ).toBe(true);
     });
+    expect(
+      mockFetch.mock.calls.some(([url]) => {
+        const urlText = String(url);
+        return (
+          urlText.includes('/api/v1/exercises/incline-dumbbell-press/last-performance') &&
+          urlText.includes('includeRelated=true')
+        );
+      }),
+    ).toBe(true);
+    expect(
+      mockFetch.mock.calls.some(([url]) => {
+        const urlText = String(url);
+        return (
+          urlText.includes('/api/v1/exercises/incline-dumbbell-press/last-performance') &&
+          !urlText.includes('includeRelated=true') &&
+          urlText.includes('limit=3')
+        );
+      }),
+    ).toBe(true);
   });
 
   it('renders reps_only and seconds_only inputs from API template tracking types', async () => {

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -139,7 +139,7 @@ describe('ActiveWorkoutPage', () => {
     expect(within(optionalCard).getByText('Optional')).toBeInTheDocument();
   });
 
-  it('triggers rest timer on auto-completion and clears it when a field is emptied', () => {
+  it('keeps the rest timer running when editing an incomplete set', () => {
     renderActiveWorkoutPage();
 
     const inclineCard = getExerciseCard('Incline Dumbbell Press');
@@ -155,43 +155,29 @@ describe('ActiveWorkoutPage', () => {
     });
 
     expect(screen.getByText('After Incline Dumbbell Press set 1')).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+
+    const remainingBeforeEdit = getRestTimerRemainingSeconds();
 
     fireEvent.change(within(inclineCard).getByLabelText('Weight for set 2'), {
       target: { value: '52.5' },
     });
-    fireEvent.change(within(inclineCard).getByLabelText('Reps for set 2'), {
-      target: { value: '8' },
-    });
     act(() => {
       vi.advanceTimersByTime(250);
     });
 
-    expect(screen.getByText('After Incline Dumbbell Press set 2')).toBeInTheDocument();
+    expect(screen.getByText('After Incline Dumbbell Press set 1')).toBeInTheDocument();
+    const remainingAfterEdit = getRestTimerRemainingSeconds();
+    expect(remainingAfterEdit).toBeLessThanOrEqual(remainingBeforeEdit);
 
     act(() => {
-      vi.advanceTimersByTime(20_000);
+      vi.advanceTimersByTime(2_000);
     });
 
-    // Editing a value on an already-completed set does not restart the rest timer
-    fireEvent.change(within(inclineCard).getByLabelText('Reps for set 2'), {
-      target: { value: '9' },
-    });
-    act(() => {
-      vi.advanceTimersByTime(250);
-    });
-
-    expect(screen.getByText('After Incline Dumbbell Press set 2')).toBeInTheDocument();
-    expect(screen.queryByText('1:30')).not.toBeInTheDocument();
-
-    // Clearing a required field auto-uncompletes and clears the rest timer
-    fireEvent.change(within(inclineCard).getByLabelText('Reps for set 2'), {
-      target: { value: '' },
-    });
-    act(() => {
-      vi.advanceTimersByTime(250);
-    });
-
-    expect(screen.queryByText('After Incline Dumbbell Press set 2')).not.toBeInTheDocument();
+    const remainingAfterTick = getRestTimerRemainingSeconds();
+    expect(remainingAfterTick).toBeLessThan(remainingAfterEdit);
   });
 
   it('moves from session logging to feedback, summary, and back to workouts', async () => {
@@ -1612,6 +1598,25 @@ function completeSet(exerciseName: string, setNumber: number) {
   if (skipButton) {
     fireEvent.click(skipButton);
   }
+}
+
+function getRestTimerRemainingSeconds() {
+  const restTimer = screen.getByRole('timer', { name: 'Rest timer' });
+  const timerText = restTimer.textContent ?? '';
+  const minuteSecondMatch = timerText.match(/(\d+):(\d{2})/);
+
+  if (minuteSecondMatch) {
+    const [, minutes, seconds] = minuteSecondMatch;
+    return Number(minutes) * 60 + Number(seconds);
+  }
+
+  const secondsMatch = timerText.match(/(\d+)s/);
+
+  if (secondsMatch) {
+    return Number(secondsMatch[1]);
+  }
+
+  throw new Error(`Unable to parse rest timer text: ${timerText}`);
 }
 
 function buildCompletedSessionResponse() {

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -1054,6 +1054,99 @@ describe('ActiveWorkoutPage', () => {
     expect(screen.getByText(/Exercise 1 of \d+/)).toBeInTheDocument();
   });
 
+  it('fetches inline last performance from the API for server-backed template sessions', async () => {
+    vi.useRealTimers();
+    const templateId = '2679a7dd-4a40-4c3e-8bf6-7a70eb4ab5db';
+
+    const mockFetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.endsWith('/api/v1/auth/register')) {
+        return Promise.resolve(jsonResponse({ data: { token: 'dev-generated-token' } }));
+      }
+
+      if (url.endsWith(`/api/v1/workout-templates/${templateId}`)) {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: templateId,
+              userId: 'user-1',
+              name: 'API Full Body',
+              description: 'Loaded from API',
+              tags: ['strength'],
+              sections: [
+                {
+                  type: 'warmup',
+                  exercises: [],
+                },
+                {
+                  type: 'main',
+                  exercises: [
+                    {
+                      id: 'template-exercise-1',
+                      exerciseId: 'incline-dumbbell-press',
+                      exerciseName: 'Incline Dumbbell Press',
+                      sets: 3,
+                      repsMin: 8,
+                      repsMax: 10,
+                      tempo: '3110',
+                      restSeconds: 90,
+                      supersetGroup: null,
+                      notes: null,
+                      cues: [],
+                    },
+                  ],
+                },
+                {
+                  type: 'cooldown',
+                  exercises: [],
+                },
+              ],
+              createdAt: 100,
+              updatedAt: 100,
+            },
+          }),
+        );
+      }
+
+      if (
+        url.includes(
+          '/api/v1/exercises/incline-dumbbell-press/last-performance?includeRelated=true',
+        )
+      ) {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              history: {
+                sessionId: 'session-1',
+                date: '2026-03-08',
+                sets: [{ setNumber: 1, weight: 70, reps: 10 }],
+              },
+              related: [],
+            },
+          }),
+        );
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch request: ${url}`));
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    renderActiveWorkoutPage(`/workouts/active?template=${templateId}`);
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'API Full Body' })).toBeVisible();
+
+    await waitFor(() => {
+      expect(
+        mockFetch.mock.calls.some(([url]) =>
+          String(url).includes(
+            '/api/v1/exercises/incline-dumbbell-press/last-performance?includeRelated=true',
+          ),
+        ),
+      ).toBe(true);
+    });
+  });
+
   it('renders reps_only and seconds_only inputs from API template tracking types', async () => {
     vi.useRealTimers();
     const templateId = '2679a7dd-4a40-4c3e-8bf6-7a70eb4ab5db';

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -1153,7 +1153,7 @@ describe('ActiveWorkoutPage', () => {
           urlText.includes('includeRelated=true')
         );
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       mockFetch.mock.calls.some(([url]) => {
         const urlText = String(url);

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -235,6 +235,7 @@ export function ActiveWorkoutPage() {
   const activeSessionId = activeSession?.id ?? null;
   const activeSessionStatus = activeSession?.status ?? null;
   const isPaused = activeSessionStatus === 'paused';
+  const enableApiLastPerformance = Boolean(activeSessionId) || shouldLoadApiTemplate;
   const activeWorkoutDraftId = activeSessionId ?? sessionId ?? template.id;
   const startTime =
     startTimeOverride ??
@@ -717,7 +718,7 @@ export function ActiveWorkoutPage() {
           <SessionContext context={sessionContext} />
 
           <SessionExerciseList
-            enableApiLastPerformance={Boolean(activeSessionId)}
+            enableApiLastPerformance={enableApiLastPerformance}
             focusSetId={focusSetId}
             onAddSet={handleAddSet}
             onExerciseNotesChange={(exerciseId, notes) =>

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -1167,13 +1167,6 @@ export function ActiveWorkoutPage() {
       );
     }
 
-    if (update.completed === false) {
-      setRestTimer(null);
-      setRestTimerTargetSetId(null);
-      setFocusSetId(null);
-      return;
-    }
-
     if (update.completed !== true || previousSet.completed || !updatedSet.completed) {
       return;
     }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     ]
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@eslint/js": "^10.0.1",
     "eslint": "^10.0.2",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/packages/shared/src/schemas/exercises.test.ts
+++ b/packages/shared/src/schemas/exercises.test.ts
@@ -360,20 +360,31 @@ describe('exerciseLastPerformanceSchema', () => {
 });
 
 describe('exerciseLastPerformanceQuerySchema', () => {
-  it('defaults includeRelated to false', () => {
+  it('defaults includeRelated to false and limit to 3', () => {
     const payload: ExerciseLastPerformanceQuery = exerciseLastPerformanceQuerySchema.parse({});
 
     expect(payload).toEqual({
       includeRelated: false,
+      limit: 3,
     });
   });
 
-  it('coerces includeRelated query string values', () => {
+  it('coerces includeRelated and limit query string values', () => {
     const payload = exerciseLastPerformanceQuerySchema.parse({
       includeRelated: 'true',
+      limit: '5',
     });
 
     expect(payload.includeRelated).toBe(true);
+    expect(payload.limit).toBe(5);
+  });
+
+  it('enforces a maximum limit of 10', () => {
+    expect(() =>
+      exerciseLastPerformanceQuerySchema.parse({
+        limit: 11,
+      }),
+    ).toThrow();
   });
 });
 

--- a/packages/shared/src/schemas/exercises.ts
+++ b/packages/shared/src/schemas/exercises.ts
@@ -134,6 +134,7 @@ export const exerciseQueryParamsSchema = z.object({
 
 export const exerciseLastPerformanceQuerySchema = z.object({
   includeRelated: z.coerce.boolean().optional().default(false),
+  limit: z.coerce.number().int().min(1).max(10).default(3),
 });
 
 export const exercisePerformanceHistoryQuerySchema = z.object({
@@ -151,6 +152,8 @@ export const exerciseLastPerformanceSchema = z.object({
   date: dateSchema,
   sets: z.array(exerciseLastPerformanceSetSchema).max(100),
 });
+
+export const exerciseLastPerformancesSchema = z.array(exerciseLastPerformanceSchema).max(10);
 
 export const relatedExerciseLastPerformanceSchema = z.object({
   exerciseId: z.string(),
@@ -184,8 +187,11 @@ export type ExerciseQueryParams = z.infer<typeof exerciseQueryParamsSchema>;
 export type ExerciseLastPerformanceQuery = z.infer<typeof exerciseLastPerformanceQuerySchema>;
 export type ExercisePerformanceHistoryQuery = z.infer<typeof exercisePerformanceHistoryQuerySchema>;
 export type ExerciseLastPerformance = z.infer<typeof exerciseLastPerformanceSchema>;
+export type ExerciseLastPerformances = z.infer<typeof exerciseLastPerformancesSchema>;
 export type ExerciseLastPerformanceSet = z.infer<typeof exerciseLastPerformanceSetSchema>;
 export type RelatedExerciseLastPerformance = z.infer<typeof relatedExerciseLastPerformanceSchema>;
 export type ExerciseHistoryWithRelated = z.infer<typeof exerciseHistoryWithRelatedSchema>;
-export type ExercisePerformanceHistorySession = z.infer<typeof exercisePerformanceHistorySessionSchema>;
+export type ExercisePerformanceHistorySession = z.infer<
+  typeof exercisePerformanceHistorySessionSchema
+>;
 export type ExercisePerformanceHistory = z.infer<typeof exercisePerformanceHistorySchema>;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,12 +1,13 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig, devices } from '@playwright/test';
 
 const apiPort = process.env.API_PORT || process.env.VITE_API_PORT || process.env.PORT || '3101';
 const e2ePort = process.env.E2E_PORT || '4173';
 const baseURL = process.env.BASE_URL || `http://127.0.0.1:${e2ePort}`;
 const apiBaseURL = process.env.API_BASE_URL || `http://127.0.0.1:${apiPort}`;
-const e2eDatabasePath =
-  process.env.E2E_DATABASE_URL || path.resolve(process.cwd(), 'data/pulse-e2e.db');
+const repoRoot = path.dirname(fileURLToPath(import.meta.url));
+const e2eDatabasePath = process.env.E2E_DATABASE_URL || path.resolve(repoRoot, 'data/pulse-e2e.db');
 
 export default defineConfig({
   testDir: './apps/web/e2e',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,39 @@
+import path from 'node:path';
+import { defineConfig, devices } from '@playwright/test';
+
+const apiPort = process.env.API_PORT || process.env.VITE_API_PORT || process.env.PORT || '3101';
+const e2ePort = process.env.E2E_PORT || '4173';
+const baseURL = process.env.BASE_URL || `http://127.0.0.1:${e2ePort}`;
+const apiBaseURL = process.env.API_BASE_URL || `http://127.0.0.1:${apiPort}`;
+const e2eDatabasePath =
+  process.env.E2E_DATABASE_URL || path.resolve(process.cwd(), 'data/pulse-e2e.db');
+
+export default defineConfig({
+  testDir: './apps/web/e2e',
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+  ],
+  webServer: [
+    {
+      command: `PORT=${apiPort} DATABASE_URL=${e2eDatabasePath} pnpm --filter api dev`,
+      cwd: process.cwd(),
+      reuseExistingServer: !process.env.CI,
+      url: `${apiBaseURL}/health`,
+    },
+    {
+      command: `VITE_API_PORT=${apiPort} pnpm --filter web dev --host 127.0.0.1 --port ${e2ePort}`,
+      cwd: process.cwd(),
+      reuseExistingServer: !process.env.CI,
+      url: baseURL,
+    },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.0.2(jiti@2.6.1))
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       eslint:
         specifier: ^10.0.2
         version: 10.0.2(jiti@2.6.1)


### PR DESCRIPTION
## Summary
This PR fixes a cluster of workout regressions and adds integrity safeguards for exercise and food metadata. On the API side, it adds `GET /api/v1/exercises/:id`, updates `GET /api/v1/exercises/:id/last-performance` to support capped recent-history responses, and hardens exercise deletion with clearer in-use conflict handling. On the web side, it fixes template exercise detail/history fallback behavior, prevents rest timer resets while editing sets, and improves inline history readability by showing three compact entries with tracking-type-aware formatting. It also introduces an admin-only reconciliation endpoint to rebuild `foods.usageCount`/`lastUsedAt` from `meal_items`, plus test coverage for the new behavior. Finally, Playwright setup and specs were aligned to the project’s non-default ports so root E2E runs are stable.

## Key Changes
- Added `GET /api/v1/exercises/:id` (visible/global or user-owned, non-deleted) for direct exercise detail lookups.
- Changed last-performance behavior:
  - Added query param `limit` (default `3`, max `10`).
  - Non-related responses now return an array of recent completed performances (empty array when none).
  - Related-history shape remains available via `includeRelated=true`.
- Fixed exercise deletion conflicts:
  - Added pre-delete `isExerciseInUse` checks against active templates/sessions.
  - Returns `409 EXERCISE_IN_USE` with a targeted message.
  - Ignores references from soft-deleted templates/sessions.
  - Added FK-constraint fallback handling for race conditions.
- Updated workout UI history flows:
  - Inline quick history now shows up to 3 compact entries.
  - Introduced shared compact set formatter used across active workout, template detail, and history modal.
  - Related history fetch is deferred until an exercise panel is expanded.
- Fixed active workout rest timer behavior so editing/uncompleting set fields no longer clears/restarts the timer unexpectedly.
- Added JWT-only `POST /api/v1/admin/reconcile-food-usage` to recompute per-user food usage metadata from meal item references.
- Added root `playwright.config.ts`, normalized E2E env/port usage (`3101`-aware), and updated specs for current UI labels/flows.

## Technical Notes
- `exerciseLastPerformanceQuerySchema` now validates both `includeRelated` and `limit`; `exerciseLastPerformancesSchema` models the capped array response.
- `useLastPerformance` now keys cache by `(exerciseId, includeRelated, limit)` and supports dual-query usage (quick history vs related history).
- `useExercise` now treats `404` as `null` instead of surfacing a hard error, allowing modal/history fallback without error toast noise.
- Reconciliation runs in a DB transaction and updates `usageCount` and `lastUsedAt` from grouped `meal_items` references for non-deleted user foods.

## Commits

- `476f2fc fix(api): add food usage reconciliation endpoint`
- `e58ef11 fix(workouts): address commit-8 review follow-ups`
- `1d5baf3 fix(workouts): handle exercise-in-use deletes and add library table view`
- `b39456c fix(workouts): apply commit-7 review fixes`
- `daff473 fix(workouts): show three compact quick history entries`
- `620e5e6 fix(web): make root playwright e2e runnable and stable`
- `a277867 fix(web): fix E2E test port config and spec mismatches`
- `088af12 fix(workouts): prevent rest timer reset on set input`
- `32ba90d fix(workouts): fix exercise history loading and template modal 404`

## Tasks

- **Fix inline history 'No history' and exercise modal 404**: Fix useLastPerformance fallback path and exercise detail modal 404 error from template page.
- **Fix rest timer resets on set input**: Fix recurring bug where set field input resets the rest timer. Write E2E Playwright test.
- **Quick history 3 entries and compact formatting**: Show last 3 history entries in inline exercise history. Standardize compact format by tracking type.
- **Exercise integrity errors and card/table view toggle**: Improve FK constraint error messages. Add card/table view toggle to exercise library.
- **Food usage_count reconciliation endpoint**: Verify existing usage tracking and add POST /api/v1/admin/reconcile-food-usage endpoint.

## Diff Stats

```
.agents/skills/pulse-app-usage/SKILL.md            |   5 +
 .../__tests__/food-usage-reconciliation.test.ts    | 326 ++++++++++++++++
 apps/api/src/index.test.ts                         |  30 +-
 apps/api/src/routes/exercises/index.test.ts        | 427 +++++++++++++++++++--
 apps/api/src/routes/exercises/index.ts             | 100 ++++-
 apps/api/src/routes/exercises/store.ts             | 181 ++++++---
 apps/api/src/routes/foods/store.ts                 |  80 +++-
 apps/api/src/routes/v1/index.ts                    |  31 +-
 apps/web/e2e/habits.spec.ts                        |  14 +-
 apps/web/e2e/smoke.spec.ts                         |   2 +-
 apps/web/e2e/test-env.ts                           |   3 +
 apps/web/e2e/workout-scheduling.spec.ts            |  35 +-
 apps/web/e2e/workout-session.spec.ts               | 114 ++++--
 apps/web/playwright.config.ts                      |   6 +-
 apps/web/src/features/workouts/api/workouts.ts     |  26 +-
 .../workouts/components/exercise-history-modal.tsx |  31 +-
 .../workouts/components/exercise-library.test.tsx  | 142 ++++++-
 .../workouts/components/exercise-library.tsx       | 121 +++++-
 .../workouts/components/session-detail.test.tsx    |   2 +-
 .../components/session-exercise-list.test.tsx      | 167 +++++++-
 .../workouts/components/session-exercise-list.tsx  | 174 ++++-----
 .../workouts/components/template-detail.test.tsx   |  57 +++
 .../workouts/components/template-detail.tsx        |  40 +-
 .../web/src/features/workouts/lib/tracking.test.ts |  29 ++
 apps/web/src/features/workouts/lib/tracking.ts     |  51 +++
 apps/web/src/features/workouts/types.ts            |   1 +
 apps/web/src/hooks/use-last-performance.test.tsx   | 147 ++++++-
 apps/web/src/hooks/use-last-performance.ts         |  40 +-
 apps/web/src/pages/active-workout.test.tsx         | 181 +++++++--
 apps/web/src/pages/active-workout.tsx              |  10 +-
 package.json                                       |   1 +
 packages/shared/src/schemas/exercises.test.ts      |  15 +-
 packages/shared/src/schemas/exercises.ts           |   8 +-
 playwright.config.ts                               |  39 ++
 pnpm-lock.yaml                                     |   3 +
 35 files changed, 2253 insertions(+), 386 deletions(-)
```