### PR TITLE
feat(web): exercise modal interaction rework and history links

### DIFF
--- a/apps/web/src/features/dashboard/components/habit-chain.test.tsx
+++ b/apps/web/src/features/dashboard/components/habit-chain.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { useUpdateHabitEntry } from '@/features/habits/api/habits';
+import { toDateKey } from '@/lib/date';
 
 import { HabitChain } from './habit-chain';
 
@@ -28,15 +29,13 @@ const DAYS = 30;
 const dayOffsets = Array.from({ length: DAYS }, (_, index) => DAYS - 1 - index);
 
 const today = new Date();
-today.setUTCHours(12, 0, 0, 0);
+today.setHours(12, 0, 0, 0);
 
 const addDays = (date: Date, days: number) => {
   const next = new Date(date);
-  next.setUTCDate(next.getUTCDate() + days);
+  next.setDate(next.getDate() + days);
   return next;
 };
-
-const formatDateKey = (date: Date) => date.toISOString().slice(0, 10);
 
 const buildHabit = (id: string, name: string, missedOffsets: number[]): HabitMock => {
   const missedDays = new Set(missedOffsets);
@@ -45,7 +44,7 @@ const buildHabit = (id: string, name: string, missedOffsets: number[]): HabitMoc
     id,
     name,
     entries: dayOffsets.map((daysAgo) => ({
-      date: formatDateKey(addDays(today, -daysAgo)),
+      date: toDateKey(addDays(today, -daysAgo)),
       completed: !missedDays.has(daysAgo),
     })),
   };

--- a/apps/web/src/features/workouts/components/exercise-detail-modal.test.tsx
+++ b/apps/web/src/features/workouts/components/exercise-detail-modal.test.tsx
@@ -99,9 +99,24 @@ describe('ExerciseDetailModal', () => {
 
     fireEvent.click(screen.getByRole('tab', { name: 'History' }));
 
-    expect(screen.getByTestId('exercise-trend-chart')).toBeInTheDocument();
     expect(screen.getByText('Mar 6, 2026 · 70x10, 70x9')).toBeInTheDocument();
     expect(screen.getByText('Notes: Felt strong.')).toBeInTheDocument();
+  });
+
+  it('renders trends tab with trend chart', () => {
+    render(
+      <ExerciseDetailModal
+        context="template"
+        exerciseId="incline-dumbbell-press"
+        onOpenChange={vi.fn()}
+        open
+        templateExerciseId="template-exercise-1"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Trends' }));
+
+    expect(screen.getByTestId('exercise-trend-chart')).toBeInTheDocument();
   });
 
   it('shows edit button in template context', () => {
@@ -171,5 +186,20 @@ describe('ExerciseDetailModal', () => {
     expect(screen.queryByRole('button', { name: 'Edit exercise' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Swap exercise' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Add to template' })).not.toBeInTheDocument();
+  });
+
+  it('defaults to history tab for session context', () => {
+    render(
+      <ExerciseDetailModal
+        context="session"
+        exerciseId="incline-dumbbell-press"
+        onOpenChange={vi.fn()}
+        open
+      />,
+    );
+
+    expect(screen.getByRole('tabpanel', { name: 'History' })).toBeInTheDocument();
+    expect(screen.getByText('Session history')).toBeInTheDocument();
+    expect(screen.queryByRole('tabpanel', { name: 'Overview' })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/workouts/components/exercise-detail-modal.test.tsx
+++ b/apps/web/src/features/workouts/components/exercise-detail-modal.test.tsx
@@ -1,4 +1,6 @@
+import type { ComponentProps } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useExerciseHistory } from '@/hooks/use-exercise-history';
@@ -24,6 +26,15 @@ vi.mock('./exercise-trend-chart', () => ({
 
 const useExerciseMock = vi.mocked(useExercise);
 const useExerciseHistoryMock = vi.mocked(useExerciseHistory);
+type ExerciseDetailModalProps = ComponentProps<typeof ExerciseDetailModal>;
+
+function renderModal(props: ExerciseDetailModalProps) {
+  return render(
+    <MemoryRouter>
+      <ExerciseDetailModal {...props} />
+    </MemoryRouter>,
+  );
+}
 
 function setup() {
   useExerciseMock.mockReturnValue({
@@ -67,15 +78,13 @@ describe('ExerciseDetailModal', () => {
   });
 
   it('renders overview tab with exercise details', () => {
-    render(
-      <ExerciseDetailModal
-        context="template"
-        exerciseId="incline-dumbbell-press"
-        onOpenChange={vi.fn()}
-        open
-        templateExerciseId="template-exercise-1"
-      />,
-    );
+    renderModal({
+      context: 'template',
+      exerciseId: 'incline-dumbbell-press',
+      onOpenChange: vi.fn(),
+      open: true,
+      templateExerciseId: 'template-exercise-1',
+    });
 
     expect(screen.getByText('Incline Dumbbell Press')).toBeInTheDocument();
     expect(screen.getByText('Category')).toBeInTheDocument();
@@ -87,15 +96,13 @@ describe('ExerciseDetailModal', () => {
   });
 
   it('renders history tab with session history and trend chart', () => {
-    render(
-      <ExerciseDetailModal
-        context="template"
-        exerciseId="incline-dumbbell-press"
-        onOpenChange={vi.fn()}
-        open
-        templateExerciseId="template-exercise-1"
-      />,
-    );
+    renderModal({
+      context: 'template',
+      exerciseId: 'incline-dumbbell-press',
+      onOpenChange: vi.fn(),
+      open: true,
+      templateExerciseId: 'template-exercise-1',
+    });
 
     fireEvent.click(screen.getByRole('tab', { name: 'History' }));
 
@@ -104,15 +111,13 @@ describe('ExerciseDetailModal', () => {
   });
 
   it('renders trends tab with trend chart', () => {
-    render(
-      <ExerciseDetailModal
-        context="template"
-        exerciseId="incline-dumbbell-press"
-        onOpenChange={vi.fn()}
-        open
-        templateExerciseId="template-exercise-1"
-      />,
-    );
+    renderModal({
+      context: 'template',
+      exerciseId: 'incline-dumbbell-press',
+      onOpenChange: vi.fn(),
+      open: true,
+      templateExerciseId: 'template-exercise-1',
+    });
 
     fireEvent.click(screen.getByRole('tab', { name: 'Trends' }));
 
@@ -120,15 +125,13 @@ describe('ExerciseDetailModal', () => {
   });
 
   it('shows edit button in template context', () => {
-    render(
-      <ExerciseDetailModal
-        context="template"
-        exerciseId="incline-dumbbell-press"
-        onOpenChange={vi.fn()}
-        open
-        templateExerciseId="template-exercise-1"
-      />,
-    );
+    renderModal({
+      context: 'template',
+      exerciseId: 'incline-dumbbell-press',
+      onOpenChange: vi.fn(),
+      open: true,
+      templateExerciseId: 'template-exercise-1',
+    });
 
     expect(screen.getByRole('button', { name: 'Edit exercise' })).toBeInTheDocument();
   });
@@ -137,15 +140,13 @@ describe('ExerciseDetailModal', () => {
     const onOpenChange = vi.fn();
     const onSwapExercise = vi.fn();
 
-    render(
-      <ExerciseDetailModal
-        context="session"
-        exerciseId="incline-dumbbell-press"
-        onOpenChange={onOpenChange}
-        onSwapExercise={onSwapExercise}
-        open
-      />,
-    );
+    renderModal({
+      context: 'session',
+      exerciseId: 'incline-dumbbell-press',
+      onOpenChange,
+      onSwapExercise,
+      open: true,
+    });
 
     fireEvent.click(screen.getByRole('button', { name: 'Swap exercise' }));
 
@@ -157,15 +158,13 @@ describe('ExerciseDetailModal', () => {
     const onAddToTemplate = vi.fn();
     const onOpenChange = vi.fn();
 
-    render(
-      <ExerciseDetailModal
-        context="library"
-        exerciseId="incline-dumbbell-press"
-        onAddToTemplate={onAddToTemplate}
-        onOpenChange={onOpenChange}
-        open
-      />,
-    );
+    renderModal({
+      context: 'library',
+      exerciseId: 'incline-dumbbell-press',
+      onAddToTemplate,
+      onOpenChange,
+      open: true,
+    });
 
     fireEvent.click(screen.getByRole('button', { name: 'Add to template' }));
 
@@ -174,14 +173,12 @@ describe('ExerciseDetailModal', () => {
   });
 
   it('shows no context action buttons in receipt context', () => {
-    render(
-      <ExerciseDetailModal
-        context="receipt"
-        exerciseId="incline-dumbbell-press"
-        onOpenChange={vi.fn()}
-        open
-      />,
-    );
+    renderModal({
+      context: 'receipt',
+      exerciseId: 'incline-dumbbell-press',
+      onOpenChange: vi.fn(),
+      open: true,
+    });
 
     expect(screen.queryByRole('button', { name: 'Edit exercise' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Swap exercise' })).not.toBeInTheDocument();
@@ -189,17 +186,33 @@ describe('ExerciseDetailModal', () => {
   });
 
   it('defaults to history tab for session context', () => {
-    render(
-      <ExerciseDetailModal
-        context="session"
-        exerciseId="incline-dumbbell-press"
-        onOpenChange={vi.fn()}
-        open
-      />,
-    );
+    renderModal({
+      context: 'session',
+      exerciseId: 'incline-dumbbell-press',
+      onOpenChange: vi.fn(),
+      open: true,
+    });
 
     expect(screen.getByRole('tabpanel', { name: 'History' })).toBeInTheDocument();
     expect(screen.getByText('Session history')).toBeInTheDocument();
     expect(screen.queryByRole('tabpanel', { name: 'Overview' })).not.toBeInTheDocument();
+  });
+
+  it('renders a full workout receipt link for each history session and closes modal on click', () => {
+    const onOpenChange = vi.fn();
+
+    renderModal({
+      context: 'session',
+      exerciseId: 'incline-dumbbell-press',
+      onOpenChange,
+      open: true,
+    });
+
+    const receiptLink = screen.getByRole('link', { name: 'View full workout' });
+    expect(receiptLink).toHaveAttribute('href', '/workouts/sessions/session-1');
+
+    fireEvent.click(receiptLink);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/apps/web/src/features/workouts/components/exercise-detail-modal.tsx
+++ b/apps/web/src/features/workouts/components/exercise-detail-modal.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo, useState } from 'react';
+import { useId, useState } from 'react';
 import type { ExerciseTrackingType } from '@pulse/shared';
 
 import { Badge } from '@/components/ui/badge';
@@ -18,7 +18,6 @@ import { useExercise } from '../api/workouts';
 import { getTemplateExerciseElementId } from '../lib/template-exercise-id';
 import { formatCompactSets } from '../lib/tracking';
 import type {
-  ActiveWorkoutExerciseHistoryPoint,
   ActiveWorkoutPerformanceHistorySession,
 } from '../types';
 import { ExerciseTrendChart } from './exercise-trend-chart';
@@ -42,6 +41,10 @@ const historyDateFormatter = new Intl.DateTimeFormat('en-US', {
 });
 const EMPTY_HISTORY: ActiveWorkoutPerformanceHistorySession[] = [];
 
+function getDefaultActiveTab(context: ExerciseDetailModalContext): 'overview' | 'history' | 'trends' {
+  return context === 'session' ? 'history' : 'overview';
+}
+
 export function ExerciseDetailModal({
   context,
   exerciseId,
@@ -53,11 +56,15 @@ export function ExerciseDetailModal({
 }: ExerciseDetailModalProps) {
   const tabId = useId();
   const { weightUnit } = useWeightUnit();
-  const [activeTab, setActiveTab] = useState<'overview' | 'history'>('overview');
+  const [activeTab, setActiveTab] = useState<'overview' | 'history' | 'trends'>(
+    getDefaultActiveTab(context),
+  );
   const overviewTabId = `${tabId}-overview-tab`;
   const historyTabId = `${tabId}-history-tab`;
+  const trendsTabId = `${tabId}-trends-tab`;
   const overviewPanelId = `${tabId}-overview-panel`;
   const historyPanelId = `${tabId}-history-panel`;
+  const trendsPanelId = `${tabId}-trends-panel`;
   const exerciseQuery = useExercise(exerciseId, { enabled: open });
   const historyQuery = useExerciseHistory(exerciseId, {
     enabled: open,
@@ -66,10 +73,6 @@ export function ExerciseDetailModal({
   const exercise = exerciseQuery.data ?? null;
   const trackingType: ExerciseTrackingType = exercise?.trackingType ?? 'weight_reps';
   const historyList = historyQuery.data ?? EMPTY_HISTORY;
-  const trendHistory = useMemo(
-    () => toExerciseTrendHistory(historyQuery.data ?? EMPTY_HISTORY, trackingType),
-    [historyQuery.data, trackingType],
-  );
 
   const title = exercise?.name ?? 'Exercise details';
   const description = exercise
@@ -77,9 +80,7 @@ export function ExerciseDetailModal({
     : 'Exercise metadata unavailable';
 
   const handleOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen) {
-      setActiveTab('overview');
-    }
+    setActiveTab(getDefaultActiveTab(context));
     onOpenChange(nextOpen);
   };
 
@@ -123,6 +124,19 @@ export function ExerciseDetailModal({
             variant={activeTab === 'history' ? 'default' : 'outline'}
           >
             History
+          </Button>
+          <Button
+            aria-controls={trendsPanelId}
+            aria-selected={activeTab === 'trends'}
+            id={trendsTabId}
+            onClick={() => setActiveTab('trends')}
+            role="tab"
+            size="sm"
+            tabIndex={activeTab === 'trends' ? 0 : -1}
+            type="button"
+            variant={activeTab === 'trends' ? 'default' : 'outline'}
+          >
+            Trends
           </Button>
         </div>
 
@@ -203,18 +217,6 @@ export function ExerciseDetailModal({
             id={historyPanelId}
             role="tabpanel"
           >
-            {historyQuery.isPending ? (
-              <p className="text-sm text-muted">Loading exercise history...</p>
-            ) : (
-              <ExerciseTrendChart
-                className="border-border shadow-none"
-                exerciseName={exercise?.name ?? 'Exercise'}
-                history={trendHistory}
-                trackingType={trackingType}
-                weightUnit={weightUnit}
-              />
-            )}
-
             <div className="space-y-2">
               <p className="text-xs font-semibold tracking-[0.08em] text-muted uppercase">
                 Session history
@@ -251,6 +253,27 @@ export function ExerciseDetailModal({
                 );
               })}
             </div>
+          </div>
+        ) : null}
+
+        {activeTab === 'trends' ? (
+          <div
+            aria-labelledby={trendsTabId}
+            className="space-y-4"
+            id={trendsPanelId}
+            role="tabpanel"
+          >
+            {historyQuery.isPending ? (
+              <p className="text-sm text-muted">Loading exercise history...</p>
+            ) : (
+              <ExerciseTrendChart
+                className="border-border shadow-none"
+                exerciseName={exercise?.name ?? 'Exercise'}
+                sessions={historyList}
+                trackingType={trackingType}
+                weightUnit={weightUnit}
+              />
+            )}
           </div>
         ) : null}
 
@@ -338,78 +361,4 @@ function formatLabel(value: string) {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
-}
-
-function toExerciseTrendHistory(
-  sessions: ActiveWorkoutPerformanceHistorySession[],
-  trackingType: ExerciseTrackingType,
-): ActiveWorkoutExerciseHistoryPoint[] {
-  return sessions.flatMap((session) => {
-    const topSet = pickTopSessionSet(session.sets, trackingType);
-
-    if (!topSet || topSet.reps == null) {
-      return [];
-    }
-
-    return [
-      {
-        date: session.date,
-        distance: trackingType === 'distance' ? topSet.reps : null,
-        reps: topSet.reps,
-        seconds:
-          trackingType === 'seconds_only' ||
-          trackingType === 'cardio' ||
-          trackingType === 'weight_seconds' ||
-          trackingType === 'reps_seconds'
-            ? topSet.reps
-            : null,
-        trackingType,
-        weight: topSet.weight ?? 0,
-      },
-    ];
-  });
-}
-
-function pickTopSessionSet(
-  sets: ActiveWorkoutPerformanceHistorySession['sets'],
-  trackingType: ExerciseTrackingType,
-) {
-  const [firstSet, ...remainingSets] = sets;
-  if (!firstSet) {
-    return null;
-  }
-
-  return remainingSets.reduce((bestSet, currentSet) => {
-    if (currentSet.reps == null) {
-      return bestSet;
-    }
-
-    if (bestSet.reps == null) {
-      return currentSet;
-    }
-
-    if (
-      trackingType === 'seconds_only' ||
-      trackingType === 'cardio' ||
-      trackingType === 'weight_seconds' ||
-      trackingType === 'reps_seconds' ||
-      trackingType === 'distance' ||
-      trackingType === 'reps_only' ||
-      trackingType === 'bodyweight_reps'
-    ) {
-      return currentSet.reps > bestSet.reps ? currentSet : bestSet;
-    }
-
-    const currentWeight = currentSet.weight ?? 0;
-    const bestWeight = bestSet.weight ?? 0;
-    if (currentWeight > bestWeight) {
-      return currentSet;
-    }
-
-    if (currentWeight === bestWeight && currentSet.reps > bestSet.reps) {
-      return currentSet;
-    }
-
-    return bestSet;
-  }, firstSet);
 }

--- a/apps/web/src/features/workouts/components/exercise-detail-modal.tsx
+++ b/apps/web/src/features/workouts/components/exercise-detail-modal.tsx
@@ -1,5 +1,7 @@
 import { useId, useState } from 'react';
 import type { ExerciseTrackingType } from '@pulse/shared';
+import { ExternalLink } from 'lucide-react';
+import { Link } from 'react-router';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -243,9 +245,19 @@ export function ExerciseDetailModal({
                     className="rounded-lg border border-border bg-card px-3 py-2.5"
                     key={session.sessionId}
                   >
-                    <p className="text-sm font-semibold text-foreground">
-                      {`${historyDateFormatter.format(new Date(`${session.date}T12:00:00`))} · ${setSummary}`}
-                    </p>
+                    <div className="flex items-start justify-between gap-3">
+                      <p className="text-sm font-semibold text-foreground">
+                        {`${historyDateFormatter.format(new Date(`${session.date}T12:00:00`))} · ${setSummary}`}
+                      </p>
+                      <Link
+                        aria-label="View full workout"
+                        className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted transition-colors hover:bg-muted/50 hover:text-foreground"
+                        onClick={() => handleOpenChange(false)}
+                        to={`/workouts/sessions/${session.sessionId}`}
+                      >
+                        <ExternalLink className="size-3.5" />
+                      </Link>
+                    </div>
                     {session.notes?.trim() ? (
                       <p className="mt-1 text-xs text-muted">{`Notes: ${session.notes.trim()}`}</p>
                     ) : null}

--- a/apps/web/src/features/workouts/components/exercise-trend-chart.test.tsx
+++ b/apps/web/src/features/workouts/components/exercise-trend-chart.test.tsx
@@ -1,8 +1,12 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { workoutExerciseHistory } from '../lib/mock-data';
 import { ExerciseTrendChart } from './exercise-trend-chart';
+import {
+  computeEstimated1RM,
+  computeSessionVolume,
+  getMetricOptionsForTrackingType,
+} from './exercise-trend-metrics';
 
 vi.mock('recharts', async () => {
   const actual = await vi.importActual<typeof import('recharts')>('recharts');
@@ -26,35 +30,70 @@ vi.mock('recharts', async () => {
   };
 });
 
+const sessions = [
+  {
+    date: '2026-01-05',
+    notes: null,
+    sessionId: 'session-1',
+    sets: [
+      { reps: 8, setNumber: 1, weight: 40 },
+      { reps: 10, setNumber: 2, weight: 35 },
+    ],
+  },
+  {
+    date: '2026-02-09',
+    notes: null,
+    sessionId: 'session-2',
+    sets: [
+      { reps: 7, setNumber: 1, weight: 50 },
+      { reps: 9, setNumber: 2, weight: 45 },
+    ],
+  },
+  {
+    date: '2026-03-01',
+    notes: null,
+    sessionId: 'session-3',
+    sets: [
+      { reps: 10, setNumber: 1, weight: 47.5 },
+      { reps: 8, setNumber: 2, weight: 50 },
+    ],
+  },
+];
+
 describe('ExerciseTrendChart', () => {
-  it('renders weight and rep trend lines for exercises with history', () => {
-    const { container } = render(
+  it('renders metric selector and switches metric values', () => {
+    render(
       <ExerciseTrendChart
         exerciseName="Incline Dumbbell Press"
-        history={workoutExerciseHistory['incline-dumbbell-press'] ?? []}
-        weightUnit="kg"
+        sessions={sessions}
+        trackingType="weight_reps"
+        weightUnit="lbs"
       />,
     );
 
-    expect(screen.getByLabelText('Incline Dumbbell Press trend chart')).toBeInTheDocument();
-    expect(container.querySelectorAll('.recharts-line .recharts-curve')).toHaveLength(2);
-    expect(screen.getByText('Latest weight')).toBeInTheDocument();
-    expect(screen.getByText('Latest reps')).toBeInTheDocument();
-    expect(screen.getByText('50 kg')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Max Weight' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Total Volume' })).toBeInTheDocument();
+    expect(screen.getByText('Latest max weight')).toBeInTheDocument();
+    expect(screen.getByText('50 lbs')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Total Volume' }));
+
+    expect(screen.getByText('Latest total volume')).toBeInTheDocument();
+    expect(screen.getByText('875 lbs*reps')).toBeInTheDocument();
   });
 
   it('filters chart history by date range', () => {
     render(
       <ExerciseTrendChart
         exerciseName="Incline Dumbbell Press"
-        history={workoutExerciseHistory['incline-dumbbell-press'] ?? []}
+        sessions={sessions}
+        trackingType="weight_reps"
       />,
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Last 30 days' }));
 
     expect(screen.queryByText('Jan 5')).not.toBeInTheDocument();
-    expect(screen.queryByText('Jan 26')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'All time' }));
 
@@ -62,7 +101,7 @@ describe('ExerciseTrendChart', () => {
   });
 
   it('shows an empty state when an exercise has no history', () => {
-    render(<ExerciseTrendChart exerciseName="Air Bike" history={[]} />);
+    render(<ExerciseTrendChart exerciseName="Air Bike" sessions={[]} trackingType="seconds_only" />);
 
     expect(screen.getByText('No history yet')).toBeInTheDocument();
     expect(
@@ -70,20 +109,29 @@ describe('ExerciseTrendChart', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders reps-only trend cards for bodyweight tracking', () => {
-    render(
-      <ExerciseTrendChart
-        exerciseName="Bodyweight Squat"
-        history={[
-          { date: '2026-02-01', reps: 12, weight: 0 },
-          { date: '2026-03-01', reps: 15, weight: 0 },
-        ]}
-        trackingType="reps_only"
-      />,
-    );
+  it('computeEstimated1RM follows Epley formula', () => {
+    expect(computeEstimated1RM(100, 10)).toBeCloseTo(133.3, 1);
+  });
 
-    expect(screen.getByText('Latest reps')).toBeInTheDocument();
-    expect(screen.getByText('15 reps')).toBeInTheDocument();
-    expect(screen.queryByText('Latest weight')).not.toBeInTheDocument();
+  it('computeSessionVolume sums weight and reps across sets', () => {
+    expect(
+      computeSessionVolume([
+        { reps: 10, weight: 100 },
+        { reps: 8, weight: 90 },
+      ]),
+    ).toBe(1720);
+  });
+
+  it('filters available metrics by tracking type', () => {
+    expect(getMetricOptionsForTrackingType('weight_reps').map((metric) => metric.key)).toEqual([
+      'max_weight',
+      'max_reps',
+      'total_volume',
+      'est_1rm',
+    ]);
+
+    expect(getMetricOptionsForTrackingType('seconds_only').map((metric) => metric.key)).toEqual([
+      'max_time',
+    ]);
   });
 });

--- a/apps/web/src/features/workouts/components/exercise-trend-chart.tsx
+++ b/apps/web/src/features/workouts/components/exercise-trend-chart.tsx
@@ -1,44 +1,34 @@
 import { useMemo, useState } from 'react';
 import { type ExerciseTrackingType, type WeightUnit } from '@pulse/shared';
-import {
-  CartesianGrid,
-  Line,
-  LineChart,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts';
+import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 
 import { getDistanceUnit } from '../lib/tracking';
-import type { ActiveWorkoutExerciseHistoryPoint } from '../types';
+import type { ActiveWorkoutPerformanceHistorySession } from '../types';
+import {
+  computeEstimated1RM,
+  computeSessionVolume,
+  getMetricOptionsForTrackingType,
+  type TrendMetricKey,
+} from './exercise-trend-metrics';
 
 type ExerciseTrendChartProps = {
   className?: string;
   exerciseName: string;
-  history: ActiveWorkoutExerciseHistoryPoint[];
+  sessions: ActiveWorkoutPerformanceHistorySession[];
   trackingType?: ExerciseTrackingType;
   weightUnit?: WeightUnit;
 };
 
 type DateRange = '30d' | '90d' | 'all';
 
-type MetricKey = 'distance' | 'reps' | 'seconds' | 'weight';
-
-type MetricConfig = {
-  color: string;
-  key: MetricKey;
-  label: string;
-  unit: string;
-  yAxisId: 'primary' | 'secondary';
-};
-
-type ChartDatum = ActiveWorkoutExerciseHistoryPoint & {
+type ChartDatum = {
+  date: string;
   dateLabel: string;
+  value: number;
 };
 
 const dateRangeOptions: Array<{ label: string; value: DateRange }> = [
@@ -66,25 +56,44 @@ const numberFormatter = new Intl.NumberFormat('en-US', {
 export function ExerciseTrendChart({
   className,
   exerciseName,
-  history,
+  sessions,
   trackingType = 'weight_reps',
   weightUnit = 'lbs',
 }: ExerciseTrendChartProps) {
   const [selectedRange, setSelectedRange] = useState<DateRange>('90d');
-  const metricConfig = getMetricConfig(trackingType, weightUnit);
+  const metricOptions = useMemo(
+    () => getMetricOptionsForTrackingType(trackingType),
+    [trackingType],
+  );
+  const [selectedMetric, setSelectedMetric] = useState<TrendMetricKey>(metricOptions[0]?.key ?? 'max_reps');
+  const activeMetric = metricOptions.some((metric) => metric.key === selectedMetric)
+    ? selectedMetric
+    : (metricOptions[0]?.key ?? 'max_reps');
 
   const chartData = useMemo(() => {
-    const sortedHistory = [...history].sort((left, right) => left.date.localeCompare(right.date));
+    const sortedHistory = [...sessions].sort((left, right) => left.date.localeCompare(right.date));
 
-    return filterHistoryByRange(sortedHistory, selectedRange).map((point) => ({
-      ...point,
-      dateLabel: axisDateFormatter.format(new Date(`${point.date}T12:00:00`)),
-      distance: point.distance ?? 0,
-      reps: point.reps ?? 0,
-      seconds: point.seconds ?? point.reps ?? 0,
-      weight: point.weight ?? 0,
-    }));
-  }, [history, selectedRange]);
+    return filterHistoryByRange(sortedHistory, selectedRange)
+      .map((session) => {
+        const value = computeMetricValueFromSession(session, activeMetric, trackingType);
+
+        if (value == null) {
+          return null;
+        }
+
+        return {
+          date: session.date,
+          dateLabel: axisDateFormatter.format(new Date(`${session.date}T12:00:00`)),
+          value,
+        };
+      })
+      .filter((point): point is ChartDatum => point != null);
+  }, [activeMetric, selectedRange, sessions, trackingType]);
+
+  const selectedMetricLabel =
+    metricOptions.find((metric) => metric.key === activeMetric)?.label ?? 'Max Reps';
+  const metricUnit = getMetricUnit(activeMetric, trackingType, weightUnit);
+  const yAxisLabel = `${selectedMetricLabel} (${metricUnit})`;
 
   return (
     <Card className={cn('w-full border-border bg-card/95 py-0 shadow-sm', className)}>
@@ -115,6 +124,26 @@ export function ExerciseTrendChart({
             ))}
           </div>
         </div>
+
+        <div
+          aria-label="Trend metric selector"
+          className="inline-flex w-full flex-wrap items-center gap-2 rounded-full border border-border bg-secondary/35 p-1"
+          role="group"
+        >
+          {metricOptions.map((metric) => (
+            <Button
+              aria-pressed={activeMetric === metric.key}
+              className="rounded-full"
+              key={metric.key}
+              onClick={() => setSelectedMetric(metric.key)}
+              size="sm"
+              type="button"
+              variant={activeMetric === metric.key ? 'default' : 'ghost'}
+            >
+              {metric.label}
+            </Button>
+          ))}
+        </div>
       </CardHeader>
 
       <CardContent className="px-4 py-5 sm:px-6">
@@ -130,20 +159,11 @@ export function ExerciseTrendChart({
           </div>
         ) : (
           <div className="mx-auto w-full max-w-4xl space-y-4">
-            <div className={cn('grid gap-3', metricConfig.secondary ? 'sm:grid-cols-2' : 'sm:grid-cols-1')}>
-              <MetricCard
-                accentClassName="bg-[var(--color-accent-mint)] text-on-mint"
-                label={`Latest ${metricConfig.primary.label.toLowerCase()}`}
-                value={formatMetricValue(chartData.at(-1), metricConfig.primary)}
-              />
-              {metricConfig.secondary ? (
-                <MetricCard
-                  accentClassName="bg-[var(--color-accent-cream)] text-on-cream"
-                  label={`Latest ${metricConfig.secondary.label.toLowerCase()}`}
-                  value={formatMetricValue(chartData.at(-1), metricConfig.secondary)}
-                />
-              ) : null}
-            </div>
+            <MetricCard
+              accentClassName="bg-[var(--color-accent-mint)] text-on-mint"
+              label={`Latest ${selectedMetricLabel.toLowerCase()}`}
+              value={`${numberFormatter.format(chartData.at(-1)?.value ?? 0)} ${metricUnit}`.trim()}
+            />
 
             <div
               aria-label={`${exerciseName} trend chart`}
@@ -164,24 +184,10 @@ export function ExerciseTrendChart({
                     axisLine={false}
                     orientation="left"
                     tick={{ fill: 'var(--color-muted)', fontSize: 12 }}
-                    tickFormatter={(value: number) => formatAxisTick(value, metricConfig.primary.unit)}
+                    tickFormatter={(value: number) => formatAxisTick(value, metricUnit)}
                     tickLine={false}
-                    yAxisId="primary"
-                    width={56}
+                    width={60}
                   />
-                  {metricConfig.secondary ? (
-                    <YAxis
-                      axisLine={false}
-                      orientation="right"
-                      tick={{ fill: 'var(--color-muted)', fontSize: 12 }}
-                      tickFormatter={(value: number) =>
-                        formatAxisTick(value, metricConfig.secondary?.unit ?? '')
-                      }
-                      tickLine={false}
-                      yAxisId="secondary"
-                      width={56}
-                    />
-                  ) : null}
                   <Tooltip
                     contentStyle={{
                       backgroundColor: 'var(--color-card)',
@@ -189,50 +195,28 @@ export function ExerciseTrendChart({
                       borderRadius: '16px',
                       color: 'var(--color-foreground)',
                     }}
-                    formatter={(value: number | undefined, name: string | undefined) => {
-                      let metric = metricConfig.primary;
-
-                      if (metricConfig.secondary && metricConfig.secondary.key === name) {
-                        metric = metricConfig.secondary;
-                      }
-
-                      return [`${numberFormatter.format(value ?? 0)} ${metric.unit}`.trim(), metric.label];
-                    }}
+                    formatter={(value: number | undefined) => [
+                      `${numberFormatter.format(value ?? 0)} ${metricUnit}`.trim(),
+                      selectedMetricLabel,
+                    ]}
                     labelFormatter={(_label, payload) => {
                       const point = payload?.[0]?.payload as ChartDatum | undefined;
 
-                      return point
-                        ? tooltipDateFormatter.format(new Date(`${point.date}T12:00:00`))
-                        : '';
+                      return point ? tooltipDateFormatter.format(new Date(`${point.date}T12:00:00`)) : '';
                     }}
                     separator=": "
                   />
                   <Line
-                    dataKey={metricConfig.primary.key}
-                    dot={{ fill: metricConfig.primary.color, r: 4, strokeWidth: 0 }}
+                    dataKey="value"
+                    dot={{ fill: 'var(--color-primary)', r: 4, strokeWidth: 0 }}
                     isAnimationActive={false}
-                    name={metricConfig.primary.key}
-                    stroke={metricConfig.primary.color}
+                    name={yAxisLabel}
+                    stroke="var(--color-primary)"
                     strokeLinecap="round"
                     strokeLinejoin="round"
                     strokeWidth={3}
                     type="monotone"
-                    yAxisId={metricConfig.primary.yAxisId}
                   />
-                  {metricConfig.secondary ? (
-                    <Line
-                      dataKey={metricConfig.secondary.key}
-                      dot={{ fill: metricConfig.secondary.color, r: 4, strokeWidth: 0 }}
-                      isAnimationActive={false}
-                      name={metricConfig.secondary.key}
-                      stroke={metricConfig.secondary.color}
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={3}
-                      type="monotone"
-                      yAxisId={metricConfig.secondary.yAxisId}
-                    />
-                  ) : null}
                 </LineChart>
               </ResponsiveContainer>
             </div>
@@ -260,78 +244,85 @@ function MetricCard({
   );
 }
 
-function getMetricConfig(trackingType: ExerciseTrackingType, weightUnit: WeightUnit) {
-  const distanceUnit = getDistanceUnit(weightUnit);
-
-  const weightMetric: MetricConfig = {
-    color: 'var(--color-primary)',
-    key: 'weight',
-    label: 'Weight',
-    unit: weightUnit,
-    yAxisId: 'primary',
-  };
-
-  const repsMetric: MetricConfig = {
-    color: 'var(--color-accent-cream)',
-    key: 'reps',
-    label: 'Reps',
-    unit: 'reps',
-    yAxisId: 'secondary',
-  };
-
-  const secondsMetric: MetricConfig = {
-    color: 'var(--color-accent-cream)',
-    key: 'seconds',
-    label: 'Duration',
-    unit: 'sec',
-    yAxisId: 'secondary',
-  };
-
-  const distanceMetric: MetricConfig = {
-    color: 'var(--color-primary)',
-    key: 'distance',
-    label: 'Distance',
-    unit: distanceUnit,
-    yAxisId: 'primary',
-  };
-
-  switch (trackingType) {
-    case 'weight_reps':
-      return { primary: weightMetric, secondary: repsMetric };
-    case 'weight_seconds':
-      return { primary: weightMetric, secondary: secondsMetric };
-    case 'bodyweight_reps':
-    case 'reps_only':
-      return { primary: { ...repsMetric, yAxisId: 'primary' as const }, secondary: null };
-    case 'reps_seconds':
-      return {
-        primary: { ...repsMetric, yAxisId: 'primary' as const },
-        secondary: secondsMetric,
-      };
-    case 'seconds_only':
-      return { primary: { ...secondsMetric, yAxisId: 'primary' as const }, secondary: null };
-    case 'distance':
-      return { primary: distanceMetric, secondary: null };
-    case 'cardio':
-      return {
-        primary: { ...secondsMetric, yAxisId: 'primary' as const },
-        secondary: { ...distanceMetric, yAxisId: 'secondary' as const },
-      };
-    default:
-      return { primary: weightMetric, secondary: repsMetric };
+function getMetricUnit(
+  metricKey: TrendMetricKey,
+  trackingType: ExerciseTrackingType,
+  weightUnit: WeightUnit,
+) {
+  if (metricKey === 'max_weight' || metricKey === 'est_1rm') {
+    return weightUnit;
   }
+
+  if (metricKey === 'max_reps') {
+    return trackingType === 'distance' ? getDistanceUnit(weightUnit) : 'reps';
+  }
+
+  if (metricKey === 'total_volume') {
+    return `${weightUnit}*reps`;
+  }
+
+  return 'sec';
 }
 
-function formatMetricValue(point: ChartDatum | undefined, metric: MetricConfig) {
-  const value = point ? Number(point[metric.key] ?? 0) : 0;
-  return `${numberFormatter.format(value)} ${metric.unit}`.trim();
+function computeMetricValueFromSession(
+  session: ActiveWorkoutPerformanceHistorySession,
+  metric: TrendMetricKey,
+  trackingType: ExerciseTrackingType,
+): number | null {
+  const setsWithReps = session.sets.filter(
+    (set): set is { reps: number; setNumber: number; weight: number | null } => set.reps != null,
+  );
+
+  if (setsWithReps.length === 0) {
+    return null;
+  }
+
+  if (metric === 'max_weight') {
+    const maxWeight = setsWithReps.reduce((best, set) => Math.max(best, set.weight ?? 0), 0);
+    return Number.isFinite(maxWeight) ? maxWeight : null;
+  }
+
+  if (metric === 'max_reps') {
+    return setsWithReps.reduce((best, set) => Math.max(best, set.reps), 0);
+  }
+
+  if (metric === 'max_time') {
+    return setsWithReps.reduce((best, set) => Math.max(best, set.reps), 0);
+  }
+
+  if (trackingType !== 'weight_reps') {
+    return null;
+  }
+
+  const weightedSets = setsWithReps.filter((set) => (set.weight ?? 0) > 0);
+  if (weightedSets.length === 0) {
+    return null;
+  }
+
+  if (metric === 'total_volume') {
+    return computeSessionVolume(
+      weightedSets.map((set) => ({
+        reps: set.reps,
+        weight: set.weight ?? 0,
+      })),
+    );
+  }
+
+  if (metric === 'est_1rm') {
+    return weightedSets.reduce((best, set) => {
+      const estimated = computeEstimated1RM(set.weight ?? 0, set.reps);
+      return estimated > best ? estimated : best;
+    }, 0);
+  }
+
+  return null;
 }
 
 function formatAxisTick(value: number, unit: string) {
   return `${numberFormatter.format(value)} ${unit}`.trim();
 }
 
-function filterHistoryByRange(history: ActiveWorkoutExerciseHistoryPoint[], range: DateRange) {
+function filterHistoryByRange(history: ActiveWorkoutPerformanceHistorySession[], range: DateRange) {
   if (range === 'all' || history.length === 0) {
     return history;
   }

--- a/apps/web/src/features/workouts/components/exercise-trend-metrics.ts
+++ b/apps/web/src/features/workouts/components/exercise-trend-metrics.ts
@@ -1,0 +1,51 @@
+import type { ExerciseTrackingType } from '@pulse/shared';
+
+export type TrendMetricKey = 'max_weight' | 'max_reps' | 'total_volume' | 'est_1rm' | 'max_time';
+
+export type TrendMetricOption = {
+  key: TrendMetricKey;
+  label: string;
+};
+
+const metricDefinitions: Record<TrendMetricKey, TrendMetricOption> = {
+  max_weight: { key: 'max_weight', label: 'Max Weight' },
+  max_reps: { key: 'max_reps', label: 'Max Reps' },
+  total_volume: { key: 'total_volume', label: 'Total Volume' },
+  est_1rm: { key: 'est_1rm', label: 'Est 1RM' },
+  max_time: { key: 'max_time', label: 'Max Time' },
+};
+
+export function computeEstimated1RM(weight: number, reps: number): number {
+  return weight * (1 + reps / 30);
+}
+
+export function computeSessionVolume(sets: Array<{ weight: number; reps: number }>): number {
+  return sets.reduce((total, set) => total + set.weight * set.reps, 0);
+}
+
+export function getMetricOptionsForTrackingType(
+  trackingType: ExerciseTrackingType,
+): TrendMetricOption[] {
+  switch (trackingType) {
+    case 'weight_reps':
+      return [
+        metricDefinitions.max_weight,
+        metricDefinitions.max_reps,
+        metricDefinitions.total_volume,
+        metricDefinitions.est_1rm,
+      ];
+    case 'weight_seconds':
+      return [metricDefinitions.max_weight, metricDefinitions.max_time];
+    case 'bodyweight_reps':
+    case 'reps_only':
+      return [metricDefinitions.max_reps];
+    case 'reps_seconds':
+    case 'seconds_only':
+    case 'cardio':
+      return [metricDefinitions.max_time];
+    case 'distance':
+      return [metricDefinitions.max_reps];
+    default:
+      return [metricDefinitions.max_weight, metricDefinitions.max_reps];
+  }
+}

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -443,6 +443,35 @@ describe('SessionExerciseList', () => {
     expect(within(dialog).getByRole('button', { name: 'Rename' })).toBeDisabled();
   });
 
+  it('toggles exercise expansion when clicking the exercise title text', () => {
+    if (!activeTemplate) {
+      throw new Error('Expected upper-push template in mock data.');
+    }
+
+    const session = buildActiveWorkoutSession(
+      activeTemplate,
+      createInitialWorkoutSetDrafts(activeTemplate, new Set()),
+    );
+
+    renderWithQueryClient(
+      <SessionExerciseList
+        onAddSet={vi.fn()}
+        onExerciseNotesChange={vi.fn()}
+        onRemoveSet={vi.fn()}
+        onSetUpdate={vi.fn()}
+        session={session}
+      />,
+    );
+
+    const rowErgToggle = getExercisePanelToggle('Row Erg', 'row-erg');
+    expect(rowErgToggle).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(screen.getByText('Row Erg'));
+
+    expect(rowErgToggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
   it('opens swap dialog from the exercise actions menu and calls session swap endpoint', async () => {
     window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
@@ -611,6 +640,80 @@ describe('SessionExerciseList', () => {
       ).toBe(true);
     });
     window.localStorage.removeItem(API_TOKEN_STORAGE_KEY);
+  });
+
+  it('opens exercise details from the kebab menu without toggling the exercise card', async () => {
+    if (!activeTemplate) {
+      throw new Error('Expected upper-push template in mock data.');
+    }
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = new URL(String(input), 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/exercises/row-erg') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: 'row-erg',
+              userId: 'user-1',
+              name: 'Row Erg',
+              muscleGroups: ['conditioning', 'upper back'],
+              equipment: 'rower',
+              category: 'cardio',
+              trackingType: 'cardio',
+              tags: [],
+              formCues: ['Stay tall'],
+              instructions: null,
+              coachingNotes: null,
+              relatedExerciseIds: [],
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/exercises/row-erg/history') {
+        return Promise.resolve(
+          jsonResponse({
+            data: [],
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    const session = buildActiveWorkoutSession(
+      activeTemplate,
+      createInitialWorkoutSetDrafts(activeTemplate, new Set()),
+    );
+
+    renderWithQueryClient(
+      <SessionExerciseList
+        onAddSet={vi.fn()}
+        onExerciseNotesChange={vi.fn()}
+        onRemoveSet={vi.fn()}
+        onSetUpdate={vi.fn()}
+        session={session}
+      />,
+    );
+
+    const rowErgCard = screen
+      .getByRole('heading', { level: 3, name: 'Row Erg' })
+      .closest('[data-slot="card"]');
+    if (!rowErgCard) throw new Error('Expected Row Erg card.');
+
+    const rowErgToggle = getExercisePanelToggle('Row Erg', 'row-erg');
+    expect(rowErgToggle).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(
+      within(rowErgCard as HTMLElement).getByRole('button', { name: 'Exercise actions for Row Erg' }),
+    );
+    fireEvent.click(within(rowErgCard as HTMLElement).getByRole('button', { name: 'Exercise Details' }));
+
+    expect(rowErgToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
   });
 
   it('shows move up/down actions and calls onReorderExercises for active workout lists', () => {

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -732,6 +732,17 @@ function ExerciseCardItem({
       ? 'border-l-4 border-l-primary'
       : 'border-l-4 border-dashed border-l-border';
   const canRemoveSet = exercise.sets.length > 1;
+  const exercisePanelId = `exercise-panel-${exercise.id}`;
+  const toggleExpanded = () => {
+    setExpandedExercises((current) => ({
+      ...current,
+      [resolvedCollapseKey]: !(current[resolvedCollapseKey] ?? false),
+    }));
+  };
+  const handleMenuAction = (action: () => void) => (event: { stopPropagation: () => void }) => {
+    event.stopPropagation();
+    action();
+  };
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
     id: exercise.id,
   });
@@ -751,11 +762,25 @@ function ExerciseCardItem({
         transition,
       }}
     >
-      <div className="flex items-center gap-1.5 px-3 py-3 sm:gap-2 sm:px-5 sm:py-5">
+      <div
+        aria-controls={exercisePanelId}
+        aria-expanded={isExpanded}
+        className="flex cursor-pointer items-center gap-1.5 px-3 py-3 transition-colors hover:bg-muted/50 sm:gap-2 sm:px-5 sm:py-5"
+        onClick={toggleExpanded}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            toggleExpanded();
+          }
+        }}
+        role="button"
+        tabIndex={0}
+      >
         {showDragHandle ? (
           <Button
             aria-label={`Drag handle for ${exercise.name}`}
             className="size-7 touch-none shrink-0 sm:size-9"
+            onClick={(event) => event.stopPropagation()}
             size="icon"
             type="button"
             variant="ghost"
@@ -775,13 +800,9 @@ function ExerciseCardItem({
                   isExerciseComplete && 'text-muted line-through',
                 )}
               >
-                <button
-                  className="cursor-pointer truncate text-left underline-offset-4 transition hover:text-primary hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  onClick={onOpenHistory}
-                  type="button"
-                >
+                <span className="truncate">
                   {exercise.name}
-                </button>
+                </span>
               </h3>
               <p className="text-xs text-muted sm:text-sm">
                 {`${exercise.completedSets}/${exercise.targetSets} sets`}
@@ -790,24 +811,13 @@ function ExerciseCardItem({
             </div>
           </div>
 
-          <button
-            aria-controls={`exercise-panel-${exercise.id}`}
-            aria-expanded={isExpanded}
-            className="flex shrink-0 cursor-pointer items-center gap-2 sm:gap-3"
-            onClick={() =>
-              setExpandedExercises((current) => ({
-                ...current,
-                [resolvedCollapseKey]: !(current[resolvedCollapseKey] ?? false),
-              }))
-            }
-            type="button"
-          >
+          <div className="flex shrink-0 items-center gap-2 sm:gap-3">
             <span className="text-xs font-medium text-muted sm:text-sm">{`#${exerciseNumber}`}</span>
             <ChevronDown
               aria-hidden="true"
               className={cn('size-4 text-muted transition-transform', isExpanded && 'rotate-180')}
             />
-          </button>
+          </div>
         </div>
 
         <DropdownMenu>
@@ -815,6 +825,7 @@ function ExerciseCardItem({
             <Button
               aria-label={`Exercise actions for ${exercise.name}`}
               className="mt-0.5 size-8 shrink-0"
+              onClick={(event) => event.stopPropagation()}
               size="icon"
               type="button"
               variant="ghost"
@@ -822,25 +833,38 @@ function ExerciseCardItem({
               <MoreVertical aria-hidden="true" className="size-4" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={onSwapExercise}>Swap exercise</DropdownMenuItem>
-            <DropdownMenuItem disabled={isMoveUpDisabled} onClick={onMoveUp}>
+          <DropdownMenuContent align="end" onClick={(event) => event.stopPropagation()}>
+            <DropdownMenuItem onClick={handleMenuAction(onSwapExercise)}>Swap exercise</DropdownMenuItem>
+            <DropdownMenuItem onClick={handleMenuAction(onOpenHistory)}>
+              Exercise Details
+            </DropdownMenuItem>
+            <DropdownMenuItem disabled={isMoveUpDisabled} onClick={handleMenuAction(onMoveUp)}>
               <ArrowUp aria-hidden="true" className="size-4" />
               Move up
             </DropdownMenuItem>
-            <DropdownMenuItem disabled={isMoveDownDisabled} onClick={onMoveDown}>
+            <DropdownMenuItem
+              disabled={isMoveDownDisabled}
+              onClick={handleMenuAction(onMoveDown)}
+            >
               <ArrowDown aria-hidden="true" className="size-4" />
               Move down
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={onRenameExercise}>Rename exercise</DropdownMenuItem>
-            <DropdownMenuItem onClick={() => onAddSet(exercise.id)}>Add Set</DropdownMenuItem>
-            <DropdownMenuItem disabled={!canRemoveSet} onClick={() => onRemoveSet(exercise.id)}>
+            <DropdownMenuItem onClick={handleMenuAction(onRenameExercise)}>
+              Rename exercise
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={handleMenuAction(() => onAddSet(exercise.id))}>
+              Add Set
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={!canRemoveSet}
+              onClick={handleMenuAction(() => onRemoveSet(exercise.id))}
+            >
               Remove Last Set
             </DropdownMenuItem>
             {onConfigureSuperset ? (
               <>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={onConfigureSuperset}>
+                <DropdownMenuItem onClick={handleMenuAction(onConfigureSuperset)}>
                   <Braces aria-hidden="true" className="size-4" />
                   Configure superset
                 </DropdownMenuItem>
@@ -853,7 +877,7 @@ function ExerciseCardItem({
       <CardContent
         className="border-t border-border bg-secondary/25 px-4 py-4 sm:px-5"
         hidden={!isExpanded}
-        id={`exercise-panel-${exercise.id}`}
+        id={exercisePanelId}
       >
         <div className="space-y-4">
           <div className="space-y-3">

--- a/apps/web/src/features/workouts/components/workout-calendar.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.test.tsx
@@ -72,8 +72,8 @@ describe('WorkoutCalendar', () => {
               {
                 id: 'schedule-2',
                 date: sessionDateKey,
-                templateId: 'template-2',
-                templateName: 'Accessory',
+                templateId: null,
+                templateName: null,
                 sessionId: null,
                 createdAt: 2,
               },


### PR DESCRIPTION
## Summary
This PR reworks exercise card and modal interactions to make active workout flow more predictable and to separate historical logs from performance analysis. In the session exercise list, the entire header row now acts as the expand/collapse control, while exercise details are opened explicitly from the kebab menu. The exercise detail modal now has distinct `History` and `Trends` tabs, moving charting out of the history log and into a dedicated analysis view. The Trends tab adds a metric selector so users can switch between tracking-relevant metrics (including estimated 1RM), and history entries now include a direct link to the full workout receipt for faster drill-down.

## Key Changes
- Updated session exercise card header behavior so clicking the header toggles expansion/collapse.
- Moved exercise detail modal entry point to the actions menu (`Exercise Details`) to avoid accidental modal opens during logging.
- Split modal tabs into `Overview`, `History`, and new `Trends`; chart content now lives in `Trends`.
- Added trend metric selection by tracking type (e.g., max weight, max reps, total volume, estimated 1RM, max time).
- Added per-session “View full workout” link in history entries that routes to `/workouts/sessions/:sessionId` and closes the modal.
- Added/updated tests for tab behavior, metric computation/selection, menu click propagation, and receipt links.

## Technical Notes
- `ExerciseTrendChart` now works from raw `ActiveWorkoutPerformanceHistorySession[]` and computes chart values per selected metric, rather than precomputing dual-series history points.
- Metric logic was extracted into `exercise-trend-metrics.ts` (`getMetricOptionsForTrackingType`, `computeSessionVolume`, `computeEstimated1RM` using Epley formula).
- Modal tab default/reset is now context-aware (`session` opens on `History`; other contexts open on `Overview`) via a shared helper.
- Menu and header interactions use explicit `stopPropagation` handling so dropdown actions do not toggle card expansion.
- Related tests were adjusted for router-linked UI (`MemoryRouter`) and deterministic date behavior (`toDateKey`/local-date handling) to reduce flaky assertions.

## Commits

- `1b96fd4 feat(workouts): add receipt links in exercise history modal`
- `2664091 feat(workouts): split exercise detail trends and metrics`
- `56de1a2 fix(workouts): toggle exercise cards from header row`

## Tasks

- **Refactor exercise header to expand/collapse on click**: Make entire header row expand/collapse; move modal access to kebab menu
- **Split exercise modal History tab into History + Trends**: Add third Trends tab; move chart from History to Trends tab
- **Add metric selector to exercise Trends tab**: Switchable metrics (max weight, reps, volume, est 1RM, time) with Epley formula
- **Add workout receipt link to exercise history entries**: Add icon button on each history session entry linking to the full workout receipt

## Diff Stats

```
.../dashboard/components/habit-chain.test.tsx      |   9 +-
 .../components/exercise-detail-modal.test.tsx      | 151 ++++++----
 .../workouts/components/exercise-detail-modal.tsx  | 159 ++++-------
 .../components/exercise-trend-chart.test.tsx       | 102 +++++--
 .../workouts/components/exercise-trend-chart.tsx   | 309 ++++++++++-----------
 .../workouts/components/exercise-trend-metrics.ts  |  51 ++++
 .../components/session-exercise-list.test.tsx      | 103 +++++++
 .../workouts/components/session-exercise-list.tsx  |  82 ++++--
 .../workouts/components/workout-calendar.test.tsx  |   4 +-
 9 files changed, 595 insertions(+), 375 deletions(-)
```