### PR TITLE
feat(web,api): foods table view, shared components, and exercise lifecycle

### DIFF
--- a/apps/api/drizzle/0035_groovy_captain_cross.sql
+++ b/apps/api/drizzle/0035_groovy_captain_cross.sql
@@ -1,0 +1,33 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_session_sets` (
+	`id` text PRIMARY KEY NOT NULL,
+	`session_id` text NOT NULL,
+	`exercise_id` text,
+	`order_index` integer DEFAULT 0 NOT NULL,
+	`set_number` integer NOT NULL,
+	`weight` real,
+	`reps` integer,
+	`target_weight` real,
+	`target_weight_min` real,
+	`target_weight_max` real,
+	`target_seconds` integer,
+	`target_distance` real,
+	`superset_group` text,
+	`completed` integer DEFAULT false NOT NULL,
+	`skipped` integer DEFAULT false NOT NULL,
+	`section` text DEFAULT 'main' NOT NULL,
+	`notes` text,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`session_id`) REFERENCES `workout_sessions`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`exercise_id`) REFERENCES `exercises`(`id`) ON UPDATE no action ON DELETE set null,
+	CONSTRAINT "session_sets_set_number_check" CHECK("__new_session_sets"."set_number" > 0),
+	CONSTRAINT "session_sets_section_check" CHECK("__new_session_sets"."section" in ('warmup', 'main', 'cooldown', 'supplemental')),
+	CONSTRAINT "session_sets_completion_state_check" CHECK(not ("__new_session_sets"."completed" and "__new_session_sets"."skipped"))
+);
+--> statement-breakpoint
+INSERT INTO `__new_session_sets`("id", "session_id", "exercise_id", "order_index", "set_number", "weight", "reps", "target_weight", "target_weight_min", "target_weight_max", "target_seconds", "target_distance", "superset_group", "completed", "skipped", "section", "notes", "created_at") SELECT "id", "session_id", "exercise_id", "order_index", "set_number", "weight", "reps", "target_weight", "target_weight_min", "target_weight_max", "target_seconds", "target_distance", "superset_group", "completed", "skipped", "section", "notes", "created_at" FROM `session_sets`;--> statement-breakpoint
+DROP TABLE `session_sets`;--> statement-breakpoint
+ALTER TABLE `__new_session_sets` RENAME TO `session_sets`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `session_sets_session_id_idx` ON `session_sets` (`session_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `session_sets_session_exercise_section_set_number_unique` ON `session_sets` (`session_id`,`exercise_id`,`section`,`set_number`);

--- a/apps/api/drizzle/meta/0035_snapshot.json
+++ b/apps/api/drizzle/meta/0035_snapshot.json
@@ -1,0 +1,3236 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b4cb4a8d-b6af-486a-87cb-6fdb88c5df67",
+  "prevId": "25d30531-7861-4d99-93a3-aaee3989bbd3",
+  "tables": {
+    "activities": {
+      "name": "activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "activities_user_date_idx": {
+          "name": "activities_user_date_idx",
+          "columns": [
+            "user_id",
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "activities_user_id_users_id_fk": {
+          "name": "activities_user_id_users_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "activities_date_format_check": {
+          "name": "activities_date_format_check",
+          "value": "\"activities\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "activities_type_check": {
+          "name": "activities_type_check",
+          "value": "\"activities\".\"type\" in ('walking', 'running', 'stretching', 'yoga', 'cycling', 'swimming', 'hiking', 'other')"
+        },
+        "activities_duration_minutes_check": {
+          "name": "activities_duration_minutes_check",
+          "value": "\"activities\".\"duration_minutes\" > 0"
+        }
+      }
+    },
+    "agent_tokens": {
+      "name": "agent_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_rotated_at": {
+          "name": "last_rotated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "agent_tokens_token_hash_unique": {
+          "name": "agent_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_tokens_user_id_users_id_fk": {
+          "name": "agent_tokens_user_id_users_id_fk",
+          "tableFrom": "agent_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "body_weight": {
+      "name": "body_weight",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "body_weight_user_id_date_unique": {
+          "name": "body_weight_user_id_date_unique",
+          "columns": [
+            "user_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "body_weight_user_id_users_id_fk": {
+          "name": "body_weight_user_id_users_id_fk",
+          "tableFrom": "body_weight",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "body_weight_date_format_check": {
+          "name": "body_weight_date_format_check",
+          "value": "\"body_weight\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "body_weight_weight_check": {
+          "name": "body_weight_weight_check",
+          "value": "\"body_weight\".\"weight\" > 0"
+        }
+      }
+    },
+    "dashboard_config": {
+      "name": "dashboard_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "habit_chain_ids": {
+          "name": "habit_chain_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "trend_metrics": {
+          "name": "trend_metrics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "visible_widgets": {
+          "name": "visible_widgets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "widget_order": {
+          "name": "widget_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "dashboard_config_user_id_unique": {
+          "name": "dashboard_config_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "dashboard_config_user_id_users_id_fk": {
+          "name": "dashboard_config_user_id_users_id_fk",
+          "tableFrom": "dashboard_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entity_links": {
+      "name": "entity_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "entity_links_user_source_type_source_id_idx": {
+          "name": "entity_links_user_source_type_source_id_idx",
+          "columns": [
+            "user_id",
+            "source_type",
+            "source_id"
+          ],
+          "isUnique": false
+        },
+        "entity_links_user_target_type_target_id_idx": {
+          "name": "entity_links_user_target_type_target_id_idx",
+          "columns": [
+            "user_id",
+            "target_type",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "entity_links_user_id_users_id_fk": {
+          "name": "entity_links_user_id_users_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "entity_links_source_type_check": {
+          "name": "entity_links_source_type_check",
+          "value": "\"entity_links\".\"source_type\" in ('journal', 'activity', 'resource')"
+        },
+        "entity_links_target_type_check": {
+          "name": "entity_links_target_type_check",
+          "value": "\"entity_links\".\"target_type\" in ('workout', 'activity', 'habit', 'injury', 'exercise', 'protocol')"
+        }
+      }
+    },
+    "equipment_items": {
+      "name": "equipment_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "equipment_items_location_id_idx": {
+          "name": "equipment_items_location_id_idx",
+          "columns": [
+            "location_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "equipment_items_location_id_equipment_locations_id_fk": {
+          "name": "equipment_items_location_id_equipment_locations_id_fk",
+          "tableFrom": "equipment_items",
+          "tableTo": "equipment_locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "equipment_items_category_check": {
+          "name": "equipment_items_category_check",
+          "value": "\"equipment_items\".\"category\" in ('free-weights', 'machines', 'cables', 'cardio', 'accessories')"
+        }
+      }
+    },
+    "equipment_locations": {
+      "name": "equipment_locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "equipment_locations_user_id_idx": {
+          "name": "equipment_locations_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "equipment_locations_user_id_users_id_fk": {
+          "name": "equipment_locations_user_id_users_id_fk",
+          "tableFrom": "equipment_locations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exercises": {
+      "name": "exercises",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "muscle_groups": {
+          "name": "muscle_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment": {
+          "name": "equipment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tracking_type": {
+          "name": "tracking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'weight_reps'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "form_cues": {
+          "name": "form_cues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coaching_notes": {
+          "name": "coaching_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "related_exercise_ids": {
+          "name": "related_exercise_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "exercises_user_id_idx": {
+          "name": "exercises_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "exercises_user_id_users_id_fk": {
+          "name": "exercises_user_id_users_id_fk",
+          "tableFrom": "exercises",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "exercises_category_check": {
+          "name": "exercises_category_check",
+          "value": "\"exercises\".\"category\" in ('compound', 'isolation', 'cardio', 'mobility')"
+        },
+        "exercises_tracking_type_check": {
+          "name": "exercises_tracking_type_check",
+          "value": "\"exercises\".\"tracking_type\" in ('weight_reps', 'weight_seconds', 'bodyweight_reps', 'reps_only', 'reps_seconds', 'seconds_only', 'distance', 'cardio')"
+        }
+      }
+    },
+    "foods": {
+      "name": "foods",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "serving_size": {
+          "name": "serving_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "serving_grams": {
+          "name": "serving_grams",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "calories": {
+          "name": "calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protein": {
+          "name": "protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fat": {
+          "name": "fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fiber": {
+          "name": "fiber",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sugar": {
+          "name": "sugar",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "foods_user_last_used_at_idx": {
+          "name": "foods_user_last_used_at_idx",
+          "columns": [
+            "user_id",
+            "last_used_at"
+          ],
+          "isUnique": false
+        },
+        "foods_user_usage_count_idx": {
+          "name": "foods_user_usage_count_idx",
+          "columns": [
+            "user_id",
+            "usage_count"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "foods_user_id_users_id_fk": {
+          "name": "foods_user_id_users_id_fk",
+          "tableFrom": "foods",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "foods_serving_grams_check": {
+          "name": "foods_serving_grams_check",
+          "value": "\"foods\".\"serving_grams\" is null or \"foods\".\"serving_grams\" > 0"
+        },
+        "foods_macros_nonnegative_check": {
+          "name": "foods_macros_nonnegative_check",
+          "value": "\"foods\".\"calories\" >= 0 and \"foods\".\"protein\" >= 0 and \"foods\".\"carbs\" >= 0 and \"foods\".\"fat\" >= 0"
+        },
+        "foods_fiber_nonnegative_check": {
+          "name": "foods_fiber_nonnegative_check",
+          "value": "\"foods\".\"fiber\" is null or \"foods\".\"fiber\" >= 0"
+        },
+        "foods_sugar_nonnegative_check": {
+          "name": "foods_sugar_nonnegative_check",
+          "value": "\"foods\".\"sugar\" is null or \"foods\".\"sugar\" >= 0"
+        }
+      }
+    },
+    "habit_entries": {
+      "name": "habit_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "habit_id": {
+          "name": "habit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_override": {
+          "name": "is_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "habit_entries_user_id_idx": {
+          "name": "habit_entries_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "habit_entries_date_idx": {
+          "name": "habit_entries_date_idx",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "habit_entries_habit_id_date_unique": {
+          "name": "habit_entries_habit_id_date_unique",
+          "columns": [
+            "habit_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "habit_entries_habit_id_habits_id_fk": {
+          "name": "habit_entries_habit_id_habits_id_fk",
+          "tableFrom": "habit_entries",
+          "tableTo": "habits",
+          "columnsFrom": [
+            "habit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "habit_entries_user_id_users_id_fk": {
+          "name": "habit_entries_user_id_users_id_fk",
+          "tableFrom": "habit_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "habit_entries_date_format_check": {
+          "name": "habit_entries_date_format_check",
+          "value": "\"habit_entries\".\"date\" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        }
+      }
+    },
+    "habits": {
+      "name": "habits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tracking_type": {
+          "name": "tracking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'daily'"
+        },
+        "frequency_target": {
+          "name": "frequency_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_days": {
+          "name": "scheduled_days",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_source": {
+          "name": "reference_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_config": {
+          "name": "reference_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_until": {
+          "name": "paused_until",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "habits_user_id_idx": {
+          "name": "habits_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "habits_user_id_users_id_fk": {
+          "name": "habits_user_id_users_id_fk",
+          "tableFrom": "habits",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "habits_tracking_type_check": {
+          "name": "habits_tracking_type_check",
+          "value": "\"habits\".\"tracking_type\" in ('boolean', 'numeric', 'time')"
+        },
+        "habits_frequency_check": {
+          "name": "habits_frequency_check",
+          "value": "\"habits\".\"frequency\" in ('daily', 'weekly', 'specific_days')"
+        }
+      }
+    },
+    "condition_protocols": {
+      "name": "condition_protocols",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition_id": {
+          "name": "condition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "condition_protocols_condition_id_idx": {
+          "name": "condition_protocols_condition_id_idx",
+          "columns": [
+            "condition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "condition_protocols_condition_id_health_conditions_id_fk": {
+          "name": "condition_protocols_condition_id_health_conditions_id_fk",
+          "tableFrom": "condition_protocols",
+          "tableTo": "health_conditions",
+          "columnsFrom": [
+            "condition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "condition_protocols_status_check": {
+          "name": "condition_protocols_status_check",
+          "value": "\"condition_protocols\".\"status\" in ('active', 'discontinued', 'completed')"
+        },
+        "condition_protocols_start_date_format_check": {
+          "name": "condition_protocols_start_date_format_check",
+          "value": "\"condition_protocols\".\"start_date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "condition_protocols_end_date_format_check": {
+          "name": "condition_protocols_end_date_format_check",
+          "value": "\"condition_protocols\".\"end_date\" is null or \"condition_protocols\".\"end_date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "condition_protocols_end_date_order_check": {
+          "name": "condition_protocols_end_date_order_check",
+          "value": "\"condition_protocols\".\"end_date\" is null or \"condition_protocols\".\"end_date\" >= \"condition_protocols\".\"start_date\""
+        }
+      }
+    },
+    "condition_severity_points": {
+      "name": "condition_severity_points",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition_id": {
+          "name": "condition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "condition_severity_points_condition_date_idx": {
+          "name": "condition_severity_points_condition_date_idx",
+          "columns": [
+            "condition_id",
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "condition_severity_points_condition_id_health_conditions_id_fk": {
+          "name": "condition_severity_points_condition_id_health_conditions_id_fk",
+          "tableFrom": "condition_severity_points",
+          "tableTo": "health_conditions",
+          "columnsFrom": [
+            "condition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "condition_severity_points_date_format_check": {
+          "name": "condition_severity_points_date_format_check",
+          "value": "\"condition_severity_points\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "condition_severity_points_value_check": {
+          "name": "condition_severity_points_value_check",
+          "value": "\"condition_severity_points\".\"value\" between 1 and 10"
+        }
+      }
+    },
+    "condition_timeline_events": {
+      "name": "condition_timeline_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition_id": {
+          "name": "condition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "condition_timeline_events_condition_date_idx": {
+          "name": "condition_timeline_events_condition_date_idx",
+          "columns": [
+            "condition_id",
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "condition_timeline_events_condition_id_health_conditions_id_fk": {
+          "name": "condition_timeline_events_condition_id_health_conditions_id_fk",
+          "tableFrom": "condition_timeline_events",
+          "tableTo": "health_conditions",
+          "columnsFrom": [
+            "condition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "condition_timeline_events_date_format_check": {
+          "name": "condition_timeline_events_date_format_check",
+          "value": "\"condition_timeline_events\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "condition_timeline_events_type_check": {
+          "name": "condition_timeline_events_type_check",
+          "value": "\"condition_timeline_events\".\"type\" in ('onset', 'flare', 'improvement', 'treatment', 'milestone')"
+        }
+      }
+    },
+    "health_conditions": {
+      "name": "health_conditions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body_area": {
+          "name": "body_area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "health_conditions_user_id_idx": {
+          "name": "health_conditions_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_conditions_user_id_users_id_fk": {
+          "name": "health_conditions_user_id_users_id_fk",
+          "tableFrom": "health_conditions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "health_conditions_status_check": {
+          "name": "health_conditions_status_check",
+          "value": "\"health_conditions\".\"status\" in ('active', 'monitoring', 'resolved')"
+        },
+        "health_conditions_onset_date_format_check": {
+          "name": "health_conditions_onset_date_format_check",
+          "value": "\"health_conditions\".\"onset_date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        }
+      }
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "journal_entries_user_date_idx": {
+          "name": "journal_entries_user_date_idx",
+          "columns": [
+            "user_id",
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_user_id_users_id_fk": {
+          "name": "journal_entries_user_id_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "journal_entries_date_format_check": {
+          "name": "journal_entries_date_format_check",
+          "value": "\"journal_entries\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "journal_entries_type_check": {
+          "name": "journal_entries_type_check",
+          "value": "\"journal_entries\".\"type\" in ('post-workout', 'milestone', 'observation', 'weekly-summary', 'injury-update')"
+        },
+        "journal_entries_created_by_check": {
+          "name": "journal_entries_created_by_check",
+          "value": "\"journal_entries\".\"created_by\" in ('agent', 'user')"
+        }
+      }
+    },
+    "meal_items": {
+      "name": "meal_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meal_id": {
+          "name": "meal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_quantity": {
+          "name": "display_quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_unit": {
+          "name": "display_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "calories": {
+          "name": "calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protein": {
+          "name": "protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fat": {
+          "name": "fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fiber": {
+          "name": "fiber",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sugar": {
+          "name": "sugar",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "meal_items_meal_id_idx": {
+          "name": "meal_items_meal_id_idx",
+          "columns": [
+            "meal_id"
+          ],
+          "isUnique": false
+        },
+        "meal_items_food_id_idx": {
+          "name": "meal_items_food_id_idx",
+          "columns": [
+            "food_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meal_items_meal_id_meals_id_fk": {
+          "name": "meal_items_meal_id_meals_id_fk",
+          "tableFrom": "meal_items",
+          "tableTo": "meals",
+          "columnsFrom": [
+            "meal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meal_items_food_id_foods_id_fk": {
+          "name": "meal_items_food_id_foods_id_fk",
+          "tableFrom": "meal_items",
+          "tableTo": "foods",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "meal_items_amount_check": {
+          "name": "meal_items_amount_check",
+          "value": "\"meal_items\".\"amount\" > 0"
+        },
+        "meal_items_display_quantity_check": {
+          "name": "meal_items_display_quantity_check",
+          "value": "\"meal_items\".\"display_quantity\" is null or \"meal_items\".\"display_quantity\" > 0"
+        },
+        "meal_items_macros_nonnegative_check": {
+          "name": "meal_items_macros_nonnegative_check",
+          "value": "\"meal_items\".\"calories\" >= 0 and \"meal_items\".\"protein\" >= 0 and \"meal_items\".\"carbs\" >= 0 and \"meal_items\".\"fat\" >= 0"
+        },
+        "meal_items_fiber_nonnegative_check": {
+          "name": "meal_items_fiber_nonnegative_check",
+          "value": "\"meal_items\".\"fiber\" is null or \"meal_items\".\"fiber\" >= 0"
+        },
+        "meal_items_sugar_nonnegative_check": {
+          "name": "meal_items_sugar_nonnegative_check",
+          "value": "\"meal_items\".\"sugar\" is null or \"meal_items\".\"sugar\" >= 0"
+        }
+      }
+    },
+    "meals": {
+      "name": "meals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nutrition_log_id": {
+          "name": "nutrition_log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "meals_nutrition_log_id_idx": {
+          "name": "meals_nutrition_log_id_idx",
+          "columns": [
+            "nutrition_log_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meals_nutrition_log_id_nutrition_logs_id_fk": {
+          "name": "meals_nutrition_log_id_nutrition_logs_id_fk",
+          "tableFrom": "meals",
+          "tableTo": "nutrition_logs",
+          "columnsFrom": [
+            "nutrition_log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "meals_time_format_check": {
+          "name": "meals_time_format_check",
+          "value": "\"meals\".\"time\" is null or \"meals\".\"time\" glob '[0-9][0-9]:[0-9][0-9]'"
+        }
+      }
+    },
+    "nutrition_logs": {
+      "name": "nutrition_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "nutrition_logs_user_id_date_unique": {
+          "name": "nutrition_logs_user_id_date_unique",
+          "columns": [
+            "user_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "nutrition_logs_user_id_users_id_fk": {
+          "name": "nutrition_logs_user_id_users_id_fk",
+          "tableFrom": "nutrition_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "nutrition_logs_date_format_check": {
+          "name": "nutrition_logs_date_format_check",
+          "value": "\"nutrition_logs\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        }
+      }
+    },
+    "nutrition_targets": {
+      "name": "nutrition_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "calories": {
+          "name": "calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protein": {
+          "name": "protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fat": {
+          "name": "fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "nutrition_targets_user_id_effective_date_unique": {
+          "name": "nutrition_targets_user_id_effective_date_unique",
+          "columns": [
+            "user_id",
+            "effective_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "nutrition_targets_user_id_users_id_fk": {
+          "name": "nutrition_targets_user_id_users_id_fk",
+          "tableFrom": "nutrition_targets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "nutrition_targets_effective_date_format_check": {
+          "name": "nutrition_targets_effective_date_format_check",
+          "value": "\"nutrition_targets\".\"effective_date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "nutrition_targets_macros_nonnegative_check": {
+          "name": "nutrition_targets_macros_nonnegative_check",
+          "value": "\"nutrition_targets\".\"calories\" >= 0 and \"nutrition_targets\".\"protein\" >= 0 and \"nutrition_targets\".\"carbs\" >= 0 and \"nutrition_targets\".\"fat\" >= 0"
+        }
+      }
+    },
+    "resources": {
+      "name": "resources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "principles": {
+          "name": "principles",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "resources_user_id_idx": {
+          "name": "resources_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "resources_user_id_users_id_fk": {
+          "name": "resources_user_id_users_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "resources_type_check": {
+          "name": "resources_type_check",
+          "value": "\"resources\".\"type\" in ('program', 'book', 'creator')"
+        }
+      }
+    },
+    "template_exercises": {
+      "name": "template_exercises",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sets": {
+          "name": "sets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reps_min": {
+          "name": "reps_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reps_max": {
+          "name": "reps_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tempo": {
+          "name": "tempo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rest_seconds": {
+          "name": "rest_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "superset_group": {
+          "name": "superset_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section": {
+          "name": "section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cues": {
+          "name": "cues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "set_targets": {
+          "name": "set_targets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "programming_notes": {
+          "name": "programming_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "template_exercises_template_id_idx": {
+          "name": "template_exercises_template_id_idx",
+          "columns": [
+            "template_id"
+          ],
+          "isUnique": false
+        },
+        "template_exercises_exercise_id_idx": {
+          "name": "template_exercises_exercise_id_idx",
+          "columns": [
+            "exercise_id"
+          ],
+          "isUnique": false
+        },
+        "template_exercises_template_section_order_unique": {
+          "name": "template_exercises_template_section_order_unique",
+          "columns": [
+            "template_id",
+            "section",
+            "order_index"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "template_exercises_template_id_workout_templates_id_fk": {
+          "name": "template_exercises_template_id_workout_templates_id_fk",
+          "tableFrom": "template_exercises",
+          "tableTo": "workout_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "template_exercises_exercise_id_exercises_id_fk": {
+          "name": "template_exercises_exercise_id_exercises_id_fk",
+          "tableFrom": "template_exercises",
+          "tableTo": "exercises",
+          "columnsFrom": [
+            "exercise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "template_exercises_section_check": {
+          "name": "template_exercises_section_check",
+          "value": "\"template_exercises\".\"section\" in ('warmup', 'main', 'cooldown', 'supplemental')"
+        },
+        "template_exercises_reps_range_check": {
+          "name": "template_exercises_reps_range_check",
+          "value": "\"template_exercises\".\"reps_min\" is null or \"template_exercises\".\"reps_max\" is null or \"template_exercises\".\"reps_min\" <= \"template_exercises\".\"reps_max\""
+        }
+      }
+    },
+    "workout_templates": {
+      "name": "workout_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "workout_templates_user_id_idx": {
+          "name": "workout_templates_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workout_templates_user_id_users_id_fk": {
+          "name": "workout_templates_user_id_users_id_fk",
+          "tableFrom": "workout_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_sets": {
+      "name": "session_sets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "set_number": {
+          "name": "set_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reps": {
+          "name": "reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_weight": {
+          "name": "target_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_weight_min": {
+          "name": "target_weight_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_weight_max": {
+          "name": "target_weight_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_seconds": {
+          "name": "target_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_distance": {
+          "name": "target_distance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "superset_group": {
+          "name": "superset_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "section": {
+          "name": "section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'main'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "session_sets_session_id_idx": {
+          "name": "session_sets_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "session_sets_session_exercise_section_set_number_unique": {
+          "name": "session_sets_session_exercise_section_set_number_unique",
+          "columns": [
+            "session_id",
+            "exercise_id",
+            "section",
+            "set_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_sets_session_id_workout_sessions_id_fk": {
+          "name": "session_sets_session_id_workout_sessions_id_fk",
+          "tableFrom": "session_sets",
+          "tableTo": "workout_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_sets_exercise_id_exercises_id_fk": {
+          "name": "session_sets_exercise_id_exercises_id_fk",
+          "tableFrom": "session_sets",
+          "tableTo": "exercises",
+          "columnsFrom": [
+            "exercise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "session_sets_set_number_check": {
+          "name": "session_sets_set_number_check",
+          "value": "\"session_sets\".\"set_number\" > 0"
+        },
+        "session_sets_section_check": {
+          "name": "session_sets_section_check",
+          "value": "\"session_sets\".\"section\" in ('warmup', 'main', 'cooldown', 'supplemental')"
+        },
+        "session_sets_completion_state_check": {
+          "name": "session_sets_completion_state_check",
+          "value": "not (\"session_sets\".\"completed\" and \"session_sets\".\"skipped\")"
+        }
+      }
+    },
+    "workout_sessions": {
+      "name": "workout_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in-progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_segments": {
+          "name": "time_segments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "workout_sessions_user_id_idx": {
+          "name": "workout_sessions_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "workout_sessions_date_idx": {
+          "name": "workout_sessions_date_idx",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workout_sessions_user_id_users_id_fk": {
+          "name": "workout_sessions_user_id_users_id_fk",
+          "tableFrom": "workout_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workout_sessions_template_id_workout_templates_id_fk": {
+          "name": "workout_sessions_template_id_workout_templates_id_fk",
+          "tableFrom": "workout_sessions",
+          "tableTo": "workout_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "workout_sessions_date_format_check": {
+          "name": "workout_sessions_date_format_check",
+          "value": "\"workout_sessions\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "workout_sessions_status_check": {
+          "name": "workout_sessions_status_check",
+          "value": "\"workout_sessions\".\"status\" in ('scheduled', 'in-progress', 'paused', 'cancelled', 'completed')"
+        },
+        "workout_sessions_completed_at_check": {
+          "name": "workout_sessions_completed_at_check",
+          "value": "(\"workout_sessions\".\"status\" != 'completed' or \"workout_sessions\".\"completed_at\" is not null) and (\"workout_sessions\".\"completed_at\" is null or \"workout_sessions\".\"completed_at\" >= \"workout_sessions\".\"started_at\")"
+        }
+      }
+    },
+    "scheduled_workouts": {
+      "name": "scheduled_workouts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "scheduled_workouts_user_date_idx": {
+          "name": "scheduled_workouts_user_date_idx",
+          "columns": [
+            "user_id",
+            "date"
+          ],
+          "isUnique": false
+        },
+        "scheduled_workouts_template_id_idx": {
+          "name": "scheduled_workouts_template_id_idx",
+          "columns": [
+            "template_id"
+          ],
+          "isUnique": false
+        },
+        "scheduled_workouts_session_id_idx": {
+          "name": "scheduled_workouts_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_workouts_user_id_users_id_fk": {
+          "name": "scheduled_workouts_user_id_users_id_fk",
+          "tableFrom": "scheduled_workouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_workouts_template_id_workout_templates_id_fk": {
+          "name": "scheduled_workouts_template_id_workout_templates_id_fk",
+          "tableFrom": "scheduled_workouts",
+          "tableTo": "workout_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scheduled_workouts_session_id_workout_sessions_id_fk": {
+          "name": "scheduled_workouts_session_id_workout_sessions_id_fk",
+          "tableFrom": "scheduled_workouts",
+          "tableTo": "workout_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_workouts_date_format_check": {
+          "name": "scheduled_workouts_date_format_check",
+          "value": "\"scheduled_workouts\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1774229145755,
       "tag": "0034_salty_ben_urich",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "6",
+      "when": 1774237014277,
+      "tag": "0035_groovy_captain_cross",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.test.ts
+++ b/apps/api/src/db/schema.test.ts
@@ -1092,6 +1092,7 @@ describe('sessionSets schema', () => {
     expect(columns.completed.default).toBe(false);
     expect(columns.skipped.default).toBe(false);
     expect(columns.orderIndex.default).toBe(0);
+    expect(columns.exerciseId.notNull).toBe(false);
     expect(columns.section.notNull).toBe(true);
     expect(columns.section.default).toBe('main');
     expect(columns.createdAt.default).toBeDefined();
@@ -1105,7 +1106,7 @@ describe('sessionSets schema', () => {
     expect(
       config.foreignKeys.find((fk) => getTableName(fk.reference().foreignTable) === 'exercises')
         ?.onDelete,
-    ).toBe('restrict');
+    ).toBe('set null');
     expect(config.indexes.map((idx) => idx.config.name)).toEqual(['session_sets_session_id_idx']);
     expect(config.uniqueConstraints).toHaveLength(1);
     expect(config.uniqueConstraints[0]?.getName()).toBe(

--- a/apps/api/src/db/schema/workout-sessions.ts
+++ b/apps/api/src/db/schema/workout-sessions.ts
@@ -126,8 +126,7 @@ export const sessionSets = sqliteTable(
       .notNull()
       .references(() => workoutSessions.id, { onDelete: 'cascade' }),
     exerciseId: text('exercise_id')
-      .notNull()
-      .references(() => exercises.id, { onDelete: 'restrict' }),
+      .references(() => exercises.id, { onDelete: 'set null' }),
     orderIndex: integer('order_index').notNull().default(0),
     setNumber: integer('set_number').notNull(),
     weight: real('weight'),

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -142,6 +142,12 @@ describe('OpenAPI docs', () => {
         tags: ['exercises'],
         security: [{ bearerAuth: [] }, { agentToken: [] }],
       });
+      expect(body.paths?.['/api/v1/exercises/{winnerId}/merge']?.post).toMatchObject({
+        summary: 'Merge one exercise into another',
+        tags: ['exercises'],
+        security: [{ bearerAuth: [] }],
+      });
+      expect(body.paths?.['/api/v1/exercises/{winnerId}/merge']?.post.requestBody).toBeTruthy();
       expect(body.paths?.['/api/v1/exercises/{id}/last-performance']?.get.parameters).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ name: 'id', in: 'path' }),

--- a/apps/api/src/middleware/agent-enrichment.ts
+++ b/apps/api/src/middleware/agent-enrichment.ts
@@ -317,8 +317,16 @@ const buildWorkoutSessionEnrichment = (
   const totalSets = sortedSets.length;
   const completedSets = sortedSets.filter((set) => set.completed).length;
   const openSets = sortedSets.filter((set) => !set.completed && !set.skipped);
-  const exerciseIds = new Set(sortedSets.map((set) => set.exerciseId));
-  const remainingExerciseIds = new Set(openSets.map((set) => set.exerciseId));
+  const exerciseIds = new Set(
+    sortedSets
+      .map((set) => set.exerciseId)
+      .filter((exerciseId): exerciseId is string => typeof exerciseId === 'string'),
+  );
+  const remainingExerciseIds = new Set(
+    openSets
+      .map((set) => set.exerciseId)
+      .filter((exerciseId): exerciseId is string => typeof exerciseId === 'string'),
+  );
   const nextSet = openSets[0];
   const nextExercise = session.exercises?.find(
     (exercise) => exercise.exerciseId === nextSet?.exerciseId,
@@ -333,7 +341,7 @@ const buildWorkoutSessionEnrichment = (
     ]),
     suggestedActions: compactStrings([
       nextSet
-        ? `Log set ${nextSet.setNumber} for ${nextExercise?.exerciseName ?? nextSet.exerciseId}.`
+        ? `Log set ${nextSet.setNumber} for ${nextExercise?.exerciseName ?? nextSet.exerciseId ?? 'Deleted exercise'}.`
         : session.status === 'in-progress'
           ? 'Mark the session completed or add a finisher set if more work is needed.'
           : 'Review notes and confirm the session status is final.',

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -217,7 +217,7 @@ describe('exercise routes', () => {
     seedUser('user-2', 'alex');
   });
 
-  it('requires auth for create, list, read, history, last-performance, update, and delete', async () => {
+  it('requires auth for create, list, read, history, merge, last-performance, update, and delete', async () => {
     const responses = await Promise.all([
       context.app.inject({
         method: 'POST',
@@ -240,6 +240,13 @@ describe('exercise routes', () => {
       context.app.inject({
         method: 'GET',
         url: '/api/v1/exercises/exercise-1/history',
+      }),
+      context.app.inject({
+        method: 'POST',
+        url: '/api/v1/exercises/11111111-1111-4111-8111-111111111111/merge',
+        payload: {
+          loserId: '22222222-2222-4222-8222-222222222222',
+        },
       }),
       context.app.inject({
         method: 'GET',
@@ -2260,6 +2267,210 @@ describe('exercise routes', () => {
 
     expect(persistedExercise).toEqual({
       deletedAt: null,
+    });
+  });
+
+  it('merges exercises by reassigning session and template references, then soft-deleting the loser', async () => {
+    seedExercise({
+      id: '11111111-1111-4111-8111-111111111111',
+      userId: 'user-1',
+      name: 'Bench Press',
+      muscleGroups: ['chest'],
+      equipment: 'barbell',
+      category: 'compound',
+    });
+    seedExercise({
+      id: '22222222-2222-4222-8222-222222222222',
+      userId: 'user-1',
+      name: 'Barbell Bench',
+      muscleGroups: ['chest'],
+      equipment: 'barbell',
+      category: 'compound',
+    });
+
+    context.db
+      .insert(workoutTemplates)
+      .values({
+        id: 'merge-template',
+        userId: 'user-1',
+        name: 'Push Day',
+        description: null,
+        tags: [],
+      })
+      .run();
+    context.db
+      .insert(templateExercises)
+      .values([
+        {
+          id: 'template-winner',
+          templateId: 'merge-template',
+          exerciseId: '11111111-1111-4111-8111-111111111111',
+          orderIndex: 0,
+          section: 'main',
+        },
+        {
+          id: 'template-loser',
+          templateId: 'merge-template',
+          exerciseId: '22222222-2222-4222-8222-222222222222',
+          orderIndex: 1,
+          section: 'main',
+        },
+      ])
+      .run();
+
+    seedWorkoutSession({
+      id: 'merge-session',
+      userId: 'user-1',
+      name: 'Push Session',
+      date: '2026-03-12',
+      startedAt: Date.parse('2026-03-12T08:00:00.000Z'),
+      status: 'completed',
+      completedAt: Date.parse('2026-03-12T08:45:00.000Z'),
+    });
+    seedSessionSet({
+      id: 'merge-winner-set',
+      sessionId: 'merge-session',
+      exerciseId: '11111111-1111-4111-8111-111111111111',
+      setNumber: 1,
+      reps: 8,
+    });
+    seedSessionSet({
+      id: 'merge-loser-set',
+      sessionId: 'merge-session',
+      exerciseId: '22222222-2222-4222-8222-222222222222',
+      setNumber: 1,
+      reps: 10,
+    });
+
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/exercises/11111111-1111-4111-8111-111111111111/merge',
+      headers: createAuthorizationHeader(authToken),
+      payload: { loserId: '22222222-2222-4222-8222-222222222222' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        id: '11111111-1111-4111-8111-111111111111',
+      }),
+    });
+
+    const mergedTemplateRows = context.db
+      .select({
+        id: templateExercises.id,
+        exerciseId: templateExercises.exerciseId,
+      })
+      .from(templateExercises)
+      .where(eq(templateExercises.templateId, 'merge-template'))
+      .all();
+    expect(mergedTemplateRows).toEqual([
+      {
+        id: 'template-winner',
+        exerciseId: '11111111-1111-4111-8111-111111111111',
+      },
+    ]);
+
+    const mergedSessionSets = context.db
+      .select({
+        id: sessionSets.id,
+        exerciseId: sessionSets.exerciseId,
+        setNumber: sessionSets.setNumber,
+      })
+      .from(sessionSets)
+      .where(eq(sessionSets.sessionId, 'merge-session'))
+      .all()
+      .sort((left, right) => left.id.localeCompare(right.id));
+    expect(mergedSessionSets).toEqual([
+      {
+        id: 'merge-loser-set',
+        exerciseId: '11111111-1111-4111-8111-111111111111',
+        setNumber: 2,
+      },
+      {
+        id: 'merge-winner-set',
+        exerciseId: '11111111-1111-4111-8111-111111111111',
+        setNumber: 1,
+      },
+    ]);
+
+    const deletedLoser = context.db
+      .select({ deletedAt: exercises.deletedAt })
+      .from(exercises)
+      .where(eq(exercises.id, '22222222-2222-4222-8222-222222222222'))
+      .get();
+    expect(deletedLoser?.deletedAt).not.toBeNull();
+  });
+
+  it('rejects invalid exercise merge requests and AgentToken callers', async () => {
+    seedExercise({
+      id: '11111111-1111-4111-8111-111111111111',
+      userId: 'user-1',
+      name: 'Bench Press',
+      muscleGroups: ['chest'],
+      equipment: 'barbell',
+      category: 'compound',
+    });
+    seedExercise({
+      id: '22222222-2222-4222-8222-222222222222',
+      userId: 'user-1',
+      name: 'Barbell Bench',
+      muscleGroups: ['chest'],
+      equipment: 'barbell',
+      category: 'compound',
+    });
+
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    const agentToken = seedAgentToken('user-1', 'exercise-merge-agent-token');
+
+    const sameIdResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/exercises/11111111-1111-4111-8111-111111111111/merge',
+      headers: createAuthorizationHeader(authToken),
+      payload: { loserId: '11111111-1111-4111-8111-111111111111' },
+    });
+    expect(sameIdResponse.statusCode).toBe(400);
+    expect(sameIdResponse.json()).toEqual({
+      error: {
+        code: 'INVALID_EXERCISE_MERGE',
+        message: 'winnerId and loserId must be different',
+      },
+    });
+
+    const notFoundResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/exercises/11111111-1111-4111-8111-111111111111/merge',
+      headers: createAuthorizationHeader(authToken),
+      payload: { loserId: '33333333-3333-4333-8333-333333333333' },
+    });
+    expect(notFoundResponse.statusCode).toBe(404);
+    expect(notFoundResponse.json()).toEqual({
+      error: {
+        code: 'EXERCISE_NOT_FOUND',
+        message: 'Exercise not found',
+      },
+    });
+
+    const agentResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/exercises/11111111-1111-4111-8111-111111111111/merge',
+      headers: createAgentTokenHeader(agentToken),
+      payload: { loserId: '22222222-2222-4222-8222-222222222222' },
+    });
+    expect(agentResponse.statusCode).toBe(403);
+    expect(agentResponse.json()).toEqual({
+      error: {
+        code: 'JWT_AUTH_REQUIRED',
+        message: 'This operation requires Bearer token authentication.',
+      },
     });
   });
 

--- a/apps/api/src/routes/exercises/index.test.ts
+++ b/apps/api/src/routes/exercises/index.test.ts
@@ -2407,6 +2407,93 @@ describe('exercise routes', () => {
     expect(deletedLoser?.deletedAt).not.toBeNull();
   });
 
+  it('preserves template rows when winner and loser are in different sections', async () => {
+    seedExercise({
+      id: '11111111-1111-4111-8111-111111111111',
+      userId: 'user-1',
+      name: 'Bench Press',
+      muscleGroups: ['chest'],
+      equipment: 'barbell',
+      category: 'compound',
+    });
+    seedExercise({
+      id: '22222222-2222-4222-8222-222222222222',
+      userId: 'user-1',
+      name: 'Barbell Bench',
+      muscleGroups: ['chest'],
+      equipment: 'barbell',
+      category: 'compound',
+    });
+
+    context.db
+      .insert(workoutTemplates)
+      .values({
+        id: 'merge-template-sections',
+        userId: 'user-1',
+        name: 'Push Day Sections',
+        description: null,
+        tags: [],
+      })
+      .run();
+    context.db
+      .insert(templateExercises)
+      .values([
+        {
+          id: 'template-winner-warmup',
+          templateId: 'merge-template-sections',
+          exerciseId: '11111111-1111-4111-8111-111111111111',
+          orderIndex: 0,
+          section: 'warmup',
+        },
+        {
+          id: 'template-loser-main',
+          templateId: 'merge-template-sections',
+          exerciseId: '22222222-2222-4222-8222-222222222222',
+          orderIndex: 0,
+          section: 'main',
+        },
+      ])
+      .run();
+
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/exercises/11111111-1111-4111-8111-111111111111/merge',
+      headers: createAuthorizationHeader(authToken),
+      payload: { loserId: '22222222-2222-4222-8222-222222222222' },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const mergedTemplateRows = context.db
+      .select({
+        id: templateExercises.id,
+        exerciseId: templateExercises.exerciseId,
+        section: templateExercises.section,
+      })
+      .from(templateExercises)
+      .where(eq(templateExercises.templateId, 'merge-template-sections'))
+      .all()
+      .sort((left, right) => left.section.localeCompare(right.section));
+
+    expect(mergedTemplateRows).toEqual([
+      {
+        id: 'template-loser-main',
+        exerciseId: '11111111-1111-4111-8111-111111111111',
+        section: 'main',
+      },
+      {
+        id: 'template-winner-warmup',
+        exerciseId: '11111111-1111-4111-8111-111111111111',
+        section: 'warmup',
+      },
+    ]);
+  });
+
   it('rejects invalid exercise merge requests and AgentToken callers', async () => {
     seedExercise({
       id: '11111111-1111-4111-8111-111111111111',
@@ -2430,6 +2517,19 @@ describe('exercise routes', () => {
       { expiresIn: '7d' },
     );
     const agentToken = seedAgentToken('user-1', 'exercise-merge-agent-token');
+
+    const invalidLoserIdResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/exercises/11111111-1111-4111-8111-111111111111/merge',
+      headers: createAuthorizationHeader(authToken),
+      payload: { loserId: 'not-a-uuid' },
+    });
+    expect(invalidLoserIdResponse.statusCode).toBe(400);
+    expectValidationError(invalidLoserIdResponse.json(), {
+      method: 'POST',
+      url: '/api/v1/exercises/11111111-1111-4111-8111-111111111111/merge',
+      instancePath: '/loserId',
+    });
 
     const sameIdResponse = await context.app.inject({
       method: 'POST',

--- a/apps/api/src/routes/exercises/index.ts
+++ b/apps/api/src/routes/exercises/index.ts
@@ -8,6 +8,7 @@ import {
   exerciseHistoryWithRelatedSchema,
   exerciseLastPerformanceQuerySchema,
   exerciseLastPerformancesSchema,
+  mergeExerciseInputSchema,
   exercisePerformanceHistoryQuerySchema,
   exercisePerformanceHistorySchema,
   exerciseQueryParamsSchema,
@@ -27,6 +28,7 @@ import {
   authSecurity,
   badRequestResponseSchema,
   idParamsSchema,
+  jwtSecurity,
   successFlagSchema,
 } from '../../openapi.js';
 
@@ -34,6 +36,8 @@ import {
   allRelatedExercisesOwned,
   createExercise,
   deleteOwnedExercise,
+  ExerciseMergeNotFoundError,
+  ExerciseMergeSameIdError,
   findExerciseDedupCandidates,
   findExerciseHistoryWithRelated,
   findExerciseLastPerformance,
@@ -44,6 +48,7 @@ import {
   isExerciseInUse,
   listExerciseFilters,
   listExercises,
+  mergeExercises,
   updateOwnedExercise,
 } from './store.js';
 
@@ -67,6 +72,20 @@ const EXERCISE_IN_USE_RESPONSE = {
   message:
     'This exercise is referenced by active workout templates or sessions and cannot be deleted.',
 } as const;
+
+const EXERCISE_MERGE_FORBIDDEN_RESPONSE = {
+  code: 'JWT_AUTH_REQUIRED',
+  message: 'This operation requires Bearer token authentication.',
+} as const;
+
+const INVALID_EXERCISE_MERGE_RESPONSE = {
+  code: 'INVALID_EXERCISE_MERGE',
+  message: 'winnerId and loserId must be different',
+} as const;
+
+const mergeExerciseParamsSchema = z.object({
+  winnerId: z.string().uuid(),
+});
 
 const isSqliteForeignKeyConstraintError = (error: unknown): error is { code: string } => {
   if (typeof error !== 'object' || error === null) {
@@ -547,6 +566,68 @@ export const exerciseRoutes: FastifyPluginAsync = async (app) => {
           success: true,
         },
       });
+    },
+  );
+
+  typedApp.post(
+    '/:winnerId/merge',
+    {
+      schema: {
+        params: mergeExerciseParamsSchema,
+        body: mergeExerciseInputSchema,
+        response: {
+          200: apiDataResponseSchema(exerciseSchema),
+          400: badRequestResponseSchema,
+          401: apiErrorResponseSchema,
+          403: apiErrorResponseSchema,
+          404: apiErrorResponseSchema,
+        },
+        tags: ['exercises'],
+        summary: 'Merge one exercise into another',
+        security: jwtSecurity,
+      },
+    },
+    async (request, reply) => {
+      if (isAgentRequest(request)) {
+        return sendError(
+          reply,
+          403,
+          EXERCISE_MERGE_FORBIDDEN_RESPONSE.code,
+          EXERCISE_MERGE_FORBIDDEN_RESPONSE.message,
+        );
+      }
+
+      try {
+        const mergedExercise = await mergeExercises(
+          request.userId,
+          request.params.winnerId,
+          request.body.loserId,
+        );
+
+        return reply.send({
+          data: mergedExercise,
+        });
+      } catch (error) {
+        if (error instanceof ExerciseMergeSameIdError) {
+          return sendError(
+            reply,
+            400,
+            INVALID_EXERCISE_MERGE_RESPONSE.code,
+            INVALID_EXERCISE_MERGE_RESPONSE.message,
+          );
+        }
+
+        if (error instanceof ExerciseMergeNotFoundError) {
+          return sendError(
+            reply,
+            404,
+            EXERCISE_NOT_FOUND_RESPONSE.code,
+            EXERCISE_NOT_FOUND_RESPONSE.message,
+          );
+        }
+
+        throw error;
+      }
     },
   );
 };

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -54,6 +54,23 @@ export type ExerciseFilters = {
   equipment: string[];
 };
 
+export class ExerciseMergeSameIdError extends Error {
+  constructor() {
+    super('winnerId and loserId must be different');
+    this.name = 'ExerciseMergeSameIdError';
+  }
+}
+
+export class ExerciseMergeNotFoundError extends Error {
+  readonly role: 'winner' | 'loser';
+
+  constructor(role: 'winner' | 'loser') {
+    super(`${role} exercise not found`);
+    this.name = 'ExerciseMergeNotFoundError';
+    this.role = role;
+  }
+}
+
 const exerciseSelection = {
   id: exercises.id,
   userId: exercises.userId,
@@ -328,6 +345,179 @@ export const deleteOwnedExercise = async (id: string, userId: string): Promise<b
     .run();
 
   return result.changes === 1;
+};
+
+type MergeSessionRow = {
+  id: string;
+  sessionId: string;
+  section: string | null;
+  setNumber: number;
+};
+
+type WinnerSectionMax = {
+  sessionId: string;
+  section: string | null;
+  maxSetNumber: number;
+};
+
+const buildSessionSectionKey = (sessionId: string, section: string | null) =>
+  `${sessionId}::${section ?? '__null__'}`;
+
+export const mergeExercises = async (
+  userId: string,
+  winnerId: string,
+  loserId: string,
+): Promise<Exercise> => {
+  if (winnerId === loserId) {
+    throw new ExerciseMergeSameIdError();
+  }
+
+  const { db } = await import('../../db/index.js');
+
+  return db.transaction((tx) => {
+    const winner = tx
+      .select(exerciseSelection)
+      .from(exercises)
+      .where(and(eq(exercises.id, winnerId), eq(exercises.userId, userId), isNull(exercises.deletedAt)))
+      .limit(1)
+      .get();
+
+    if (!winner) {
+      throw new ExerciseMergeNotFoundError('winner');
+    }
+
+    const loser = tx
+      .select(exerciseSelection)
+      .from(exercises)
+      .where(and(eq(exercises.id, loserId), eq(exercises.userId, userId), isNull(exercises.deletedAt)))
+      .limit(1)
+      .get();
+
+    if (!loser) {
+      throw new ExerciseMergeNotFoundError('loser');
+    }
+
+    const winnerSectionMaxRows = tx
+      .select({
+        sessionId: sessionSets.sessionId,
+        section: sessionSets.section,
+        maxSetNumber: sql<number>`max(${sessionSets.setNumber})`,
+      })
+      .from(sessionSets)
+      .innerJoin(workoutSessions, eq(workoutSessions.id, sessionSets.sessionId))
+      .where(and(eq(workoutSessions.userId, userId), eq(sessionSets.exerciseId, winnerId)))
+      .groupBy(sessionSets.sessionId, sessionSets.section)
+      .all() as WinnerSectionMax[];
+
+    const winnerSectionMaxByKey = new Map(
+      winnerSectionMaxRows.map((row) => [
+        buildSessionSectionKey(row.sessionId, row.section),
+        row.maxSetNumber,
+      ]),
+    );
+
+    const loserSetRows = tx
+      .select({
+        id: sessionSets.id,
+        sessionId: sessionSets.sessionId,
+        section: sessionSets.section,
+        setNumber: sessionSets.setNumber,
+      })
+      .from(sessionSets)
+      .innerJoin(workoutSessions, eq(workoutSessions.id, sessionSets.sessionId))
+      .where(and(eq(workoutSessions.userId, userId), eq(sessionSets.exerciseId, loserId)))
+      .all() as MergeSessionRow[];
+
+    const loserRowsBySessionSection = new Map<string, MergeSessionRow[]>();
+    for (const row of loserSetRows) {
+      const key = buildSessionSectionKey(row.sessionId, row.section);
+      const rows = loserRowsBySessionSection.get(key) ?? [];
+      rows.push(row);
+      loserRowsBySessionSection.set(key, rows);
+    }
+
+    for (const [key, rows] of loserRowsBySessionSection.entries()) {
+      const offset = winnerSectionMaxByKey.get(key) ?? 0;
+      if (offset <= 0) {
+        continue;
+      }
+
+      for (const row of rows) {
+        tx.update(sessionSets)
+          .set({ setNumber: row.setNumber + offset })
+          .where(eq(sessionSets.id, row.id))
+          .run();
+      }
+    }
+
+    tx.update(sessionSets)
+      .set({ exerciseId: winnerId })
+      .where(
+        and(
+          eq(sessionSets.exerciseId, loserId),
+          sql`exists (
+            select 1
+            from ${workoutSessions}
+            where ${workoutSessions.id} = ${sessionSets.sessionId}
+              and ${workoutSessions.userId} = ${userId}
+          )`,
+        ),
+      )
+      .run();
+
+    tx.delete(templateExercises)
+      .where(
+        and(
+          eq(templateExercises.exerciseId, loserId),
+          sql`exists (
+            select 1
+            from ${workoutTemplates}
+            where ${workoutTemplates.id} = ${templateExercises.templateId}
+              and ${workoutTemplates.userId} = ${userId}
+          )`,
+          sql`exists (
+            select 1
+            from ${templateExercises} as winner_template_exercises
+            where winner_template_exercises.template_id = ${templateExercises.templateId}
+              and winner_template_exercises.exercise_id = ${winnerId}
+          )`,
+        ),
+      )
+      .run();
+
+    tx.update(templateExercises)
+      .set({ exerciseId: winnerId })
+      .where(
+        and(
+          eq(templateExercises.exerciseId, loserId),
+          sql`exists (
+            select 1
+            from ${workoutTemplates}
+            where ${workoutTemplates.id} = ${templateExercises.templateId}
+              and ${workoutTemplates.userId} = ${userId}
+          )`,
+        ),
+      )
+      .run();
+
+    tx.update(exercises)
+      .set({ deletedAt: new Date().toISOString(), updatedAt: Date.now() })
+      .where(and(eq(exercises.id, loserId), eq(exercises.userId, userId), isNull(exercises.deletedAt)))
+      .run();
+
+    const mergedWinner = tx
+      .select(exerciseSelection)
+      .from(exercises)
+      .where(and(eq(exercises.id, winnerId), eq(exercises.userId, userId), isNull(exercises.deletedAt)))
+      .limit(1)
+      .get();
+
+    if (!mergedWinner) {
+      throw new Error('Failed to load merged winner exercise');
+    }
+
+    return mergedWinner;
+  });
 };
 
 export const isExerciseInUse = async ({
@@ -871,6 +1061,10 @@ const findExercisesLastPerformanceById = async ({
   >();
 
   for (const row of latestSessionCandidates) {
+    if (row.exerciseId === null) {
+      continue;
+    }
+
     if (!latestSessionByExerciseId.has(row.exerciseId)) {
       latestSessionByExerciseId.set(row.exerciseId, {
         sessionId: row.sessionId,
@@ -918,6 +1112,10 @@ const findExercisesLastPerformanceById = async ({
   >();
 
   for (const set of latestSets) {
+    if (set.exerciseId === null) {
+      continue;
+    }
+
     const latestSession = latestSessionByExerciseId.get(set.exerciseId);
     if (!latestSession || latestSession.sessionId !== set.sessionId) {
       continue;

--- a/apps/api/src/routes/exercises/store.ts
+++ b/apps/api/src/routes/exercises/store.ts
@@ -438,7 +438,7 @@ export const mergeExercises = async (
 
     for (const [key, rows] of loserRowsBySessionSection.entries()) {
       const offset = winnerSectionMaxByKey.get(key) ?? 0;
-      if (offset <= 0) {
+      if (offset === 0) {
         continue;
       }
 
@@ -479,6 +479,7 @@ export const mergeExercises = async (
             select 1
             from ${templateExercises} as winner_template_exercises
             where winner_template_exercises.template_id = ${templateExercises.templateId}
+              and winner_template_exercises.section = ${templateExercises.section}
               and winner_template_exercises.exercise_id = ${winnerId}
           )`,
         ),

--- a/apps/api/src/routes/trash/index.test.ts
+++ b/apps/api/src/routes/trash/index.test.ts
@@ -358,4 +358,92 @@ describe('trash routes', () => {
         .get(),
     ).toBeUndefined();
   });
+
+  it('requires force when purging exercises with session history and sets session_set exercise_id to null', async () => {
+    context.db
+      .insert(exercises)
+      .values({
+        id: 'exercise-history',
+        userId: 'user-1',
+        name: 'Bench Press',
+        muscleGroups: ['chest'],
+        equipment: 'barbell',
+        category: 'compound',
+        tags: [],
+        formCues: [],
+        instructions: null,
+        deletedAt: '2026-03-10T00:00:00.000Z',
+      })
+      .run();
+
+    context.db
+      .insert(workoutSessions)
+      .values({
+        id: 'session-history',
+        userId: 'user-1',
+        templateId: null,
+        name: 'Push Day',
+        date: '2026-03-10',
+        startedAt: Date.now(),
+      })
+      .run();
+    context.db
+      .insert(sessionSets)
+      .values({
+        id: 'set-history',
+        sessionId: 'session-history',
+        exerciseId: 'exercise-history',
+        setNumber: 1,
+      })
+      .run();
+
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    const warningResponse = await context.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/trash/exercises/exercise-history',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(warningResponse.statusCode).toBe(409);
+    expect(warningResponse.json()).toEqual({
+      error: {
+        code: 'EXERCISE_PURGE_REQUIRES_FORCE',
+        message:
+          'Exercise has session history. Retry with force=true to purge. Referenced sets: 1.',
+      },
+    });
+
+    const forcedResponse = await context.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/trash/exercises/exercise-history?force=true',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(forcedResponse.statusCode).toBe(200);
+    expect(forcedResponse.json()).toEqual({
+      data: { success: true },
+    });
+
+    expect(
+      context.db
+        .select({ id: exercises.id })
+        .from(exercises)
+        .where(eq(exercises.id, 'exercise-history'))
+        .get(),
+    ).toBeUndefined();
+
+    expect(
+      context.db
+        .select({ exerciseId: sessionSets.exerciseId })
+        .from(sessionSets)
+        .where(eq(sessionSets.id, 'set-history'))
+        .get(),
+    ).toEqual({
+      exerciseId: null,
+    });
+  });
 });

--- a/apps/api/src/routes/trash/index.ts
+++ b/apps/api/src/routes/trash/index.ts
@@ -42,6 +42,25 @@ const TRASH_ITEM_NOT_FOUND_RESPONSE = {
   message: 'Trash item not found',
 } as const;
 
+const EXERCISE_PURGE_REQUIRES_FORCE_RESPONSE = {
+  code: 'EXERCISE_PURGE_REQUIRES_FORCE',
+  message: 'Exercise has session history. Retry with force=true to purge.',
+} as const;
+
+const purgeTrashQuerySchema = z.object({
+  force: z.coerce.boolean().optional().default(false),
+});
+
+class ExercisePurgeRequiresForceError extends Error {
+  readonly historyCount: number;
+
+  constructor(historyCount: number) {
+    super(EXERCISE_PURGE_REQUIRES_FORCE_RESPONSE.message);
+    this.name = 'ExercisePurgeRequiresForceError';
+    this.historyCount = historyCount;
+  }
+}
+
 const requireDeletedAt = (value: string | null): string => {
   if (value === null) {
     throw new Error('deletedAt unexpectedly null in trash list');
@@ -219,10 +238,12 @@ const restoreTrashItem = async ({
 
 const purgeTrashItem = async ({
   id,
+  force,
   type,
   userId,
 }: {
   id: string;
+  force: boolean;
   type: TrashType;
   userId: string;
 }): Promise<boolean> => {
@@ -268,6 +289,29 @@ const purgeTrashItem = async ({
           return false;
         }
 
+        const historyCountResult = tx
+          .select({
+            total: sql<number>`count(*)`,
+          })
+          .from(sessionSets)
+          .where(
+            and(
+              eq(sessionSets.exerciseId, id),
+              sql`exists (
+                select 1
+                from ${workoutSessions}
+                where ${workoutSessions.id} = ${sessionSets.sessionId}
+                  and ${workoutSessions.userId} = ${userId}
+              )`,
+            ),
+          )
+          .get();
+        const historyCount = historyCountResult?.total ?? 0;
+
+        if (historyCount > 0 && !force) {
+          throw new ExercisePurgeRequiresForceError(historyCount);
+        }
+
         tx.delete(templateExercises)
           .where(
             and(
@@ -277,20 +321,6 @@ const purgeTrashItem = async ({
                 from ${workoutTemplates}
                 where ${workoutTemplates.id} = ${templateExercises.templateId}
                   and ${workoutTemplates.userId} = ${userId}
-              )`,
-            ),
-          )
-          .run();
-
-        tx.delete(sessionSets)
-          .where(
-            and(
-              eq(sessionSets.exerciseId, id),
-              sql`exists (
-                select 1
-                from ${workoutSessions}
-                where ${workoutSessions.id} = ${sessionSets.sessionId}
-                  and ${workoutSessions.userId} = ${userId}
               )`,
             ),
           )
@@ -403,10 +433,12 @@ export const trashRoutes: FastifyPluginAsync = async (app) => {
     {
       schema: {
         params: trashItemParamsSchema,
+        querystring: purgeTrashQuerySchema,
         response: {
           200: apiDataResponseSchema(successFlagSchema),
           400: badRequestResponseSchema,
           401: apiErrorResponseSchema,
+          409: apiErrorResponseSchema,
           404: apiErrorResponseSchema,
         },
         tags: ['trash'],
@@ -450,11 +482,27 @@ export const trashRoutes: FastifyPluginAsync = async (app) => {
       },
     },
     async (request, reply) => {
-      const purged = await purgeTrashItem({
-        id: request.params.id,
-        type: request.params.type,
-        userId: request.userId,
-      });
+      const query = request.query as z.infer<typeof purgeTrashQuerySchema>;
+      let purged: boolean;
+      try {
+        purged = await purgeTrashItem({
+          id: request.params.id,
+          force: query.force,
+          type: request.params.type,
+          userId: request.userId,
+        });
+      } catch (error) {
+        if (error instanceof ExercisePurgeRequiresForceError) {
+          return sendError(
+            reply,
+            409,
+            EXERCISE_PURGE_REQUIRES_FORCE_RESPONSE.code,
+            `${EXERCISE_PURGE_REQUIRES_FORCE_RESPONSE.message} Referenced sets: ${error.historyCount}.`,
+          );
+        }
+
+        throw error;
+      }
       if (!purged) {
         return sendError(
           reply,

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -839,11 +839,11 @@ describe('workout session routes', () => {
     expect(groupedResponse.json()).toEqual({
       data: expect.arrayContaining([
         expect.objectContaining({
-          exerciseId: 'deleted-main-0',
+          exerciseId: null,
           sets: [expect.objectContaining({ id: 'set-null-group-main' })],
         }),
         expect.objectContaining({
-          exerciseId: 'deleted-cooldown-1',
+          exerciseId: null,
           sets: [expect.objectContaining({ id: 'set-null-group-cooldown' })],
         }),
       ]),

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -666,7 +666,7 @@ describe('workout session routes', () => {
     });
   });
 
-  it('omits metadata from soft-deleted exercises in session detail responses', async () => {
+  it('includes metadata from soft-deleted exercises in session detail responses', async () => {
     const authToken = context.app.jwt.sign(
       { sub: 'user-1', type: 'session', iss: 'pulse-api' },
       { expiresIn: '7d' },
@@ -718,13 +718,70 @@ describe('workout session routes', () => {
         exercises: expect.arrayContaining([
           expect.objectContaining({
             exerciseId: 'user-1-soft-deleted',
-            exerciseName: 'Unknown Exercise',
-            trackingType: null,
+            exerciseName: 'Deleted Exercise',
+            deletedAt: '2026-03-12T00:00:00.000Z',
+            trackingType: 'seconds_only',
             exercise: {
-              formCues: [],
-              coachingNotes: null,
-              instructions: null,
+              formCues: ['This should not be returned'],
+              coachingNotes: 'Should be hidden',
+              instructions: 'Should be hidden',
             },
+          }),
+        ]),
+      }),
+    });
+  });
+
+  it('returns deleted exercise placeholders when session sets have null exerciseId values', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'session-null-exercise-id',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: 1_700_000_000_000,
+      completedAt: 1_700_000_010_000,
+    });
+
+    context.db
+      .insert(sessionSets)
+      .values({
+        id: 'set-null-exercise-id-1',
+        sessionId: 'session-null-exercise-id',
+        exerciseId: null,
+        setNumber: 1,
+        reps: 12,
+        section: 'main',
+      })
+      .run();
+
+    const response = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/workout-sessions/session-null-exercise-id',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        id: 'session-null-exercise-id',
+        sets: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'set-null-exercise-id-1',
+            exerciseId: null,
+            reps: 12,
+          }),
+        ]),
+        exercises: expect.arrayContaining([
+          expect.objectContaining({
+            exerciseId: null,
+            exerciseName: 'Deleted exercise',
           }),
         ]),
       }),
@@ -826,7 +883,7 @@ describe('workout session routes', () => {
           return left.orderIndex - right.orderIndex;
         }
 
-        return left.exerciseId.localeCompare(right.exerciseId);
+        return (left.exerciseId ?? '').localeCompare(right.exerciseId ?? '');
       });
 
     expect(persistedOrder).toEqual([

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -788,6 +788,68 @@ describe('workout session routes', () => {
     });
   });
 
+  it('keeps null exerciseId set groups distinct by section and order index', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'session-null-exercise-groups',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Null Group Session',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: 1_700_000_000_000,
+      completedAt: 1_700_000_010_000,
+    });
+
+    context.db
+      .insert(sessionSets)
+      .values([
+        {
+          id: 'set-null-group-main',
+          sessionId: 'session-null-exercise-groups',
+          exerciseId: null,
+          orderIndex: 0,
+          setNumber: 1,
+          reps: 12,
+          section: 'main',
+        },
+        {
+          id: 'set-null-group-cooldown',
+          sessionId: 'session-null-exercise-groups',
+          exerciseId: null,
+          orderIndex: 1,
+          setNumber: 1,
+          reps: 20,
+          section: 'cooldown',
+        },
+      ])
+      .run();
+
+    const groupedResponse = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/workout-sessions/session-null-exercise-groups/sets',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(groupedResponse.statusCode).toBe(200);
+    expect(groupedResponse.json()).toEqual({
+      data: expect.arrayContaining([
+        expect.objectContaining({
+          exerciseId: 'deleted-main-0',
+          sets: [expect.objectContaining({ id: 'set-null-group-main' })],
+        }),
+        expect.objectContaining({
+          exerciseId: 'deleted-cooldown-1',
+          sets: [expect.objectContaining({ id: 'set-null-group-cooldown' })],
+        }),
+      ]),
+    });
+  });
+
   it('reorders active session exercises by updating set orderIndex while preserving set data', async () => {
     const authToken = context.app.jwt.sign(
       { sub: 'user-1', type: 'session', iss: 'pulse-api' },

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -183,9 +183,14 @@ const toCreateWorkoutSessionInput = (
     throw new Error('Workout session must exist to build an update payload');
   }
 
-  const supersetGroupByExerciseId = new Map(
-    (session.exercises ?? []).map((exercise) => [exercise.exerciseId, exercise.supersetGroup]),
-  );
+  const supersetGroupByExerciseId = new Map<string, string | null>();
+  for (const exercise of session.exercises ?? []) {
+    if (typeof exercise.exerciseId !== 'string') {
+      continue;
+    }
+
+    supersetGroupByExerciseId.set(exercise.exerciseId, exercise.supersetGroup);
+  }
 
   return {
     templateId: session.templateId,
@@ -198,18 +203,24 @@ const toCreateWorkoutSessionInput = (
     timeSegments: session.timeSegments,
     feedback: session.feedback,
     notes: session.notes,
-    sets: session.sets.map((set) => ({
-      exerciseId: set.exerciseId,
-      orderIndex: set.orderIndex ?? 0,
-      setNumber: set.setNumber,
-      weight: set.weight,
-      reps: set.reps,
-      completed: set.completed,
-      skipped: set.skipped,
-      supersetGroup: supersetGroupByExerciseId.get(set.exerciseId) ?? null,
-      section: set.section,
-      notes: set.notes,
-    })),
+    sets: session.sets.flatMap((set) =>
+      typeof set.exerciseId !== 'string'
+        ? []
+        : [
+            {
+              exerciseId: set.exerciseId,
+              orderIndex: set.orderIndex ?? 0,
+              setNumber: set.setNumber,
+              weight: set.weight,
+              reps: set.reps,
+              completed: set.completed,
+              skipped: set.skipped,
+              supersetGroup: supersetGroupByExerciseId.get(set.exerciseId) ?? null,
+              section: set.section,
+              notes: set.notes,
+            },
+          ],
+    ),
   };
 };
 
@@ -1320,9 +1331,10 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
                 return (left.orderIndex ?? 0) - (right.orderIndex ?? 0);
               }
 
-              return left.exerciseId.localeCompare(right.exerciseId);
+              return (left.exerciseId ?? '').localeCompare(right.exerciseId ?? '');
             })
-            .map((set) => set.exerciseId),
+            .map((set) => set.exerciseId)
+            .filter((exerciseId): exerciseId is string => typeof exerciseId === 'string'),
         ),
       );
       const requestedIds = request.body.exerciseIds;

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -204,6 +204,7 @@ const toCreateWorkoutSessionInput = (
     feedback: session.feedback,
     notes: session.notes,
     sets: session.sets.flatMap((set) =>
+      // Deleted exercises cannot be resolved back into actionable active-session inputs.
       typeof set.exerciseId !== 'string'
         ? []
         : [

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -93,7 +93,7 @@ const sessionExerciseParamsSchema = idParamsSchema.extend({
 });
 
 const sessionSetGroupSchema = z.object({
-  exerciseId: z.string(),
+  exerciseId: z.string().nullable(),
   sets: z.array(sessionSetSchema),
 });
 

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -56,7 +56,7 @@ type WorkoutSessionAccessRecord = {
 type SessionSetRecord = {
   id: string;
   sessionId: string;
-  exerciseId: string;
+  exerciseId: string | null;
   orderIndex: number;
   setNumber: number;
   weight: number | null;
@@ -155,8 +155,10 @@ const sortSessionSets = (left: SessionSetRecord, right: SessionSetRecord) => {
     return left.orderIndex - right.orderIndex;
   }
 
-  if (left.exerciseId !== right.exerciseId) {
-    return left.exerciseId.localeCompare(right.exerciseId);
+  const leftExerciseId = left.exerciseId ?? '';
+  const rightExerciseId = right.exerciseId ?? '';
+  if (leftExerciseId !== rightExerciseId) {
+    return leftExerciseId.localeCompare(rightExerciseId);
   }
 
   if (left.setNumber !== right.setNumber) {
@@ -189,7 +191,8 @@ const buildSessionSetGroups = (sets: SessionSetRecord[]): SessionSetGroup[] => {
   const groups = new Map<string, SessionSet[]>();
 
   for (const set of sets.sort(sortSessionSets)) {
-    const existingGroup = groups.get(set.exerciseId);
+    const groupKey = set.exerciseId ?? 'deleted-exercise';
+    const existingGroup = groups.get(groupKey);
     const parsedSet = buildSessionSet(set);
 
     if (existingGroup) {
@@ -197,7 +200,7 @@ const buildSessionSetGroups = (sets: SessionSetRecord[]): SessionSetGroup[] => {
       continue;
     }
 
-    groups.set(set.exerciseId, [parsedSet]);
+    groups.set(groupKey, [parsedSet]);
   }
 
   return Array.from(groups.entries()).map(([exerciseId, groupedSets]) => ({
@@ -213,6 +216,7 @@ const buildWorkoutSession = (
     string,
     {
       name: string;
+      deletedAt: string | null;
       trackingType: ExerciseTrackingType | null;
       formCues: string[];
       coachingNotes: string | null;
@@ -252,6 +256,7 @@ const buildWorkoutSessionExercises = (
     string,
     {
       name: string;
+      deletedAt: string | null;
       trackingType: ExerciseTrackingType | null;
       formCues: string[];
       coachingNotes: string | null;
@@ -262,8 +267,9 @@ const buildWorkoutSessionExercises = (
   const groupedByExercise = new Map<
     string,
     {
-      exerciseId: string;
+      exerciseId: string | null;
       exerciseName: string;
+      deletedAt: string | null;
       supersetGroup: string | null;
       trackingType: ExerciseTrackingType | null;
       orderIndex: number;
@@ -276,10 +282,11 @@ const buildWorkoutSessionExercises = (
   >();
 
   for (const set of sets.sort(sortSessionSets)) {
-    const existing = groupedByExercise.get(set.exerciseId);
+    const groupKey = set.exerciseId ?? `deleted-${set.section ?? 'supplemental'}-${set.orderIndex}`;
+    const existing = groupedByExercise.get(groupKey);
     const parsedSet = buildSessionSet(set);
-    const exerciseInfo = exerciseInfoById.get(set.exerciseId);
-    const exerciseName = exerciseInfo?.name ?? 'Unknown Exercise';
+    const exerciseInfo = typeof set.exerciseId === 'string' ? exerciseInfoById.get(set.exerciseId) : undefined;
+    const exerciseName = set.exerciseId === null ? 'Deleted exercise' : (exerciseInfo?.name ?? 'Unknown Exercise');
 
     if (existing) {
       existing.orderIndex = Math.min(existing.orderIndex, set.orderIndex);
@@ -290,9 +297,10 @@ const buildWorkoutSessionExercises = (
       continue;
     }
 
-    groupedByExercise.set(set.exerciseId, {
+    groupedByExercise.set(groupKey, {
       exerciseId: set.exerciseId,
       exerciseName,
+      deletedAt: exerciseInfo?.deletedAt ?? null,
       supersetGroup: set.supersetGroup,
       trackingType: (exerciseInfo?.trackingType as ExerciseTrackingType) ?? null,
       orderIndex: set.orderIndex,
@@ -324,6 +332,7 @@ const buildWorkoutSessionExercises = (
     .map((exercise) => ({
       exerciseId: exercise.exerciseId,
       exerciseName: exercise.exerciseName,
+      deletedAt: exercise.deletedAt,
       supersetGroup: exercise.supersetGroup,
       trackingType: exercise.trackingType,
       exercise: {
@@ -772,11 +781,13 @@ export const batchUpsertSessionSets = async ({
       const currentNextOrderIndex = nextOrderIndexBySection.get(set.section) ?? 0;
       nextOrderIndexBySection.set(set.section, Math.max(currentNextOrderIndex, set.orderIndex + 1));
 
-      const existingSupersetGroup = supersetGroupByExerciseId.get(set.exerciseId);
-      if (existingSupersetGroup === undefined) {
-        supersetGroupByExerciseId.set(set.exerciseId, set.supersetGroup);
-      } else if (existingSupersetGroup === null && set.supersetGroup !== null) {
-        supersetGroupByExerciseId.set(set.exerciseId, set.supersetGroup);
+      if (set.exerciseId !== null) {
+        const existingSupersetGroup = supersetGroupByExerciseId.get(set.exerciseId);
+        if (existingSupersetGroup === undefined) {
+          supersetGroupByExerciseId.set(set.exerciseId, set.supersetGroup);
+        } else if (existingSupersetGroup === null && set.supersetGroup !== null) {
+          supersetGroupByExerciseId.set(set.exerciseId, set.supersetGroup);
+        }
       }
     }
 
@@ -981,26 +992,31 @@ export const findWorkoutSessionById = async (
     .all();
 
   const uniqueExerciseIds = [...new Set(sets.map((set) => set.exerciseId))];
+  const nonNullExerciseIds = uniqueExerciseIds.filter(
+    (exerciseId): exerciseId is string => typeof exerciseId === 'string',
+  );
   const exerciseNameRows =
-    uniqueExerciseIds.length === 0
+    nonNullExerciseIds.length === 0
       ? []
       : db
           .select({
             id: exercises.id,
             name: exercises.name,
+            deletedAt: exercises.deletedAt,
             trackingType: exercises.trackingType,
             formCues: exercises.formCues,
             coachingNotes: exercises.coachingNotes,
             instructions: exercises.instructions,
           })
           .from(exercises)
-          .where(and(inArray(exercises.id, uniqueExerciseIds), isNull(exercises.deletedAt)))
+          .where(inArray(exercises.id, nonNullExerciseIds))
           .all();
   const exerciseInfoById = new Map(
     exerciseNameRows.map((row) => [
       row.id,
       {
         name: row.name,
+        deletedAt: row.deletedAt,
         trackingType: row.trackingType,
         formCues: row.formCues ?? [],
         coachingNotes: row.coachingNotes,
@@ -1263,6 +1279,10 @@ export const saveCompletedSessionAsTemplate = async ({
   >();
 
   for (const set of session.sets) {
+    if (set.exerciseId === null) {
+      continue;
+    }
+
     const section = mapSessionSectionToTemplateSection(set.section);
     const groupKey = `${section}:${set.exerciseId}`;
     const existing = groupedExercises.get(groupKey);

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -191,7 +191,7 @@ const buildSessionSetGroups = (sets: SessionSetRecord[]): SessionSetGroup[] => {
   const groups = new Map<string, SessionSet[]>();
 
   for (const set of sets.sort(sortSessionSets)) {
-    const groupKey = set.exerciseId ?? 'deleted-exercise';
+    const groupKey = set.exerciseId ?? `deleted-${set.section ?? 'supplemental'}-${set.orderIndex}`;
     const existingGroup = groups.get(groupKey);
     const parsedSet = buildSessionSet(set);
 

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -75,7 +75,7 @@ type SessionSetRecord = {
 };
 
 export type SessionSetGroup = {
-  exerciseId: string;
+  exerciseId: string | null;
   sets: SessionSet[];
 };
 
@@ -188,7 +188,7 @@ const buildSessionSet = (set: SessionSetRecord): SessionSet => ({
 });
 
 const buildSessionSetGroups = (sets: SessionSetRecord[]): SessionSetGroup[] => {
-  const groups = new Map<string, SessionSet[]>();
+  const groups = new Map<string, { exerciseId: string | null; sets: SessionSet[] }>();
 
   for (const set of sets.sort(sortSessionSets)) {
     const groupKey = set.exerciseId ?? `deleted-${set.section ?? 'supplemental'}-${set.orderIndex}`;
@@ -196,16 +196,19 @@ const buildSessionSetGroups = (sets: SessionSetRecord[]): SessionSetGroup[] => {
     const parsedSet = buildSessionSet(set);
 
     if (existingGroup) {
-      existingGroup.push(parsedSet);
+      existingGroup.sets.push(parsedSet);
       continue;
     }
 
-    groups.set(groupKey, [parsedSet]);
+    groups.set(groupKey, {
+      exerciseId: set.exerciseId,
+      sets: [parsedSet],
+    });
   }
 
-  return Array.from(groups.entries()).map(([exerciseId, groupedSets]) => ({
-    exerciseId,
-    sets: groupedSets,
+  return Array.from(groups.values()).map((group) => ({
+    exerciseId: group.exerciseId,
+    sets: group.sets,
   }));
 };
 
@@ -1280,6 +1283,7 @@ export const saveCompletedSessionAsTemplate = async ({
 
   for (const set of session.sets) {
     if (set.exerciseId === null) {
+      // Deleted exercises cannot be part of new templates because template rows require a valid exercise id.
       continue;
     }
 

--- a/apps/api/src/scripts/repair-workout-exercise-links.ts
+++ b/apps/api/src/scripts/repair-workout-exercise-links.ts
@@ -21,7 +21,7 @@ type OrphanLinkRow = {
   rowId: string;
   ownerId: string;
   ownerUserId: string;
-  exerciseId: string;
+  exerciseId: string | null;
   exerciseUserId: string | null;
   exerciseDeletedAt: string | null;
   exerciseName: string | null;
@@ -38,6 +38,8 @@ type RepairResultRow = {
   action: RepairAction;
   note: string;
 };
+
+const stringifyExerciseId = (exerciseId: string | null) => exerciseId ?? 'null';
 
 export type RepairWorkoutExerciseLinksOptions = {
   userId: string | null;
@@ -302,13 +304,26 @@ export const repairWorkoutExerciseLinks = async (
         (row.exerciseUserId === null || row.exerciseUserId === row.ownerUserId);
 
       if (canRestoreOriginal) {
+        if (row.exerciseId === null) {
+          results.push({
+            source: row.source,
+            rowId: row.rowId,
+            ownerUserId: row.ownerUserId,
+            previousExerciseId: stringifyExerciseId(row.exerciseId),
+            nextExerciseId: stringifyExerciseId(row.exerciseId),
+            action: 'manual-review',
+            note: 'Encountered null exercise_id with restore metadata; requires manual review.',
+          });
+          continue;
+        }
+
         restoreExercise(row.exerciseId);
         results.push({
           source: row.source,
           rowId: row.rowId,
           ownerUserId: row.ownerUserId,
-          previousExerciseId: row.exerciseId,
-          nextExerciseId: row.exerciseId,
+          previousExerciseId: stringifyExerciseId(row.exerciseId),
+          nextExerciseId: stringifyExerciseId(row.exerciseId),
           action: 'restored-soft-deleted',
           note: 'Restored soft-deleted exercise referenced by workout row.',
         });
@@ -318,7 +333,9 @@ export const repairWorkoutExerciseLinks = async (
       const nameHint =
         row.exerciseName && row.exerciseName.trim().length > 0
           ? row.exerciseName
-          : deriveExerciseNameFromId(row.exerciseId);
+          : row.exerciseId
+            ? deriveExerciseNameFromId(row.exerciseId)
+            : 'Recovered Exercise';
       const candidate = findCandidateByName({
         name: nameHint,
         ownerUserId: row.ownerUserId,
@@ -339,7 +356,7 @@ export const repairWorkoutExerciseLinks = async (
             source: row.source,
             rowId: row.rowId,
             ownerUserId: row.ownerUserId,
-            previousExerciseId: row.exerciseId,
+            previousExerciseId: stringifyExerciseId(row.exerciseId),
             nextExerciseId: candidate.id,
             action: 'relinked-by-name',
             note: crossUserReference
@@ -351,8 +368,8 @@ export const repairWorkoutExerciseLinks = async (
             source: row.source,
             rowId: row.rowId,
             ownerUserId: row.ownerUserId,
-            previousExerciseId: row.exerciseId,
-            nextExerciseId: row.exerciseId,
+            previousExerciseId: stringifyExerciseId(row.exerciseId),
+            nextExerciseId: stringifyExerciseId(row.exerciseId),
             action: 'manual-review',
             note: `Relink failed and requires manual review: ${String(error)}`,
           });
@@ -375,7 +392,7 @@ export const repairWorkoutExerciseLinks = async (
           source: row.source,
           rowId: row.rowId,
           ownerUserId: row.ownerUserId,
-          previousExerciseId: row.exerciseId,
+          previousExerciseId: stringifyExerciseId(row.exerciseId),
           nextExerciseId: placeholderId,
           action: 'created-placeholder',
           note: crossUserReference
@@ -397,8 +414,8 @@ export const repairWorkoutExerciseLinks = async (
           source: row.source,
           rowId: row.rowId,
           ownerUserId: row.ownerUserId,
-          previousExerciseId: row.exerciseId,
-          nextExerciseId: row.exerciseId,
+          previousExerciseId: stringifyExerciseId(row.exerciseId),
+          nextExerciseId: stringifyExerciseId(row.exerciseId),
           action: 'manual-review',
           note: `Placeholder relink failed and requires manual review: ${String(error)}`,
         });

--- a/apps/web/src/components/layout/page-header.test.tsx
+++ b/apps/web/src/components/layout/page-header.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { BadgeCheck } from 'lucide-react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { PageHeader } from './page-header';
 
@@ -9,37 +9,6 @@ describe('PageHeader', () => {
     render(<PageHeader title="Dashboard" />);
 
     expect(screen.getByRole('heading', { level: 1, name: 'Dashboard' })).toBeInTheDocument();
-  });
-
-  it('renders a back button when showBack is true', () => {
-    const historyBackSpy = vi.spyOn(window.history, 'back').mockImplementation(() => {});
-    window.history.pushState({}, '', '/settings');
-
-    render(<PageHeader showBack title="Settings" />);
-
-    const backButton = screen.getByRole('button', { name: 'Back' });
-    expect(backButton).toBeInTheDocument();
-
-    fireEvent.click(backButton);
-    expect(historyBackSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('falls back to backFallbackHref when there is no previous history entry', () => {
-    const historyLengthSpy = vi.spyOn(window.history, 'length', 'get').mockReturnValue(1);
-    const locationAssignSpy = vi.fn();
-    vi.stubGlobal('location', {
-      ...window.location,
-      assign: locationAssignSpy,
-    });
-
-    render(<PageHeader backFallbackHref="/workouts" showBack title="Settings" />);
-
-    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
-
-    expect(locationAssignSpy).toHaveBeenCalledWith('/workouts');
-
-    vi.unstubAllGlobals();
-    historyLengthSpy.mockRestore();
   });
 
   it('renders actions in the actions container', () => {

--- a/apps/web/src/components/layout/page-header.tsx
+++ b/apps/web/src/components/layout/page-header.tsx
@@ -1,54 +1,26 @@
 import type { ReactNode } from 'react';
-import { ArrowLeft } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
 type PageHeaderProps = {
   actions?: ReactNode;
-  backFallbackHref?: string;
   children?: ReactNode;
   className?: string;
   description?: string;
   icon?: ReactNode;
-  showBack?: boolean;
   title: ReactNode;
 };
 
 export function PageHeader({
   actions,
-  backFallbackHref,
   children,
   className,
   description,
   icon,
-  showBack = false,
   title,
 }: PageHeaderProps) {
-  const handleBackClick = () => {
-    if (window.history.length > 1) {
-      window.history.back();
-      return;
-    }
-
-    if (backFallbackHref) {
-      window.location.assign(backFallbackHref);
-    }
-  };
-
   return (
     <header className={cn('space-y-3', className)}>
-      {showBack ? (
-        <button
-          className="inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center gap-1.5 rounded-md px-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-          data-slot="page-header-back-button"
-          onClick={handleBackClick}
-          type="button"
-        >
-          <ArrowLeft aria-hidden="true" className="size-4" />
-          Back
-        </button>
-      ) : null}
-
       <div className="flex items-start justify-between gap-4" data-slot="page-header-main">
         <div className="flex min-w-0 items-center gap-3" data-slot="page-header-identity">
           {icon ? (

--- a/apps/web/src/components/ui/column-picker.test.tsx
+++ b/apps/web/src/components/ui/column-picker.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { ColumnPicker } from './column-picker';
+
+describe('ColumnPicker', () => {
+  it('shows and hides selected columns', () => {
+    function TestHarness() {
+      const [visibleColumns, setVisibleColumns] = useState<string[]>(['name', 'calories']);
+
+      return (
+        <>
+          <ColumnPicker
+            columns={[
+              { key: 'name', label: 'Name' },
+              { key: 'calories', label: 'Calories' },
+              { key: 'protein', label: 'Protein' },
+            ]}
+            onChange={setVisibleColumns}
+            visibleColumns={visibleColumns}
+          />
+          <p>{visibleColumns.join(',')}</p>
+        </>
+      );
+    }
+
+    render(<TestHarness />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Columns' }));
+
+    const caloriesCheckbox = screen.getByRole('checkbox', { name: 'Calories' });
+    const proteinCheckbox = screen.getByRole('checkbox', { name: 'Protein' });
+
+    expect(caloriesCheckbox).toBeChecked();
+    expect(proteinCheckbox).not.toBeChecked();
+
+    fireEvent.click(caloriesCheckbox);
+    expect(screen.getByText('name')).toBeInTheDocument();
+
+    fireEvent.click(proteinCheckbox);
+    expect(screen.getByText('name,protein')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/column-picker.tsx
+++ b/apps/web/src/components/ui/column-picker.tsx
@@ -37,8 +37,18 @@ export function ColumnPicker({
 }: ColumnPickerProps) {
   const fallbackId = useId();
   const hasHydrated = useRef(false);
+  const visibleColumnsRef = useRef(visibleColumns);
+  const onChangeRef = useRef(onChange);
   const normalizedStorageKey = useMemo(() => storageKey?.trim() ?? '', [storageKey]);
   const validKeys = useMemo(() => new Set(columns.map((column) => column.key)), [columns]);
+
+  useEffect(() => {
+    visibleColumnsRef.current = visibleColumns;
+  }, [visibleColumns]);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
 
   useEffect(() => {
     if (!normalizedStorageKey) {
@@ -61,17 +71,17 @@ export function ColumnPicker({
         .filter((key): key is string => typeof key === 'string' && validKeys.has(key))
         .filter((key, index, array) => array.indexOf(key) === index);
 
-      if (arraysEqual(nextVisibleColumns, visibleColumns)) {
+      if (arraysEqual(nextVisibleColumns, visibleColumnsRef.current)) {
         return;
       }
 
-      onChange(nextVisibleColumns);
+      onChangeRef.current(nextVisibleColumns);
     } catch {
       return;
     } finally {
       hasHydrated.current = true;
     }
-  }, [normalizedStorageKey, onChange, validKeys, visibleColumns]);
+  }, [normalizedStorageKey, validKeys]);
 
   useEffect(() => {
     if (!normalizedStorageKey || !hasHydrated.current) {

--- a/apps/web/src/components/ui/column-picker.tsx
+++ b/apps/web/src/components/ui/column-picker.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useId, useMemo } from 'react';
+import { Columns3 } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+import { Button } from './button';
+import { Checkbox } from './checkbox';
+import { Popover, PopoverContent, PopoverHeader, PopoverTitle, PopoverTrigger } from './popover';
+
+type PickerColumn = {
+  key: string;
+  label: string;
+};
+
+type ColumnPickerProps = {
+  columns: PickerColumn[];
+  visibleColumns: string[];
+  onChange: (columns: string[]) => void;
+  storageKey?: string;
+  className?: string;
+};
+
+function arraysEqual(left: string[], right: string[]) {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((value, index) => value === right[index]);
+}
+
+export function ColumnPicker({
+  columns,
+  visibleColumns,
+  onChange,
+  storageKey,
+  className,
+}: ColumnPickerProps) {
+  const fallbackId = useId();
+  const normalizedStorageKey = useMemo(() => storageKey?.trim() ?? '', [storageKey]);
+  const validKeys = useMemo(() => new Set(columns.map((column) => column.key)), [columns]);
+
+  useEffect(() => {
+    if (!normalizedStorageKey) {
+      return;
+    }
+
+    try {
+      const rawValue = window.localStorage.getItem(normalizedStorageKey);
+      if (!rawValue) {
+        return;
+      }
+
+      const parsedValue = JSON.parse(rawValue);
+      if (!Array.isArray(parsedValue)) {
+        return;
+      }
+
+      const nextVisibleColumns = parsedValue
+        .filter((key): key is string => typeof key === 'string' && validKeys.has(key))
+        .filter((key, index, array) => array.indexOf(key) === index);
+
+      if (arraysEqual(nextVisibleColumns, visibleColumns)) {
+        return;
+      }
+
+      onChange(nextVisibleColumns);
+    } catch {
+      return;
+    }
+  }, [normalizedStorageKey, onChange, validKeys, visibleColumns]);
+
+  useEffect(() => {
+    if (!normalizedStorageKey) {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(normalizedStorageKey, JSON.stringify(visibleColumns));
+    } catch {
+      return;
+    }
+  }, [normalizedStorageKey, visibleColumns]);
+
+  function toggleColumn(columnKey: string, checked: boolean) {
+    const visibleSet = new Set(visibleColumns);
+
+    if (checked) {
+      visibleSet.add(columnKey);
+    } else {
+      visibleSet.delete(columnKey);
+    }
+
+    const nextVisibleColumns = columns
+      .map((column) => column.key)
+      .filter((columnKeyOption) => visibleSet.has(columnKeyOption));
+
+    onChange(nextVisibleColumns);
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button className={cn('h-9', className)} size="sm" type="button" variant="outline">
+          <Columns3 aria-hidden="true" className="size-4" />
+          Columns
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-56 space-y-3 p-3">
+        <PopoverHeader>
+          <PopoverTitle>Visible columns</PopoverTitle>
+        </PopoverHeader>
+        <div className="space-y-2">
+          {columns.map((column, index) => {
+            const columnId = `${fallbackId}-${index}-${column.key}`;
+            const checked = visibleColumns.includes(column.key);
+
+            return (
+              <label className="flex cursor-pointer items-center gap-2 text-sm" htmlFor={columnId} key={column.key}>
+                <Checkbox
+                  checked={checked}
+                  id={columnId}
+                  onCheckedChange={(nextChecked) => toggleColumn(column.key, nextChecked === true)}
+                />
+                <span>{column.label}</span>
+              </label>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/ui/column-picker.tsx
+++ b/apps/web/src/components/ui/column-picker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo } from 'react';
+import { useEffect, useId, useMemo, useRef } from 'react';
 import { Columns3 } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
@@ -36,11 +36,13 @@ export function ColumnPicker({
   className,
 }: ColumnPickerProps) {
   const fallbackId = useId();
+  const hasHydrated = useRef(false);
   const normalizedStorageKey = useMemo(() => storageKey?.trim() ?? '', [storageKey]);
   const validKeys = useMemo(() => new Set(columns.map((column) => column.key)), [columns]);
 
   useEffect(() => {
     if (!normalizedStorageKey) {
+      hasHydrated.current = true;
       return;
     }
 
@@ -66,11 +68,13 @@ export function ColumnPicker({
       onChange(nextVisibleColumns);
     } catch {
       return;
+    } finally {
+      hasHydrated.current = true;
     }
   }, [normalizedStorageKey, onChange, validKeys, visibleColumns]);
 
   useEffect(() => {
-    if (!normalizedStorageKey) {
+    if (!normalizedStorageKey || !hasHydrated.current) {
       return;
     }
 

--- a/apps/web/src/components/ui/data-table.test.tsx
+++ b/apps/web/src/components/ui/data-table.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { DataTable, type Column } from './data-table';
+
+type Row = {
+  name: string;
+  calories: number;
+};
+
+const columns: Column<Row>[] = [
+  {
+    key: 'name',
+    header: 'Name',
+    accessor: (row) => row.name,
+  },
+  {
+    key: 'calories',
+    header: 'Calories',
+    accessor: (row) => row.calories,
+  },
+];
+
+describe('DataTable', () => {
+  it('renders provided columns and rows', () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={[
+          { name: 'Greek yogurt', calories: 120 },
+          { name: 'Banana', calories: 90 },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Calories' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Greek yogurt' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: '120' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Banana' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: '90' })).toBeInTheDocument();
+  });
+
+  it('shows empty state when no rows are provided', () => {
+    render(<DataTable columns={columns} data={[]} emptyMessage="No foods found" />);
+
+    expect(screen.getByText('No foods found')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/data-table.test.tsx
+++ b/apps/web/src/components/ui/data-table.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 
 import { DataTable, type Column } from './data-table';
 
@@ -45,5 +45,52 @@ describe('DataTable', () => {
     render(<DataTable columns={columns} data={[]} emptyMessage="No foods found" />);
 
     expect(screen.getByText('No foods found')).toBeInTheDocument();
+  });
+
+  it('calls onSort for sortable headers', () => {
+    const handleSort = vi.fn();
+
+    render(
+      <DataTable
+        columns={[
+          {
+            key: 'name',
+            header: 'Name',
+            accessor: (row) => row.name,
+            sortable: true,
+          },
+        ]}
+        data={[{ name: 'Greek yogurt', calories: 120 }]}
+        onSort={handleSort}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Name' }));
+    expect(handleSort).toHaveBeenCalledWith('name');
+  });
+
+  it('supports keyboard interaction for clickable rows', () => {
+    const handleRowClick = vi.fn();
+
+    render(
+      <DataTable
+        columns={columns}
+        data={[{ name: 'Greek yogurt', calories: 120 }]}
+        onRowClick={handleRowClick}
+      />,
+    );
+
+    const row = screen.getByRole('cell', { name: 'Greek yogurt' }).closest('tr');
+    expect(row).toHaveAttribute('tabindex', '0');
+    if (!row) {
+      throw new Error('Expected row to exist');
+    }
+
+    fireEvent.keyDown(row, { key: 'Enter' });
+    fireEvent.keyDown(row, { key: ' ' });
+
+    expect(handleRowClick).toHaveBeenCalledTimes(2);
+    expect(handleRowClick).toHaveBeenNthCalledWith(1, { name: 'Greek yogurt', calories: 120 });
+    expect(handleRowClick).toHaveBeenNthCalledWith(2, { name: 'Greek yogurt', calories: 120 });
   });
 });

--- a/apps/web/src/components/ui/data-table.tsx
+++ b/apps/web/src/components/ui/data-table.tsx
@@ -1,0 +1,113 @@
+import type { ReactNode } from 'react';
+import { ArrowUpDown } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+import { Skeleton } from './skeleton';
+
+export type Column<T> = {
+  key: string;
+  header: string;
+  accessor: (row: T) => ReactNode;
+  sortable?: boolean;
+  className?: string;
+};
+
+type DataTableProps<T> = {
+  columns: Column<T>[];
+  data: T[];
+  isLoading?: boolean;
+  emptyMessage?: string;
+  onRowClick?: (row: T) => void;
+};
+
+const DEFAULT_EMPTY_MESSAGE = 'No results found.';
+const SKELETON_ROW_COUNT = 5;
+
+function getRowKey<T>(row: T, index: number) {
+  if (typeof row === 'object' && row !== null && 'id' in row) {
+    const maybeId = (row as { id?: unknown }).id;
+    if (typeof maybeId === 'string' || typeof maybeId === 'number') {
+      return maybeId;
+    }
+  }
+
+  return index;
+}
+
+export function DataTable<T>({
+  columns,
+  data,
+  isLoading = false,
+  emptyMessage = DEFAULT_EMPTY_MESSAGE,
+  onRowClick,
+}: DataTableProps<T>) {
+  return (
+    <div className="w-full overflow-x-auto rounded-xl border border-border/70">
+      <table className="min-w-full border-collapse text-sm">
+        <thead className="sticky top-0 z-10 bg-card">
+          <tr className="border-b border-border/70">
+            {columns.map((column) => (
+              <th
+                className={cn(
+                  'px-4 py-3 text-left text-xs font-semibold tracking-wide text-muted-foreground uppercase',
+                  column.className,
+                )}
+                key={column.key}
+                scope="col"
+              >
+                <span className="inline-flex items-center gap-1.5">
+                  {column.header}
+                  {column.sortable ? <ArrowUpDown aria-hidden="true" className="size-3.5" /> : null}
+                </span>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {isLoading
+            ? Array.from({ length: SKELETON_ROW_COUNT }).map((_, rowIndex) => (
+                <tr className="border-b border-border/50 last:border-0" key={`skeleton-${rowIndex}`}>
+                  {columns.map((column) => (
+                    <td className={cn('px-4 py-3 align-middle', column.className)} key={column.key}>
+                      <Skeleton className="h-4 w-full max-w-[11rem]" />
+                    </td>
+                  ))}
+                </tr>
+              ))
+            : null}
+
+          {!isLoading && data.length === 0 ? (
+            <tr>
+              <td className="px-4 py-10 text-center text-sm text-muted-foreground" colSpan={columns.length}>
+                {emptyMessage}
+              </td>
+            </tr>
+          ) : null}
+
+          {!isLoading
+            ? data.map((row, rowIndex) => {
+                const clickable = typeof onRowClick === 'function';
+                return (
+                  <tr
+                    className={cn(
+                      'border-b border-border/50 last:border-0',
+                      clickable ? 'cursor-pointer hover:bg-accent/40 focus-within:bg-accent/40' : undefined,
+                    )}
+                    key={getRowKey(row, rowIndex)}
+                    onClick={clickable ? () => onRowClick(row) : undefined}
+                  >
+                    {columns.map((column) => (
+                      <td className={cn('px-4 py-3 align-middle', column.className)} key={column.key}>
+                        {column.accessor(row)}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })
+            : null}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/data-table.tsx
+++ b/apps/web/src/components/ui/data-table.tsx
@@ -18,6 +18,7 @@ type DataTableProps<T> = {
   data: T[];
   isLoading?: boolean;
   emptyMessage?: string;
+  tableAriaLabel?: string;
   onSort?: (columnKey: string) => void;
   onRowClick?: (row: T) => void;
 };
@@ -41,12 +42,13 @@ export function DataTable<T>({
   data,
   isLoading = false,
   emptyMessage = DEFAULT_EMPTY_MESSAGE,
+  tableAriaLabel,
   onSort,
   onRowClick,
 }: DataTableProps<T>) {
   return (
     <div className="w-full overflow-x-auto rounded-xl border border-border/70">
-      <table className="min-w-full border-collapse text-sm">
+      <table aria-label={tableAriaLabel} className="min-w-full border-collapse text-sm">
         <thead className="sticky top-0 z-10 bg-card">
           <tr className="border-b border-border/70">
             {columns.map((column) => (

--- a/apps/web/src/components/ui/data-table.tsx
+++ b/apps/web/src/components/ui/data-table.tsx
@@ -18,6 +18,7 @@ type DataTableProps<T> = {
   data: T[];
   isLoading?: boolean;
   emptyMessage?: string;
+  onSort?: (columnKey: string) => void;
   onRowClick?: (row: T) => void;
 };
 
@@ -40,6 +41,7 @@ export function DataTable<T>({
   data,
   isLoading = false,
   emptyMessage = DEFAULT_EMPTY_MESSAGE,
+  onSort,
   onRowClick,
 }: DataTableProps<T>) {
   return (
@@ -56,10 +58,18 @@ export function DataTable<T>({
                 key={column.key}
                 scope="col"
               >
-                <span className="inline-flex items-center gap-1.5">
-                  {column.header}
-                  {column.sortable ? <ArrowUpDown aria-hidden="true" className="size-3.5" /> : null}
-                </span>
+                {column.sortable && onSort ? (
+                  <button
+                    className="inline-flex items-center gap-1.5 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    onClick={() => onSort(column.key)}
+                    type="button"
+                  >
+                    {column.header}
+                    <ArrowUpDown aria-hidden="true" className="size-3.5" />
+                  </button>
+                ) : (
+                  <span className="inline-flex items-center gap-1.5">{column.header}</span>
+                )}
               </th>
             ))}
           </tr>
@@ -96,6 +106,17 @@ export function DataTable<T>({
                     )}
                     key={getRowKey(row, rowIndex)}
                     onClick={clickable ? () => onRowClick(row) : undefined}
+                    onKeyDown={
+                      clickable
+                        ? (event) => {
+                            if (event.key === 'Enter' || event.key === ' ') {
+                              event.preventDefault();
+                              onRowClick(row);
+                            }
+                          }
+                        : undefined
+                    }
+                    tabIndex={clickable ? 0 : undefined}
                   >
                     {columns.map((column) => (
                       <td className={cn('px-4 py-3 align-middle', column.className)} key={column.key}>

--- a/apps/web/src/components/ui/filter-bar.test.tsx
+++ b/apps/web/src/components/ui/filter-bar.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { FilterBar } from './filter-bar';
+
+describe('FilterBar', () => {
+  it('renders controls, children, and className', () => {
+    const { container } = render(
+      <FilterBar
+        className="custom-filter-bar"
+        perPageControl={<div>Per page</div>}
+        searchControl={<div>Search</div>}
+        sortControl={<div>Sort</div>}
+        viewToggle={<div>View</div>}
+      >
+        <div>Extra child</div>
+      </FilterBar>,
+    );
+
+    expect(screen.getByText('Search')).toBeInTheDocument();
+    expect(screen.getByText('Sort')).toBeInTheDocument();
+    expect(screen.getByText('Per page')).toBeInTheDocument();
+    expect(screen.getByText('View')).toBeInTheDocument();
+    expect(screen.getByText('Extra child')).toBeInTheDocument();
+    expect(container.firstChild).toHaveClass('custom-filter-bar');
+  });
+});

--- a/apps/web/src/components/ui/filter-bar.tsx
+++ b/apps/web/src/components/ui/filter-bar.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '@/lib/utils';
+
+type FilterBarProps = {
+  searchControl?: ReactNode;
+  sortControl?: ReactNode;
+  perPageControl?: ReactNode;
+  viewToggle?: ReactNode;
+  children?: ReactNode;
+  className?: string;
+};
+
+export function FilterBar({
+  searchControl,
+  sortControl,
+  perPageControl,
+  viewToggle,
+  children,
+  className,
+}: FilterBarProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-3 rounded-xl border border-border/60 bg-card p-3 sm:flex-row sm:flex-wrap sm:items-end',
+        className,
+      )}
+    >
+      {searchControl ? <div className="w-full sm:min-w-[16rem] sm:flex-1">{searchControl}</div> : null}
+      {sortControl ? <div className="w-full sm:min-w-[12rem] sm:flex-1">{sortControl}</div> : null}
+      {children}
+      {perPageControl || viewToggle ? (
+        <div className="flex w-full flex-col gap-3 sm:ml-auto sm:w-auto sm:flex-row sm:items-center">
+          {perPageControl}
+          {viewToggle}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/pagination-bar.test.tsx
+++ b/apps/web/src/components/ui/pagination-bar.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PaginationBar } from './pagination-bar';
+
+describe('PaginationBar', () => {
+  it('navigates pages with previous and next buttons', () => {
+    const handlePageChange = vi.fn();
+
+    render(<PaginationBar onPageChange={handlePageChange} page={2} totalPages={5} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+    expect(handlePageChange).toHaveBeenNthCalledWith(1, 1);
+    expect(handlePageChange).toHaveBeenNthCalledWith(2, 3);
+    expect(screen.getByText('Page 2 of 5')).toBeInTheDocument();
+  });
+
+  it('disables navigation at pagination bounds', () => {
+    render(<PaginationBar onPageChange={() => {}} page={1} totalPages={1} />);
+
+    expect(screen.getByRole('button', { name: 'Previous' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+  });
+});

--- a/apps/web/src/components/ui/pagination-bar.tsx
+++ b/apps/web/src/components/ui/pagination-bar.tsx
@@ -1,0 +1,70 @@
+import { cn } from '@/lib/utils';
+
+import { Button } from './button';
+import { PerPageSelector } from './per-page-selector';
+
+type PaginationBarProps = {
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  perPage?: number;
+  onPerPageChange?: (value: number) => void;
+  perPageAriaLabel?: string;
+  total?: number;
+  isLoading?: boolean;
+  className?: string;
+};
+
+const FIRST_PAGE = 1;
+
+export function PaginationBar({
+  page,
+  totalPages,
+  onPageChange,
+  perPage,
+  onPerPageChange,
+  perPageAriaLabel = 'Items per page',
+  total,
+  isLoading = false,
+  className,
+}: PaginationBarProps) {
+  const normalizedTotalPages = Math.max(FIRST_PAGE, totalPages);
+  const normalizedPage = Math.min(Math.max(FIRST_PAGE, page), normalizedTotalPages);
+  const disablePrevious = normalizedPage <= FIRST_PAGE || isLoading;
+  const disableNext = normalizedPage >= normalizedTotalPages || isLoading;
+
+  return (
+    <div className={cn('flex flex-wrap items-center justify-between gap-3', className)}>
+      <div className="flex flex-wrap items-center gap-2">
+        {typeof total === 'number' ? (
+          <p className="text-sm text-muted-foreground">{`${total} total`}</p>
+        ) : null}
+        {typeof perPage === 'number' && typeof onPerPageChange === 'function' ? (
+          <PerPageSelector ariaLabel={perPageAriaLabel} onChange={onPerPageChange} value={perPage} />
+        ) : null}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button
+          disabled={disablePrevious}
+          onClick={() => onPageChange(Math.max(FIRST_PAGE, normalizedPage - 1))}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          Previous
+        </Button>
+        <p className="text-sm text-muted-foreground">{`Page ${normalizedPage} of ${normalizedTotalPages}`}</p>
+        <Button
+          disabled={disableNext}
+          onClick={() => onPageChange(Math.min(normalizedTotalPages, normalizedPage + 1))}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/view-toggle.test.tsx
+++ b/apps/web/src/components/ui/view-toggle.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ViewToggle, type ViewToggleMode } from './view-toggle';
+
+describe('ViewToggle', () => {
+  it('toggles between card and table views', () => {
+    const handleChange = vi.fn();
+
+    render(<ViewToggle onChange={handleChange} view="card" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Table view' }));
+
+    expect(handleChange).toHaveBeenCalledWith('table');
+  });
+
+  it('loads and persists view preference via localStorage', () => {
+    const storageKey = 'foods-view-preference';
+    window.localStorage.setItem(storageKey, 'table');
+
+    function TestHarness() {
+      const [view, setView] = useState<ViewToggleMode>('card');
+
+      return <ViewToggle onChange={setView} storageKey={storageKey} view={view} />;
+    }
+
+    render(<TestHarness />);
+
+    expect(screen.getByRole('button', { name: 'Table view' })).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Card view' }));
+
+    expect(window.localStorage.getItem(storageKey)).toBe('card');
+  });
+});

--- a/apps/web/src/components/ui/view-toggle.tsx
+++ b/apps/web/src/components/ui/view-toggle.tsx
@@ -21,6 +21,7 @@ function isViewMode(value: string | null): value is ViewToggleMode {
 export function ViewToggle({ view, onChange, storageKey, className }: ViewToggleProps) {
   const normalizedStorageKey = useMemo(() => storageKey?.trim() ?? '', [storageKey]);
 
+  // Keep onChange in deps for correctness; callers should pass a stable callback to avoid extra no-op hydration checks.
   useEffect(() => {
     if (!normalizedStorageKey) {
       return;

--- a/apps/web/src/components/ui/view-toggle.tsx
+++ b/apps/web/src/components/ui/view-toggle.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useMemo } from 'react';
+import { LayoutGrid, List } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+import { Button } from './button';
+
+export type ViewToggleMode = 'card' | 'table';
+
+type ViewToggleProps = {
+  view: ViewToggleMode;
+  onChange: (view: ViewToggleMode) => void;
+  storageKey?: string;
+  className?: string;
+};
+
+function isViewMode(value: string | null): value is ViewToggleMode {
+  return value === 'card' || value === 'table';
+}
+
+export function ViewToggle({ view, onChange, storageKey, className }: ViewToggleProps) {
+  const normalizedStorageKey = useMemo(() => storageKey?.trim() ?? '', [storageKey]);
+
+  useEffect(() => {
+    if (!normalizedStorageKey) {
+      return;
+    }
+
+    try {
+      const storedValue = window.localStorage.getItem(normalizedStorageKey);
+      if (!isViewMode(storedValue) || storedValue === view) {
+        return;
+      }
+
+      onChange(storedValue);
+    } catch {
+      return;
+    }
+  }, [normalizedStorageKey, onChange, view]);
+
+  function selectView(nextView: ViewToggleMode) {
+    if (nextView === view) {
+      return;
+    }
+
+    if (normalizedStorageKey) {
+      try {
+        window.localStorage.setItem(normalizedStorageKey, nextView);
+      } catch {
+        // Ignore localStorage write failures.
+      }
+    }
+
+    onChange(nextView);
+  }
+
+  return (
+    <div
+      aria-label="View mode"
+      className={cn(
+        'inline-flex min-h-[44px] w-fit items-center gap-1 rounded-full border border-border bg-card p-1',
+        className,
+      )}
+      role="group"
+    >
+      <Button
+        aria-label="Card view"
+        aria-pressed={view === 'card'}
+        className="h-8 w-8 rounded-full p-0"
+        onClick={() => selectView('card')}
+        size="sm"
+        type="button"
+        variant={view === 'card' ? 'default' : 'ghost'}
+      >
+        <LayoutGrid aria-hidden="true" className="size-4" />
+      </Button>
+      <Button
+        aria-label="Table view"
+        aria-pressed={view === 'table'}
+        className="h-8 w-8 rounded-full p-0"
+        onClick={() => selectView('table')}
+        size="sm"
+        type="button"
+        variant={view === 'table' ? 'default' : 'ghost'}
+      >
+        <List aria-hidden="true" className="size-4" />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.test.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { weightQueryKeys } from '@/features/weight/api/weight';
 import { dashboardWeightTrendQueryKeys } from '@/hooks/use-weight-trend';
 import { createQueryClientWrapper } from '@/test/query-client';
 
@@ -187,7 +188,7 @@ describe('WeightTrendChart', () => {
 
     await act(async () => {
       await queryClient.invalidateQueries({
-        queryKey: dashboardWeightTrendQueryKeys.all,
+        queryKey: weightQueryKeys.all,
       });
     });
 
@@ -198,6 +199,30 @@ describe('WeightTrendChart', () => {
         ).length,
       ).toBeGreaterThanOrEqual(2);
     });
+  });
+
+  it('uses a dedicated weight-entry query key to avoid dashboard trend cache collisions', async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setQueryData(dashboardWeightTrendQueryKeys.range('2026-02-07', '2026-03-08'), [
+      { date: '2026-03-08', value: 180.5 },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <WeightTrendChart />
+      </MemoryRouter>,
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v1/weight?from=2026-02-07&to=2026-03-08',
+        expect.any(Object),
+      );
+    });
+
+    expect(screen.getByRole('img', { name: 'Weight trend chart' })).toBeInTheDocument();
+    expect(screen.queryByText('Log your weight to see trends')).not.toBeInTheDocument();
   });
 
   it('allows toggling each legend series', async () => {

--- a/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
+++ b/apps/web/src/features/dashboard/components/weight-trend-chart.tsx
@@ -5,7 +5,7 @@ import { computeEWMA, computeWeightInsights } from '@pulse/shared';
 import { Link } from 'react-router';
 
 import { DashboardCardHeaderLink } from '@/features/dashboard/components/dashboard-drilldown-link';
-import { dashboardWeightTrendQueryKeys } from '@/hooks/use-weight-trend';
+import { weightQueryKeys } from '@/features/weight/api/weight';
 import {
   CartesianGrid,
   Line,
@@ -82,13 +82,11 @@ const resolveRange = (days: number | null): ResolvedRange => {
   return { from, to };
 };
 
-const getQueryKeyForRange = ({ from, to }: ResolvedRange) => {
-  if (from && to) {
-    return dashboardWeightTrendQueryKeys.range(from, to);
-  }
-
-  return [...dashboardWeightTrendQueryKeys.all, 'all'] as const;
-};
+const getQueryKeyForRange = ({ from, to }: ResolvedRange) =>
+  weightQueryKeys.trend({
+    from: from ?? undefined,
+    to: to ?? undefined,
+  });
 
 const fetchWeightEntries = async ({ from, to }: ResolvedRange) => {
   const params = new URLSearchParams();

--- a/apps/web/src/features/equipment/components/equipment-page.tsx
+++ b/apps/web/src/features/equipment/components/equipment-page.tsx
@@ -159,7 +159,6 @@ export function EquipmentPage() {
             </div>
           }
           description="Keep a clear view of what is available in each training space before planning sessions or swapping exercises."
-          showBack
           title="Equipment"
         />
 

--- a/apps/web/src/features/foods/components/food-list.test.tsx
+++ b/apps/web/src/features/foods/components/food-list.test.tsx
@@ -7,6 +7,8 @@ import { FoodList } from '@/features/foods/components/food-list';
 import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
 import { createAppQueryClient, resetAppQueryClient } from '@/lib/query-client';
 
+const FOOD_LIST_VIEW_STORAGE_KEY = 'food-list-view';
+
 function createDeferredResponse() {
   let resolve: (value: Response) => void = () => {};
 
@@ -662,5 +664,77 @@ describe('FoodList', () => {
     await waitFor(() => {
       expect(screen.getByText('Showing 25 of 27 foods')).toBeInTheDocument();
     });
+  });
+
+  it('renders card and table views and persists the selected view', async () => {
+    const api = createFoodsApiMock(paginatedFoods);
+    vi.stubGlobal('fetch', api.fetchMock);
+
+    const firstRender = renderFoodList();
+
+    expect(await screen.findByRole('heading', { level: 3, name: 'Spinach' })).toBeInTheDocument();
+    expect(screen.queryByRole('table', { name: 'Foods table view' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Table view' }));
+    expect(await screen.findByRole('table', { name: 'Foods table view' })).toBeInTheDocument();
+    expect(window.localStorage.getItem(FOOD_LIST_VIEW_STORAGE_KEY)).toBe('table');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Card view' }));
+    expect(await screen.findByRole('heading', { level: 3, name: 'Spinach' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Table view' }));
+    expect(await screen.findByRole('table', { name: 'Foods table view' })).toBeInTheDocument();
+
+    firstRender.unmount();
+    renderFoodList();
+
+    expect(await screen.findByRole('table', { name: 'Foods table view' })).toBeInTheDocument();
+  });
+
+  it('paginates in table mode', async () => {
+    const api = createFoodsApiMock(paginatedFoods);
+    vi.stubGlobal('fetch', api.fetchMock);
+
+    renderFoodList();
+
+    await screen.findByRole('heading', { level: 3, name: 'Spinach' });
+    fireEvent.click(screen.getByRole('button', { name: 'Table view' }));
+    await screen.findByRole('table', { name: 'Foods table view' });
+    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => {
+      expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('table', { name: 'Foods table view' })).toBeInTheDocument();
+  });
+
+  it('preserves filter and sort state when switching between card and table views', async () => {
+    const api = createFoodsApiMock(paginatedFoods);
+    vi.stubGlobal('fetch', api.fetchMock);
+
+    renderFoodList();
+
+    await screen.findByRole('heading', { level: 3, name: 'Spinach' });
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search foods' }), {
+      target: { value: 'fair' },
+    });
+    selectSortOption('Name (A-Z)');
+
+    await waitFor(() => {
+      expect(window.location.search).toContain('sort=name-asc');
+    });
+    expect(await screen.findByRole('heading', { level: 3, name: '2% Milk' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Table view' }));
+    expect(await screen.findByRole('table', { name: 'Foods table view' })).toBeInTheDocument();
+    expect(screen.getByText('2% Milk')).toBeInTheDocument();
+    expect(window.location.search).toContain('sort=name-asc');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Card view' }));
+    expect(await screen.findByRole('heading', { level: 3, name: '2% Milk' })).toBeInTheDocument();
+    expect(screen.getByRole('searchbox', { name: 'Search foods' })).toHaveValue('fair');
+    expect(window.location.search).toContain('sort=name-asc');
   });
 });

--- a/apps/web/src/features/foods/components/food-list.test.tsx
+++ b/apps/web/src/features/foods/components/food-list.test.tsx
@@ -9,6 +9,38 @@ import { createAppQueryClient, resetAppQueryClient } from '@/lib/query-client';
 
 const FOOD_LIST_VIEW_STORAGE_KEY = 'food-list-view';
 
+vi.mock('@/components/ui/column-picker', () => ({
+  ColumnPicker: ({
+    columns,
+    onChange,
+    visibleColumns,
+  }: {
+    columns: { key: string; label: string }[];
+    onChange: (columns: string[]) => void;
+    visibleColumns: string[];
+    storageKey?: string;
+    className?: string;
+  }) => {
+    const removeProtein = columns
+      .map((column) => column.key)
+      .filter((key) => visibleColumns.includes(key) && key !== 'protein');
+    const withProtein = columns
+      .map((column) => column.key)
+      .filter((key) => key === 'protein' || visibleColumns.includes(key));
+
+    return (
+      <div>
+        <button onClick={() => onChange(removeProtein)} type="button">
+          Hide protein column
+        </button>
+        <button onClick={() => onChange(withProtein)} type="button">
+          Show protein column
+        </button>
+      </div>
+    );
+  },
+}));
+
 function createDeferredResponse() {
   let resolve: (value: Response) => void = () => {};
 
@@ -707,6 +739,43 @@ describe('FoodList', () => {
       expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
     });
     expect(screen.getByRole('table', { name: 'Foods table view' })).toBeInTheDocument();
+  });
+
+  it('shows and hides table columns through the shared column picker integration', async () => {
+    const api = createFoodsApiMock(paginatedFoods);
+    vi.stubGlobal('fetch', api.fetchMock);
+
+    renderFoodList();
+
+    await screen.findByRole('heading', { level: 3, name: 'Spinach' });
+    fireEvent.click(screen.getByRole('button', { name: 'Table view' }));
+    await screen.findByRole('table', { name: 'Foods table view' });
+    expect(screen.getByRole('columnheader', { name: 'Protein' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide protein column' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('columnheader', { name: 'Protein' })).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show protein column' }));
+    expect(screen.getByRole('columnheader', { name: 'Protein' })).toBeInTheDocument();
+  });
+
+  it('opens table inline editing only from the food name cell', async () => {
+    const api = createFoodsApiMock(paginatedFoods);
+    vi.stubGlobal('fetch', api.fetchMock);
+
+    renderFoodList();
+
+    await screen.findByRole('heading', { level: 3, name: 'Spinach' });
+    fireEvent.click(screen.getByRole('button', { name: 'Table view' }));
+    await screen.findByRole('table', { name: 'Foods table view' });
+
+    fireEvent.click(screen.getByRole('cell', { name: '13g' }));
+    expect(screen.queryByRole('textbox', { name: 'Edit 2% Milk name' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '2% Milk' }));
+    expect(await screen.findByRole('textbox', { name: 'Edit 2% Milk name' })).toBeInTheDocument();
   });
 
   it('preserves filter and sort state when switching between card and table views', async () => {

--- a/apps/web/src/features/foods/components/food-list.tsx
+++ b/apps/web/src/features/foods/components/food-list.tsx
@@ -131,6 +131,7 @@ function formatLastUsedValue(lastUsedAt: number | null, now: Date) {
 
 type TableSortDirection = 'asc' | 'desc';
 type ClientFoodSortKey = 'calories' | 'protein';
+type FoodTableSortColumnKey = 'name' | 'usageCount' | ClientFoodSortKey;
 
 type ClientFoodSort = {
   key: ClientFoodSortKey;
@@ -334,7 +335,15 @@ export function FoodList({ now = new Date() }: FoodListProps) {
             );
           }
 
-          return <span className="font-medium text-foreground">{food.name}</span>;
+          return (
+            <button
+              className="cursor-pointer text-left font-medium text-foreground transition-colors hover:text-primary"
+              onClick={() => beginEditing(food)}
+              type="button"
+            >
+              {food.name}
+            </button>
+          );
         },
       },
       {
@@ -389,7 +398,6 @@ export function FoodList({ now = new Date() }: FoodListProps) {
       {
         key: 'lastUsed',
         header: 'Last Used',
-        sortable: true,
         accessor: (food) => formatLastUsedValue(food.lastUsedAt, now),
       },
       {
@@ -400,6 +408,7 @@ export function FoodList({ now = new Date() }: FoodListProps) {
       },
     ];
   }, [
+    beginEditing,
     cancelEditing,
     draftFoodName,
     editingFoodId,
@@ -506,6 +515,10 @@ export function FoodList({ now = new Date() }: FoodListProps) {
   }
 
   function handleFoodTableSort(columnKey: string) {
+    if (!isFoodTableSortColumnKey(columnKey)) {
+      return;
+    }
+
     if (columnKey === 'name') {
       setClientTableSort(null);
       updateUrlSort(sortBy === 'name-asc' ? 'name-desc' : 'name-asc');
@@ -518,15 +531,7 @@ export function FoodList({ now = new Date() }: FoodListProps) {
       return;
     }
 
-    if (columnKey === 'lastUsed') {
-      setClientTableSort(null);
-      updateUrlSort('recently-updated');
-      return;
-    }
-
-    if (columnKey === 'calories' || columnKey === 'protein') {
-      toggleClientSort(columnKey);
-    }
+    toggleClientSort(columnKey);
   }
 
   const handleVisibleTableColumnsChange = useCallback((nextColumns: string[]) => {
@@ -722,7 +727,6 @@ export function FoodList({ now = new Date() }: FoodListProps) {
             <DataTable
               columns={visibleFoodColumns}
               data={sortedFoods}
-              onRowClick={(food) => beginEditing(food)}
               onSort={handleFoodTableSort}
               tableAriaLabel="Foods table view"
             />
@@ -992,4 +996,13 @@ function parsePageSize(value: string | null) {
   return PER_PAGE_OPTIONS.includes(parsedValue as (typeof PER_PAGE_OPTIONS)[number])
     ? parsedValue
     : DEFAULT_PER_PAGE;
+}
+
+function isFoodTableSortColumnKey(columnKey: string): columnKey is FoodTableSortColumnKey {
+  return (
+    columnKey === 'name' ||
+    columnKey === 'usageCount' ||
+    columnKey === 'calories' ||
+    columnKey === 'protein'
+  );
 }

--- a/apps/web/src/features/foods/components/food-list.tsx
+++ b/apps/web/src/features/foods/components/food-list.tsx
@@ -1,12 +1,16 @@
 import { CheckCircle2Icon, SearchIcon, Trash2Icon, XIcon } from 'lucide-react';
 import type { Food, FoodSort } from '@pulse/shared';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router';
 import { FoodCardSkeleton } from '@/components/skeletons';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { ColumnPicker } from '@/components/ui/column-picker';
 import { DEFAULT_PER_PAGE, PER_PAGE_OPTIONS } from '@/components/ui/per-page-constants';
+import { DataTable, type Column } from '@/components/ui/data-table';
+import { FilterBar } from '@/components/ui/filter-bar';
 import { PaginationBar } from '@/components/ui/pagination-bar';
+import { ViewToggle, type ViewToggleMode } from '@/components/ui/view-toggle';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import { Input } from '@/components/ui/input';
@@ -24,6 +28,9 @@ const SEARCH_DEBOUNCE_MS = 300;
 const DEFAULT_PAGE = 1;
 const DEFAULT_SORT_BY: FoodSort = 'recently-updated';
 const FOOD_TAG_LIMIT = 20;
+const FOOD_LIST_VIEW_STORAGE_KEY = 'food-list-view';
+const FOOD_LIST_COLUMNS_STORAGE_KEY = 'food-list-columns';
+const DEFAULT_VISIBLE_FOOD_COLUMN_KEYS = ['name', 'calories', 'protein', 'carbs', 'fat', 'tags'];
 
 const FOOD_SORT_VALUES: FoodSort[] = [
   'name-asc',
@@ -109,11 +116,37 @@ function formatServing(food: Food) {
   return 'Not provided';
 }
 
+function formatLastUsedValue(lastUsedAt: number | null, now: Date) {
+  if (!lastUsedAt) {
+    return 'Never';
+  }
+
+  const daysAgo = getDaysAgo(lastUsedAt, now);
+
+  if (daysAgo === 0) return 'Today';
+  if (daysAgo === 1) return 'Yesterday';
+
+  return `${daysAgo} days ago`;
+}
+
+type TableSortDirection = 'asc' | 'desc';
+type ClientFoodSortKey = 'calories' | 'protein';
+
+type ClientFoodSort = {
+  key: ClientFoodSortKey;
+  direction: TableSortDirection;
+};
+
 export function FoodList({ now = new Date() }: FoodListProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const { confirm, dialog } = useConfirmation();
   const [searchInput, setSearchInput] = useState('');
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
+  const [view, setView] = useState<ViewToggleMode>('card');
+  const [clientTableSort, setClientTableSort] = useState<ClientFoodSort | null>(null);
+  const [visibleTableColumns, setVisibleTableColumns] = useState<string[]>(
+    DEFAULT_VISIBLE_FOOD_COLUMN_KEYS,
+  );
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [editingFoodId, setEditingFoodId] = useState<string | null>(null);
   const [draftFoodName, setDraftFoodName] = useState('');
@@ -147,6 +180,28 @@ export function FoodList({ now = new Date() }: FoodListProps) {
   const deleteFood = useDeleteFood();
 
   const foods = useMemo(() => foodsQuery.data?.data ?? [], [foodsQuery.data?.data]);
+  const sortedFoods = useMemo(() => {
+    if (!clientTableSort) {
+      return foods;
+    }
+
+    const sorted = [...foods];
+
+    return sorted.sort((left, right) => {
+      const leftValue = left[clientTableSort.key];
+      const rightValue = right[clientTableSort.key];
+
+      if (leftValue === rightValue) {
+        return left.name.localeCompare(right.name);
+      }
+
+      if (clientTableSort.direction === 'asc') {
+        return leftValue - rightValue;
+      }
+
+      return rightValue - leftValue;
+    });
+  }, [clientTableSort, foods]);
   const availableTags = useMemo(() => {
     const tagSet = new Set<string>();
     foods.forEach((food) => {
@@ -187,20 +242,20 @@ export function FoodList({ now = new Date() }: FoodListProps) {
     );
   }, [page, setSearchParams, totalPages]);
 
-  function beginEditing(food: Food) {
+  const beginEditing = useCallback((food: Food) => {
     editCancelledRef.current = false;
     setEditingFoodId(food.id);
     setDraftFoodName(food.name);
-  }
+  }, []);
 
-  function cancelEditing() {
+  const cancelEditing = useCallback(() => {
     editCancelledRef.current = true;
     setEditingFoodId(null);
     setDraftFoodName('');
     setIsSavingEdit(false);
-  }
+  }, []);
 
-  async function saveEditing() {
+  const saveEditing = useCallback(async () => {
     if (!editingFoodId || isEditingFoodPending) {
       return;
     }
@@ -231,7 +286,142 @@ export function FoodList({ now = new Date() }: FoodListProps) {
     } finally {
       setIsSavingEdit(false);
     }
-  }
+  }, [cancelEditing, draftFoodName, editingFoodId, foods, isEditingFoodPending, updateFood]);
+
+  const foodColumns = useMemo<Column<Food>[]>(() => {
+    return [
+      {
+        key: 'name',
+        header: 'Name',
+        sortable: true,
+        className: 'min-w-52',
+        accessor: (food) => {
+          const isUpdatingFood = updateFood.isPending && updateFood.variables?.id === food.id;
+
+          if (editingFoodId === food.id) {
+            return (
+              <form
+                className="space-y-1"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  void saveEditing();
+                }}
+              >
+                <Input
+                  aria-label={`Edit ${food.name} name`}
+                  autoFocus
+                  className="h-8"
+                  aria-disabled={isUpdatingFood}
+                  onBlur={() => {
+                    if (!isUpdatingFood && !editCancelledRef.current) {
+                      void saveEditing();
+                    }
+                  }}
+                  onChange={(event) => setDraftFoodName(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Escape') {
+                      event.preventDefault();
+                      cancelEditing();
+                    }
+                  }}
+                  readOnly={isUpdatingFood}
+                  value={draftFoodName}
+                />
+                <p className="text-xs text-muted-foreground">
+                  {isUpdatingFood ? 'Saving…' : 'Enter to save, Escape to cancel.'}
+                </p>
+              </form>
+            );
+          }
+
+          return <span className="font-medium text-foreground">{food.name}</span>;
+        },
+      },
+      {
+        key: 'brand',
+        header: 'Brand',
+        accessor: (food) => food.brand ?? '—',
+      },
+      {
+        key: 'serving',
+        header: 'Serving',
+        accessor: (food) => formatServing(food),
+      },
+      {
+        key: 'calories',
+        header: 'Calories',
+        sortable: true,
+        accessor: (food) => `${food.calories} cal`,
+      },
+      {
+        key: 'protein',
+        header: 'Protein',
+        sortable: true,
+        accessor: (food) => `${food.protein}g`,
+      },
+      {
+        key: 'carbs',
+        header: 'Carbs',
+        accessor: (food) => `${food.carbs}g`,
+      },
+      {
+        key: 'fat',
+        header: 'Fat',
+        accessor: (food) => `${food.fat}g`,
+      },
+      {
+        key: 'tags',
+        header: 'Tags',
+        className: 'min-w-56',
+        accessor: (food) =>
+          food.tags.length === 0 ? (
+            <span className="text-xs text-muted-foreground">No tags</span>
+          ) : (
+            <div className="flex flex-wrap gap-1">
+              {normalizeFoodTags(food.tags).map((tag) => (
+                <Badge className="h-6 rounded-full px-2 text-xs" key={tag} variant="secondary">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          ),
+      },
+      {
+        key: 'lastUsed',
+        header: 'Last Used',
+        sortable: true,
+        accessor: (food) => formatLastUsedValue(food.lastUsedAt, now),
+      },
+      {
+        key: 'usageCount',
+        header: 'Usage Count',
+        sortable: true,
+        accessor: (food) => food.usageCount,
+      },
+    ];
+  }, [
+    cancelEditing,
+    draftFoodName,
+    editingFoodId,
+    now,
+    saveEditing,
+    updateFood.isPending,
+    updateFood.variables?.id,
+  ]);
+
+  const visibleFoodColumns = useMemo(
+    () => foodColumns.filter((column) => visibleTableColumns.includes(column.key)),
+    [foodColumns, visibleTableColumns],
+  );
+
+  const pickerColumns = useMemo(
+    () =>
+      foodColumns.map((column) => ({
+        key: column.key,
+        label: column.header,
+      })),
+    [foodColumns],
+  );
 
   function setTagDraft(foodId: string, value: string) {
     setTagDrafts((current) => ({
@@ -290,6 +480,63 @@ export function FoodList({ now = new Date() }: FoodListProps) {
     });
   }
 
+  function updateUrlSort(nextSort: FoodSort) {
+    setSearchParams(
+      (current) => {
+        const next = new URLSearchParams(current);
+        next.set('sort', nextSort);
+        next.set('page', String(DEFAULT_PAGE));
+        return next;
+      },
+      { replace: true },
+    );
+  }
+
+  function toggleClientSort(key: ClientFoodSortKey) {
+    setClientTableSort((current) => {
+      if (!current || current.key !== key) {
+        return { key, direction: 'asc' };
+      }
+
+      return {
+        key,
+        direction: current.direction === 'asc' ? 'desc' : 'asc',
+      };
+    });
+  }
+
+  function handleFoodTableSort(columnKey: string) {
+    if (columnKey === 'name') {
+      setClientTableSort(null);
+      updateUrlSort(sortBy === 'name-asc' ? 'name-desc' : 'name-asc');
+      return;
+    }
+
+    if (columnKey === 'usageCount') {
+      setClientTableSort(null);
+      updateUrlSort(sortBy === 'most-used' ? 'least-used' : 'most-used');
+      return;
+    }
+
+    if (columnKey === 'lastUsed') {
+      setClientTableSort(null);
+      updateUrlSort('recently-updated');
+      return;
+    }
+
+    if (columnKey === 'calories' || columnKey === 'protein') {
+      toggleClientSort(columnKey);
+    }
+  }
+
+  const handleVisibleTableColumnsChange = useCallback((nextColumns: string[]) => {
+    if (nextColumns.length === 0) {
+      return;
+    }
+
+    setVisibleTableColumns(nextColumns);
+  }, []);
+
   const isInitialLoading = foodsQuery.isLoading;
   const isRefreshing = foodsQuery.isFetching && !foodsQuery.isLoading;
 
@@ -303,108 +550,124 @@ export function FoodList({ now = new Date() }: FoodListProps) {
           </CardDescription>
         </CardHeader>
 
-        <CardContent className="grid gap-3 px-5 sm:grid-cols-[minmax(0,1fr)_13rem] sm:px-6">
-          <label className="space-y-2">
-            <span className="text-sm font-medium text-on-cream dark:text-foreground">
-              Search foods
-            </span>
-            <div className="relative">
-              <SearchIcon className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-gray-500" />
-              <Input
-                aria-label="Search foods"
-                className="border-black/10 bg-white/80 pl-9 text-on-cream placeholder:text-gray-500 dark:border-border dark:bg-background dark:text-foreground dark:placeholder:text-muted"
-                onChange={(event) => {
-                  setSearchInput(event.target.value);
-                  setSearchParams(
-                    (current) => {
-                      const next = new URLSearchParams(current);
-                      next.set('page', String(DEFAULT_PAGE));
-                      return next;
-                    },
-                    { replace: true },
-                  );
-                }}
-                placeholder="Chicken, Fairlife, oats..."
-                type="search"
-                value={searchInput}
-              />
-            </div>
-          </label>
+        <CardContent className="px-5 sm:px-6">
+          <FilterBar
+            className="border-black/10 bg-white/55 dark:border-border dark:bg-card"
+            searchControl={
+              <label className="space-y-2">
+                <span className="text-sm font-medium text-on-cream dark:text-foreground">
+                  Search foods
+                </span>
+                <div className="relative">
+                  <SearchIcon className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-gray-500" />
+                  <Input
+                    aria-label="Search foods"
+                    className="border-black/10 bg-white/80 pl-9 text-on-cream placeholder:text-gray-500 dark:border-border dark:bg-background dark:text-foreground dark:placeholder:text-muted"
+                    onChange={(event) => {
+                      setSearchInput(event.target.value);
+                      setSearchParams(
+                        (current) => {
+                          const next = new URLSearchParams(current);
+                          next.set('page', String(DEFAULT_PAGE));
+                          return next;
+                        },
+                        { replace: true },
+                      );
+                    }}
+                    placeholder="Chicken, Fairlife, oats..."
+                    type="search"
+                    value={searchInput}
+                  />
+                </div>
+              </label>
+            }
+            sortControl={
+              <label className="space-y-2">
+                <span className="text-sm font-medium text-on-cream dark:text-foreground">Sort by</span>
+                <SortSelector
+                  ariaLabel="Sort foods"
+                  onChange={(value) => {
+                    if (!isFoodSort(value)) {
+                      return;
+                    }
 
-          <label className="space-y-2">
-            <span className="text-sm font-medium text-on-cream dark:text-foreground">Sort by</span>
-            <SortSelector
-              ariaLabel="Sort foods"
-              onChange={(value) => {
-                if (!isFoodSort(value)) {
-                  return;
-                }
-
-                setSearchParams(
-                  (current) => {
-                    const next = new URLSearchParams(current);
-                    next.set('sort', value);
-                    next.set('page', String(DEFAULT_PAGE));
-                    return next;
-                  },
-                  { replace: true },
-                );
-              }}
-              options={SORT_OPTIONS}
-              triggerClassName="border-black/10 bg-white/80 text-on-cream dark:border-border dark:bg-background dark:text-foreground"
-              value={sortBy}
-            />
-          </label>
-        </CardContent>
-
-        <CardContent className="px-5 pt-0 sm:px-6">
-          <div className="space-y-2">
-            <p className="text-sm font-medium text-on-cream dark:text-foreground">Filter by tags</p>
-            {filterTags.length === 0 ? (
-              <p className="text-sm text-muted-foreground">No tags yet</p>
-            ) : (
-              <div className="flex flex-wrap gap-2">
-                {filterTags.map((tag) => {
-                  const isSelected = activeSelectedTags.includes(tag);
-                  return (
+                    setClientTableSort(null);
+                    setSearchParams(
+                      (current) => {
+                        const next = new URLSearchParams(current);
+                        next.set('sort', value);
+                        next.set('page', String(DEFAULT_PAGE));
+                        return next;
+                      },
+                      { replace: true },
+                    );
+                  }}
+                  options={SORT_OPTIONS}
+                  triggerClassName="border-black/10 bg-white/80 text-on-cream dark:border-border dark:bg-background dark:text-foreground"
+                  value={sortBy}
+                />
+              </label>
+            }
+            perPageControl={
+              view === 'table' ? (
+                <ColumnPicker
+                  columns={pickerColumns}
+                  onChange={handleVisibleTableColumnsChange}
+                  storageKey={FOOD_LIST_COLUMNS_STORAGE_KEY}
+                  visibleColumns={visibleTableColumns}
+                />
+              ) : null
+            }
+            viewToggle={<ViewToggle onChange={setView} storageKey={FOOD_LIST_VIEW_STORAGE_KEY} view={view} />}
+          >
+            <div className="w-full space-y-2 sm:basis-full">
+              <p className="text-sm font-medium text-on-cream dark:text-foreground">Filter by tags</p>
+              {filterTags.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No tags yet</p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {filterTags.map((tag) => {
+                    const isSelected = activeSelectedTags.includes(tag);
+                    return (
+                      <Button
+                        key={tag}
+                        className="h-7 rounded-full px-3 text-xs"
+                        onClick={() => {
+                          setSelectedTags((current) =>
+                            normalizeFoodTags(current).includes(tag)
+                              ? normalizeFoodTags(current).filter((currentTag) => currentTag !== tag)
+                              : [...normalizeFoodTags(current), tag],
+                          );
+                          setSearchParams(
+                            (current) => {
+                              const next = new URLSearchParams(current);
+                              next.set('page', String(DEFAULT_PAGE));
+                              return next;
+                            },
+                            { replace: true },
+                          );
+                        }}
+                        type="button"
+                        variant={isSelected ? 'default' : 'outline'}
+                      >
+                        {tag}
+                      </Button>
+                    );
+                  })}
+                  {activeSelectedTags.length > 0 ? (
                     <Button
-                      key={tag}
                       className="h-7 rounded-full px-3 text-xs"
-                      onClick={() => {
-                        setSelectedTags((current) =>
-                          normalizeFoodTags(current).includes(tag)
-                            ? normalizeFoodTags(current).filter((currentTag) => currentTag !== tag)
-                            : [...normalizeFoodTags(current), tag],
-                        );
-                        setSearchParams(
-                          (current) => {
-                            const next = new URLSearchParams(current);
-                            next.set('page', String(DEFAULT_PAGE));
-                            return next;
-                          },
-                          { replace: true },
-                        );
-                      }}
+                      onClick={() => setSelectedTags([])}
                       type="button"
-                      variant={isSelected ? 'default' : 'outline'}
+                      variant="ghost"
                     >
-                      {tag}
+                      Clear
                     </Button>
-                  );
-                })}
-                {activeSelectedTags.length > 0 ? (
-                  <Button
-                    className="h-7 rounded-full px-3 text-xs"
-                    onClick={() => setSelectedTags([])}
-                    type="button"
-                    variant="ghost"
-                  >
-                    Clear
-                  </Button>
-                ) : null}
-              </div>
-            )}
-          </div>
+                  ) : null}
+                </div>
+              )}
+            </div>
+          </FilterBar>
         </CardContent>
 
         <CardContent className="px-5 pt-0 sm:px-6">
@@ -455,221 +718,231 @@ export function FoodList({ now = new Date() }: FoodListProps) {
         </Card>
       ) : (
         <>
-          <div className="grid gap-4 lg:grid-cols-2">
-            {foods.map((food) => {
-              const isUpdatingFood = updateFood.isPending && updateFood.variables?.id === food.id;
-              const isDeletingFood = deleteFood.isPending && deleteFood.variables === food.id;
+          {view === 'table' ? (
+            <DataTable
+              columns={visibleFoodColumns}
+              data={sortedFoods}
+              onRowClick={(food) => beginEditing(food)}
+              onSort={handleFoodTableSort}
+              tableAriaLabel="Foods table view"
+            />
+          ) : (
+            <div className="grid gap-4 lg:grid-cols-2">
+              {foods.map((food) => {
+                const isUpdatingFood = updateFood.isPending && updateFood.variables?.id === food.id;
+                const isDeletingFood = deleteFood.isPending && deleteFood.variables === food.id;
 
-              return (
-                <Card
-                  key={food.id}
-                  className="gap-4 border-border bg-card py-5 shadow-none"
-                  role="article"
-                >
-                  <CardHeader className="gap-3 px-5 sm:px-6">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="space-y-1">
-                        {editingFoodId === food.id ? (
-                          <form
-                            className="space-y-2"
-                            onSubmit={(event) => {
-                              event.preventDefault();
-                              void saveEditing();
-                            }}
-                          >
-                            <Input
-                              aria-label={`Edit ${food.name} name`}
-                              autoFocus
-                              className="h-9"
-                              aria-disabled={isUpdatingFood}
-                              onBlur={() => {
-                                if (!isUpdatingFood && !editCancelledRef.current) {
-                                  void saveEditing();
-                                }
+                return (
+                  <Card
+                    key={food.id}
+                    className="gap-4 border-border bg-card py-5 shadow-none"
+                    role="article"
+                  >
+                    <CardHeader className="gap-3 px-5 sm:px-6">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="space-y-1">
+                          {editingFoodId === food.id ? (
+                            <form
+                              className="space-y-2"
+                              onSubmit={(event) => {
+                                event.preventDefault();
+                                void saveEditing();
                               }}
-                              onChange={(event) => setDraftFoodName(event.target.value)}
-                              onKeyDown={(event) => {
-                                if (event.key === 'Escape') {
-                                  event.preventDefault();
-                                  cancelEditing();
-                                }
-                              }}
-                              readOnly={isUpdatingFood}
-                              value={draftFoodName}
-                            />
-                            <p className="text-xs text-muted-foreground">
-                              {isUpdatingFood
-                                ? 'Saving changes…'
-                                : 'Press Enter or click away to save, Escape to cancel.'}
-                            </p>
-                          </form>
-                        ) : (
-                          <CardTitle aria-level={3} className="text-lg" role="heading">
-                            <button
-                              className="cursor-pointer text-left transition-colors hover:text-primary"
-                              onClick={() => beginEditing(food)}
-                              type="button"
                             >
-                              {food.name}
-                            </button>
-                          </CardTitle>
-                        )}
-                        {food.brand ? <CardDescription>{food.brand}</CardDescription> : null}
-                      </div>
-
-                      <div className="flex items-start gap-2">
-                        {food.verified ? (
-                          <TooltipProvider>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Badge className="bg-emerald-100 text-emerald-800 hover:bg-emerald-100 dark:bg-emerald-500/15 dark:text-emerald-400 dark:hover:bg-emerald-500/15">
-                                  <CheckCircle2Icon className="size-3.5" />
-                                  Verified
-                                </Badge>
-                              </TooltipTrigger>
-                              <TooltipContent side="top">
-                                {food.source ? `Source: ${food.source}` : 'Verified nutrition data'}
-                              </TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
-                        ) : null}
-
-                        <Button
-                          aria-label={`Delete ${food.name}`}
-                          className="text-muted-foreground hover:text-destructive"
-                          disabled={isDeletingFood}
-                          onClick={() => handleDeleteFood(food.id, food.name)}
-                          size="icon-xs"
-                          type="button"
-                          variant="ghost"
-                        >
-                          <Trash2Icon className="size-3.5" />
-                        </Button>
-                      </div>
-                    </div>
-
-                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
-                      <span>Serving: {formatServing(food)}</span>
-                      <span aria-hidden="true">•</span>
-                      <span>{formatLastUsed(food.lastUsedAt, now)}</span>
-                      {food.usageCount > 0 ? (
-                        <>
-                          <span aria-hidden="true">•</span>
-                          <span>Used {food.usageCount} times</span>
-                        </>
-                      ) : null}
-                    </div>
-
-                    <div className="space-y-2">
-                      <div className="flex flex-wrap gap-2">
-                        {food.tags.length === 0 ? (
-                          <span className="text-xs text-muted-foreground">No tags</span>
-                        ) : (
-                          normalizeFoodTags(food.tags).map((tag) => (
-                            <Badge
-                              key={tag}
-                              className="h-6 rounded-full gap-1 px-2 text-xs"
-                              variant="secondary"
-                            >
-                              {tag}
-                              <button
-                                aria-label={`Remove ${tag} tag from ${food.name}`}
-                                className="rounded-full p-0.5 text-muted-foreground hover:text-foreground"
-                                disabled={isUpdatingFood}
-                                onClick={() => {
-                                  void saveFoodTags(
-                                    food,
-                                    food.tags.filter(
-                                      (foodTag) => normalizeFoodTag(foodTag) !== tag,
-                                    ),
-                                  ).catch(() => {
-                                    return;
-                                  });
+                              <Input
+                                aria-label={`Edit ${food.name} name`}
+                                autoFocus
+                                className="h-9"
+                                aria-disabled={isUpdatingFood}
+                                onBlur={() => {
+                                  if (!isUpdatingFood && !editCancelledRef.current) {
+                                    void saveEditing();
+                                  }
                                 }}
+                                onChange={(event) => setDraftFoodName(event.target.value)}
+                                onKeyDown={(event) => {
+                                  if (event.key === 'Escape') {
+                                    event.preventDefault();
+                                    cancelEditing();
+                                  }
+                                }}
+                                readOnly={isUpdatingFood}
+                                value={draftFoodName}
+                              />
+                              <p className="text-xs text-muted-foreground">
+                                {isUpdatingFood
+                                  ? 'Saving changes…'
+                                  : 'Press Enter or click away to save, Escape to cancel.'}
+                              </p>
+                            </form>
+                          ) : (
+                            <CardTitle aria-level={3} className="text-lg" role="heading">
+                              <button
+                                className="cursor-pointer text-left transition-colors hover:text-primary"
+                                onClick={() => beginEditing(food)}
                                 type="button"
                               >
-                                <XIcon className="size-3" />
+                                {food.name}
                               </button>
-                            </Badge>
-                          ))
-                        )}
+                            </CardTitle>
+                          )}
+                          {food.brand ? <CardDescription>{food.brand}</CardDescription> : null}
+                        </div>
+
+                        <div className="flex items-start gap-2">
+                          {food.verified ? (
+                            <TooltipProvider>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Badge className="bg-emerald-100 text-emerald-800 hover:bg-emerald-100 dark:bg-emerald-500/15 dark:text-emerald-400 dark:hover:bg-emerald-500/15">
+                                    <CheckCircle2Icon className="size-3.5" />
+                                    Verified
+                                  </Badge>
+                                </TooltipTrigger>
+                                <TooltipContent side="top">
+                                  {food.source ? `Source: ${food.source}` : 'Verified nutrition data'}
+                                </TooltipContent>
+                              </Tooltip>
+                            </TooltipProvider>
+                          ) : null}
+
+                          <Button
+                            aria-label={`Delete ${food.name}`}
+                            className="text-muted-foreground hover:text-destructive"
+                            disabled={isDeletingFood}
+                            onClick={() => handleDeleteFood(food.id, food.name)}
+                            size="icon-xs"
+                            type="button"
+                            variant="ghost"
+                          >
+                            <Trash2Icon className="size-3.5" />
+                          </Button>
+                        </div>
                       </div>
 
-                      <div className="flex items-center gap-2">
-                        <Input
-                          aria-label={`Add tag for ${food.name}`}
-                          className="h-8 text-xs"
-                          onChange={(event) => setTagDraft(food.id, event.target.value)}
-                          onKeyDown={(event) => {
-                            if (event.key === 'Enter' || event.key === ',') {
-                              event.preventDefault();
+                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+                        <span>Serving: {formatServing(food)}</span>
+                        <span aria-hidden="true">•</span>
+                        <span>{formatLastUsed(food.lastUsedAt, now)}</span>
+                        {food.usageCount > 0 ? (
+                          <>
+                            <span aria-hidden="true">•</span>
+                            <span>Used {food.usageCount} times</span>
+                          </>
+                        ) : null}
+                      </div>
+
+                      <div className="space-y-2">
+                        <div className="flex flex-wrap gap-2">
+                          {food.tags.length === 0 ? (
+                            <span className="text-xs text-muted-foreground">No tags</span>
+                          ) : (
+                            normalizeFoodTags(food.tags).map((tag) => (
+                              <Badge
+                                key={tag}
+                                className="h-6 rounded-full gap-1 px-2 text-xs"
+                                variant="secondary"
+                              >
+                                {tag}
+                                <button
+                                  aria-label={`Remove ${tag} tag from ${food.name}`}
+                                  className="rounded-full p-0.5 text-muted-foreground hover:text-foreground"
+                                  disabled={isUpdatingFood}
+                                  onClick={() => {
+                                    void saveFoodTags(
+                                      food,
+                                      food.tags.filter(
+                                        (foodTag) => normalizeFoodTag(foodTag) !== tag,
+                                      ),
+                                    ).catch(() => {
+                                      return;
+                                    });
+                                  }}
+                                  type="button"
+                                >
+                                  <XIcon className="size-3" />
+                                </button>
+                              </Badge>
+                            ))
+                          )}
+                        </div>
+
+                        <div className="flex items-center gap-2">
+                          <Input
+                            aria-label={`Add tag for ${food.name}`}
+                            className="h-8 text-xs"
+                            onChange={(event) => setTagDraft(food.id, event.target.value)}
+                            onKeyDown={(event) => {
+                              if (event.key === 'Enter' || event.key === ',') {
+                                event.preventDefault();
+                                void commitDraftTag(food).catch(() => {
+                                  return;
+                                });
+                              }
+                            }}
+                            placeholder="Add tag"
+                            readOnly={isUpdatingFood}
+                            value={tagDrafts[food.id] ?? ''}
+                          />
+                          <Button
+                            className="h-8 px-2 text-xs"
+                            disabled={isUpdatingFood}
+                            onClick={() => {
                               void commitDraftTag(food).catch(() => {
                                 return;
                               });
-                            }
-                          }}
-                          placeholder="Add tag"
-                          readOnly={isUpdatingFood}
-                          value={tagDrafts[food.id] ?? ''}
-                        />
-                        <Button
-                          className="h-8 px-2 text-xs"
-                          disabled={isUpdatingFood}
-                          onClick={() => {
-                            void commitDraftTag(food).catch(() => {
-                              return;
-                            });
-                          }}
-                          type="button"
-                          variant="outline"
-                        >
-                          Add
-                        </Button>
+                            }}
+                            type="button"
+                            variant="outline"
+                          >
+                            Add
+                          </Button>
+                        </div>
                       </div>
-                    </div>
-                  </CardHeader>
+                    </CardHeader>
 
-                  <CardContent className="px-5 sm:px-6">
-                    <dl className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-                      <div className="rounded-lg border border-border/70 bg-background/70 px-3 py-2">
-                        <dt className="text-xs font-medium tracking-[0.16em] text-muted-foreground uppercase">
-                          Calories
-                        </dt>
-                        <dd className="mt-1 text-sm font-semibold text-foreground">
-                          {food.calories} cal
-                        </dd>
-                      </div>
+                    <CardContent className="px-5 sm:px-6">
+                      <dl className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                        <div className="rounded-lg border border-border/70 bg-background/70 px-3 py-2">
+                          <dt className="text-xs font-medium tracking-[0.16em] text-muted-foreground uppercase">
+                            Calories
+                          </dt>
+                          <dd className="mt-1 text-sm font-semibold text-foreground">
+                            {food.calories} cal
+                          </dd>
+                        </div>
 
-                      <div className="rounded-lg border border-border/70 bg-background/70 px-3 py-2">
-                        <dt className="text-xs font-medium tracking-[0.16em] text-muted-foreground uppercase">
-                          Protein
-                        </dt>
-                        <dd className="mt-1 text-sm font-semibold text-foreground">
-                          {food.protein}g
-                        </dd>
-                      </div>
+                        <div className="rounded-lg border border-border/70 bg-background/70 px-3 py-2">
+                          <dt className="text-xs font-medium tracking-[0.16em] text-muted-foreground uppercase">
+                            Protein
+                          </dt>
+                          <dd className="mt-1 text-sm font-semibold text-foreground">
+                            {food.protein}g
+                          </dd>
+                        </div>
 
-                      <div className="rounded-lg border border-border/70 bg-background/70 px-3 py-2">
-                        <dt className="text-xs font-medium tracking-[0.16em] text-muted-foreground uppercase">
-                          Carbs
-                        </dt>
-                        <dd className="mt-1 text-sm font-semibold text-foreground">
-                          {food.carbs}g
-                        </dd>
-                      </div>
+                        <div className="rounded-lg border border-border/70 bg-background/70 px-3 py-2">
+                          <dt className="text-xs font-medium tracking-[0.16em] text-muted-foreground uppercase">
+                            Carbs
+                          </dt>
+                          <dd className="mt-1 text-sm font-semibold text-foreground">
+                            {food.carbs}g
+                          </dd>
+                        </div>
 
-                      <div className="rounded-lg border border-border/70 bg-background/70 px-3 py-2">
-                        <dt className="text-xs font-medium tracking-[0.16em] text-muted-foreground uppercase">
-                          Fat
-                        </dt>
-                        <dd className="mt-1 text-sm font-semibold text-foreground">{food.fat}g</dd>
-                      </div>
-                    </dl>
-                  </CardContent>
-                </Card>
-              );
-            })}
-          </div>
+                        <div className="rounded-lg border border-border/70 bg-background/70 px-3 py-2">
+                          <dt className="text-xs font-medium tracking-[0.16em] text-muted-foreground uppercase">
+                            Fat
+                          </dt>
+                          <dd className="mt-1 text-sm font-semibold text-foreground">{food.fat}g</dd>
+                        </div>
+                      </dl>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
 
           {totalFoods !== undefined && totalPages !== undefined && totalFoods > pageSize ? (
             <PaginationBar

--- a/apps/web/src/features/foods/components/food-list.tsx
+++ b/apps/web/src/features/foods/components/food-list.tsx
@@ -6,10 +6,10 @@ import { FoodCardSkeleton } from '@/components/skeletons';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { DEFAULT_PER_PAGE, PER_PAGE_OPTIONS } from '@/components/ui/per-page-constants';
+import { PaginationBar } from '@/components/ui/pagination-bar';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import { Input } from '@/components/ui/input';
-import { PerPageSelector } from '@/components/ui/per-page-selector';
 import { SortSelector, type SortOption } from '@/components/ui/sort-selector';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useDeleteFood, useFoods, useUpdateFood } from '@/features/foods/api/foods';
@@ -672,52 +672,29 @@ export function FoodList({ now = new Date() }: FoodListProps) {
           </div>
 
           {totalFoods !== undefined && totalPages !== undefined && totalFoods > pageSize ? (
-            <div className="flex items-center justify-between gap-3">
-              <PerPageSelector
-                ariaLabel="Foods per page"
-                onChange={(value) => {
-                  setSearchParams((current) => {
-                    const next = new URLSearchParams(current);
-                    next.set('limit', String(value));
-                    next.set('page', String(DEFAULT_PAGE));
-                    return next;
-                  });
-                }}
-                triggerClassName="border-border bg-background"
-                value={pageSize}
-              />
-              <Button
-                disabled={page === 1 || foodsQuery.isFetching}
-                onClick={() =>
-                  setSearchParams((current) => {
-                    const next = new URLSearchParams(current);
-                    next.set('page', String(Math.max(DEFAULT_PAGE, page - 1)));
-                    return next;
-                  })
-                }
-                type="button"
-                variant="outline"
-              >
-                Previous
-              </Button>
-              <p className="text-sm text-muted-foreground">
-                Page {page} of {totalPages}
-              </p>
-              <Button
-                disabled={page >= totalPages || foodsQuery.isFetching}
-                onClick={() =>
-                  setSearchParams((current) => {
-                    const next = new URLSearchParams(current);
-                    next.set('page', String(Math.min(totalPages, page + 1)));
-                    return next;
-                  })
-                }
-                type="button"
-                variant="outline"
-              >
-                Next
-              </Button>
-            </div>
+            <PaginationBar
+              isLoading={foodsQuery.isFetching}
+              onPageChange={(nextPage) =>
+                setSearchParams((current) => {
+                  const next = new URLSearchParams(current);
+                  next.set('page', String(nextPage));
+                  return next;
+                })
+              }
+              onPerPageChange={(value) =>
+                setSearchParams((current) => {
+                  const next = new URLSearchParams(current);
+                  next.set('limit', String(value));
+                  next.set('page', String(DEFAULT_PAGE));
+                  return next;
+                })
+              }
+              page={page}
+              perPage={pageSize}
+              perPageAriaLabel="Foods per page"
+              total={resolvedTotalFoods}
+              totalPages={totalPages}
+            />
           ) : null}
         </>
       )}

--- a/apps/web/src/features/injuries/components/condition-detail.tsx
+++ b/apps/web/src/features/injuries/components/condition-detail.tsx
@@ -138,7 +138,6 @@ export function ConditionDetail({ condition }: ConditionDetailProps) {
           </Badge>
         }
         description={condition.description}
-        showBack
         title={condition.name}
       />
 

--- a/apps/web/src/features/injuries/components/conditions-list.tsx
+++ b/apps/web/src/features/injuries/components/conditions-list.tsx
@@ -245,7 +245,6 @@ export function ConditionsList({ conditions = mockHealthConditions }: Conditions
           </Button>
         }
         description="Keep the current condition list visible, sort the recovery picture quickly, and capture new issues without leaving the prototype flow."
-        showBack
         title="Health Tracking"
       />
 

--- a/apps/web/src/features/journal/components/journal-entry-detail.tsx
+++ b/apps/web/src/features/journal/components/journal-entry-detail.tsx
@@ -24,7 +24,7 @@ export function JournalEntryDetail({ entry }: JournalEntryDetailProps) {
 
   return (
     <section className="space-y-6">
-      <PageHeader description={formatJournalEntryDate(entry.date)} showBack title="Journal entry" />
+      <PageHeader description={formatJournalEntryDate(entry.date)} title="Journal entry" />
 
       <Card className="gap-4 overflow-hidden border-transparent bg-card/80 py-0">
         <div className="space-y-4 bg-[var(--color-accent-cream)] px-6 py-6 text-on-cream dark:border-b dark:border-border dark:bg-card dark:text-foreground">

--- a/apps/web/src/features/resources/components/resource-detail.test.tsx
+++ b/apps/web/src/features/resources/components/resource-detail.test.tsx
@@ -17,7 +17,7 @@ describe('ResourceDetail', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 1, name: 'McGill Big 3' })).toBeInTheDocument();
     expect(screen.getByText('Program')).toBeInTheDocument();
     expect(screen.getByText('Dr. Stuart McGill')).toBeInTheDocument();

--- a/apps/web/src/features/resources/components/resource-detail.tsx
+++ b/apps/web/src/features/resources/components/resource-detail.tsx
@@ -32,7 +32,6 @@ export function ResourceDetail({ resource }: ResourceDetailProps) {
             ? `${resourceTypeLabels[resource.type]} by ${resource.author}`
             : 'The requested resource is not available in the current prototype library.'
         }
-        showBack
         title={resource ? resource.title : 'Resource not found'}
       />
 

--- a/apps/web/src/features/resources/components/resource-grid.test.tsx
+++ b/apps/web/src/features/resources/components/resource-grid.test.tsx
@@ -17,7 +17,7 @@ describe('ResourceGrid', () => {
     );
 
     expect(screen.getByRole('heading', { name: 'Resources' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
     expect(screen.getAllByRole('link', { name: /^Open / })).toHaveLength(mockResources.length);
 
     fireEvent.click(screen.getByRole('button', { name: 'Books' }));

--- a/apps/web/src/features/resources/components/resource-grid.tsx
+++ b/apps/web/src/features/resources/components/resource-grid.tsx
@@ -54,7 +54,6 @@ export function ResourceGrid({ resources }: ResourceGridProps) {
           </p>
         }
         description="Browse saved programs, books, and creators with quick tag search and type filters."
-        showBack
         title="Resources"
       />
 

--- a/apps/web/src/features/workouts/components/exercise-library.test.tsx
+++ b/apps/web/src/features/workouts/components/exercise-library.test.tsx
@@ -406,19 +406,37 @@ describe('ExerciseLibrary', () => {
     expect(screen.getByRole('columnheader', { name: 'Tracking Type' })).toBeInTheDocument();
   });
 
-  it('opens the trend dialog from the exercise name button in table view', async () => {
+  it('opens the trend dialog from a table row in table view', async () => {
     mockExerciseRequests();
 
     renderExerciseLibrary();
 
     fireEvent.click(screen.getByRole('button', { name: 'Table view' }));
     await screen.findByRole('table', { name: 'Exercise library table view' });
+    expect(await screen.findByText('Air Bike')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Air Bike' }));
+    fireEvent.click(screen.getByText('Air Bike'));
 
     const dialog = await screen.findByRole('dialog');
     expect(dialog).toBeInTheDocument();
     expect(within(dialog).getByRole('button', { name: 'Add to template' })).toBeInTheDocument();
+  });
+
+  it('toggles exercise table columns with the shared column picker', async () => {
+    mockExerciseRequests();
+
+    renderExerciseLibrary();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Table view' }));
+    await screen.findByRole('table', { name: 'Exercise library table view' });
+    expect(screen.getByRole('columnheader', { name: 'Custom' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Columns' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Custom' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('columnheader', { name: 'Custom' })).not.toBeInTheDocument();
+    });
   });
 
   it('does not write the initial view preference to localStorage on mount', async () => {

--- a/apps/web/src/features/workouts/components/exercise-library.tsx
+++ b/apps/web/src/features/workouts/components/exercise-library.tsx
@@ -367,20 +367,22 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
         </div>
       )}
 
-      <PaginationBar
-        isLoading={exercisesQuery.isFetching}
-        onPageChange={(nextPage) =>
-          updateSearchParams(searchParams, setSearchParams, { page: String(nextPage) }, false)
-        }
-        onPerPageChange={(value) =>
-          updateSearchParams(searchParams, setSearchParams, { limit: String(value) })
-        }
-        page={page}
-        perPage={limit}
-        perPageAriaLabel="Exercises per page"
-        total={totalResults}
-        totalPages={totalPages}
-      />
+      {!exercisesQuery.isPending && totalResults > limit ? (
+        <PaginationBar
+          isLoading={exercisesQuery.isFetching}
+          onPageChange={(nextPage) =>
+            updateSearchParams(searchParams, setSearchParams, { page: String(nextPage) }, false)
+          }
+          onPerPageChange={(value) =>
+            updateSearchParams(searchParams, setSearchParams, { limit: String(value) })
+          }
+          page={page}
+          perPage={limit}
+          perPageAriaLabel="Exercises per page"
+          total={totalResults}
+          totalPages={totalPages}
+        />
+      ) : null}
 
       <RenameExerciseDialog
         key={renameTarget ? `${renameTarget.id}-open` : 'rename-library-closed'}

--- a/apps/web/src/features/workouts/components/exercise-library.tsx
+++ b/apps/web/src/features/workouts/components/exercise-library.tsx
@@ -1,16 +1,20 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
-import { LayoutGrid, List, MoreVertical } from 'lucide-react';
+import { MoreVertical } from 'lucide-react';
 import type { Exercise, ExerciseSort } from '@pulse/shared';
 import { toast } from 'sonner';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { ColumnPicker } from '@/components/ui/column-picker';
+import { DataTable, type Column } from '@/components/ui/data-table';
+import { FilterBar } from '@/components/ui/filter-bar';
 import { Input } from '@/components/ui/input';
 import { DEFAULT_PER_PAGE, PER_PAGE_OPTIONS } from '@/components/ui/per-page-constants';
-import { PerPageSelector } from '@/components/ui/per-page-selector';
+import { PaginationBar } from '@/components/ui/pagination-bar';
 import { SortSelector, type SortOption } from '@/components/ui/sort-selector';
+import { ViewToggle, type ViewToggleMode } from '@/components/ui/view-toggle';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -52,8 +56,16 @@ const exerciseSortOptions: SortOption[] = [
   { value: 'recently-updated', label: 'Recently Updated', direction: 'desc' },
 ];
 const EXERCISE_LIBRARY_VIEW_STORAGE_KEY = 'exercise-library-view';
+const EXERCISE_LIST_COLUMNS_STORAGE_KEY = 'exercise-list-columns';
 
-type ExerciseLibraryView = 'card' | 'table';
+const DEFAULT_VISIBLE_EXERCISE_COLUMNS = [
+  'name',
+  'category',
+  'equipment',
+  'muscleGroups',
+  'trackingType',
+  'custom',
+];
 
 type ExerciseLibraryProps = {
   className?: string;
@@ -65,8 +77,8 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
   const [searchTerm, setSearchTerm] = useState(searchParams.get('q') ?? '');
   const [selectedExerciseId, setSelectedExerciseId] = useState<string | null>(null);
   const [renameTarget, setRenameTarget] = useState<Exercise | null>(null);
-  const [view, setView] = useState<ExerciseLibraryView>(() => loadExerciseLibraryViewPreference());
-  const initialViewRef = useRef(view);
+  const [view, setView] = useState<ViewToggleMode>('card');
+  const [visibleColumns, setVisibleColumns] = useState<string[]>(DEFAULT_VISIBLE_EXERCISE_COLUMNS);
 
   const currentQuery = searchParams.get('q') ?? '';
   const muscleGroup = searchParams.get('muscleGroup') ?? 'all';
@@ -101,14 +113,6 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
     return () => window.clearTimeout(timeoutId);
   }, [currentQuery, searchTerm, setSearchParams]);
 
-  useEffect(() => {
-    if (view === initialViewRef.current) {
-      return;
-    }
-
-    window.localStorage.setItem(EXERCISE_LIBRARY_VIEW_STORAGE_KEY, view);
-  }, [view]);
-
   const exercisesQuery = useExercises({
     category: parseCategory(category),
     equipment: normalizeFilterParam(equipment),
@@ -133,6 +137,82 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
     () => exerciseFiltersQuery.data?.data.equipment ?? [],
     [exerciseFiltersQuery.data],
   );
+  const tableColumns = useMemo<Column<Exercise>[]>(() => {
+    return [
+      {
+        key: 'name',
+        header: 'Name',
+        sortable: true,
+        className: 'min-w-56 font-medium text-foreground',
+        accessor: (exercise) => exercise.name,
+      },
+      {
+        key: 'category',
+        header: 'Category',
+        accessor: (exercise) => formatLabel(exercise.category),
+      },
+      {
+        key: 'equipment',
+        header: 'Equipment',
+        accessor: (exercise) => formatLabel(exercise.equipment),
+      },
+      {
+        key: 'muscleGroups',
+        header: 'Muscle Groups',
+        className: 'min-w-56',
+        accessor: (exercise) => exercise.muscleGroups.map((group) => formatLabel(group)).join(', '),
+      },
+      {
+        key: 'trackingType',
+        header: 'Tracking Type',
+        accessor: (exercise) => formatLabel(exercise.trackingType),
+      },
+      {
+        key: 'custom',
+        header: 'Custom',
+        accessor: (exercise) =>
+          exercise.userId ? (
+            <Badge className="border-border bg-secondary/65" variant="outline">
+              Custom
+            </Badge>
+          ) : (
+            <Badge className="border-border bg-card" variant="outline">
+              System
+            </Badge>
+          ),
+      },
+    ];
+  }, []);
+  const visibleTableColumns = useMemo(
+    () => tableColumns.filter((column) => visibleColumns.includes(column.key)),
+    [tableColumns, visibleColumns],
+  );
+  const pickerColumns = useMemo(
+    () =>
+      tableColumns.map((column) => ({
+        key: column.key,
+        label: column.header,
+      })),
+    [tableColumns],
+  );
+
+  const handleVisibleColumnsChange = useCallback((nextColumns: string[]) => {
+    if (nextColumns.length === 0) {
+      return;
+    }
+
+    setVisibleColumns(nextColumns);
+  }, []);
+
+  function handleTableSort(columnKey: string) {
+    if (columnKey !== 'name') {
+      return;
+    }
+
+    updateSearchParams(searchParams, setSearchParams, {
+      sort: sort === 'name-asc' ? 'name-desc' : 'name-asc',
+    });
+  }
 
   return (
     <section className={cn('space-y-4', className)}>
@@ -144,8 +224,18 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
         </p>
       </div>
 
-      <Card className="gap-4 py-0">
-        <CardContent className="grid gap-4 py-5 md:grid-cols-2 xl:grid-cols-6">
+      <FilterBar
+        perPageControl={
+          view === 'table' ? (
+            <ColumnPicker
+              columns={pickerColumns}
+              onChange={handleVisibleColumnsChange}
+              storageKey={EXERCISE_LIST_COLUMNS_STORAGE_KEY}
+              visibleColumns={visibleColumns}
+            />
+          ) : null
+        }
+        searchControl={
           <FilterField label="Search by name">
             <Input
               aria-label="Search exercises"
@@ -154,67 +244,8 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
               value={searchTerm}
             />
           </FilterField>
-
-          <FilterField label="Muscle group">
-            <select
-              aria-label="Filter by muscle group"
-              className="min-h-[44px] w-full cursor-pointer rounded-md border border-input bg-background px-3 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
-              onChange={(event) =>
-                updateSearchParams(searchParams, setSearchParams, {
-                  muscleGroup: event.target.value,
-                })
-              }
-              value={muscleGroup}
-            >
-              <option value="all">All muscle groups</option>
-              {muscleGroupOptions.map((option) => (
-                <option key={option} value={option}>
-                  {formatLabel(option)}
-                </option>
-              ))}
-            </select>
-          </FilterField>
-
-          <FilterField label="Equipment">
-            <select
-              aria-label="Filter by equipment"
-              className="min-h-[44px] w-full cursor-pointer rounded-md border border-input bg-background px-3 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
-              onChange={(event) =>
-                updateSearchParams(searchParams, setSearchParams, {
-                  equipment: event.target.value,
-                })
-              }
-              value={equipment}
-            >
-              <option value="all">All equipment</option>
-              {equipmentOptions.map((option) => (
-                <option key={option} value={option}>
-                  {formatLabel(option)}
-                </option>
-              ))}
-            </select>
-          </FilterField>
-
-          <FilterField label="Category">
-            <select
-              aria-label="Filter by category"
-              className="min-h-[44px] w-full cursor-pointer rounded-md border border-input bg-background px-3 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
-              onChange={(event) =>
-                updateSearchParams(searchParams, setSearchParams, {
-                  category: event.target.value,
-                })
-              }
-              value={category}
-            >
-              <option value="all">All categories</option>
-              {categoryOptions.map((option) => (
-                <option key={option} value={option}>
-                  {formatLabel(option)}
-                </option>
-              ))}
-            </select>
-          </FilterField>
-
+        }
+        sortControl={
           <FilterField label="Sort">
             <SortSelector
               ariaLabel="Sort exercises"
@@ -231,79 +262,78 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
               value={sort}
             />
           </FilterField>
+        }
+        viewToggle={
+          <ViewToggle onChange={setView} storageKey={EXERCISE_LIBRARY_VIEW_STORAGE_KEY} view={view} />
+        }
+      >
+        <FilterField label="Muscle group">
+          <select
+            aria-label="Filter by muscle group"
+            className="min-h-[44px] w-full cursor-pointer rounded-md border border-input bg-background px-3 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            onChange={(event) =>
+              updateSearchParams(searchParams, setSearchParams, {
+                muscleGroup: event.target.value,
+              })
+            }
+            value={muscleGroup}
+          >
+            <option value="all">All muscle groups</option>
+            {muscleGroupOptions.map((option) => (
+              <option key={option} value={option}>
+                {formatLabel(option)}
+              </option>
+            ))}
+          </select>
+        </FilterField>
 
-          <FilterField label="View">
-            <div
-              aria-label="Exercise library view"
-              className="inline-flex min-h-[44px] w-fit items-center gap-1 rounded-full border border-border bg-card p-1"
-              role="group"
-            >
-              <Button
-                aria-label="Card view"
-                aria-pressed={view === 'card'}
-                className="h-8 w-8 rounded-full p-0"
-                onClick={() => setView('card')}
-                size="sm"
-                type="button"
-                variant={view === 'card' ? 'default' : 'ghost'}
-              >
-                <LayoutGrid aria-hidden="true" className="size-4" />
-              </Button>
-              <Button
-                aria-label="Table view"
-                aria-pressed={view === 'table'}
-                className="h-8 w-8 rounded-full p-0"
-                onClick={() => setView('table')}
-                size="sm"
-                type="button"
-                variant={view === 'table' ? 'default' : 'ghost'}
-              >
-                <List aria-hidden="true" className="size-4" />
-              </Button>
-            </div>
-          </FilterField>
-        </CardContent>
-      </Card>
+        <FilterField label="Equipment">
+          <select
+            aria-label="Filter by equipment"
+            className="min-h-[44px] w-full cursor-pointer rounded-md border border-input bg-background px-3 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            onChange={(event) =>
+              updateSearchParams(searchParams, setSearchParams, {
+                equipment: event.target.value,
+              })
+            }
+            value={equipment}
+          >
+            <option value="all">All equipment</option>
+            {equipmentOptions.map((option) => (
+              <option key={option} value={option}>
+                {formatLabel(option)}
+              </option>
+            ))}
+          </select>
+        </FilterField>
 
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <FilterField label="Category">
+          <select
+            aria-label="Filter by category"
+            className="min-h-[44px] w-full cursor-pointer rounded-md border border-input bg-background px-3 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            onChange={(event) =>
+              updateSearchParams(searchParams, setSearchParams, {
+                category: event.target.value,
+              })
+            }
+            value={category}
+          >
+            <option value="all">All categories</option>
+            {categoryOptions.map((option) => (
+              <option key={option} value={option}>
+                {formatLabel(option)}
+              </option>
+            ))}
+          </select>
+        </FilterField>
+      </FilterBar>
+
+      <div className="flex flex-col gap-3">
         <p className="text-sm text-muted">
           {exercisesQuery.isFetching && !exercisesQuery.isPending
             ? 'Updating results...'
             : `${totalResults} exercise${totalResults === 1 ? '' : 's'} shown`}
         </p>
-
-        <div className="flex items-center gap-2">
-          <PerPageSelector
-            ariaLabel="Exercises per page"
-            onChange={(value) =>
-              updateSearchParams(searchParams, setSearchParams, { limit: String(value) })
-            }
-            value={limit}
-          />
-          <Button
-            disabled={page <= 1 || exercisesQuery.isFetching}
-            onClick={() =>
-              updateSearchParams(searchParams, setSearchParams, { page: String(page - 1) }, false)
-            }
-            size="sm"
-            type="button"
-            variant="outline"
-          >
-            Previous
-          </Button>
-          <span className="text-sm text-muted">{`Page ${page} of ${totalPages}`}</span>
-          <Button
-            disabled={page >= totalPages || exercisesQuery.isFetching}
-            onClick={() =>
-              updateSearchParams(searchParams, setSearchParams, { page: String(page + 1) }, false)
-            }
-            size="sm"
-            type="button"
-            variant="outline"
-          >
-            Next
-          </Button>
-        </div>
       </div>
 
       {exercisesQuery.isPending ? (
@@ -317,7 +347,13 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
           </CardContent>
         </Card>
       ) : view === 'table' ? (
-        <ExerciseTable exercises={filteredExercises} onSelectTrend={setSelectedExerciseId} />
+        <DataTable
+          columns={visibleTableColumns}
+          data={filteredExercises}
+          onRowClick={(exercise) => setSelectedExerciseId(exercise.id)}
+          onSort={handleTableSort}
+          tableAriaLabel="Exercise library table view"
+        />
       ) : (
         <div className="grid gap-4 xl:grid-cols-2">
           {filteredExercises.map((exercise) => (
@@ -330,6 +366,21 @@ export function ExerciseLibrary({ className }: ExerciseLibraryProps) {
           ))}
         </div>
       )}
+
+      <PaginationBar
+        isLoading={exercisesQuery.isFetching}
+        onPageChange={(nextPage) =>
+          updateSearchParams(searchParams, setSearchParams, { page: String(nextPage) }, false)
+        }
+        onPerPageChange={(value) =>
+          updateSearchParams(searchParams, setSearchParams, { limit: String(value) })
+        }
+        page={page}
+        perPage={limit}
+        perPageAriaLabel="Exercises per page"
+        total={totalResults}
+        totalPages={totalPages}
+      />
 
       <RenameExerciseDialog
         key={renameTarget ? `${renameTarget.id}-open` : 'rename-library-closed'}
@@ -463,95 +514,24 @@ function ExerciseCard({
   );
 }
 
-function ExerciseTable({
-  exercises,
-  onSelectTrend,
-}: {
-  exercises: Exercise[];
-  onSelectTrend: (exerciseId: string) => void;
-}) {
-  return (
-    <Card className="gap-0 py-0">
-      <div className="overflow-x-auto">
-        <table aria-label="Exercise library table view" className="min-w-full text-left text-sm">
-          <thead>
-            <tr className="border-b border-border text-muted">
-              <th className="px-4 py-3 font-medium">Name</th>
-              <th className="px-4 py-3 font-medium">Category</th>
-              <th className="px-4 py-3 font-medium">Muscle Group</th>
-              <th className="px-4 py-3 font-medium">Equipment</th>
-              <th className="px-4 py-3 font-medium">Tracking Type</th>
-            </tr>
-          </thead>
-          <tbody>
-            {exercises.map((exercise) => (
-              <tr
-                className="border-b border-border/70 transition-colors hover:bg-secondary/35 focus-within:bg-secondary/35"
-                key={exercise.id}
-              >
-                <td className="px-4 py-3 font-medium text-foreground">
-                  <button
-                    className="cursor-pointer text-left underline-offset-4 transition hover:text-primary hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    onClick={() => onSelectTrend(exercise.id)}
-                    type="button"
-                  >
-                    {exercise.name}
-                  </button>
-                </td>
-                <td className="px-4 py-3 text-muted">{formatLabel(exercise.category)}</td>
-                <td className="px-4 py-3 text-muted">
-                  {exercise.muscleGroups.map((group) => formatLabel(group)).join(', ')}
-                </td>
-                <td className="px-4 py-3 text-muted">{formatLabel(exercise.equipment)}</td>
-                <td className="px-4 py-3 text-muted">{formatLabel(exercise.trackingType)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </Card>
-  );
-}
-
-function ExerciseLibrarySkeleton({ view }: { view: ExerciseLibraryView }) {
+function ExerciseLibrarySkeleton({ view }: { view: ViewToggleMode }) {
   if (view === 'table') {
     return (
-      <Card aria-label="Loading exercises table view" className="gap-0 py-0">
-        <div className="overflow-x-auto">
-          <table className="min-w-full text-left text-sm">
-            <thead>
-              <tr className="border-b border-border text-muted">
-                <th className="px-4 py-3 font-medium">Name</th>
-                <th className="px-4 py-3 font-medium">Category</th>
-                <th className="px-4 py-3 font-medium">Muscle Group</th>
-                <th className="px-4 py-3 font-medium">Equipment</th>
-                <th className="px-4 py-3 font-medium">Tracking Type</th>
-              </tr>
-            </thead>
-            <tbody>
-              {Array.from({ length: 6 }).map((_, index) => (
-                <tr className="border-b border-border/70" key={index}>
-                  <td className="px-4 py-3">
-                    <div className="h-4 w-40 animate-pulse rounded-full bg-secondary" />
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="h-4 w-24 animate-pulse rounded-full bg-secondary" />
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="h-4 w-32 animate-pulse rounded-full bg-secondary" />
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="h-4 w-24 animate-pulse rounded-full bg-secondary" />
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="h-4 w-28 animate-pulse rounded-full bg-secondary" />
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </Card>
+      <div aria-label="Loading exercises table view">
+        <DataTable
+          columns={[
+            { key: 'name', header: 'Name', accessor: () => null },
+            { key: 'category', header: 'Category', accessor: () => null },
+            { key: 'equipment', header: 'Equipment', accessor: () => null },
+            { key: 'muscleGroups', header: 'Muscle Groups', accessor: () => null },
+            { key: 'trackingType', header: 'Tracking Type', accessor: () => null },
+            { key: 'custom', header: 'Custom', accessor: () => null },
+          ]}
+          data={[]}
+          isLoading
+          tableAriaLabel="Exercise library table view"
+        />
+      </div>
     );
   }
 
@@ -640,16 +620,6 @@ function isExerciseSort(value: string): value is ExerciseSort {
 
 function parseExerciseSort(value: string | null): ExerciseSort {
   return value !== null && isExerciseSort(value) ? value : 'name-asc';
-}
-
-function loadExerciseLibraryViewPreference(): ExerciseLibraryView {
-  const storedValue = window.localStorage.getItem(EXERCISE_LIBRARY_VIEW_STORAGE_KEY);
-
-  if (storedValue === 'table') {
-    return 'table';
-  }
-
-  return 'card';
 }
 
 function formatLabel(value: string) {

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -130,6 +130,114 @@ describe('SessionDetail', () => {
     expect(screen.getByText('Bench at setting 5; keep elbows tucked.')).toBeInTheDocument();
   });
 
+  it('renders deleted exercise placeholders for sets with null exerciseId', async () => {
+    const currentSession = createSession({
+      id: 'session-null-exercise',
+      templateId: 'template-upper-push',
+      sets: [
+        createSet({
+          id: 'set-deleted-1',
+          exerciseId: null,
+          setNumber: 1,
+          reps: 12,
+          weight: 95,
+          section: 'main',
+        }),
+      ],
+      exercises: [
+        {
+          exerciseId: null,
+          exerciseName: 'Deleted exercise',
+          deletedAt: null,
+          supersetGroup: null,
+          trackingType: null,
+          orderIndex: 0,
+          section: 'main',
+          sets: [
+            createSet({
+              id: 'set-deleted-1',
+              exerciseId: null,
+              setNumber: 1,
+              reps: 12,
+              weight: 95,
+              section: 'main',
+            }),
+          ],
+        },
+      ],
+    });
+
+    mockSessionDetailRequests({
+      sessionId: currentSession.id,
+      session: currentSession,
+      sessions: [
+        createSessionListItem({
+          id: currentSession.id,
+          templateId: currentSession.templateId,
+          templateName: 'Upper Push',
+          startedAt: currentSession.startedAt,
+        }),
+      ],
+    });
+
+    renderSessionDetail(currentSession.id);
+
+    expect(await screen.findByText('Deleted exercise')).toBeInTheDocument();
+    expect(screen.getByText(/Set 1: 95 lbs × 12 reps/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open Deleted exercise history' })).toBeDisabled();
+  });
+
+  it('shows an Archived badge for soft-deleted exercises in historical session views', async () => {
+    const archivedSet = createSet({
+      id: 'set-archived-1',
+      exerciseId: 'incline-dumbbell-press',
+      setNumber: 1,
+      reps: 8,
+      weight: 60,
+      section: 'main',
+    });
+    const currentSession = createSession({
+      id: 'session-archived-exercise',
+      templateId: 'template-upper-push',
+      sets: [archivedSet],
+      exercises: [
+        {
+          exerciseId: 'incline-dumbbell-press',
+          exerciseName: 'Incline Dumbbell Press',
+          deletedAt: '2026-03-10T00:00:00.000Z',
+          supersetGroup: null,
+          trackingType: 'weight_reps',
+          orderIndex: 0,
+          section: 'main',
+          sets: [archivedSet],
+          exercise: {
+            formCues: [],
+            coachingNotes: null,
+            instructions: null,
+          },
+        },
+      ],
+    });
+
+    mockSessionDetailRequests({
+      sessionId: currentSession.id,
+      session: currentSession,
+      sessions: [
+        createSessionListItem({
+          id: currentSession.id,
+          templateId: currentSession.templateId,
+          templateName: 'Upper Push',
+          startedAt: currentSession.startedAt,
+        }),
+      ],
+    });
+
+    renderSessionDetail(currentSession.id);
+
+    expect(await screen.findByText('Incline Dumbbell Press')).toBeInTheDocument();
+    expect(screen.getByText('Archived')).toBeInTheDocument();
+  });
+
   it('formats receipt duration from seconds', async () => {
     const currentSession = createSession({
       id: 'session-duration-format',

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -68,9 +68,11 @@ type SessionDetailProps = {
 type SessionDetailSectionType = WorkoutTemplateSectionType;
 
 type SessionDetailExercise = {
-  exerciseId: string;
+  exerciseId: string | null;
+  groupKey: string;
   name: string;
   notes: string | null;
+  archived: boolean;
   phaseBadge: 'moderate' | 'rebuild' | 'recovery' | 'test';
   sets: SessionSet[];
   supersetGroup: string | null;
@@ -99,6 +101,7 @@ type SessionSetEditorField = {
 };
 
 type SessionMetricLabel = TrackingSummaryMetricLabel | 'mixed';
+type WorkoutSessionExerciseRecord = NonNullable<WorkoutSession['exercises']>[number];
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   weekday: 'long',
@@ -206,7 +209,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
   const sections = buildSections(session, template);
   const selectedExercise = sections
     .flatMap((section) => section.exercises)
-    .find((exercise) => exercise.exerciseId === selectedExerciseId);
+    .find((exercise) => exercise.exerciseId === selectedExerciseId && exercise.exerciseId !== null);
 
   const startEditing = () => {
     setSetDrafts(buildSessionSetDrafts(session.sets));
@@ -471,21 +474,26 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
                     isEditing &&
                       'border-[color-mix(in_srgb,var(--color-accent-mint)_55%,transparent)] bg-[color-mix(in_srgb,var(--color-accent-mint)_10%,transparent)]',
                   )}
-                  key={`${section.type}-${exercise.exerciseId}`}
+                  key={`${section.type}-${exercise.groupKey}`}
                 >
                   <CardHeader className="gap-2.5 py-3">
                     <div className="flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between">
                       <div className="space-y-2">
                         <div className="flex flex-wrap items-center gap-2">
                           <CardTitle>
-                            <button
-                              className="cursor-pointer text-left underline-offset-4 transition hover:text-primary hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                              onClick={() => setSelectedExerciseId(exercise.exerciseId)}
-                              type="button"
-                            >
-                              {exercise.name}
-                            </button>
+                            {exercise.exerciseId ? (
+                              <button
+                                className="cursor-pointer text-left underline-offset-4 transition hover:text-primary hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                onClick={() => setSelectedExerciseId(exercise.exerciseId)}
+                                type="button"
+                              >
+                                {exercise.name}
+                              </button>
+                            ) : (
+                              <span className="text-muted">{exercise.name}</span>
+                            )}
                           </CardTitle>
+                          {exercise.archived ? <Badge variant="outline">Archived</Badge> : null}
                           <Badge
                             className={cn(
                               'border-transparent',
@@ -509,6 +517,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
                       <Button
                         aria-label={`Open ${exercise.name} history`}
                         className="h-9 self-start px-3 text-xs"
+                        disabled={!exercise.exerciseId}
                         onClick={() => setSelectedExerciseId(exercise.exerciseId)}
                         type="button"
                         variant="outline"
@@ -545,7 +554,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
                       </div>
                     )}
 
-                    {showComparison ? (
+                    {showComparison && exercise.exerciseId ? (
                       <SessionExerciseComparison
                         currentSession={session}
                         exerciseId={exercise.exerciseId}
@@ -641,7 +650,7 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
         </Button>
       ) : null}
 
-      {selectedExercise ? (
+      {selectedExercise && selectedExercise.exerciseId ? (
         <ExerciseDetailModal
           context="receipt"
           exerciseId={selectedExercise.exerciseId}
@@ -890,15 +899,38 @@ function buildSections(
   session: WorkoutSession,
   template?: WorkoutTemplate,
 ): SessionDetailSection[] {
+  const buildDeletedSetGroupKey = (set: SessionSet) =>
+    `deleted-${set.section ?? 'supplemental'}-${set.orderIndex ?? 0}`;
   const templateSectionByExerciseId = new Map<string, WorkoutTemplateSectionType>();
   const templateExerciseNameById = new Map<string, string>();
   const templateSupersetGroupByExerciseId = new Map<string, string | null>();
   const templateTrackingTypeById = new Map<string, ExerciseTrackingType>();
+  const sessionExerciseMetaById = new Map(
+    (session.exercises ?? [])
+      .filter((exercise): exercise is WorkoutSessionExerciseRecord & { exerciseId: string } =>
+        typeof exercise.exerciseId === 'string',
+      )
+      .map((exercise) => [
+        exercise.exerciseId,
+        {
+          deletedAt: exercise.deletedAt ?? null,
+          exerciseName: exercise.exerciseName,
+          supersetGroup: exercise.supersetGroup ?? null,
+          trackingType: exercise.trackingType ?? null,
+        },
+      ]),
+  );
   const sessionTrackingTypeById = new Map(
-    (session.exercises ?? []).map((exercise) => [exercise.exerciseId, exercise.trackingType]),
+    [...sessionExerciseMetaById.entries()].map(([exerciseId, meta]) => [
+      exerciseId,
+      meta.trackingType,
+    ]),
   );
   const sessionSupersetGroupByExerciseId = new Map(
-    (session.exercises ?? []).map((exercise) => [exercise.exerciseId, exercise.supersetGroup]),
+    [...sessionExerciseMetaById.entries()].map(([exerciseId, meta]) => [
+      exerciseId,
+      meta.supersetGroup,
+    ]),
   );
 
   template?.sections.forEach((section) => {
@@ -912,7 +944,10 @@ function buildSections(
     });
   });
 
-  const sectionBuckets = new Map<SessionDetailSectionType, Map<string, SessionSet[]>>([
+  const sectionBuckets = new Map<
+    SessionDetailSectionType,
+    Map<string, { exerciseId: string | null; sets: SessionSet[] }>
+  >([
     ['warmup', new Map()],
     ['main', new Map()],
     ['cooldown', new Map()],
@@ -923,35 +958,62 @@ function buildSections(
   );
 
   for (const set of sortedSets) {
-    const derivedSection =
-      set.section ?? templateSectionByExerciseId.get(set.exerciseId) ?? 'supplemental';
-    const sectionMap = sectionBuckets.get(derivedSection) ?? new Map<string, SessionSet[]>();
-    const exerciseSets = sectionMap.get(set.exerciseId) ?? [];
+    const templateSection =
+      typeof set.exerciseId === 'string' ? templateSectionByExerciseId.get(set.exerciseId) : undefined;
+    const derivedSection = set.section ?? templateSection ?? 'supplemental';
+    const sectionMap =
+      sectionBuckets.get(derivedSection) ??
+      new Map<string, { exerciseId: string | null; sets: SessionSet[] }>();
+    const groupKey = set.exerciseId ?? buildDeletedSetGroupKey(set);
+    const grouped = sectionMap.get(groupKey) ?? {
+      exerciseId: set.exerciseId,
+      sets: [],
+    };
 
-    exerciseSets.push(set);
-    sectionMap.set(set.exerciseId, exerciseSets);
+    grouped.sets.push(set);
+    sectionMap.set(groupKey, grouped);
     sectionBuckets.set(derivedSection, sectionMap);
   }
 
   return (['warmup', 'main', 'cooldown', 'supplemental'] as const)
     .map((sectionType) => {
-      const groupedExercises = sectionBuckets.get(sectionType) ?? new Map<string, SessionSet[]>();
-      const exercises = [...groupedExercises.entries()].map(([exerciseId, sets]) => {
-        const name = templateExerciseNameById.get(exerciseId) ?? formatLabel(exerciseId);
+      const groupedExercises =
+        sectionBuckets.get(sectionType) ??
+        new Map<string, { exerciseId: string | null; sets: SessionSet[] }>();
+      const exercises = [...groupedExercises.entries()].map(([groupKey, grouped]) => {
+        const { exerciseId, sets } = grouped;
+        const sessionExerciseMeta =
+          typeof exerciseId === 'string' ? sessionExerciseMetaById.get(exerciseId) : undefined;
+        const name =
+          exerciseId === null
+            ? 'Deleted exercise'
+            : sessionExerciseMeta?.exerciseName ??
+              templateExerciseNameById.get(exerciseId) ??
+              formatLabel(exerciseId);
         return {
+          groupKey,
           exerciseId,
           name,
+          archived: Boolean(sessionExerciseMeta?.deletedAt),
           notes: sets.find((set) => set.notes)?.notes ?? null,
           phaseBadge: inferPhaseBadge(sectionType),
           sets: [...sets].sort((left, right) => left.setNumber - right.setNumber),
           supersetGroup:
-            sessionSupersetGroupByExerciseId.get(exerciseId) ??
-            templateSupersetGroupByExerciseId.get(exerciseId) ??
+            (typeof exerciseId === 'string'
+              ? sessionSupersetGroupByExerciseId.get(exerciseId)
+              : undefined) ??
+            (typeof exerciseId === 'string'
+              ? templateSupersetGroupByExerciseId.get(exerciseId)
+              : undefined) ??
             null,
           trackingType: resolveTrackingType({
             trackingType:
-              sessionTrackingTypeById.get(exerciseId) ??
-              templateTrackingTypeById.get(exerciseId) ??
+              (typeof exerciseId === 'string'
+                ? sessionTrackingTypeById.get(exerciseId)
+                : undefined) ??
+              (typeof exerciseId === 'string'
+                ? templateTrackingTypeById.get(exerciseId)
+                : undefined) ??
               undefined,
             exerciseId,
             exerciseName: name,
@@ -982,9 +1044,13 @@ function buildSectionSubtitle(sectionType: SessionDetailSectionType, count: numb
 }
 
 function getSessionSummary(session: WorkoutSession, template: WorkoutTemplate | null) {
-  const exerciseIds = new Set<string>();
+  const exerciseIds = new Set<string | null>();
   const sessionTrackingTypeById = new Map(
-    (session.exercises ?? []).map((exercise) => [exercise.exerciseId, exercise.trackingType]),
+    (session.exercises ?? [])
+      .filter((exercise): exercise is WorkoutSessionExerciseRecord & { exerciseId: string } =>
+        typeof exercise.exerciseId === 'string',
+      )
+      .map((exercise) => [exercise.exerciseId, exercise.trackingType]),
   );
   const templateTrackingTypeById = new Map<string, ExerciseTrackingType>();
   template?.sections.forEach((section) => {
@@ -1003,8 +1069,12 @@ function getSessionSummary(session: WorkoutSession, template: WorkoutTemplate | 
       summary.totalExercises = exerciseIds.size;
       const trackingType = resolveTrackingType({
         trackingType:
-          sessionTrackingTypeById.get(set.exerciseId) ??
-          templateTrackingTypeById.get(set.exerciseId) ??
+          (typeof set.exerciseId === 'string'
+            ? sessionTrackingTypeById.get(set.exerciseId)
+            : undefined) ??
+          (typeof set.exerciseId === 'string'
+            ? templateTrackingTypeById.get(set.exerciseId)
+            : undefined) ??
           undefined,
         exerciseId: set.exerciseId,
       });

--- a/apps/web/src/features/workouts/lib/session-notes.ts
+++ b/apps/web/src/features/workouts/lib/session-notes.ts
@@ -20,8 +20,10 @@ type TemplateExerciseLookup = Map<
 export function extractExerciseNotes(sessionSets: SessionSet[]) {
   const exerciseNotes: Record<string, string> = {};
   const sortedSessionSets = [...sessionSets].sort((left, right) => {
-    if (left.exerciseId !== right.exerciseId) {
-      return left.exerciseId.localeCompare(right.exerciseId);
+    const leftExerciseId = left.exerciseId ?? '';
+    const rightExerciseId = right.exerciseId ?? '';
+    if (leftExerciseId !== rightExerciseId) {
+      return leftExerciseId.localeCompare(rightExerciseId);
     }
 
     if (left.setNumber !== right.setNumber) {
@@ -32,6 +34,10 @@ export function extractExerciseNotes(sessionSets: SessionSet[]) {
   });
 
   for (const set of sortedSessionSets) {
+    if (!set.exerciseId) {
+      continue;
+    }
+
     const normalizedNotes = normalizeExerciseNote(set.notes);
     if (!normalizedNotes || exerciseNotes[set.exerciseId]) {
       continue;

--- a/apps/web/src/hooks/use-session-sets.ts
+++ b/apps/web/src/hooks/use-session-sets.ts
@@ -50,7 +50,7 @@ async function patchSessionSet(sessionId: string, setId: string, input: UpdateSe
 }
 
 const compareSessionSets = (left: SessionSet, right: SessionSet) =>
-  left.exerciseId.localeCompare(right.exerciseId) ||
+  (left.exerciseId ?? '').localeCompare(right.exerciseId ?? '') ||
   left.setNumber - right.setNumber ||
   left.createdAt - right.createdAt ||
   left.id.localeCompare(right.id);

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -328,7 +328,11 @@ export function ActiveWorkoutPage() {
       setExerciseOrderBySection(serverExerciseOrder);
       setExerciseNotes((current) => {
         const nextNotes: Record<string, string> = {};
-        const activeExerciseIds = new Set(activeSession.sets.map((set) => set.exerciseId));
+        const activeExerciseIds = new Set(
+          activeSession.sets
+            .map((set) => set.exerciseId)
+            .filter((exerciseId): exerciseId is string => typeof exerciseId === 'string'),
+        );
 
         for (const exerciseId of activeExerciseIds) {
           const currentNote = current[exerciseId];
@@ -1720,6 +1724,10 @@ function createSessionSetDrafts(
   const drafts = createInitialWorkoutSetDrafts(template, new Set<string>());
 
   for (const sessionSet of sessionSets) {
+    if (!sessionSet.exerciseId) {
+      continue;
+    }
+
     const trackingType =
       templateExerciseById.get(sessionSet.exerciseId)?.trackingType ?? 'weight_reps';
     const isTimeBased = isTimeBasedTrackingType(trackingType);
@@ -1816,7 +1824,7 @@ function buildSessionStructureSignature(session: ApiWorkoutSession) {
     }
 
     if (left.exerciseId !== right.exerciseId) {
-      return left.exerciseId.localeCompare(right.exerciseId);
+      return (left.exerciseId ?? '').localeCompare(right.exerciseId ?? '');
     }
 
     return left.setNumber - right.setNumber;
@@ -1824,7 +1832,8 @@ function buildSessionStructureSignature(session: ApiWorkoutSession) {
 
   return sortedSets
     .map(
-      (set) => `${set.section ?? 'main'}:${set.exerciseId}:${set.orderIndex ?? 0}:${set.setNumber}`,
+      (set) =>
+        `${set.section ?? 'main'}:${set.exerciseId ?? 'deleted-exercise'}:${set.orderIndex ?? 0}:${set.setNumber}`,
     )
     .join('|');
 }
@@ -1868,13 +1877,17 @@ function buildExerciseOrderFromSessionSets(
     }
 
     if (left.exerciseId !== right.exerciseId) {
-      return left.exerciseId.localeCompare(right.exerciseId);
+      return (left.exerciseId ?? '').localeCompare(right.exerciseId ?? '');
     }
 
     return left.setNumber - right.setNumber;
   });
 
   for (const set of sortedSets) {
+    if (!set.exerciseId) {
+      continue;
+    }
+
     if (
       set.section !== 'warmup' &&
       set.section !== 'main' &&
@@ -2406,6 +2419,10 @@ function buildTemplateFromSession(
   >(sectionOrder.map((type) => [type, { type, title: sectionTitleByType[type], exercises: [] }]));
 
   for (const sessionExercise of sessionExercises) {
+    if (!sessionExercise.exerciseId) {
+      continue;
+    }
+
     const sectionType = sessionExercise.section ?? 'main';
     const targetSection = sectionsByType.get(sectionType);
     if (!targetSection) {
@@ -2465,10 +2482,9 @@ function buildTemplateFromSession(
 
 function buildSessionExercisesFromSets(session: ApiWorkoutSession) {
   const namesById = new Map(
-    session.sets.map((set) => [
-      set.exerciseId,
-      startCase(set.exerciseId),
-    ]),
+    session.sets
+      .filter((set): set is SessionSet & { exerciseId: string } => typeof set.exerciseId === 'string')
+      .map((set) => [set.exerciseId, startCase(set.exerciseId)]),
   );
   const grouped = new Map<
     string,
@@ -2484,6 +2500,10 @@ function buildSessionExercisesFromSets(session: ApiWorkoutSession) {
   >();
 
   for (const set of session.sets) {
+    if (!set.exerciseId) {
+      continue;
+    }
+
     const existing = grouped.get(set.exerciseId);
     if (existing) {
       existing.orderIndex = Math.min(existing.orderIndex, set.orderIndex ?? 0);

--- a/apps/web/src/pages/equipment.test.tsx
+++ b/apps/web/src/pages/equipment.test.tsx
@@ -44,7 +44,7 @@ describe('EquipmentRoutePage', () => {
 
     expect(screen.getByRole('heading', { name: 'Equipment' })).toBeInTheDocument();
     expect(screen.getByText(PREVIEW_BANNER_DEFAULT_MESSAGE)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
     expect(screen.getByText('2 locations, 32 total items')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Add Location' })).toBeInTheDocument();
     expect(getLocationCard('Home Gym').toggle).toHaveAttribute('aria-expanded', 'false');

--- a/apps/web/src/pages/injury-detail.tsx
+++ b/apps/web/src/pages/injury-detail.tsx
@@ -13,7 +13,6 @@ export function InjuryDetailPage() {
       <section className="mx-auto flex w-full max-w-3xl flex-col gap-6 pb-10">
         <PageHeader
           description="The requested condition ID is not present in the mock injuries dataset."
-          showBack
           title="Condition not found"
         />
 

--- a/apps/web/src/pages/journal-entry.test.tsx
+++ b/apps/web/src/pages/journal-entry.test.tsx
@@ -22,7 +22,7 @@ describe('JournalEntryPage', () => {
     renderWithRoute('missing-entry');
 
     expect(screen.getByRole('heading', { name: 'Journal entry not found' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
   });
 
   it('renders full entry content and linked entities for a valid entry', () => {
@@ -41,7 +41,7 @@ describe('JournalEntryPage', () => {
     expect(screen.getByRole('heading', { level: 3, name: 'Wins' })).toBeInTheDocument();
     expect(screen.getByText(/Session focus:/)).toBeInTheDocument();
     expect(screen.getByText('Linked To')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Upper Push' })).toHaveAttribute(
       'href',
       '/workouts/template/upper-push',

--- a/apps/web/src/pages/journal-entry.tsx
+++ b/apps/web/src/pages/journal-entry.tsx
@@ -13,13 +13,14 @@ export function JournalEntryPage() {
       <section className="space-y-4">
         <PageHeader
           description="The requested journal entry is not available in the current prototype data."
-          showBack
           title="Journal entry not found"
         />
         <Card>
           <CardHeader className="space-y-2">
             <h2 className="text-2xl font-semibold text-foreground">Entry unavailable</h2>
-            <p className="text-sm text-muted">Return to the journal feed and select another entry.</p>
+            <p className="text-sm text-muted">
+              Return to the journal feed and select another entry.
+            </p>
           </CardHeader>
         </Card>
       </section>

--- a/apps/web/src/pages/scheduled-workout-detail.tsx
+++ b/apps/web/src/pages/scheduled-workout-detail.tsx
@@ -7,7 +7,7 @@ export function ScheduledWorkoutDetailPage() {
 
   return (
     <section className="space-y-4">
-      <PageHeader backFallbackHref="/workouts?view=schedule" showBack title="Scheduled Workout" />
+      <PageHeader title="Scheduled Workout" />
       <ScheduledWorkoutDetail id={id} />
     </section>
   );

--- a/apps/web/src/pages/settings.tsx
+++ b/apps/web/src/pages/settings.tsx
@@ -490,7 +490,6 @@ export function SettingsPage() {
     <section className="mx-auto flex w-full max-w-6xl flex-col gap-5 pb-8">
       <PageHeader
         description="Manage the profile and appearance details that shape the Pulse experience across devices."
-        showBack
         title="Settings"
       />
 

--- a/apps/web/src/pages/weight-history.test.tsx
+++ b/apps/web/src/pages/weight-history.test.tsx
@@ -128,7 +128,7 @@ describe('WeightHistoryPage', () => {
     renderPage();
 
     expect(await screen.findByRole('heading', { name: 'Weight History' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
     expect(screen.getByRole('img', { name: 'Weight history trend chart' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '30D' })).toHaveAttribute('aria-pressed', 'true');
 

--- a/apps/web/src/pages/weight-history.tsx
+++ b/apps/web/src/pages/weight-history.tsx
@@ -25,7 +25,6 @@ export function WeightHistoryPage() {
           </HelpIcon>
         }
         description="Review your full body weight log, inspect longer-term trends, add new entries, and clean up mistakes."
-        showBack
         title="Weight History"
       />
       <WeightHistory />

--- a/apps/web/src/pages/workout-session-detail.tsx
+++ b/apps/web/src/pages/workout-session-detail.tsx
@@ -8,7 +8,7 @@ export function WorkoutSessionDetailPage() {
 
   return (
     <section className="space-y-6">
-      <PageHeader backFallbackHref="/workouts?view=history" showBack title="Workout Session" />
+      <PageHeader title="Workout Session" />
       <SessionDetail sessionId={sessionId} />
     </section>
   );

--- a/apps/web/src/pages/workout-template-detail.tsx
+++ b/apps/web/src/pages/workout-template-detail.tsx
@@ -7,7 +7,7 @@ export function WorkoutTemplateDetailPage() {
 
   return (
     <section className="space-y-6">
-      <PageHeader backFallbackHref="/workouts?view=templates" showBack title="Workout Template" />
+      <PageHeader title="Workout Template" />
       <WorkoutTemplateDetail templateId={templateId} />
     </section>
   );

--- a/packages/shared/src/schemas/exercises.test.ts
+++ b/packages/shared/src/schemas/exercises.test.ts
@@ -268,20 +268,20 @@ describe('updateExerciseInputSchema', () => {
 });
 
 describe('mergeExerciseInputSchema', () => {
-  it('accepts non-empty loserId values', () => {
+  it('accepts UUID loserId values', () => {
     expect(
       mergeExerciseInputSchema.parse({
-        loserId: 'exercise-2',
+        loserId: '22222222-2222-4222-8222-222222222222',
       }),
     ).toEqual({
-      loserId: 'exercise-2',
+      loserId: '22222222-2222-4222-8222-222222222222',
     });
   });
 
-  it('rejects empty loserId values', () => {
+  it('rejects non-UUID loserId values', () => {
     expect(() =>
       mergeExerciseInputSchema.parse({
-        loserId: '',
+        loserId: 'exercise-2',
       }),
     ).toThrow();
   });

--- a/packages/shared/src/schemas/exercises.test.ts
+++ b/packages/shared/src/schemas/exercises.test.ts
@@ -8,6 +8,7 @@ import {
   exerciseLastPerformanceSchema,
   exerciseQueryParamsSchema,
   exerciseSchema,
+  mergeExerciseInputSchema,
   type CreateExerciseInput,
   type Exercise,
   type ExerciseHistoryWithRelated,
@@ -263,6 +264,26 @@ describe('updateExerciseInputSchema', () => {
     };
 
     expect(payload.equipment).toBe('cable');
+  });
+});
+
+describe('mergeExerciseInputSchema', () => {
+  it('accepts non-empty loserId values', () => {
+    expect(
+      mergeExerciseInputSchema.parse({
+        loserId: 'exercise-2',
+      }),
+    ).toEqual({
+      loserId: 'exercise-2',
+    });
+  });
+
+  it('rejects empty loserId values', () => {
+    expect(() =>
+      mergeExerciseInputSchema.parse({
+        loserId: '',
+      }),
+    ).toThrow();
   });
 });
 

--- a/packages/shared/src/schemas/exercises.ts
+++ b/packages/shared/src/schemas/exercises.ts
@@ -131,7 +131,7 @@ export const updateExerciseInputSchema = z
   });
 
 export const mergeExerciseInputSchema = z.object({
-  loserId: z.string().min(1),
+  loserId: z.string().uuid(),
 });
 
 export const exerciseQueryParamsSchema = z.object({

--- a/packages/shared/src/schemas/exercises.ts
+++ b/packages/shared/src/schemas/exercises.ts
@@ -130,6 +130,10 @@ export const updateExerciseInputSchema = z
     message: 'At least one exercise field must be provided',
   });
 
+export const mergeExerciseInputSchema = z.object({
+  loserId: z.string().min(1),
+});
+
 export const exerciseQueryParamsSchema = z.object({
   q: optionalStringSchema,
   muscleGroup: optionalStringSchema,
@@ -192,6 +196,7 @@ export type ExerciseTrackingType = z.infer<typeof exerciseTrackingTypeSchema>;
 export type Exercise = z.infer<typeof exerciseSchema>;
 export type CreateExerciseInput = z.infer<typeof createExerciseInputSchema>;
 export type UpdateExerciseInput = z.infer<typeof updateExerciseInputSchema>;
+export type MergeExerciseInput = z.infer<typeof mergeExerciseInputSchema>;
 export type ExerciseQueryParams = z.infer<typeof exerciseQueryParamsSchema>;
 export type ExerciseLastPerformanceQuery = z.infer<typeof exerciseLastPerformanceQuerySchema>;
 export type ExercisePerformanceHistoryQuery = z.infer<typeof exercisePerformanceHistoryQuerySchema>;

--- a/packages/shared/src/schemas/workout-sessions.test.ts
+++ b/packages/shared/src/schemas/workout-sessions.test.ts
@@ -189,6 +189,36 @@ describe('sessionSetInputSchema', () => {
 });
 
 describe('sessionSetSchema', () => {
+  it('accepts null exerciseId for historical sets from purged exercises', () => {
+    expect(
+      sessionSetSchema.parse({
+        id: 'set-null-exercise',
+        exerciseId: null,
+        orderIndex: 0,
+        setNumber: 1,
+        weight: 185,
+        reps: 8,
+        completed: false,
+        skipped: false,
+        section: 'main',
+        notes: null,
+        createdAt: 1_700_000_000_500,
+      }),
+    ).toEqual({
+      id: 'set-null-exercise',
+      exerciseId: null,
+      orderIndex: 0,
+      setNumber: 1,
+      weight: 185,
+      reps: 8,
+      completed: false,
+      skipped: false,
+      section: 'main',
+      notes: null,
+      createdAt: 1_700_000_000_500,
+    });
+  });
+
   it('rejects persisted target weight ranges where min exceeds max', () => {
     expect(() =>
       sessionSetSchema.parse({
@@ -273,6 +303,43 @@ describe('sessionCorrectionRequestSchema', () => {
 });
 
 describe('workoutSessionSchema', () => {
+  it('preserves deleted exercise metadata in historical session responses', () => {
+    const session = workoutSessionSchema.parse({
+      id: 'session-deleted-metadata',
+      userId: 'user-1',
+      templateId: null,
+      name: 'Push Day',
+      date: '2026-03-01',
+      status: 'completed',
+      startedAt: 1_700_000_000_000,
+      completedAt: 1_700_000_030_000,
+      duration: 1800,
+      timeSegments: [{ start: '2026-03-01T10:00:00.000Z', end: '2026-03-01T10:30:00.000Z' }],
+      feedback: null,
+      notes: null,
+      exercises: [
+        {
+          exerciseId: 'exercise-archived',
+          exerciseName: 'Barbell Row',
+          deletedAt: '2026-03-02T00:00:00.000Z',
+          trackingType: 'weight_reps',
+          supersetGroup: null,
+          orderIndex: 0,
+          section: 'main',
+          sets: [],
+        },
+      ],
+      sets: [],
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_030_000,
+    });
+
+    expect(session.exercises?.[0]).toMatchObject({
+      exerciseId: 'exercise-archived',
+      deletedAt: '2026-03-02T00:00:00.000Z',
+    });
+  });
+
   it('parses a persisted workout session with nested sets', () => {
     const session: WorkoutSession = workoutSessionSchema.parse({
       id: 'session-1',

--- a/packages/shared/src/schemas/workout-sessions.ts
+++ b/packages/shared/src/schemas/workout-sessions.ts
@@ -249,7 +249,7 @@ export const workoutSessionFeedbackSchema = z.object({
 export const sessionSetSchema = z
   .object({
     id: z.string(),
-    exerciseId: requiredStringSchema,
+    exerciseId: requiredStringSchema.nullable(),
     orderIndex: z.number().int().min(0).optional(),
     setNumber: z.number().int().min(1),
     weight: z.number().min(0).nullable(),
@@ -275,8 +275,9 @@ export const sessionSetSchema = z
   });
 
 export const workoutSessionExerciseSchema = z.object({
-  exerciseId: requiredStringSchema,
+  exerciseId: requiredStringSchema.nullable(),
   exerciseName: requiredStringSchema,
+  deletedAt: z.string().nullable().optional(),
   supersetGroup: nullableShortStringSchema.default(null),
   trackingType: exerciseTrackingTypeSchema.nullable().optional(),
   exercise: z


### PR DESCRIPTION
## Summary
This PR introduces a shared table-view UI foundation in web and applies it to both Foods and Exercise Library so catalog pages now support consistent card/table toggles, filters, column selection, and pagination behavior. It also expands exercise lifecycle handling in the API by adding `POST /api/v1/exercises/:winnerId/merge`, which reassigns workout/template references, resolves set-number collisions, and soft-deletes the merged (loser) exercise. To preserve workout history fidelity, `session_sets.exercise_id` is now nullable with `ON DELETE SET NULL`, and session APIs/frontend rendering were updated to correctly represent deleted or archived exercises instead of dropping those sets. Dashboard weight trend caching was corrected for the 1M range by switching to dedicated weight query keys, fixing the empty/zeroed chart issue. The PR also removes the custom `PageHeader` back button API and migrates consumers to the simplified header contract.

## Key Changes
- Added shared web UI primitives for catalog/table pages:
  - `DataTable`
  - `ViewToggle` (with localStorage persistence)
  - `FilterBar`
  - `ColumnPicker` (with localStorage persistence)
  - `PaginationBar`
- Refactored Foods list to support card/table modes using shared components, including table sorting, column visibility, pagination, and inline name editing in table mode.
- Refactored Exercise Library to use shared filter/table/view/pagination components and removed bespoke table/view implementations.
- Added exercise merge API flow:
  - New shared schema `mergeExerciseInputSchema`
  - New route `POST /api/v1/exercises/:winnerId/merge` (JWT-only; AgentToken rejected)
  - Store-level transactional merge logic for `session_sets` and `template_exercises`, with section-aware template conflict handling and set-number offsetting.
- Introduced DB migration making `session_sets.exercise_id` nullable and changing FK behavior to `ON DELETE SET NULL`.
- Updated workout session API/domain handling for nullable `exerciseId` and soft-deleted exercise metadata (`deletedAt`) so historical responses remain actionable.
- Updated frontend workout session/detail flows to show `Deleted exercise` placeholders and an `Archived` badge for soft-deleted exercises.
- Added trash purge safety for exercises with session history: purge now returns `409 EXERCISE_PURGE_REQUIRES_FORCE` unless `force=true`.
- Fixed dashboard weight trend query-key collision causing incorrect 1M chart state.
- Removed `showBack`/`backFallbackHref` from `PageHeader` and updated all affected page consumers/tests.

## Technical Notes
- The merge operation is transaction-scoped and intentionally remaps loser sets before reassignment to keep `setNumber` uniqueness valid within `(session_id, exercise_id, section, set_number)`.
- Nullable `exerciseId` required broad null-safe sorting/grouping updates across API and web; deleted-set groups are keyed by section/order fallback to avoid collapsing unrelated null-ID sets.
- Session detail APIs now include archived exercise metadata rather than filtering soft-deleted exercises out, which improves historical rendering but changes response expectations for consumers.
- Exercise purge semantics changed: historical session references are preserved by nulling FK links, and hard purge of exercises with history requires explicit `force=true`.
- Coverage was expanded across schema tests, route tests, and UI tests for merge behavior, null exercise IDs, archived badges/placeholders, and shared table interactions.

## Commits

- `dfa214f fix(api): return nullable exercise ids in set groups`
- `71f7684 fix(api): apply commit-17 review fixes`
- `03fdc01 feat(api): add exercise merge and null-safe session history`
- `201c0e3 fix(web): address commit-16 review feedback`
- `a2c1aa8 feat(web): add shared table views for foods and exercises`
- `41044aa fix(web): resolve shared table interaction review gaps`
- `b1ff971 feat(web): add shared catalog ui components`
- `d23fb3e fix(dashboard): prevent 1m weight trend cache collision`
- `af84886 chore(pr-4): verify review fixes and quality gates`
- `4ad5bbe fix(web): remove custom page header back button`

## Tasks

- **Remove custom back button from PageHeader**: Remove showBack/backFallbackHref props and back button from PageHeader + all ~13 consumers
- **Fix weight trend card empty on 1M view**: Investigate and fix why 1M range shows 0 lbs / empty chart; other ranges work
- **Build shared DataTable, ViewToggle, FilterBar, ColumnPicker, PaginationBar**: Create 5 reusable shared UI components for table views and catalog pages
- **Add table view to foods library**: Integrate shared table components into foods; card/table toggle with column picker
- **Refactor exercise library to use shared table components**: Replace exercise library custom table/filter with shared DataTable, FilterBar, ViewToggle
- **Migration: change exerciseId FK to SET NULL**: Make session_sets.exerciseId nullable with ON DELETE SET NULL; update schemas
- **Create exercise merge endpoint**: POST /exercises/:winnerId/merge — reassign sets/templates, handle conflicts, soft-delete loser
- **Handle null exerciseId and archived exercises in frontend**: Show 'Deleted exercise' for null exerciseId; add 'Archived' badge for soft-deleted exercises

## Diff Stats

```
apps/api/drizzle/0035_groovy_captain_cross.sql     |   33 +
 apps/api/drizzle/meta/0035_snapshot.json           | 3236 ++++++++++++++++++++
 apps/api/drizzle/meta/_journal.json                |    7 +
 apps/api/src/db/schema.test.ts                     |    3 +-
 apps/api/src/db/schema/workout-sessions.ts         |    3 +-
 apps/api/src/index.test.ts                         |    6 +
 apps/api/src/middleware/agent-enrichment.ts        |   14 +-
 apps/api/src/routes/exercises/index.test.ts        |  313 +-
 apps/api/src/routes/exercises/index.ts             |   81 +
 apps/api/src/routes/exercises/store.ts             |  199 ++
 apps/api/src/routes/trash/index.test.ts            |   88 +
 apps/api/src/routes/trash/index.ts                 |   80 +-
 apps/api/src/routes/workout-sessions/index.test.ts |  133 +-
 apps/api/src/routes/workout-sessions/index.ts      |   49 +-
 apps/api/src/routes/workout-sessions/store.ts      |   70 +-
 .../src/scripts/repair-workout-exercise-links.ts   |   37 +-
 .../web/src/components/layout/page-header.test.tsx |   35 +-
 apps/web/src/components/layout/page-header.tsx     |   28 -
 apps/web/src/components/ui/column-picker.test.tsx  |   44 +
 apps/web/src/components/ui/column-picker.tsx       |  146 +
 apps/web/src/components/ui/data-table.test.tsx     |   96 +
 apps/web/src/components/ui/data-table.tsx          |  136 +
 apps/web/src/components/ui/filter-bar.test.tsx     |   27 +
 apps/web/src/components/ui/filter-bar.tsx          |   40 +
 apps/web/src/components/ui/pagination-bar.test.tsx |   26 +
 apps/web/src/components/ui/pagination-bar.tsx      |   70 +
 apps/web/src/components/ui/view-toggle.test.tsx    |   36 +
 apps/web/src/components/ui/view-toggle.tsx         |   91 +
 .../components/weight-trend-chart.test.tsx         |   27 +-
 .../dashboard/components/weight-trend-chart.tsx    |   14 +-
 .../equipment/components/equipment-page.tsx        |    1 -
 .../features/foods/components/food-list.test.tsx   |  143 +
 .../src/features/foods/components/food-list.tsx    |  971 +++---
 .../injuries/components/condition-detail.tsx       |    1 -
 .../injuries/components/conditions-list.tsx        |    1 -
 .../journal/components/journal-entry-detail.tsx    |    2 +-
 .../resources/components/resource-detail.test.tsx  |    2 +-
 .../resources/components/resource-detail.tsx       |    1 -
 .../resources/components/resource-grid.test.tsx    |    2 +-
 .../resources/components/resource-grid.tsx         |    1 -
 .../workouts/components/exercise-library.test.tsx  |   22 +-
 .../workouts/components/exercise-library.tsx       |  458 ++-
 .../workouts/components/session-detail.test.tsx    |  108 +
 .../workouts/components/session-detail.tsx         |  134 +-
 .../web/src/features/workouts/lib/session-notes.ts |   10 +-
 apps/web/src/hooks/use-session-sets.ts             |    2 +-
 apps/web/src/pages/active-workout.tsx              |   36 +-
 apps/web/src/pages/equipment.test.tsx              |    2 +-
 apps/web/src/pages/injury-detail.tsx               |    1 -
 apps/web/src/pages/journal-entry.test.tsx          |    4 +-
 apps/web/src/pages/journal-entry.tsx               |    5 +-
 apps/web/src/pages/scheduled-workout-detail.tsx    |    2 +-
 apps/web/src/pages/settings.tsx                    |    1 -
 apps/web/src/pages/weight-history.test.tsx         |    2 +-
 apps/web/src/pages/weight-history.tsx              |    1 -
 apps/web/src/pages/workout-session-detail.tsx      |    2 +-
 apps/web/src/pages/workout-template-detail.tsx     |    2 +-
 packages/shared/src/schemas/exercises.test.ts      |   21 +
 packages/shared/src/schemas/exercises.ts           |    5 +
 .../shared/src/schemas/workout-sessions.test.ts    |   67 +
 packages/shared/src/schemas/workout-sessions.ts    |    5 +-
 61 files changed, 6368 insertions(+), 815 deletions(-)
```