### PR TITLE
fix(workouts): active-session UX bugs (swap, rest-timer, number-input wheel)

### DIFF
--- a/apps/web/src/components/ui/input.test.tsx
+++ b/apps/web/src/components/ui/input.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Input } from './input';
+
+describe('Input', () => {
+  it('keeps number input value unchanged when wheel fires while focused', () => {
+    render(<Input type="number" defaultValue={10} />);
+
+    const input = screen.getByRole('spinbutton');
+    input.focus();
+    expect(input).toHaveFocus();
+
+    fireEvent.wheel(input);
+
+    expect(input).toHaveValue(10);
+  });
+
+  it('does not change text input value or focus on wheel', () => {
+    render(<Input type="text" defaultValue="hello" />);
+
+    const input = screen.getByDisplayValue('hello');
+    input.focus();
+    expect(input).toHaveFocus();
+
+    fireEvent.wheel(input);
+
+    expect(input).toHaveValue('hello');
+    expect(input).toHaveFocus();
+  });
+
+  it('calls caller supplied onWheel for number inputs', () => {
+    const handleWheel = vi.fn();
+    render(<Input type="number" onWheel={handleWheel} defaultValue={10} />);
+
+    const input = screen.getByRole('spinbutton');
+    fireEvent.wheel(input);
+
+    expect(handleWheel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -2,7 +2,18 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+function Input({ className, onWheel, type, ...props }: React.ComponentProps<'input'>) {
+  const handleWheel = React.useCallback<React.WheelEventHandler<HTMLInputElement>>(
+    (event) => {
+      if (type === 'number') {
+        event.currentTarget.blur();
+      }
+
+      onWheel?.(event);
+    },
+    [onWheel, type],
+  );
+
   return (
     <input
       type={type}
@@ -13,6 +24,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
         'aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
         className,
       )}
+      onWheel={handleWheel}
       {...props}
     />
   );

--- a/apps/web/src/features/habits/components/daily-habits.test.tsx
+++ b/apps/web/src/features/habits/components/daily-habits.test.tsx
@@ -14,6 +14,7 @@ import {
   useUpdateHabitEntry,
 } from '@/features/habits/api/habits';
 import { DailyHabits } from '@/features/habits/components/daily-habits';
+import { addDays, getToday, toDateKey } from '@/lib/date';
 
 vi.mock('@/features/habits/api/habits', () => ({
   useCreateHabit: vi.fn(),
@@ -110,7 +111,7 @@ const habits: Habit[] = [
     frequency: 'daily',
     frequencyTarget: null,
     scheduledDays: null,
-    pausedUntil: '2026-04-01',
+    pausedUntil: toDateKey(addDays(getToday(), 7)),
     updatedAt: 3,
     userId: 'user-1',
   },

--- a/apps/web/src/features/habits/components/habit-card-menu.test.tsx
+++ b/apps/web/src/features/habits/components/habit-card-menu.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useDeleteHabit, useReorderHabits, useUpdateHabit } from '@/features/habits/api/habits';
 import { HabitCardMenu } from '@/features/habits/components/habit-card-menu';
 import { useDashboardConfig, useSaveDashboardConfig } from '@/hooks/use-dashboard-config';
+import { addDays, getToday, toDateKey } from '@/lib/date';
 
 vi.mock('@/components/ui/dropdown-menu', () => ({
   DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -163,7 +164,9 @@ describe('HabitCardMenu', () => {
       isLoading: false,
     } as unknown as ReturnType<typeof useDashboardConfig>);
     mockedUseSaveDashboardConfig.mockReturnValue(
-      createSaveDashboardConfigMutationMock() as unknown as ReturnType<typeof useSaveDashboardConfig>,
+      createSaveDashboardConfigMutationMock() as unknown as ReturnType<
+        typeof useSaveDashboardConfig
+      >,
     );
     mockedUseDeleteHabit.mockReturnValue(
       createMutationMock() as unknown as ReturnType<typeof useDeleteHabit>,
@@ -317,14 +320,15 @@ describe('HabitCardMenu', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Pause scheduling' }));
     expect(screen.getByRole('heading', { name: 'Pause scheduling' })).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText('Pause until'), { target: { value: '2026-03-25' } });
+    const futurePauseDate = toDateKey(addDays(getToday(), 14));
+    fireEvent.change(screen.getByLabelText('Pause until'), { target: { value: futurePauseDate } });
     fireEvent.click(screen.getByRole('button', { name: 'Save pause' }));
 
     await waitFor(() =>
       expect(updateMutation.mutateAsync).toHaveBeenCalledWith({
         id: 'sleep',
         values: {
-          pausedUntil: '2026-03-25',
+          pausedUntil: futurePauseDate,
         },
       }),
     );
@@ -377,7 +381,7 @@ describe('HabitCardMenu', () => {
   it('shows resume scheduling for paused habits and clears pausedUntil', async () => {
     const pausedHabit = {
       ...getHabitById('sleep'),
-      pausedUntil: '2026-03-25',
+      pausedUntil: toDateKey(addDays(getToday(), 14)),
     };
     const updateMutation = createMutationMock();
     mockedUseUpdateHabit.mockReturnValue(

--- a/apps/web/src/features/workouts/api/workouts.mutations.test.tsx
+++ b/apps/web/src/features/workouts/api/workouts.mutations.test.tsx
@@ -207,7 +207,7 @@ describe('workout mutation hooks', () => {
     expect(toast.success).toHaveBeenCalledWith('Exercise swapped');
   });
 
-  it('invalidates session detail and list caches when swapping a session exercise', async () => {
+  it('writes through and invalidates active-session caches when swapping a session exercise', async () => {
     mockFetch.mockResolvedValueOnce(
       createJsonResponse({
         id: 'session-1',
@@ -222,7 +222,57 @@ describe('workout mutation hooks', () => {
         timeSegments: [],
         feedback: null,
         notes: null,
-        sets: [],
+        exercises: [
+          {
+            id: 'session-exercise-1',
+            exerciseId: 'exercise-2',
+            exerciseName: 'Single-Arm Cable Press',
+            orderIndex: 0,
+            section: 'main',
+            notes: null,
+            supersetGroup: null,
+            sets: [
+              {
+                id: 'set-1',
+                exerciseId: 'exercise-2',
+                setNumber: 1,
+                orderIndex: 0,
+                weight: null,
+                reps: null,
+                targetWeight: null,
+                targetWeightMin: null,
+                targetWeightMax: null,
+                targetSeconds: null,
+                targetDistance: null,
+                completed: false,
+                skipped: false,
+                section: 'main',
+                notes: null,
+                createdAt: 1,
+              },
+            ],
+          },
+        ],
+        sets: [
+          {
+            id: 'set-1',
+            exerciseId: 'exercise-2',
+            setNumber: 1,
+            orderIndex: 0,
+            weight: null,
+            reps: null,
+            targetWeight: null,
+            targetWeightMin: null,
+            targetWeightMax: null,
+            targetSeconds: null,
+            targetDistance: null,
+            completed: false,
+            skipped: false,
+            section: 'main',
+            notes: null,
+            createdAt: 1,
+          },
+        ],
         createdAt: 1,
         updatedAt: 2,
       }),
@@ -232,16 +282,21 @@ describe('workout mutation hooks', () => {
     const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
     const { result } = renderHook(() => useSwapSessionExercise(), { wrapper });
 
-    await act(async () => {
-      await result.current.mutateAsync({
+    const response = await act(async () => {
+      return await result.current.mutateAsync({
         exerciseId: 'exercise-1',
         newExerciseId: 'exercise-2',
         sessionId: 'session-1',
       });
     });
 
+    expect(queryClient.getQueryData(['workout-sessions', 'session-1'])).toEqual(response.data);
+    expect(queryClient.getQueryData(workoutQueryKeys.session('session-1'))).toEqual(response.data);
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: workoutQueryKeys.sessions(),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['workout-sessions', 'session-1'],
     });
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: workoutQueryKeys.session('session-1'),

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -217,6 +217,7 @@ const normalizeWorkoutSessionParams = (params: WorkoutSessionQueryParams = {}) =
 
 const completedSessionsKey = () =>
   ['workouts', 'sessions', { from: null, limit: null, status: 'completed', to: null }] as const;
+const workoutSessionDetailKey = (sessionId: string) => ['workout-sessions', sessionId] as const;
 const exercisesKey = (params?: ExerciseQueryParams) =>
   params
     ? (['workouts', 'exercises', normalizeExerciseParams(params)] as const)
@@ -357,7 +358,9 @@ const isTemplateListQueryKey = (queryKey: QueryKey | undefined) =>
 
 // Empty paginated arrays are shape-ambiguous (exercise list vs template list). This remains safe because
 // callers of template cache updaters are already scoped by template query keys upstream.
-const isWorkoutTemplatesResponse = (value: RenameTemplateCache | undefined): value is WorkoutTemplatesResponse =>
+const isWorkoutTemplatesResponse = (
+  value: RenameTemplateCache | undefined,
+): value is WorkoutTemplatesResponse =>
   isPaginatedResponse(value) && value.data.every((entry) => isWorkoutTemplateRecord(entry));
 
 const isExerciseRecord = (value: unknown): value is Exercise =>
@@ -1067,10 +1070,14 @@ export function useRenameExercise() {
       workoutQueryKeys.sessionDetailPrefix(),
     ],
     reconcile: (current, exercise, variables, context) =>
-      updateExerciseNameInCache(current, {
-        id: variables.id,
-        name: exercise.name,
-      }, context.queryKey),
+      updateExerciseNameInCache(
+        current,
+        {
+          id: variables.id,
+          name: exercise.name,
+        },
+        context.queryKey,
+      ),
     updater: (current, variables, context) =>
       updateExerciseNameInCache(current, variables, context.queryKey),
   });
@@ -1241,10 +1248,16 @@ export function useSwapSessionExercise() {
 
   return useMutation<SwapSessionExerciseResponse, Error, SwapSessionExerciseRequest>({
     mutationFn: swapSessionExercise,
-    onSuccess: async (_, variables) => {
+    onSuccess: async (payload, variables) => {
+      queryClient.setQueryData(workoutSessionDetailKey(variables.sessionId), payload.data);
+      queryClient.setQueryData(workoutQueryKeys.session(variables.sessionId), payload.data);
+
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.sessions(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutSessionDetailKey(variables.sessionId),
         }),
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.session(variables.sessionId),

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -96,7 +96,7 @@ describe('ActiveWorkoutPage', () => {
     }
   });
 
-  it('renders the active workout UI and does not auto-focus a different section after rest timer completion', () => {
+  it('renders the active workout UI and does not auto-focus any set after rest timer completion', () => {
     renderActiveWorkoutPage();
 
     const heading = screen.getByRole('heading', { level: 1, name: 'Upper Push' });
@@ -148,8 +148,109 @@ describe('ActiveWorkoutPage', () => {
     expect(within(nextExerciseCard).getByLabelText('Seconds for set 1')).not.toHaveFocus();
     expect(screen.queryByText('After Incline Dumbbell Press set 3')).not.toBeInTheDocument();
 
+    completeSet('Row Erg', 1);
+    completeSet('Banded Shoulder External Rotation', 1);
+    completeSet('Banded Shoulder External Rotation', 2);
+
+    fireEvent.change(within(inclineCard).getByLabelText('Weight for set 1'), {
+      target: { value: '50' },
+    });
+    fireEvent.change(within(inclineCard).getByLabelText('Reps for set 1'), {
+      target: { value: '8' },
+    });
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    expect(screen.getByText('After Incline Dumbbell Press set 1')).toBeInTheDocument();
+
+    const seatedPressCard = getExerciseCard('Seated Dumbbell Shoulder Press');
+    const seatedPressSetOneInput = within(seatedPressCard).getByLabelText(
+      'Reps for set 1',
+    ) as HTMLInputElement;
+    seatedPressSetOneInput.focus();
+    expect(seatedPressSetOneInput).toHaveFocus();
+
+    act(() => {
+      vi.advanceTimersByTime(90_100);
+    });
+
+    expect(seatedPressSetOneInput).toHaveFocus();
+    expect(within(inclineCard).getByLabelText('Reps for set 2')).not.toHaveFocus();
+    expect(screen.queryByText('After Incline Dumbbell Press set 1')).not.toBeInTheDocument();
+
     const optionalCard = getExerciseCard('Rope Triceps Pushdown');
     expect(within(optionalCard).getByText('Optional')).toBeInTheDocument();
+  });
+
+  it('keeps focus unchanged when a superset rest timer expires', () => {
+    const templateId = 'superset-focus-template';
+    const baseTemplate = buildWorkoutTemplateResponse('upper-push');
+    if (!baseTemplate) {
+      throw new Error('Expected upper-push fixture template to exist.');
+    }
+    const supersetTemplate = {
+      ...baseTemplate,
+      id: templateId,
+      name: 'Superset Focus QA',
+      sections: baseTemplate.sections.map((section) =>
+        section.type !== 'main'
+          ? section
+          : {
+              ...section,
+              exercises: section.exercises.map((exercise, index) =>
+                index < 2
+                  ? {
+                      ...exercise,
+                      restSeconds: 1,
+                      sets: 1,
+                      supersetGroup: 'A',
+                    }
+                  : exercise,
+              ),
+            },
+      ),
+    };
+    const queryClient = createAppQueryClient();
+    queryClient.clear();
+    queryClient.setQueryData(workoutQueryKeys.template(templateId), supersetTemplate);
+
+    renderWithQueryClient(
+      <MemoryRouter initialEntries={[`/workouts/active?template=${templateId}`]}>
+        <Routes>
+          <Route element={<ActiveWorkoutPage />} path="/workouts/active" />
+          <Route element={<h1>Workouts</h1>} path="/workouts" />
+        </Routes>
+      </MemoryRouter>,
+      { queryClient },
+    );
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Superset Focus QA' })).toBeVisible();
+
+    const a1Card = getExerciseCard('Incline Dumbbell Press');
+    fireEvent.change(within(a1Card).getByLabelText('Weight for set 1'), {
+      target: { value: '50' },
+    });
+    fireEvent.change(within(a1Card).getByLabelText('Reps for set 1'), {
+      target: { value: '10' },
+    });
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    expect(screen.getByText('After Incline Dumbbell Press set 1')).toBeInTheDocument();
+
+    const a2Card = getExerciseCard('Seated Dumbbell Shoulder Press');
+    const a2SetOneInput = within(a2Card).getByLabelText('Reps for set 1') as HTMLInputElement;
+    a2SetOneInput.focus();
+    expect(a2SetOneInput).toHaveFocus();
+
+    act(() => {
+      vi.advanceTimersByTime(1_100);
+    });
+
+    expect(a2SetOneInput).toHaveFocus();
+    expect(screen.queryByText('After Incline Dumbbell Press set 1')).not.toBeInTheDocument();
   });
 
   it('keeps the rest timer running when editing an incomplete set', () => {

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -207,7 +207,6 @@ export function ActiveWorkoutPage() {
   const [completedSessionId, setCompletedSessionId] = useState<string | null>(null);
   const [summarySaving, setSummarySaving] = useState(false);
   const [restTimer, setRestTimer] = useState<RestTimerState | null>(null);
-  const [restTimerTargetSetId, setRestTimerTargetSetId] = useState<string | null>(null);
   const [focusSetId, setFocusSetId] = useState<string | null>(null);
   const [showDragHandles, setShowDragHandles] = useState(false);
   const [exerciseSupersetOverrides, setExerciseSupersetOverrides] = useState<
@@ -1039,7 +1038,6 @@ export function ActiveWorkoutPage() {
             });
 
             setRestTimer(null);
-            setRestTimerTargetSetId(null);
             setFocusSetId(createdSet.id);
           },
         },
@@ -1056,7 +1054,6 @@ export function ActiveWorkoutPage() {
     }));
 
     setRestTimer(null);
-    setRestTimerTargetSetId(null);
     setFocusSetId(nextSet.id);
   }
 
@@ -1087,10 +1084,6 @@ export function ActiveWorkoutPage() {
 
     if (restTimer?.setId === removedSet.id) {
       setRestTimer(null);
-    }
-
-    if (restTimerTargetSetId === removedSet.id) {
-      setRestTimerTargetSetId(null);
     }
 
     if (focusSetId === removedSet.id) {
@@ -1183,10 +1176,6 @@ export function ActiveWorkoutPage() {
       removedSetIds.has(restTimer?.setId ?? '')
     ) {
       setRestTimer(null);
-    }
-
-    if (removedSetIds.has(restTimerTargetSetId ?? '')) {
-      setRestTimerTargetSetId(null);
     }
 
     if (removedSetIds.has(focusSetId ?? '')) {
@@ -1348,21 +1337,15 @@ export function ActiveWorkoutPage() {
       sessionStartedAt: startTime,
     });
 
-    const nextTargetSetId = findNextPendingSetId(updatedSession);
+    const hasPendingSets = updatedSession.sections.some((section) =>
+      section.exercises.some((exercise) => exercise.sets.some((set) => !set.completed)),
+    );
 
-    if (!nextTargetSetId) {
+    if (!hasPendingSets) {
       setRestTimer(null);
-      setRestTimerTargetSetId(null);
       setFocusSetId(null);
       return;
     }
-
-    const completedSetSectionId = findSetSectionId(updatedSession, updatedSet.id);
-    const nextSetSectionId = findSetSectionId(updatedSession, nextTargetSetId);
-    const shouldFocusNextSet =
-      completedSetSectionId !== null &&
-      nextSetSectionId !== null &&
-      completedSetSectionId === nextSetSectionId;
 
     restTimerTokenRef.current += 1;
     setRestTimer({
@@ -1376,7 +1359,6 @@ export function ActiveWorkoutPage() {
       setNumber: updatedSet.number,
       token: restTimerTokenRef.current,
     });
-    setRestTimerTargetSetId(shouldFocusNextSet ? nextTargetSetId : null);
     setFocusSetId(null);
   }
 
@@ -1533,8 +1515,6 @@ export function ActiveWorkoutPage() {
 
   function handleRestTimerComplete() {
     setRestTimer(null);
-    setFocusSetId(restTimerTargetSetId);
-    setRestTimerTargetSetId(null);
   }
 
   function handleCompleteWorkout() {
@@ -1552,7 +1532,6 @@ export function ActiveWorkoutPage() {
 
   function transitionToFeedbackStage() {
     setRestTimer(null);
-    setRestTimerTargetSetId(null);
     setFocusSetId(null);
     setSessionCompletedAt((current) => current ?? new Date().toISOString());
     setStage('feedback');
@@ -2210,32 +2189,6 @@ function isSessionNotActiveError(error: unknown) {
   return (
     error instanceof ApiError && error.status === 409 && error.code === 'WORKOUT_SESSION_NOT_ACTIVE'
   );
-}
-
-function findNextPendingSetId(session: ReturnType<typeof buildActiveWorkoutSession>) {
-  for (const section of session.sections) {
-    for (const exercise of section.exercises) {
-      const nextSet = exercise.sets.find((set) => !set.completed);
-
-      if (nextSet) {
-        return nextSet.id;
-      }
-    }
-  }
-
-  return null;
-}
-
-function findSetSectionId(session: ReturnType<typeof buildActiveWorkoutSession>, setId: string) {
-  for (const section of session.sections) {
-    for (const exercise of section.exercises) {
-      if (exercise.sets.some((set) => set.id === setId)) {
-        return section.id;
-      }
-    }
-  }
-
-  return null;
 }
 
 function normalizeSetDraftForTrackingType<T extends { weight: number | null }>(


### PR DESCRIPTION
## Summary
This PR fixes three UX regressions in the active workout flow and shared form input behavior. Exercise swaps now update the active-session query caches immediately, so the active workout screen reflects the new exercise without waiting for a refetch cycle. Rest timer completion was simplified to stop only the timer, removing automatic focus jumps that could pull users away from the field they were editing. It also hardens number inputs app-wide by preventing wheel-based value changes through the shared `Input` component while still preserving consumer `onWheel` handlers.

## Key Changes
- Updated `useSwapSessionExercise` success handling to write through both active session cache keys before invalidation:
  - `['workout-sessions', sessionId]`
  - `workoutQueryKeys.session(sessionId)`
- Expanded swap mutation tests to assert post-mutation cache state and explicit invalidation of list and detail/session keys.
- Removed rest-timer-driven focus targeting in `ActiveWorkoutPage`:
  - deleted `restTimerTargetSetId` state
  - removed related pending-set/section helper logic
  - changed `handleRestTimerComplete` to clear timer state only
- Added stronger active workout coverage to confirm focus remains stable when rest timers expire, including superset scenarios.
- Updated shared `Input` to blur on wheel only when `type="number"` and forward caller-provided `onWheel`.
- Added new `input.test.tsx` coverage for number/text wheel behavior and `onWheel` passthrough.
- Updated two habits tests to use date helpers (`getToday`, `addDays`, `toDateKey`) instead of fixed dates, preventing time-sensitive brittleness.

## Technical Notes
- The cache update strategy intentionally combines `setQueryData` (for immediate UI consistency) with `invalidateQueries` (for eventual server truth), which is important because this codebase currently uses multiple session detail key shapes.
- Rest timer completion no longer performs implicit navigation/focus behavior; this reduces surprise focus jumps and avoids cross-section/superset edge cases where auto-focus could interrupt active input.
- The wheel fix is implemented in the shared input primitive, so all numeric fields benefit uniformly without per-page handlers; forwarding `onWheel` preserves existing extensibility for callers that rely on wheel events.

## Commits

- `40c700f fix(web): disable wheel-scroll on number inputs`
- `fdc9baf fix(workouts): drop rest-timer auto-focus`
- `3a2dd15 fix(workouts): sync active session cache after exercise swap`

## Tasks

- **Refresh active-session cache after exercise swap**: Write through or invalidate the TanStack Query session cache in the swap mutation's onSuccess so the active-workout view re-renders immediately; add test covering post-swap cache state.
- **Drop rest-timer auto-focus behavior**: Simplify handleRestTimerComplete to only clear timer state; remove restTimerTargetSetId, shouldFocusNextSet, and findNextPendingSetId if unused; update active-workout.test.tsx accordingly.
- **Disable wheel-scroll on number inputs via shared Input**: Intercept onWheel on the shared Input component; blur when type='number'; pass through caller-supplied onWheel handlers; add colocated unit test.

## Diff Stats

```
apps/web/src/components/ui/input.test.tsx          |  41 ++++++++
 apps/web/src/components/ui/input.tsx               |  14 ++-
 .../habits/components/daily-habits.test.tsx        |   3 +-
 .../habits/components/habit-card-menu.test.tsx     |  12 ++-
 .../workouts/api/workouts.mutations.test.tsx       |  63 ++++++++++++-
 apps/web/src/features/workouts/api/workouts.ts     |  25 +++--
 apps/web/src/pages/active-workout.test.tsx         | 103 ++++++++++++++++++++-
 apps/web/src/pages/active-workout.tsx              |  55 +----------
 8 files changed, 248 insertions(+), 68 deletions(-)
```