### PR TITLE
feat(workouts): snapshot template programming notes onto sessions

### DIFF
--- a/apps/api/drizzle/0036_bitter_fat_cobra.sql
+++ b/apps/api/drizzle/0036_bitter_fat_cobra.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `workout_sessions` ADD `exercise_programming_notes` text;

--- a/apps/api/drizzle/meta/0036_snapshot.json
+++ b/apps/api/drizzle/meta/0036_snapshot.json
@@ -1,0 +1,3015 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ee97dc5f-896a-44c5-9140-8f3b4c137d22",
+  "prevId": "b4cb4a8d-b6af-486a-87cb-6fdb88c5df67",
+  "tables": {
+    "activities": {
+      "name": "activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "activities_user_date_idx": {
+          "name": "activities_user_date_idx",
+          "columns": ["user_id", "date"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "activities_user_id_users_id_fk": {
+          "name": "activities_user_id_users_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "activities_date_format_check": {
+          "name": "activities_date_format_check",
+          "value": "\"activities\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "activities_type_check": {
+          "name": "activities_type_check",
+          "value": "\"activities\".\"type\" in ('walking', 'running', 'stretching', 'yoga', 'cycling', 'swimming', 'hiking', 'other')"
+        },
+        "activities_duration_minutes_check": {
+          "name": "activities_duration_minutes_check",
+          "value": "\"activities\".\"duration_minutes\" > 0"
+        }
+      }
+    },
+    "agent_tokens": {
+      "name": "agent_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_rotated_at": {
+          "name": "last_rotated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "agent_tokens_token_hash_unique": {
+          "name": "agent_tokens_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_tokens_user_id_users_id_fk": {
+          "name": "agent_tokens_user_id_users_id_fk",
+          "tableFrom": "agent_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "body_weight": {
+      "name": "body_weight",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "body_weight_user_id_date_unique": {
+          "name": "body_weight_user_id_date_unique",
+          "columns": ["user_id", "date"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "body_weight_user_id_users_id_fk": {
+          "name": "body_weight_user_id_users_id_fk",
+          "tableFrom": "body_weight",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "body_weight_date_format_check": {
+          "name": "body_weight_date_format_check",
+          "value": "\"body_weight\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "body_weight_weight_check": {
+          "name": "body_weight_weight_check",
+          "value": "\"body_weight\".\"weight\" > 0"
+        }
+      }
+    },
+    "dashboard_config": {
+      "name": "dashboard_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "habit_chain_ids": {
+          "name": "habit_chain_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "trend_metrics": {
+          "name": "trend_metrics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "visible_widgets": {
+          "name": "visible_widgets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "widget_order": {
+          "name": "widget_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "dashboard_config_user_id_unique": {
+          "name": "dashboard_config_user_id_unique",
+          "columns": ["user_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "dashboard_config_user_id_users_id_fk": {
+          "name": "dashboard_config_user_id_users_id_fk",
+          "tableFrom": "dashboard_config",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entity_links": {
+      "name": "entity_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "entity_links_user_source_type_source_id_idx": {
+          "name": "entity_links_user_source_type_source_id_idx",
+          "columns": ["user_id", "source_type", "source_id"],
+          "isUnique": false
+        },
+        "entity_links_user_target_type_target_id_idx": {
+          "name": "entity_links_user_target_type_target_id_idx",
+          "columns": ["user_id", "target_type", "target_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "entity_links_user_id_users_id_fk": {
+          "name": "entity_links_user_id_users_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "entity_links_source_type_check": {
+          "name": "entity_links_source_type_check",
+          "value": "\"entity_links\".\"source_type\" in ('journal', 'activity', 'resource')"
+        },
+        "entity_links_target_type_check": {
+          "name": "entity_links_target_type_check",
+          "value": "\"entity_links\".\"target_type\" in ('workout', 'activity', 'habit', 'injury', 'exercise', 'protocol')"
+        }
+      }
+    },
+    "equipment_items": {
+      "name": "equipment_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "equipment_items_location_id_idx": {
+          "name": "equipment_items_location_id_idx",
+          "columns": ["location_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "equipment_items_location_id_equipment_locations_id_fk": {
+          "name": "equipment_items_location_id_equipment_locations_id_fk",
+          "tableFrom": "equipment_items",
+          "tableTo": "equipment_locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "equipment_items_category_check": {
+          "name": "equipment_items_category_check",
+          "value": "\"equipment_items\".\"category\" in ('free-weights', 'machines', 'cables', 'cardio', 'accessories')"
+        }
+      }
+    },
+    "equipment_locations": {
+      "name": "equipment_locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "equipment_locations_user_id_idx": {
+          "name": "equipment_locations_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "equipment_locations_user_id_users_id_fk": {
+          "name": "equipment_locations_user_id_users_id_fk",
+          "tableFrom": "equipment_locations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exercises": {
+      "name": "exercises",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "muscle_groups": {
+          "name": "muscle_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment": {
+          "name": "equipment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tracking_type": {
+          "name": "tracking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'weight_reps'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "form_cues": {
+          "name": "form_cues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coaching_notes": {
+          "name": "coaching_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "related_exercise_ids": {
+          "name": "related_exercise_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "exercises_user_id_idx": {
+          "name": "exercises_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "exercises_user_id_users_id_fk": {
+          "name": "exercises_user_id_users_id_fk",
+          "tableFrom": "exercises",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "exercises_category_check": {
+          "name": "exercises_category_check",
+          "value": "\"exercises\".\"category\" in ('compound', 'isolation', 'cardio', 'mobility')"
+        },
+        "exercises_tracking_type_check": {
+          "name": "exercises_tracking_type_check",
+          "value": "\"exercises\".\"tracking_type\" in ('weight_reps', 'weight_seconds', 'bodyweight_reps', 'reps_only', 'reps_seconds', 'seconds_only', 'distance', 'cardio')"
+        }
+      }
+    },
+    "foods": {
+      "name": "foods",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "serving_size": {
+          "name": "serving_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "serving_grams": {
+          "name": "serving_grams",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "calories": {
+          "name": "calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protein": {
+          "name": "protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fat": {
+          "name": "fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fiber": {
+          "name": "fiber",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sugar": {
+          "name": "sugar",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "foods_user_last_used_at_idx": {
+          "name": "foods_user_last_used_at_idx",
+          "columns": ["user_id", "last_used_at"],
+          "isUnique": false
+        },
+        "foods_user_usage_count_idx": {
+          "name": "foods_user_usage_count_idx",
+          "columns": ["user_id", "usage_count"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "foods_user_id_users_id_fk": {
+          "name": "foods_user_id_users_id_fk",
+          "tableFrom": "foods",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "foods_serving_grams_check": {
+          "name": "foods_serving_grams_check",
+          "value": "\"foods\".\"serving_grams\" is null or \"foods\".\"serving_grams\" > 0"
+        },
+        "foods_macros_nonnegative_check": {
+          "name": "foods_macros_nonnegative_check",
+          "value": "\"foods\".\"calories\" >= 0 and \"foods\".\"protein\" >= 0 and \"foods\".\"carbs\" >= 0 and \"foods\".\"fat\" >= 0"
+        },
+        "foods_fiber_nonnegative_check": {
+          "name": "foods_fiber_nonnegative_check",
+          "value": "\"foods\".\"fiber\" is null or \"foods\".\"fiber\" >= 0"
+        },
+        "foods_sugar_nonnegative_check": {
+          "name": "foods_sugar_nonnegative_check",
+          "value": "\"foods\".\"sugar\" is null or \"foods\".\"sugar\" >= 0"
+        }
+      }
+    },
+    "habit_entries": {
+      "name": "habit_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "habit_id": {
+          "name": "habit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_override": {
+          "name": "is_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "habit_entries_user_id_idx": {
+          "name": "habit_entries_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "habit_entries_date_idx": {
+          "name": "habit_entries_date_idx",
+          "columns": ["date"],
+          "isUnique": false
+        },
+        "habit_entries_habit_id_date_unique": {
+          "name": "habit_entries_habit_id_date_unique",
+          "columns": ["habit_id", "date"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "habit_entries_habit_id_habits_id_fk": {
+          "name": "habit_entries_habit_id_habits_id_fk",
+          "tableFrom": "habit_entries",
+          "tableTo": "habits",
+          "columnsFrom": ["habit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "habit_entries_user_id_users_id_fk": {
+          "name": "habit_entries_user_id_users_id_fk",
+          "tableFrom": "habit_entries",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "habit_entries_date_format_check": {
+          "name": "habit_entries_date_format_check",
+          "value": "\"habit_entries\".\"date\" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        }
+      }
+    },
+    "habits": {
+      "name": "habits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tracking_type": {
+          "name": "tracking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'daily'"
+        },
+        "frequency_target": {
+          "name": "frequency_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_days": {
+          "name": "scheduled_days",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_source": {
+          "name": "reference_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_config": {
+          "name": "reference_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_until": {
+          "name": "paused_until",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "habits_user_id_idx": {
+          "name": "habits_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "habits_user_id_users_id_fk": {
+          "name": "habits_user_id_users_id_fk",
+          "tableFrom": "habits",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "habits_tracking_type_check": {
+          "name": "habits_tracking_type_check",
+          "value": "\"habits\".\"tracking_type\" in ('boolean', 'numeric', 'time')"
+        },
+        "habits_frequency_check": {
+          "name": "habits_frequency_check",
+          "value": "\"habits\".\"frequency\" in ('daily', 'weekly', 'specific_days')"
+        }
+      }
+    },
+    "condition_protocols": {
+      "name": "condition_protocols",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition_id": {
+          "name": "condition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "condition_protocols_condition_id_idx": {
+          "name": "condition_protocols_condition_id_idx",
+          "columns": ["condition_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "condition_protocols_condition_id_health_conditions_id_fk": {
+          "name": "condition_protocols_condition_id_health_conditions_id_fk",
+          "tableFrom": "condition_protocols",
+          "tableTo": "health_conditions",
+          "columnsFrom": ["condition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "condition_protocols_status_check": {
+          "name": "condition_protocols_status_check",
+          "value": "\"condition_protocols\".\"status\" in ('active', 'discontinued', 'completed')"
+        },
+        "condition_protocols_start_date_format_check": {
+          "name": "condition_protocols_start_date_format_check",
+          "value": "\"condition_protocols\".\"start_date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "condition_protocols_end_date_format_check": {
+          "name": "condition_protocols_end_date_format_check",
+          "value": "\"condition_protocols\".\"end_date\" is null or \"condition_protocols\".\"end_date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "condition_protocols_end_date_order_check": {
+          "name": "condition_protocols_end_date_order_check",
+          "value": "\"condition_protocols\".\"end_date\" is null or \"condition_protocols\".\"end_date\" >= \"condition_protocols\".\"start_date\""
+        }
+      }
+    },
+    "condition_severity_points": {
+      "name": "condition_severity_points",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition_id": {
+          "name": "condition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "condition_severity_points_condition_date_idx": {
+          "name": "condition_severity_points_condition_date_idx",
+          "columns": ["condition_id", "date"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "condition_severity_points_condition_id_health_conditions_id_fk": {
+          "name": "condition_severity_points_condition_id_health_conditions_id_fk",
+          "tableFrom": "condition_severity_points",
+          "tableTo": "health_conditions",
+          "columnsFrom": ["condition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "condition_severity_points_date_format_check": {
+          "name": "condition_severity_points_date_format_check",
+          "value": "\"condition_severity_points\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "condition_severity_points_value_check": {
+          "name": "condition_severity_points_value_check",
+          "value": "\"condition_severity_points\".\"value\" between 1 and 10"
+        }
+      }
+    },
+    "condition_timeline_events": {
+      "name": "condition_timeline_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition_id": {
+          "name": "condition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "condition_timeline_events_condition_date_idx": {
+          "name": "condition_timeline_events_condition_date_idx",
+          "columns": ["condition_id", "date"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "condition_timeline_events_condition_id_health_conditions_id_fk": {
+          "name": "condition_timeline_events_condition_id_health_conditions_id_fk",
+          "tableFrom": "condition_timeline_events",
+          "tableTo": "health_conditions",
+          "columnsFrom": ["condition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "condition_timeline_events_date_format_check": {
+          "name": "condition_timeline_events_date_format_check",
+          "value": "\"condition_timeline_events\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "condition_timeline_events_type_check": {
+          "name": "condition_timeline_events_type_check",
+          "value": "\"condition_timeline_events\".\"type\" in ('onset', 'flare', 'improvement', 'treatment', 'milestone')"
+        }
+      }
+    },
+    "health_conditions": {
+      "name": "health_conditions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body_area": {
+          "name": "body_area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "health_conditions_user_id_idx": {
+          "name": "health_conditions_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_conditions_user_id_users_id_fk": {
+          "name": "health_conditions_user_id_users_id_fk",
+          "tableFrom": "health_conditions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "health_conditions_status_check": {
+          "name": "health_conditions_status_check",
+          "value": "\"health_conditions\".\"status\" in ('active', 'monitoring', 'resolved')"
+        },
+        "health_conditions_onset_date_format_check": {
+          "name": "health_conditions_onset_date_format_check",
+          "value": "\"health_conditions\".\"onset_date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        }
+      }
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": ["username"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "journal_entries_user_date_idx": {
+          "name": "journal_entries_user_date_idx",
+          "columns": ["user_id", "date"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_user_id_users_id_fk": {
+          "name": "journal_entries_user_id_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "journal_entries_date_format_check": {
+          "name": "journal_entries_date_format_check",
+          "value": "\"journal_entries\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "journal_entries_type_check": {
+          "name": "journal_entries_type_check",
+          "value": "\"journal_entries\".\"type\" in ('post-workout', 'milestone', 'observation', 'weekly-summary', 'injury-update')"
+        },
+        "journal_entries_created_by_check": {
+          "name": "journal_entries_created_by_check",
+          "value": "\"journal_entries\".\"created_by\" in ('agent', 'user')"
+        }
+      }
+    },
+    "meal_items": {
+      "name": "meal_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meal_id": {
+          "name": "meal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_quantity": {
+          "name": "display_quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_unit": {
+          "name": "display_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "calories": {
+          "name": "calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protein": {
+          "name": "protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fat": {
+          "name": "fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fiber": {
+          "name": "fiber",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sugar": {
+          "name": "sugar",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "meal_items_meal_id_idx": {
+          "name": "meal_items_meal_id_idx",
+          "columns": ["meal_id"],
+          "isUnique": false
+        },
+        "meal_items_food_id_idx": {
+          "name": "meal_items_food_id_idx",
+          "columns": ["food_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meal_items_meal_id_meals_id_fk": {
+          "name": "meal_items_meal_id_meals_id_fk",
+          "tableFrom": "meal_items",
+          "tableTo": "meals",
+          "columnsFrom": ["meal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meal_items_food_id_foods_id_fk": {
+          "name": "meal_items_food_id_foods_id_fk",
+          "tableFrom": "meal_items",
+          "tableTo": "foods",
+          "columnsFrom": ["food_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "meal_items_amount_check": {
+          "name": "meal_items_amount_check",
+          "value": "\"meal_items\".\"amount\" > 0"
+        },
+        "meal_items_display_quantity_check": {
+          "name": "meal_items_display_quantity_check",
+          "value": "\"meal_items\".\"display_quantity\" is null or \"meal_items\".\"display_quantity\" > 0"
+        },
+        "meal_items_macros_nonnegative_check": {
+          "name": "meal_items_macros_nonnegative_check",
+          "value": "\"meal_items\".\"calories\" >= 0 and \"meal_items\".\"protein\" >= 0 and \"meal_items\".\"carbs\" >= 0 and \"meal_items\".\"fat\" >= 0"
+        },
+        "meal_items_fiber_nonnegative_check": {
+          "name": "meal_items_fiber_nonnegative_check",
+          "value": "\"meal_items\".\"fiber\" is null or \"meal_items\".\"fiber\" >= 0"
+        },
+        "meal_items_sugar_nonnegative_check": {
+          "name": "meal_items_sugar_nonnegative_check",
+          "value": "\"meal_items\".\"sugar\" is null or \"meal_items\".\"sugar\" >= 0"
+        }
+      }
+    },
+    "meals": {
+      "name": "meals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nutrition_log_id": {
+          "name": "nutrition_log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "meals_nutrition_log_id_idx": {
+          "name": "meals_nutrition_log_id_idx",
+          "columns": ["nutrition_log_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meals_nutrition_log_id_nutrition_logs_id_fk": {
+          "name": "meals_nutrition_log_id_nutrition_logs_id_fk",
+          "tableFrom": "meals",
+          "tableTo": "nutrition_logs",
+          "columnsFrom": ["nutrition_log_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "meals_time_format_check": {
+          "name": "meals_time_format_check",
+          "value": "\"meals\".\"time\" is null or \"meals\".\"time\" glob '[0-9][0-9]:[0-9][0-9]'"
+        }
+      }
+    },
+    "nutrition_logs": {
+      "name": "nutrition_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "nutrition_logs_user_id_date_unique": {
+          "name": "nutrition_logs_user_id_date_unique",
+          "columns": ["user_id", "date"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "nutrition_logs_user_id_users_id_fk": {
+          "name": "nutrition_logs_user_id_users_id_fk",
+          "tableFrom": "nutrition_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "nutrition_logs_date_format_check": {
+          "name": "nutrition_logs_date_format_check",
+          "value": "\"nutrition_logs\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        }
+      }
+    },
+    "nutrition_targets": {
+      "name": "nutrition_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "calories": {
+          "name": "calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protein": {
+          "name": "protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fat": {
+          "name": "fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "nutrition_targets_user_id_effective_date_unique": {
+          "name": "nutrition_targets_user_id_effective_date_unique",
+          "columns": ["user_id", "effective_date"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "nutrition_targets_user_id_users_id_fk": {
+          "name": "nutrition_targets_user_id_users_id_fk",
+          "tableFrom": "nutrition_targets",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "nutrition_targets_effective_date_format_check": {
+          "name": "nutrition_targets_effective_date_format_check",
+          "value": "\"nutrition_targets\".\"effective_date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "nutrition_targets_macros_nonnegative_check": {
+          "name": "nutrition_targets_macros_nonnegative_check",
+          "value": "\"nutrition_targets\".\"calories\" >= 0 and \"nutrition_targets\".\"protein\" >= 0 and \"nutrition_targets\".\"carbs\" >= 0 and \"nutrition_targets\".\"fat\" >= 0"
+        }
+      }
+    },
+    "resources": {
+      "name": "resources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "principles": {
+          "name": "principles",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "resources_user_id_idx": {
+          "name": "resources_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "resources_user_id_users_id_fk": {
+          "name": "resources_user_id_users_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "resources_type_check": {
+          "name": "resources_type_check",
+          "value": "\"resources\".\"type\" in ('program', 'book', 'creator')"
+        }
+      }
+    },
+    "template_exercises": {
+      "name": "template_exercises",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sets": {
+          "name": "sets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reps_min": {
+          "name": "reps_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reps_max": {
+          "name": "reps_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tempo": {
+          "name": "tempo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rest_seconds": {
+          "name": "rest_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "superset_group": {
+          "name": "superset_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section": {
+          "name": "section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cues": {
+          "name": "cues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "set_targets": {
+          "name": "set_targets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "programming_notes": {
+          "name": "programming_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "template_exercises_template_id_idx": {
+          "name": "template_exercises_template_id_idx",
+          "columns": ["template_id"],
+          "isUnique": false
+        },
+        "template_exercises_exercise_id_idx": {
+          "name": "template_exercises_exercise_id_idx",
+          "columns": ["exercise_id"],
+          "isUnique": false
+        },
+        "template_exercises_template_section_order_unique": {
+          "name": "template_exercises_template_section_order_unique",
+          "columns": ["template_id", "section", "order_index"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "template_exercises_template_id_workout_templates_id_fk": {
+          "name": "template_exercises_template_id_workout_templates_id_fk",
+          "tableFrom": "template_exercises",
+          "tableTo": "workout_templates",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "template_exercises_exercise_id_exercises_id_fk": {
+          "name": "template_exercises_exercise_id_exercises_id_fk",
+          "tableFrom": "template_exercises",
+          "tableTo": "exercises",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "template_exercises_section_check": {
+          "name": "template_exercises_section_check",
+          "value": "\"template_exercises\".\"section\" in ('warmup', 'main', 'cooldown', 'supplemental')"
+        },
+        "template_exercises_reps_range_check": {
+          "name": "template_exercises_reps_range_check",
+          "value": "\"template_exercises\".\"reps_min\" is null or \"template_exercises\".\"reps_max\" is null or \"template_exercises\".\"reps_min\" <= \"template_exercises\".\"reps_max\""
+        }
+      }
+    },
+    "workout_templates": {
+      "name": "workout_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "workout_templates_user_id_idx": {
+          "name": "workout_templates_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workout_templates_user_id_users_id_fk": {
+          "name": "workout_templates_user_id_users_id_fk",
+          "tableFrom": "workout_templates",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_sets": {
+      "name": "session_sets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "set_number": {
+          "name": "set_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reps": {
+          "name": "reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_weight": {
+          "name": "target_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_weight_min": {
+          "name": "target_weight_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_weight_max": {
+          "name": "target_weight_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_seconds": {
+          "name": "target_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_distance": {
+          "name": "target_distance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "superset_group": {
+          "name": "superset_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "section": {
+          "name": "section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'main'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "session_sets_session_id_idx": {
+          "name": "session_sets_session_id_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        },
+        "session_sets_session_exercise_section_set_number_unique": {
+          "name": "session_sets_session_exercise_section_set_number_unique",
+          "columns": ["session_id", "exercise_id", "section", "set_number"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_sets_session_id_workout_sessions_id_fk": {
+          "name": "session_sets_session_id_workout_sessions_id_fk",
+          "tableFrom": "session_sets",
+          "tableTo": "workout_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_sets_exercise_id_exercises_id_fk": {
+          "name": "session_sets_exercise_id_exercises_id_fk",
+          "tableFrom": "session_sets",
+          "tableTo": "exercises",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "session_sets_set_number_check": {
+          "name": "session_sets_set_number_check",
+          "value": "\"session_sets\".\"set_number\" > 0"
+        },
+        "session_sets_section_check": {
+          "name": "session_sets_section_check",
+          "value": "\"session_sets\".\"section\" in ('warmup', 'main', 'cooldown', 'supplemental')"
+        },
+        "session_sets_completion_state_check": {
+          "name": "session_sets_completion_state_check",
+          "value": "not (\"session_sets\".\"completed\" and \"session_sets\".\"skipped\")"
+        }
+      }
+    },
+    "workout_sessions": {
+      "name": "workout_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in-progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_segments": {
+          "name": "time_segments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exercise_programming_notes": {
+          "name": "exercise_programming_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "workout_sessions_user_id_idx": {
+          "name": "workout_sessions_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "workout_sessions_date_idx": {
+          "name": "workout_sessions_date_idx",
+          "columns": ["date"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workout_sessions_user_id_users_id_fk": {
+          "name": "workout_sessions_user_id_users_id_fk",
+          "tableFrom": "workout_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workout_sessions_template_id_workout_templates_id_fk": {
+          "name": "workout_sessions_template_id_workout_templates_id_fk",
+          "tableFrom": "workout_sessions",
+          "tableTo": "workout_templates",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "workout_sessions_date_format_check": {
+          "name": "workout_sessions_date_format_check",
+          "value": "\"workout_sessions\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "workout_sessions_status_check": {
+          "name": "workout_sessions_status_check",
+          "value": "\"workout_sessions\".\"status\" in ('scheduled', 'in-progress', 'paused', 'cancelled', 'completed')"
+        },
+        "workout_sessions_completed_at_check": {
+          "name": "workout_sessions_completed_at_check",
+          "value": "(\"workout_sessions\".\"status\" != 'completed' or \"workout_sessions\".\"completed_at\" is not null) and (\"workout_sessions\".\"completed_at\" is null or \"workout_sessions\".\"completed_at\" >= \"workout_sessions\".\"started_at\")"
+        }
+      }
+    },
+    "scheduled_workouts": {
+      "name": "scheduled_workouts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "scheduled_workouts_user_date_idx": {
+          "name": "scheduled_workouts_user_date_idx",
+          "columns": ["user_id", "date"],
+          "isUnique": false
+        },
+        "scheduled_workouts_template_id_idx": {
+          "name": "scheduled_workouts_template_id_idx",
+          "columns": ["template_id"],
+          "isUnique": false
+        },
+        "scheduled_workouts_session_id_idx": {
+          "name": "scheduled_workouts_session_id_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_workouts_user_id_users_id_fk": {
+          "name": "scheduled_workouts_user_id_users_id_fk",
+          "tableFrom": "scheduled_workouts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_workouts_template_id_workout_templates_id_fk": {
+          "name": "scheduled_workouts_template_id_workout_templates_id_fk",
+          "tableFrom": "scheduled_workouts",
+          "tableTo": "workout_templates",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scheduled_workouts_session_id_workout_sessions_id_fk": {
+          "name": "scheduled_workouts_session_id_workout_sessions_id_fk",
+          "tableFrom": "scheduled_workouts",
+          "tableTo": "workout_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_workouts_date_format_check": {
+          "name": "scheduled_workouts_date_format_check",
+          "value": "\"scheduled_workouts\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1774237014277,
       "tag": "0035_groovy_captain_cross",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "6",
+      "when": 1776708492985,
+      "tag": "0036_bitter_fat_cobra",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.test.ts
+++ b/apps/api/src/db/schema.test.ts
@@ -974,6 +974,7 @@ describe('workoutSessions schema', () => {
       'duration',
       'timeSegments',
       'feedback',
+      'exerciseProgrammingNotes',
       'notes',
       'deletedAt',
       'createdAt',

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -13,6 +13,7 @@ export * from './resources.js';
 export * from './exercises.js';
 export * from './json-arrays.js';
 export * from './workout-session-feedback.js';
+export * from './workout-session-programming-notes.js';
 export * from './workout-session-time-segments.js';
 export * from './workout-templates.js';
 export * from './workout-sessions.js';

--- a/apps/api/src/db/schema/workout-session-programming-notes.ts
+++ b/apps/api/src/db/schema/workout-session-programming-notes.ts
@@ -1,0 +1,52 @@
+export type WorkoutSessionExerciseProgrammingNotes = Record<string, string | null>;
+
+const INVALID_WORKOUT_SESSION_PROGRAMMING_NOTES_ERROR =
+  'Expected a JSON-encoded workout session programming notes record.';
+
+function isProgrammingNotesRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function serializeWorkoutSessionExerciseProgrammingNotes(
+  value: WorkoutSessionExerciseProgrammingNotes | null | undefined,
+): string | null {
+  if (value == null) {
+    return null;
+  }
+
+  if (
+    !isProgrammingNotesRecord(value) ||
+    Object.values(value).some((entry) => entry !== null && typeof entry !== 'string')
+  ) {
+    throw new TypeError(INVALID_WORKOUT_SESSION_PROGRAMMING_NOTES_ERROR);
+  }
+
+  return JSON.stringify(value);
+}
+
+export function parseWorkoutSessionExerciseProgrammingNotes(
+  value: string | null | undefined,
+): WorkoutSessionExerciseProgrammingNotes {
+  if (value == null) {
+    return {};
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new TypeError(INVALID_WORKOUT_SESSION_PROGRAMMING_NOTES_ERROR);
+  }
+
+  if (
+    !isProgrammingNotesRecord(parsed) ||
+    Object.values(parsed).some((entry) => entry !== null && typeof entry !== 'string')
+  ) {
+    throw new TypeError(INVALID_WORKOUT_SESSION_PROGRAMMING_NOTES_ERROR);
+  }
+
+  return Object.fromEntries(
+    Object.entries(parsed).map(([key, entry]) => [key, entry === null ? null : String(entry)]),
+  );
+}

--- a/apps/api/src/db/schema/workout-sessions.ts
+++ b/apps/api/src/db/schema/workout-sessions.ts
@@ -87,6 +87,8 @@ export const workoutSessions = sqliteTable(
     timeSegments: text('time_segments').notNull().default('[]').$type<string>(),
     // JSON-encoded WorkoutSessionFeedback; use the serializer helpers when reading or writing.
     feedback: text('feedback'),
+    // JSON-encoded Record<`${section}::${exerciseId}`, string | null>; snapshots template notes at session start.
+    exerciseProgrammingNotes: text('exercise_programming_notes'),
     notes: text('notes'),
     deletedAt: text('deleted_at'),
     createdAt: integer('created_at', { mode: 'number' })

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -100,6 +100,36 @@ const seedTemplate = (values: {
     })
     .run();
 
+const seedTemplateExercise = (values: {
+  id: string;
+  templateId: string;
+  exerciseId: string;
+  orderIndex: number;
+  section?: 'warmup' | 'main' | 'cooldown' | 'supplemental';
+  sets?: number | null;
+  notes?: string | null;
+}) =>
+  context.db
+    .insert(templateExercises)
+    .values({
+      id: values.id,
+      templateId: values.templateId,
+      exerciseId: values.exerciseId,
+      orderIndex: values.orderIndex,
+      sets: values.sets ?? 1,
+      repsMin: null,
+      repsMax: null,
+      tempo: null,
+      restSeconds: null,
+      supersetGroup: null,
+      section: values.section ?? 'main',
+      notes: values.notes ?? null,
+      cues: [],
+      setTargets: null,
+      programmingNotes: null,
+    })
+    .run();
+
 const seedExercise = (values: {
   id: string;
   userId?: string | null;
@@ -2095,6 +2125,209 @@ describe('workout session routes', () => {
         message:
           'Workout session corrections must include weight or reps. Set-level RPE corrections are not persisted yet: set-1',
       },
+    });
+  });
+
+  it('snapshots template exercise notes into per-exercise programming notes when starting a session', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedTemplateExercise({
+      id: 'template-note-exercise-1',
+      templateId: 'template-1',
+      exerciseId: 'global-bench-press',
+      orderIndex: 0,
+      section: 'warmup',
+      sets: 1,
+      notes: 'Hardstyle setup before loading.',
+    });
+    seedTemplateExercise({
+      id: 'template-note-exercise-2',
+      templateId: 'template-1',
+      exerciseId: 'user-1-lat-pulldown',
+      orderIndex: 0,
+      section: 'main',
+      sets: 2,
+      notes: 'Keep ribs down and pull to sternum.',
+    });
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        name: 'Upper Push',
+        date: '2026-03-12',
+        status: 'in-progress',
+        startedAt: 1_700_000_000_000,
+        sets: [],
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        templateId: 'template-1',
+        exercises: expect.arrayContaining([
+          expect.objectContaining({
+            exerciseId: 'global-bench-press',
+            section: 'warmup',
+            programmingNotes: 'Hardstyle setup before loading.',
+          }),
+          expect.objectContaining({
+            exerciseId: 'user-1-lat-pulldown',
+            section: 'main',
+            programmingNotes: 'Keep ribs down and pull to sternum.',
+          }),
+        ]),
+      }),
+    });
+  });
+
+  it('stores null programming notes for template exercises that have null notes', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedTemplateExercise({
+      id: 'template-null-note-exercise-1',
+      templateId: 'template-1',
+      exerciseId: 'global-bench-press',
+      orderIndex: 0,
+      section: 'main',
+      sets: 1,
+      notes: null,
+    });
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        name: 'Upper Push',
+        date: '2026-03-12',
+        status: 'in-progress',
+        startedAt: 1_700_000_100_000,
+        sets: [],
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        exercises: expect.arrayContaining([
+          expect.objectContaining({
+            exerciseId: 'global-bench-press',
+            programmingNotes: null,
+          }),
+        ]),
+      }),
+    });
+  });
+
+  it('returns null programming notes for ad-hoc sessions without a template', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: null,
+        name: 'Ad-hoc Session',
+        date: '2026-03-12',
+        status: 'in-progress',
+        startedAt: 1_700_000_200_000,
+        sets: [
+          {
+            exerciseId: 'global-bench-press',
+            setNumber: 1,
+            section: 'main',
+          },
+          {
+            exerciseId: 'user-1-lat-pulldown',
+            setNumber: 1,
+            section: 'main',
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    const payload = response.json() as {
+      data: { exercises?: Array<{ exerciseId: string | null; programmingNotes: string | null }> };
+    };
+
+    expect(payload.data.exercises).toBeDefined();
+    expect(payload.data.exercises?.every((exercise) => exercise.programmingNotes === null)).toBe(
+      true,
+    );
+  });
+
+  it('keeps session programming-note snapshots immutable after template notes change', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedTemplateExercise({
+      id: 'template-immutable-note-exercise-1',
+      templateId: 'template-1',
+      exerciseId: 'global-bench-press',
+      orderIndex: 0,
+      section: 'main',
+      sets: 1,
+      notes: 'Original programming note',
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        name: 'Upper Push',
+        date: '2026-03-12',
+        status: 'in-progress',
+        startedAt: 1_700_000_300_000,
+        sets: [],
+      },
+    });
+
+    expect(createResponse.statusCode).toBe(201);
+    const sessionId = (createResponse.json() as { data: { id: string } }).data.id;
+
+    context.db
+      .update(templateExercises)
+      .set({ notes: 'Updated template note after session start' })
+      .where(eq(templateExercises.id, 'template-immutable-note-exercise-1'))
+      .run();
+
+    const detailResponse = await context.app.inject({
+      method: 'GET',
+      url: `/api/v1/workout-sessions/${sessionId}`,
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(detailResponse.statusCode).toBe(200);
+    expect(detailResponse.json()).toEqual({
+      data: expect.objectContaining({
+        id: sessionId,
+        exercises: expect.arrayContaining([
+          expect.objectContaining({
+            exerciseId: 'global-bench-press',
+            programmingNotes: 'Original programming note',
+          }),
+        ]),
+      }),
     });
   });
 

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -15,6 +15,7 @@ import {
   parseWorkoutSessionTimeSegments,
   scheduledWorkouts,
   serializeWorkoutSessionFeedback,
+  serializeWorkoutSessionExerciseProgrammingNotes,
   serializeWorkoutSessionTimeSegments,
   sessionSets,
   templateExercises,
@@ -186,6 +187,7 @@ const seedWorkoutSession = (values: {
     end: string | null;
     section?: 'warmup' | 'main' | 'cooldown' | 'supplemental';
   }>;
+  exerciseProgrammingNotes?: Record<string, string | null>;
 }) =>
   context.db
     .insert(workoutSessions)
@@ -206,6 +208,9 @@ const seedWorkoutSession = (values: {
         })),
       ),
       feedback: serializeWorkoutSessionFeedback(values.feedback ?? null),
+      exerciseProgrammingNotes: serializeWorkoutSessionExerciseProgrammingNotes(
+        values.exerciseProgrammingNotes,
+      ),
       notes: values.notes ?? null,
     })
     .run();
@@ -642,6 +647,185 @@ describe('workout session routes', () => {
         code: 'WORKOUT_SESSION_NOT_FOUND',
         message: 'Workout session not found',
       },
+    });
+  });
+
+  it('round-trips programming notes in save-as-template and drops session-specific exercise notes', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'session-roundtrip-programming-notes',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Completed Upper Push',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: 1_700_000_000_000,
+      completedAt: 1_700_000_003_000,
+      duration: 50,
+      exerciseProgrammingNotes: {
+        'warmup::global-bench-press': null,
+        'main::user-1-lat-pulldown': 'Stay stacked and drive elbows down.',
+      },
+    });
+
+    seedSessionSet({
+      id: 'roundtrip-note-set-warmup-1',
+      sessionId: 'session-roundtrip-programming-notes',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      section: 'warmup',
+      reps: 10,
+      notes: 'User warmup note that should not round-trip',
+    });
+    seedSessionSet({
+      id: 'roundtrip-note-set-main-1',
+      sessionId: 'session-roundtrip-programming-notes',
+      exerciseId: 'user-1-lat-pulldown',
+      setNumber: 1,
+      section: 'main',
+      reps: 10,
+      weight: 140,
+      notes: 'User main note that should not round-trip',
+    });
+    seedSessionSet({
+      id: 'roundtrip-note-set-main-2',
+      sessionId: 'session-roundtrip-programming-notes',
+      exerciseId: 'user-1-lat-pulldown',
+      setNumber: 2,
+      section: 'main',
+      reps: 9,
+      weight: 145,
+    });
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions/session-roundtrip-programming-notes/save-as-template',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(201);
+    const payload = response.json() as { data: { id: string } };
+
+    const persistedTemplateExercises = context.db
+      .select({
+        exerciseId: templateExercises.exerciseId,
+        section: templateExercises.section,
+        notes: templateExercises.notes,
+      })
+      .from(templateExercises)
+      .where(eq(templateExercises.templateId, payload.data.id))
+      .all()
+      .sort((left, right) => {
+        const sectionOrder: Record<string, number> = {
+          warmup: 0,
+          main: 1,
+          cooldown: 2,
+          supplemental: 3,
+        };
+        if (left.section !== right.section) {
+          return sectionOrder[left.section] - sectionOrder[right.section];
+        }
+
+        return left.exerciseId.localeCompare(right.exerciseId);
+      });
+
+    expect(persistedTemplateExercises).toEqual([
+      {
+        exerciseId: 'global-bench-press',
+        section: 'warmup',
+        notes: null,
+      },
+      {
+        exerciseId: 'user-1-lat-pulldown',
+        section: 'main',
+        notes: 'Stay stacked and drive elbows down.',
+      },
+    ]);
+    expect(
+      persistedTemplateExercises.some(
+        (exercise) => exercise.notes === 'User warmup note that should not round-trip',
+      ),
+    ).toBe(false);
+    expect(
+      persistedTemplateExercises.some(
+        (exercise) => exercise.notes === 'User main note that should not round-trip',
+      ),
+    ).toBe(false);
+  });
+
+  it('uses session programming-note snapshots when save-as-template runs after template edits or deletion', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedTemplateExercise({
+      id: 'template-roundtrip-source-note',
+      templateId: 'template-1',
+      exerciseId: 'global-bench-press',
+      orderIndex: 0,
+      section: 'main',
+      sets: 1,
+      notes: 'Template note before session started',
+    });
+    seedWorkoutSession({
+      id: 'session-roundtrip-from-snapshot',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Completed Upper Push',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: 1_700_000_000_000,
+      completedAt: 1_700_000_003_000,
+      duration: 50,
+      exerciseProgrammingNotes: {
+        'main::global-bench-press': 'Session snapshot programming note',
+      },
+    });
+    seedSessionSet({
+      id: 'roundtrip-snapshot-set-main-1',
+      sessionId: 'session-roundtrip-from-snapshot',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      section: 'main',
+      reps: 8,
+    });
+
+    context.db
+      .update(templateExercises)
+      .set({ notes: 'Template note edited after session started' })
+      .where(eq(templateExercises.id, 'template-roundtrip-source-note'))
+      .run();
+    context.db
+      .update(workoutTemplates)
+      .set({ deletedAt: '2026-03-20T12:00:00.000Z' })
+      .where(eq(workoutTemplates.id, 'template-1'))
+      .run();
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions/session-roundtrip-from-snapshot/save-as-template',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(201);
+    const payload = response.json() as { data: { id: string } };
+
+    const persistedExercise = context.db
+      .select({
+        notes: templateExercises.notes,
+      })
+      .from(templateExercises)
+      .where(eq(templateExercises.templateId, payload.data.id))
+      .limit(1)
+      .get();
+
+    expect(persistedExercise).toEqual({
+      notes: 'Session snapshot programming note',
     });
   });
 

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -256,6 +256,39 @@ const toCreateWorkoutSessionInput = (
 const getReferencedExerciseIds = (sets: CreateWorkoutSessionInput['sets']) =>
   sets.map((set) => set.exerciseId);
 
+const buildTemplateProgrammingNotesSnapshot = ({
+  templateSections,
+  sets,
+}: {
+  templateSections: Array<{
+    type: CreateWorkoutSessionInput['sets'][number]['section'];
+    exercises: Array<{ exerciseId: string; notes?: string | null }>;
+  }>;
+  sets: CreateWorkoutSessionInput['sets'];
+}): Record<string, string | null> => {
+  const templateNotesByExerciseSection = new Map<string, string | null>();
+
+  for (const section of templateSections) {
+    const sectionKey = section.type ?? 'main';
+    for (const exercise of section.exercises) {
+      templateNotesByExerciseSection.set(
+        `${sectionKey}::${exercise.exerciseId}`,
+        exercise.notes ?? null,
+      );
+    }
+  }
+
+  const sessionExerciseKeys = new Set(
+    sets.map((set) => `${set.section ?? 'main'}::${set.exerciseId}`),
+  );
+  return Object.fromEntries(
+    Array.from(sessionExerciseKeys).map((key) => [
+      key,
+      templateNotesByExerciseSection.get(key) ?? null,
+    ]),
+  );
+};
+
 const buildInvalidExerciseMessage = (invalidExerciseIds: string[]) => {
   const preview = invalidExerciseIds.slice(0, 3).join(', ');
   const suffix = invalidExerciseIds.length > 3 ? ', ...' : '';
@@ -345,6 +378,7 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
     },
     async (request, reply) => {
       let input: CreateWorkoutSessionInput = request.body;
+      let programmingNotesByExerciseSection: Record<string, string | null> | undefined;
       // templateName is an AgentToken-only convenience; JWT callers must send templateId.
       if (request.body.templateName !== undefined && !isAgentRequest(request)) {
         return sendError(
@@ -383,6 +417,11 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
             sets: buildInitialSessionSets(template.sections),
           };
         }
+
+        programmingNotesByExerciseSection = buildTemplateProgrammingNotesSnapshot({
+          templateSections: template.sections,
+          sets: input.sets,
+        });
       }
 
       const invalidExerciseIds = await findInvalidSessionExerciseIds({
@@ -402,6 +441,7 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
         id: randomUUID(),
         userId: request.userId,
         input,
+        programmingNotesByExerciseSection,
       });
 
       if (input.templateId !== null) {

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -19,9 +19,11 @@ import type {
 import {
   exercises,
   parseWorkoutSessionFeedback,
+  parseWorkoutSessionExerciseProgrammingNotes,
   parseWorkoutSessionTimeSegments,
   sessionSets,
   serializeWorkoutSessionFeedback,
+  serializeWorkoutSessionExerciseProgrammingNotes,
   serializeWorkoutSessionTimeSegments,
   templateExercises,
   workoutSessions,
@@ -44,6 +46,7 @@ type WorkoutSessionRecord = {
   duration: number | null;
   timeSegments: string;
   feedback: string | null;
+  exerciseProgrammingNotes: string | null;
   notes: string | null;
   createdAt: number;
   updatedAt: number;
@@ -92,6 +95,7 @@ const workoutSessionSelection = {
   duration: workoutSessions.duration,
   timeSegments: workoutSessions.timeSegments,
   feedback: workoutSessions.feedback,
+  exerciseProgrammingNotes: workoutSessions.exerciseProgrammingNotes,
   notes: workoutSessions.notes,
   createdAt: workoutSessions.createdAt,
   updatedAt: workoutSessions.updatedAt,
@@ -231,6 +235,9 @@ const buildWorkoutSession = (
   const timeSegments = backfillTimeSegmentSections(
     parseWorkoutSessionTimeSegments(session.timeSegments),
   );
+  const programmingNotesByExerciseSection = parseWorkoutSessionExerciseProgrammingNotes(
+    session.exerciseProgrammingNotes,
+  );
   const sectionDurations = calculateSectionDurations(timeSegments);
 
   return {
@@ -247,7 +254,11 @@ const buildWorkoutSession = (
     sectionDurations,
     feedback: parseWorkoutSessionFeedback(session.feedback),
     notes: session.notes,
-    exercises: buildWorkoutSessionExercises(sets, exerciseInfoById),
+    exercises: buildWorkoutSessionExercises(
+      sets,
+      exerciseInfoById,
+      programmingNotesByExerciseSection,
+    ),
     sets: sets.sort(sortSessionSets).map<SessionSet>(buildSessionSet),
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
@@ -267,6 +278,7 @@ const buildWorkoutSessionExercises = (
       instructions: string | null;
     }
   >,
+  programmingNotesByExerciseSection: Record<string, string | null>,
 ): WorkoutSessionExercise[] => {
   const groupedByExercise = new Map<
     string,
@@ -348,6 +360,12 @@ const buildWorkoutSessionExercises = (
       },
       orderIndex: exercise.orderIndex,
       section: exercise.section,
+      programmingNotes:
+        exercise.exerciseId === null
+          ? null
+          : (programmingNotesByExerciseSection[
+              `${exercise.section ?? 'main'}::${exercise.exerciseId}`
+            ] ?? null),
       sets: exercise.sets,
     }));
 };
@@ -869,10 +887,12 @@ export const createWorkoutSession = async ({
   id,
   userId,
   input,
+  programmingNotesByExerciseSection,
 }: {
   id: string;
   userId: string;
   input: CreateWorkoutSessionInput;
+  programmingNotesByExerciseSection?: Record<string, string | null>;
 }): Promise<WorkoutSession> => {
   const { db } = await import('../../db/index.js');
   const setRows = buildSessionSetRows(id, input.sets);
@@ -892,6 +912,9 @@ export const createWorkoutSession = async ({
         duration: input.duration,
         timeSegments: serializeWorkoutSessionTimeSegments(input.timeSegments),
         feedback: serializeWorkoutSessionFeedback(input.feedback),
+        exerciseProgrammingNotes: serializeWorkoutSessionExerciseProgrammingNotes(
+          programmingNotesByExerciseSection,
+        ),
         notes: input.notes,
       })
       .run();

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -1281,6 +1281,21 @@ const mapSessionSectionToTemplateSection = (
   section: WorkoutTemplateSectionType | null,
 ): WorkoutTemplateSectionType => section ?? 'main';
 
+type SessionExerciseTemplateRoundTripSource = WorkoutSessionExercise & {
+  notes?: string | null;
+  agentNotes?: string | null;
+};
+
+const getTemplateNotesFromSessionExercise = (
+  exercise: SessionExerciseTemplateRoundTripSource,
+): string | null => {
+  // Agent notes and user notes do not round-trip — they are session-specific.
+  const { programmingNotes, notes, agentNotes } = exercise;
+  void notes;
+  void agentNotes;
+  return programmingNotes ?? null;
+};
+
 export const saveCompletedSessionAsTemplate = async ({
   input,
   userId,
@@ -1306,6 +1321,17 @@ export const saveCompletedSessionAsTemplate = async ({
       setCount: number;
     }
   >();
+  const programmingNotesByExercise = new Map<string, string | null>();
+
+  for (const exercise of session.exercises ?? []) {
+    if (exercise.exerciseId === null) {
+      continue;
+    }
+
+    const section = mapSessionSectionToTemplateSection(exercise.section);
+    const groupKey = `${section}:${exercise.exerciseId}`;
+    programmingNotesByExercise.set(groupKey, getTemplateNotesFromSessionExercise(exercise));
+  }
 
   for (const set of session.sets) {
     if (set.exerciseId === null) {
@@ -1341,7 +1367,7 @@ export const saveCompletedSessionAsTemplate = async ({
     restSeconds: null,
     supersetGroup: null,
     section: exercise.section,
-    notes: null,
+    notes: programmingNotesByExercise.get(`${exercise.section}:${exercise.exerciseId}`) ?? null,
     cues: [],
   }));
 

--- a/apps/web/src/features/workouts/api/workouts.test.tsx
+++ b/apps/web/src/features/workouts/api/workouts.test.tsx
@@ -230,6 +230,7 @@ function createSession(overrides: Partial<WorkoutSession> = {}): WorkoutSession 
         supersetGroup: null,
         orderIndex: 0,
         section: 'main',
+        programmingNotes: null,
         sets: [
           {
             id: 'set-1',

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -153,6 +153,7 @@ describe('SessionDetail', () => {
           trackingType: null,
           orderIndex: 0,
           section: 'main',
+          programmingNotes: null,
           sets: [
             createSet({
               id: 'set-deleted-1',
@@ -209,6 +210,7 @@ describe('SessionDetail', () => {
           trackingType: 'weight_reps',
           orderIndex: 0,
           section: 'main',
+          programmingNotes: null,
           sets: [archivedSet],
           exercise: {
             formCues: [],

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -130,6 +130,127 @@ describe('SessionDetail', () => {
     expect(screen.getByText('Bench at setting 5; keep elbows tucked.')).toBeInTheDocument();
   });
 
+  it('renders programming notes separately from exercise notes', async () => {
+    const currentSession = createSession({
+      id: 'session-programming-notes',
+      templateId: 'template-upper-push',
+      sets: [
+        createSet({
+          id: 'set-programming-note-1',
+          exerciseId: 'incline-dumbbell-press',
+          setNumber: 1,
+          notes: 'User observation: left shoulder felt stable.',
+          reps: 10,
+          section: 'main',
+          weight: 50,
+        }),
+      ],
+      exercises: [
+        {
+          exerciseId: 'incline-dumbbell-press',
+          exerciseName: 'Incline Dumbbell Press',
+          deletedAt: null,
+          supersetGroup: null,
+          trackingType: 'weight_reps',
+          orderIndex: 0,
+          section: 'main',
+          programmingNotes: 'Hardstyle, hips snap',
+          sets: [
+            createSet({
+              id: 'set-programming-note-1',
+              exerciseId: 'incline-dumbbell-press',
+              setNumber: 1,
+              notes: 'User observation: left shoulder felt stable.',
+              reps: 10,
+              section: 'main',
+              weight: 50,
+            }),
+          ],
+        },
+      ],
+    });
+
+    mockSessionDetailRequests({
+      sessionId: currentSession.id,
+      session: currentSession,
+      sessions: [
+        createSessionListItem({
+          id: currentSession.id,
+          templateId: currentSession.templateId,
+          templateName: 'Upper Push',
+          startedAt: currentSession.startedAt,
+        }),
+      ],
+    });
+
+    renderSessionDetail(currentSession.id);
+
+    expect(await screen.findByText('Workout receipt')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('exercise-programming-notes-incline-dumbbell-press'),
+    ).toHaveTextContent('Hardstyle, hips snap');
+    expect(screen.getByText('User observation: left shoulder felt stable.')).toBeInTheDocument();
+  });
+
+  it('does not render a programming notes block when programmingNotes is null', async () => {
+    const currentSession = createSession({
+      id: 'session-no-programming-notes',
+      templateId: 'template-upper-push',
+      exercises: [
+        {
+          exerciseId: 'incline-dumbbell-press',
+          exerciseName: 'Incline Dumbbell Press',
+          deletedAt: null,
+          supersetGroup: null,
+          trackingType: 'weight_reps',
+          orderIndex: 0,
+          section: 'main',
+          programmingNotes: null,
+          sets: [
+            createSet({
+              id: 'set-no-programming-note-1',
+              exerciseId: 'incline-dumbbell-press',
+              setNumber: 1,
+              reps: 10,
+              section: 'main',
+              weight: 50,
+            }),
+          ],
+        },
+      ],
+      sets: [
+        createSet({
+          id: 'set-no-programming-note-1',
+          exerciseId: 'incline-dumbbell-press',
+          setNumber: 1,
+          reps: 10,
+          section: 'main',
+          weight: 50,
+        }),
+      ],
+    });
+
+    mockSessionDetailRequests({
+      sessionId: currentSession.id,
+      session: currentSession,
+      sessions: [
+        createSessionListItem({
+          id: currentSession.id,
+          templateId: currentSession.templateId,
+          templateName: 'Upper Push',
+          startedAt: currentSession.startedAt,
+        }),
+      ],
+    });
+
+    renderSessionDetail(currentSession.id);
+
+    expect(await screen.findByText('Workout receipt')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('exercise-programming-notes-incline-dumbbell-press'),
+    ).not.toBeInTheDocument();
+  });
+
   it('renders deleted exercise placeholders for sets with null exerciseId', async () => {
     const currentSession = createSession({
       id: 'session-null-exercise',

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useSearchParams } from 'react-router';
 import {
   ArrowLeft,
   ChevronDown,
+  ClipboardList,
   Dumbbell,
   ListChecks,
   NotebookPen,
@@ -72,6 +73,7 @@ type SessionDetailExercise = {
   groupKey: string;
   name: string;
   notes: string | null;
+  programmingNotes: string | null;
   archived: boolean;
   phaseBadge: 'moderate' | 'rebuild' | 'recovery' | 'test';
   sets: SessionSet[];
@@ -528,6 +530,26 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
                   </CardHeader>
 
                   <CardContent className="space-y-3 pb-3">
+                    {exercise.programmingNotes ? (
+                      <div
+                        className="flex items-start gap-2 rounded-xl border-l-2 border-primary/35 bg-secondary/35 px-3 py-2"
+                        data-testid={`exercise-programming-notes-${exercise.groupKey}`}
+                      >
+                        <ClipboardList
+                          aria-hidden="true"
+                          className="mt-0.5 size-3.5 shrink-0 text-muted"
+                        />
+                        <div className="space-y-0.5">
+                          <p className="text-[10px] font-semibold tracking-[0.16em] text-muted uppercase">
+                            Programming notes
+                          </p>
+                          <p className="whitespace-pre-wrap text-[13px] italic text-muted">
+                            {exercise.programmingNotes}
+                          </p>
+                        </div>
+                      </div>
+                    ) : null}
+
                     {isEditing ? (
                       <div className="space-y-2.5 rounded-2xl border border-[color-mix(in_srgb,var(--color-accent-mint)_55%,transparent)] bg-[color-mix(in_srgb,var(--color-accent-mint)_10%,transparent)] p-2.5">
                         {exercise.sets.map((set) => (
@@ -915,6 +937,7 @@ function buildSections(
         {
           deletedAt: exercise.deletedAt ?? null,
           exerciseName: exercise.exerciseName,
+          programmingNotes: exercise.programmingNotes?.trim() ?? null,
           supersetGroup: exercise.supersetGroup ?? null,
           trackingType: exercise.trackingType ?? null,
         },
@@ -996,6 +1019,7 @@ function buildSections(
           name,
           archived: Boolean(sessionExerciseMeta?.deletedAt),
           notes: sets.find((set) => set.notes)?.notes ?? null,
+          programmingNotes: sessionExerciseMeta?.programmingNotes ?? null,
           phaseBadge: inferPhaseBadge(sectionType),
           sets: [...sets].sort((left, right) => left.setNumber - right.setNumber),
           supersetGroup:

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -316,6 +316,96 @@ describe('SessionExerciseList', () => {
     }
   });
 
+  it('renders programming notes separately from editable session notes', () => {
+    if (!activeTemplate) {
+      throw new Error('Expected upper-push template in mock data.');
+    }
+
+    const session = buildActiveWorkoutSession(
+      activeTemplate,
+      createInitialWorkoutSetDrafts(activeTemplate, new Set()),
+    );
+    const rowErgExercise = session.sections
+      .flatMap((section) => section.exercises)
+      .find((exercise) => exercise.id === 'row-erg');
+
+    if (!rowErgExercise) {
+      throw new Error('Expected Row Erg exercise in active workout session.');
+    }
+
+    rowErgExercise.programmingNotes = 'Hardstyle, hips snap';
+    rowErgExercise.notes = '';
+
+    renderWithQueryClient(
+      <SessionExerciseList
+        onAddSet={vi.fn()}
+        onExerciseNotesChange={vi.fn()}
+        onRemoveSet={vi.fn()}
+        onSetUpdate={vi.fn()}
+        session={session}
+      />,
+    );
+
+    const rowErgCard = screen
+      .getByRole('heading', { level: 3, name: 'Row Erg' })
+      .closest('[data-slot="card"]');
+
+    if (!rowErgCard) {
+      throw new Error('Expected Row Erg card.');
+    }
+
+    fireEvent.click(getExercisePanelToggle('Row Erg', 'row-erg'));
+
+    expect(
+      within(rowErgCard as HTMLElement).getByTestId('exercise-programming-notes-row-erg'),
+    ).toHaveTextContent('Hardstyle, hips snap');
+
+    fireEvent.click(within(rowErgCard as HTMLElement).getByText('Session notes'));
+    const notesInput = within(rowErgCard as HTMLElement).getByPlaceholderText(
+      'Add any technique reminders, machine settings, or quick context.',
+    );
+    expect(notesInput).toHaveValue('');
+
+    fireEvent.change(notesInput, { target: { value: 'Lower drag factor to 120.' } });
+    expect(notesInput).toHaveValue('Lower drag factor to 120.');
+    expect(
+      within(rowErgCard as HTMLElement).getByTestId('exercise-programming-notes-row-erg'),
+    ).toHaveTextContent('Hardstyle, hips snap');
+  });
+
+  it('does not render a programming notes block when programmingNotes is null', () => {
+    if (!activeTemplate) {
+      throw new Error('Expected upper-push template in mock data.');
+    }
+
+    const session = buildActiveWorkoutSession(
+      activeTemplate,
+      createInitialWorkoutSetDrafts(activeTemplate, new Set()),
+    );
+    const rowErgExercise = session.sections
+      .flatMap((section) => section.exercises)
+      .find((exercise) => exercise.id === 'row-erg');
+
+    if (!rowErgExercise) {
+      throw new Error('Expected Row Erg exercise in active workout session.');
+    }
+
+    rowErgExercise.programmingNotes = null;
+
+    renderWithQueryClient(
+      <SessionExerciseList
+        onAddSet={vi.fn()}
+        onExerciseNotesChange={vi.fn()}
+        onRemoveSet={vi.fn()}
+        onSetUpdate={vi.fn()}
+        session={session}
+      />,
+    );
+
+    fireEvent.click(getExercisePanelToggle('Row Erg', 'row-erg'));
+    expect(screen.queryByTestId('exercise-programming-notes-row-erg')).not.toBeInTheDocument();
+  });
+
   it('flushes pending exercise notes update on blur', () => {
     vi.useFakeTimers();
 

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -28,6 +28,7 @@ import {
   AlertTriangle,
   ArrowDown,
   ArrowUp,
+  ClipboardList,
   Braces,
   ChevronDown,
   Check,
@@ -795,6 +796,7 @@ function ExerciseCardItem({
   const isExerciseComplete = state === 'completed';
   const formCues = exercise.formCues;
   const templateCues = exercise.templateCues;
+  const programmingNotes = exercise.programmingNotes?.trim() ?? '';
   const hasInjuryCues = exercise.injuryCues.length > 0;
   const priorityAccentClass = embeddedInSuperset
     ? ''
@@ -990,6 +992,21 @@ function ExerciseCardItem({
               ) : null}
             </div>
 
+            {programmingNotes ? (
+              <div
+                className="flex items-start gap-2 rounded-xl border-l-2 border-primary/35 bg-secondary/35 px-3 py-2"
+                data-testid={`exercise-programming-notes-${exercise.id}`}
+              >
+                <ClipboardList aria-hidden="true" className="mt-0.5 size-3.5 shrink-0 text-muted" />
+                <div className="space-y-0.5">
+                  <p className="text-[10px] font-semibold tracking-[0.16em] text-muted uppercase">
+                    Programming notes
+                  </p>
+                  <p className="whitespace-pre-wrap text-[13px] italic text-muted">{programmingNotes}</p>
+                </div>
+              </div>
+            ) : null}
+
             <div className="flex flex-col gap-3 sm:flex-row">
               <div className="space-y-2 rounded-2xl border border-border bg-background/80 p-4 sm:flex-1">
                 <div className="flex items-center justify-between">
@@ -1037,7 +1054,6 @@ function ExerciseCardItem({
                   exerciseCues={formCues}
                   sessionCues={sessionCues}
                   templateCues={templateCues}
-                  templateProgrammingNotes={exercise.programmingNotes}
                 />
               </div>
             </div>

--- a/apps/web/src/features/workouts/components/session-summary.test.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.test.tsx
@@ -19,6 +19,7 @@ describe('SessionSummary', () => {
             id: 'incline-press',
             name: 'Incline Dumbbell Press',
             notes: 'Kept shoulder blades pinned and reduced ROM for shoulder comfort.',
+            programmingNotes: 'Hardstyle, hips snap',
             reps: 32,
             setsCompleted: 4,
             totalSets: 4,
@@ -107,6 +108,9 @@ describe('SessionSummary', () => {
     expect(screen.getByText('14/14')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Exercise results' })).toBeInTheDocument();
     expect(screen.getByText('Incline Dumbbell Press')).toBeInTheDocument();
+    expect(screen.getByTestId('exercise-programming-notes-incline-press')).toHaveTextContent(
+      'Hardstyle, hips snap',
+    );
     expect(
       screen.getByText('Kept shoulder blades pinned and reduced ROM for shoulder comfort.'),
     ).toBeInTheDocument();
@@ -145,6 +149,9 @@ describe('SessionSummary', () => {
       },
     );
     expect(notesChangeSpy).toHaveBeenCalledWith('Tempo was good but shoulders fatigued early.');
+    expect(screen.getByTestId('exercise-programming-notes-incline-press')).toHaveTextContent(
+      'Hardstyle, hips snap',
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Save as Template' }));
 
@@ -252,5 +259,33 @@ describe('SessionSummary', () => {
     expect(screen.getByText('conservative').tagName).toBe('EM');
     expect(screen.getByText('<script>alert("xss")</script>')).toBeInTheDocument();
     expect(document.querySelector('script')).not.toBeInTheDocument();
+  });
+
+  it('does not render a programming notes block when programmingNotes is null', () => {
+    renderWithQueryClient(
+      <SessionSummary
+        duration="10:00"
+        exerciseResults={[
+          {
+            id: 'incline-press',
+            name: 'Incline Dumbbell Press',
+            notes: '',
+            programmingNotes: null,
+            reps: 12,
+            setsCompleted: 2,
+            totalSets: 2,
+            volume: 600,
+          },
+        ]}
+        exercisesCompleted={1}
+        onDone={() => {}}
+        totalReps={12}
+        totalSets={2}
+        totalVolume={600}
+        workoutName="Upper Push"
+      />,
+    );
+
+    expect(screen.queryByTestId('exercise-programming-notes-incline-press')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/workouts/components/session-summary.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { CheckCircle2, Clock3, Dumbbell, ListChecks, Save, X } from 'lucide-react';
+import { CheckCircle2, ClipboardList, Clock3, Dumbbell, ListChecks, Save, X } from 'lucide-react';
 import { formatWeight, type WeightUnit } from '@pulse/shared';
 
 import { Badge } from '@/components/ui/badge';
@@ -61,6 +61,7 @@ export type SessionSummaryExerciseResult = {
   metricValue?: number;
   name: string;
   notes?: string | null;
+  programmingNotes?: string | null;
   reps: number;
   setsCompleted: number;
   totalSets: number;
@@ -216,6 +217,25 @@ export function SessionSummary({
                         <MetricChip label="Reps" tone="count" value={`${exercise.reps}`} />
                       ) : null}
                     </div>
+                    {exercise.programmingNotes?.trim() ? (
+                      <div
+                        className="mt-2 flex items-start gap-2 rounded-xl border-l-2 border-primary/35 bg-secondary/35 px-3 py-2"
+                        data-testid={`exercise-programming-notes-${exercise.id}`}
+                      >
+                        <ClipboardList
+                          aria-hidden="true"
+                          className="mt-0.5 size-3.5 shrink-0 text-muted"
+                        />
+                        <div className="space-y-0.5">
+                          <p className="text-[10px] font-semibold tracking-[0.16em] text-muted uppercase">
+                            Programming notes
+                          </p>
+                          <p className="whitespace-pre-wrap text-[13px] italic text-muted">
+                            {exercise.programmingNotes.trim()}
+                          </p>
+                        </div>
+                      </div>
+                    ) : null}
                     {exercise.notes?.trim() ? (
                       <MarkdownNote
                         className="mt-2 text-xs text-muted"

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -498,6 +498,7 @@ export function ActiveWorkoutPage() {
               ),
               name: exercise.name,
               notes: exercise.notes,
+              programmingNotes: exercise.programmingNotes,
               reps: isRepTrackingType(exercise.trackingType)
                 ? completedSets.reduce((total, set) => total + (set.reps ?? 0), 0)
                 : 0,

--- a/docs/conventions/data-models.md
+++ b/docs/conventions/data-models.md
@@ -187,6 +187,7 @@ Constraints:
 - `duration`: nullable `integer` minutes
 - `timeSegments`: required JSON text array of `{ start: string, end: string | null, section: 'warmup' | 'main' | 'cooldown' | 'supplemental' }`, default `'[]'`
 - `feedback`: nullable JSON text object for post-session ratings and notes
+- `exerciseProgrammingNotes`: nullable JSON text record keyed by `${section}::${exerciseId}` with `string | null` values; snapshots `template_exercises.notes` at session start
 - `notes`: nullable `text`
 - `deletedAt`: nullable `text` ISO timestamp for soft delete
 - `createdAt`: `integer` Unix ms, required, default now
@@ -201,6 +202,7 @@ Constraints:
 Notes:
 
 - `timeSegments` is stored as JSON text, so schema evolution from legacy `{ start, end }` segments to section-tagged segments is handled in the store/parser layer with read-time backfill (`section: 'main'`) rather than a SQL migration.
+- `exerciseProgrammingNotes` is forward-apply snapshot data: newly created template-backed sessions persist a copy of template exercise notes, while historical sessions keep `null` until explicitly recreated.
 
 #### `session_sets`
 

--- a/docs/conventions/design-system.md
+++ b/docs/conventions/design-system.md
@@ -168,6 +168,16 @@ Guardrails:
 - Always use `--color-on-accent` (or a semantic alias that resolves to it) for text on accent-colored cards.
 - Always verify foreground contrast before shipping.
 
+## Programming Notes Block
+
+Use this treatment for read-only exercise programming notes sourced from templates/snapshots in session UIs.
+
+- Placement: render inside the exercise card body below the exercise header/metrics and above set rows.
+- Separation: keep this block visually distinct from any user-editable notes textarea. Never prefill or merge into the textarea.
+- Visibility: render only when `programmingNotes` is a non-empty string after trim.
+- Visual pattern: `flex items-start gap-2` container with a subtle left accent (`border-l-2 border-primary/35`) and muted surface (`bg-secondary/35`), plus a small `ClipboardList` icon.
+- Typography: compact uppercase label (`text-[10px] font-semibold tracking-[0.16em] text-muted`) and italic body copy (`text-[13px] italic text-muted`) with `whitespace-pre-wrap`.
+
 ## Workout Section Header Controls
 
 Active workout section headers use a dual-action layout:

--- a/docs/conventions/workout-domain.md
+++ b/docs/conventions/workout-domain.md
@@ -85,6 +85,15 @@ Completed sessions should also store exercise-level set logs and post-workout fe
 
 Session exercise metadata should preserve `supersetGroup` values so completed receipts and history can render grouped supersets consistently.
 
+### Session Exercise Notes Layers
+
+Session exercises intentionally keep two separate note channels:
+
+- `programmingNotes` (read-only): a snapshot of `template_exercises.notes` taken when the session starts from a template. This does not change if the template is edited later.
+- user exercise notes (editable): the workout-time notes entered during the session via the existing exercise-notes flow.
+
+Do not merge these two layers into one textarea; template prescription context and user observations must remain distinct.
+
 ## Superset Grouping
 
 - A superset is represented by assigning the same non-null `supersetGroup` id to 2+ exercises in the same section.

--- a/docs/conventions/workout-domain.md
+++ b/docs/conventions/workout-domain.md
@@ -94,6 +94,8 @@ Session exercises intentionally keep two separate note channels:
 
 Do not merge these two layers into one textarea; template prescription context and user observations must remain distinct.
 
+When a completed session is saved as a new template (`POST /api/v1/workout-sessions/:id/save-as-template`), only `programmingNotes` round-trips onto `template_exercises.notes`. Session-specific note channels (user exercise notes, and agent notes when present) must be dropped so transient workout context is not promoted into reusable programming.
+
 ## Superset Grouping
 
 - A superset is represented by assigning the same non-null `supersetGroup` id to 2+ exercises in the same section.

--- a/packages/shared/src/schemas/workout-sessions.test.ts
+++ b/packages/shared/src/schemas/workout-sessions.test.ts
@@ -305,6 +305,59 @@ describe('sessionCorrectionRequestSchema', () => {
 });
 
 describe('workoutSessionSchema', () => {
+  it('accepts nullable per-exercise programming notes', () => {
+    const session = workoutSessionSchema.parse({
+      id: 'session-programming-notes',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Programming Notes Session',
+      date: '2026-03-01',
+      status: 'completed',
+      startedAt: 1_700_000_000_000,
+      completedAt: 1_700_000_030_000,
+      duration: 1800,
+      timeSegments: [
+        { start: '2026-03-01T10:00:00.000Z', end: '2026-03-01T10:30:00.000Z', section: 'main' },
+      ],
+      sectionDurations: {
+        warmup: 0,
+        main: 1_800_000,
+        cooldown: 0,
+        supplemental: 0,
+      },
+      feedback: null,
+      notes: null,
+      exercises: [
+        {
+          exerciseId: 'exercise-1',
+          exerciseName: 'Barbell Row',
+          trackingType: 'weight_reps',
+          supersetGroup: null,
+          orderIndex: 0,
+          section: 'main',
+          programmingNotes: ' Keep lats tight ',
+          sets: [],
+        },
+        {
+          exerciseId: 'exercise-2',
+          exerciseName: 'Goblet Squat',
+          trackingType: 'weight_reps',
+          supersetGroup: null,
+          orderIndex: 1,
+          section: 'main',
+          programmingNotes: null,
+          sets: [],
+        },
+      ],
+      sets: [],
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_030_000,
+    });
+
+    expect(session.exercises?.[0]?.programmingNotes).toBe('Keep lats tight');
+    expect(session.exercises?.[1]?.programmingNotes).toBeNull();
+  });
+
   it('preserves deleted exercise metadata in historical session responses', () => {
     const session = workoutSessionSchema.parse({
       id: 'session-deleted-metadata',
@@ -393,6 +446,7 @@ describe('workoutSessionSchema', () => {
           },
           orderIndex: 0,
           section: 'main',
+          programmingNotes: null,
           sets: [
             {
               id: 'set-1',
@@ -470,6 +524,7 @@ describe('workoutSessionSchema', () => {
           },
           orderIndex: 0,
           section: 'main',
+          programmingNotes: null,
           sets: [
             {
               id: 'set-1',

--- a/packages/shared/src/schemas/workout-sessions.ts
+++ b/packages/shared/src/schemas/workout-sessions.ts
@@ -329,6 +329,7 @@ export const workoutSessionExerciseSchema = z.object({
     .optional(),
   orderIndex: z.number().int().min(0),
   section: workoutTemplateSectionTypeSchema.nullable(),
+  programmingNotes: nullableLongStringSchema.default(null),
   sets: z.array(sessionSetSchema).max(500),
 });
 


### PR DESCRIPTION
## Summary
This PR introduces a dedicated “programming notes” lane for workout sessions so template prescription context is preserved without mixing into user-entered session notes. When a session is created from a template, the backend snapshots each template exercise note and persists it on the session, then returns it in session detail responses. The same snapshot is used when saving a completed session as a new template, so template notes round-trip from session state rather than from potentially changed/deleted source templates. On the web side, programming notes now render as a read-only, visually distinct block in active workout cards, session detail, and session summary, separate from editable workout-time notes.

## Key Changes
- Added `workout_sessions.exercise_programming_notes` via migration and wired Drizzle schema support.
- Added serialization/parsing helpers for programming-notes snapshots as JSON records keyed by ``${section}::${exerciseId}``.
- Updated session creation (`POST /workout-sessions`, template path) to snapshot template exercise notes into session programming notes.
- Updated session read/build paths to expose `programmingNotes` per session exercise in shared schemas and API responses.
- Updated `POST /workout-sessions/:id/save-as-template` to populate new template exercise `notes` from session `programmingNotes`, explicitly excluding session-specific note channels.
- Added UI rendering for read-only programming notes in active workout, session detail, and summary views, with tests ensuring these notes remain separate from editable notes.

## Technical Notes
- Snapshot storage is intentionally denormalized into a single JSON column on `workout_sessions` (instead of a separate session-exercise table), keyed by section+exercise for stable lookup during response shaping.
- Snapshot behavior is immutable by design: sessions keep the note state captured at start time even if template exercise notes are edited (or the original template is soft-deleted) later.
- Save-as-template now treats `programmingNotes` as the only source of reusable template note content and drops transient user/agent session notes to avoid promoting in-session context into future programming.
- The frontend trims/guards empty values and only renders the programming-notes block when non-empty, preventing visual noise and accidental conflation with editable note textareas.

## Commits

- `d914ce4 feat(web): render programming notes on session exercise cards`
- `6c5a60f feat(api): round-trip programming notes in save-as-template`
- `9da6203 feat(workouts): snapshot template programming notes onto sessions`

## Tasks

- **Snapshot template notes onto session at creation**: Add session_exercises.programmingNotes column via Drizzle migration; copy template_exercises.notes on session create (templateId path); expose programmingNotes on GET /workout-sessions/:id; store + route tests.
- **Round-trip programmingNotes in save-as-template**: Extend POST /workout-sessions/:id/save-as-template to copy each session exercise's programmingNotes back onto template_exercises.notes on the new template. Drop agentNotes and user notes server-side. Route tests covering the round-trip.
- **Render programmingNotes in session views**: Add a read-only programming-notes block to active-workout exercise card (session-exercise-list.tsx), session-detail.tsx, and session-summary.tsx. Visually distinct from the user's editable notes textarea (muted, compact, icon). Component tests assert both blocks coexist and are not conflated.

## Diff Stats

```
apps/api/drizzle/0036_bitter_fat_cobra.sql         |    1 +
 apps/api/drizzle/meta/0036_snapshot.json           | 3015 ++++++++++++++++++++
 apps/api/drizzle/meta/_journal.json                |    9 +-
 apps/api/src/db/schema.test.ts                     |    1 +
 apps/api/src/db/schema/index.ts                    |    1 +
 .../db/schema/workout-session-programming-notes.ts |   52 +
 apps/api/src/db/schema/workout-sessions.ts         |    2 +
 apps/api/src/routes/workout-sessions/index.test.ts |  417 +++
 apps/api/src/routes/workout-sessions/index.ts      |   40 +
 apps/api/src/routes/workout-sessions/store.ts      |   53 +-
 .../src/features/workouts/api/workouts.test.tsx    |    1 +
 .../workouts/components/session-detail.test.tsx    |  123 +
 .../workouts/components/session-detail.tsx         |   24 +
 .../components/session-exercise-list.test.tsx      |   90 +
 .../workouts/components/session-exercise-list.tsx  |   18 +-
 .../workouts/components/session-summary.test.tsx   |   35 +
 .../workouts/components/session-summary.tsx        |   22 +-
 apps/web/src/pages/active-workout.tsx              |    1 +
 docs/conventions/data-models.md                    |    2 +
 docs/conventions/design-system.md                  |   10 +
 docs/conventions/workout-domain.md                 |   11 +
 .../shared/src/schemas/workout-sessions.test.ts    |   55 +
 packages/shared/src/schemas/workout-sessions.ts    |    1 +
 23 files changed, 3979 insertions(+), 5 deletions(-)
```