### PR TITLE
refactor(workouts): shared WorkoutExerciseCard primitive for read-only views

### DIFF
--- a/apps/web/src/features/workouts/components/exercise-detail-modal.test.tsx
+++ b/apps/web/src/features/workouts/components/exercise-detail-modal.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useExerciseHistory } from '@/hooks/use-exercise-history';
 
 import { useExercise } from '../api/workouts';
+import { getWorkoutExerciseCardElementId } from './workout-exercise-card';
 import { ExerciseDetailModal } from './exercise-detail-modal';
 
 vi.mock('../api/workouts', () => ({
@@ -134,6 +135,33 @@ describe('ExerciseDetailModal', () => {
     });
 
     expect(screen.getByRole('button', { name: 'Edit exercise' })).toBeInTheDocument();
+  });
+
+  it('scrolls to the shared exercise card when editing from template context', () => {
+    const onOpenChange = vi.fn();
+    const scrollIntoView = vi.fn();
+    const target = document.createElement('div');
+    target.id = getWorkoutExerciseCardElementId('template-exercise-1');
+    target.scrollIntoView = scrollIntoView;
+    document.body.appendChild(target);
+
+    renderModal({
+      context: 'template',
+      exerciseId: 'incline-dumbbell-press',
+      onOpenChange,
+      open: true,
+      templateExerciseId: 'template-exercise-1',
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit exercise' }));
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'center',
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    target.remove();
   });
 
   it('shows swap button in session context and invokes swap callback', () => {

--- a/apps/web/src/features/workouts/components/exercise-detail-modal.tsx
+++ b/apps/web/src/features/workouts/components/exercise-detail-modal.tsx
@@ -18,7 +18,7 @@ import { useExerciseHistory } from '@/hooks/use-exercise-history';
 import { useWeightUnit } from '@/hooks/use-weight-unit';
 
 import { useExercise } from '../api/workouts';
-import { getTemplateExerciseElementId } from '../lib/template-exercise-id';
+import { getWorkoutExerciseCardElementId } from './workout-exercise-card';
 import { formatCompactSets } from '../lib/tracking';
 import type {
   ActiveWorkoutPerformanceHistorySession,
@@ -301,7 +301,7 @@ export function ExerciseDetailModal({
               onClick={() => {
                 if (templateExerciseId) {
                   const target = document.getElementById(
-                    getTemplateExerciseElementId(templateExerciseId),
+                    getWorkoutExerciseCardElementId(templateExerciseId),
                   );
                   target?.scrollIntoView?.({
                     behavior: 'smooth',

--- a/apps/web/src/features/workouts/components/scheduled-workout-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/scheduled-workout-detail.test.tsx
@@ -1,10 +1,46 @@
-import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { toDateKey } from '@/lib/date-utils';
 import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
 import { renderWithQueryClient } from '@/test/render-with-query-client';
 import { jsonResponse } from '@/test/test-utils';
+
+vi.mock('./schedule-workout-dialog', () => ({
+  ScheduleWorkoutDialog: ({
+    onOpenChange,
+    onSubmitDate,
+    open,
+    title,
+  }: {
+    onOpenChange: (open: boolean) => void;
+    onSubmitDate: (dateKey: string) => Promise<unknown>;
+    open: boolean;
+    title: string;
+  }) => {
+    if (!open) {
+      return null;
+    }
+
+    return (
+      <div>
+        <p>{title}</p>
+        <button
+          onClick={() => {
+            void onSubmitDate('2099-12-31');
+          }}
+          type="button"
+        >
+          Submit reschedule
+        </button>
+        <button onClick={() => onOpenChange(false)} type="button">
+          Close reschedule
+        </button>
+      </div>
+    );
+  },
+}));
 
 import { ScheduledWorkoutDetail } from './scheduled-workout-detail';
 
@@ -18,114 +54,24 @@ afterEach(() => {
 });
 
 describe('ScheduledWorkoutDetail', () => {
-  it('opens and closes exercise history modal from planned workout rows', async () => {
-    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+  it('renders shared workout exercise cards and programming notes from scheduled template data', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
       const url = new URL(String(input), 'https://pulse.test');
+      const method = init?.method ?? 'GET';
 
-      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1') {
+      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'GET') {
         return Promise.resolve(
           jsonResponse({
-            data: {
-              id: 'scheduled-1',
-              userId: 'user-1',
-              templateId: 'template-1',
-              date: '2026-03-18',
-              sessionId: null,
-              createdAt: 1,
-              updatedAt: 1,
-              template: {
-                id: 'template-1',
-                userId: 'user-1',
-                name: 'Upper Push',
-                description: null,
-                tags: ['push'],
-                sections: [
-                  {
-                    type: 'warmup',
-                    exercises: [],
-                  },
-                  {
-                    type: 'main',
-                    exercises: [
-                      {
-                        id: 'template-exercise-1',
-                        exerciseId: 'incline-dumbbell-press',
-                        exerciseName: 'Incline Dumbbell Press',
-                        trackingType: 'weight_reps',
-                        sets: 3,
-                        repsMin: 8,
-                        repsMax: 10,
-                        tempo: null,
-                        restSeconds: 90,
-                        supersetGroup: null,
-                        notes: null,
-                        cues: [],
-                      },
-                    ],
-                  },
-                  {
-                    type: 'cooldown',
-                    exercises: [],
-                  },
-                ],
-                createdAt: 1,
-                updatedAt: 1,
-              },
-            },
+            data: createScheduledWorkoutDetailPayload({ date: toDateKey(new Date()) }),
           }),
         );
       }
 
-      if (url.pathname === '/api/v1/workout-sessions') {
-        return Promise.resolve(
-          jsonResponse({
-            data: [],
-          }),
-        );
+      if (url.pathname === '/api/v1/workout-sessions' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
       }
 
-      if (url.pathname === '/api/v1/exercises/incline-dumbbell-press') {
-        return Promise.resolve(
-          jsonResponse({
-            data: {
-              id: 'incline-dumbbell-press',
-              userId: 'user-1',
-              name: 'Incline Dumbbell Press',
-              muscleGroups: ['upper chest', 'triceps'],
-              equipment: 'Dumbbells',
-              category: 'compound',
-              trackingType: 'weight_reps',
-              tags: [],
-              formCues: ['Tuck shoulder blades'],
-              instructions: 'Lower with control and drive up.',
-              coachingNotes: 'Keep your upper back pinned.',
-              relatedExerciseIds: [],
-              createdAt: 1,
-              updatedAt: 1,
-            },
-          }),
-        );
-      }
-
-      if (url.pathname === '/api/v1/exercises/incline-dumbbell-press/history') {
-        return Promise.resolve(
-          jsonResponse({
-            data: [
-              {
-                sessionId: 'session-1',
-                date: '2026-03-12',
-                notes: null,
-                sets: [
-                  { setNumber: 1, reps: 10, weight: 70 },
-                  { setNumber: 2, reps: 9, weight: 70 },
-                ],
-              },
-            ],
-          }),
-        );
-      }
-
-      throw new Error(`Unhandled request: ${url.pathname}`);
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
     });
 
     renderWithQueryClient(
@@ -134,18 +80,306 @@ describe('ScheduledWorkoutDetail', () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText('Upper Push')).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 1, name: 'Upper Push' })).toBeInTheDocument();
+    expect(screen.getByTestId('workout-exercise-card-template-exercise-1')).toBeInTheDocument();
+    expect(screen.getByText('Programming notes')).toBeInTheDocument();
+    expect(screen.getByText('Top set first, then reduce load for back-off sets.')).toBeInTheDocument();
+    expect(screen.getByText('Show full set detail')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open Incline Dumbbell Press history' }));
+    expect(
+      fetchSpy.mock.calls.some(
+        ([input, requestInit]) =>
+          String(input).includes('/api/v1/scheduled-workouts/scheduled-1') &&
+          (requestInit?.method ?? 'GET') === 'GET',
+      ),
+    ).toBe(true);
+  });
 
-    const dialog = await screen.findByRole('dialog');
-    fireEvent.click(await within(dialog).findByRole('tab', { name: 'History' }));
-    expect(await within(dialog).findByText('Mar 12, 2026 · 70x10, 70x9')).toBeInTheDocument();
+  it('starts the scheduled workout via the start-session mutation', async () => {
+    const todayKey = toDateKey(new Date());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = new URL(String(input), 'https://pulse.test');
+      const method = init?.method ?? 'GET';
 
-    fireEvent.click(within(dialog).getAllByRole('button', { name: 'Close' })[0] as HTMLElement);
+      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: createScheduledWorkoutDetailPayload({ date: todayKey }),
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions' && method === 'POST') {
+        return Promise.resolve(
+          jsonResponse(
+            {
+              data: {
+                id: 'session-1',
+                userId: 'user-1',
+                templateId: 'template-1',
+                name: 'Upper Push',
+                date: todayKey,
+                status: 'in-progress',
+                startedAt: 1,
+                completedAt: null,
+                duration: null,
+                timeSegments: [
+                  {
+                    start: '2026-03-07T00:00:00.000Z',
+                    end: null,
+                    section: 'main',
+                  },
+                ],
+                feedback: null,
+                notes: null,
+                sets: [],
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            },
+            { status: 201 },
+          ),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <ScheduledWorkoutDetail id="scheduled-1" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Start workout' }));
 
     await waitFor(() => {
-      expect(screen.queryByText('Mar 12, 2026 · 70x10, 70x9')).not.toBeInTheDocument();
+      const startCall = fetchSpy.mock.calls.find(([input, requestInit]) => {
+        const requestUrl = String(input);
+        const requestMethod = requestInit?.method ?? 'GET';
+        return requestUrl.includes('/api/v1/workout-sessions') && requestMethod === 'POST';
+      });
+
+      expect(startCall).toBeDefined();
+    });
+
+    const startCall = fetchSpy.mock.calls.find(([input, requestInit]) => {
+      const requestUrl = String(input);
+      const requestMethod = requestInit?.method ?? 'GET';
+      return requestUrl.includes('/api/v1/workout-sessions') && requestMethod === 'POST';
+    });
+
+    const requestBody = JSON.parse(String(startCall?.[1]?.body));
+    expect(requestBody).toMatchObject({
+      name: 'Upper Push',
+      templateId: 'template-1',
+    });
+  });
+
+  it('keeps reschedule and cancel affordances wired to scheduled-workout mutations', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = new URL(String(input), 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: createScheduledWorkoutDetailPayload({ date: toDateKey(new Date()) }),
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'PATCH') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              id: 'scheduled-1',
+              userId: 'user-1',
+              templateId: 'template-1',
+              date: '2099-12-31',
+              sessionId: null,
+              createdAt: 1,
+              updatedAt: 2,
+            },
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'DELETE') {
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              success: true,
+            },
+          }),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <ScheduledWorkoutDetail id="scheduled-1" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Reschedule' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Submit reschedule' }));
+
+    await waitFor(() => {
+      const rescheduleCall = fetchSpy.mock.calls.find(([input, requestInit]) => {
+        const requestUrl = String(input);
+        const requestMethod = requestInit?.method ?? 'GET';
+        return (
+          requestUrl.includes('/api/v1/scheduled-workouts/scheduled-1') &&
+          requestMethod === 'PATCH'
+        );
+      });
+
+      expect(rescheduleCall).toBeDefined();
+    });
+
+    const rescheduleCall = fetchSpy.mock.calls.find(([input, requestInit]) => {
+      const requestUrl = String(input);
+      const requestMethod = requestInit?.method ?? 'GET';
+      return requestUrl.includes('/api/v1/scheduled-workouts/scheduled-1') && requestMethod === 'PATCH';
+    });
+    const rescheduleBody = JSON.parse(String(rescheduleCall?.[1]?.body));
+    expect(rescheduleBody).toEqual({ date: '2099-12-31' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel workout' }));
+
+    await waitFor(() => {
+      const cancelCall = fetchSpy.mock.calls.find(([input, requestInit]) => {
+        const requestUrl = String(input);
+        const requestMethod = requestInit?.method ?? 'GET';
+        return (
+          requestUrl.includes('/api/v1/scheduled-workouts/scheduled-1') &&
+          requestMethod === 'DELETE'
+        );
+      });
+
+      expect(cancelCall).toBeDefined();
     });
   });
 });
+
+function createScheduledWorkoutDetailPayload({
+  date,
+}: {
+  date: string;
+}): {
+  id: string;
+  userId: string;
+  templateId: string;
+  date: string;
+  sessionId: null;
+  createdAt: number;
+  updatedAt: number;
+  template: {
+    id: string;
+    userId: string;
+    name: string;
+    description: string;
+    tags: string[];
+    sections: Array<{
+      type: 'warmup' | 'main' | 'cooldown';
+      exercises: Array<{
+        id: string;
+        exerciseId: string;
+        exerciseName: string;
+        trackingType: 'weight_reps';
+        sets: number;
+        repsMin: number;
+        repsMax: number;
+        tempo: '3110';
+        restSeconds: number;
+        supersetGroup: null;
+        notes: string;
+        cues: string[];
+        setTargets: Array<{
+          setNumber: number;
+          targetWeight: number;
+        }>;
+        programmingNotes: string;
+        exercise: {
+          formCues: string[];
+          coachingNotes: string;
+          instructions: string;
+        };
+      }>;
+    }>;
+    createdAt: number;
+    updatedAt: number;
+  };
+} {
+  return {
+    id: 'scheduled-1',
+    userId: 'user-1',
+    templateId: 'template-1',
+    date,
+    sessionId: null,
+    createdAt: 1,
+    updatedAt: 1,
+    template: {
+      id: 'template-1',
+      userId: 'user-1',
+      name: 'Upper Push',
+      description: 'Chest, shoulders, and triceps emphasis.',
+      tags: ['push'],
+      sections: [
+        {
+          type: 'warmup',
+          exercises: [],
+        },
+        {
+          type: 'main',
+          exercises: [
+            {
+              id: 'template-exercise-1',
+              exerciseId: 'incline-dumbbell-press',
+              exerciseName: 'Incline Dumbbell Press',
+              trackingType: 'weight_reps',
+              sets: 3,
+              repsMin: 8,
+              repsMax: 10,
+              tempo: '3110',
+              restSeconds: 90,
+              supersetGroup: null,
+              notes: 'Drive feet into the floor.',
+              cues: ['Drive feet into the floor', 'Keep wrists stacked'],
+              setTargets: [
+                {
+                  setNumber: 1,
+                  targetWeight: 70,
+                },
+              ],
+              programmingNotes: 'Top set first, then reduce load for back-off sets.',
+              exercise: {
+                formCues: ['Tuck shoulder blades'],
+                coachingNotes: 'Keep your upper back pinned to the bench.',
+                instructions: 'Lower dumbbells with control, then drive straight up.',
+              },
+            },
+          ],
+        },
+        {
+          type: 'cooldown',
+          exercises: [],
+        },
+      ],
+      createdAt: 1,
+      updatedAt: 1,
+    },
+  };
+}

--- a/apps/web/src/features/workouts/components/scheduled-workout-detail.tsx
+++ b/apps/web/src/features/workouts/components/scheduled-workout-detail.tsx
@@ -1,11 +1,16 @@
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 import { useNavigate } from 'react-router';
-import { CalendarClock, Dumbbell, History, TriangleAlert } from 'lucide-react';
-import type { WorkoutTemplate, WorkoutTemplateExercise, WeightUnit } from '@pulse/shared';
+import { History } from 'lucide-react';
+import type {
+  WorkoutTemplate,
+  WorkoutTemplateExercise,
+  WorkoutTemplateSectionType,
+  WeightUnit,
+} from '@pulse/shared';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
 import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import { useStartSession } from '@/hooks/use-workout-session';
 import { useWeightUnit } from '@/hooks/use-weight-unit';
@@ -18,10 +23,14 @@ import {
   useUnscheduleWorkout,
   useWorkoutSessions,
 } from '../api/workouts';
-import { getDistanceUnit } from '../lib/tracking';
 import { buildInitialSessionSets } from '../lib/workout-session-sets';
 import { ExerciseDetailModal } from './exercise-detail-modal';
 import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
+import { ScheduledWorkoutHeader } from './scheduled-workout-header';
+import {
+  WorkoutExerciseCard,
+  type WorkoutExerciseCardScheduledExercise,
+} from './workout-exercise-card';
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   weekday: 'long',
@@ -30,23 +39,26 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
 });
 
-const sectionLabels: Record<string, string> = {
+const sectionLabels: Record<WorkoutTemplateSectionType, string> = {
   warmup: 'Warmup',
   main: 'Main',
   cooldown: 'Cooldown',
+  supplemental: 'Supplemental',
 };
 
-const sectionAccentStyles: Record<string, string> = {
-  warmup: 'border-amber-500/30',
-  main: 'border-primary/30',
-  cooldown: 'border-sky-500/30',
+const sectionAccentStyles: Record<WorkoutTemplateSectionType, string> = {
+  warmup: 'border-l-[var(--color-accent-mint)]',
+  main: 'border-l-[var(--color-accent-pink)]',
+  cooldown: 'border-l-[var(--color-accent-cream)]',
+  supplemental: 'border-l-[var(--color-accent-cream)]',
 };
 
 type ScheduledWorkoutDetailProps = {
+  bannerSlot?: ReactNode;
   id: string;
 };
 
-export function ScheduledWorkoutDetail({ id }: ScheduledWorkoutDetailProps) {
+export function ScheduledWorkoutDetail({ bannerSlot, id }: ScheduledWorkoutDetailProps) {
   const navigate = useNavigate();
   const { weightUnit } = useWeightUnit();
   const { data: scheduledWorkout, isLoading, isError } = useScheduledWorkoutDetail(id);
@@ -124,18 +136,33 @@ export function ScheduledWorkoutDetail({ id }: ScheduledWorkoutDetailProps) {
     if (!scheduledWorkout) {
       return;
     }
+
     await rescheduleWorkoutMutation.mutateAsync({
       date: requestedDate,
       id: scheduledWorkout.id,
     });
   }
 
-  async function handleRemoveFromSchedule() {
+  async function handleCancel() {
     if (!scheduledWorkout) {
       return;
     }
+
     await unscheduleWorkoutMutation.mutateAsync({ id: scheduledWorkout.id });
     navigate('/workouts');
+  }
+
+  function confirmCancel() {
+    confirm({
+      title: 'Cancel this scheduled workout?',
+      description:
+        'This scheduled workout will be removed. Your template and exercise library are not affected.',
+      confirmLabel: 'Cancel workout',
+      variant: 'destructive',
+      onConfirm: async () => {
+        await handleCancel();
+      },
+    });
   }
 
   if (isLoading) {
@@ -158,69 +185,22 @@ export function ScheduledWorkoutDetail({ id }: ScheduledWorkoutDetailProps) {
     );
   }
 
-  const scheduledDate = new Date(`${scheduledWorkout.date}T12:00:00`);
-
   return (
     <div className="space-y-4">
-      <Card>
-        <CardHeader className="gap-3">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-            <div className="space-y-1">
-              <CardTitle className="text-xl">{template?.name ?? 'Workout unavailable'}</CardTitle>
-              <p className="flex items-center gap-1.5 text-sm text-muted">
-                <CalendarClock aria-hidden="true" className="size-4" />
-                {dateFormatter.format(scheduledDate)}
-              </p>
-            </div>
-            <Badge
-              className={cn(
-                'w-fit',
-                isTemplateAvailable
-                  ? 'bg-secondary text-muted-foreground'
-                  : 'bg-destructive/10 text-destructive',
-              )}
-              variant="secondary"
-            >
-              {isTemplateAvailable ? 'Scheduled' : 'Unavailable'}
-            </Badge>
-          </div>
-        </CardHeader>
-
-        <CardContent className="space-y-4">
-          {!isTemplateAvailable ? (
-            <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
-              <TriangleAlert aria-hidden="true" className="size-4 shrink-0" />
-              The template for this workout has been deleted. You can remove this from your
-              schedule.
-            </div>
-          ) : null}
-
-          <div className="flex flex-wrap gap-2">
-            <Button
-              disabled={isMutating || !isTemplateAvailable}
-              onClick={() => {
-                void handleStart();
-              }}
-              size="sm"
-              type="button"
-            >
-              Start
-            </Button>
-            <Button
-              disabled={isMutating || !isTemplateAvailable}
-              onClick={() => setIsRescheduleDialogOpen(true)}
-              size="sm"
-              type="button"
-              variant="outline"
-            >
-              Reschedule
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+      {bannerSlot}
+      <ScheduledWorkoutHeader
+        isMutating={isMutating}
+        isTemplateAvailable={isTemplateAvailable}
+        onCancel={confirmCancel}
+        onReschedule={() => setIsRescheduleDialogOpen(true)}
+        onStart={handleStart}
+        scheduledDateLabel={dateFormatter.format(new Date(`${scheduledWorkout.date}T12:00:00`))}
+        templateId={scheduledWorkout.templateId}
+        templateName={template?.name ?? null}
+      />
 
       {template ? (
-        <TemplateSections
+        <ScheduledWorkoutSections
           onOpenHistory={(exercise) =>
             setHistoryTarget({
               exerciseId: exercise.exerciseId,
@@ -232,21 +212,19 @@ export function ScheduledWorkoutDetail({ id }: ScheduledWorkoutDetailProps) {
         />
       ) : null}
 
-      {scheduledWorkout ? (
-        <ScheduleWorkoutDialog
-          description={`Move ${template?.name ?? 'this workout'} to a new date.`}
-          initialDate={scheduledWorkout.date}
-          isPending={rescheduleWorkoutMutation.isPending}
-          onOpenChange={setIsRescheduleDialogOpen}
-          onRemove={handleRemoveFromSchedule}
-          onSubmitDate={handleReschedule}
-          open={isRescheduleDialogOpen}
-          disallowDateKey={scheduledWorkout.date}
-          disallowDateMessage="Pick a different date to reschedule."
-          submitLabel="Save"
-          title="Reschedule workout"
-        />
-      ) : null}
+      <ScheduleWorkoutDialog
+        description={`Move ${template?.name ?? 'this workout'} to a new date.`}
+        disallowDateKey={scheduledWorkout.date}
+        disallowDateMessage="Pick a different date to reschedule."
+        initialDate={scheduledWorkout.date}
+        isPending={rescheduleWorkoutMutation.isPending}
+        onOpenChange={setIsRescheduleDialogOpen}
+        onSubmitDate={handleReschedule}
+        open={isRescheduleDialogOpen}
+        submitLabel="Save"
+        title="Reschedule workout"
+      />
+
       {historyTarget ? (
         <ExerciseDetailModal
           context="receipt"
@@ -264,7 +242,7 @@ export function ScheduledWorkoutDetail({ id }: ScheduledWorkoutDetailProps) {
   );
 }
 
-function TemplateSections({
+function ScheduledWorkoutSections({
   onOpenHistory,
   template,
   weightUnit,
@@ -288,157 +266,99 @@ function TemplateSections({
   return (
     <div className="space-y-3">
       {nonEmptySections.map((section) => (
-        <Card className={cn('border-l-4', sectionAccentStyles[section.type])} key={section.type}>
-          <CardHeader className="gap-1 py-3">
-            <div className="flex items-center justify-between">
-              <h3 className="text-sm font-semibold uppercase tracking-[0.12em] text-muted">
-                {sectionLabels[section.type] ?? section.type}
-              </h3>
-              <span className="text-xs text-muted">
-                {section.exercises.length} exercise{section.exercises.length === 1 ? '' : 's'}
-              </span>
+        <details
+          className={cn(
+            'overflow-hidden rounded-3xl border border-border border-l-4 bg-card shadow-sm',
+            sectionAccentStyles[section.type],
+          )}
+          key={section.type}
+          open={section.type === 'main'}
+        >
+          <summary className="cursor-pointer list-outside px-4 py-3">
+            <div className="flex flex-col gap-1.5 pr-6 sm:flex-row sm:items-center sm:justify-between">
+              <h2 className="text-lg font-bold tracking-wide text-foreground">
+                {sectionLabels[section.type]}
+              </h2>
+              <Badge className="border-transparent bg-secondary text-secondary-foreground" variant="outline">
+                {`${section.exercises.length} exercise${section.exercises.length === 1 ? '' : 's'}`}
+              </Badge>
             </div>
-          </CardHeader>
-          <CardContent className="space-y-2 pb-3">
+          </summary>
+
+          <div className="space-y-1.5 border-t border-border/80 px-3 py-3 sm:px-4 sm:py-3">
             {section.exercises.map((exercise, index) => (
-              <div
-                className="flex items-center gap-3 rounded-lg border border-border bg-secondary/20 px-3 py-2"
+              <ScheduledExerciseCard
+                exercise={exercise}
+                index={index}
                 key={exercise.id}
-              >
-                <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-secondary text-xs font-semibold text-muted">
-                  {index + 1}
-                </span>
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium text-foreground">
-                    {exercise.exerciseName}
-                  </p>
-                  <p className="text-xs text-muted">
-                    {formatExerciseSummary(exercise, weightUnit)}
-                  </p>
-                </div>
-                {exercise.supersetGroup ? (
-                  <Badge className="shrink-0" variant="secondary">
-                    {exercise.supersetGroup}
-                  </Badge>
-                ) : null}
-                <Button
-                  aria-label={`Open ${exercise.exerciseName} history`}
-                  className="size-8 min-h-8 min-w-8"
-                  onClick={() => onOpenHistory(exercise)}
-                  size="icon-sm"
-                  type="button"
-                  variant="ghost"
-                >
-                  <History aria-hidden="true" className="size-4 shrink-0 text-muted" />
-                </Button>
-                <Dumbbell aria-hidden="true" className="size-4 shrink-0 text-muted" />
-              </div>
+                onOpenHistory={() => onOpenHistory(exercise)}
+                weightUnit={weightUnit}
+              />
             ))}
-          </CardContent>
-        </Card>
+          </div>
+        </details>
       ))}
     </div>
   );
 }
 
-function formatExerciseSummary(exercise: WorkoutTemplateExercise, weightUnit: WeightUnit) {
-  const segments = [
-    `${exercise.sets} set${exercise.sets === 1 ? '' : 's'}`,
-    formatExerciseTarget(exercise, weightUnit),
-    exercise.restSeconds != null ? `${exercise.restSeconds} sec rest` : null,
-  ].filter((segment): segment is string => segment != null && segment.length > 0);
-
-  return segments.join(' · ');
-}
-
-function formatExerciseTarget(exercise: WorkoutTemplateExercise, weightUnit: WeightUnit) {
-  const repsTarget = formatRepTarget(exercise.repsMin, exercise.repsMax);
-  const firstTarget = (exercise.setTargets ?? [])[0] ?? null;
-  const targetWeight =
-    firstTarget?.targetWeight != null
-      ? `${firstTarget.targetWeight} ${weightUnit}`
-      : firstTarget?.targetWeightMin != null && firstTarget?.targetWeightMax != null
-        ? `${firstTarget.targetWeightMin}-${firstTarget.targetWeightMax} ${weightUnit}`
-        : null;
-  const targetSeconds =
-    firstTarget?.targetSeconds != null ? `${firstTarget.targetSeconds} sec` : null;
-  const targetDistance =
-    firstTarget?.targetDistance != null
-      ? `${firstTarget.targetDistance} ${getDistanceUnit(weightUnit)}`
-      : null;
-
-  switch (exercise.trackingType) {
-    case 'weight_reps':
-      return targetWeight ?? withRepUnit(repsTarget);
-    case 'weight_seconds':
-      if (targetWeight && targetSeconds) {
-        return `${targetWeight} × ${targetSeconds}`;
+function ScheduledExerciseCard({
+  exercise,
+  index,
+  onOpenHistory,
+  weightUnit,
+}: {
+  exercise: WorkoutTemplateExercise;
+  index: number;
+  onOpenHistory: () => void;
+  weightUnit: WeightUnit;
+}) {
+  return (
+    <WorkoutExerciseCard
+      exercise={toWorkoutExerciseCardScheduledExercise(exercise)}
+      footerSlot={
+        <p className="text-[10px] font-semibold tracking-[0.14em] text-muted uppercase">{`Exercise #${index + 1}`}</p>
       }
-      return targetWeight ?? targetSeconds ?? withSecUnit(repsTarget);
-    case 'bodyweight_reps':
-    case 'reps_only':
-      return withRepUnit(repsTarget);
-    case 'reps_seconds':
-      if (repsTarget && targetSeconds) {
-        return `${withRepUnit(repsTarget)} × ${targetSeconds}`;
+      headerSlot={
+        <Button
+          aria-label={`Open ${exercise.exerciseName} history`}
+          className="size-11 min-h-11 min-w-11"
+          onClick={onOpenHistory}
+          size="icon"
+          type="button"
+          variant="ghost"
+        >
+          <History aria-hidden="true" className="size-4" />
+        </Button>
       }
-      return targetSeconds ?? withSecUnit(repsTarget);
-    case 'seconds_only':
-      return targetSeconds ?? withSecUnit(repsTarget);
-    case 'distance':
-      return targetDistance ?? withDistanceUnit(repsTarget, weightUnit);
-    case 'cardio':
-      if (targetSeconds && targetDistance) {
-        return `${targetSeconds} + ${targetDistance}`;
-      }
-      return targetSeconds ?? targetDistance ?? withSecUnit(repsTarget);
-    default:
-      return withRepUnit(repsTarget);
-  }
+      mode="readonly-scheduled"
+      onOpenDetails={onOpenHistory}
+      weightUnit={weightUnit}
+    />
+  );
 }
 
-function formatRepTarget(repsMin: number | null, repsMax: number | null) {
-  if (repsMin != null && repsMax != null) {
-    return repsMin === repsMax ? `${repsMin}` : `${repsMin}-${repsMax}`;
-  }
-
-  if (repsMin != null) {
-    return `${repsMin}+`;
-  }
-
-  if (repsMax != null) {
-    return `Up to ${repsMax}`;
-  }
-
-  return null;
-}
-
-function withRepUnit(value: string | null) {
-  if (!value) {
-    return null;
-  }
-
-  const lower = value.toLowerCase();
-  return lower.includes('rep') || lower.includes('sec') || lower.includes('min')
-    ? value
-    : `${value} reps`;
-}
-
-function withSecUnit(value: string | null) {
-  if (!value) {
-    return null;
-  }
-
-  const lower = value.toLowerCase();
-  return lower.includes('sec') || lower.includes('min') ? value : `${value} sec`;
-}
-
-function withDistanceUnit(value: string | null, weightUnit: WeightUnit) {
-  if (!value) {
-    return null;
-  }
-
-  const lower = value.toLowerCase();
-  const distanceUnit = getDistanceUnit(weightUnit);
-  return lower.includes('mi') || lower.includes('km') ? value : `${value} ${distanceUnit}`;
+function toWorkoutExerciseCardScheduledExercise(
+  exercise: WorkoutTemplateExercise,
+): WorkoutExerciseCardScheduledExercise {
+  return {
+    coachingNotes: exercise.exercise?.coachingNotes ?? null,
+    equipment: null,
+    exerciseId: exercise.exerciseId,
+    formCues: exercise.exercise?.formCues ?? exercise.formCues ?? [],
+    id: exercise.id,
+    instructions: exercise.exercise?.instructions ?? null,
+    muscleGroups: [],
+    name: exercise.exerciseName,
+    notes: exercise.notes,
+    programmingNotes: exercise.programmingNotes ?? null,
+    repsMax: exercise.repsMax,
+    repsMin: exercise.repsMin,
+    restSeconds: exercise.restSeconds,
+    setTargets: exercise.setTargets ?? [],
+    sets: exercise.sets,
+    tempo: exercise.tempo,
+    templateCues: exercise.cues,
+    trackingType: exercise.trackingType,
+  };
 }

--- a/apps/web/src/features/workouts/components/scheduled-workout-header.tsx
+++ b/apps/web/src/features/workouts/components/scheduled-workout-header.tsx
@@ -1,0 +1,94 @@
+import { Link } from 'react-router';
+import { CalendarClock } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+type ScheduledWorkoutHeaderProps = {
+  isMutating: boolean;
+  isTemplateAvailable: boolean;
+  onCancel: () => void;
+  onReschedule: () => void;
+  onStart: () => void;
+  scheduledDateLabel: string;
+  templateId: string | null;
+  templateName: string | null;
+};
+
+export function ScheduledWorkoutHeader({
+  isMutating,
+  isTemplateAvailable,
+  onCancel,
+  onReschedule,
+  onStart,
+  scheduledDateLabel,
+  templateId,
+  templateName,
+}: ScheduledWorkoutHeaderProps) {
+  return (
+    <Card className="gap-4 overflow-hidden border-transparent bg-card/80 py-0">
+      <CardContent className="space-y-4 bg-[var(--color-accent-cream)] px-6 py-6 text-on-cream dark:border-b dark:border-border dark:bg-card dark:text-foreground">
+        <div className="space-y-2">
+          <p className="text-xs font-semibold tracking-[0.22em] text-on-cream/80 uppercase dark:text-muted">
+            Scheduled workout
+          </p>
+          <h1 className="text-3xl font-semibold tracking-tight">
+            {templateName ?? 'Workout unavailable'}
+          </h1>
+          <p className="flex items-center gap-1.5 text-sm text-on-cream/85 dark:text-muted">
+            <CalendarClock aria-hidden="true" className="size-4" />
+            {scheduledDateLabel}
+          </p>
+          {templateId ? (
+            <p className="text-sm text-on-cream/85 dark:text-muted">
+              Template:{' '}
+              <Link className="font-medium underline" to={`/workouts/template/${templateId}`}>
+                {templateName ?? 'Unavailable template'}
+              </Link>
+            </p>
+          ) : null}
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            disabled={isMutating || !isTemplateAvailable}
+            onClick={onStart}
+            size="sm"
+            type="button"
+          >
+            Start workout
+          </Button>
+          <Button
+            disabled={isMutating || !isTemplateAvailable}
+            onClick={onReschedule}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            Reschedule
+          </Button>
+          <Button
+            disabled={isMutating}
+            onClick={onCancel}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            Cancel
+          </Button>
+          <Badge
+            className={cn(
+              'w-fit border-transparent bg-secondary text-secondary-foreground',
+              !isTemplateAvailable ? 'bg-destructive/10 text-destructive' : null,
+            )}
+            variant="outline"
+          >
+            {isTemplateAvailable ? 'Scheduled' : 'Unavailable'}
+          </Badge>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/features/workouts/components/session-detail-exercise-card.tsx
+++ b/apps/web/src/features/workouts/components/session-detail-exercise-card.tsx
@@ -1,0 +1,333 @@
+import type { ExerciseTrackingType, SessionSet, WeightUnit, WorkoutSession } from '@pulse/shared';
+import { History } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { formatServing } from '@/lib/format-utils';
+import { cn } from '@/lib/utils';
+
+import { formatSetSummary, getDistanceUnit, getSetDistance } from '../lib/tracking';
+import { MarkdownNote } from './markdown-note';
+import { SessionExerciseComparison } from './session-comparison';
+import {
+  WorkoutExerciseCard,
+  type WorkoutExerciseCardCompletedExercise,
+} from './workout-exercise-card';
+
+export type SessionSetDraft = {
+  reps: string;
+  weight: string;
+};
+
+export type SessionSetDraftKey = keyof SessionSetDraft;
+
+type SessionDetailExerciseCardExercise = {
+  cardExercise: WorkoutExerciseCardCompletedExercise;
+  exerciseId: string | null;
+  notes: string | null;
+  archived: boolean;
+  sets: SessionSet[];
+  supersetGroup: string | null;
+  trackingType: ExerciseTrackingType;
+};
+
+const integerFormatter = new Intl.NumberFormat('en-US');
+
+export function SessionDetailExerciseCard({
+  currentSession,
+  exercise,
+  isEditing,
+  onOpenDetails,
+  onUpdateSetDraft,
+  previousSession,
+  setDrafts,
+  showComparison,
+  weightUnit,
+}: {
+  currentSession: WorkoutSession;
+  exercise: SessionDetailExerciseCardExercise;
+  isEditing: boolean;
+  onOpenDetails: (exerciseId: string | null) => void;
+  onUpdateSetDraft: (set: SessionSet, key: SessionSetDraftKey, value: string) => void;
+  previousSession: WorkoutSession | null;
+  setDrafts: Record<string, SessionSetDraft>;
+  showComparison: boolean;
+  weightUnit: WeightUnit;
+}) {
+  return (
+    <WorkoutExerciseCard
+      className={cn(
+        isEditing &&
+          'border-[color-mix(in_srgb,var(--color-accent-mint)_55%,transparent)] bg-[color-mix(in_srgb,var(--color-accent-mint)_10%,transparent)]',
+      )}
+      exercise={exercise.cardExercise}
+      footerSlot={
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            {exercise.archived ? <Badge variant="outline">Archived</Badge> : null}
+            {exercise.supersetGroup ? (
+              <Badge variant="secondary">
+                {`Superset ${formatLabel(exercise.supersetGroup.replace(/^superset-?/i, ''))}`}
+              </Badge>
+            ) : null}
+            <p className="text-sm text-muted">
+              {`${exercise.sets.length} logged set${exercise.sets.length === 1 ? '' : 's'}`}
+            </p>
+          </div>
+
+          {isEditing ? (
+            <div className="space-y-2.5 rounded-2xl border border-[color-mix(in_srgb,var(--color-accent-mint)_55%,transparent)] bg-[color-mix(in_srgb,var(--color-accent-mint)_10%,transparent)] p-2.5">
+              {exercise.sets.map((set) => (
+                <SessionSetEditor
+                  draft={setDrafts[set.id] ?? createSessionSetDraft(set)}
+                  key={set.id}
+                  onChange={(key, value) => onUpdateSetDraft(set, key, value)}
+                  set={set}
+                  trackingType={exercise.trackingType}
+                  weightUnit={weightUnit}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="flex flex-wrap gap-1.5">
+              {exercise.sets.map((set) => (
+                <span
+                  className="inline-flex rounded-full border border-border bg-secondary/55 px-2.5 py-1 text-[13px] text-foreground"
+                  key={set.id}
+                >
+                  {formatSetLabel(set, exercise.trackingType, weightUnit)}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {showComparison && exercise.exerciseId ? (
+            <SessionExerciseComparison
+              currentSession={currentSession}
+              exerciseId={exercise.exerciseId}
+              previousSession={previousSession}
+              trackingType={exercise.trackingType}
+              weightUnit={weightUnit}
+            />
+          ) : null}
+
+          {exercise.notes ? (
+            <div className="rounded-2xl border border-border bg-secondary/35 px-3 py-2.5 text-sm text-foreground">
+              <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
+                Exercise notes
+              </p>
+              <MarkdownNote className="text-sm text-foreground" content={exercise.notes} />
+            </div>
+          ) : null}
+        </div>
+      }
+      headerSlot={
+        <Button
+          aria-label={`Open ${exercise.cardExercise.name} history`}
+          className="h-9 self-start px-3 text-xs"
+          disabled={!exercise.exerciseId}
+          onClick={() => onOpenDetails(exercise.exerciseId)}
+          type="button"
+          variant="outline"
+        >
+          <History aria-hidden="true" className="size-3.5" />
+          History
+        </Button>
+      }
+      mode="readonly-completed"
+      onOpenDetails={exercise.exerciseId ? () => onOpenDetails(exercise.exerciseId) : undefined}
+      showLastPerformance={Boolean(exercise.exerciseId)}
+      showSetList={!isEditing}
+      weightUnit={weightUnit}
+    />
+  );
+}
+
+function SessionSetEditor({
+  draft,
+  onChange,
+  set,
+  trackingType,
+  weightUnit,
+}: {
+  draft: SessionSetDraft;
+  onChange: (key: SessionSetDraftKey, value: string) => void;
+  set: SessionSet;
+  trackingType: ExerciseTrackingType;
+  weightUnit: WeightUnit;
+}) {
+  const fields = getSessionSetEditorFields(trackingType, weightUnit);
+  const readOnlySummary = getReadOnlyCorrectionSummary(set, trackingType, weightUnit);
+
+  return (
+    <div className="rounded-2xl border border-border/70 bg-background/70 p-2.5">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="space-y-1">
+          <p className="text-sm font-semibold text-foreground">{`Set ${set.setNumber}`}</p>
+          <p className="text-xs text-muted">{formatSetLabel(set, trackingType, weightUnit)}</p>
+        </div>
+        {set.skipped ? (
+          <Badge className="border-border bg-secondary/70" variant="outline">
+            Skipped
+          </Badge>
+        ) : null}
+      </div>
+
+      {fields.length > 0 ? (
+        <div
+          className={cn(
+            'mt-2.5 grid gap-2',
+            fields.length === 1 ? 'sm:grid-cols-[minmax(0,11rem)]' : 'sm:grid-cols-2',
+          )}
+        >
+          {fields.map((field) => {
+            const inputId = `${set.id}-${field.key}`;
+
+            return (
+              <div className="space-y-2" key={field.key}>
+                <Label
+                  className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted"
+                  htmlFor={inputId}
+                >
+                  {field.label}
+                </Label>
+                <div className="relative">
+                  <Input
+                    aria-label={`${field.label} for set ${set.setNumber}`}
+                    className={cn('h-10 pr-10', field.suffix ? 'pr-12' : '')}
+                    id={inputId}
+                    inputMode={field.inputMode}
+                    min={0}
+                    onChange={(event) => onChange(field.key, event.currentTarget.value)}
+                    step={field.step}
+                    type="number"
+                    value={draft[field.key]}
+                  />
+                  {field.suffix ? (
+                    <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-[10px] font-semibold uppercase text-muted">
+                      {field.suffix}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="mt-2.5 text-sm text-muted">
+          No editable set values are available for this entry.
+        </p>
+      )}
+
+      {readOnlySummary ? <p className="mt-2.5 text-xs text-muted">{readOnlySummary}</p> : null}
+    </div>
+  );
+}
+
+type SessionSetEditorField = {
+  inputMode: 'decimal' | 'numeric';
+  key: SessionSetDraftKey;
+  label: string;
+  step: string;
+  suffix?: string;
+};
+
+function getSessionSetEditorFields(
+  trackingType: ExerciseTrackingType,
+  weightUnit: WeightUnit,
+): SessionSetEditorField[] {
+  const weightField: SessionSetEditorField = {
+    inputMode: 'decimal',
+    key: 'weight',
+    label: 'Weight',
+    step: '0.5',
+    suffix: weightUnit,
+  };
+
+  const repsField: SessionSetEditorField = {
+    inputMode: 'numeric',
+    key: 'reps',
+    label: 'Reps',
+    step: '1',
+  };
+
+  const secondsField: SessionSetEditorField = {
+    inputMode: 'numeric',
+    key: 'reps',
+    // seconds are stored in the reps column for time-based tracking types
+    label: 'Seconds',
+    step: '1',
+    suffix: 'sec',
+  };
+
+  switch (trackingType) {
+    case 'weight_reps':
+      return [weightField, repsField];
+    case 'weight_seconds':
+      return [weightField, secondsField];
+    case 'bodyweight_reps':
+    case 'reps_only':
+    case 'reps_seconds':
+      return [repsField];
+    case 'seconds_only':
+    case 'cardio':
+      return [secondsField];
+    case 'distance':
+    default:
+      return [];
+  }
+}
+
+function getReadOnlyCorrectionSummary(
+  set: SessionSet,
+  trackingType: ExerciseTrackingType,
+  weightUnit: WeightUnit,
+) {
+  const distance = getSetDistance(set);
+
+  if ((trackingType === 'cardio' || trackingType === 'distance') && distance != null) {
+    return `Logged distance remains ${formatNumber(distance)} ${getDistanceUnit(weightUnit)}.`;
+  }
+
+  if (trackingType === 'reps_seconds') {
+    return 'Time corrections are not persisted separately yet, so only reps can be adjusted here.';
+  }
+
+  return null;
+}
+
+export function createSessionSetDraft(set: SessionSet): SessionSetDraft {
+  return {
+    reps: set.reps != null ? `${set.reps}` : '',
+    weight: set.weight != null ? `${set.weight}` : '',
+  };
+}
+
+function formatSetLabel(
+  set: SessionSet,
+  trackingType: ExerciseTrackingType,
+  weightUnit: WeightUnit,
+) {
+  return formatSetSummary(set, trackingType, {
+    includeSetNumber: true,
+    weightUnit,
+  });
+}
+
+function formatLabel(value: string) {
+  return value
+    .split(/[- ]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function formatNumber(value: number) {
+  if (Number.isInteger(value)) {
+    return integerFormatter.format(value);
+  }
+
+  return formatServing(value);
+}

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import type { WorkoutSession, WorkoutSessionListItem } from '@pulse/shared';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -121,7 +121,9 @@ describe('SessionDetail', () => {
     expect(screen.getByText('Session Notes')).toBeInTheDocument();
     expect(screen.getByLabelText(/show comparison/i)).toBeInTheDocument();
     expect(screen.queryByText('Volume progression')).not.toBeInTheDocument();
-    expect(screen.getAllByText(/Set 1:/i).length).toBeGreaterThan(0);
+    expect(
+      screen.getByTestId('workout-exercise-card-incline-dumbbell-press'),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Open Incline Dumbbell Press history' }),
     ).toBeInTheDocument();
@@ -190,6 +192,108 @@ describe('SessionDetail', () => {
       screen.getByTestId('exercise-programming-notes-incline-dumbbell-press'),
     ).toHaveTextContent('Hardstyle, hips snap');
     expect(screen.getByText('User observation: left shoulder felt stable.')).toBeInTheDocument();
+  });
+
+  it('renders completed-mode set rows with actual logged values across tracking types', async () => {
+    const weightSet = createSet({
+      id: 'set-completed-weights',
+      exerciseId: 'incline-dumbbell-press',
+      reps: 10,
+      section: 'main',
+      setNumber: 1,
+      targetWeight: 65,
+      weight: 50,
+    });
+    const timeSet = createSet({
+      id: 'set-completed-time',
+      exerciseId: 'plank-hold',
+      reps: 75,
+      section: 'main',
+      setNumber: 1,
+      targetSeconds: 90,
+      weight: null,
+    });
+    const distanceSet = createSet({
+      id: 'set-completed-distance',
+      exerciseId: 'treadmill-run',
+      reps: 2,
+      section: 'main',
+      setNumber: 1,
+      targetDistance: 3,
+      weight: null,
+    });
+    const currentSession = createSession({
+      id: 'session-completed-mode-set-values',
+      templateId: 'template-upper-push',
+      exercises: [
+        {
+          exerciseId: 'incline-dumbbell-press',
+          exerciseName: 'Incline Dumbbell Press',
+          deletedAt: null,
+          supersetGroup: null,
+          trackingType: 'weight_reps',
+          orderIndex: 0,
+          section: 'main',
+          programmingNotes: null,
+          sets: [weightSet],
+        },
+        {
+          exerciseId: 'plank-hold',
+          exerciseName: 'Plank Hold',
+          deletedAt: null,
+          supersetGroup: null,
+          trackingType: 'seconds_only',
+          orderIndex: 1,
+          section: 'main',
+          programmingNotes: null,
+          sets: [timeSet],
+        },
+        {
+          exerciseId: 'treadmill-run',
+          exerciseName: 'Treadmill Run',
+          deletedAt: null,
+          supersetGroup: null,
+          trackingType: 'distance',
+          orderIndex: 2,
+          section: 'main',
+          programmingNotes: null,
+          sets: [distanceSet],
+        },
+      ],
+      sets: [weightSet, timeSet, distanceSet],
+    });
+
+    mockSessionDetailRequests({
+      sessionId: currentSession.id,
+      session: currentSession,
+      sessions: [
+        createSessionListItem({
+          id: currentSession.id,
+          templateId: currentSession.templateId,
+          templateName: 'Upper Push',
+          startedAt: currentSession.startedAt,
+        }),
+      ],
+    });
+
+    renderSessionDetail(currentSession.id);
+    await screen.findByText('Workout receipt');
+
+    const weightCard = screen.getByTestId('workout-exercise-card-incline-dumbbell-press');
+    fireEvent.click(within(weightCard).getByText('Show full set detail'));
+    expect(within(weightCard).getByLabelText('Weight for set 1')).toHaveValue(50);
+    expect(within(weightCard).getByLabelText('Reps for set 1')).toHaveValue(10);
+    expect(within(weightCard).queryByText('Target: 65 lbs')).not.toBeInTheDocument();
+
+    const timeCard = screen.getByTestId('workout-exercise-card-plank-hold');
+    fireEvent.click(within(timeCard).getByText('Show full set detail'));
+    expect(within(timeCard).getByLabelText('Seconds for set 1')).toHaveValue(75);
+    expect(within(timeCard).queryByText('Target: 90 sec')).not.toBeInTheDocument();
+
+    const distanceCard = screen.getByTestId('workout-exercise-card-treadmill-run');
+    fireEvent.click(within(distanceCard).getByText('Show full set detail'));
+    expect(within(distanceCard).getByLabelText('Distance for set 1')).toHaveValue(2);
+    expect(within(distanceCard).queryByText('Target: 3 mi')).not.toBeInTheDocument();
   });
 
   it('does not render a programming notes block when programmingNotes is null', async () => {

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -1,15 +1,6 @@
 import { useId, useMemo, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router';
-import {
-  ArrowLeft,
-  ChevronDown,
-  ClipboardList,
-  Dumbbell,
-  ListChecks,
-  NotebookPen,
-  Repeat2,
-  Scale,
-} from 'lucide-react';
+import { ArrowLeft, ChevronDown, Dumbbell, ListChecks, NotebookPen, Repeat2, Scale } from 'lucide-react';
 import {
   type ExerciseTrackingType,
   type SessionSet,
@@ -25,7 +16,6 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { useConfirmation } from '@/components/ui/confirmation-dialog';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { StatCard } from '@/components/ui/stat-card';
 import { useStartSession } from '@/hooks/use-workout-session';
@@ -48,7 +38,6 @@ import {
 import { buildInitialSessionSets } from '../lib/workout-session-sets';
 import {
   formatTrackingMetricBreakdown,
-  formatSetSummary,
   getDistanceUnit,
   getSetDistance,
   getSetSummaryMetricValue,
@@ -60,22 +49,31 @@ import {
 import { findPreviousTemplateSession } from '../lib/session-comparison';
 import { ExerciseDetailModal } from './exercise-detail-modal';
 import { MarkdownNote } from './markdown-note';
-import { SessionComparison, SessionExerciseComparison } from './session-comparison';
+import { SessionComparison } from './session-comparison';
+import {
+  createSessionSetDraft,
+  SessionDetailExerciseCard,
+  type SessionSetDraft,
+  type SessionSetDraftKey,
+} from './session-detail-exercise-card';
+import {
+  type WorkoutExerciseCardCompletedExercise,
+  type WorkoutExerciseSetListItem,
+} from './workout-exercise-card';
 
 type SessionDetailProps = {
   sessionId: string;
 };
 
 type SessionDetailSectionType = WorkoutTemplateSectionType;
+type SessionPhaseBadge = 'moderate' | 'rebuild' | 'recovery' | 'test';
 
 type SessionDetailExercise = {
+  cardExercise: WorkoutExerciseCardCompletedExercise;
   exerciseId: string | null;
   groupKey: string;
-  name: string;
   notes: string | null;
-  programmingNotes: string | null;
   archived: boolean;
-  phaseBadge: 'moderate' | 'rebuild' | 'recovery' | 'test';
   sets: SessionSet[];
   supersetGroup: string | null;
   trackingType: ExerciseTrackingType;
@@ -85,21 +83,6 @@ type SessionDetailSection = {
   exercises: SessionDetailExercise[];
   subtitle: string;
   type: SessionDetailSectionType;
-};
-
-type SessionSetDraft = {
-  reps: string;
-  weight: string;
-};
-
-type SessionSetDraftKey = keyof SessionSetDraft;
-
-type SessionSetEditorField = {
-  inputMode: 'decimal' | 'numeric';
-  key: SessionSetDraftKey;
-  label: string;
-  step: string;
-  suffix?: string;
 };
 
 type SessionMetricLabel = TrackingSummaryMetricLabel | 'mixed';
@@ -129,16 +112,6 @@ const sectionLabels: Record<SessionDetailSectionType, string> = {
   cooldown: 'Cooldown',
   supplemental: 'Supplemental',
 };
-
-const phaseBadgeStyles = {
-  rebuild:
-    'border-transparent bg-[var(--color-accent-mint)] text-on-mint dark:bg-emerald-500/20 dark:text-emerald-400',
-  recovery:
-    'border-transparent bg-[var(--color-accent-cream)] text-on-cream dark:bg-amber-500/20 dark:text-amber-400',
-  moderate:
-    'border-transparent bg-secondary text-secondary-foreground dark:bg-secondary/80 dark:text-foreground',
-  test: 'border-transparent bg-[var(--color-accent-pink)] text-on-pink dark:bg-pink-500/20 dark:text-pink-400',
-} as const;
 
 export function SessionDetail({ sessionId }: SessionDetailProps) {
   const { weightUnit } = useWeightUnit();
@@ -470,135 +443,18 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
 
             <div className="space-y-2.5 border-t border-border px-3 py-3 sm:px-5 sm:py-4">
               {section.exercises.map((exercise) => (
-                <Card
-                  className={cn(
-                    'gap-3 py-0',
-                    isEditing &&
-                      'border-[color-mix(in_srgb,var(--color-accent-mint)_55%,transparent)] bg-[color-mix(in_srgb,var(--color-accent-mint)_10%,transparent)]',
-                  )}
+                <SessionDetailExerciseCard
+                  currentSession={session}
+                  exercise={exercise}
+                  isEditing={isEditing}
                   key={`${section.type}-${exercise.groupKey}`}
-                >
-                  <CardHeader className="gap-2.5 py-3">
-                    <div className="flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between">
-                      <div className="space-y-2">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <CardTitle>
-                            {exercise.exerciseId ? (
-                              <button
-                                className="cursor-pointer text-left underline-offset-4 transition hover:text-primary hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                                onClick={() => setSelectedExerciseId(exercise.exerciseId)}
-                                type="button"
-                              >
-                                {exercise.name}
-                              </button>
-                            ) : (
-                              <span className="text-muted">{exercise.name}</span>
-                            )}
-                          </CardTitle>
-                          {exercise.archived ? <Badge variant="outline">Archived</Badge> : null}
-                          <Badge
-                            className={cn(
-                              'border-transparent',
-                              phaseBadgeStyles[exercise.phaseBadge],
-                            )}
-                            variant="outline"
-                          >
-                            {formatLabel(exercise.phaseBadge)}
-                          </Badge>
-                          {exercise.supersetGroup ? (
-                            <Badge variant="secondary">
-                              {`Superset ${formatLabel(exercise.supersetGroup.replace(/^superset-?/i, ''))}`}
-                            </Badge>
-                          ) : null}
-                        </div>
-                        <p className="text-sm text-muted">
-                          {`${exercise.sets.length} logged set${exercise.sets.length === 1 ? '' : 's'}`}
-                        </p>
-                      </div>
-
-                      <Button
-                        aria-label={`Open ${exercise.name} history`}
-                        className="h-9 self-start px-3 text-xs"
-                        disabled={!exercise.exerciseId}
-                        onClick={() => setSelectedExerciseId(exercise.exerciseId)}
-                        type="button"
-                        variant="outline"
-                      >
-                        History
-                      </Button>
-                    </div>
-                  </CardHeader>
-
-                  <CardContent className="space-y-3 pb-3">
-                    {exercise.programmingNotes ? (
-                      <div
-                        className="flex items-start gap-2 rounded-xl border-l-2 border-primary/35 bg-secondary/35 px-3 py-2"
-                        data-testid={`exercise-programming-notes-${exercise.groupKey}`}
-                      >
-                        <ClipboardList
-                          aria-hidden="true"
-                          className="mt-0.5 size-3.5 shrink-0 text-muted"
-                        />
-                        <div className="space-y-0.5">
-                          <p className="text-[10px] font-semibold tracking-[0.16em] text-muted uppercase">
-                            Programming notes
-                          </p>
-                          <p className="whitespace-pre-wrap text-[13px] italic text-muted">
-                            {exercise.programmingNotes}
-                          </p>
-                        </div>
-                      </div>
-                    ) : null}
-
-                    {isEditing ? (
-                      <div className="space-y-2.5 rounded-2xl border border-[color-mix(in_srgb,var(--color-accent-mint)_55%,transparent)] bg-[color-mix(in_srgb,var(--color-accent-mint)_10%,transparent)] p-2.5">
-                        {exercise.sets.map((set) => (
-                          <SessionSetEditor
-                            draft={setDrafts[set.id] ?? createSessionSetDraft(set)}
-                            key={set.id}
-                            onChange={(key, value) => updateSetDraft(set, key, value)}
-                            set={set}
-                            trackingType={exercise.trackingType}
-                            weightUnit={weightUnit}
-                          />
-                        ))}
-                      </div>
-                    ) : (
-                      <div className="flex flex-wrap gap-1.5">
-                        {exercise.sets.map((set) => (
-                          <span
-                            className="inline-flex rounded-full border border-border bg-secondary/55 px-2.5 py-1 text-[13px] text-foreground"
-                            key={set.id}
-                          >
-                            {formatSetLabel(set, exercise.trackingType, weightUnit)}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-
-                    {showComparison && exercise.exerciseId ? (
-                      <SessionExerciseComparison
-                        currentSession={session}
-                        exerciseId={exercise.exerciseId}
-                        previousSession={previousSession}
-                        trackingType={exercise.trackingType}
-                        weightUnit={weightUnit}
-                      />
-                    ) : null}
-
-                    {exercise.notes ? (
-                      <div className="rounded-2xl border border-border bg-secondary/35 px-3 py-2.5 text-sm text-foreground">
-                        <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
-                          Exercise notes
-                        </p>
-                        <MarkdownNote
-                          className="text-sm text-foreground"
-                          content={exercise.notes}
-                        />
-                      </div>
-                    ) : null}
-                  </CardContent>
-                </Card>
+                  onOpenDetails={(exerciseId) => setSelectedExerciseId(exerciseId)}
+                  onUpdateSetDraft={updateSetDraft}
+                  previousSession={previousSession}
+                  setDrafts={setDrafts}
+                  showComparison={showComparison}
+                  weightUnit={weightUnit}
+                />
               ))}
             </div>
           </details>
@@ -728,96 +584,8 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
   }
 }
 
-function SessionSetEditor({
-  draft,
-  onChange,
-  set,
-  trackingType,
-  weightUnit,
-}: {
-  draft: SessionSetDraft;
-  onChange: (key: SessionSetDraftKey, value: string) => void;
-  set: SessionSet;
-  trackingType: ExerciseTrackingType;
-  weightUnit: WeightUnit;
-}) {
-  const fields = getSessionSetEditorFields(trackingType, weightUnit);
-  const readOnlySummary = getReadOnlyCorrectionSummary(set, trackingType, weightUnit);
-
-  return (
-    <div className="rounded-2xl border border-border/70 bg-background/70 p-2.5">
-      <div className="flex flex-wrap items-start justify-between gap-2">
-        <div className="space-y-1">
-          <p className="text-sm font-semibold text-foreground">{`Set ${set.setNumber}`}</p>
-          <p className="text-xs text-muted">{formatSetLabel(set, trackingType, weightUnit)}</p>
-        </div>
-        {set.skipped ? (
-          <Badge className="border-border bg-secondary/70" variant="outline">
-            Skipped
-          </Badge>
-        ) : null}
-      </div>
-
-      {fields.length > 0 ? (
-        <div
-          className={cn(
-            'mt-2.5 grid gap-2',
-            fields.length === 1 ? 'sm:grid-cols-[minmax(0,11rem)]' : 'sm:grid-cols-2',
-          )}
-        >
-          {fields.map((field) => {
-            const inputId = `${set.id}-${field.key}`;
-
-            return (
-              <div className="space-y-2" key={field.key}>
-                <Label
-                  className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted"
-                  htmlFor={inputId}
-                >
-                  {field.label}
-                </Label>
-                <div className="relative">
-                  <Input
-                    aria-label={`${field.label} for set ${set.setNumber}`}
-                    className={cn('h-10 pr-10', field.suffix ? 'pr-12' : '')}
-                    id={inputId}
-                    inputMode={field.inputMode}
-                    min={0}
-                    onChange={(event) => onChange(field.key, event.currentTarget.value)}
-                    step={field.step}
-                    type="number"
-                    value={draft[field.key]}
-                  />
-                  {field.suffix ? (
-                    <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-[10px] font-semibold uppercase text-muted">
-                      {field.suffix}
-                    </span>
-                  ) : null}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      ) : (
-        <p className="mt-2.5 text-sm text-muted">
-          No editable set values are available for this entry.
-        </p>
-      )}
-
-      {readOnlySummary ? <p className="mt-2.5 text-xs text-muted">{readOnlySummary}</p> : null}
-    </div>
-  );
-}
-
 function buildSessionSetDrafts(sets: SessionSet[]) {
   return Object.fromEntries(sets.map((set) => [set.id, createSessionSetDraft(set)]));
-}
-
-function createSessionSetDraft(set: SessionSet): SessionSetDraft {
-  return {
-    reps: set.reps != null ? `${set.reps}` : '',
-    weight: set.weight != null ? `${set.weight}` : '',
-  };
 }
 
 function buildChangedSetCorrections(
@@ -854,67 +622,63 @@ function resolveCorrectionMetric(value: string, fallback: number | null) {
   return Number.isFinite(parsedValue) ? parsedValue : fallback;
 }
 
-function getSessionSetEditorFields(
-  trackingType: ExerciseTrackingType,
-  weightUnit: WeightUnit,
-): SessionSetEditorField[] {
-  const weightField: SessionSetEditorField = {
-    inputMode: 'decimal',
-    key: 'weight',
-    label: 'Weight',
-    step: '0.5',
-    suffix: weightUnit,
-  };
 
-  const repsField: SessionSetEditorField = {
-    inputMode: 'numeric',
-    key: 'reps',
-    label: 'Reps',
-    step: '1',
-  };
-
-  const secondsField: SessionSetEditorField = {
-    inputMode: 'numeric',
-    key: 'reps', // seconds are stored in the reps column for time-based tracking types
-    label: 'Seconds',
-    step: '1',
-    suffix: 'sec',
-  };
-
-  switch (trackingType) {
-    case 'weight_reps':
-      return [weightField, repsField];
-    case 'weight_seconds':
-      return [weightField, secondsField];
-    case 'bodyweight_reps':
-    case 'reps_only':
-    case 'reps_seconds':
-      return [repsField];
-    case 'seconds_only':
-    case 'cardio':
-      return [secondsField];
-    case 'distance':
-    default:
-      return [];
-  }
-}
-
-function getReadOnlyCorrectionSummary(
+function toCompletedSetListItem(
   set: SessionSet,
   trackingType: ExerciseTrackingType,
-  weightUnit: WeightUnit,
-) {
-  const distance = getSetDistance(set);
-
-  if ((trackingType === 'cardio' || trackingType === 'distance') && distance != null) {
-    return `Logged distance remains ${formatNumber(distance)} ${getDistanceUnit(weightUnit)}.`;
+): WorkoutExerciseSetListItem {
+  switch (trackingType) {
+    case 'weight_seconds':
+      return {
+        completed: set.completed,
+        reps: null,
+        seconds: set.reps,
+        setNumber: set.setNumber,
+        weight: set.weight,
+      };
+    case 'seconds_only':
+      return {
+        completed: set.completed,
+        reps: null,
+        seconds: set.reps,
+        setNumber: set.setNumber,
+        weight: set.weight,
+      };
+    case 'distance':
+      return {
+        completed: set.completed,
+        distance: getSetDistance(set) ?? set.reps ?? null,
+        reps: null,
+        setNumber: set.setNumber,
+        weight: set.weight,
+      };
+    case 'cardio':
+      return {
+        completed: set.completed,
+        distance: getSetDistance(set),
+        reps: null,
+        seconds: set.reps,
+        setNumber: set.setNumber,
+        weight: set.weight,
+      };
+    case 'reps_seconds':
+      return {
+        completed: set.completed,
+        reps: set.reps,
+        // Temporary bridge until reps_seconds has a dedicated persisted seconds field.
+        seconds: set.reps,
+        setNumber: set.setNumber,
+        weight: set.weight,
+      };
+    default:
+      return {
+        completed: set.completed,
+        distance: getSetDistance(set),
+        reps: set.reps,
+        setNumber: set.setNumber,
+        weight: set.weight,
+      };
   }
-
-  if (trackingType === 'reps_seconds') {
-    return 'Time corrections are not persisted separately yet, so only reps can be adjusted here.';
-  }
-
-  return null;
 }
 
 function buildSections(
@@ -925,7 +689,11 @@ function buildSections(
     `deleted-${set.section ?? 'supplemental'}-${set.orderIndex ?? 0}`;
   const templateSectionByExerciseId = new Map<string, WorkoutTemplateSectionType>();
   const templateExerciseNameById = new Map<string, string>();
+  const templateRepsMaxByExerciseId = new Map<string, number | null>();
+  const templateRepsMinByExerciseId = new Map<string, number | null>();
+  const templateRestSecondsByExerciseId = new Map<string, number | null>();
   const templateSupersetGroupByExerciseId = new Map<string, string | null>();
+  const templateTempoByExerciseId = new Map<string, string | null>();
   const templateTrackingTypeById = new Map<string, ExerciseTrackingType>();
   const sessionExerciseMetaById = new Map(
     (session.exercises ?? [])
@@ -960,7 +728,11 @@ function buildSections(
     section.exercises.forEach((exercise) => {
       templateSectionByExerciseId.set(exercise.exerciseId, section.type);
       templateExerciseNameById.set(exercise.exerciseId, exercise.exerciseName);
+      templateRepsMaxByExerciseId.set(exercise.exerciseId, exercise.repsMax);
+      templateRepsMinByExerciseId.set(exercise.exerciseId, exercise.repsMin);
+      templateRestSecondsByExerciseId.set(exercise.exerciseId, exercise.restSeconds);
       templateSupersetGroupByExerciseId.set(exercise.exerciseId, exercise.supersetGroup);
+      templateTempoByExerciseId.set(exercise.exerciseId, exercise.tempo);
       if (exercise.trackingType) {
         templateTrackingTypeById.set(exercise.exerciseId, exercise.trackingType);
       }
@@ -1005,6 +777,7 @@ function buildSections(
         new Map<string, { exerciseId: string | null; sets: SessionSet[] }>();
       const exercises = [...groupedExercises.entries()].map(([groupKey, grouped]) => {
         const { exerciseId, sets } = grouped;
+        const sortedSets = [...sets].sort((left, right) => left.setNumber - right.setNumber);
         const sessionExerciseMeta =
           typeof exerciseId === 'string' ? sessionExerciseMetaById.get(exerciseId) : undefined;
         const name =
@@ -1013,15 +786,54 @@ function buildSections(
             : sessionExerciseMeta?.exerciseName ??
               templateExerciseNameById.get(exerciseId) ??
               formatLabel(exerciseId);
+        const trackingType = resolveTrackingType({
+          trackingType:
+            (typeof exerciseId === 'string'
+              ? sessionTrackingTypeById.get(exerciseId)
+              : undefined) ??
+            (typeof exerciseId === 'string'
+              ? templateTrackingTypeById.get(exerciseId)
+              : undefined) ??
+            undefined,
+          exerciseId,
+          exerciseName: name,
+        });
+        const phaseBadge = inferPhaseBadge(sectionType);
+
         return {
+          cardExercise: {
+            completedSets: sortedSets.map((set) => toCompletedSetListItem(set, trackingType)),
+            equipment: null,
+            exerciseId: exerciseId ?? groupKey,
+            id: exerciseId ?? groupKey,
+            muscleGroups: [],
+            name,
+            notes: null,
+            phaseBadge: formatLabel(phaseBadge),
+            programmingNotes: sessionExerciseMeta?.programmingNotes ?? null,
+            repsMax:
+              (typeof exerciseId === 'string'
+                ? templateRepsMaxByExerciseId.get(exerciseId)
+                : undefined) ?? null,
+            repsMin:
+              (typeof exerciseId === 'string'
+                ? templateRepsMinByExerciseId.get(exerciseId)
+                : undefined) ?? null,
+            restSeconds:
+              (typeof exerciseId === 'string'
+                ? templateRestSecondsByExerciseId.get(exerciseId)
+                : undefined) ?? null,
+            tempo:
+              (typeof exerciseId === 'string'
+                ? templateTempoByExerciseId.get(exerciseId)
+                : undefined) ?? null,
+            trackingType,
+          },
           groupKey,
           exerciseId,
-          name,
           archived: Boolean(sessionExerciseMeta?.deletedAt),
-          notes: sets.find((set) => set.notes)?.notes ?? null,
-          programmingNotes: sessionExerciseMeta?.programmingNotes ?? null,
-          phaseBadge: inferPhaseBadge(sectionType),
-          sets: [...sets].sort((left, right) => left.setNumber - right.setNumber),
+          notes: sortedSets.find((set) => set.notes)?.notes ?? null,
+          sets: sortedSets,
           supersetGroup:
             (typeof exerciseId === 'string'
               ? sessionSupersetGroupByExerciseId.get(exerciseId)
@@ -1030,18 +842,7 @@ function buildSections(
               ? templateSupersetGroupByExerciseId.get(exerciseId)
               : undefined) ??
             null,
-          trackingType: resolveTrackingType({
-            trackingType:
-              (typeof exerciseId === 'string'
-                ? sessionTrackingTypeById.get(exerciseId)
-                : undefined) ??
-              (typeof exerciseId === 'string'
-                ? templateTrackingTypeById.get(exerciseId)
-                : undefined) ??
-              undefined,
-            exerciseId,
-            exerciseName: name,
-          }),
+          trackingType,
         };
       });
 
@@ -1166,9 +967,7 @@ function formatFeedbackResponseValue(response: WorkoutSessionFeedbackResponse) {
   return '-';
 }
 
-function inferPhaseBadge(
-  sectionType: SessionDetailSectionType,
-): SessionDetailExercise['phaseBadge'] {
+function inferPhaseBadge(sectionType: SessionDetailSectionType): SessionPhaseBadge {
   switch (sectionType) {
     case 'warmup':
     case 'cooldown':
@@ -1178,17 +977,6 @@ function inferPhaseBadge(
     default:
       return 'moderate';
   }
-}
-
-function formatSetLabel(
-  set: SessionSet,
-  trackingType: ExerciseTrackingType,
-  weightUnit: WeightUnit,
-) {
-  return formatSetSummary(set, trackingType, {
-    includeSetNumber: true,
-    weightUnit,
-  });
 }
 
 function formatSummaryMetric(
@@ -1238,12 +1026,4 @@ function formatLabel(value: string) {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
-}
-
-function formatNumber(value: number) {
-  if (Number.isInteger(value)) {
-    return integerFormatter.format(value);
-  }
-
-  return formatServing(value);
 }

--- a/apps/web/src/features/workouts/components/session-summary-exercise-card.tsx
+++ b/apps/web/src/features/workouts/components/session-summary-exercise-card.tsx
@@ -1,9 +1,7 @@
-import { formatWeight, type ExerciseTrackingType, type WeightUnit } from '@pulse/shared';
-
-import { formatServing } from '@/lib/format-utils';
+import { type ExerciseTrackingType, type WeightUnit } from '@pulse/shared';
 import { cn } from '@/lib/utils';
 
-import { getDistanceUnit, type TrackingSummaryMetricLabel } from '../lib/tracking';
+import { formatSummaryMetricValue, type TrackingSummaryMetricLabel } from '../lib/tracking';
 import { MarkdownNote } from './markdown-note';
 import {
   WorkoutExerciseCard,
@@ -50,6 +48,7 @@ export function SessionSummaryExerciseCard({
     exerciseId: exercise.id,
     id: exercise.id,
     name: exercise.name,
+    // Notes are intentionally rendered in footerSlot to keep the condensed header clean.
     notes: null,
     programmingNotes: exercise.programmingNotes ?? null,
     repsMax: null,
@@ -150,26 +149,6 @@ function getMetricTone(label: TrackingSummaryMetricLabel): 'count' | 'time' | 'v
   }
 
   return 'count';
-}
-
-function formatSummaryMetricValue(
-  value: number,
-  label: TrackingSummaryMetricLabel,
-  weightUnit: WeightUnit,
-) {
-  if (label === 'volume') {
-    return formatWeight(value, weightUnit);
-  }
-
-  if (label === 'reps') {
-    return `${Math.round(value)}`;
-  }
-
-  if (label === 'seconds') {
-    return `${formatServing(value)} sec`;
-  }
-
-  return `${formatServing(value)} ${getDistanceUnit(weightUnit)}`;
 }
 
 function MetricChip({

--- a/apps/web/src/features/workouts/components/session-summary-exercise-card.tsx
+++ b/apps/web/src/features/workouts/components/session-summary-exercise-card.tsx
@@ -1,0 +1,196 @@
+import { formatWeight, type ExerciseTrackingType, type WeightUnit } from '@pulse/shared';
+
+import { formatServing } from '@/lib/format-utils';
+import { cn } from '@/lib/utils';
+
+import { getDistanceUnit, type TrackingSummaryMetricLabel } from '../lib/tracking';
+import { MarkdownNote } from './markdown-note';
+import {
+  WorkoutExerciseCard,
+  type WorkoutExerciseCardCompletedExercise,
+  type WorkoutExerciseSetListItem,
+} from './workout-exercise-card';
+
+export type SessionSummaryExerciseSetResult = {
+  completed?: boolean;
+  distance?: number | null;
+  reps?: number | null;
+  seconds?: number | null;
+  setNumber: number;
+  weight?: number | null;
+};
+
+export type SessionSummaryExerciseResult = {
+  completedSetValues?: SessionSummaryExerciseSetResult[];
+  id: string;
+  metricLabel?: TrackingSummaryMetricLabel;
+  metricValue?: number;
+  name: string;
+  notes?: string | null;
+  programmingNotes?: string | null;
+  reps: number;
+  setsCompleted: number;
+  totalSets: number;
+  trackingType?: ExerciseTrackingType | null;
+  volume?: number;
+};
+
+export function SessionSummaryExerciseCard({
+  exercise,
+  weightUnit,
+}: {
+  exercise: SessionSummaryExerciseResult;
+  weightUnit: WeightUnit;
+}) {
+  const metricLabel = exercise.metricLabel ?? 'volume';
+  const trackingType = resolveSummaryTrackingType(exercise);
+  const setValues = exercise.completedSetValues ?? [];
+  const cardExercise: WorkoutExerciseCardCompletedExercise = {
+    completedSets: setValues.map(toCompletedSetListItem),
+    exerciseId: exercise.id,
+    id: exercise.id,
+    name: exercise.name,
+    notes: null,
+    programmingNotes: exercise.programmingNotes ?? null,
+    repsMax: null,
+    repsMin: null,
+    restSeconds: null,
+    tempo: null,
+    trackingType,
+  };
+
+  return (
+    <WorkoutExerciseCard
+      density="condensed"
+      exercise={cardExercise}
+      footerSlot={
+        <div className="space-y-2">
+          <div className="flex flex-wrap gap-1.5">
+            <MetricChip
+              label={getExerciseMetricLabel(metricLabel)}
+              tone={getMetricTone(metricLabel)}
+              value={formatSummaryMetricValue(
+                exercise.metricValue ?? exercise.volume ?? 0,
+                metricLabel,
+                weightUnit,
+              )}
+            />
+            {exercise.reps > 0 && metricLabel !== 'reps' ? (
+              <MetricChip label="Reps" tone="count" value={`${exercise.reps}`} />
+            ) : null}
+          </div>
+
+          {exercise.notes?.trim() ? (
+            <MarkdownNote className="text-xs text-muted" content={exercise.notes.trim()} />
+          ) : null}
+        </div>
+      }
+      headerSlot={
+        <span className="shrink-0 rounded-full bg-fuchsia-500/15 px-2 py-0.5 text-[11px] font-semibold text-fuchsia-700 dark:text-fuchsia-300">
+          {`${exercise.setsCompleted}/${exercise.totalSets} sets`}
+        </span>
+      }
+      mode="readonly-completed"
+      showSetList={setValues.length > 0}
+      weightUnit={weightUnit}
+    />
+  );
+}
+
+function toCompletedSetListItem(set: SessionSummaryExerciseSetResult): WorkoutExerciseSetListItem {
+  return {
+    completed: set.completed ?? true,
+    distance: set.distance ?? null,
+    reps: set.reps ?? null,
+    seconds: set.seconds ?? null,
+    setNumber: set.setNumber,
+    weight: set.weight ?? null,
+  };
+}
+
+function resolveSummaryTrackingType(exercise: SessionSummaryExerciseResult): ExerciseTrackingType {
+  if (exercise.trackingType) {
+    return exercise.trackingType;
+  }
+
+  switch (exercise.metricLabel) {
+    case 'seconds':
+      return 'seconds_only';
+    case 'distance':
+      return 'distance';
+    case 'reps':
+      return 'reps_only';
+    case 'volume':
+    default:
+      return 'weight_reps';
+  }
+}
+
+function getExerciseMetricLabel(label: TrackingSummaryMetricLabel) {
+  switch (label) {
+    case 'reps':
+      return 'Reps';
+    case 'seconds':
+      return 'Seconds';
+    case 'distance':
+      return 'Distance';
+    case 'volume':
+    default:
+      return 'Volume';
+  }
+}
+
+function getMetricTone(label: TrackingSummaryMetricLabel): 'count' | 'time' | 'volume' {
+  if (label === 'seconds') {
+    return 'time';
+  }
+
+  if (label === 'volume') {
+    return 'volume';
+  }
+
+  return 'count';
+}
+
+function formatSummaryMetricValue(
+  value: number,
+  label: TrackingSummaryMetricLabel,
+  weightUnit: WeightUnit,
+) {
+  if (label === 'volume') {
+    return formatWeight(value, weightUnit);
+  }
+
+  if (label === 'reps') {
+    return `${Math.round(value)}`;
+  }
+
+  if (label === 'seconds') {
+    return `${formatServing(value)} sec`;
+  }
+
+  return `${formatServing(value)} ${getDistanceUnit(weightUnit)}`;
+}
+
+function MetricChip({
+  label,
+  tone,
+  value,
+}: {
+  label: string;
+  tone: 'count' | 'time' | 'volume';
+  value: string;
+}) {
+  const toneClass =
+    tone === 'volume'
+      ? 'bg-blue-500/12 text-blue-800 dark:text-blue-200'
+      : tone === 'time'
+        ? 'bg-emerald-500/12 text-emerald-800 dark:text-emerald-200'
+        : 'bg-fuchsia-500/12 text-fuchsia-800 dark:text-fuchsia-200';
+
+  return (
+    <span className={cn('rounded-full px-2 py-0.5 text-[11px] font-medium', toneClass)}>
+      {`${label}: ${value}`}
+    </span>
+  );
+}

--- a/apps/web/src/features/workouts/components/session-summary.test.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { renderWithQueryClient } from '@/test/render-with-query-client';
@@ -6,8 +6,9 @@ import { renderWithQueryClient } from '@/test/render-with-query-client';
 import { SessionSummary } from './session-summary';
 
 describe('SessionSummary', () => {
-  it('opens the save-as-template dialog with prefilled fields and performs a mock save', () => {
+  it('renders condensed shared-card exercise results and preserves summary actions', () => {
     const notesChangeSpy = vi.fn();
+    const doneSpy = vi.fn();
 
     renderWithQueryClient(
       <SessionSummary
@@ -16,6 +17,20 @@ describe('SessionSummary', () => {
         duration="47:12"
         exerciseResults={[
           {
+            completedSetValues: [
+              {
+                completed: true,
+                reps: 10,
+                setNumber: 1,
+                weight: 50,
+              },
+              {
+                completed: true,
+                reps: 9,
+                setNumber: 2,
+                weight: 45,
+              },
+            ],
             id: 'incline-press',
             name: 'Incline Dumbbell Press',
             notes: 'Kept shoulder blades pinned and reduced ROM for shoulder comfort.',
@@ -23,15 +38,25 @@ describe('SessionSummary', () => {
             reps: 32,
             setsCompleted: 4,
             totalSets: 4,
+            trackingType: 'weight_reps',
             volume: 1760,
           },
           {
+            completedSetValues: [
+              {
+                completed: true,
+                reps: 7,
+                setNumber: 1,
+                weight: 15,
+              },
+            ],
             id: 'lateral-raise',
             name: 'Cable Lateral Raise',
             notes: '',
             reps: 28,
             setsCompleted: 4,
             totalSets: 4,
+            trackingType: 'weight_reps',
             volume: 420,
           },
         ]}
@@ -87,7 +112,7 @@ describe('SessionSummary', () => {
             value: 'Pause the first rep of each incline set next time.',
           },
         ]}
-        onDone={() => {}}
+        onDone={doneSpy}
         completedSets={14}
         onNotesChange={notesChangeSpy}
         sessionNotes=""
@@ -106,16 +131,27 @@ describe('SessionSummary', () => {
     expect(screen.getByText('7,460 lbs')).toBeInTheDocument();
     expect(screen.getByText('47:12')).toBeInTheDocument();
     expect(screen.getByText('14/14')).toBeInTheDocument();
+
     expect(screen.getByRole('heading', { name: 'Exercise results' })).toBeInTheDocument();
+    const inclineCard = screen.getByTestId('workout-exercise-card-incline-press');
     expect(screen.getByText('Incline Dumbbell Press')).toBeInTheDocument();
+    expect(within(inclineCard).getByText('4/4 sets')).toBeInTheDocument();
+    expect(within(inclineCard).getByText('Volume: 1,760 lbs')).toBeInTheDocument();
+    expect(within(inclineCard).getByText('Reps: 32')).toBeInTheDocument();
     expect(screen.getByTestId('exercise-programming-notes-incline-press')).toHaveTextContent(
       'Hardstyle, hips snap',
     );
     expect(
       screen.getByText('Kept shoulder blades pinned and reduced ROM for shoulder comfort.'),
     ).toBeInTheDocument();
-    expect(screen.getByText('Volume: 1,760 lbs')).toBeInTheDocument();
-    expect(screen.getByText('Reps: 32')).toBeInTheDocument();
+
+    expect(within(inclineCard).queryByText('Prescription')).not.toBeInTheDocument();
+    expect(within(inclineCard).queryByRole('button', { name: 'Show form cues' })).not.toBeInTheDocument();
+
+    fireEvent.click(within(inclineCard).getByText('Show set values'));
+    expect(within(inclineCard).getByLabelText('Weight for set 1')).toHaveValue(50);
+    expect(within(inclineCard).getByLabelText('Reps for set 1')).toHaveValue(10);
+
     expect(screen.getByRole('heading', { name: 'Session feedback' })).toBeInTheDocument();
     expect(screen.getByText('2 / 5')).toBeInTheDocument();
     expect(screen.getByText('🙂')).toBeInTheDocument();
@@ -125,6 +161,7 @@ describe('SessionSummary', () => {
     expect(
       screen.getByText('Pause the first rep of each incline set next time.'),
     ).toBeInTheDocument();
+
     expect(
       screen.getByPlaceholderText('What happened today? Anything notable about this session?'),
     ).toBeInTheDocument();
@@ -149,9 +186,6 @@ describe('SessionSummary', () => {
       },
     );
     expect(notesChangeSpy).toHaveBeenCalledWith('Tempo was good but shoulders fatigued early.');
-    expect(screen.getByTestId('exercise-programming-notes-incline-press')).toHaveTextContent(
-      'Hardstyle, hips snap',
-    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Save as Template' }));
 
@@ -187,6 +221,9 @@ describe('SessionSummary', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(screen.getByText('Saved "Upper Push" to mock templates.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }));
+    expect(doneSpy).toHaveBeenCalledTimes(1);
   });
 
   it('renders tracking-aware summary labels for time-based and mixed sessions', () => {
@@ -195,6 +232,13 @@ describe('SessionSummary', () => {
         duration="12:00"
         exerciseResults={[
           {
+            completedSetValues: [
+              {
+                completed: true,
+                seconds: 120,
+                setNumber: 1,
+              },
+            ],
             id: 'plank',
             metricLabel: 'seconds',
             metricValue: 120,
@@ -202,6 +246,7 @@ describe('SessionSummary', () => {
             reps: 0,
             setsCompleted: 2,
             totalSets: 2,
+            trackingType: 'seconds_only',
           },
         ]}
         exercisesCompleted={1}
@@ -227,12 +272,21 @@ describe('SessionSummary', () => {
         duration="15:24"
         exerciseResults={[
           {
+            completedSetValues: [
+              {
+                completed: true,
+                reps: 8,
+                setNumber: 1,
+                weight: 55,
+              },
+            ],
             id: 'incline-press',
             name: 'Incline Dumbbell Press',
             notes: '- **Brace** at lockout\n- Keep elbows stacked',
             reps: 16,
             setsCompleted: 2,
             totalSets: 2,
+            trackingType: 'weight_reps',
             volume: 880,
           },
         ]}
@@ -267,6 +321,14 @@ describe('SessionSummary', () => {
         duration="10:00"
         exerciseResults={[
           {
+            completedSetValues: [
+              {
+                completed: true,
+                reps: 12,
+                setNumber: 1,
+                weight: 50,
+              },
+            ],
             id: 'incline-press',
             name: 'Incline Dumbbell Press',
             notes: '',
@@ -274,6 +336,7 @@ describe('SessionSummary', () => {
             reps: 12,
             setsCompleted: 2,
             totalSets: 2,
+            trackingType: 'weight_reps',
             volume: 600,
           },
         ]}

--- a/apps/web/src/features/workouts/components/session-summary.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { CheckCircle2, ClipboardList, Clock3, Dumbbell, ListChecks, Save, X } from 'lucide-react';
+import { CheckCircle2, Clock3, Dumbbell, ListChecks, Save, X } from 'lucide-react';
 import { formatWeight, type WeightUnit } from '@pulse/shared';
 
 import { Badge } from '@/components/ui/badge';
@@ -30,6 +30,10 @@ import {
 import { getDistanceUnit, type TrackingSummaryMetricLabel } from '../lib/tracking';
 import type { ActiveWorkoutFeedbackDraft } from '../types';
 import { MarkdownNote } from './markdown-note';
+import {
+  SessionSummaryExerciseCard,
+  type SessionSummaryExerciseResult,
+} from './session-summary-exercise-card';
 
 type SessionSummaryProps = {
   className?: string;
@@ -55,18 +59,7 @@ type SessionSummaryProps = {
   workoutName: string;
 };
 
-export type SessionSummaryExerciseResult = {
-  id: string;
-  metricLabel?: TrackingSummaryMetricLabel;
-  metricValue?: number;
-  name: string;
-  notes?: string | null;
-  programmingNotes?: string | null;
-  reps: number;
-  setsCompleted: number;
-  totalSets: number;
-  volume?: number;
-};
+export type { SessionSummaryExerciseResult };
 
 export function SessionSummary({
   className,
@@ -193,56 +186,11 @@ export function SessionSummary({
               </h2>
               <div className="space-y-2">
                 {exerciseResults.map((exercise) => (
-                  <article
-                    className="rounded-2xl border border-black/10 bg-white/45 p-3 dark:border-border dark:bg-card"
+                  <SessionSummaryExerciseCard
+                    exercise={exercise}
                     key={exercise.id}
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <p className="text-sm font-semibold text-foreground">{exercise.name}</p>
-                      <span className="shrink-0 rounded-full bg-fuchsia-500/15 px-2 py-0.5 text-[11px] font-semibold text-fuchsia-700 dark:text-fuchsia-300">
-                        {`${exercise.setsCompleted}/${exercise.totalSets} sets`}
-                      </span>
-                    </div>
-                    <div className="mt-1 flex flex-wrap gap-1.5">
-                      <MetricChip
-                        label={getExerciseMetricLabel(exercise.metricLabel ?? 'volume')}
-                        tone={getMetricTone(exercise.metricLabel ?? 'volume')}
-                        value={formatSummaryMetricValue(
-                          exercise.metricValue ?? exercise.volume ?? 0,
-                          exercise.metricLabel ?? 'volume',
-                          weightUnit,
-                        )}
-                      />
-                      {exercise.reps > 0 && (exercise.metricLabel ?? 'volume') !== 'reps' ? (
-                        <MetricChip label="Reps" tone="count" value={`${exercise.reps}`} />
-                      ) : null}
-                    </div>
-                    {exercise.programmingNotes?.trim() ? (
-                      <div
-                        className="mt-2 flex items-start gap-2 rounded-xl border-l-2 border-primary/35 bg-secondary/35 px-3 py-2"
-                        data-testid={`exercise-programming-notes-${exercise.id}`}
-                      >
-                        <ClipboardList
-                          aria-hidden="true"
-                          className="mt-0.5 size-3.5 shrink-0 text-muted"
-                        />
-                        <div className="space-y-0.5">
-                          <p className="text-[10px] font-semibold tracking-[0.16em] text-muted uppercase">
-                            Programming notes
-                          </p>
-                          <p className="whitespace-pre-wrap text-[13px] italic text-muted">
-                            {exercise.programmingNotes.trim()}
-                          </p>
-                        </div>
-                      </div>
-                    ) : null}
-                    {exercise.notes?.trim() ? (
-                      <MarkdownNote
-                        className="mt-2 text-xs text-muted"
-                        content={exercise.notes.trim()}
-                      />
-                    ) : null}
-                  </article>
+                    weightUnit={weightUnit}
+                  />
                 ))}
               </div>
             </section>
@@ -536,20 +484,6 @@ function getSummaryMetricLabel(label: TrackingSummaryMetricLabel | 'mixed') {
   }
 }
 
-function getExerciseMetricLabel(label: TrackingSummaryMetricLabel) {
-  switch (label) {
-    case 'reps':
-      return 'Reps';
-    case 'seconds':
-      return 'Seconds';
-    case 'distance':
-      return 'Distance';
-    case 'volume':
-    default:
-      return 'Volume';
-  }
-}
-
 function formatSummaryMetricValue(
   value: number,
   label: TrackingSummaryMetricLabel,
@@ -645,28 +579,5 @@ function SummaryPill({
       </div>
       <p className="text-sm font-semibold">{value}</p>
     </div>
-  );
-}
-
-function MetricChip({
-  label,
-  tone,
-  value,
-}: {
-  label: string;
-  tone: 'count' | 'time' | 'volume';
-  value: string;
-}) {
-  const toneClass =
-    tone === 'volume'
-      ? 'bg-blue-500/12 text-blue-800 dark:text-blue-200'
-      : tone === 'time'
-        ? 'bg-emerald-500/12 text-emerald-800 dark:text-emerald-200'
-        : 'bg-fuchsia-500/12 text-fuchsia-800 dark:text-fuchsia-200';
-
-  return (
-    <span className={cn('rounded-full px-2 py-0.5 text-[11px] font-medium', toneClass)}>
-      {`${label}: ${value}`}
-    </span>
   );
 }

--- a/apps/web/src/features/workouts/components/session-summary.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { CheckCircle2, Clock3, Dumbbell, ListChecks, Save, X } from 'lucide-react';
-import { formatWeight, type WeightUnit } from '@pulse/shared';
+import { type WeightUnit } from '@pulse/shared';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -18,7 +18,6 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { formatServing } from '@/lib/format-utils';
 import { cn } from '@/lib/utils';
 
 import {
@@ -27,7 +26,7 @@ import {
   TEMPLATE_TAG_LIMIT,
   TEMPLATE_TAG_SUGGESTIONS,
 } from '../lib/template-tags';
-import { getDistanceUnit, type TrackingSummaryMetricLabel } from '../lib/tracking';
+import { formatSummaryMetricValue, type TrackingSummaryMetricLabel } from '../lib/tracking';
 import type { ActiveWorkoutFeedbackDraft } from '../types';
 import { MarkdownNote } from './markdown-note';
 import {
@@ -482,26 +481,6 @@ function getSummaryMetricLabel(label: TrackingSummaryMetricLabel | 'mixed') {
     default:
       return 'Total volume';
   }
-}
-
-function formatSummaryMetricValue(
-  value: number,
-  label: TrackingSummaryMetricLabel,
-  weightUnit: WeightUnit,
-) {
-  if (label === 'volume') {
-    return formatWeight(value, weightUnit);
-  }
-
-  if (label === 'reps') {
-    return `${Math.round(value)}`;
-  }
-
-  if (label === 'seconds') {
-    return `${formatServing(value)} sec`;
-  }
-
-  return `${formatServing(value)} ${getDistanceUnit(weightUnit)}`;
 }
 
 function getSummaryMetricValue({

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -280,6 +280,87 @@ describe('WorkoutTemplateDetail', () => {
     expect(supplementalSection).toHaveClass('border-l-[var(--color-accent-cream)]');
   });
 
+  it('edits template exercise prescription fields from the exercise menu', async () => {
+    const mutableTemplate = structuredClone(templatePayload);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const requestUrl = input instanceof Request ? input.url : String(input);
+      const url = new URL(requestUrl, 'https://pulse.test');
+
+      if (url.pathname === '/api/v1/workout-templates/upper-push' && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body ?? '{}'));
+        mutableTemplate.data.sections = body.sections;
+        return Promise.resolve(jsonResponse(mutableTemplate));
+      }
+
+      if (url.pathname === '/api/v1/workout-templates/upper-push') {
+        return Promise.resolve(jsonResponse(mutableTemplate));
+      }
+
+      throw new Error(`Unhandled request: ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <WorkoutTemplateDetail templateId="upper-push" />
+      </MemoryRouter>,
+    );
+
+    const exerciseCard = (await screen.findByText('Incline Dumbbell Press')).closest(
+      '[data-slot="card"]',
+    );
+    expect(exerciseCard).not.toBeNull();
+
+    fireEvent.click(
+      within(exerciseCard as HTMLElement).getByRole('button', {
+        name: 'Exercise actions for Incline Dumbbell Press',
+      }),
+    );
+    fireEvent.click(
+      within(exerciseCard as HTMLElement).getByRole('button', { name: 'Edit prescription' }),
+    );
+
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.change(within(dialog).getByLabelText('Sets for Incline Dumbbell Press'), {
+      target: { value: '4' },
+    });
+    fireEvent.change(within(dialog).getByLabelText('Reps for Incline Dumbbell Press'), {
+      target: { value: '6-8' },
+    });
+    fireEvent.change(within(dialog).getByLabelText('Rest for Incline Dumbbell Press'), {
+      target: { value: '75' },
+    });
+    fireEvent.change(within(dialog).getByLabelText('Notes for Incline Dumbbell Press'), {
+      target: { value: 'Pause one second at bottom.' },
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+    await waitFor(
+      () => {
+        expect(
+          fetchSpy.mock.calls.some(
+            ([input, init]) =>
+              String(input).includes('/api/v1/workout-templates/upper-push') &&
+              init?.method === 'PATCH',
+          ),
+        ).toBe(true);
+      },
+      { timeout: 2_000 },
+    );
+
+    const updateCall = fetchSpy.mock.calls.find(
+      ([input, init]) =>
+        String(input).includes('/api/v1/workout-templates/upper-push') && init?.method === 'PATCH',
+    );
+    const body = JSON.parse(String(updateCall?.[1]?.body));
+    const updatedExercise = body.sections[1].exercises[0];
+
+    expect(updatedExercise.sets).toBe(4);
+    expect(updatedExercise.repsMin).toBe(6);
+    expect(updatedExercise.repsMax).toBe(8);
+    expect(updatedExercise.restSeconds).toBe(75);
+    expect(updatedExercise.notes).toBe('Pause one second at bottom.');
+  });
+
   it('renders add exercise button for each section and adds to selected section', async () => {
     const mutableTemplate = structuredClone(templatePayload);
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {

--- a/apps/web/src/features/workouts/components/template-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.test.tsx
@@ -196,18 +196,28 @@ describe('WorkoutTemplateDetail', () => {
         name: 'Exercise actions for Incline Dumbbell Press',
       }),
     ).toHaveClass('size-11', 'min-h-11', 'min-w-11');
+    expect(inclinePressCard).toHaveAttribute(
+      'data-testid',
+      'workout-exercise-card-template-exercise-incline',
+    );
     expect(within(inclinePressCard as HTMLElement).getByText('3×8-10')).toBeInTheDocument();
-    expect(within(inclinePressCard as HTMLElement).getByText('Tempo: 3-1-1-0')).toBeInTheDocument();
-    expect(within(inclinePressCard as HTMLElement).getByText(/Rest: 90s/)).toBeInTheDocument();
+    expect(within(inclinePressCard as HTMLElement).getByText('Prescription')).toBeInTheDocument();
+    expect(
+      within(inclinePressCard as HTMLElement).getByTestId(
+        'exercise-programming-notes-template-exercise-incline',
+      ),
+    ).toBeInTheDocument();
     expect(
       within(inclinePressCard as HTMLElement).getAllByText('Drive feet into the floor.').length,
     ).toBeGreaterThan(0);
 
-    fireEvent.click(within(inclinePressCard as HTMLElement).getByText('Show full set detail'));
+    fireEvent.click(
+      within(inclinePressCard as HTMLElement).getByRole('button', { name: 'Show form cues' }),
+    );
+    expect(within(inclinePressCard as HTMLElement).getByText('Form cues')).toBeInTheDocument();
     fireEvent.click(
       within(inclinePressCard as HTMLElement).getByRole('button', { name: 'Show notes' }),
     );
-    expect(within(inclinePressCard as HTMLElement).getByText('Form cues')).toBeInTheDocument();
     expect(
       within(inclinePressCard as HTMLElement).getByText('Tuck shoulder blades'),
     ).toBeInTheDocument();
@@ -222,9 +232,6 @@ describe('WorkoutTemplateDetail', () => {
       within(inclinePressCard as HTMLElement).getByText(
         'Keep your upper back pinned to the bench.',
       ),
-    ).toBeInTheDocument();
-    expect(
-      within(inclinePressCard as HTMLElement).getByText('Template programming notes'),
     ).toBeInTheDocument();
     expect(
       within(inclinePressCard as HTMLElement).getByText(
@@ -271,72 +278,6 @@ describe('WorkoutTemplateDetail', () => {
 
     expect(supplementalSection).not.toBeNull();
     expect(supplementalSection).toHaveClass('border-l-[var(--color-accent-cream)]');
-  });
-
-  it('saves inline sets, reps, rest, and notes on blur with debounce', async () => {
-    const mutableTemplate = structuredClone(templatePayload);
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
-      const requestUrl = input instanceof Request ? input.url : String(input);
-      const url = new URL(requestUrl, 'https://pulse.test');
-
-      if (url.pathname === '/api/v1/workout-templates/upper-push' && init?.method === 'PATCH') {
-        const body = JSON.parse(String(init.body ?? '{}'));
-        mutableTemplate.data.sections = body.sections;
-        return Promise.resolve(jsonResponse(mutableTemplate));
-      }
-
-      if (url.pathname === '/api/v1/workout-templates/upper-push') {
-        return Promise.resolve(jsonResponse(mutableTemplate));
-      }
-
-      throw new Error(`Unhandled request: ${url.pathname}`);
-    });
-
-    renderWithQueryClient(
-      <MemoryRouter>
-        <WorkoutTemplateDetail templateId="upper-push" />
-      </MemoryRouter>,
-    );
-
-    const setsInput = await screen.findByLabelText('Sets for Incline Dumbbell Press');
-    const repsInput = screen.getByLabelText('Reps for Incline Dumbbell Press');
-    const restInput = screen.getByLabelText('Rest for Incline Dumbbell Press');
-    const notesInput = screen.getByLabelText('Notes for Incline Dumbbell Press');
-
-    fireEvent.change(setsInput, { target: { value: '4' } });
-    fireEvent.blur(setsInput);
-    fireEvent.change(repsInput, { target: { value: '6-8' } });
-    fireEvent.blur(repsInput);
-    fireEvent.change(restInput, { target: { value: '75' } });
-    fireEvent.blur(restInput);
-    fireEvent.change(notesInput, { target: { value: 'Pause one second at bottom.' } });
-    fireEvent.blur(notesInput);
-
-    await waitFor(
-      () => {
-        expect(
-          fetchSpy.mock.calls.some(
-            ([input, init]) =>
-              String(input).includes('/api/v1/workout-templates/upper-push') &&
-              init?.method === 'PATCH',
-          ),
-        ).toBe(true);
-      },
-      { timeout: 2_000 },
-    );
-
-    const updateCall = fetchSpy.mock.calls.find(
-      ([input, init]) =>
-        String(input).includes('/api/v1/workout-templates/upper-push') && init?.method === 'PATCH',
-    );
-    const body = JSON.parse(String(updateCall?.[1]?.body));
-    const updatedExercise = body.sections[1].exercises[0];
-
-    expect(updatedExercise.sets).toBe(4);
-    expect(updatedExercise.repsMin).toBe(6);
-    expect(updatedExercise.repsMax).toBe(8);
-    expect(updatedExercise.restSeconds).toBe(75);
-    expect(updatedExercise.notes).toBe('Pause one second at bottom.');
   });
 
   it('renders add exercise button for each section and adds to selected section', async () => {

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -46,6 +46,7 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
@@ -56,6 +57,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import { useWeightUnit } from '@/hooks/use-weight-unit';
 import { useStartSession } from '@/hooks/use-workout-session';
 import { ApiError } from '@/lib/api-client';
@@ -87,6 +89,13 @@ import {
 
 type WorkoutTemplateDetailProps = {
   templateId: string;
+};
+
+type EditableExerciseFields = {
+  notes: string;
+  reps: string;
+  restSeconds: string;
+  sets: string;
 };
 
 const sectionLabels = {
@@ -137,6 +146,12 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
   const [exerciseDetailTarget, setExerciseDetailTarget] = useState<{
     exerciseId: string;
     templateExerciseId: string;
+  } | null>(null);
+  const [prescriptionEditTarget, setPrescriptionEditTarget] = useState<{
+    exerciseId: string;
+    exerciseName: string;
+    initialFields: EditableExerciseFields;
+    sectionType: WorkoutTemplateSectionType;
   } | null>(null);
   const [isScheduleDialogOpen, setIsScheduleDialogOpen] = useState(false);
 
@@ -256,6 +271,65 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
       </Card>
     );
   }
+
+  const saveExerciseEdits = (
+    sectionType: WorkoutTemplateSectionType,
+    exerciseId: string,
+    fields: EditableExerciseFields,
+  ) => {
+    const parsedReps = parseRepsInput(fields.reps);
+    if (!parsedReps.valid) {
+      toast.error('Reps must be like 8, 8-10, or 8+');
+      return false;
+    }
+
+    const sets = parseNullablePositiveInt(fields.sets);
+    const restSeconds = parseNullableNonNegativeInt(fields.restSeconds);
+    if (sets === undefined || restSeconds === undefined) {
+      toast.error('Sets and rest must be numbers');
+      return false;
+    }
+
+    const targetIndex = template.sections
+      .find((section) => section.type === sectionType)
+      ?.exercises.findIndex((exercise) => exercise.id === exerciseId);
+
+    if (targetIndex == null || targetIndex < 0) {
+      return false;
+    }
+
+    queueTemplateSectionsUpdate(
+      (currentSections) =>
+        currentSections.map((section) => {
+          if (section.type !== sectionType) {
+            return section;
+          }
+
+          return {
+            ...section,
+            exercises: section.exercises.map((exercise, index) =>
+              index === targetIndex
+                ? {
+                    ...exercise,
+                    notes: toNullableString(fields.notes),
+                    repsMax: parsedReps.repsMax,
+                    repsMin: parsedReps.repsMin,
+                    restSeconds,
+                    sets,
+                  }
+                : exercise,
+            ),
+          };
+        }),
+      {
+        onError: () => {
+          toast.error('Unable to save prescription edits. Try again.');
+        },
+      },
+    );
+
+    return true;
+  };
 
   const addExerciseToSection = (sectionType: WorkoutTemplateSectionType, exerciseId: string) => {
     queueTemplateSectionsUpdate(
@@ -506,6 +580,14 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
                                 exerciseName: exercise.exerciseName,
                               })
                             }
+                            onEditPrescription={() =>
+                              setPrescriptionEditTarget({
+                                exerciseId: exercise.id,
+                                exerciseName: exercise.exerciseName,
+                                initialFields: toEditableFields(exercise),
+                                sectionType: section.type,
+                              })
+                            }
                             onSwap={() =>
                               setSwapTarget({
                                 exerciseId: exercise.exerciseId,
@@ -595,6 +677,14 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
                                     setRenameTarget({
                                       exerciseId: exercise.exerciseId,
                                       exerciseName: exercise.exerciseName,
+                                    })
+                                  }
+                                  onEditPrescription={() =>
+                                    setPrescriptionEditTarget({
+                                      exerciseId: exercise.id,
+                                      exerciseName: exercise.exerciseName,
+                                      initialFields: toEditableFields(exercise),
+                                      sectionType: section.type,
                                     })
                                   }
                                   onSwap={() =>
@@ -711,6 +801,24 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
         sourceExerciseName={swapTarget?.exerciseName ?? ''}
         sourceLabel="this template"
       />
+      {prescriptionEditTarget ? (
+        <EditTemplateExercisePrescriptionDialog
+          exerciseName={prescriptionEditTarget.exerciseName}
+          fields={prescriptionEditTarget.initialFields}
+          onOpenChange={(open) => {
+            if (!open) {
+              setPrescriptionEditTarget(null);
+            }
+          }}
+          onSave={(fields) =>
+            saveExerciseEdits(
+              prescriptionEditTarget.sectionType,
+              prescriptionEditTarget.exerciseId,
+              fields,
+            )
+          }
+        />
+      ) : null}
       {supersetSectionTarget ? (
         <SupersetManagerDialog
           onApply={(exerciseIds, supersetGroup) => {
@@ -826,6 +934,7 @@ function TemplateExerciseCard({
   onMoveUp,
   onOpenDetails,
   onRename,
+  onEditPrescription,
   onSwap,
   weightUnit,
 }: {
@@ -838,6 +947,7 @@ function TemplateExerciseCard({
   onMoveUp: () => void;
   onOpenDetails: () => void;
   onRename: () => void;
+  onEditPrescription: () => void;
   onSwap: () => void;
   weightUnit: WeightUnit;
 }) {
@@ -878,6 +988,7 @@ function TemplateExerciseCard({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem onClick={onSwap}>Swap exercise</DropdownMenuItem>
+              <DropdownMenuItem onClick={onEditPrescription}>Edit prescription</DropdownMenuItem>
               <DropdownMenuItem disabled={isMoveUpDisabled} onClick={onMoveUp}>
                 <ArrowUp aria-hidden="true" className="size-4" />
                 Move up
@@ -920,11 +1031,13 @@ function toWorkoutExerciseCardTemplateExercise(
 ): WorkoutExerciseCardTemplateExercise {
   return {
     coachingNotes: exercise.exercise?.coachingNotes ?? null,
+    // TODO(pulse-issues-11): populate from template exercise API once nested `exercise` includes equipment.
     equipment: null,
     exerciseId: exercise.exerciseId,
     formCues: exercise.exercise?.formCues ?? exercise.formCues ?? [],
     id: exercise.id,
     instructions: exercise.exercise?.instructions ?? null,
+    // TODO(pulse-issues-11): populate from template exercise API once nested `exercise` includes muscleGroups.
     muscleGroups: [],
     name: exercise.exerciseName,
     notes: exercise.notes,
@@ -1203,6 +1316,103 @@ function AddExerciseOption({
   );
 }
 
+function EditTemplateExercisePrescriptionDialog({
+  exerciseName,
+  fields: initialFields,
+  onOpenChange,
+  onSave,
+}: {
+  exerciseName: string;
+  fields: EditableExerciseFields;
+  onOpenChange: (open: boolean) => void;
+  onSave: (fields: EditableExerciseFields) => boolean;
+}) {
+  const [fields, setFields] = useState<EditableExerciseFields>(initialFields);
+
+  useEffect(() => {
+    setFields(initialFields);
+  }, [initialFields]);
+
+  return (
+    <Dialog open onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Edit prescription</DialogTitle>
+          <DialogDescription>{`Update sets, reps, rest, and notes for ${exerciseName}.`}</DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="space-y-1">
+            <span className="text-xs font-medium text-muted">Sets</span>
+            <Input
+              aria-label={`Sets for ${exerciseName}`}
+              onChange={(event) =>
+                setFields((current) => ({ ...current, sets: event.currentTarget.value }))
+              }
+              placeholder="3"
+              value={fields.sets}
+            />
+          </label>
+
+          <label className="space-y-1">
+            <span className="text-xs font-medium text-muted">Reps</span>
+            <Input
+              aria-label={`Reps for ${exerciseName}`}
+              onChange={(event) =>
+                setFields((current) => ({ ...current, reps: event.currentTarget.value }))
+              }
+              placeholder="8-10"
+              value={fields.reps}
+            />
+          </label>
+
+          <label className="space-y-1">
+            <span className="text-xs font-medium text-muted">Rest (seconds)</span>
+            <Input
+              aria-label={`Rest for ${exerciseName}`}
+              onChange={(event) =>
+                setFields((current) => ({ ...current, restSeconds: event.currentTarget.value }))
+              }
+              placeholder="90"
+              value={fields.restSeconds}
+            />
+          </label>
+
+          <label className="space-y-1 sm:col-span-2">
+            <span className="text-xs font-medium text-muted">Notes</span>
+            <Textarea
+              aria-label={`Notes for ${exerciseName}`}
+              className="min-h-20"
+              onChange={(event) =>
+                setFields((current) => ({ ...current, notes: event.currentTarget.value }))
+              }
+              placeholder="Optional note"
+              value={fields.notes}
+            />
+          </label>
+        </div>
+
+        <DialogFooter>
+          <Button onClick={() => onOpenChange(false)} type="button" variant="outline">
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              const saved = onSave(fields);
+              if (saved) {
+                onOpenChange(false);
+              }
+            }}
+            type="button"
+          >
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 function TemplateDetailSkeleton() {
   return (
     <section aria-label="Loading workout template" className="space-y-6">
@@ -1342,6 +1552,114 @@ function formatLabel(value: string) {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
+}
+
+function toNullableString(value: string) {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function parseNullablePositiveInt(value: string) {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(normalized, 10);
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function parseNullableNonNegativeInt(value: string) {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(normalized, 10);
+  if (Number.isNaN(parsed) || parsed < 0) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function parseRepsInput(
+  value: string,
+): { valid: true; repsMax: number | null; repsMin: number | null } | { valid: false } {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    return {
+      valid: true,
+      repsMax: null,
+      repsMin: null,
+    };
+  }
+
+  if (/^\d+$/.test(normalized)) {
+    const parsed = Number.parseInt(normalized, 10);
+    return {
+      valid: true,
+      repsMax: parsed,
+      repsMin: parsed,
+    };
+  }
+
+  const rangeMatch = normalized.match(/^(\d+)\s*-\s*(\d+)$/);
+  if (rangeMatch) {
+    const min = Number.parseInt(rangeMatch[1] ?? '', 10);
+    const max = Number.parseInt(rangeMatch[2] ?? '', 10);
+
+    if (min <= max) {
+      return {
+        valid: true,
+        repsMax: max,
+        repsMin: min,
+      };
+    }
+
+    return { valid: false };
+  }
+
+  const plusMatch = normalized.match(/^(\d+)\+$/);
+  if (plusMatch) {
+    const min = Number.parseInt(plusMatch[1] ?? '', 10);
+    return {
+      valid: true,
+      repsMax: null,
+      repsMin: min,
+    };
+  }
+
+  return { valid: false };
+}
+
+function toEditableFields(exercise: WorkoutTemplateExercise): EditableExerciseFields {
+  return {
+    notes: exercise.notes ?? '',
+    reps: formatEditableReps(exercise.repsMin, exercise.repsMax),
+    restSeconds: exercise.restSeconds?.toString() ?? '',
+    sets: exercise.sets?.toString() ?? '',
+  };
+}
+
+function formatEditableReps(repsMin: number | null, repsMax: number | null) {
+  if (repsMin !== null && repsMax !== null) {
+    return repsMin === repsMax ? `${repsMin}` : `${repsMin}-${repsMax}`;
+  }
+
+  if (repsMin !== null) {
+    return `${repsMin}+`;
+  }
+
+  if (repsMax !== null) {
+    return `${repsMax}`;
+  }
+
+  return '';
 }
 
 function toUpdateSection(

--- a/apps/web/src/features/workouts/components/template-detail.tsx
+++ b/apps/web/src/features/workouts/components/template-detail.tsx
@@ -29,7 +29,6 @@ import {
 
 import type {
   Exercise,
-  ExerciseTrackingType,
   UpdateWorkoutTemplateInput,
   WorkoutTemplate,
   WorkoutTemplateExercise,
@@ -40,7 +39,7 @@ import { toast } from 'sonner';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import {
@@ -57,12 +56,10 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
 import { useWeightUnit } from '@/hooks/use-weight-unit';
 import { useStartSession } from '@/hooks/use-workout-session';
 import { ApiError } from '@/lib/api-client';
 import { toDateKey } from '@/lib/date-utils';
-import { useDebouncedCallback } from '@/lib/use-debounced-callback';
 import { cn } from '@/lib/utils';
 
 import {
@@ -78,24 +75,18 @@ import {
   getDayWorkoutConflicts,
 } from '../lib/day-workout-conflicts';
 import { getSupersetAccentClass } from '../lib/superset-utils';
-import { getTemplateExerciseElementId } from '../lib/template-exercise-id';
-import { getDistanceUnit } from '../lib/tracking';
 import { buildInitialSessionSets } from '../lib/workout-session-sets';
 import { ExerciseDetailModal } from './exercise-detail-modal';
-import { FormCueChips } from './form-cue-chips';
 import { RenameExerciseDialog } from './rename-exercise-dialog';
 import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
 import { SwapExerciseDialog } from './swap-exercise-dialog';
+import {
+  WorkoutExerciseCard,
+  type WorkoutExerciseCardTemplateExercise,
+} from './workout-exercise-card';
 
 type WorkoutTemplateDetailProps = {
   templateId: string;
-};
-
-type EditableExerciseFields = {
-  notes: string;
-  reps: string;
-  restSeconds: string;
-  sets: string;
 };
 
 const sectionLabels = {
@@ -265,57 +256,6 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
       </Card>
     );
   }
-
-  const saveExerciseEdits = (
-    sectionType: WorkoutTemplateSectionType,
-    exerciseId: string,
-    fields: EditableExerciseFields,
-  ) => {
-    const parsedReps = parseRepsInput(fields.reps);
-    if (!parsedReps.valid) {
-      toast.error('Reps must be like 8, 8-10, or 8+');
-      return;
-    }
-
-    const sets = parseNullablePositiveInt(fields.sets);
-    const restSeconds = parseNullableNonNegativeInt(fields.restSeconds);
-    if (sets === undefined || restSeconds === undefined) {
-      toast.error('Sets and rest must be numbers');
-      return;
-    }
-
-    const targetIndex = template.sections
-      .find((section) => section.type === sectionType)
-      ?.exercises.findIndex((exercise) => exercise.id === exerciseId);
-
-    if (targetIndex == null || targetIndex < 0) {
-      return;
-    }
-
-    queueTemplateSectionsUpdate((currentSections) =>
-      currentSections.map((section) => {
-        if (section.type !== sectionType) {
-          return section;
-        }
-
-        return {
-          ...section,
-          exercises: section.exercises.map((exercise, index) =>
-            index === targetIndex
-              ? {
-                  ...exercise,
-                  notes: toNullableString(fields.notes),
-                  repsMax: parsedReps.repsMax,
-                  repsMin: parsedReps.repsMin,
-                  restSeconds,
-                  sets,
-                }
-              : exercise,
-          ),
-        };
-      }),
-    );
-  };
 
   const addExerciseToSection = (sectionType: WorkoutTemplateSectionType, exerciseId: string) => {
     queueTemplateSectionsUpdate(
@@ -566,9 +506,6 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
                                 exerciseName: exercise.exerciseName,
                               })
                             }
-                            onSaveInline={(fields) =>
-                              saveExerciseEdits(section.type, exercise.id, fields)
-                            }
                             onSwap={() =>
                               setSwapTarget({
                                 exerciseId: exercise.exerciseId,
@@ -659,9 +596,6 @@ export function WorkoutTemplateDetail({ templateId }: WorkoutTemplateDetailProps
                                       exerciseId: exercise.exerciseId,
                                       exerciseName: exercise.exerciseName,
                                     })
-                                  }
-                                  onSaveInline={(fields) =>
-                                    saveExerciseEdits(section.type, exercise.id, fields)
                                   }
                                   onSwap={() =>
                                     setSwapTarget({
@@ -892,7 +826,6 @@ function TemplateExerciseCard({
   onMoveUp,
   onOpenDetails,
   onRename,
-  onSaveInline,
   onSwap,
   weightUnit,
 }: {
@@ -905,231 +838,106 @@ function TemplateExerciseCard({
   onMoveUp: () => void;
   onOpenDetails: () => void;
   onRename: () => void;
-  onSaveInline: (fields: EditableExerciseFields) => void;
   onSwap: () => void;
   weightUnit: WeightUnit;
 }) {
-  const compactSummary = formatCompactSetSummary(exercise, weightUnit);
-  const targetBreakdown = formatSetTargetBreakdown(exercise, weightUnit);
-  const [fields, setFields] = useState<EditableExerciseFields>(() => toEditableFields(exercise));
-  const focusedFieldCountRef = useRef(0);
-
-  useEffect(() => {
-    if (focusedFieldCountRef.current > 0) {
-      return;
-    }
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- local editable state must resync to server snapshot when not actively editing
-    setFields(toEditableFields(exercise));
-  }, [exercise]);
-
-  const debouncedInlineSave = useDebouncedCallback((nextFields: EditableExerciseFields) => {
-    onSaveInline(nextFields);
-  });
-
-  useEffect(
-    () => () => {
-      debouncedInlineSave.flush();
-    },
-    [debouncedInlineSave],
-  );
-
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
     id: exercise.id,
   });
 
   return (
-    <Card
-      className="gap-1.5 py-0"
-      id={getTemplateExerciseElementId(exercise.id)}
-      ref={setNodeRef}
+    <WorkoutExerciseCard
+      cardRef={setNodeRef}
+      exercise={toWorkoutExerciseCardTemplateExercise(exercise)}
+      footerSlot={
+        <p className="text-[10px] font-semibold tracking-[0.14em] text-muted uppercase">{`Exercise #${index + 1}`}</p>
+      }
+      headerSlot={
+        <>
+          <Button
+            aria-label={`Open ${exercise.exerciseName} history`}
+            className="size-11 min-h-11 min-w-11"
+            onClick={onOpenHistory}
+            size="icon"
+            type="button"
+            variant="ghost"
+          >
+            <History aria-hidden="true" className="size-4" />
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                aria-label={`Exercise actions for ${exercise.exerciseName}`}
+                className="-mr-1 size-11 min-h-11 min-w-11"
+                size="icon"
+                type="button"
+                variant="ghost"
+              >
+                <MoreVertical aria-hidden="true" className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={onSwap}>Swap exercise</DropdownMenuItem>
+              <DropdownMenuItem disabled={isMoveUpDisabled} onClick={onMoveUp}>
+                <ArrowUp aria-hidden="true" className="size-4" />
+                Move up
+              </DropdownMenuItem>
+              <DropdownMenuItem disabled={isMoveDownDisabled} onClick={onMoveDown}>
+                <ArrowDown aria-hidden="true" className="size-4" />
+                Move down
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={onRename}>Rename exercise</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </>
+      }
+      leadingSlot={
+        <Button
+          aria-label={`Drag handle for ${exercise.exerciseName}`}
+          className="-ml-1 mt-0.5 size-11 min-h-11 min-w-11 touch-none"
+          size="icon"
+          type="button"
+          variant="ghost"
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical aria-hidden="true" className="size-4" />
+        </Button>
+      }
+      mode="readonly-template"
+      onOpenDetails={onOpenDetails}
       style={{
         transform: CSS.Transform.toString(transform),
         transition,
       }}
-    >
-      <CardHeader className="gap-1.5 py-2.5">
-        <div className="flex items-start justify-between gap-2">
-          <div className="flex min-w-0 items-start gap-1.5">
-            <Button
-              aria-label={`Drag handle for ${exercise.exerciseName}`}
-              className="-ml-1 mt-0.5 size-11 min-h-11 min-w-11 touch-none"
-              size="icon"
-              type="button"
-              variant="ghost"
-              {...attributes}
-              {...listeners}
-            >
-              <GripVertical aria-hidden="true" className="size-4" />
-            </Button>
-            <div className="min-w-0 space-y-0.5">
-              <CardTitle className="truncate text-base font-semibold sm:text-lg">
-                <button
-                  className="cursor-pointer truncate text-left hover:text-primary hover:underline"
-                  onClick={onOpenDetails}
-                  type="button"
-                >
-                  {exercise.exerciseName}
-                </button>
-              </CardTitle>
-              <p className="text-xs font-medium text-muted sm:text-sm">{compactSummary}</p>
-              {exercise.notes ? (
-                <p className="line-clamp-2 text-[11px] italic text-muted/85">{exercise.notes}</p>
-              ) : null}
-              {exercise.tempo || exercise.restSeconds !== null ? (
-                <p className="text-[11px] text-muted">
-                  {exercise.tempo ? `Tempo: ${formatTempo(exercise.tempo)}` : null}
-                  {exercise.tempo && exercise.restSeconds !== null ? ' • ' : null}
-                  {exercise.restSeconds !== null ? `Rest: ${exercise.restSeconds}s` : null}
-                </p>
-              ) : null}
-            </div>
-          </div>
-          <div className="flex items-center gap-1">
-            <Button
-              aria-label={`Open ${exercise.exerciseName} history`}
-              className="size-11 min-h-11 min-w-11"
-              onClick={onOpenHistory}
-              size="icon"
-              type="button"
-              variant="ghost"
-            >
-              <History aria-hidden="true" className="size-4" />
-            </Button>
-
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  aria-label={`Exercise actions for ${exercise.exerciseName}`}
-                  className="-mr-1 size-11 min-h-11 min-w-11"
-                  size="icon"
-                  type="button"
-                  variant="ghost"
-                >
-                  <MoreVertical aria-hidden="true" className="size-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={onSwap}>Swap exercise</DropdownMenuItem>
-                <DropdownMenuItem disabled={isMoveUpDisabled} onClick={onMoveUp}>
-                  <ArrowUp aria-hidden="true" className="size-4" />
-                  Move up
-                </DropdownMenuItem>
-                <DropdownMenuItem disabled={isMoveDownDisabled} onClick={onMoveDown}>
-                  <ArrowDown aria-hidden="true" className="size-4" />
-                  Move down
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={onRename}>Rename exercise</DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-1.5 pb-2.5">
-        <p className="text-[10px] font-semibold tracking-[0.14em] text-muted uppercase">{`Exercise #${index + 1}`}</p>
-
-        <div className="grid gap-1.5 sm:grid-cols-3 lg:grid-cols-4">
-          <InlineEditField
-            ariaLabel={`Sets for ${exercise.exerciseName}`}
-            label="Sets"
-            onBlur={() => {
-              debouncedInlineSave.run(fields);
-              setTimeout(() => {
-                focusedFieldCountRef.current = Math.max(0, focusedFieldCountRef.current - 1);
-              }, 0);
-            }}
-            onFocus={() => {
-              focusedFieldCountRef.current += 1;
-            }}
-            onChange={(nextValue) => setFields((current) => ({ ...current, sets: nextValue }))}
-            placeholder="3"
-            value={fields.sets}
-          />
-          <InlineEditField
-            ariaLabel={`Reps for ${exercise.exerciseName}`}
-            label="Reps"
-            onBlur={() => {
-              debouncedInlineSave.run(fields);
-              setTimeout(() => {
-                focusedFieldCountRef.current = Math.max(0, focusedFieldCountRef.current - 1);
-              }, 0);
-            }}
-            onFocus={() => {
-              focusedFieldCountRef.current += 1;
-            }}
-            onChange={(nextValue) => setFields((current) => ({ ...current, reps: nextValue }))}
-            placeholder="8-10"
-            value={fields.reps}
-          />
-          <InlineEditField
-            ariaLabel={`Rest for ${exercise.exerciseName}`}
-            label="Rest (s)"
-            onBlur={() => {
-              debouncedInlineSave.run(fields);
-              setTimeout(() => {
-                focusedFieldCountRef.current = Math.max(0, focusedFieldCountRef.current - 1);
-              }, 0);
-            }}
-            onFocus={() => {
-              focusedFieldCountRef.current += 1;
-            }}
-            onChange={(nextValue) =>
-              setFields((current) => ({ ...current, restSeconds: nextValue }))
-            }
-            placeholder="90"
-            value={fields.restSeconds}
-          />
-          <InlineEditField
-            ariaLabel={`Notes for ${exercise.exerciseName}`}
-            className="sm:col-span-3 lg:col-span-1"
-            label="Notes"
-            multiline
-            onBlur={() => {
-              debouncedInlineSave.run(fields);
-              setTimeout(() => {
-                focusedFieldCountRef.current = Math.max(0, focusedFieldCountRef.current - 1);
-              }, 0);
-            }}
-            onFocus={() => {
-              focusedFieldCountRef.current += 1;
-            }}
-            onChange={(nextValue) => setFields((current) => ({ ...current, notes: nextValue }))}
-            placeholder="Optional note"
-            value={fields.notes}
-          />
-        </div>
-
-        <details className="rounded-xl border border-border/80 bg-secondary/20 px-3 py-2">
-          <summary className="cursor-pointer text-xs font-semibold text-muted">
-            Show full set detail
-          </summary>
-          <div className="mt-2 space-y-2">
-            <p className="text-xs font-medium text-foreground">
-              {formatPrescription(exercise, weightUnit)}
-            </p>
-            {targetBreakdown ? <p className="text-xs text-muted">{targetBreakdown}</p> : null}
-            {exercise.tempo ? (
-              <p className="text-xs text-muted">Tempo: {formatTempo(exercise.tempo)}</p>
-            ) : null}
-
-            {(exercise.exercise?.formCues?.length ?? exercise.formCues?.length ?? 0) > 0 ||
-            exercise.cues.length > 0 ||
-            Boolean(exercise.exercise?.coachingNotes) ||
-            Boolean(exercise.programmingNotes) ? (
-              <div className="rounded-lg border border-border bg-card px-3 py-2">
-                <FormCueChips
-                  exerciseCoachingNotes={exercise.exercise?.coachingNotes ?? null}
-                  exerciseCues={exercise.exercise?.formCues ?? exercise.formCues ?? []}
-                  templateCues={exercise.cues}
-                  templateProgrammingNotes={exercise.programmingNotes ?? null}
-                />
-              </div>
-            ) : null}
-          </div>
-        </details>
-      </CardContent>
-    </Card>
+      weightUnit={weightUnit}
+    />
   );
+}
+
+function toWorkoutExerciseCardTemplateExercise(
+  exercise: WorkoutTemplateExercise,
+): WorkoutExerciseCardTemplateExercise {
+  return {
+    coachingNotes: exercise.exercise?.coachingNotes ?? null,
+    equipment: null,
+    exerciseId: exercise.exerciseId,
+    formCues: exercise.exercise?.formCues ?? exercise.formCues ?? [],
+    id: exercise.id,
+    instructions: exercise.exercise?.instructions ?? null,
+    muscleGroups: [],
+    name: exercise.exerciseName,
+    notes: exercise.notes,
+    programmingNotes: exercise.programmingNotes ?? null,
+    repsMax: exercise.repsMax,
+    repsMin: exercise.repsMin,
+    restSeconds: exercise.restSeconds,
+    setTargets: exercise.setTargets ?? [],
+    sets: exercise.sets,
+    tempo: exercise.tempo,
+    templateCues: exercise.cues,
+    trackingType: exercise.trackingType,
+  };
 }
 
 function SupersetManagerDialog({
@@ -1395,58 +1203,6 @@ function AddExerciseOption({
   );
 }
 
-function InlineEditField({
-  ariaLabel,
-  className,
-  label,
-  multiline = false,
-  onBlur,
-  onFocus,
-  onChange,
-  placeholder,
-  value,
-}: {
-  ariaLabel: string;
-  className?: string;
-  label: string;
-  multiline?: boolean;
-  onBlur: () => void;
-  onFocus: () => void;
-  onChange: (value: string) => void;
-  placeholder: string;
-  value: string;
-}) {
-  return (
-    <label className={cn('space-y-1', className)}>
-      <span className="text-[10px] font-semibold tracking-[0.08em] text-muted uppercase">
-        {label}
-      </span>
-      {multiline ? (
-        <Textarea
-          aria-label={ariaLabel}
-          className="min-h-9 px-2 py-1 text-xs focus-visible:border-primary focus-visible:bg-card"
-          onBlur={onBlur}
-          onFocus={onFocus}
-          onChange={(event) => onChange(event.currentTarget.value)}
-          placeholder={placeholder}
-          rows={2}
-          value={value}
-        />
-      ) : (
-        <Input
-          aria-label={ariaLabel}
-          className="h-8 text-xs focus-visible:border-primary focus-visible:bg-card"
-          onBlur={onBlur}
-          onFocus={onFocus}
-          onChange={(event) => onChange(event.currentTarget.value)}
-          placeholder={placeholder}
-          value={value}
-        />
-      )}
-    </label>
-  );
-}
-
 function TemplateDetailSkeleton() {
   return (
     <section aria-label="Loading workout template" className="space-y-6">
@@ -1588,208 +1344,6 @@ function formatLabel(value: string) {
     .join(' ');
 }
 
-function formatPrescription(exercise: WorkoutTemplateExercise, weightUnit: WeightUnit) {
-  const repsTarget = formatRepTarget(exercise.repsMin, exercise.repsMax);
-  const setTargetSummary = summarizeSetTargets(exercise, weightUnit);
-  const trackingTypeLabel = exercise.trackingType === 'bodyweight_reps' ? ' (bodyweight)' : '';
-
-  if (setTargetSummary) {
-    if (exercise.sets !== null) {
-      return `${exercise.sets} x ${setTargetSummary}${trackingTypeLabel}`;
-    }
-
-    return `${setTargetSummary}${trackingTypeLabel}`;
-  }
-
-  if (exercise.trackingType === 'seconds_only') {
-    if (repsTarget) {
-      if (exercise.sets !== null) {
-        return `${exercise.sets} x ${repsTarget} sec`;
-      }
-
-      return `${repsTarget} sec`;
-    }
-
-    if (exercise.sets !== null) {
-      return `${exercise.sets} timed set${exercise.sets === 1 ? '' : 's'}`;
-    }
-  }
-
-  if (exercise.trackingType === 'distance') {
-    if (repsTarget) {
-      if (exercise.sets !== null) {
-        return `${exercise.sets} x ${repsTarget} ${getDistanceUnit(weightUnit)}`;
-      }
-
-      return `${repsTarget} ${getDistanceUnit(weightUnit)}`;
-    }
-
-    if (exercise.sets !== null) {
-      return `${exercise.sets} distance set${exercise.sets === 1 ? '' : 's'}`;
-    }
-  }
-
-  if (exercise.sets !== null && repsTarget) {
-    return `${exercise.sets} x ${repsTarget}${trackingTypeLabel}`;
-  }
-
-  if (exercise.sets !== null) {
-    return `${exercise.sets} set${exercise.sets === 1 ? '' : 's'}`;
-  }
-
-  if (repsTarget) {
-    return `${repsTarget}${trackingTypeLabel}`;
-  }
-
-  return 'Prescription not set';
-}
-
-function formatCompactSetSummary(exercise: WorkoutTemplateExercise, weightUnit: WeightUnit) {
-  const setTargetSummary = summarizeSetTargets(exercise, weightUnit);
-  const repsTarget = formatRepTarget(exercise.repsMin, exercise.repsMax);
-
-  if (exercise.sets !== null && setTargetSummary) {
-    return `${exercise.sets}×${setTargetSummary}`;
-  }
-
-  if (exercise.sets !== null && repsTarget) {
-    return `${exercise.sets}×${repsTarget}`;
-  }
-
-  if (exercise.sets !== null) {
-    return `${exercise.sets} set${exercise.sets === 1 ? '' : 's'}`;
-  }
-
-  return formatPrescription(exercise, weightUnit);
-}
-
-function formatSetTargetBreakdown(exercise: WorkoutTemplateExercise, weightUnit: WeightUnit) {
-  const repsTarget = formatRepTarget(exercise.repsMin, exercise.repsMax);
-  const targets = (exercise.setTargets ?? [])
-    .map((setTarget) => {
-      const label = formatTargetByTrackingType(
-        exercise.trackingType,
-        setTarget,
-        weightUnit,
-        repsTarget,
-      );
-
-      if (!label) {
-        return null;
-      }
-
-      return `Set ${setTarget.setNumber}: ${label}`;
-    })
-    .filter((value): value is string => value !== null);
-
-  if (targets.length <= 1) {
-    return null;
-  }
-
-  return targets.join(' • ');
-}
-
-function summarizeSetTargets(exercise: WorkoutTemplateExercise, weightUnit: WeightUnit) {
-  if (!exercise.setTargets || exercise.setTargets.length === 0) {
-    return null;
-  }
-
-  const repsTarget = formatRepTarget(exercise.repsMin, exercise.repsMax);
-  const labels = exercise.setTargets
-    .map((setTarget) =>
-      formatTargetByTrackingType(exercise.trackingType, setTarget, weightUnit, repsTarget),
-    )
-    .filter((value): value is string => value !== null);
-  if (labels.length === 0) {
-    return null;
-  }
-
-  const uniqueLabels = [...new Set(labels)];
-  if (uniqueLabels.length === 1) {
-    return uniqueLabels[0] ?? null;
-  }
-
-  return labels[0] ?? null;
-}
-
-function formatTargetByTrackingType(
-  trackingType: ExerciseTrackingType,
-  target: NonNullable<WorkoutTemplateExercise['setTargets']>[number],
-  weightUnit: WeightUnit,
-  repsTarget: string | null,
-) {
-  const weightLabel = formatTargetWeight(target, weightUnit);
-  const secondsLabel = target?.targetSeconds != null ? `${target.targetSeconds} sec` : null;
-  const distanceLabel =
-    target?.targetDistance != null
-      ? `${target.targetDistance} ${getDistanceUnit(weightUnit)}`
-      : null;
-
-  switch (trackingType) {
-    case 'seconds_only':
-      return secondsLabel;
-    case 'weight_seconds':
-      if (weightLabel && secondsLabel) {
-        return `${weightLabel} x ${secondsLabel}`;
-      }
-
-      return weightLabel ?? secondsLabel;
-    case 'reps_seconds':
-      if (repsTarget && secondsLabel) {
-        return `${repsTarget} x ${secondsLabel}`;
-      }
-
-      return secondsLabel;
-    case 'distance':
-      return distanceLabel;
-    case 'cardio':
-      if (secondsLabel && distanceLabel) {
-        return `${secondsLabel} + ${distanceLabel}`;
-      }
-
-      return secondsLabel ?? distanceLabel;
-    case 'weight_reps':
-      return weightLabel;
-    default:
-      return null;
-  }
-}
-
-function formatTargetWeight(
-  target: NonNullable<WorkoutTemplateExercise['setTargets']>[number],
-  weightUnit: WeightUnit,
-) {
-  if (target?.targetWeight != null) {
-    return `${target.targetWeight} ${weightUnit}`;
-  }
-
-  if (target?.targetWeightMin != null && target?.targetWeightMax != null) {
-    return `${target.targetWeightMin}-${target.targetWeightMax} ${weightUnit}`;
-  }
-
-  return null;
-}
-
-function formatRepTarget(repsMin: number | null, repsMax: number | null) {
-  if (repsMin !== null && repsMax !== null) {
-    return repsMin === repsMax ? `${repsMin}` : `${repsMin}-${repsMax}`;
-  }
-
-  if (repsMin !== null) {
-    return `${repsMin}+`;
-  }
-
-  if (repsMax !== null) {
-    return `Up to ${repsMax}`;
-  }
-
-  return null;
-}
-
-function formatTempo(tempo: string) {
-  return tempo.split('').join('-');
-}
-
 function toUpdateSection(
   section: WorkoutTemplate['sections'][number],
 ): NonNullable<UpdateWorkoutTemplateInput['sections']>[number] {
@@ -1815,112 +1369,4 @@ function toUpdateExercise(
     supersetGroup: exercise.supersetGroup,
     tempo: exercise.tempo,
   };
-}
-
-function toNullableString(value: string) {
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-function parseNullablePositiveInt(value: string) {
-  const normalized = value.trim();
-  if (normalized.length === 0) {
-    return null;
-  }
-
-  const parsed = Number.parseInt(normalized, 10);
-  if (Number.isNaN(parsed) || parsed < 1) {
-    return undefined;
-  }
-
-  return parsed;
-}
-
-function parseNullableNonNegativeInt(value: string) {
-  const normalized = value.trim();
-  if (normalized.length === 0) {
-    return null;
-  }
-
-  const parsed = Number.parseInt(normalized, 10);
-  if (Number.isNaN(parsed) || parsed < 0) {
-    return undefined;
-  }
-
-  return parsed;
-}
-
-function parseRepsInput(
-  value: string,
-): { valid: true; repsMax: number | null; repsMin: number | null } | { valid: false } {
-  const normalized = value.trim();
-  if (normalized.length === 0) {
-    return {
-      valid: true,
-      repsMax: null,
-      repsMin: null,
-    };
-  }
-
-  if (/^\d+$/.test(normalized)) {
-    const parsed = Number.parseInt(normalized, 10);
-    return {
-      valid: true,
-      repsMax: parsed,
-      repsMin: parsed,
-    };
-  }
-
-  const rangeMatch = normalized.match(/^(\d+)\s*-\s*(\d+)$/);
-  if (rangeMatch) {
-    const min = Number.parseInt(rangeMatch[1] ?? '', 10);
-    const max = Number.parseInt(rangeMatch[2] ?? '', 10);
-
-    if (min <= max) {
-      return {
-        valid: true,
-        repsMax: max,
-        repsMin: min,
-      };
-    }
-
-    return { valid: false };
-  }
-
-  const plusMatch = normalized.match(/^(\d+)\+$/);
-  if (plusMatch) {
-    const min = Number.parseInt(plusMatch[1] ?? '', 10);
-    return {
-      valid: true,
-      repsMax: null,
-      repsMin: min,
-    };
-  }
-
-  return { valid: false };
-}
-
-function toEditableFields(exercise: WorkoutTemplateExercise): EditableExerciseFields {
-  return {
-    notes: exercise.notes ?? '',
-    reps: formatEditableReps(exercise.repsMin, exercise.repsMax),
-    restSeconds: exercise.restSeconds?.toString() ?? '',
-    sets: exercise.sets?.toString() ?? '',
-  };
-}
-
-function formatEditableReps(repsMin: number | null, repsMax: number | null) {
-  if (repsMin !== null && repsMax !== null) {
-    return repsMin === repsMax ? `${repsMin}` : `${repsMin}-${repsMax}`;
-  }
-
-  if (repsMin !== null) {
-    return `${repsMin}+`;
-  }
-
-  if (repsMax !== null) {
-    return `${repsMax}`;
-  }
-
-  return '';
 }

--- a/apps/web/src/features/workouts/components/workout-exercise-card/exercise-header.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/exercise-header.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ExerciseHeader } from './exercise-header';
+
+describe('ExerciseHeader', () => {
+  it('renders the exercise name, tracking label, and metadata badges', () => {
+    render(
+      <ExerciseHeader
+        exercise={{
+          equipment: 'dumbbell',
+          muscleGroups: ['chest', 'triceps'],
+          name: 'Incline Dumbbell Press',
+          notes: 'Drive through the floor.',
+          phaseBadge: 'rebuild',
+          priorityBadge: 'required',
+          trackingType: 'weight_reps',
+        }}
+        targetHint="3×8-10"
+      />,
+    );
+
+    expect(screen.getByText('Incline Dumbbell Press')).toBeInTheDocument();
+    expect(screen.getByText('3×8-10')).toBeInTheDocument();
+    expect(screen.getByText('Weight × Reps')).toBeInTheDocument();
+    expect(screen.getByText('rebuild')).toBeInTheDocument();
+    expect(screen.getByText('required')).toBeInTheDocument();
+    expect(screen.getByText('dumbbell')).toBeInTheDocument();
+    expect(screen.getByText('chest')).toBeInTheDocument();
+    expect(screen.getByText('triceps')).toBeInTheDocument();
+    expect(screen.getByText('Drive through the floor.')).toBeInTheDocument();
+  });
+
+  it('calls onOpenDetails when the title is clicked', () => {
+    const onOpenDetails = vi.fn();
+
+    render(
+      <ExerciseHeader
+        exercise={{
+          name: 'Deadlift',
+          trackingType: 'weight_reps',
+        }}
+        onOpenDetails={onOpenDetails}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Deadlift' }));
+
+    expect(onOpenDetails).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/workouts/components/workout-exercise-card/exercise-header.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/exercise-header.tsx
@@ -5,10 +5,11 @@ import { cn } from '@/lib/utils';
 
 import { formatTrackingTypeLabel } from './formatters';
 
-import type { WorkoutExerciseCardTemplateExercise } from './types';
+import type { WorkoutExerciseCardDensity, WorkoutExerciseCardTemplateExercise } from './types';
 
 type ExerciseHeaderProps = {
   className?: string;
+  density?: WorkoutExerciseCardDensity;
   exercise: Pick<
     WorkoutExerciseCardTemplateExercise,
     | 'equipment'
@@ -27,21 +28,23 @@ type ExerciseHeaderProps = {
 
 export function ExerciseHeader({
   className,
+  density = 'default',
   exercise,
   leadingSlot,
   onOpenDetails,
   targetHint,
   trailingSlot,
 }: ExerciseHeaderProps) {
+  const isCondensed = density === 'condensed';
   const trackingTypeLabel = formatTrackingTypeLabel(exercise.trackingType);
 
   return (
-    <div className={cn('space-y-1.5', className)}>
+    <div className={cn(isCondensed ? 'space-y-1' : 'space-y-1.5', className)}>
       <div className="flex items-start justify-between gap-2">
         <div className="flex min-w-0 items-start gap-1.5">
           {leadingSlot ? <div className="pt-0.5">{leadingSlot}</div> : null}
           <div className="min-w-0 space-y-0.5">
-            <h3 className="truncate text-base font-semibold sm:text-lg">
+            <h3 className={cn('truncate text-base font-semibold', !isCondensed && 'sm:text-lg')}>
               {onOpenDetails ? (
                 <button
                   className="cursor-pointer truncate text-left hover:text-primary hover:underline"
@@ -57,7 +60,7 @@ export function ExerciseHeader({
             {targetHint ? (
               <p className="text-xs font-medium text-muted sm:text-sm">{targetHint}</p>
             ) : null}
-            {exercise.notes ? (
+            {exercise.notes && !isCondensed ? (
               <p className="line-clamp-2 text-[11px] italic text-muted/85">{exercise.notes}</p>
             ) : null}
           </div>

--- a/apps/web/src/features/workouts/components/workout-exercise-card/exercise-header.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/exercise-header.tsx
@@ -1,0 +1,99 @@
+import type { ReactNode } from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+import { formatTrackingTypeLabel } from './formatters';
+
+import type { WorkoutExerciseCardTemplateExercise } from './types';
+
+type ExerciseHeaderProps = {
+  className?: string;
+  exercise: Pick<
+    WorkoutExerciseCardTemplateExercise,
+    | 'equipment'
+    | 'muscleGroups'
+    | 'name'
+    | 'notes'
+    | 'phaseBadge'
+    | 'priorityBadge'
+    | 'trackingType'
+  >;
+  leadingSlot?: ReactNode;
+  onOpenDetails?: () => void;
+  targetHint?: string | null;
+  trailingSlot?: ReactNode;
+};
+
+export function ExerciseHeader({
+  className,
+  exercise,
+  leadingSlot,
+  onOpenDetails,
+  targetHint,
+  trailingSlot,
+}: ExerciseHeaderProps) {
+  const trackingTypeLabel = formatTrackingTypeLabel(exercise.trackingType);
+
+  return (
+    <div className={cn('space-y-1.5', className)}>
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex min-w-0 items-start gap-1.5">
+          {leadingSlot ? <div className="pt-0.5">{leadingSlot}</div> : null}
+          <div className="min-w-0 space-y-0.5">
+            <h3 className="truncate text-base font-semibold sm:text-lg">
+              {onOpenDetails ? (
+                <button
+                  className="cursor-pointer truncate text-left hover:text-primary hover:underline"
+                  onClick={onOpenDetails}
+                  type="button"
+                >
+                  {exercise.name}
+                </button>
+              ) : (
+                exercise.name
+              )}
+            </h3>
+            {targetHint ? (
+              <p className="text-xs font-medium text-muted sm:text-sm">{targetHint}</p>
+            ) : null}
+            {exercise.notes ? (
+              <p className="line-clamp-2 text-[11px] italic text-muted/85">{exercise.notes}</p>
+            ) : null}
+          </div>
+        </div>
+
+        {trailingSlot ? (
+          <div className="flex shrink-0 items-center gap-1">{trailingSlot}</div>
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1.5">
+        <Badge
+          className="border-transparent bg-secondary text-secondary-foreground"
+          variant="outline"
+        >
+          {trackingTypeLabel}
+        </Badge>
+        {exercise.phaseBadge ? (
+          <Badge variant="outline">{exercise.phaseBadge.replaceAll('-', ' ')}</Badge>
+        ) : null}
+        {exercise.priorityBadge ? (
+          <Badge className="capitalize" variant="outline">
+            {exercise.priorityBadge.replaceAll('-', ' ')}
+          </Badge>
+        ) : null}
+        {exercise.equipment ? (
+          <Badge className="capitalize" variant="outline">
+            {exercise.equipment.replaceAll('-', ' ')}
+          </Badge>
+        ) : null}
+        {(exercise.muscleGroups ?? []).slice(0, 2).map((group) => (
+          <Badge className="capitalize" key={group} variant="outline">
+            {group.replaceAll('-', ' ')}
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/workouts/components/workout-exercise-card/form-cues-block.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/form-cues-block.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { FormCuesBlock } from './form-cues-block';
+
+describe('FormCuesBlock', () => {
+  it('renders an empty state when no cues, notes, or instructions exist', () => {
+    render(<FormCuesBlock />);
+
+    expect(screen.getByText('No form cues provided.')).toBeInTheDocument();
+  });
+
+  it('supports collapsed and expanded states', () => {
+    render(
+      <FormCuesBlock
+        coachingNotes="Keep shoulder blades pinned."
+        exerciseCues={['Brace before each rep']}
+        instructions="Lower with control."
+        templateCues={['Pause one second at the bottom']}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Show form cues' })).toBeInTheDocument();
+    expect(screen.queryByText('Brace before each rep')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show form cues' }));
+
+    expect(screen.getByText('Brace before each rep')).toBeInTheDocument();
+    expect(screen.getByText('Pause one second at the bottom')).toBeInTheDocument();
+    expect(screen.getByText('Instructions')).toBeInTheDocument();
+    expect(screen.getByText('Lower with control.')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/workouts/components/workout-exercise-card/form-cues-block.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/form-cues-block.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+
+import { FormCueChips } from '../form-cue-chips';
+import { MarkdownNote } from '../markdown-note';
+
+type FormCuesBlockProps = {
+  coachingNotes?: string | null;
+  exerciseCues?: string[];
+  instructions?: string | null;
+  sessionCues?: string[];
+  templateCues?: string[];
+};
+
+export function FormCuesBlock({
+  coachingNotes = null,
+  exerciseCues = [],
+  instructions = null,
+  sessionCues = [],
+  templateCues = [],
+}: FormCuesBlockProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const hasCues = exerciseCues.length > 0 || templateCues.length > 0 || sessionCues.length > 0;
+  const hasNotes = Boolean(coachingNotes && coachingNotes.trim().length > 0);
+  const hasInstructions = Boolean(instructions && instructions.trim().length > 0);
+
+  if (!hasCues && !hasNotes && !hasInstructions) {
+    return <p className="text-xs text-muted">No form cues provided.</p>;
+  }
+
+  return (
+    <div className="space-y-2 rounded-xl border border-border/80 bg-secondary/20 px-3 py-2">
+      <Button
+        aria-expanded={isExpanded}
+        className="h-7 px-2"
+        onClick={() => setIsExpanded((current) => !current)}
+        size="xs"
+        type="button"
+        variant={isExpanded ? 'secondary' : 'outline'}
+      >
+        {isExpanded ? 'Hide form cues' : 'Show form cues'}
+      </Button>
+
+      {isExpanded ? (
+        <div className="space-y-2">
+          <FormCueChips
+            exerciseCoachingNotes={coachingNotes}
+            exerciseCues={exerciseCues}
+            sessionCues={sessionCues}
+            templateCues={templateCues}
+          />
+
+          {hasInstructions ? (
+            <div className="space-y-1 rounded-lg border border-border bg-card px-3 py-2">
+              <p className="text-xs font-semibold tracking-[0.16em] text-muted uppercase">
+                Instructions
+              </p>
+              <MarkdownNote className="text-sm text-muted" content={instructions ?? ''} />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/workouts/components/workout-exercise-card/formatters.ts
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/formatters.ts
@@ -1,0 +1,302 @@
+import type { ExerciseTrackingType, WeightUnit } from '@pulse/shared';
+
+import { getDistanceUnit } from '../../lib/tracking';
+
+import type {
+  WorkoutExerciseCardTemplateExercise,
+  WorkoutExerciseSetListItem,
+  WorkoutExerciseSetTarget,
+} from './types';
+
+export function formatRepTarget(repsMin: number | null, repsMax: number | null) {
+  if (repsMin !== null && repsMax !== null) {
+    return repsMin === repsMax ? `${repsMin}` : `${repsMin}-${repsMax}`;
+  }
+
+  if (repsMin !== null) {
+    return `${repsMin}+`;
+  }
+
+  if (repsMax !== null) {
+    return `Up to ${repsMax}`;
+  }
+
+  return null;
+}
+
+export function formatTempo(tempo: string) {
+  return tempo.split('').join('-');
+}
+
+export function formatTrackingTypeLabel(trackingType: ExerciseTrackingType) {
+  switch (trackingType) {
+    case 'weight_reps':
+      return 'Weight × Reps';
+    case 'bodyweight_reps':
+      return 'Bodyweight Reps';
+    case 'reps_only':
+      return 'Reps Only';
+    case 'weight_seconds':
+      return 'Weight × Seconds';
+    case 'reps_seconds':
+      return 'Reps × Seconds';
+    case 'seconds_only':
+      return 'Seconds Only';
+    case 'distance':
+      return 'Distance';
+    case 'cardio':
+      return 'Cardio';
+    default:
+      return 'Weight × Reps';
+  }
+}
+
+function formatTargetWeight(target: WorkoutExerciseSetTarget, weightUnit: WeightUnit) {
+  if (target.targetWeight != null) {
+    return `${target.targetWeight} ${weightUnit}`;
+  }
+
+  if (target.targetWeightMin != null && target.targetWeightMax != null) {
+    return `${target.targetWeightMin}-${target.targetWeightMax} ${weightUnit}`;
+  }
+
+  return null;
+}
+
+function formatTargetByTrackingType(
+  trackingType: ExerciseTrackingType,
+  target: WorkoutExerciseSetTarget,
+  weightUnit: WeightUnit,
+  repsTarget: string | null,
+) {
+  const weightLabel = formatTargetWeight(target, weightUnit);
+  const secondsLabel = target.targetSeconds != null ? `${target.targetSeconds} sec` : null;
+  const distanceLabel =
+    target.targetDistance != null
+      ? `${target.targetDistance} ${getDistanceUnit(weightUnit)}`
+      : null;
+
+  switch (trackingType) {
+    case 'seconds_only':
+      return secondsLabel;
+    case 'weight_seconds':
+      if (weightLabel && secondsLabel) {
+        return `${weightLabel} x ${secondsLabel}`;
+      }
+      return weightLabel ?? secondsLabel;
+    case 'reps_seconds':
+      if (repsTarget && secondsLabel) {
+        return `${repsTarget} x ${secondsLabel}`;
+      }
+      return secondsLabel;
+    case 'distance':
+      return distanceLabel;
+    case 'cardio':
+      if (secondsLabel && distanceLabel) {
+        return `${secondsLabel} + ${distanceLabel}`;
+      }
+      return secondsLabel ?? distanceLabel;
+    case 'weight_reps':
+      return weightLabel;
+    default:
+      return null;
+  }
+}
+
+function summarizeSetTargets(
+  exercise: {
+    repsMax: number | null;
+    repsMin: number | null;
+    setTargets?: WorkoutExerciseSetTarget[] | null;
+    trackingType: ExerciseTrackingType;
+  },
+  weightUnit: WeightUnit,
+) {
+  if (!exercise.setTargets || exercise.setTargets.length === 0) {
+    return null;
+  }
+
+  const repsTarget = formatRepTarget(exercise.repsMin, exercise.repsMax);
+  const labels = exercise.setTargets
+    .map((setTarget) =>
+      formatTargetByTrackingType(exercise.trackingType, setTarget, weightUnit, repsTarget),
+    )
+    .filter((value): value is string => value !== null);
+
+  if (labels.length === 0) {
+    return null;
+  }
+
+  const uniqueLabels = [...new Set(labels)];
+  if (uniqueLabels.length === 1) {
+    return uniqueLabels[0] ?? null;
+  }
+
+  return labels[0] ?? null;
+}
+
+export function formatSetTargetBreakdown(
+  exercise: {
+    repsMax: number | null;
+    repsMin: number | null;
+    setTargets?: WorkoutExerciseSetTarget[] | null;
+    trackingType: ExerciseTrackingType;
+  },
+  weightUnit: WeightUnit,
+) {
+  const repsTarget = formatRepTarget(exercise.repsMin, exercise.repsMax);
+  const targets = (exercise.setTargets ?? [])
+    .map((setTarget) => {
+      const label = formatTargetByTrackingType(
+        exercise.trackingType,
+        setTarget,
+        weightUnit,
+        repsTarget,
+      );
+
+      if (!label) {
+        return null;
+      }
+
+      return `Set ${setTarget.setNumber}: ${label}`;
+    })
+    .filter((value): value is string => value !== null);
+
+  if (targets.length <= 1) {
+    return null;
+  }
+
+  return targets.join(' • ');
+}
+
+export function formatPrescription(
+  exercise: {
+    repsMax: number | null;
+    repsMin: number | null;
+    restSeconds: number | null;
+    setTargets?: WorkoutExerciseSetTarget[] | null;
+    sets: number | null;
+    trackingType: ExerciseTrackingType;
+  },
+  weightUnit: WeightUnit,
+) {
+  const repsTarget = formatRepTarget(exercise.repsMin, exercise.repsMax);
+  const setTargetSummary = summarizeSetTargets(exercise, weightUnit);
+  const trackingTypeLabel = exercise.trackingType === 'bodyweight_reps' ? ' (bodyweight)' : '';
+
+  if (setTargetSummary) {
+    if (exercise.sets !== null) {
+      return `${exercise.sets} x ${setTargetSummary}${trackingTypeLabel}`;
+    }
+
+    return `${setTargetSummary}${trackingTypeLabel}`;
+  }
+
+  if (exercise.trackingType === 'seconds_only') {
+    if (repsTarget) {
+      if (exercise.sets !== null) {
+        return `${exercise.sets} x ${repsTarget} sec`;
+      }
+
+      return `${repsTarget} sec`;
+    }
+
+    if (exercise.sets !== null) {
+      return `${exercise.sets} timed set${exercise.sets === 1 ? '' : 's'}`;
+    }
+  }
+
+  if (exercise.trackingType === 'distance') {
+    if (repsTarget) {
+      if (exercise.sets !== null) {
+        return `${exercise.sets} x ${repsTarget} ${getDistanceUnit(weightUnit)}`;
+      }
+
+      return `${repsTarget} ${getDistanceUnit(weightUnit)}`;
+    }
+
+    if (exercise.sets !== null) {
+      return `${exercise.sets} distance set${exercise.sets === 1 ? '' : 's'}`;
+    }
+  }
+
+  if (exercise.sets !== null && repsTarget) {
+    return `${exercise.sets} x ${repsTarget}${trackingTypeLabel}`;
+  }
+
+  if (exercise.sets !== null) {
+    return `${exercise.sets} set${exercise.sets === 1 ? '' : 's'}`;
+  }
+
+  if (repsTarget) {
+    return `${repsTarget}${trackingTypeLabel}`;
+  }
+
+  return 'Prescription not set';
+}
+
+export function formatCompactSetSummary(
+  exercise: {
+    repsMax: number | null;
+    repsMin: number | null;
+    setTargets?: WorkoutExerciseSetTarget[] | null;
+    sets: number | null;
+    trackingType: ExerciseTrackingType;
+  },
+  weightUnit: WeightUnit,
+) {
+  const setTargetSummary = summarizeSetTargets(exercise, weightUnit);
+  const repsTarget = formatRepTarget(exercise.repsMin, exercise.repsMax);
+
+  if (exercise.sets !== null && setTargetSummary) {
+    return `${exercise.sets}×${setTargetSummary}`;
+  }
+
+  if (exercise.sets !== null && repsTarget) {
+    return `${exercise.sets}×${repsTarget}`;
+  }
+
+  if (exercise.sets !== null) {
+    return `${exercise.sets} set${exercise.sets === 1 ? '' : 's'}`;
+  }
+
+  return formatPrescription(
+    {
+      repsMax: exercise.repsMax,
+      repsMin: exercise.repsMin,
+      restSeconds: null,
+      setTargets: exercise.setTargets,
+      sets: exercise.sets,
+      trackingType: exercise.trackingType,
+    },
+    weightUnit,
+  );
+}
+
+export function buildTemplateSetListItems(
+  exercise: Pick<WorkoutExerciseCardTemplateExercise, 'setTargets' | 'sets' | 'trackingType'>,
+): WorkoutExerciseSetListItem[] {
+  const setCount = Math.max(exercise.sets ?? 0, exercise.setTargets?.length ?? 0);
+
+  return Array.from({ length: setCount }).map((_, index) => {
+    const setNumber = index + 1;
+    const target =
+      exercise.setTargets?.find((setTarget) => setTarget.setNumber === setNumber) ??
+      exercise.setTargets?.[index] ??
+      null;
+
+    return {
+      completed: false,
+      distance: null,
+      reps: null,
+      seconds: null,
+      setNumber,
+      targetDistance: target?.targetDistance ?? null,
+      targetSeconds: target?.targetSeconds ?? null,
+      targetWeight: target?.targetWeight ?? null,
+      targetWeightMax: target?.targetWeightMax ?? null,
+      targetWeightMin: target?.targetWeightMin ?? null,
+      weight: null,
+    };
+  });
+}

--- a/apps/web/src/features/workouts/components/workout-exercise-card/index.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/index.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  getWorkoutExerciseCardElementId,
+  getWorkoutExerciseCardTestId,
+  WorkoutExerciseCard,
+} from './index';
+
+describe('WorkoutExerciseCard', () => {
+  it('orchestrates read-only template mode blocks', () => {
+    render(
+      <WorkoutExerciseCard
+        exercise={{
+          coachingNotes: 'Keep upper back tight.',
+          equipment: 'barbell',
+          exerciseId: 'exercise-1',
+          formCues: ['Brace first'],
+          id: 'template-exercise-1',
+          instructions: 'Control the eccentric.',
+          muscleGroups: ['back'],
+          name: 'Barbell Row',
+          notes: 'Drive elbows back.',
+          programmingNotes: 'Top set first, then two back-off sets.',
+          repsMax: 10,
+          repsMin: 8,
+          restSeconds: 90,
+          setTargets: [{ setNumber: 1, targetWeight: 95 }],
+          sets: 3,
+          tempo: '2110',
+          trackingType: 'weight_reps',
+        }}
+        mode="readonly-template"
+      />,
+    );
+
+    expect(screen.getByText('Barbell Row')).toBeInTheDocument();
+    expect(screen.getByText('Prescription')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('exercise-programming-notes-template-exercise-1'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Show full set detail')).toBeInTheDocument();
+    expect(
+      screen.getByTestId(getWorkoutExerciseCardTestId('template-exercise-1')),
+    ).toBeInTheDocument();
+    expect(
+      document.getElementById(getWorkoutExerciseCardElementId('template-exercise-1')),
+    ).not.toBeNull();
+  });
+
+  it('calls onOpenDetails when exercise name is clicked', () => {
+    const onOpenDetails = vi.fn();
+
+    render(
+      <WorkoutExerciseCard
+        exercise={{
+          completedSets: [
+            {
+              completed: true,
+              reps: 8,
+              setNumber: 1,
+              weight: 135,
+            },
+          ],
+          exerciseId: 'exercise-1',
+          id: 'completed-exercise-1',
+          name: 'Back Squat',
+          repsMax: null,
+          repsMin: null,
+          restSeconds: null,
+          tempo: null,
+          trackingType: 'weight_reps',
+        }}
+        mode="readonly-completed"
+        onOpenDetails={onOpenDetails}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back Squat' }));
+
+    expect(onOpenDetails).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/workouts/components/workout-exercise-card/index.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/index.test.tsx
@@ -108,4 +108,35 @@ describe('WorkoutExerciseCard', () => {
     expect(screen.queryByRole('button', { name: 'Show form cues' })).not.toBeInTheDocument();
     expect(screen.getByText('Show set values')).toBeInTheDocument();
   });
+
+  it('applies condensed density in readonly-completed mode', () => {
+    render(
+      <WorkoutExerciseCard
+        density="condensed"
+        exercise={{
+          completedSets: [
+            {
+              completed: true,
+              reps: 8,
+              setNumber: 1,
+              weight: 135,
+            },
+          ],
+          exerciseId: 'exercise-3',
+          id: 'completed-exercise-2',
+          name: 'Romanian Deadlift',
+          programmingNotes: 'Control the lowering phase.',
+          repsMax: null,
+          repsMin: null,
+          restSeconds: null,
+          tempo: null,
+          trackingType: 'weight_reps',
+        }}
+        mode="readonly-completed"
+      />,
+    );
+
+    expect(screen.queryByText('Prescription')).not.toBeInTheDocument();
+    expect(screen.getByText('Show set values')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/workouts/components/workout-exercise-card/index.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/index.test.tsx
@@ -80,4 +80,32 @@ describe('WorkoutExerciseCard', () => {
 
     expect(onOpenDetails).toHaveBeenCalledTimes(1);
   });
+
+  it('applies condensed density by omitting prescription and form-cue blocks', () => {
+    render(
+      <WorkoutExerciseCard
+        density="condensed"
+        exercise={{
+          coachingNotes: 'Cue shoulder blades down and back.',
+          exerciseId: 'exercise-2',
+          formCues: ['Drive knees out'],
+          id: 'template-exercise-2',
+          instructions: 'Stay braced throughout.',
+          name: 'Front Squat',
+          repsMax: 8,
+          repsMin: 6,
+          restSeconds: 120,
+          setTargets: [{ setNumber: 1, targetWeight: 135 }],
+          sets: 3,
+          tempo: '3110',
+          trackingType: 'weight_reps',
+        }}
+        mode="readonly-template"
+      />,
+    );
+
+    expect(screen.queryByText('Prescription')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Show form cues' })).not.toBeInTheDocument();
+    expect(screen.getByText('Show set values')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/workouts/components/workout-exercise-card/index.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/index.tsx
@@ -31,6 +31,7 @@ export function WorkoutExerciseCard(props: WorkoutExerciseCardProps) {
   const {
     cardRef,
     className,
+    density = 'default',
     footerSlot,
     headerSlot,
     leadingSlot,
@@ -41,6 +42,7 @@ export function WorkoutExerciseCard(props: WorkoutExerciseCardProps) {
     style,
     weightUnit = 'lbs',
   } = props;
+  const isCondensed = density === 'condensed';
 
   const exercise = props.exercise;
   const setItems =
@@ -74,6 +76,7 @@ export function WorkoutExerciseCard(props: WorkoutExerciseCardProps) {
   const hasProgrammingNotes =
     typeof exercise.programmingNotes === 'string' && exercise.programmingNotes.trim().length > 0;
   const shouldShowFormCues =
+    !isCondensed &&
     cuesExercise !== null &&
     ((cuesExercise.formCues?.length ?? 0) > 0 ||
       (cuesExercise.templateCues?.length ?? 0) > 0 ||
@@ -84,14 +87,15 @@ export function WorkoutExerciseCard(props: WorkoutExerciseCardProps) {
 
   return (
     <Card
-      className={cn('gap-1.5 py-0', className)}
+      className={cn(isCondensed ? 'gap-1 py-0' : 'gap-1.5 py-0', className)}
       data-testid={getWorkoutExerciseCardTestId(exercise.id)}
       id={getWorkoutExerciseCardElementId(exercise.id)}
       ref={cardRef}
       style={style}
     >
-      <CardHeader className="gap-1.5 py-2.5">
+      <CardHeader className={cn(isCondensed ? 'gap-1 py-2' : 'gap-1.5 py-2.5')}>
         <ExerciseHeader
+          density={density}
           exercise={exercise}
           leadingSlot={leadingSlot}
           onOpenDetails={onOpenDetails}
@@ -100,7 +104,7 @@ export function WorkoutExerciseCard(props: WorkoutExerciseCardProps) {
         />
       </CardHeader>
 
-      <CardContent className="space-y-2 pb-2.5">
+      <CardContent className={cn(isCondensed ? 'space-y-1.5 pb-2' : 'space-y-2 pb-2.5')}>
         {showLastPerformance ? (
           <LastPerformanceChip
             exerciseId={exercise.exerciseId}
@@ -109,16 +113,18 @@ export function WorkoutExerciseCard(props: WorkoutExerciseCardProps) {
           />
         ) : null}
 
-        <PrescriptionBlock
-          repsMax={exercise.repsMax}
-          repsMin={exercise.repsMin}
-          restSeconds={exercise.restSeconds}
-          setTargets={prescriptionSetTargets}
-          sets={prescriptionSets}
-          tempo={exercise.tempo}
-          trackingType={exercise.trackingType}
-          weightUnit={weightUnit}
-        />
+        {!isCondensed ? (
+          <PrescriptionBlock
+            repsMax={exercise.repsMax}
+            repsMin={exercise.repsMin}
+            restSeconds={exercise.restSeconds}
+            setTargets={prescriptionSetTargets}
+            sets={prescriptionSets}
+            tempo={exercise.tempo}
+            trackingType={exercise.trackingType}
+            weightUnit={weightUnit}
+          />
+        ) : null}
 
         {hasProgrammingNotes ? (
           <ProgrammingNotesBlock
@@ -140,7 +146,7 @@ export function WorkoutExerciseCard(props: WorkoutExerciseCardProps) {
         {showSetList ? (
           <details className="rounded-xl border border-border/80 bg-secondary/20 px-3 py-2">
             <summary className="cursor-pointer text-xs font-semibold text-muted">
-              Show full set detail
+              {isCondensed ? 'Show set values' : 'Show full set detail'}
             </summary>
             <div className="mt-2">
               <WorkoutExerciseSetList
@@ -162,6 +168,7 @@ export function WorkoutExerciseCard(props: WorkoutExerciseCardProps) {
 export type { WorkoutExerciseCardMode };
 export type {
   WorkoutExerciseCardCompletedExercise,
+  WorkoutExerciseCardDensity,
   WorkoutExerciseCardScheduledExercise,
   WorkoutExerciseCardTemplateExercise,
   WorkoutExerciseSetListItem,

--- a/apps/web/src/features/workouts/components/workout-exercise-card/index.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/index.tsx
@@ -9,7 +9,12 @@ import { PrescriptionBlock } from './prescription-block';
 import { ProgrammingNotesBlock } from './programming-notes-block';
 import { WorkoutExerciseSetList } from './workout-exercise-set-list';
 
-import type { WorkoutExerciseCardMode, WorkoutExerciseCardProps } from './types';
+import type {
+  WorkoutExerciseCardMode,
+  WorkoutExerciseCardProps,
+  WorkoutExerciseCardScheduledExercise,
+  WorkoutExerciseCardTemplateExercise,
+} from './types';
 
 const WORKOUT_EXERCISE_CARD_TEST_ID_PREFIX = 'workout-exercise-card-';
 const WORKOUT_EXERCISE_ELEMENT_ID_PREFIX = 'workout-exercise-';
@@ -62,6 +67,20 @@ export function WorkoutExerciseCard(props: WorkoutExerciseCardProps) {
         );
   const prescriptionSetTargets = 'setTargets' in exercise ? exercise.setTargets : null;
   const prescriptionSets = 'sets' in exercise ? exercise.sets : setItems.length;
+  const cuesExercise =
+    mode === 'readonly-completed'
+      ? null
+      : (exercise as WorkoutExerciseCardTemplateExercise | WorkoutExerciseCardScheduledExercise);
+  const hasProgrammingNotes =
+    typeof exercise.programmingNotes === 'string' && exercise.programmingNotes.trim().length > 0;
+  const shouldShowFormCues =
+    cuesExercise !== null &&
+    ((cuesExercise.formCues?.length ?? 0) > 0 ||
+      (cuesExercise.templateCues?.length ?? 0) > 0 ||
+      (cuesExercise.sessionCues?.length ?? 0) > 0 ||
+      (typeof cuesExercise.instructions === 'string' && cuesExercise.instructions.trim().length > 0) ||
+      (typeof cuesExercise.coachingNotes === 'string' &&
+        cuesExercise.coachingNotes.trim().length > 0));
 
   return (
     <Card
@@ -101,20 +120,20 @@ export function WorkoutExerciseCard(props: WorkoutExerciseCardProps) {
           weightUnit={weightUnit}
         />
 
-        {'programmingNotes' in exercise ? (
+        {hasProgrammingNotes ? (
           <ProgrammingNotesBlock
             notes={exercise.programmingNotes}
             testId={`exercise-programming-notes-${exercise.id}`}
           />
         ) : null}
 
-        {'formCues' in exercise || 'templateCues' in exercise || 'sessionCues' in exercise ? (
+        {shouldShowFormCues ? (
           <FormCuesBlock
-            coachingNotes={'coachingNotes' in exercise ? exercise.coachingNotes : null}
-            exerciseCues={'formCues' in exercise ? (exercise.formCues ?? []) : []}
-            instructions={'instructions' in exercise ? exercise.instructions : null}
-            sessionCues={'sessionCues' in exercise ? (exercise.sessionCues ?? []) : []}
-            templateCues={'templateCues' in exercise ? (exercise.templateCues ?? []) : []}
+            coachingNotes={cuesExercise?.coachingNotes}
+            exerciseCues={cuesExercise?.formCues ?? []}
+            instructions={cuesExercise?.instructions}
+            sessionCues={cuesExercise?.sessionCues ?? []}
+            templateCues={cuesExercise?.templateCues ?? []}
           />
         ) : null}
 

--- a/apps/web/src/features/workouts/components/workout-exercise-card/index.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/index.tsx
@@ -1,0 +1,150 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+import { ExerciseHeader } from './exercise-header';
+import { buildTemplateSetListItems, formatCompactSetSummary } from './formatters';
+import { FormCuesBlock } from './form-cues-block';
+import { LastPerformanceChip } from './last-performance-chip';
+import { PrescriptionBlock } from './prescription-block';
+import { ProgrammingNotesBlock } from './programming-notes-block';
+import { WorkoutExerciseSetList } from './workout-exercise-set-list';
+
+import type { WorkoutExerciseCardMode, WorkoutExerciseCardProps } from './types';
+
+const WORKOUT_EXERCISE_CARD_TEST_ID_PREFIX = 'workout-exercise-card-';
+const WORKOUT_EXERCISE_ELEMENT_ID_PREFIX = 'workout-exercise-';
+
+export function getWorkoutExerciseCardTestId(exerciseId: string) {
+  return `${WORKOUT_EXERCISE_CARD_TEST_ID_PREFIX}${exerciseId}`;
+}
+
+export function getWorkoutExerciseCardElementId(exerciseId: string) {
+  return `${WORKOUT_EXERCISE_ELEMENT_ID_PREFIX}${exerciseId}`;
+}
+
+export function WorkoutExerciseCard(props: WorkoutExerciseCardProps) {
+  const {
+    cardRef,
+    className,
+    footerSlot,
+    headerSlot,
+    leadingSlot,
+    mode,
+    onOpenDetails,
+    showLastPerformance = false,
+    showSetList = true,
+    style,
+    weightUnit = 'lbs',
+  } = props;
+
+  const exercise = props.exercise;
+  const setItems =
+    mode === 'readonly-completed'
+      ? props.exercise.completedSets
+      : buildTemplateSetListItems({
+          setTargets: props.exercise.setTargets,
+          sets: props.exercise.sets,
+          trackingType: props.exercise.trackingType,
+        });
+
+  const compactHint =
+    mode === 'readonly-completed'
+      ? null
+      : formatCompactSetSummary(
+          {
+            repsMax: props.exercise.repsMax,
+            repsMin: props.exercise.repsMin,
+            setTargets: props.exercise.setTargets,
+            sets: props.exercise.sets,
+            trackingType: props.exercise.trackingType,
+          },
+          weightUnit,
+        );
+  const prescriptionSetTargets = 'setTargets' in exercise ? exercise.setTargets : null;
+  const prescriptionSets = 'sets' in exercise ? exercise.sets : setItems.length;
+
+  return (
+    <Card
+      className={cn('gap-1.5 py-0', className)}
+      data-testid={getWorkoutExerciseCardTestId(exercise.id)}
+      id={getWorkoutExerciseCardElementId(exercise.id)}
+      ref={cardRef}
+      style={style}
+    >
+      <CardHeader className="gap-1.5 py-2.5">
+        <ExerciseHeader
+          exercise={exercise}
+          leadingSlot={leadingSlot}
+          onOpenDetails={onOpenDetails}
+          targetHint={compactHint}
+          trailingSlot={headerSlot}
+        />
+      </CardHeader>
+
+      <CardContent className="space-y-2 pb-2.5">
+        {showLastPerformance ? (
+          <LastPerformanceChip
+            exerciseId={exercise.exerciseId}
+            trackingType={exercise.trackingType}
+            weightUnit={weightUnit}
+          />
+        ) : null}
+
+        <PrescriptionBlock
+          repsMax={exercise.repsMax}
+          repsMin={exercise.repsMin}
+          restSeconds={exercise.restSeconds}
+          setTargets={prescriptionSetTargets}
+          sets={prescriptionSets}
+          tempo={exercise.tempo}
+          trackingType={exercise.trackingType}
+          weightUnit={weightUnit}
+        />
+
+        {'programmingNotes' in exercise ? (
+          <ProgrammingNotesBlock
+            notes={exercise.programmingNotes}
+            testId={`exercise-programming-notes-${exercise.id}`}
+          />
+        ) : null}
+
+        {'formCues' in exercise || 'templateCues' in exercise || 'sessionCues' in exercise ? (
+          <FormCuesBlock
+            coachingNotes={'coachingNotes' in exercise ? exercise.coachingNotes : null}
+            exerciseCues={'formCues' in exercise ? (exercise.formCues ?? []) : []}
+            instructions={'instructions' in exercise ? exercise.instructions : null}
+            sessionCues={'sessionCues' in exercise ? (exercise.sessionCues ?? []) : []}
+            templateCues={'templateCues' in exercise ? (exercise.templateCues ?? []) : []}
+          />
+        ) : null}
+
+        {showSetList ? (
+          <details className="rounded-xl border border-border/80 bg-secondary/20 px-3 py-2">
+            <summary className="cursor-pointer text-xs font-semibold text-muted">
+              Show full set detail
+            </summary>
+            <div className="mt-2">
+              <WorkoutExerciseSetList
+                mode={mode}
+                sets={setItems}
+                trackingType={exercise.trackingType}
+                weightUnit={weightUnit}
+              />
+            </div>
+          </details>
+        ) : null}
+
+        {footerSlot}
+      </CardContent>
+    </Card>
+  );
+}
+
+export type { WorkoutExerciseCardMode };
+export type {
+  WorkoutExerciseCardCompletedExercise,
+  WorkoutExerciseCardScheduledExercise,
+  WorkoutExerciseCardTemplateExercise,
+  WorkoutExerciseSetListItem,
+  WorkoutExerciseSetTarget,
+} from './types';

--- a/apps/web/src/features/workouts/components/workout-exercise-card/last-performance-chip.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/last-performance-chip.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useLastPerformance } from '@/hooks/use-last-performance';
+
+import { LastPerformanceChip } from './last-performance-chip';
+
+vi.mock('@/hooks/use-last-performance', () => ({
+  useLastPerformance: vi.fn(),
+}));
+
+const useLastPerformanceMock = vi.mocked(useLastPerformance);
+const asQueryResult = <T,>(value: T) => value as unknown as ReturnType<typeof useLastPerformance>;
+
+describe('LastPerformanceChip', () => {
+  it('renders loading state', () => {
+    useLastPerformanceMock.mockReturnValue(
+      asQueryResult({
+        data: null,
+        isPending: true,
+      }),
+    );
+
+    render(
+      <LastPerformanceChip exerciseId="exercise-1" trackingType="weight_reps" weightUnit="lbs" />,
+    );
+
+    expect(screen.getByText('Last performance: loading…')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no history exists', () => {
+    useLastPerformanceMock.mockReturnValue(
+      asQueryResult({
+        data: { history: null, historyEntries: [], related: [] },
+        isPending: false,
+      }),
+    );
+
+    render(
+      <LastPerformanceChip exerciseId="exercise-1" trackingType="weight_reps" weightUnit="lbs" />,
+    );
+
+    expect(screen.getByText('Last performance: no history')).toBeInTheDocument();
+  });
+
+  it('renders formatted history chip when data exists', () => {
+    useLastPerformanceMock.mockReturnValue(
+      asQueryResult({
+        data: {
+          history: {
+            date: '2026-04-15',
+            notes: null,
+            sessionId: 'session-1',
+            sets: [{ completed: true, reps: 8, setNumber: 1, weight: 135 }],
+          },
+          historyEntries: [
+            {
+              date: '2026-04-15',
+              notes: null,
+              sessionId: 'session-1',
+              sets: [{ completed: true, reps: 8, setNumber: 1, weight: 135 }],
+            },
+          ],
+          related: [],
+        },
+        isPending: false,
+      }),
+    );
+
+    render(
+      <LastPerformanceChip exerciseId="exercise-1" trackingType="weight_reps" weightUnit="lbs" />,
+    );
+
+    expect(screen.getByText(/Last: Apr 15, 2026 · 135x8/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/workouts/components/workout-exercise-card/last-performance-chip.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/last-performance-chip.tsx
@@ -1,0 +1,62 @@
+import type { ExerciseTrackingType, WeightUnit } from '@pulse/shared';
+
+import { Badge } from '@/components/ui/badge';
+import { useLastPerformance } from '@/hooks/use-last-performance';
+
+import { formatCompactSets } from '../../lib/tracking';
+
+const historyDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+type LastPerformanceChipProps = {
+  enabled?: boolean;
+  exerciseId: string;
+  trackingType: ExerciseTrackingType;
+  weightUnit: WeightUnit;
+};
+
+export function LastPerformanceChip({
+  enabled = true,
+  exerciseId,
+  trackingType,
+  weightUnit,
+}: LastPerformanceChipProps) {
+  const historyQuery = useLastPerformance(exerciseId, {
+    enabled,
+    includeRelated: false,
+    limit: 1,
+  });
+
+  if (!enabled) {
+    return null;
+  }
+
+  if (historyQuery.isPending) {
+    return <Badge variant="outline">Last performance: loading…</Badge>;
+  }
+
+  const lastEntry = historyQuery.data?.historyEntries[0] ?? historyQuery.data?.history ?? null;
+  if (!lastEntry) {
+    return <Badge variant="outline">Last performance: no history</Badge>;
+  }
+
+  const setSummary = formatCompactSets(
+    lastEntry.sets.map((set) =>
+      trackingType === 'distance'
+        ? { distance: set.reps, weight: set.weight }
+        : { reps: set.reps, weight: set.weight },
+    ),
+    trackingType,
+    {
+      useLegacySecondsFallback: trackingType !== 'reps_seconds',
+      weightUnit,
+    },
+  );
+
+  return (
+    <Badge variant="outline">{`Last: ${historyDateFormatter.format(new Date(`${lastEntry.date}T12:00:00`))} · ${setSummary}`}</Badge>
+  );
+}

--- a/apps/web/src/features/workouts/components/workout-exercise-card/last-performance-chip.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/last-performance-chip.tsx
@@ -38,6 +38,7 @@ export function LastPerformanceChip({
     return <Badge variant="outline">Last performance: loading…</Badge>;
   }
 
+  // `useLastPerformance` returns `historyEntries` in current API responses and `history` in legacy responses.
   const lastEntry = historyQuery.data?.historyEntries[0] ?? historyQuery.data?.history ?? null;
   if (!lastEntry) {
     return <Badge variant="outline">Last performance: no history</Badge>;

--- a/apps/web/src/features/workouts/components/workout-exercise-card/prescription-block.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/prescription-block.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { PrescriptionBlock } from './prescription-block';
+
+describe('PrescriptionBlock', () => {
+  it('formats weight-reps prescriptions and tempo/rest details', () => {
+    render(
+      <PrescriptionBlock
+        repsMax={10}
+        repsMin={8}
+        restSeconds={90}
+        setTargets={[
+          { setNumber: 1, targetWeight: 50 },
+          { setNumber: 2, targetWeight: 50 },
+        ]}
+        sets={3}
+        tempo="3110"
+        trackingType="weight_reps"
+        weightUnit="lbs"
+      />,
+    );
+
+    expect(screen.getByText('3 x 50 lbs')).toBeInTheDocument();
+    expect(screen.getByText('Tempo: 3-1-1-0 • Rest: 90s')).toBeInTheDocument();
+  });
+
+  it('formats time-based prescriptions with set breakdown', () => {
+    render(
+      <PrescriptionBlock
+        repsMax={null}
+        repsMin={null}
+        restSeconds={45}
+        setTargets={[
+          { setNumber: 1, targetSeconds: 30 },
+          { setNumber: 2, targetSeconds: 45 },
+        ]}
+        sets={2}
+        tempo={null}
+        trackingType="seconds_only"
+        weightUnit="lbs"
+      />,
+    );
+
+    expect(screen.getByText('2 x 30 sec')).toBeInTheDocument();
+    expect(screen.getByText('Set 1: 30 sec • Set 2: 45 sec')).toBeInTheDocument();
+  });
+
+  it('formats distance-based prescriptions', () => {
+    render(
+      <PrescriptionBlock
+        repsMax={null}
+        repsMin={null}
+        restSeconds={60}
+        setTargets={[{ setNumber: 1, targetDistance: 0.4 }]}
+        sets={3}
+        tempo={null}
+        trackingType="distance"
+        weightUnit="kg"
+      />,
+    );
+
+    expect(screen.getByText('3 x 0.4 km')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/workouts/components/workout-exercise-card/prescription-block.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/prescription-block.tsx
@@ -1,0 +1,68 @@
+import type { ExerciseTrackingType, WeightUnit } from '@pulse/shared';
+
+import { cn } from '@/lib/utils';
+
+import { formatPrescription, formatSetTargetBreakdown, formatTempo } from './formatters';
+import type { WorkoutExerciseSetTarget } from './types';
+
+type PrescriptionBlockProps = {
+  className?: string;
+  repsMax: number | null;
+  repsMin: number | null;
+  restSeconds: number | null;
+  setTargets?: WorkoutExerciseSetTarget[] | null;
+  sets: number | null;
+  tempo: string | null;
+  trackingType: ExerciseTrackingType;
+  weightUnit: WeightUnit;
+};
+
+export function PrescriptionBlock({
+  className,
+  repsMax,
+  repsMin,
+  restSeconds,
+  setTargets,
+  sets,
+  tempo,
+  trackingType,
+  weightUnit,
+}: PrescriptionBlockProps) {
+  const prescription = formatPrescription(
+    {
+      repsMax,
+      repsMin,
+      restSeconds,
+      setTargets,
+      sets,
+      trackingType,
+    },
+    weightUnit,
+  );
+  const targetBreakdown = formatSetTargetBreakdown(
+    {
+      repsMax,
+      repsMin,
+      setTargets,
+      trackingType,
+    },
+    weightUnit,
+  );
+
+  return (
+    <div className={cn('space-y-1.5', className)}>
+      <p className="text-[10px] font-semibold tracking-[0.14em] text-muted uppercase">
+        Prescription
+      </p>
+      <p className="text-sm font-medium text-foreground">{prescription}</p>
+      {targetBreakdown ? <p className="text-xs text-muted">{targetBreakdown}</p> : null}
+      {tempo || restSeconds !== null ? (
+        <p className="text-xs text-muted">
+          {tempo ? `Tempo: ${formatTempo(tempo)}` : null}
+          {tempo && restSeconds !== null ? ' • ' : null}
+          {restSeconds !== null ? `Rest: ${restSeconds}s` : null}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/workouts/components/workout-exercise-card/programming-notes-block.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/programming-notes-block.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ProgrammingNotesBlock } from './programming-notes-block';
+
+describe('ProgrammingNotesBlock', () => {
+  it('does not render when notes are empty', () => {
+    const { container } = render(<ProgrammingNotesBlock notes="   " />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders trimmed notes with the standard programming note treatment', () => {
+    render(
+      <ProgrammingNotesBlock
+        notes="  Keep elbows tucked and pause on chest.  "
+        testId="exercise-programming-notes-id-1"
+      />,
+    );
+
+    expect(screen.getByTestId('exercise-programming-notes-id-1')).toBeInTheDocument();
+    expect(screen.getByText('Programming notes')).toBeInTheDocument();
+    expect(screen.getByText('Keep elbows tucked and pause on chest.')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/workouts/components/workout-exercise-card/programming-notes-block.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/programming-notes-block.tsx
@@ -1,0 +1,30 @@
+import { ClipboardList } from 'lucide-react';
+
+import { MarkdownNote } from '../markdown-note';
+
+type ProgrammingNotesBlockProps = {
+  notes: string | null | undefined;
+  testId?: string;
+};
+
+export function ProgrammingNotesBlock({ notes, testId }: ProgrammingNotesBlockProps) {
+  const trimmedNotes = notes?.trim() ?? '';
+  if (!trimmedNotes) {
+    return null;
+  }
+
+  return (
+    <div
+      className="flex items-start gap-2 rounded-xl border-l-2 border-primary/35 bg-secondary/35 px-3 py-2"
+      data-testid={testId}
+    >
+      <ClipboardList aria-hidden="true" className="mt-0.5 size-3.5 shrink-0 text-muted" />
+      <div className="space-y-0.5">
+        <p className="text-[10px] font-semibold tracking-[0.16em] text-muted uppercase">
+          Programming notes
+        </p>
+        <MarkdownNote className="text-[13px] italic text-muted" content={trimmedNotes} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/workouts/components/workout-exercise-card/types.ts
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/types.ts
@@ -1,0 +1,111 @@
+import type { CSSProperties, ReactNode } from 'react';
+import type { ExerciseTrackingType, WeightUnit } from '@pulse/shared';
+
+export type WorkoutExerciseCardMode =
+  | 'readonly-template'
+  | 'readonly-scheduled'
+  | 'readonly-completed';
+// Reserved for a later migration round.
+// | 'in-progress'
+
+export type WorkoutExerciseSetTarget = {
+  setNumber: number;
+  targetDistance?: number | null;
+  targetSeconds?: number | null;
+  targetWeight?: number | null;
+  targetWeightMax?: number | null;
+  targetWeightMin?: number | null;
+};
+
+export type WorkoutExerciseSetListItem = {
+  completed?: boolean;
+  distance?: number | null;
+  reps?: number | null;
+  seconds?: number | null;
+  setNumber: number;
+  targetDistance?: number | null;
+  targetSeconds?: number | null;
+  targetWeight?: number | null;
+  targetWeightMax?: number | null;
+  targetWeightMin?: number | null;
+  weight?: number | null;
+};
+
+export type WorkoutExerciseCardTemplateExercise = {
+  coachingNotes?: string | null;
+  equipment?: string | null;
+  exerciseId: string;
+  formCues?: string[];
+  id: string;
+  instructions?: string | null;
+  muscleGroups?: string[];
+  name: string;
+  notes?: string | null;
+  phaseBadge?: string | null;
+  priorityBadge?: string | null;
+  programmingNotes?: string | null;
+  repsMax: number | null;
+  repsMin: number | null;
+  restSeconds: number | null;
+  setTargets?: WorkoutExerciseSetTarget[] | null;
+  sets: number | null;
+  sessionCues?: string[];
+  tempo: string | null;
+  templateCues?: string[];
+  trackingType: ExerciseTrackingType;
+};
+
+export type WorkoutExerciseCardScheduledExercise = WorkoutExerciseCardTemplateExercise & {
+  scheduledDateLabel?: string | null;
+};
+
+export type WorkoutExerciseCardCompletedExercise = {
+  completedSets: WorkoutExerciseSetListItem[];
+  equipment?: string | null;
+  exerciseId: string;
+  id: string;
+  muscleGroups?: string[];
+  name: string;
+  notes?: string | null;
+  phaseBadge?: string | null;
+  priorityBadge?: string | null;
+  programmingNotes?: string | null;
+  repsMax: number | null;
+  repsMin: number | null;
+  restSeconds: number | null;
+  tempo: string | null;
+  trackingType: ExerciseTrackingType;
+};
+
+type WorkoutExerciseCardCommonProps = {
+  cardRef?: (node: HTMLDivElement | null) => void;
+  className?: string;
+  footerSlot?: ReactNode;
+  headerSlot?: ReactNode;
+  leadingSlot?: ReactNode;
+  onOpenDetails?: () => void;
+  showLastPerformance?: boolean;
+  showSetList?: boolean;
+  style?: CSSProperties;
+  weightUnit?: WeightUnit;
+};
+
+export type WorkoutExerciseCardTemplateProps = WorkoutExerciseCardCommonProps & {
+  exercise: WorkoutExerciseCardTemplateExercise;
+  mode: 'readonly-template';
+};
+
+export type WorkoutExerciseCardScheduledProps = WorkoutExerciseCardCommonProps & {
+  exercise: WorkoutExerciseCardScheduledExercise;
+  mode: 'readonly-scheduled';
+};
+
+export type WorkoutExerciseCardCompletedProps = WorkoutExerciseCardCommonProps & {
+  exercise: WorkoutExerciseCardCompletedExercise;
+  mode: 'readonly-completed';
+};
+
+export type WorkoutExerciseCardProps =
+  | WorkoutExerciseCardTemplateProps
+  | WorkoutExerciseCardScheduledProps
+  | WorkoutExerciseCardCompletedProps;

--- a/apps/web/src/features/workouts/components/workout-exercise-card/types.ts
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/types.ts
@@ -8,6 +8,8 @@ export type WorkoutExerciseCardMode =
 // Reserved for a later migration round.
 // | 'in-progress'
 
+export type WorkoutExerciseCardDensity = 'default' | 'condensed';
+
 export type WorkoutExerciseSetTarget = {
   setNumber: number;
   targetDistance?: number | null;
@@ -80,6 +82,7 @@ export type WorkoutExerciseCardCompletedExercise = {
 type WorkoutExerciseCardCommonProps = {
   cardRef?: (node: HTMLDivElement | null) => void;
   className?: string;
+  density?: WorkoutExerciseCardDensity;
   footerSlot?: ReactNode;
   headerSlot?: ReactNode;
   leadingSlot?: ReactNode;

--- a/apps/web/src/features/workouts/components/workout-exercise-card/workout-exercise-set-list.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/workout-exercise-set-list.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { WorkoutExerciseSetList } from './workout-exercise-set-list';
+
+describe('WorkoutExerciseSetList', () => {
+  it('renders template/scheduled modes as readonly set rows', () => {
+    const { container } = render(
+      <WorkoutExerciseSetList
+        mode="readonly-template"
+        sets={[
+          {
+            reps: null,
+            setNumber: 1,
+            targetWeight: 65,
+          },
+        ]}
+        trackingType="weight_reps"
+        weightUnit="lbs"
+      />,
+    );
+
+    expect(screen.getByText('Target: 65 lbs')).toBeInTheDocument();
+    expect(container.querySelector('.pointer-events-none')).not.toBeNull();
+  });
+
+  it('renders completed mode with value-only rows', () => {
+    render(
+      <WorkoutExerciseSetList
+        mode="readonly-completed"
+        sets={[
+          {
+            completed: true,
+            reps: 8,
+            setNumber: 1,
+            weight: 135,
+          },
+        ]}
+        trackingType="weight_reps"
+        weightUnit="lbs"
+      />,
+    );
+
+    expect(screen.getByLabelText('Weight for set 1')).toHaveValue(135);
+    expect(screen.getByLabelText('Reps for set 1')).toHaveValue(8);
+  });
+});

--- a/apps/web/src/features/workouts/components/workout-exercise-card/workout-exercise-set-list.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/workout-exercise-set-list.tsx
@@ -1,0 +1,61 @@
+import type { ExerciseTrackingType, WeightUnit } from '@pulse/shared';
+
+import { cn } from '@/lib/utils';
+
+import { SetRow } from '../set-row';
+
+import type { WorkoutExerciseCardMode, WorkoutExerciseSetListItem } from './types';
+
+type WorkoutExerciseSetListProps = {
+  className?: string;
+  mode: WorkoutExerciseCardMode;
+  sets: WorkoutExerciseSetListItem[];
+  trackingType: ExerciseTrackingType;
+  weightUnit: WeightUnit;
+};
+
+export function WorkoutExerciseSetList({
+  className,
+  mode,
+  sets,
+  trackingType,
+  weightUnit,
+}: WorkoutExerciseSetListProps) {
+  if (sets.length === 0) {
+    return null;
+  }
+
+  const isReadOnly = mode === 'readonly-template' || mode === 'readonly-scheduled';
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      {sets.map((setItem) => (
+        <div
+          className={isReadOnly ? 'pointer-events-none' : undefined}
+          key={`set-row-${setItem.setNumber}`}
+        >
+          <SetRow
+            completed={mode === 'readonly-completed' ? (setItem.completed ?? true) : false}
+            distance={setItem.distance ?? null}
+            onUpdate={() => undefined}
+            reps={setItem.reps ?? null}
+            seconds={setItem.seconds ?? null}
+            setNumber={setItem.setNumber}
+            targetDistance={mode === 'readonly-completed' ? null : (setItem.targetDistance ?? null)}
+            targetSeconds={mode === 'readonly-completed' ? null : (setItem.targetSeconds ?? null)}
+            targetWeight={mode === 'readonly-completed' ? null : (setItem.targetWeight ?? null)}
+            targetWeightMax={
+              mode === 'readonly-completed' ? null : (setItem.targetWeightMax ?? null)
+            }
+            targetWeightMin={
+              mode === 'readonly-completed' ? null : (setItem.targetWeightMin ?? null)
+            }
+            trackingType={trackingType}
+            weight={setItem.weight ?? null}
+            weightUnit={weightUnit}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/workouts/lib/tracking.ts
+++ b/apps/web/src/features/workouts/lib/tracking.ts
@@ -1,4 +1,6 @@
-import type { ExerciseTrackingType, WeightUnit } from '@pulse/shared';
+import { formatWeight, type ExerciseTrackingType, type WeightUnit } from '@pulse/shared';
+
+import { formatServing } from '@/lib/format-utils';
 
 type SetMetrics = {
   distance?: number | null;
@@ -83,6 +85,26 @@ export function resolveTrackingType({
 
 export function getDistanceUnit(weightUnit: WeightUnit) {
   return weightUnit === 'kg' ? 'km' : 'mi';
+}
+
+export function formatSummaryMetricValue(
+  value: number,
+  label: TrackingSummaryMetricLabel,
+  weightUnit: WeightUnit,
+) {
+  if (label === 'volume') {
+    return formatWeight(value, weightUnit);
+  }
+
+  if (label === 'reps') {
+    return `${Math.round(value)}`;
+  }
+
+  if (label === 'seconds') {
+    return `${formatServing(value)} sec`;
+  }
+
+  return `${formatServing(value)} ${getDistanceUnit(weightUnit)}`;
 }
 
 export function isWeightedTrackingType(trackingType: ExerciseTrackingType) {

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -490,6 +490,14 @@ export function ActiveWorkoutPage() {
             const completedSets = exercise.sets.filter((set) => set.completed);
             const metricLabel = getTrackingSummaryMetricLabel(exercise.trackingType);
             return {
+              completedSetValues: completedSets.map((set) => ({
+                completed: set.completed,
+                distance: set.distance,
+                reps: set.reps,
+                seconds: set.seconds,
+                setNumber: set.number,
+                weight: set.weight,
+              })),
               id: exercise.id,
               metricLabel,
               metricValue: completedSets.reduce(
@@ -504,6 +512,7 @@ export function ActiveWorkoutPage() {
                 : 0,
               setsCompleted: exercise.completedSets,
               totalSets: exercise.targetSets,
+              trackingType: exercise.trackingType,
             };
           }),
       ),

--- a/docs/conventions/design-system.md
+++ b/docs/conventions/design-system.md
@@ -113,6 +113,24 @@ export function Card({ className, ...props }: Props) {
 }
 ```
 
+## Workout Exercise Card Primitive
+
+Use `WorkoutExerciseCard` from
+`apps/web/src/features/workouts/components/workout-exercise-card/` as the canonical renderer for
+read-only workout exercises.
+
+- Modes: `readonly-template`, `readonly-scheduled`, `readonly-completed` (`in-progress` remains
+  reserved for the later active-workout migration).
+- Composition: this primitive orchestrates `ExerciseHeader`, `PrescriptionBlock`,
+  `ProgrammingNotesBlock`, `FormCuesBlock`, `LastPerformanceChip`, and
+  `WorkoutExerciseSetList`.
+- Identity contract: every caller must provide a canonical `exercise.id` string. The primitive
+  derives both DOM id and test id from this value (`workout-exercise-{id}` and
+  `workout-exercise-card-{id}`), so downstream views and tests stay consistent across template,
+  scheduled, and completed pages.
+- Slot contract: use `leadingSlot`, `headerSlot`, and `footerSlot` for view-specific affordances
+  (for example drag handles, date chips, or correction actions) without forking the core card UI.
+
 ## Page Header Pattern
 
 Use `PageHeader` (`apps/web/src/components/layout/page-header.tsx`) as the default heading primitive for app routes.

--- a/docs/conventions/design-system.md
+++ b/docs/conventions/design-system.md
@@ -130,6 +130,10 @@ read-only workout exercises.
   scheduled, and completed pages.
 - Slot contract: use `leadingSlot`, `headerSlot`, and `footerSlot` for view-specific affordances
   (for example drag handles, date chips, or correction actions) without forking the core card UI.
+- Density variant: use `density="default"` for full read-only detail and
+  `density="condensed"` for summary surfaces. Condensed cards tighten spacing, hide the
+  prescription/form-cue blocks, and relabel the set disclosure as "Show set values" while still
+  using the same primitive contract.
 
 ## Page Header Pattern
 

--- a/docs/conventions/feature-structure.md
+++ b/docs/conventions/feature-structure.md
@@ -52,6 +52,31 @@ Rules:
 - `index.ts`: feature public API barrel.
 - Feature folders and file names are kebab-case.
 
+### Shared Primitive Subdirectory Pattern
+
+When a feature-scoped component grows into a shared primitive with internal building blocks, create
+a dedicated subdirectory under that feature's `components/` folder.
+
+Example:
+
+```text
+src/features/workouts/components/workout-exercise-card/
+  index.tsx
+  exercise-header.tsx
+  prescription-block.tsx
+  programming-notes-block.tsx
+  form-cues-block.tsx
+  last-performance-chip.tsx
+  workout-exercise-set-list.tsx
+  *.test.tsx
+```
+
+Rules:
+
+- Keep the orchestrator in `index.tsx`; colocate sub-primitives and their focused tests.
+- Export only the primitive's public surface from `index.tsx`.
+- Reuse this shape for future shared feature primitives instead of introducing one-off flat files.
+
 ## Barrel Export Pattern
 
 Every feature must expose a stable public surface through `index.ts`.

--- a/docs/conventions/workout-domain.md
+++ b/docs/conventions/workout-domain.md
@@ -29,6 +29,15 @@ The scheduled-workout detail page should mirror template-detail exercise renderi
 - `programmingNotes` shown on scheduled cards comes from the resolved template exercise data.
 - Reserve a page-level `bannerSlot` area above the header for future scheduled-workout warning banners. Leave it empty unless a warning feature explicitly populates it.
 
+## Completed Session Detail Surface
+
+The completed-session detail page should render each exercise through shared `WorkoutExerciseCard` primitives in `readonly-completed` mode.
+
+- Exercise rows render through shared `WorkoutExerciseCard` in `readonly-completed` mode.
+- Completed-mode set rows must show logged values (weight/reps/seconds/distance) and must not fall back to template target values.
+- Session-level composition (history button, comparison blocks, correction editors, and exercise-note markdown) should be injected via card slots from `session-detail.tsx`, not reimplemented as a separate card layout.
+- `programmingNotes` on completed cards comes from the session-exercise snapshot (`session_exercises.programmingNotes`) and is rendered by the primitive `ProgrammingNotesBlock`.
+
 ## Exercise In Template
 
 Each template exercise stores prescription data, not completed performance.

--- a/docs/conventions/workout-domain.md
+++ b/docs/conventions/workout-domain.md
@@ -20,6 +20,15 @@ Template sections use this fixed sequence:
 
 Each section contains an ordered `exercises` array. Preserve order exactly as authored; the UI should not reorder template exercises automatically.
 
+## Scheduled Workout Detail Surface
+
+The scheduled-workout detail page should mirror template-detail exercise rendering and only add scheduling controls.
+
+- Exercise rows render through shared `WorkoutExerciseCard` in `readonly-scheduled` mode.
+- Header controls are schedule-specific: scheduled date, source template link, `Start workout`, `Reschedule`, and `Cancel`.
+- `programmingNotes` shown on scheduled cards comes from the resolved template exercise data.
+- Reserve a page-level `bannerSlot` area above the header for future scheduled-workout warning banners. Leave it empty unless a warning feature explicitly populates it.
+
 ## Exercise In Template
 
 Each template exercise stores prescription data, not completed performance.


### PR DESCRIPTION
## Summary
This PR introduces a shared `WorkoutExerciseCard` primitive for workout exercise read-only surfaces and migrates template detail, scheduled workout detail, session detail, and session summary to that shared renderer. The refactor removes duplicated prescription/target/form-cue/set-row formatting logic and replaces it with mode-driven composition (`readonly-template`, `readonly-scheduled`, `readonly-completed`) plus slot-based page-specific affordances. It also preserves and restores critical workflows during migration, including template prescription editing, scheduled workout start/reschedule/cancel flows, and completed-session corrections/history behavior. The result is a single exercise-card contract with improved parity across views and broader component/test coverage.

## Key Changes
- Added `workout-exercise-card/` shared primitive with sub-primitives:
  - `ExerciseHeader`, `PrescriptionBlock`, `ProgrammingNotesBlock`, `FormCuesBlock`, `LastPerformanceChip`, `WorkoutExerciseSetList`
  - shared formatters/types and canonical element/test-id helpers
- Rebuilt `template-detail` to render exercises through `WorkoutExerciseCard` in `readonly-template` mode.
- Replaced template inline blur/debounce prescription edits with explicit **Edit prescription** dialog save flow, and kept template exercise actions (swap/move/rename/history) via card slots.
- Rebuilt `scheduled-workout-detail` on `WorkoutExerciseCard` in `readonly-scheduled` mode and extracted a `ScheduledWorkoutHeader` with date, template link, Start/Reschedule/Cancel controls, and confirmation-backed cancel.
- Rebuilt `session-detail` to use `SessionDetailExerciseCard` + `WorkoutExerciseCard` in `readonly-completed` mode, preserving comparison, notes, history, and correction editors.
- Rebuilt `session-summary` on a condensed `SessionSummaryExerciseCard` variant of `WorkoutExerciseCard`, including optional per-set value disclosure.
- Centralized summary metric formatting by moving `formatSummaryMetricValue` into `lib/tracking`, and updated active workout summary payloads to include completed set values/tracking type for card rendering.
- Updated domain/design/convention docs to codify the shared-card contract and feature structure pattern.

## Technical Notes
- The card now defines an identity contract (`workout-exercise-{id}` / `workout-exercise-card-{id}`) used across pages/tests and for modal scroll targeting.
- Mode behavior is intentionally strict: completed mode renders logged set values (not template targets), while template/scheduled modes render target-oriented set rows.
- `density="condensed"` intentionally omits prescription/form-cue blocks for summary surfaces while retaining programming notes and optional set-value disclosure.
- Template/scheduled mappings currently set `equipment` and `muscleGroups` placeholders where nested API data is not yet available (explicit TODOs retained).
- `reps_seconds` remains bridged to current persisted shape (seconds read from `reps`) until dedicated storage exists; this is preserved in completed-mode set conversion and editor behavior.
- Test coverage was expanded around mode-specific rendering, mutation wiring, and regression cases (notably completed-set value rendering and template edit flow).

## Commits

- `05a947a fix(workouts): dedupe session summary metric formatting`
- `4a5589a refactor(web): rebuild session-summary on shared card`
- `3a5cb55 refactor(web): rebuild session-detail on shared card`
- `5066e7c refactor(web): rebuild scheduled-workout-detail on shared card`
- `8773e6e fix(workouts): restore template exercise edit behavior`
- `7313455 refactor(web): extract WorkoutExerciseCard primitive`

## Tasks

- **Extract WorkoutExerciseCard + sub-primitives from template-detail**: Create WorkoutExerciseCard shell plus ExerciseHeader, PrescriptionBlock, ProgrammingNotesBlock, FormCuesBlock, LastPerformanceChip, WorkoutExerciseSetList. Rebuild template-detail.tsx on the shared primitive as the baseline. Component tests for each primitive and for the rebuilt template view.
- **Rebuild scheduled-workout-detail on shared card**: Replace the sparse scheduled-workout-detail rendering with the shared WorkoutExerciseCard in readonly-scheduled mode. Add a scheduling-specific header (date + Start workout CTA + reschedule/cancel affordances). Visual parity with template-detail plus scheduling additions. Component tests.
- **Rebuild session-detail on shared card**: Migrate session-detail.tsx onto WorkoutExerciseCard in readonly-completed mode (value-only set rows). Preserve current completed-session affordances (per-set actuals, user notes textarea, corrections). Component tests.
- **Rebuild session-summary on shared card**: Migrate session-summary.tsx onto WorkoutExerciseCard in readonly-completed mode with a condensed header variant. Confirm no divergence from session-detail for the shared card surface. Component tests.

## Diff Stats

```
.../components/exercise-detail-modal.test.tsx      |  28 +
 .../workouts/components/exercise-detail-modal.tsx  |   4 +-
 .../components/scheduled-workout-detail.test.tsx   | 390 ++++++++--
 .../components/scheduled-workout-detail.tsx        | 374 ++++------
 .../components/scheduled-workout-header.tsx        |  94 +++
 .../components/session-detail-exercise-card.tsx    | 333 +++++++++
 .../workouts/components/session-detail.test.tsx    | 108 ++-
 .../workouts/components/session-detail.tsx         | 480 ++++--------
 .../components/session-summary-exercise-card.tsx   | 175 +++++
 .../workouts/components/session-summary.test.tsx   |  79 +-
 .../workouts/components/session-summary.tsx        | 134 +---
 .../workouts/components/template-detail.test.tsx   |  64 +-
 .../workouts/components/template-detail.tsx        | 808 ++++++++-------------
 .../workout-exercise-card/exercise-header.test.tsx |  51 ++
 .../workout-exercise-card/exercise-header.tsx      | 102 +++
 .../workout-exercise-card/form-cues-block.test.tsx |  33 +
 .../workout-exercise-card/form-cues-block.tsx      |  66 ++
 .../components/workout-exercise-card/formatters.ts | 302 ++++++++
 .../workout-exercise-card/index.test.tsx           | 142 ++++
 .../components/workout-exercise-card/index.tsx     | 176 +++++
 .../last-performance-chip.test.tsx                 |  76 ++
 .../last-performance-chip.tsx                      |  63 ++
 .../prescription-block.test.tsx                    |  65 ++
 .../workout-exercise-card/prescription-block.tsx   |  68 ++
 .../programming-notes-block.test.tsx               |  25 +
 .../programming-notes-block.tsx                    |  30 +
 .../components/workout-exercise-card/types.ts      | 114 +++
 .../workout-exercise-set-list.test.tsx             |  47 ++
 .../workout-exercise-set-list.tsx                  |  61 ++
 apps/web/src/features/workouts/lib/tracking.ts     |  24 +-
 apps/web/src/pages/active-workout.tsx              |   9 +
 docs/conventions/design-system.md                  |  22 +
 docs/conventions/feature-structure.md              |  25 +
 docs/conventions/workout-domain.md                 |  18 +
 34 files changed, 3257 insertions(+), 1333 deletions(-)
```