### PR TITLE
feat(workouts): agent-enriched scheduled workout snapshot

### DIFF
--- a/.agents/skills/pulse-app-usage/SKILL.md
+++ b/.agents/skills/pulse-app-usage/SKILL.md
@@ -243,6 +243,45 @@ If no new foods were created, explicitly say that existing food entries were reu
 - **Create**: `POST /api/v1/scheduled-workouts/` — schedule a template on calendar date(s).
 - **Review**: `GET /api/v1/scheduled-workouts/?from=<YYYY-MM-DD>&to=<YYYY-MM-DD>`
 
+### Scheduled-workout enrichment
+
+This step fits between **Scheduling** (`POST /api/v1/scheduled-workouts/`) and **Sessions → Start**
+(`POST /api/v1/workout-sessions/` with `scheduledWorkoutId`).
+
+1. Schedule first: `POST /api/v1/scheduled-workouts/` returns a scheduled workout snapshot with
+   exercise ids and default prescriptions copied from the template.
+2. Pull context before writing notes: check recent sessions for the same template, last
+   performance for each exercise, weight trend, habit state, and journal/injury flags when
+   available.
+3. Decide note-by-note whether enrichment adds value. Many exercises should have no note.
+   High-signal examples:
+   - progression cues from last session
+   - injury accommodations
+   - rest-period adjustments based on recent volume/fatigue
+4. Write session-specific notes with AgentToken auth:
+
+```json
+PATCH /api/v1/scheduled-workouts/:id/exercise-notes
+{
+  "notes": [
+    { "exerciseId": "exercise-uuid", "agentNotes": "Last session: 3x15 at 53 lb. Try 62 lb today." }
+  ]
+}
+```
+
+- Send `agentNotes: null` to clear a previously written note.
+
+5. In the user-facing confirmation message, summarize what changed, for example:
+   "I scheduled your workout for Tuesday and added 3 notes: bench progression, shoulder-friendly
+   incline option, and longer deadlift rest."
+
+What not to do:
+
+- Do not overwrite programming notes (`programmingNotes` is template-level and read-only from the
+  scheduled-workout enrichment surface).
+- Do not write notes for completeness; only write notes where context-specific guidance helps.
+- Do not include dates inside note text; generation/schedule timestamps live in metadata.
+
 ### Planning a Workout
 
 1. Load planning context from `~/Obsidian/Master/2-Areas/Health & Fitness/Workouts` (status, injury notes, equipment, and recent session notes).

--- a/apps/api/drizzle/0037_vengeful_tigra.sql
+++ b/apps/api/drizzle/0037_vengeful_tigra.sql
@@ -1,0 +1,119 @@
+CREATE TABLE `scheduled_workout_exercises` (
+	`id` text PRIMARY KEY NOT NULL,
+	`scheduled_workout_id` text NOT NULL,
+	`exercise_id` text NOT NULL,
+	`section` text NOT NULL,
+	`order_index` integer NOT NULL,
+	`programming_notes` text,
+	`agent_notes` text,
+	`agent_notes_meta` text,
+	`template_cues` text,
+	`superset_group` text,
+	`tempo` text,
+	`rest_seconds` integer,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`scheduled_workout_id`) REFERENCES `scheduled_workouts`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`exercise_id`) REFERENCES `exercises`(`id`) ON UPDATE no action ON DELETE restrict,
+	CONSTRAINT "scheduled_workout_exercises_section_check" CHECK("scheduled_workout_exercises"."section" in ('warmup', 'main', 'cooldown', 'supplemental'))
+);
+--> statement-breakpoint
+CREATE INDEX `scheduled_workout_exercises_scheduled_workout_id_idx` ON `scheduled_workout_exercises` (`scheduled_workout_id`);--> statement-breakpoint
+CREATE INDEX `scheduled_workout_exercises_exercise_id_idx` ON `scheduled_workout_exercises` (`exercise_id`);--> statement-breakpoint
+CREATE TABLE `scheduled_workout_exercise_sets` (
+	`id` text PRIMARY KEY NOT NULL,
+	`scheduled_workout_exercise_id` text NOT NULL,
+	`set_number` integer NOT NULL,
+	`reps_min` integer,
+	`reps_max` integer,
+	`reps` integer,
+	`target_weight` real,
+	`target_weight_min` real,
+	`target_weight_max` real,
+	`target_seconds` integer,
+	`target_distance` real,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`scheduled_workout_exercise_id`) REFERENCES `scheduled_workout_exercises`(`id`) ON UPDATE no action ON DELETE cascade,
+	CONSTRAINT "scheduled_workout_exercise_sets_set_number_check" CHECK("scheduled_workout_exercise_sets"."set_number" > 0),
+	CONSTRAINT "scheduled_workout_exercise_sets_reps_range_check" CHECK("scheduled_workout_exercise_sets"."reps_min" is null or "scheduled_workout_exercise_sets"."reps_max" is null or "scheduled_workout_exercise_sets"."reps_min" <= "scheduled_workout_exercise_sets"."reps_max"),
+	CONSTRAINT "scheduled_workout_exercise_sets_target_weight_range_check" CHECK("scheduled_workout_exercise_sets"."target_weight_min" is null or "scheduled_workout_exercise_sets"."target_weight_max" is null or "scheduled_workout_exercise_sets"."target_weight_min" <= "scheduled_workout_exercise_sets"."target_weight_max")
+);
+--> statement-breakpoint
+CREATE INDEX `scheduled_workout_exercise_sets_exercise_id_idx` ON `scheduled_workout_exercise_sets` (`scheduled_workout_exercise_id`);--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_workout_sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`template_id` text,
+	`scheduled_workout_id` text,
+	`name` text NOT NULL,
+	`date` text NOT NULL,
+	`status` text DEFAULT 'in-progress' NOT NULL,
+	`started_at` integer NOT NULL,
+	`completed_at` integer,
+	`duration` integer,
+	`time_segments` text DEFAULT '[]' NOT NULL,
+	`feedback` text,
+	`exercise_programming_notes` text,
+	`exercise_agent_notes` text,
+	`exercise_agent_notes_meta` text,
+	`notes` text,
+	`deleted_at` text,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`template_id`) REFERENCES `workout_templates`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`scheduled_workout_id`) REFERENCES `scheduled_workouts`(`id`) ON UPDATE no action ON DELETE set null,
+	CONSTRAINT "workout_sessions_date_format_check" CHECK("__new_workout_sessions"."date" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'),
+	CONSTRAINT "workout_sessions_status_check" CHECK("__new_workout_sessions"."status" in ('scheduled', 'in-progress', 'paused', 'cancelled', 'completed')),
+	CONSTRAINT "workout_sessions_completed_at_check" CHECK(("__new_workout_sessions"."status" != 'completed' or "__new_workout_sessions"."completed_at" is not null) and ("__new_workout_sessions"."completed_at" is null or "__new_workout_sessions"."completed_at" >= "__new_workout_sessions"."started_at"))
+);
+--> statement-breakpoint
+INSERT INTO `__new_workout_sessions`(
+	"id",
+	"user_id",
+	"template_id",
+	"scheduled_workout_id",
+	"name",
+	"date",
+	"status",
+	"started_at",
+	"completed_at",
+	"duration",
+	"time_segments",
+	"feedback",
+	"exercise_programming_notes",
+	"exercise_agent_notes",
+	"exercise_agent_notes_meta",
+	"notes",
+	"deleted_at",
+	"created_at",
+	"updated_at"
+) SELECT
+	"id",
+	"user_id",
+	"template_id",
+	null,
+	"name",
+	"date",
+	"status",
+	"started_at",
+	"completed_at",
+	"duration",
+	"time_segments",
+	"feedback",
+	"exercise_programming_notes",
+	null,
+	null,
+	"notes",
+	"deleted_at",
+	"created_at",
+	"updated_at"
+FROM `workout_sessions`;--> statement-breakpoint
+DROP TABLE `workout_sessions`;--> statement-breakpoint
+ALTER TABLE `__new_workout_sessions` RENAME TO `workout_sessions`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `workout_sessions_user_id_idx` ON `workout_sessions` (`user_id`);--> statement-breakpoint
+CREATE INDEX `workout_sessions_date_idx` ON `workout_sessions` (`date`);--> statement-breakpoint
+CREATE INDEX `workout_sessions_scheduled_workout_id_idx` ON `workout_sessions` (`scheduled_workout_id`);--> statement-breakpoint
+ALTER TABLE `scheduled_workouts` ADD `template_version` text;

--- a/apps/api/drizzle/meta/0037_snapshot.json
+++ b/apps/api/drizzle/meta/0037_snapshot.json
@@ -1,0 +1,3326 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6bc402cd-0930-405d-872a-fb3ba3e433c4",
+  "prevId": "ee97dc5f-896a-44c5-9140-8f3b4c137d22",
+  "tables": {
+    "activities": {
+      "name": "activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "activities_user_date_idx": {
+          "name": "activities_user_date_idx",
+          "columns": ["user_id", "date"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "activities_user_id_users_id_fk": {
+          "name": "activities_user_id_users_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "activities_date_format_check": {
+          "name": "activities_date_format_check",
+          "value": "\"activities\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "activities_type_check": {
+          "name": "activities_type_check",
+          "value": "\"activities\".\"type\" in ('walking', 'running', 'stretching', 'yoga', 'cycling', 'swimming', 'hiking', 'other')"
+        },
+        "activities_duration_minutes_check": {
+          "name": "activities_duration_minutes_check",
+          "value": "\"activities\".\"duration_minutes\" > 0"
+        }
+      }
+    },
+    "agent_tokens": {
+      "name": "agent_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_rotated_at": {
+          "name": "last_rotated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "agent_tokens_token_hash_unique": {
+          "name": "agent_tokens_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_tokens_user_id_users_id_fk": {
+          "name": "agent_tokens_user_id_users_id_fk",
+          "tableFrom": "agent_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "body_weight": {
+      "name": "body_weight",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "body_weight_user_id_date_unique": {
+          "name": "body_weight_user_id_date_unique",
+          "columns": ["user_id", "date"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "body_weight_user_id_users_id_fk": {
+          "name": "body_weight_user_id_users_id_fk",
+          "tableFrom": "body_weight",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "body_weight_date_format_check": {
+          "name": "body_weight_date_format_check",
+          "value": "\"body_weight\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "body_weight_weight_check": {
+          "name": "body_weight_weight_check",
+          "value": "\"body_weight\".\"weight\" > 0"
+        }
+      }
+    },
+    "dashboard_config": {
+      "name": "dashboard_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "habit_chain_ids": {
+          "name": "habit_chain_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "trend_metrics": {
+          "name": "trend_metrics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "visible_widgets": {
+          "name": "visible_widgets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "widget_order": {
+          "name": "widget_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "dashboard_config_user_id_unique": {
+          "name": "dashboard_config_user_id_unique",
+          "columns": ["user_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "dashboard_config_user_id_users_id_fk": {
+          "name": "dashboard_config_user_id_users_id_fk",
+          "tableFrom": "dashboard_config",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entity_links": {
+      "name": "entity_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "entity_links_user_source_type_source_id_idx": {
+          "name": "entity_links_user_source_type_source_id_idx",
+          "columns": ["user_id", "source_type", "source_id"],
+          "isUnique": false
+        },
+        "entity_links_user_target_type_target_id_idx": {
+          "name": "entity_links_user_target_type_target_id_idx",
+          "columns": ["user_id", "target_type", "target_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "entity_links_user_id_users_id_fk": {
+          "name": "entity_links_user_id_users_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "entity_links_source_type_check": {
+          "name": "entity_links_source_type_check",
+          "value": "\"entity_links\".\"source_type\" in ('journal', 'activity', 'resource')"
+        },
+        "entity_links_target_type_check": {
+          "name": "entity_links_target_type_check",
+          "value": "\"entity_links\".\"target_type\" in ('workout', 'activity', 'habit', 'injury', 'exercise', 'protocol')"
+        }
+      }
+    },
+    "equipment_items": {
+      "name": "equipment_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "equipment_items_location_id_idx": {
+          "name": "equipment_items_location_id_idx",
+          "columns": ["location_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "equipment_items_location_id_equipment_locations_id_fk": {
+          "name": "equipment_items_location_id_equipment_locations_id_fk",
+          "tableFrom": "equipment_items",
+          "tableTo": "equipment_locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "equipment_items_category_check": {
+          "name": "equipment_items_category_check",
+          "value": "\"equipment_items\".\"category\" in ('free-weights', 'machines', 'cables', 'cardio', 'accessories')"
+        }
+      }
+    },
+    "equipment_locations": {
+      "name": "equipment_locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "equipment_locations_user_id_idx": {
+          "name": "equipment_locations_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "equipment_locations_user_id_users_id_fk": {
+          "name": "equipment_locations_user_id_users_id_fk",
+          "tableFrom": "equipment_locations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exercises": {
+      "name": "exercises",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "muscle_groups": {
+          "name": "muscle_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment": {
+          "name": "equipment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tracking_type": {
+          "name": "tracking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'weight_reps'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "form_cues": {
+          "name": "form_cues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coaching_notes": {
+          "name": "coaching_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "related_exercise_ids": {
+          "name": "related_exercise_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "exercises_user_id_idx": {
+          "name": "exercises_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "exercises_user_id_users_id_fk": {
+          "name": "exercises_user_id_users_id_fk",
+          "tableFrom": "exercises",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "exercises_category_check": {
+          "name": "exercises_category_check",
+          "value": "\"exercises\".\"category\" in ('compound', 'isolation', 'cardio', 'mobility')"
+        },
+        "exercises_tracking_type_check": {
+          "name": "exercises_tracking_type_check",
+          "value": "\"exercises\".\"tracking_type\" in ('weight_reps', 'weight_seconds', 'bodyweight_reps', 'reps_only', 'reps_seconds', 'seconds_only', 'distance', 'cardio')"
+        }
+      }
+    },
+    "foods": {
+      "name": "foods",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "serving_size": {
+          "name": "serving_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "serving_grams": {
+          "name": "serving_grams",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "calories": {
+          "name": "calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protein": {
+          "name": "protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fat": {
+          "name": "fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fiber": {
+          "name": "fiber",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sugar": {
+          "name": "sugar",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "foods_user_last_used_at_idx": {
+          "name": "foods_user_last_used_at_idx",
+          "columns": ["user_id", "last_used_at"],
+          "isUnique": false
+        },
+        "foods_user_usage_count_idx": {
+          "name": "foods_user_usage_count_idx",
+          "columns": ["user_id", "usage_count"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "foods_user_id_users_id_fk": {
+          "name": "foods_user_id_users_id_fk",
+          "tableFrom": "foods",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "foods_serving_grams_check": {
+          "name": "foods_serving_grams_check",
+          "value": "\"foods\".\"serving_grams\" is null or \"foods\".\"serving_grams\" > 0"
+        },
+        "foods_macros_nonnegative_check": {
+          "name": "foods_macros_nonnegative_check",
+          "value": "\"foods\".\"calories\" >= 0 and \"foods\".\"protein\" >= 0 and \"foods\".\"carbs\" >= 0 and \"foods\".\"fat\" >= 0"
+        },
+        "foods_fiber_nonnegative_check": {
+          "name": "foods_fiber_nonnegative_check",
+          "value": "\"foods\".\"fiber\" is null or \"foods\".\"fiber\" >= 0"
+        },
+        "foods_sugar_nonnegative_check": {
+          "name": "foods_sugar_nonnegative_check",
+          "value": "\"foods\".\"sugar\" is null or \"foods\".\"sugar\" >= 0"
+        }
+      }
+    },
+    "habit_entries": {
+      "name": "habit_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "habit_id": {
+          "name": "habit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_override": {
+          "name": "is_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "habit_entries_user_id_idx": {
+          "name": "habit_entries_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "habit_entries_date_idx": {
+          "name": "habit_entries_date_idx",
+          "columns": ["date"],
+          "isUnique": false
+        },
+        "habit_entries_habit_id_date_unique": {
+          "name": "habit_entries_habit_id_date_unique",
+          "columns": ["habit_id", "date"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "habit_entries_habit_id_habits_id_fk": {
+          "name": "habit_entries_habit_id_habits_id_fk",
+          "tableFrom": "habit_entries",
+          "tableTo": "habits",
+          "columnsFrom": ["habit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "habit_entries_user_id_users_id_fk": {
+          "name": "habit_entries_user_id_users_id_fk",
+          "tableFrom": "habit_entries",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "habit_entries_date_format_check": {
+          "name": "habit_entries_date_format_check",
+          "value": "\"habit_entries\".\"date\" GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        }
+      }
+    },
+    "habits": {
+      "name": "habits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tracking_type": {
+          "name": "tracking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'daily'"
+        },
+        "frequency_target": {
+          "name": "frequency_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_days": {
+          "name": "scheduled_days",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_source": {
+          "name": "reference_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_config": {
+          "name": "reference_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_until": {
+          "name": "paused_until",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "habits_user_id_idx": {
+          "name": "habits_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "habits_user_id_users_id_fk": {
+          "name": "habits_user_id_users_id_fk",
+          "tableFrom": "habits",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "habits_tracking_type_check": {
+          "name": "habits_tracking_type_check",
+          "value": "\"habits\".\"tracking_type\" in ('boolean', 'numeric', 'time')"
+        },
+        "habits_frequency_check": {
+          "name": "habits_frequency_check",
+          "value": "\"habits\".\"frequency\" in ('daily', 'weekly', 'specific_days')"
+        }
+      }
+    },
+    "condition_protocols": {
+      "name": "condition_protocols",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition_id": {
+          "name": "condition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "condition_protocols_condition_id_idx": {
+          "name": "condition_protocols_condition_id_idx",
+          "columns": ["condition_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "condition_protocols_condition_id_health_conditions_id_fk": {
+          "name": "condition_protocols_condition_id_health_conditions_id_fk",
+          "tableFrom": "condition_protocols",
+          "tableTo": "health_conditions",
+          "columnsFrom": ["condition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "condition_protocols_status_check": {
+          "name": "condition_protocols_status_check",
+          "value": "\"condition_protocols\".\"status\" in ('active', 'discontinued', 'completed')"
+        },
+        "condition_protocols_start_date_format_check": {
+          "name": "condition_protocols_start_date_format_check",
+          "value": "\"condition_protocols\".\"start_date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "condition_protocols_end_date_format_check": {
+          "name": "condition_protocols_end_date_format_check",
+          "value": "\"condition_protocols\".\"end_date\" is null or \"condition_protocols\".\"end_date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "condition_protocols_end_date_order_check": {
+          "name": "condition_protocols_end_date_order_check",
+          "value": "\"condition_protocols\".\"end_date\" is null or \"condition_protocols\".\"end_date\" >= \"condition_protocols\".\"start_date\""
+        }
+      }
+    },
+    "condition_severity_points": {
+      "name": "condition_severity_points",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition_id": {
+          "name": "condition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "condition_severity_points_condition_date_idx": {
+          "name": "condition_severity_points_condition_date_idx",
+          "columns": ["condition_id", "date"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "condition_severity_points_condition_id_health_conditions_id_fk": {
+          "name": "condition_severity_points_condition_id_health_conditions_id_fk",
+          "tableFrom": "condition_severity_points",
+          "tableTo": "health_conditions",
+          "columnsFrom": ["condition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "condition_severity_points_date_format_check": {
+          "name": "condition_severity_points_date_format_check",
+          "value": "\"condition_severity_points\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "condition_severity_points_value_check": {
+          "name": "condition_severity_points_value_check",
+          "value": "\"condition_severity_points\".\"value\" between 1 and 10"
+        }
+      }
+    },
+    "condition_timeline_events": {
+      "name": "condition_timeline_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition_id": {
+          "name": "condition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "condition_timeline_events_condition_date_idx": {
+          "name": "condition_timeline_events_condition_date_idx",
+          "columns": ["condition_id", "date"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "condition_timeline_events_condition_id_health_conditions_id_fk": {
+          "name": "condition_timeline_events_condition_id_health_conditions_id_fk",
+          "tableFrom": "condition_timeline_events",
+          "tableTo": "health_conditions",
+          "columnsFrom": ["condition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "condition_timeline_events_date_format_check": {
+          "name": "condition_timeline_events_date_format_check",
+          "value": "\"condition_timeline_events\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "condition_timeline_events_type_check": {
+          "name": "condition_timeline_events_type_check",
+          "value": "\"condition_timeline_events\".\"type\" in ('onset', 'flare', 'improvement', 'treatment', 'milestone')"
+        }
+      }
+    },
+    "health_conditions": {
+      "name": "health_conditions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body_area": {
+          "name": "body_area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "health_conditions_user_id_idx": {
+          "name": "health_conditions_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_conditions_user_id_users_id_fk": {
+          "name": "health_conditions_user_id_users_id_fk",
+          "tableFrom": "health_conditions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "health_conditions_status_check": {
+          "name": "health_conditions_status_check",
+          "value": "\"health_conditions\".\"status\" in ('active', 'monitoring', 'resolved')"
+        },
+        "health_conditions_onset_date_format_check": {
+          "name": "health_conditions_onset_date_format_check",
+          "value": "\"health_conditions\".\"onset_date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        }
+      }
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": ["username"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "journal_entries_user_date_idx": {
+          "name": "journal_entries_user_date_idx",
+          "columns": ["user_id", "date"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_user_id_users_id_fk": {
+          "name": "journal_entries_user_id_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "journal_entries_date_format_check": {
+          "name": "journal_entries_date_format_check",
+          "value": "\"journal_entries\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "journal_entries_type_check": {
+          "name": "journal_entries_type_check",
+          "value": "\"journal_entries\".\"type\" in ('post-workout', 'milestone', 'observation', 'weekly-summary', 'injury-update')"
+        },
+        "journal_entries_created_by_check": {
+          "name": "journal_entries_created_by_check",
+          "value": "\"journal_entries\".\"created_by\" in ('agent', 'user')"
+        }
+      }
+    },
+    "meal_items": {
+      "name": "meal_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meal_id": {
+          "name": "meal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_quantity": {
+          "name": "display_quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_unit": {
+          "name": "display_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "calories": {
+          "name": "calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protein": {
+          "name": "protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fat": {
+          "name": "fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fiber": {
+          "name": "fiber",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sugar": {
+          "name": "sugar",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "meal_items_meal_id_idx": {
+          "name": "meal_items_meal_id_idx",
+          "columns": ["meal_id"],
+          "isUnique": false
+        },
+        "meal_items_food_id_idx": {
+          "name": "meal_items_food_id_idx",
+          "columns": ["food_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meal_items_meal_id_meals_id_fk": {
+          "name": "meal_items_meal_id_meals_id_fk",
+          "tableFrom": "meal_items",
+          "tableTo": "meals",
+          "columnsFrom": ["meal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meal_items_food_id_foods_id_fk": {
+          "name": "meal_items_food_id_foods_id_fk",
+          "tableFrom": "meal_items",
+          "tableTo": "foods",
+          "columnsFrom": ["food_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "meal_items_amount_check": {
+          "name": "meal_items_amount_check",
+          "value": "\"meal_items\".\"amount\" > 0"
+        },
+        "meal_items_display_quantity_check": {
+          "name": "meal_items_display_quantity_check",
+          "value": "\"meal_items\".\"display_quantity\" is null or \"meal_items\".\"display_quantity\" > 0"
+        },
+        "meal_items_macros_nonnegative_check": {
+          "name": "meal_items_macros_nonnegative_check",
+          "value": "\"meal_items\".\"calories\" >= 0 and \"meal_items\".\"protein\" >= 0 and \"meal_items\".\"carbs\" >= 0 and \"meal_items\".\"fat\" >= 0"
+        },
+        "meal_items_fiber_nonnegative_check": {
+          "name": "meal_items_fiber_nonnegative_check",
+          "value": "\"meal_items\".\"fiber\" is null or \"meal_items\".\"fiber\" >= 0"
+        },
+        "meal_items_sugar_nonnegative_check": {
+          "name": "meal_items_sugar_nonnegative_check",
+          "value": "\"meal_items\".\"sugar\" is null or \"meal_items\".\"sugar\" >= 0"
+        }
+      }
+    },
+    "meals": {
+      "name": "meals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nutrition_log_id": {
+          "name": "nutrition_log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "meals_nutrition_log_id_idx": {
+          "name": "meals_nutrition_log_id_idx",
+          "columns": ["nutrition_log_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meals_nutrition_log_id_nutrition_logs_id_fk": {
+          "name": "meals_nutrition_log_id_nutrition_logs_id_fk",
+          "tableFrom": "meals",
+          "tableTo": "nutrition_logs",
+          "columnsFrom": ["nutrition_log_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "meals_time_format_check": {
+          "name": "meals_time_format_check",
+          "value": "\"meals\".\"time\" is null or \"meals\".\"time\" glob '[0-9][0-9]:[0-9][0-9]'"
+        }
+      }
+    },
+    "nutrition_logs": {
+      "name": "nutrition_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "nutrition_logs_user_id_date_unique": {
+          "name": "nutrition_logs_user_id_date_unique",
+          "columns": ["user_id", "date"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "nutrition_logs_user_id_users_id_fk": {
+          "name": "nutrition_logs_user_id_users_id_fk",
+          "tableFrom": "nutrition_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "nutrition_logs_date_format_check": {
+          "name": "nutrition_logs_date_format_check",
+          "value": "\"nutrition_logs\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        }
+      }
+    },
+    "nutrition_targets": {
+      "name": "nutrition_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "calories": {
+          "name": "calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protein": {
+          "name": "protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fat": {
+          "name": "fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "nutrition_targets_user_id_effective_date_unique": {
+          "name": "nutrition_targets_user_id_effective_date_unique",
+          "columns": ["user_id", "effective_date"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "nutrition_targets_user_id_users_id_fk": {
+          "name": "nutrition_targets_user_id_users_id_fk",
+          "tableFrom": "nutrition_targets",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "nutrition_targets_effective_date_format_check": {
+          "name": "nutrition_targets_effective_date_format_check",
+          "value": "\"nutrition_targets\".\"effective_date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "nutrition_targets_macros_nonnegative_check": {
+          "name": "nutrition_targets_macros_nonnegative_check",
+          "value": "\"nutrition_targets\".\"calories\" >= 0 and \"nutrition_targets\".\"protein\" >= 0 and \"nutrition_targets\".\"carbs\" >= 0 and \"nutrition_targets\".\"fat\" >= 0"
+        }
+      }
+    },
+    "resources": {
+      "name": "resources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "principles": {
+          "name": "principles",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "resources_user_id_idx": {
+          "name": "resources_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "resources_user_id_users_id_fk": {
+          "name": "resources_user_id_users_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "resources_type_check": {
+          "name": "resources_type_check",
+          "value": "\"resources\".\"type\" in ('program', 'book', 'creator')"
+        }
+      }
+    },
+    "template_exercises": {
+      "name": "template_exercises",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sets": {
+          "name": "sets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reps_min": {
+          "name": "reps_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reps_max": {
+          "name": "reps_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tempo": {
+          "name": "tempo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rest_seconds": {
+          "name": "rest_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "superset_group": {
+          "name": "superset_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section": {
+          "name": "section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cues": {
+          "name": "cues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "set_targets": {
+          "name": "set_targets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "programming_notes": {
+          "name": "programming_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "template_exercises_template_id_idx": {
+          "name": "template_exercises_template_id_idx",
+          "columns": ["template_id"],
+          "isUnique": false
+        },
+        "template_exercises_exercise_id_idx": {
+          "name": "template_exercises_exercise_id_idx",
+          "columns": ["exercise_id"],
+          "isUnique": false
+        },
+        "template_exercises_template_section_order_unique": {
+          "name": "template_exercises_template_section_order_unique",
+          "columns": ["template_id", "section", "order_index"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "template_exercises_template_id_workout_templates_id_fk": {
+          "name": "template_exercises_template_id_workout_templates_id_fk",
+          "tableFrom": "template_exercises",
+          "tableTo": "workout_templates",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "template_exercises_exercise_id_exercises_id_fk": {
+          "name": "template_exercises_exercise_id_exercises_id_fk",
+          "tableFrom": "template_exercises",
+          "tableTo": "exercises",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "template_exercises_section_check": {
+          "name": "template_exercises_section_check",
+          "value": "\"template_exercises\".\"section\" in ('warmup', 'main', 'cooldown', 'supplemental')"
+        },
+        "template_exercises_reps_range_check": {
+          "name": "template_exercises_reps_range_check",
+          "value": "\"template_exercises\".\"reps_min\" is null or \"template_exercises\".\"reps_max\" is null or \"template_exercises\".\"reps_min\" <= \"template_exercises\".\"reps_max\""
+        }
+      }
+    },
+    "workout_templates": {
+      "name": "workout_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "workout_templates_user_id_idx": {
+          "name": "workout_templates_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workout_templates_user_id_users_id_fk": {
+          "name": "workout_templates_user_id_users_id_fk",
+          "tableFrom": "workout_templates",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_sets": {
+      "name": "session_sets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "set_number": {
+          "name": "set_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reps": {
+          "name": "reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_weight": {
+          "name": "target_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_weight_min": {
+          "name": "target_weight_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_weight_max": {
+          "name": "target_weight_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_seconds": {
+          "name": "target_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_distance": {
+          "name": "target_distance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "superset_group": {
+          "name": "superset_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "section": {
+          "name": "section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'main'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "session_sets_session_id_idx": {
+          "name": "session_sets_session_id_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        },
+        "session_sets_session_exercise_section_set_number_unique": {
+          "name": "session_sets_session_exercise_section_set_number_unique",
+          "columns": ["session_id", "exercise_id", "section", "set_number"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_sets_session_id_workout_sessions_id_fk": {
+          "name": "session_sets_session_id_workout_sessions_id_fk",
+          "tableFrom": "session_sets",
+          "tableTo": "workout_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_sets_exercise_id_exercises_id_fk": {
+          "name": "session_sets_exercise_id_exercises_id_fk",
+          "tableFrom": "session_sets",
+          "tableTo": "exercises",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "session_sets_set_number_check": {
+          "name": "session_sets_set_number_check",
+          "value": "\"session_sets\".\"set_number\" > 0"
+        },
+        "session_sets_section_check": {
+          "name": "session_sets_section_check",
+          "value": "\"session_sets\".\"section\" in ('warmup', 'main', 'cooldown', 'supplemental')"
+        },
+        "session_sets_completion_state_check": {
+          "name": "session_sets_completion_state_check",
+          "value": "not (\"session_sets\".\"completed\" and \"session_sets\".\"skipped\")"
+        }
+      }
+    },
+    "workout_sessions": {
+      "name": "workout_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_workout_id": {
+          "name": "scheduled_workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in-progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_segments": {
+          "name": "time_segments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exercise_programming_notes": {
+          "name": "exercise_programming_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exercise_agent_notes": {
+          "name": "exercise_agent_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exercise_agent_notes_meta": {
+          "name": "exercise_agent_notes_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "workout_sessions_user_id_idx": {
+          "name": "workout_sessions_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "workout_sessions_date_idx": {
+          "name": "workout_sessions_date_idx",
+          "columns": ["date"],
+          "isUnique": false
+        },
+        "workout_sessions_scheduled_workout_id_idx": {
+          "name": "workout_sessions_scheduled_workout_id_idx",
+          "columns": ["scheduled_workout_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workout_sessions_user_id_users_id_fk": {
+          "name": "workout_sessions_user_id_users_id_fk",
+          "tableFrom": "workout_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workout_sessions_template_id_workout_templates_id_fk": {
+          "name": "workout_sessions_template_id_workout_templates_id_fk",
+          "tableFrom": "workout_sessions",
+          "tableTo": "workout_templates",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workout_sessions_scheduled_workout_id_scheduled_workouts_id_fk": {
+          "name": "workout_sessions_scheduled_workout_id_scheduled_workouts_id_fk",
+          "tableFrom": "workout_sessions",
+          "tableTo": "scheduled_workouts",
+          "columnsFrom": ["scheduled_workout_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "workout_sessions_date_format_check": {
+          "name": "workout_sessions_date_format_check",
+          "value": "\"workout_sessions\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        },
+        "workout_sessions_status_check": {
+          "name": "workout_sessions_status_check",
+          "value": "\"workout_sessions\".\"status\" in ('scheduled', 'in-progress', 'paused', 'cancelled', 'completed')"
+        },
+        "workout_sessions_completed_at_check": {
+          "name": "workout_sessions_completed_at_check",
+          "value": "(\"workout_sessions\".\"status\" != 'completed' or \"workout_sessions\".\"completed_at\" is not null) and (\"workout_sessions\".\"completed_at\" is null or \"workout_sessions\".\"completed_at\" >= \"workout_sessions\".\"started_at\")"
+        }
+      }
+    },
+    "scheduled_workouts": {
+      "name": "scheduled_workouts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_version": {
+          "name": "template_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "scheduled_workouts_user_date_idx": {
+          "name": "scheduled_workouts_user_date_idx",
+          "columns": ["user_id", "date"],
+          "isUnique": false
+        },
+        "scheduled_workouts_template_id_idx": {
+          "name": "scheduled_workouts_template_id_idx",
+          "columns": ["template_id"],
+          "isUnique": false
+        },
+        "scheduled_workouts_session_id_idx": {
+          "name": "scheduled_workouts_session_id_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_workouts_user_id_users_id_fk": {
+          "name": "scheduled_workouts_user_id_users_id_fk",
+          "tableFrom": "scheduled_workouts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_workouts_template_id_workout_templates_id_fk": {
+          "name": "scheduled_workouts_template_id_workout_templates_id_fk",
+          "tableFrom": "scheduled_workouts",
+          "tableTo": "workout_templates",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scheduled_workouts_session_id_workout_sessions_id_fk": {
+          "name": "scheduled_workouts_session_id_workout_sessions_id_fk",
+          "tableFrom": "scheduled_workouts",
+          "tableTo": "workout_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_workouts_date_format_check": {
+          "name": "scheduled_workouts_date_format_check",
+          "value": "\"scheduled_workouts\".\"date\" glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'"
+        }
+      }
+    },
+    "scheduled_workout_exercises": {
+      "name": "scheduled_workout_exercises",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_workout_id": {
+          "name": "scheduled_workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "section": {
+          "name": "section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "programming_notes": {
+          "name": "programming_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_notes": {
+          "name": "agent_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_notes_meta": {
+          "name": "agent_notes_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_cues": {
+          "name": "template_cues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "superset_group": {
+          "name": "superset_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tempo": {
+          "name": "tempo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rest_seconds": {
+          "name": "rest_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "scheduled_workout_exercises_scheduled_workout_id_idx": {
+          "name": "scheduled_workout_exercises_scheduled_workout_id_idx",
+          "columns": ["scheduled_workout_id"],
+          "isUnique": false
+        },
+        "scheduled_workout_exercises_exercise_id_idx": {
+          "name": "scheduled_workout_exercises_exercise_id_idx",
+          "columns": ["exercise_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_workout_exercises_scheduled_workout_id_scheduled_workouts_id_fk": {
+          "name": "scheduled_workout_exercises_scheduled_workout_id_scheduled_workouts_id_fk",
+          "tableFrom": "scheduled_workout_exercises",
+          "tableTo": "scheduled_workouts",
+          "columnsFrom": ["scheduled_workout_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_workout_exercises_exercise_id_exercises_id_fk": {
+          "name": "scheduled_workout_exercises_exercise_id_exercises_id_fk",
+          "tableFrom": "scheduled_workout_exercises",
+          "tableTo": "exercises",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_workout_exercises_section_check": {
+          "name": "scheduled_workout_exercises_section_check",
+          "value": "\"scheduled_workout_exercises\".\"section\" in ('warmup', 'main', 'cooldown', 'supplemental')"
+        }
+      }
+    },
+    "scheduled_workout_exercise_sets": {
+      "name": "scheduled_workout_exercise_sets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_workout_exercise_id": {
+          "name": "scheduled_workout_exercise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "set_number": {
+          "name": "set_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reps_min": {
+          "name": "reps_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reps_max": {
+          "name": "reps_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reps": {
+          "name": "reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_weight": {
+          "name": "target_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_weight_min": {
+          "name": "target_weight_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_weight_max": {
+          "name": "target_weight_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_seconds": {
+          "name": "target_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_distance": {
+          "name": "target_distance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "scheduled_workout_exercise_sets_exercise_id_idx": {
+          "name": "scheduled_workout_exercise_sets_exercise_id_idx",
+          "columns": ["scheduled_workout_exercise_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_workout_exercise_sets_scheduled_workout_exercise_id_scheduled_workout_exercises_id_fk": {
+          "name": "scheduled_workout_exercise_sets_scheduled_workout_exercise_id_scheduled_workout_exercises_id_fk",
+          "tableFrom": "scheduled_workout_exercise_sets",
+          "tableTo": "scheduled_workout_exercises",
+          "columnsFrom": ["scheduled_workout_exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_workout_exercise_sets_set_number_check": {
+          "name": "scheduled_workout_exercise_sets_set_number_check",
+          "value": "\"scheduled_workout_exercise_sets\".\"set_number\" > 0"
+        },
+        "scheduled_workout_exercise_sets_reps_range_check": {
+          "name": "scheduled_workout_exercise_sets_reps_range_check",
+          "value": "\"scheduled_workout_exercise_sets\".\"reps_min\" is null or \"scheduled_workout_exercise_sets\".\"reps_max\" is null or \"scheduled_workout_exercise_sets\".\"reps_min\" <= \"scheduled_workout_exercise_sets\".\"reps_max\""
+        },
+        "scheduled_workout_exercise_sets_target_weight_range_check": {
+          "name": "scheduled_workout_exercise_sets_target_weight_range_check",
+          "value": "\"scheduled_workout_exercise_sets\".\"target_weight_min\" is null or \"scheduled_workout_exercise_sets\".\"target_weight_max\" is null or \"scheduled_workout_exercise_sets\".\"target_weight_min\" <= \"scheduled_workout_exercise_sets\".\"target_weight_max\""
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1776708492985,
       "tag": "0036_bitter_fat_cobra",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "6",
+      "when": 1776718040472,
+      "tag": "0037_vengeful_tigra",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.test.json",
     "db:migrate": "NODE_OPTIONS='--require tsx/cjs' drizzle-kit generate && drizzle-kit migrate",
+    "db:backfill:scheduled-workout-snapshots": "tsx src/db/backfill/run-scheduled-workout-snapshot-backfill.ts",
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {

--- a/apps/api/src/__tests__/habits-weight-targets.test.ts
+++ b/apps/api/src/__tests__/habits-weight-targets.test.ts
@@ -576,7 +576,7 @@ describe('weight and nutrition target integration', () => {
     } finally {
       await app.close();
     }
-  }, 10_000);
+  }, 20_000);
 
   it('filters weight entries by days lookback', async () => {
     const { app } = await createTestApp();

--- a/apps/api/src/db/backfill/run-scheduled-workout-snapshot-backfill.ts
+++ b/apps/api/src/db/backfill/run-scheduled-workout-snapshot-backfill.ts
@@ -1,0 +1,12 @@
+import { backfillScheduledWorkoutSnapshots } from './scheduled-workout-snapshots.js';
+import { db, sqlite } from '../index.js';
+
+const run = async () => {
+  try {
+    await backfillScheduledWorkoutSnapshots({ database: db });
+  } finally {
+    sqlite.close();
+  }
+};
+
+void run();

--- a/apps/api/src/db/backfill/scheduled-workout-snapshots.test.ts
+++ b/apps/api/src/db/backfill/scheduled-workout-snapshots.test.ts
@@ -1,0 +1,177 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Database from 'better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import * as schema from '../schema/index.js';
+import {
+  exercises,
+  scheduledWorkoutExerciseSets,
+  scheduledWorkoutExercises,
+  scheduledWorkouts,
+  templateExercises,
+  users,
+  workoutTemplates,
+} from '../schema/index.js';
+
+import { backfillScheduledWorkoutSnapshots } from './scheduled-workout-snapshots.js';
+
+type TestDatabase = ReturnType<typeof drizzle<typeof schema>>;
+
+const tempDirs: string[] = [];
+
+const createTestDatabase = () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'pulse-snapshot-backfill-'));
+  tempDirs.push(tempDir);
+  const dbPath = join(tempDir, 'test.db');
+  const sqlite = new Database(dbPath);
+  sqlite.pragma('foreign_keys = ON');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, {
+    migrationsFolder: fileURLToPath(new URL('../../../drizzle', import.meta.url)),
+  });
+
+  return { db, sqlite, tempDir };
+};
+
+const seedTemplate = (db: TestDatabase, values: { id: string; deletedAt?: string | null }) =>
+  db
+    .insert(workoutTemplates)
+    .values({
+      id: values.id,
+      userId: 'user-1',
+      name: values.id,
+      description: null,
+      tags: [],
+      deletedAt: values.deletedAt ?? null,
+    })
+    .run();
+
+describe('scheduled workout snapshot backfill', () => {
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('backfills snapshots for live templates and skips soft-deleted templates with warnings', async () => {
+    const { db, sqlite } = createTestDatabase();
+    try {
+      db.insert(users)
+        .values({
+          id: 'user-1',
+          username: 'derek',
+          name: 'Derek',
+          passwordHash: 'hash',
+        })
+        .run();
+
+      db.insert(exercises)
+        .values({
+          id: 'exercise-1',
+          userId: null,
+          name: 'Back Squat',
+          muscleGroups: ['quads'],
+          equipment: 'barbell',
+          category: 'compound',
+          trackingType: 'weight_reps',
+        })
+        .run();
+
+      seedTemplate(db, { id: 'template-live' });
+      seedTemplate(db, { id: 'template-deleted', deletedAt: '2026-04-20T10:00:00.000Z' });
+
+      db.insert(templateExercises)
+        .values({
+          id: 'template-live-exercise',
+          templateId: 'template-live',
+          exerciseId: 'exercise-1',
+          section: 'main',
+          orderIndex: 0,
+          sets: 3,
+          repsMin: 5,
+          repsMax: 5,
+          notes: 'Use belt from set two.',
+        })
+        .run();
+
+      db.insert(scheduledWorkouts)
+        .values([
+          {
+            id: 'scheduled-live',
+            userId: 'user-1',
+            templateId: 'template-live',
+            date: '2026-04-21',
+          },
+          {
+            id: 'scheduled-deleted-template',
+            userId: 'user-1',
+            templateId: 'template-deleted',
+            date: '2026-04-22',
+          },
+        ])
+        .run();
+
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+      };
+
+      const summary = await backfillScheduledWorkoutSnapshots({
+        database: db,
+        logger,
+      });
+
+      expect(summary).toEqual({
+        processed: 1,
+        skipped: 1,
+        snapshotRowsWritten: 1,
+        setRowsWritten: 3,
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('scheduled-deleted-template'),
+      );
+
+      const snapshotExerciseRows = db
+        .select({
+          id: scheduledWorkoutExercises.id,
+          scheduledWorkoutId: scheduledWorkoutExercises.scheduledWorkoutId,
+        })
+        .from(scheduledWorkoutExercises)
+        .all();
+
+      expect(snapshotExerciseRows).toEqual([
+        {
+          id: expect.any(String),
+          scheduledWorkoutId: 'scheduled-live',
+        },
+      ]);
+
+      const scheduledLiveRow = db
+        .select({ templateVersion: scheduledWorkouts.templateVersion })
+        .from(scheduledWorkouts)
+        .where(eq(scheduledWorkouts.id, 'scheduled-live'))
+        .limit(1)
+        .get();
+
+      expect(scheduledLiveRow?.templateVersion).toMatch(/^[0-9a-f]{64}$/);
+
+      const setRows = db
+        .select({ id: scheduledWorkoutExerciseSets.id })
+        .from(scheduledWorkoutExerciseSets)
+        .all();
+      expect(setRows).toHaveLength(3);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/src/db/backfill/scheduled-workout-snapshots.ts
+++ b/apps/api/src/db/backfill/scheduled-workout-snapshots.ts
@@ -1,0 +1,85 @@
+import { eq, isNotNull } from 'drizzle-orm';
+
+import { scheduledWorkouts, workoutTemplates } from '../schema/index.js';
+import { writeSnapshot } from '../../routes/scheduled-workouts/snapshot-store.js';
+
+type PulseDb = typeof import('../index.js').db;
+
+type BackfillLogger = {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+};
+
+export type ScheduledWorkoutSnapshotBackfillSummary = {
+  processed: number;
+  skipped: number;
+  snapshotRowsWritten: number;
+  setRowsWritten: number;
+};
+
+const defaultLogger: BackfillLogger = {
+  info: (message) => console.info(message),
+  warn: (message) => console.warn(message),
+};
+
+export const backfillScheduledWorkoutSnapshots = async ({
+  database,
+  logger = defaultLogger,
+}: {
+  database: PulseDb;
+  logger?: BackfillLogger;
+}): Promise<ScheduledWorkoutSnapshotBackfillSummary> => {
+  const scheduledWorkoutRows = database
+    .select({
+      scheduledWorkoutId: scheduledWorkouts.id,
+      templateId: scheduledWorkouts.templateId,
+      resolvedTemplateId: workoutTemplates.id,
+      templateDeletedAt: workoutTemplates.deletedAt,
+    })
+    .from(scheduledWorkouts)
+    .leftJoin(workoutTemplates, eq(workoutTemplates.id, scheduledWorkouts.templateId))
+    .where(isNotNull(scheduledWorkouts.templateId))
+    .all();
+
+  let processed = 0;
+  let skipped = 0;
+  let snapshotRowsWritten = 0;
+  let setRowsWritten = 0;
+
+  for (const row of scheduledWorkoutRows) {
+    const templateId = row.templateId;
+    if (!templateId) {
+      skipped += 1;
+      continue;
+    }
+
+    if (!row.resolvedTemplateId || row.templateDeletedAt !== null) {
+      logger.warn(
+        `Skipping scheduled workout ${row.scheduledWorkoutId}: template ${templateId} is missing or soft-deleted`,
+      );
+      skipped += 1;
+      continue;
+    }
+
+    const snapshotResult = await writeSnapshot({
+      scheduledWorkoutId: row.scheduledWorkoutId,
+      templateId,
+      database,
+    });
+
+    processed += 1;
+    snapshotRowsWritten += snapshotResult.exerciseCount;
+    setRowsWritten += snapshotResult.setCount;
+  }
+
+  logger.info(
+    `Scheduled workout snapshot backfill complete: processed=${processed}, skipped=${skipped}, exercises=${snapshotRowsWritten}, sets=${setRowsWritten}`,
+  );
+
+  return {
+    processed,
+    skipped,
+    snapshotRowsWritten,
+    setRowsWritten,
+  };
+};

--- a/apps/api/src/db/migrations.test.ts
+++ b/apps/api/src/db/migrations.test.ts
@@ -564,16 +564,31 @@ describe('migration 0025_meal_summary', () => {
         `,
       );
 
-      insertMealItem.run('item-1', 'meal-1', null, 'Orgain shake', 1, 'serving', 150, 30, 7, 4, now);
+      insertMealItem.run(
+        'item-1',
+        'meal-1',
+        null,
+        'Orgain shake',
+        1,
+        'serving',
+        150,
+        30,
+        7,
+        4,
+        now,
+      );
       insertMealItem.run('item-2', 'meal-1', null, 'milk', 1, 'cup', 120, 8, 12, 5, now + 1);
       insertMealItem.run('item-3', 'meal-1', null, 'creamer', 1, 'tbsp', 35, 0, 5, 1.5, now + 2);
 
-      const migrationSql = readFileSync(join(process.cwd(), 'drizzle/0025_meal_summary.sql'), 'utf8');
+      const migrationSql = readFileSync(
+        join(process.cwd(), 'drizzle/0025_meal_summary.sql'),
+        'utf8',
+      );
       runSqlStatements(db, migrationSql);
 
-      const migrated = db
-        .prepare(`SELECT summary FROM meals WHERE id = ?`)
-        .get('meal-1') as { summary: string | null };
+      const migrated = db.prepare(`SELECT summary FROM meals WHERE id = ?`).get('meal-1') as {
+        summary: string | null;
+      };
 
       expect(migrated.summary).toBe('Orgain shake, milk, creamer');
     } finally {
@@ -653,14 +668,29 @@ describe('migration 0025_meal_summary', () => {
       );
 
       insertMealItem.run('item-1', 'meal-1', null, longFoodName, 1, 'serving', 150, 30, 7, 4, now);
-      insertMealItem.run('item-2', 'meal-1', null, longFoodName, 1, 'serving', 150, 30, 7, 4, now + 1);
+      insertMealItem.run(
+        'item-2',
+        'meal-1',
+        null,
+        longFoodName,
+        1,
+        'serving',
+        150,
+        30,
+        7,
+        4,
+        now + 1,
+      );
 
-      const migrationSql = readFileSync(join(process.cwd(), 'drizzle/0025_meal_summary.sql'), 'utf8');
+      const migrationSql = readFileSync(
+        join(process.cwd(), 'drizzle/0025_meal_summary.sql'),
+        'utf8',
+      );
       runSqlStatements(db, migrationSql);
 
-      const migrated = db
-        .prepare(`SELECT summary FROM meals WHERE id = ?`)
-        .get('meal-1') as { summary: string | null };
+      const migrated = db.prepare(`SELECT summary FROM meals WHERE id = ?`).get('meal-1') as {
+        summary: string | null;
+      };
 
       expect(migrated.summary).toHaveLength(500);
       expect(migrated.summary).toBe(`${longFoodName}, ${longFoodName.slice(0, 247)}`);
@@ -1017,9 +1047,7 @@ describe('migration 0028_food_usage_and_tags', () => {
       expect(migratedRow.usageCount).toBe(0);
       expect(JSON.parse(migratedRow.tags)).toEqual([]);
 
-      const indexRows = db
-        .prepare(`PRAGMA index_list('foods')`)
-        .all() as Array<{ name: string }>;
+      const indexRows = db.prepare(`PRAGMA index_list('foods')`).all() as Array<{ name: string }>;
       expect(indexRows.some((indexRow) => indexRow.name === 'foods_user_usage_count_idx')).toBe(
         true,
       );
@@ -1090,5 +1118,24 @@ describe('migration 0029_agent_token_expiry', () => {
     } finally {
       db.close();
     }
+  });
+});
+
+describe('migration 0037 scheduled workout snapshot schema', () => {
+  it('creates snapshot tables and adds scheduled workout linkage columns', () => {
+    const migrationSql = readFileSync(
+      join(process.cwd(), 'drizzle/0037_vengeful_tigra.sql'),
+      'utf8',
+    );
+
+    expect(migrationSql).toContain('CREATE TABLE `scheduled_workout_exercises`');
+    expect(migrationSql).toContain('CREATE TABLE `scheduled_workout_exercise_sets`');
+    expect(migrationSql).toContain('ALTER TABLE `scheduled_workouts` ADD `template_version` text');
+    expect(migrationSql).toContain('`scheduled_workout_id` text');
+    expect(migrationSql).toContain('`exercise_agent_notes` text');
+    expect(migrationSql).toContain('`exercise_agent_notes_meta` text');
+    expect(migrationSql).toContain(
+      'FOREIGN KEY (`scheduled_workout_id`) REFERENCES `scheduled_workouts`(`id`) ON UPDATE no action ON DELETE set null',
+    );
   });
 });

--- a/apps/api/src/db/schema.test.ts
+++ b/apps/api/src/db/schema.test.ts
@@ -45,6 +45,8 @@ import {
   parseWorkoutSessionFeedback,
   parseWorkoutSessionTimeSegments,
   resources,
+  scheduledWorkoutExercises,
+  scheduledWorkoutExerciseSets,
   scheduledWorkouts,
   sessionSets,
   serializeJsonStringArray,
@@ -966,6 +968,7 @@ describe('workoutSessions schema', () => {
       'id',
       'userId',
       'templateId',
+      'scheduledWorkoutId',
       'name',
       'date',
       'status',
@@ -975,6 +978,8 @@ describe('workoutSessions schema', () => {
       'timeSegments',
       'feedback',
       'exerciseProgrammingNotes',
+      'exerciseAgentNotes',
+      'exerciseAgentNotesMeta',
       'notes',
       'deletedAt',
       'createdAt',
@@ -993,10 +998,10 @@ describe('workoutSessions schema', () => {
     expect(columns.updatedAt.onUpdateFn).toBeTypeOf('function');
 
     const config = getTableConfig(workoutSessions);
-    expect(config.foreignKeys).toHaveLength(2);
+    expect(config.foreignKeys).toHaveLength(3);
     expect(
       config.foreignKeys.map((fk) => getTableName(fk.reference().foreignTable)).sort(),
-    ).toEqual(['users', 'workout_templates']);
+    ).toEqual(['scheduled_workouts', 'users', 'workout_templates']);
     expect(
       config.foreignKeys.find(
         (fk) => getTableName(fk.reference().foreignTable) === 'workout_templates',
@@ -1006,8 +1011,14 @@ describe('workoutSessions schema', () => {
       config.foreignKeys.find((fk) => getTableName(fk.reference().foreignTable) === 'users')
         ?.onDelete,
     ).toBe('cascade');
+    expect(
+      config.foreignKeys.find(
+        (fk) => getTableName(fk.reference().foreignTable) === 'scheduled_workouts',
+      )?.onDelete,
+    ).toBe('set null');
     expect(config.indexes.map((idx) => idx.config.name).sort()).toEqual([
       'workout_sessions_date_idx',
+      'workout_sessions_scheduled_workout_id_idx',
       'workout_sessions_user_id_idx',
     ]);
     expect(config.checks.map((constraint) => constraint.name).sort()).toEqual([
@@ -1136,6 +1147,7 @@ describe('scheduledWorkouts schema', () => {
       'id',
       'userId',
       'templateId',
+      'templateVersion',
       'date',
       'sessionId',
       'createdAt',
@@ -1173,6 +1185,89 @@ describe('scheduledWorkouts schema', () => {
     ]);
     expect(config.checks.map((constraint) => constraint.name)).toEqual([
       'scheduled_workouts_date_format_check',
+    ]);
+  });
+});
+
+describe('scheduledWorkoutExercises schema', () => {
+  it('defines snapshot exercise columns, constraints, and foreign keys', () => {
+    expect(getTableName(scheduledWorkoutExercises)).toBe('scheduled_workout_exercises');
+
+    const columns = getTableColumns(scheduledWorkoutExercises);
+    expect(Object.keys(columns)).toEqual([
+      'id',
+      'scheduledWorkoutId',
+      'exerciseId',
+      'section',
+      'orderIndex',
+      'programmingNotes',
+      'agentNotes',
+      'agentNotesMeta',
+      'templateCues',
+      'supersetGroup',
+      'tempo',
+      'restSeconds',
+      'createdAt',
+      'updatedAt',
+    ]);
+
+    const config = getTableConfig(scheduledWorkoutExercises);
+    expect(config.foreignKeys).toHaveLength(2);
+    expect(
+      config.foreignKeys.map((fk) => getTableName(fk.reference().foreignTable)).sort(),
+    ).toEqual(['exercises', 'scheduled_workouts']);
+    expect(
+      config.foreignKeys.find(
+        (fk) => getTableName(fk.reference().foreignTable) === 'scheduled_workouts',
+      )?.onDelete,
+    ).toBe('cascade');
+    expect(
+      config.foreignKeys.find((fk) => getTableName(fk.reference().foreignTable) === 'exercises')
+        ?.onDelete,
+    ).toBe('restrict');
+    expect(config.indexes.map((idx) => idx.config.name).sort()).toEqual([
+      'scheduled_workout_exercises_exercise_id_idx',
+      'scheduled_workout_exercises_scheduled_workout_id_idx',
+    ]);
+    expect(config.checks.map((constraint) => constraint.name)).toEqual([
+      'scheduled_workout_exercises_section_check',
+    ]);
+  });
+});
+
+describe('scheduledWorkoutExerciseSets schema', () => {
+  it('defines snapshot set columns, guardrails, and exercise foreign key', () => {
+    expect(getTableName(scheduledWorkoutExerciseSets)).toBe('scheduled_workout_exercise_sets');
+
+    const columns = getTableColumns(scheduledWorkoutExerciseSets);
+    expect(Object.keys(columns)).toEqual([
+      'id',
+      'scheduledWorkoutExerciseId',
+      'setNumber',
+      'repsMin',
+      'repsMax',
+      'reps',
+      'targetWeight',
+      'targetWeightMin',
+      'targetWeightMax',
+      'targetSeconds',
+      'targetDistance',
+      'createdAt',
+    ]);
+
+    const config = getTableConfig(scheduledWorkoutExerciseSets);
+    expect(config.foreignKeys).toHaveLength(1);
+    expect(getTableName(config.foreignKeys[0].reference().foreignTable)).toBe(
+      'scheduled_workout_exercises',
+    );
+    expect(config.foreignKeys[0]?.onDelete).toBe('cascade');
+    expect(config.indexes.map((idx) => idx.config.name)).toEqual([
+      'scheduled_workout_exercise_sets_exercise_id_idx',
+    ]);
+    expect(config.checks.map((constraint) => constraint.name).sort()).toEqual([
+      'scheduled_workout_exercise_sets_reps_range_check',
+      'scheduled_workout_exercise_sets_set_number_check',
+      'scheduled_workout_exercise_sets_target_weight_range_check',
     ]);
   });
 });

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -18,5 +18,7 @@ export * from './workout-session-time-segments.js';
 export * from './workout-templates.js';
 export * from './workout-sessions.js';
 export * from './scheduled-workouts.js';
+export * from './scheduled-workout-exercises.js';
+export * from './scheduled-workout-exercise-sets.js';
 export * from './habits.js';
 export * from './agent-tokens.js';

--- a/apps/api/src/db/schema/scheduled-workout-exercise-sets.ts
+++ b/apps/api/src/db/schema/scheduled-workout-exercise-sets.ts
@@ -1,0 +1,43 @@
+import { randomUUID } from 'node:crypto';
+
+import { sql } from 'drizzle-orm';
+import { check, index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+import { scheduledWorkoutExercises } from './scheduled-workout-exercises.js';
+
+export const scheduledWorkoutExerciseSets = sqliteTable(
+  'scheduled_workout_exercise_sets',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => randomUUID()),
+    scheduledWorkoutExerciseId: text('scheduled_workout_exercise_id')
+      .notNull()
+      .references(() => scheduledWorkoutExercises.id, { onDelete: 'cascade' }),
+    setNumber: integer('set_number').notNull(),
+    repsMin: integer('reps_min'),
+    repsMax: integer('reps_max'),
+    reps: integer('reps'),
+    targetWeight: real('target_weight'),
+    targetWeightMin: real('target_weight_min'),
+    targetWeightMax: real('target_weight_max'),
+    targetSeconds: integer('target_seconds'),
+    targetDistance: real('target_distance'),
+    createdAt: integer('created_at', { mode: 'number' })
+      .notNull()
+      .default(sql`(unixepoch() * 1000)`)
+      .$defaultFn(() => Date.now()),
+  },
+  (table) => [
+    index('scheduled_workout_exercise_sets_exercise_id_idx').on(table.scheduledWorkoutExerciseId),
+    check('scheduled_workout_exercise_sets_set_number_check', sql`${table.setNumber} > 0`),
+    check(
+      'scheduled_workout_exercise_sets_reps_range_check',
+      sql`${table.repsMin} is null or ${table.repsMax} is null or ${table.repsMin} <= ${table.repsMax}`,
+    ),
+    check(
+      'scheduled_workout_exercise_sets_target_weight_range_check',
+      sql`${table.targetWeightMin} is null or ${table.targetWeightMax} is null or ${table.targetWeightMin} <= ${table.targetWeightMax}`,
+    ),
+  ],
+);

--- a/apps/api/src/db/schema/scheduled-workout-exercises.ts
+++ b/apps/api/src/db/schema/scheduled-workout-exercises.ts
@@ -1,0 +1,58 @@
+import { randomUUID } from 'node:crypto';
+
+import { sql } from 'drizzle-orm';
+import { check, index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+import { exercises } from './exercises.js';
+import type { WorkoutTemplateSectionType } from './workout-templates.js';
+import { scheduledWorkouts } from './scheduled-workouts.js';
+
+export type ScheduledWorkoutExerciseAgentNotesMeta = {
+  author: string;
+  generatedAt: string;
+  scheduledDateAtGeneration: string;
+  stale?: boolean;
+};
+
+export const scheduledWorkoutExercises = sqliteTable(
+  'scheduled_workout_exercises',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => randomUUID()),
+    scheduledWorkoutId: text('scheduled_workout_id')
+      .notNull()
+      .references(() => scheduledWorkouts.id, { onDelete: 'cascade' }),
+    exerciseId: text('exercise_id')
+      .notNull()
+      .references(() => exercises.id, { onDelete: 'restrict' }),
+    section: text('section').$type<WorkoutTemplateSectionType>().notNull(),
+    orderIndex: integer('order_index').notNull(),
+    programmingNotes: text('programming_notes'),
+    agentNotes: text('agent_notes'),
+    agentNotesMeta: text('agent_notes_meta', {
+      mode: 'json',
+    }).$type<ScheduledWorkoutExerciseAgentNotesMeta | null>(),
+    templateCues: text('template_cues', { mode: 'json' }).$type<string[] | null>(),
+    supersetGroup: text('superset_group'),
+    tempo: text('tempo'),
+    restSeconds: integer('rest_seconds'),
+    createdAt: integer('created_at', { mode: 'number' })
+      .notNull()
+      .default(sql`(unixepoch() * 1000)`)
+      .$defaultFn(() => Date.now()),
+    updatedAt: integer('updated_at', { mode: 'number' })
+      .notNull()
+      .default(sql`(unixepoch() * 1000)`)
+      .$defaultFn(() => Date.now())
+      .$onUpdateFn(() => Date.now()),
+  },
+  (table) => [
+    index('scheduled_workout_exercises_scheduled_workout_id_idx').on(table.scheduledWorkoutId),
+    index('scheduled_workout_exercises_exercise_id_idx').on(table.exerciseId),
+    check(
+      'scheduled_workout_exercises_section_check',
+      sql`${table.section} in ('warmup', 'main', 'cooldown', 'supplemental')`,
+    ),
+  ],
+);

--- a/apps/api/src/db/schema/scheduled-workouts.ts
+++ b/apps/api/src/db/schema/scheduled-workouts.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import { sql } from 'drizzle-orm';
 import {
+  type AnySQLiteColumn,
   check,
   index,
   integer,
@@ -16,14 +17,16 @@ import { users } from './users.js';
 export const scheduledWorkouts = sqliteTable(
   'scheduled_workouts',
   {
-    id: text('id').primaryKey().$defaultFn(() => randomUUID()),
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => randomUUID()),
     userId: text('user_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
-    templateId: text('template_id')
-      .references(() => workoutTemplates.id, { onDelete: 'set null' }),
+    templateId: text('template_id').references(() => workoutTemplates.id, { onDelete: 'set null' }),
+    templateVersion: text('template_version'),
     date: text('date').notNull(),
-    sessionId: text('session_id').references(() => workoutSessions.id, {
+    sessionId: text('session_id').references((): AnySQLiteColumn => workoutSessions.id, {
       onDelete: 'set null',
     }),
     createdAt: integer('created_at', { mode: 'number' })

--- a/apps/api/src/db/schema/workout-sessions.ts
+++ b/apps/api/src/db/schema/workout-sessions.ts
@@ -1,9 +1,19 @@
 import { randomUUID } from 'node:crypto';
 
 import { sql } from 'drizzle-orm';
-import { check, index, integer, real, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
+import {
+  type AnySQLiteColumn,
+  check,
+  index,
+  integer,
+  real,
+  sqliteTable,
+  text,
+  unique,
+} from 'drizzle-orm/sqlite-core';
 
 import { exercises } from './exercises.js';
+import { scheduledWorkouts } from './scheduled-workouts.js';
 import type { WorkoutTemplateSectionType } from './workout-templates.js';
 import { workoutTemplates } from './workout-templates.js';
 import { users } from './users.js';
@@ -65,6 +75,13 @@ export type WorkoutSessionFeedback = {
   >;
 };
 
+export type WorkoutSessionExerciseAgentNotesMeta = {
+  author: string;
+  generatedAt: string;
+  scheduledDateAtGeneration: string;
+  stale?: boolean;
+};
+
 export const workoutSessions = sqliteTable(
   'workout_sessions',
   {
@@ -77,6 +94,12 @@ export const workoutSessions = sqliteTable(
     templateId: text('template_id').references(() => workoutTemplates.id, {
       onDelete: 'set null',
     }),
+    scheduledWorkoutId: text('scheduled_workout_id').references(
+      (): AnySQLiteColumn => scheduledWorkouts.id,
+      {
+        onDelete: 'set null',
+      },
+    ),
     name: text('name').notNull(),
     date: text('date').notNull(),
     status: text('status').$type<WorkoutSessionStatus>().notNull().default('in-progress'),
@@ -89,6 +112,16 @@ export const workoutSessions = sqliteTable(
     feedback: text('feedback'),
     // JSON-encoded Record<`${section}::${exerciseId}`, string | null>; snapshots template notes at session start.
     exerciseProgrammingNotes: text('exercise_programming_notes'),
+    // JSON-encoded Record<`${section}::${exerciseId}`, string | null>; snapshots agent notes at session start.
+    exerciseAgentNotes: text('exercise_agent_notes', { mode: 'json' }).$type<Record<
+      string,
+      string | null
+    > | null>(),
+    // JSON-encoded Record<`${section}::${exerciseId}`, WorkoutSessionExerciseAgentNotesMeta | null>.
+    exerciseAgentNotesMeta: text('exercise_agent_notes_meta', { mode: 'json' }).$type<Record<
+      string,
+      WorkoutSessionExerciseAgentNotesMeta | null
+    > | null>(),
     notes: text('notes'),
     deletedAt: text('deleted_at'),
     createdAt: integer('created_at', { mode: 'number' })
@@ -104,6 +137,7 @@ export const workoutSessions = sqliteTable(
   (table) => [
     index('workout_sessions_user_id_idx').on(table.userId),
     index('workout_sessions_date_idx').on(table.date),
+    index('workout_sessions_scheduled_workout_id_idx').on(table.scheduledWorkoutId),
     check(
       'workout_sessions_date_format_check',
       sql`${table.date} glob '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'`,

--- a/apps/api/src/routes/scheduled-workouts/index.test.ts
+++ b/apps/api/src/routes/scheduled-workouts/index.test.ts
@@ -1164,6 +1164,103 @@ describe('scheduled workout routes', () => {
     expect(swappedRows).toEqual([{ exerciseId: 'exercise-swap-target' }]);
   });
 
+  it('clears exercise agent notes metadata when swapping exercises', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedExercise({
+      id: 'exercise-swap-notes-source',
+      userId: 'user-1',
+      name: 'Barbell Bench Press',
+      trackingType: 'weight_reps',
+    });
+    seedExercise({
+      id: 'exercise-swap-notes-target',
+      userId: 'user-1',
+      name: 'Incline Dumbbell Press',
+      trackingType: 'weight_reps',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-swap-notes-source',
+      templateId: 'template-1',
+      exerciseId: 'exercise-swap-notes-source',
+      section: 'main',
+      orderIndex: 0,
+      programmingNotes: 'Touch and go.',
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        date: '2026-03-12',
+      },
+    });
+    expect(createResponse.statusCode).toBe(201);
+    const scheduledWorkoutId = (createResponse.json() as { data: { id: string } }).data.id;
+
+    context.db
+      .update(scheduledWorkoutExercises)
+      .set({
+        agentNotes: 'Try 62 lb today.',
+        agentNotesMeta: {
+          author: 'Coach Pulse',
+          generatedAt: '2026-03-11T00:00:00.000Z',
+          scheduledDateAtGeneration: '2026-03-12',
+          stale: false,
+        },
+      })
+      .where(
+        eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId),
+      )
+      .run();
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-swap`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        fromExerciseId: 'exercise-swap-notes-source',
+        toExerciseId: 'exercise-swap-notes-target',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        id: scheduledWorkoutId,
+        exercises: [
+          expect.objectContaining({
+            exerciseId: 'exercise-swap-notes-target',
+            agentNotes: null,
+            agentNotesMeta: null,
+          }),
+        ],
+      }),
+    });
+
+    const swappedRows = context.db
+      .select({
+        exerciseId: scheduledWorkoutExercises.exerciseId,
+        agentNotes: scheduledWorkoutExercises.agentNotes,
+        agentNotesMeta: scheduledWorkoutExercises.agentNotesMeta,
+      })
+      .from(scheduledWorkoutExercises)
+      .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId))
+      .all();
+    expect(swappedRows).toEqual([
+      {
+        exerciseId: 'exercise-swap-notes-target',
+        agentNotes: null,
+        agentNotesMeta: null,
+      },
+    ]);
+  });
+
   it('swaps snapshot exercises for AgentToken callers and supports carry-over options', async () => {
     const authToken = context.app.jwt.sign(
       { sub: 'user-1', type: 'session', iss: 'pulse-api' },
@@ -1234,6 +1331,117 @@ describe('scheduled workout routes', () => {
           }),
         ],
       }),
+    });
+  });
+
+  it('removes snapshot exercises when swapped to null', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedExercise({
+      id: 'exercise-swap-remove-source',
+      userId: 'user-1',
+      name: 'Push-up',
+      trackingType: 'bodyweight_reps',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-swap-remove-source',
+      templateId: 'template-1',
+      exerciseId: 'exercise-swap-remove-source',
+      section: 'main',
+      orderIndex: 0,
+      sets: 3,
+      repsMin: 12,
+      repsMax: 12,
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        date: '2026-03-12',
+      },
+    });
+    expect(createResponse.statusCode).toBe(201);
+    const scheduledWorkoutId = (createResponse.json() as { data: { id: string } }).data.id;
+
+    const removeResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-swap`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        fromExerciseId: 'exercise-swap-remove-source',
+        toExerciseId: null,
+      },
+    });
+    expect(removeResponse.statusCode).toBe(200);
+
+    const detailResponse = await context.app.inject({
+      method: 'GET',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}`,
+      headers: createAuthorizationHeader(authToken),
+    });
+    expect(detailResponse.statusCode).toBe(200);
+    expect(detailResponse.json()).toEqual({
+      data: expect.objectContaining({
+        id: scheduledWorkoutId,
+        exercises: [],
+      }),
+    });
+  });
+
+  it('rejects identity exercise swaps', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedExercise({
+      id: 'exercise-swap-identity',
+      userId: 'user-1',
+      name: 'Back Squat',
+      trackingType: 'weight_reps',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-swap-identity',
+      templateId: 'template-1',
+      exerciseId: 'exercise-swap-identity',
+      section: 'main',
+      orderIndex: 0,
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        date: '2026-03-12',
+      },
+    });
+    expect(createResponse.statusCode).toBe(201);
+    const scheduledWorkoutId = (createResponse.json() as { data: { id: string } }).data.id;
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-swap`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        fromExerciseId: 'exercise-swap-identity',
+        toExerciseId: 'exercise-swap-identity',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'INVALID_SCHEDULED_WORKOUT_EXERCISE',
+        message: 'Exercise is not available for this user',
+      },
     });
   });
 

--- a/apps/api/src/routes/scheduled-workouts/index.test.ts
+++ b/apps/api/src/routes/scheduled-workouts/index.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -9,6 +10,7 @@ import type { FastifyInstance } from 'fastify';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  agentTokens,
   exercises,
   scheduledWorkoutExerciseSets,
   scheduledWorkoutExercises,
@@ -32,6 +34,10 @@ let context: TestContext;
 
 const createAuthorizationHeader = (token: string) => ({
   authorization: `Bearer ${token}`,
+});
+
+const createAgentTokenHeader = (token: string) => ({
+  authorization: `AgentToken ${token}`,
 });
 
 const expectRequestValidationError = (
@@ -61,6 +67,24 @@ const seedUser = (id: string, username: string) =>
       passwordHash: 'not-used-in-this-suite',
     })
     .run();
+
+const seedAgentToken = (
+  userId: string,
+  token = `plain-agent-token-${userId}`,
+  name = `Agent ${userId}`,
+) => {
+  context.db
+    .insert(agentTokens)
+    .values({
+      id: `agent-token-${userId}`,
+      userId,
+      name,
+      tokenHash: createHash('sha256').update(token).digest('hex'),
+    })
+    .run();
+
+  return token;
+};
 
 const seedTemplate = (values: {
   id: string;
@@ -240,6 +264,7 @@ describe('scheduled workout routes', () => {
   });
 
   beforeEach(() => {
+    context.db.delete(agentTokens).run();
     context.db.delete(scheduledWorkouts).run();
     context.db.delete(templateExercises).run();
     context.db.delete(exercises).run();
@@ -761,6 +786,629 @@ describe('scheduled workout routes', () => {
         templateDeleted: true,
         template: null,
       }),
+    });
+  });
+
+  it('updates scheduled workout exercise notes with AgentToken auth and server-written metadata', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    const agentToken = seedAgentToken('user-1', 'scheduled-notes-agent', 'Coach Pulse');
+
+    seedExercise({
+      id: 'exercise-notes-source',
+      userId: 'user-1',
+      name: 'Kettlebell Swing',
+      trackingType: 'weight_reps',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-notes-source',
+      templateId: 'template-1',
+      exerciseId: 'exercise-notes-source',
+      section: 'main',
+      orderIndex: 0,
+      sets: 3,
+      repsMin: 12,
+      repsMax: 12,
+      programmingNotes: 'Keep the hinge explosive.',
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        date: '2026-03-12',
+      },
+    });
+    expect(createResponse.statusCode).toBe(201);
+    const scheduledWorkoutId = (createResponse.json() as { data: { id: string } }).data.id;
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-notes`,
+      headers: createAgentTokenHeader(agentToken),
+      payload: {
+        notes: [
+          {
+            exerciseId: 'exercise-notes-source',
+            agentNotes: '  Last session was easy; increase load by 5%.  ',
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const payload = response.json() as {
+      data: {
+        exercises: Array<{
+          exerciseId: string;
+          agentNotes: string | null;
+          agentNotesMeta: {
+            author: string;
+            generatedAt: string;
+            scheduledDateAtGeneration: string;
+            stale: boolean;
+          } | null;
+        }>;
+      };
+    };
+    expect(payload.data.exercises).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          exerciseId: 'exercise-notes-source',
+          agentNotes: 'Last session was easy; increase load by 5%.',
+          agentNotesMeta: expect.objectContaining({
+            author: 'Coach Pulse',
+            scheduledDateAtGeneration: '2026-03-12',
+            stale: false,
+          }),
+        }),
+      ]),
+    );
+    const agentNotesMeta = payload.data.exercises[0]?.agentNotesMeta;
+    expect(typeof agentNotesMeta?.generatedAt).toBe('string');
+    expect(new Date(agentNotesMeta?.generatedAt ?? '').toISOString()).toBe(agentNotesMeta?.generatedAt);
+
+    const storedExercise = context.db
+      .select({
+        agentNotes: scheduledWorkoutExercises.agentNotes,
+        agentNotesMeta: scheduledWorkoutExercises.agentNotesMeta,
+      })
+      .from(scheduledWorkoutExercises)
+      .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId))
+      .limit(1)
+      .get();
+
+    expect(storedExercise).toEqual({
+      agentNotes: 'Last session was easy; increase load by 5%.',
+      agentNotesMeta: expect.objectContaining({
+        author: 'Coach Pulse',
+        scheduledDateAtGeneration: '2026-03-12',
+        stale: false,
+      }),
+    });
+  });
+
+  it('clears exercise agent notes and metadata when agentNotes is null', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    const agentToken = seedAgentToken('user-1', 'scheduled-notes-clear-agent');
+
+    seedExercise({
+      id: 'exercise-notes-clear',
+      userId: 'user-1',
+      name: 'Goblet Squat',
+      trackingType: 'weight_reps',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-notes-clear',
+      templateId: 'template-1',
+      exerciseId: 'exercise-notes-clear',
+      section: 'main',
+      orderIndex: 0,
+      programmingNotes: 'Stay tall at the bottom.',
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        date: '2026-03-12',
+      },
+    });
+    expect(createResponse.statusCode).toBe(201);
+    const scheduledWorkoutId = (createResponse.json() as { data: { id: string } }).data.id;
+
+    const setResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-notes`,
+      headers: createAgentTokenHeader(agentToken),
+      payload: {
+        notes: [
+          {
+            exerciseId: 'exercise-notes-clear',
+            agentNotes: 'Work up gradually.',
+          },
+        ],
+      },
+    });
+    expect(setResponse.statusCode).toBe(200);
+
+    const clearResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-notes`,
+      headers: createAgentTokenHeader(agentToken),
+      payload: {
+        notes: [
+          {
+            exerciseId: 'exercise-notes-clear',
+            agentNotes: null,
+          },
+        ],
+      },
+    });
+    expect(clearResponse.statusCode).toBe(200);
+    expect(clearResponse.json()).toEqual({
+      data: expect.objectContaining({
+        id: scheduledWorkoutId,
+        exercises: [expect.objectContaining({ agentNotes: null, agentNotesMeta: null })],
+      }),
+    });
+
+    const storedExercise = context.db
+      .select({
+        agentNotes: scheduledWorkoutExercises.agentNotes,
+        agentNotesMeta: scheduledWorkoutExercises.agentNotesMeta,
+      })
+      .from(scheduledWorkoutExercises)
+      .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId))
+      .limit(1)
+      .get();
+
+    expect(storedExercise).toEqual({
+      agentNotes: null,
+      agentNotesMeta: null,
+    });
+  });
+
+  it('rejects exercise-notes updates for JWT callers', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedExercise({
+      id: 'exercise-notes-jwt-forbidden',
+      userId: 'user-1',
+      name: 'Single-arm Row',
+      trackingType: 'weight_reps',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-notes-jwt-forbidden',
+      templateId: 'template-1',
+      exerciseId: 'exercise-notes-jwt-forbidden',
+      section: 'main',
+      orderIndex: 0,
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        date: '2026-03-12',
+      },
+    });
+    expect(createResponse.statusCode).toBe(201);
+    const scheduledWorkoutId = (createResponse.json() as { data: { id: string } }).data.id;
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-notes`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        notes: [
+          {
+            exerciseId: 'exercise-notes-jwt-forbidden',
+            agentNotes: 'Test note',
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'FORBIDDEN',
+        message: 'Agent token authentication required',
+      },
+    });
+  });
+
+  it('rejects exercise-notes updates for exercise ids not present in the snapshot', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    const agentToken = seedAgentToken('user-1', 'scheduled-notes-unknown-exercise-agent');
+
+    seedExercise({
+      id: 'exercise-notes-known',
+      userId: 'user-1',
+      name: 'Push-up',
+      trackingType: 'bodyweight_reps',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-notes-known',
+      templateId: 'template-1',
+      exerciseId: 'exercise-notes-known',
+      section: 'main',
+      orderIndex: 0,
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        date: '2026-03-12',
+      },
+    });
+    expect(createResponse.statusCode).toBe(201);
+    const scheduledWorkoutId = (createResponse.json() as { data: { id: string } }).data.id;
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-notes`,
+      headers: createAgentTokenHeader(agentToken),
+      payload: {
+        notes: [
+          {
+            exerciseId: 'exercise-does-not-exist-in-snapshot',
+            agentNotes: 'Test note',
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: expect.stringContaining('Unknown exerciseId values'),
+      },
+    });
+  });
+
+  it('swaps snapshot exercises for JWT callers', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedExercise({
+      id: 'exercise-swap-source',
+      userId: 'user-1',
+      name: 'Barbell Bench Press',
+      trackingType: 'weight_reps',
+    });
+    seedExercise({
+      id: 'exercise-swap-target',
+      userId: 'user-1',
+      name: 'Incline Dumbbell Press',
+      trackingType: 'weight_reps',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-swap-source',
+      templateId: 'template-1',
+      exerciseId: 'exercise-swap-source',
+      section: 'main',
+      orderIndex: 0,
+      sets: 3,
+      repsMin: 8,
+      repsMax: 8,
+      programmingNotes: 'Touch and go.',
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        date: '2026-03-12',
+      },
+    });
+    expect(createResponse.statusCode).toBe(201);
+    const scheduledWorkoutId = (createResponse.json() as { data: { id: string } }).data.id;
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-swap`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        fromExerciseId: 'exercise-swap-source',
+        toExerciseId: 'exercise-swap-target',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        id: scheduledWorkoutId,
+        exercises: [
+          expect.objectContaining({
+            exerciseId: 'exercise-swap-target',
+            programmingNotes: null,
+          }),
+        ],
+      }),
+    });
+
+    const swappedRows = context.db
+      .select({
+        exerciseId: scheduledWorkoutExercises.exerciseId,
+      })
+      .from(scheduledWorkoutExercises)
+      .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId))
+      .all();
+    expect(swappedRows).toEqual([{ exerciseId: 'exercise-swap-target' }]);
+  });
+
+  it('swaps snapshot exercises for AgentToken callers and supports carry-over options', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    const agentToken = seedAgentToken('user-1', 'scheduled-swap-agent');
+
+    seedExercise({
+      id: 'exercise-swap-agent-source',
+      userId: 'user-1',
+      name: 'Goblet Squat',
+      trackingType: 'weight_reps',
+    });
+    seedExercise({
+      id: 'exercise-swap-agent-target',
+      userId: 'user-1',
+      name: 'Front Squat',
+      trackingType: 'weight_reps',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-swap-agent-source',
+      templateId: 'template-1',
+      exerciseId: 'exercise-swap-agent-source',
+      section: 'main',
+      orderIndex: 0,
+      sets: 2,
+      repsMin: 10,
+      repsMax: 10,
+      programmingNotes: 'Brace before each rep.',
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        date: '2026-03-12',
+      },
+    });
+    expect(createResponse.statusCode).toBe(201);
+    const scheduledWorkoutId = (createResponse.json() as { data: { id: string } }).data.id;
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-swap`,
+      headers: createAgentTokenHeader(agentToken),
+      payload: {
+        fromExerciseId: 'exercise-swap-agent-source',
+        toExerciseId: 'exercise-swap-agent-target',
+        carryOverProgrammingNotes: true,
+        preserveSets: true,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        id: scheduledWorkoutId,
+        exercises: [
+          expect.objectContaining({
+            exerciseId: 'exercise-swap-agent-target',
+            programmingNotes: 'Brace before each rep.',
+            sets: [
+              expect.objectContaining({ setNumber: 1, reps: 10 }),
+              expect.objectContaining({ setNumber: 2, reps: 10 }),
+            ],
+          }),
+        ],
+      }),
+    });
+  });
+
+  it('marks agent notes stale when rescheduling by more than two days', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    const agentToken = seedAgentToken('user-1', 'scheduled-stale-marker-agent');
+
+    seedExercise({
+      id: 'exercise-stale-marker',
+      userId: 'user-1',
+      name: 'Romanian Deadlift',
+      trackingType: 'weight_reps',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-stale-marker',
+      templateId: 'template-1',
+      exerciseId: 'exercise-stale-marker',
+      section: 'main',
+      orderIndex: 0,
+      programmingNotes: 'Keep the lats engaged.',
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        date: '2026-03-12',
+      },
+    });
+    expect(createResponse.statusCode).toBe(201);
+    const scheduledWorkoutId = (createResponse.json() as { data: { id: string } }).data.id;
+
+    const notesResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-notes`,
+      headers: createAgentTokenHeader(agentToken),
+      payload: {
+        notes: [
+          {
+            exerciseId: 'exercise-stale-marker',
+            agentNotes: 'If sleep was poor, cap top set at RPE 7.',
+          },
+        ],
+      },
+    });
+    expect(notesResponse.statusCode).toBe(200);
+
+    const rescheduleResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        date: '2026-03-16',
+      },
+    });
+    expect(rescheduleResponse.statusCode).toBe(200);
+
+    const updatedExercise = context.db
+      .select({
+        agentNotesMeta: scheduledWorkoutExercises.agentNotesMeta,
+      })
+      .from(scheduledWorkoutExercises)
+      .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId))
+      .limit(1)
+      .get();
+    expect(updatedExercise?.agentNotesMeta).toMatchObject({
+      scheduledDateAtGeneration: '2026-03-12',
+      stale: true,
+    });
+  });
+
+  it('does not mark agent notes stale when rescheduling within two days', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    const agentToken = seedAgentToken('user-1', 'scheduled-stale-within-threshold-agent');
+
+    seedExercise({
+      id: 'exercise-stale-threshold',
+      userId: 'user-1',
+      name: 'Split Squat',
+      trackingType: 'reps_only',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-stale-threshold',
+      templateId: 'template-1',
+      exerciseId: 'exercise-stale-threshold',
+      section: 'main',
+      orderIndex: 0,
+      programmingNotes: 'Control tempo on the eccentric.',
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        date: '2026-03-12',
+      },
+    });
+    expect(createResponse.statusCode).toBe(201);
+    const scheduledWorkoutId = (createResponse.json() as { data: { id: string } }).data.id;
+
+    const notesResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-notes`,
+      headers: createAgentTokenHeader(agentToken),
+      payload: {
+        notes: [
+          {
+            exerciseId: 'exercise-stale-threshold',
+            agentNotes: 'Keep reps smooth and symmetrical.',
+          },
+        ],
+      },
+    });
+    expect(notesResponse.statusCode).toBe(200);
+
+    const rescheduleResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        date: '2026-03-13',
+      },
+    });
+    expect(rescheduleResponse.statusCode).toBe(200);
+
+    const updatedExercise = context.db
+      .select({
+        agentNotesMeta: scheduledWorkoutExercises.agentNotesMeta,
+      })
+      .from(scheduledWorkoutExercises)
+      .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId))
+      .limit(1)
+      .get();
+    expect(updatedExercise?.agentNotesMeta).toMatchObject({
+      scheduledDateAtGeneration: '2026-03-12',
+      stale: false,
+    });
+  });
+
+  it('documents scheduled workout exercise-note and swap paths in OpenAPI with correct security', async () => {
+    const response = await context.app.inject({
+      method: 'GET',
+      url: '/api/docs/json',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as {
+      paths: Record<
+        string,
+        {
+          patch?: {
+            security?: unknown;
+            summary?: string;
+          };
+        }
+      >;
+    };
+
+    expect(body.paths['/api/v1/scheduled-workouts/{id}/exercise-notes']?.patch).toMatchObject({
+      summary: 'Update per-exercise agent notes on a scheduled workout',
+      security: [{ agentToken: [] }],
+    });
+    expect(body.paths['/api/v1/scheduled-workouts/{id}/exercise-swap']?.patch).toMatchObject({
+      summary: 'Swap or remove an exercise in a scheduled workout snapshot',
+      security: [{ bearerAuth: [] }, { agentToken: [] }],
     });
   });
 

--- a/apps/api/src/routes/scheduled-workouts/index.test.ts
+++ b/apps/api/src/routes/scheduled-workouts/index.test.ts
@@ -10,6 +10,8 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 
 import {
   exercises,
+  scheduledWorkoutExerciseSets,
+  scheduledWorkoutExercises,
   scheduledWorkouts,
   templateExercises,
   users,
@@ -156,8 +158,25 @@ const seedTemplateExercise = (values: {
   id: string;
   templateId: string;
   exerciseId: string;
-  section: 'warmup' | 'main' | 'cooldown';
+  section: 'warmup' | 'main' | 'cooldown' | 'supplemental';
   orderIndex: number;
+  sets?: number | null;
+  repsMin?: number | null;
+  repsMax?: number | null;
+  tempo?: string | null;
+  restSeconds?: number | null;
+  supersetGroup?: string | null;
+  notes?: string | null;
+  programmingNotes?: string | null;
+  cues?: string[] | null;
+  setTargets?: Array<{
+    setNumber: number;
+    targetWeight?: number | null;
+    targetWeightMin?: number | null;
+    targetWeightMax?: number | null;
+    targetSeconds?: number | null;
+    targetDistance?: number | null;
+  }> | null;
 }) =>
   context.db
     .insert(templateExercises)
@@ -167,6 +186,16 @@ const seedTemplateExercise = (values: {
       exerciseId: values.exerciseId,
       section: values.section,
       orderIndex: values.orderIndex,
+      sets: values.sets ?? null,
+      repsMin: values.repsMin ?? null,
+      repsMax: values.repsMax ?? null,
+      tempo: values.tempo ?? null,
+      restSeconds: values.restSeconds ?? null,
+      supersetGroup: values.supersetGroup ?? null,
+      notes: values.notes ?? null,
+      programmingNotes: values.programmingNotes ?? null,
+      cues: values.cues ?? null,
+      setTargets: values.setTargets ?? null,
     })
     .run();
 
@@ -315,6 +344,10 @@ describe('scheduled workout routes', () => {
         templateId: string;
         date: string;
         sessionId: string | null;
+        exercises: unknown[];
+        templateDrift: unknown;
+        staleExercises: unknown[];
+        templateDeleted: boolean;
         createdAt: number;
         updatedAt: number;
       };
@@ -329,6 +362,10 @@ describe('scheduled workout routes', () => {
     expect(createdPayload.data.id).toBeTruthy();
     expect(createdPayload.data.createdAt).toBeTypeOf('number');
     expect(createdPayload.data.updatedAt).toBeTypeOf('number');
+    expect(createdPayload.data.exercises).toEqual([]);
+    expect(createdPayload.data.templateDrift).toBeNull();
+    expect(createdPayload.data.staleExercises).toEqual([]);
+    expect(createdPayload.data.templateDeleted).toBe(false);
 
     const listResponse = await context.app.inject({
       method: 'GET',
@@ -356,6 +393,374 @@ describe('scheduled workout routes', () => {
           createdAt: expect.any(Number),
         },
       ],
+    });
+  });
+
+  it('creates snapshot rows on POST and stores templateVersion', async () => {
+    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+
+    seedExercise({
+      id: 'exercise-swing',
+      userId: 'user-1',
+      name: 'Kettlebell Swing',
+      trackingType: 'weight_reps',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-swing',
+      templateId: 'template-1',
+      exerciseId: 'exercise-swing',
+      section: 'main',
+      orderIndex: 0,
+      sets: 2,
+      repsMin: 8,
+      repsMax: 8,
+      notes: 'Fallback note',
+      programmingNotes: null,
+      restSeconds: 90,
+      cues: ['Brace', 'Hinge'],
+    });
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        date: '2026-03-12',
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    const payload = response.json() as {
+      data: {
+        id: string;
+        exercises: Array<{
+          exerciseId: string;
+          programmingNotes: string | null;
+          sets: Array<{ setNumber: number; reps: number | null }>;
+        }>;
+      };
+    };
+
+    expect(payload.data.exercises).toEqual([
+      expect.objectContaining({
+        exerciseId: 'exercise-swing',
+        programmingNotes: 'Fallback note',
+        sets: [
+          expect.objectContaining({ setNumber: 1, reps: 8 }),
+          expect.objectContaining({ setNumber: 2, reps: 8 }),
+        ],
+      }),
+    ]);
+
+    const templateVersion = context.db
+      .select({
+        templateVersion: scheduledWorkouts.templateVersion,
+      })
+      .from(scheduledWorkouts)
+      .where(eq(scheduledWorkouts.id, payload.data.id))
+      .limit(1)
+      .get();
+    expect(templateVersion?.templateVersion).toMatch(/^[0-9a-f]{64}$/);
+
+    const exerciseRows = context.db
+      .select({ id: scheduledWorkoutExercises.id })
+      .from(scheduledWorkoutExercises)
+      .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, payload.data.id))
+      .all();
+    expect(exerciseRows).toHaveLength(1);
+
+    const setRows = context.db
+      .select({ id: scheduledWorkoutExerciseSets.id })
+      .from(scheduledWorkoutExerciseSets)
+      .all();
+    expect(setRows).toHaveLength(2);
+  });
+
+  it('returns snapshot detail with programming notes and all-clear markers on GET by id', async () => {
+    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+
+    seedExercise({
+      id: 'exercise-press',
+      userId: 'user-1',
+      name: 'Overhead Press',
+      trackingType: 'weight_reps',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-press',
+      templateId: 'template-1',
+      exerciseId: 'exercise-press',
+      section: 'main',
+      orderIndex: 0,
+      repsMin: 5,
+      repsMax: 5,
+      programmingNotes: 'Keep glutes tight and bar path straight.',
+      restSeconds: 120,
+      tempo: '3010',
+      setTargets: [
+        { setNumber: 1, targetWeight: 95 },
+        { setNumber: 2, targetWeight: 105 },
+      ],
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        date: '2026-03-13',
+      },
+    });
+    expect(createResponse.statusCode).toBe(201);
+    const createdId = (createResponse.json() as { data: { id: string } }).data.id;
+
+    const response = await context.app.inject({
+      method: 'GET',
+      url: `/api/v1/scheduled-workouts/${createdId}`,
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: {
+        id: createdId,
+        userId: 'user-1',
+        templateId: 'template-1',
+        date: '2026-03-13',
+        sessionId: null,
+        createdAt: expect.any(Number),
+        updatedAt: expect.any(Number),
+        exercises: [
+          {
+            exerciseId: 'exercise-press',
+            section: 'main',
+            orderIndex: 0,
+            programmingNotes: 'Keep glutes tight and bar path straight.',
+            agentNotes: null,
+            agentNotesMeta: null,
+            templateCues: null,
+            supersetGroup: null,
+            tempo: '3010',
+            restSeconds: 120,
+            sets: [
+              {
+                setNumber: 1,
+                repsMin: 5,
+                repsMax: 5,
+                reps: 5,
+                targetWeight: 95,
+                targetWeightMin: null,
+                targetWeightMax: null,
+                targetSeconds: null,
+                targetDistance: null,
+              },
+              {
+                setNumber: 2,
+                repsMin: 5,
+                repsMax: 5,
+                reps: 5,
+                targetWeight: 105,
+                targetWeightMin: null,
+                targetWeightMax: null,
+                targetSeconds: null,
+                targetDistance: null,
+              },
+            ],
+          },
+        ],
+        templateDrift: null,
+        staleExercises: [],
+        templateDeleted: false,
+        template: expect.objectContaining({
+          id: 'template-1',
+          name: 'Upper Push',
+        }),
+      },
+    });
+  });
+
+  it('returns templateDrift marker when template changes after scheduling', async () => {
+    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+
+    seedExercise({
+      id: 'exercise-squat',
+      userId: 'user-1',
+      name: 'Back Squat',
+      trackingType: 'weight_reps',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-squat',
+      templateId: 'template-1',
+      exerciseId: 'exercise-squat',
+      section: 'main',
+      orderIndex: 0,
+      repsMin: 5,
+      repsMax: 5,
+      programmingNotes: 'Drive out of the hole.',
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        date: '2026-03-14',
+      },
+    });
+    expect(createResponse.statusCode).toBe(201);
+    const scheduledWorkoutId = (createResponse.json() as { data: { id: string } }).data.id;
+
+    const changedAt = Date.UTC(2026, 2, 14, 14, 30, 0);
+    context.db
+      .update(templateExercises)
+      .set({
+        programmingNotes: 'Work up to a strong top set, then backoff.',
+      })
+      .where(eq(templateExercises.id, 'template-exercise-squat'))
+      .run();
+    context.db
+      .update(workoutTemplates)
+      .set({
+        updatedAt: changedAt,
+      })
+      .where(eq(workoutTemplates.id, 'template-1'))
+      .run();
+
+    const response = await context.app.inject({
+      method: 'GET',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}`,
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        id: scheduledWorkoutId,
+        templateDrift: {
+          changedAt,
+          summary: 'Template has been updated since scheduling.',
+        },
+        staleExercises: [],
+        templateDeleted: false,
+      }),
+    });
+  });
+
+  it('returns staleExercises marker when snapshot exercises are soft-deleted', async () => {
+    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+
+    seedExercise({
+      id: 'exercise-stale',
+      userId: 'user-1',
+      name: 'Dips',
+      trackingType: 'bodyweight_reps',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-stale',
+      templateId: 'template-1',
+      exerciseId: 'exercise-stale',
+      section: 'main',
+      orderIndex: 0,
+      programmingNotes: 'Controlled depth.',
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        date: '2026-03-15',
+      },
+    });
+    expect(createResponse.statusCode).toBe(201);
+    const scheduledWorkoutId = (createResponse.json() as { data: { id: string } }).data.id;
+
+    context.db
+      .update(exercises)
+      .set({
+        deletedAt: '2026-03-15T12:00:00.000Z',
+      })
+      .where(eq(exercises.id, 'exercise-stale'))
+      .run();
+
+    const response = await context.app.inject({
+      method: 'GET',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}`,
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        id: scheduledWorkoutId,
+        templateDrift: null,
+        staleExercises: [
+          {
+            exerciseId: 'exercise-stale',
+            snapshotName: 'Dips',
+          },
+        ],
+        templateDeleted: false,
+      }),
+    });
+  });
+
+  it('returns templateDeleted marker when the source template is soft-deleted', async () => {
+    const authToken = context.app.jwt.sign({ sub: 'user-1', type: "session", iss: "pulse-api" }, { expiresIn: "7d" });
+
+    seedExercise({
+      id: 'exercise-row',
+      userId: 'user-1',
+      name: 'Barbell Row',
+      trackingType: 'weight_reps',
+    });
+    seedTemplateExercise({
+      id: 'template-exercise-row',
+      templateId: 'template-1',
+      exerciseId: 'exercise-row',
+      section: 'main',
+      orderIndex: 0,
+      programmingNotes: 'Pull to lower ribs.',
+    });
+
+    const createResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/scheduled-workouts',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        templateId: 'template-1',
+        date: '2026-03-16',
+      },
+    });
+    expect(createResponse.statusCode).toBe(201);
+    const scheduledWorkoutId = (createResponse.json() as { data: { id: string } }).data.id;
+
+    context.db
+      .update(workoutTemplates)
+      .set({
+        deletedAt: '2026-03-16T08:00:00.000Z',
+      })
+      .where(eq(workoutTemplates.id, 'template-1'))
+      .run();
+
+    const response = await context.app.inject({
+      method: 'GET',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}`,
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        id: scheduledWorkoutId,
+        templateDrift: null,
+        staleExercises: [],
+        templateDeleted: true,
+        template: null,
+      }),
     });
   });
 

--- a/apps/api/src/routes/scheduled-workouts/index.ts
+++ b/apps/api/src/routes/scheduled-workouts/index.ts
@@ -15,7 +15,7 @@ import type { FastifyPluginAsync } from 'fastify';
 import { type ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 
-import { exercises, scheduledWorkouts, workoutTemplates } from '../../db/schema/index.js';
+import { exercises, workoutTemplates } from '../../db/schema/index.js';
 import { sendError } from '../../lib/reply.js';
 import { requireAuth } from '../../middleware/auth.js';
 import {
@@ -37,6 +37,7 @@ import {
   createScheduledWorkout,
   deleteScheduledWorkout,
   findScheduledWorkoutById,
+  findScheduledWorkoutByIdWithTemplateVersion,
   listScheduledWorkouts,
   updateScheduledWorkout,
 } from './store.js';
@@ -88,7 +89,10 @@ const buildScheduledWorkoutDetail = async ({
   scheduledWorkoutId: string;
   userId: string;
 }) => {
-  const scheduledWorkout = await findScheduledWorkoutById(scheduledWorkoutId, userId);
+  const scheduledWorkout = await findScheduledWorkoutByIdWithTemplateVersion(
+    scheduledWorkoutId,
+    userId,
+  );
   if (!scheduledWorkout) {
     return null;
   }
@@ -118,26 +122,19 @@ const buildScheduledWorkoutDetail = async ({
   for (const snapshotExercise of snapshotExercises) {
     const exercise = exercisesById.get(snapshotExercise.exerciseId);
     const isMissing = !exercise;
-    const isSoftDeleted = exercise?.deletedAt !== null;
+    const isSoftDeleted = exercise?.deletedAt != null;
     const isOutsideUserScope =
       exercise !== undefined && exercise.userId !== null && exercise.userId !== userId;
 
     if (isMissing || isSoftDeleted || isOutsideUserScope) {
       staleByExerciseId.set(snapshotExercise.exerciseId, {
         exerciseId: snapshotExercise.exerciseId,
+        // Snapshot rows do not currently denormalize exercise names, so
+        // hard-deleted exercises fall back to the historical exercise id.
         snapshotName: exercise?.name ?? snapshotExercise.exerciseId,
       });
     }
   }
-
-  const scheduledWorkoutRecord = db
-    .select({
-      templateVersion: scheduledWorkouts.templateVersion,
-    })
-    .from(scheduledWorkouts)
-    .where(and(eq(scheduledWorkouts.id, scheduledWorkout.id), eq(scheduledWorkouts.userId, userId)))
-    .limit(1)
-    .get();
 
   let templateDeleted = false;
   let templateDrift: { changedAt: number; summary: string } | null = null;
@@ -161,13 +158,13 @@ const buildScheduledWorkoutDetail = async ({
 
     templateDeleted = !sourceTemplate || sourceTemplate.deletedAt !== null;
 
-    if (sourceTemplate && sourceTemplate.deletedAt === null && scheduledWorkoutRecord?.templateVersion) {
+    if (sourceTemplate && sourceTemplate.deletedAt === null && scheduledWorkout.templateVersion) {
       const currentTemplateVersion = await computeTemplateVersionForTemplateId(
         scheduledWorkout.templateId,
         db,
       );
 
-      if (currentTemplateVersion !== scheduledWorkoutRecord.templateVersion) {
+      if (currentTemplateVersion !== scheduledWorkout.templateVersion) {
         templateDrift = {
           changedAt: sourceTemplate.updatedAt,
           summary: TEMPLATE_DRIFT_SUMMARY,
@@ -314,18 +311,8 @@ export const scheduledWorkoutRoutes: FastifyPluginAsync = async (app) => {
       },
     },
     async (request, reply) => {
-      const scheduledWorkout = await findScheduledWorkoutById(request.params.id, request.userId);
-      if (!scheduledWorkout) {
-        return sendError(
-          reply,
-          404,
-          SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.code,
-          SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.message,
-        );
-      }
-
       const scheduledWorkoutDetail = await buildScheduledWorkoutDetailWithTemplate({
-        scheduledWorkoutId: scheduledWorkout.id,
+        scheduledWorkoutId: request.params.id,
         userId: request.userId,
       });
       if (!scheduledWorkoutDetail) {

--- a/apps/api/src/routes/scheduled-workouts/index.ts
+++ b/apps/api/src/routes/scheduled-workouts/index.ts
@@ -314,20 +314,16 @@ const markRescheduledAgentNotesAsStale = async ({
   newDate: string;
 }) => {
   const { db } = await import('../../db/index.js');
-  const exercisesWithAgentNotes = db
-    .select({
-      id: scheduledWorkoutExercises.id,
-      agentNotesMeta: scheduledWorkoutExercises.agentNotesMeta,
-    })
-    .from(scheduledWorkoutExercises)
-    .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId))
-    .all();
-
-  if (exercisesWithAgentNotes.length === 0) {
-    return;
-  }
-
   db.transaction((tx) => {
+    const exercisesWithAgentNotes = tx
+      .select({
+        id: scheduledWorkoutExercises.id,
+        agentNotesMeta: scheduledWorkoutExercises.agentNotesMeta,
+      })
+      .from(scheduledWorkoutExercises)
+      .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId))
+      .all();
+
     for (const row of exercisesWithAgentNotes) {
       if (!row.agentNotesMeta) {
         continue;
@@ -527,21 +523,23 @@ export const scheduledWorkoutRoutes: FastifyPluginAsync = async (app) => {
       }
 
       const { db } = await import('../../db/index.js');
-      const tokenIdentity =
-        request.agentTokenId === undefined
-          ? undefined
-          : db
-              .select({ name: agentTokens.name })
-              .from(agentTokens)
-              .where(
-                and(
-                  eq(agentTokens.id, request.agentTokenId),
-                  eq(agentTokens.userId, request.userId),
-                ),
-              )
-              .limit(1)
-              .get();
-      const author = tokenIdentity?.name ?? request.agentTokenId ?? 'agent-token';
+      const agentTokenId = request.agentTokenId;
+      if (!agentTokenId) {
+        throw new Error('Agent token id missing for AgentToken-authenticated request');
+      }
+
+      const tokenIdentity = db
+        .select({ name: agentTokens.name })
+        .from(agentTokens)
+        .where(
+          and(
+            eq(agentTokens.id, agentTokenId),
+            eq(agentTokens.userId, request.userId),
+          ),
+        )
+        .limit(1)
+        .get();
+      const author = tokenIdentity?.name ?? agentTokenId;
       const generatedAt = new Date().toISOString();
 
       db.transaction((tx) => {
@@ -625,9 +623,17 @@ export const scheduledWorkoutRoutes: FastifyPluginAsync = async (app) => {
         );
       }
 
+      if (request.body.toExerciseId === request.body.fromExerciseId) {
+        return sendError(
+          reply,
+          400,
+          INVALID_SCHEDULED_WORKOUT_EXERCISE_RESPONSE.code,
+          INVALID_SCHEDULED_WORKOUT_EXERCISE_RESPONSE.message,
+        );
+      }
+
       if (
         request.body.toExerciseId !== null &&
-        request.body.toExerciseId !== request.body.fromExerciseId &&
         snapshot.exercises.some((exercise) => exercise.exerciseId === request.body.toExerciseId)
       ) {
         return sendError(
@@ -697,6 +703,8 @@ export const scheduledWorkoutRoutes: FastifyPluginAsync = async (app) => {
             .set({
               exerciseId: request.body.toExerciseId,
               programmingNotes: carryOverProgrammingNotes ? sourceRow.programmingNotes : null,
+              agentNotes: null,
+              agentNotesMeta: null,
               templateCues: null,
             })
             .where(eq(scheduledWorkoutExercises.id, sourceRow.id))

--- a/apps/api/src/routes/scheduled-workouts/index.ts
+++ b/apps/api/src/routes/scheduled-workouts/index.ts
@@ -83,6 +83,7 @@ const INVALID_SCHEDULED_WORKOUT_EXERCISE_RESPONSE = {
 } as const;
 
 const TEMPLATE_DRIFT_SUMMARY = 'Template has been updated since scheduling.';
+const UNKNOWN_SNAPSHOT_EXERCISE_NAME = 'Unknown exercise';
 
 const scheduledWorkoutDetailWithTemplateSchema = scheduledWorkoutDetailSchema.extend({
   template: workoutTemplateSchema.nullable(),
@@ -96,7 +97,12 @@ const mapSnapshotExercise = (exercise: Awaited<ReturnType<typeof readSnapshot>>[
   orderIndex: exercise.orderIndex,
   programmingNotes: exercise.programmingNotes,
   agentNotes: exercise.agentNotes,
-  agentNotesMeta: exercise.agentNotesMeta,
+  agentNotesMeta: exercise.agentNotesMeta
+    ? {
+        ...exercise.agentNotesMeta,
+        stale: exercise.agentNotesMeta.stale ?? false,
+      }
+    : null,
   templateCues: exercise.templateCues,
   supersetGroup: exercise.supersetGroup,
   tempo: exercise.tempo,
@@ -227,9 +233,7 @@ const buildScheduledWorkoutDetail = async ({
     if (isMissing || isSoftDeleted || isOutsideUserScope) {
       staleByExerciseId.set(snapshotExercise.exerciseId, {
         exerciseId: snapshotExercise.exerciseId,
-        // Snapshot rows do not currently denormalize exercise names, so
-        // hard-deleted exercises fall back to the historical exercise id.
-        snapshotName: exercise?.name ?? snapshotExercise.exerciseId,
+        snapshotName: exercise?.name ?? UNKNOWN_SNAPSHOT_EXERCISE_NAME,
       });
     }
   }

--- a/apps/api/src/routes/scheduled-workouts/index.ts
+++ b/apps/api/src/routes/scheduled-workouts/index.ts
@@ -7,24 +7,39 @@ import {
   scheduledWorkoutListItemSchema,
   scheduledWorkoutQueryParamsSchema,
   scheduledWorkoutSchema,
+  swapScheduledWorkoutExerciseInputSchema,
+  swapScheduledWorkoutExerciseResponseSchema,
+  updateScheduledWorkoutExerciseNotesInputSchema,
+  updateScheduledWorkoutExerciseNotesResponseSchema,
   updateScheduledWorkoutInputSchema,
   workoutTemplateSchema,
 } from '@pulse/shared';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, asc, eq, inArray } from 'drizzle-orm';
 import type { FastifyPluginAsync } from 'fastify';
 import { type ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 
-import { exercises, workoutTemplates } from '../../db/schema/index.js';
+import type { TemplateExerciseSetTarget } from '../../db/schema/index.js';
+import {
+  agentTokens,
+  exercises,
+  scheduledWorkoutExerciseSets,
+  scheduledWorkoutExercises,
+  scheduledWorkouts,
+  templateExercises,
+  workoutTemplates,
+} from '../../db/schema/index.js';
 import { sendError } from '../../lib/reply.js';
-import { requireAuth } from '../../middleware/auth.js';
+import { requireAgentOnly, requireAuth } from '../../middleware/auth.js';
 import {
   apiErrorResponseSchema,
+  agentTokenSecurity,
   authSecurity,
   badRequestResponseSchema,
   idParamsSchema,
   successFlagSchema,
 } from '../../openapi.js';
+import { allRelatedExercisesOwned } from '../exercises/store.js';
 import { templateBelongsToUser } from '../workout-templates/template-access.js';
 import { findWorkoutTemplateById } from '../workout-templates/store.js';
 
@@ -52,11 +67,28 @@ const WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE = {
   message: 'Workout template not found',
 } as const;
 
+const SCHEDULED_WORKOUT_EXERCISE_NOT_FOUND_RESPONSE = {
+  code: 'SCHEDULED_WORKOUT_EXERCISE_NOT_FOUND',
+  message: 'Scheduled workout exercise not found',
+} as const;
+
+const SCHEDULED_WORKOUT_DUPLICATE_EXERCISE_RESPONSE = {
+  code: 'SCHEDULED_WORKOUT_DUPLICATE_EXERCISE',
+  message: 'Target exercise already exists in this scheduled workout',
+} as const;
+
+const INVALID_SCHEDULED_WORKOUT_EXERCISE_RESPONSE = {
+  code: 'INVALID_SCHEDULED_WORKOUT_EXERCISE',
+  message: 'Exercise is not available for this user',
+} as const;
+
 const TEMPLATE_DRIFT_SUMMARY = 'Template has been updated since scheduling.';
 
 const scheduledWorkoutDetailWithTemplateSchema = scheduledWorkoutDetailSchema.extend({
   template: workoutTemplateSchema.nullable(),
 });
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 const mapSnapshotExercise = (exercise: Awaited<ReturnType<typeof readSnapshot>>['exercises'][number]) => ({
   exerciseId: exercise.exerciseId,
@@ -81,6 +113,72 @@ const mapSnapshotExercise = (exercise: Awaited<ReturnType<typeof readSnapshot>>[
     targetDistance: set.targetDistance,
   })),
 });
+
+const toUtcDay = (date: string): number => {
+  const [yearText, monthText, dayText] = date.split('-');
+  const year = Number.parseInt(yearText ?? '', 10);
+  const month = Number.parseInt(monthText ?? '', 10);
+  const day = Number.parseInt(dayText ?? '', 10);
+  return Math.trunc(Date.UTC(year, month - 1, day) / DAY_MS);
+};
+
+const shouldMarkAgentNoteStale = ({
+  scheduledDateAtGeneration,
+  newDate,
+}: {
+  scheduledDateAtGeneration: string;
+  newDate: string;
+}) => Math.abs(toUtcDay(newDate) - toUtcDay(scheduledDateAtGeneration)) > 2;
+
+const toExactReps = (repsMin: number | null, repsMax: number | null): number | null => {
+  if (repsMin === null || repsMax === null) {
+    return null;
+  }
+
+  return repsMin === repsMax ? repsMin : null;
+};
+
+const toSnapshotSetDrafts = ({
+  sets,
+  repsMin,
+  repsMax,
+  setTargets,
+}: {
+  sets: number | null;
+  repsMin: number | null;
+  repsMax: number | null;
+  setTargets: TemplateExerciseSetTarget[] | null;
+}) => {
+  const sortedTargets = [...(setTargets ?? [])].sort((left, right) => left.setNumber - right.setNumber);
+  const reps = toExactReps(repsMin, repsMax);
+
+  if (sortedTargets.length > 0) {
+    return sortedTargets.map((target) => ({
+      setNumber: target.setNumber,
+      repsMin,
+      repsMax,
+      reps,
+      targetWeight: target.targetWeight ?? null,
+      targetWeightMin: target.targetWeightMin ?? null,
+      targetWeightMax: target.targetWeightMax ?? null,
+      targetSeconds: target.targetSeconds ?? null,
+      targetDistance: target.targetDistance ?? null,
+    }));
+  }
+
+  const setCount = Math.max(1, sets ?? 1);
+  return Array.from({ length: setCount }, (_, index) => ({
+    setNumber: index + 1,
+    repsMin,
+    repsMax,
+    reps,
+    targetWeight: null,
+    targetWeightMin: null,
+    targetWeightMax: null,
+    targetSeconds: null,
+    targetDistance: null,
+  }));
+};
 
 const buildScheduledWorkoutDetail = async ({
   scheduledWorkoutId,
@@ -208,6 +306,55 @@ const buildScheduledWorkoutDetailWithTemplate = async ({
   };
 };
 
+const markRescheduledAgentNotesAsStale = async ({
+  scheduledWorkoutId,
+  newDate,
+}: {
+  scheduledWorkoutId: string;
+  newDate: string;
+}) => {
+  const { db } = await import('../../db/index.js');
+  const exercisesWithAgentNotes = db
+    .select({
+      id: scheduledWorkoutExercises.id,
+      agentNotesMeta: scheduledWorkoutExercises.agentNotesMeta,
+    })
+    .from(scheduledWorkoutExercises)
+    .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId))
+    .all();
+
+  if (exercisesWithAgentNotes.length === 0) {
+    return;
+  }
+
+  db.transaction((tx) => {
+    for (const row of exercisesWithAgentNotes) {
+      if (!row.agentNotesMeta) {
+        continue;
+      }
+
+      if (
+        !shouldMarkAgentNoteStale({
+          scheduledDateAtGeneration: row.agentNotesMeta.scheduledDateAtGeneration,
+          newDate,
+        })
+      ) {
+        continue;
+      }
+
+      tx.update(scheduledWorkoutExercises)
+        .set({
+          agentNotesMeta: {
+            ...row.agentNotesMeta,
+            stale: true,
+          },
+        })
+        .where(eq(scheduledWorkoutExercises.id, row.id))
+        .run();
+    }
+  });
+};
+
 export const scheduledWorkoutRoutes: FastifyPluginAsync = async (app) => {
   app.addHook('onRequest', requireAuth);
 
@@ -331,6 +478,317 @@ export const scheduledWorkoutRoutes: FastifyPluginAsync = async (app) => {
   );
 
   typedApp.patch(
+    '/:id/exercise-notes',
+    {
+      preHandler: requireAgentOnly,
+      schema: {
+        params: idParamsSchema,
+        body: updateScheduledWorkoutExerciseNotesInputSchema,
+        response: {
+          200: apiDataResponseSchema(updateScheduledWorkoutExerciseNotesResponseSchema),
+          400: badRequestResponseSchema,
+          401: apiErrorResponseSchema,
+          403: apiErrorResponseSchema,
+          404: apiErrorResponseSchema,
+        },
+        tags: ['scheduled-workouts'],
+        summary: 'Update per-exercise agent notes on a scheduled workout',
+        security: agentTokenSecurity,
+      },
+    },
+    async (request, reply) => {
+      const scheduledWorkout = await findScheduledWorkoutById(request.params.id, request.userId);
+      if (!scheduledWorkout) {
+        return sendError(
+          reply,
+          404,
+          SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.code,
+          SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      const snapshot = await readSnapshot(scheduledWorkout.id);
+      const snapshotExerciseIds = new Set(snapshot.exercises.map((exercise) => exercise.exerciseId));
+      const noteUpdates = new Map<string, string | null>();
+      for (const note of request.body.notes) {
+        noteUpdates.set(note.exerciseId, note.agentNotes);
+      }
+
+      const unknownExerciseIds = [...noteUpdates.keys()].filter(
+        (exerciseId) => !snapshotExerciseIds.has(exerciseId),
+      );
+      if (unknownExerciseIds.length > 0) {
+        return sendError(
+          reply,
+          400,
+          'VALIDATION_ERROR',
+          `Unknown exerciseId values for this scheduled workout: ${unknownExerciseIds.join(', ')}`,
+        );
+      }
+
+      const { db } = await import('../../db/index.js');
+      const tokenIdentity =
+        request.agentTokenId === undefined
+          ? undefined
+          : db
+              .select({ name: agentTokens.name })
+              .from(agentTokens)
+              .where(
+                and(
+                  eq(agentTokens.id, request.agentTokenId),
+                  eq(agentTokens.userId, request.userId),
+                ),
+              )
+              .limit(1)
+              .get();
+      const author = tokenIdentity?.name ?? request.agentTokenId ?? 'agent-token';
+      const generatedAt = new Date().toISOString();
+
+      db.transaction((tx) => {
+        for (const [exerciseId, agentNotes] of noteUpdates.entries()) {
+          tx.update(scheduledWorkoutExercises)
+            .set({
+              agentNotes,
+              agentNotesMeta:
+                agentNotes === null
+                  ? null
+                  : {
+                      author,
+                      generatedAt,
+                      scheduledDateAtGeneration: scheduledWorkout.date,
+                      stale: false,
+                    },
+            })
+            .where(
+              and(
+                eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkout.id),
+                eq(scheduledWorkoutExercises.exerciseId, exerciseId),
+              ),
+            )
+            .run();
+        }
+      });
+
+      const updatedDetail = await buildScheduledWorkoutDetail({
+        scheduledWorkoutId: scheduledWorkout.id,
+        userId: request.userId,
+      });
+      if (!updatedDetail) {
+        throw new Error('Updated scheduled workout could not be loaded');
+      }
+
+      return reply.send({
+        data: updatedDetail,
+      });
+    },
+  );
+
+  typedApp.patch(
+    '/:id/exercise-swap',
+    {
+      schema: {
+        params: idParamsSchema,
+        body: swapScheduledWorkoutExerciseInputSchema,
+        response: {
+          200: apiDataResponseSchema(swapScheduledWorkoutExerciseResponseSchema),
+          400: badRequestResponseSchema,
+          401: apiErrorResponseSchema,
+          404: apiErrorResponseSchema,
+          409: apiErrorResponseSchema,
+        },
+        tags: ['scheduled-workouts'],
+        summary: 'Swap or remove an exercise in a scheduled workout snapshot',
+        security: authSecurity,
+      },
+    },
+    async (request, reply) => {
+      const scheduledWorkout = await findScheduledWorkoutById(request.params.id, request.userId);
+      if (!scheduledWorkout) {
+        return sendError(
+          reply,
+          404,
+          SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.code,
+          SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      const snapshot = await readSnapshot(scheduledWorkout.id);
+      const sourceSnapshotExercise = snapshot.exercises.find(
+        (exercise) => exercise.exerciseId === request.body.fromExerciseId,
+      );
+      if (!sourceSnapshotExercise) {
+        return sendError(
+          reply,
+          404,
+          SCHEDULED_WORKOUT_EXERCISE_NOT_FOUND_RESPONSE.code,
+          SCHEDULED_WORKOUT_EXERCISE_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      if (
+        request.body.toExerciseId !== null &&
+        request.body.toExerciseId !== request.body.fromExerciseId &&
+        snapshot.exercises.some((exercise) => exercise.exerciseId === request.body.toExerciseId)
+      ) {
+        return sendError(
+          reply,
+          409,
+          SCHEDULED_WORKOUT_DUPLICATE_EXERCISE_RESPONSE.code,
+          SCHEDULED_WORKOUT_DUPLICATE_EXERCISE_RESPONSE.message,
+        );
+      }
+
+      if (request.body.toExerciseId !== null) {
+        const hasValidSwapTarget = await allRelatedExercisesOwned({
+          userId: request.userId,
+          exerciseIds: [request.body.toExerciseId],
+        });
+        if (!hasValidSwapTarget) {
+          return sendError(
+            reply,
+            400,
+            INVALID_SCHEDULED_WORKOUT_EXERCISE_RESPONSE.code,
+            INVALID_SCHEDULED_WORKOUT_EXERCISE_RESPONSE.message,
+          );
+        }
+      }
+
+      const { db } = await import('../../db/index.js');
+      const swapSucceeded = db.transaction((tx) => {
+        const sourceRows = tx
+          .select({
+            id: scheduledWorkoutExercises.id,
+            programmingNotes: scheduledWorkoutExercises.programmingNotes,
+          })
+          .from(scheduledWorkoutExercises)
+          .where(
+            and(
+              eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkout.id),
+              eq(scheduledWorkoutExercises.exerciseId, request.body.fromExerciseId),
+            ),
+          )
+          .all();
+
+        if (sourceRows.length === 0) {
+          return false;
+        }
+
+        if (request.body.toExerciseId === null) {
+          tx.delete(scheduledWorkoutExercises)
+            .where(
+              and(
+                eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkout.id),
+                eq(scheduledWorkoutExercises.exerciseId, request.body.fromExerciseId),
+              ),
+            )
+            .run();
+
+          tx.update(scheduledWorkouts)
+            .set({ updatedAt: Date.now() })
+            .where(eq(scheduledWorkouts.id, scheduledWorkout.id))
+            .run();
+
+          return true;
+        }
+
+        const carryOverProgrammingNotes = request.body.carryOverProgrammingNotes === true;
+        for (const sourceRow of sourceRows) {
+          tx.update(scheduledWorkoutExercises)
+            .set({
+              exerciseId: request.body.toExerciseId,
+              programmingNotes: carryOverProgrammingNotes ? sourceRow.programmingNotes : null,
+              templateCues: null,
+            })
+            .where(eq(scheduledWorkoutExercises.id, sourceRow.id))
+            .run();
+        }
+
+        const templateIdForDefaults = scheduledWorkout.templateId;
+        const shouldResetSets =
+          request.body.preserveSets !== true && templateIdForDefaults !== null;
+        if (shouldResetSets) {
+          const targetTemplateExercise = tx
+            .select({
+              id: templateExercises.id,
+              sets: templateExercises.sets,
+              repsMin: templateExercises.repsMin,
+              repsMax: templateExercises.repsMax,
+              setTargets: templateExercises.setTargets,
+            })
+            .from(templateExercises)
+            .where(
+              and(
+                eq(templateExercises.templateId, templateIdForDefaults),
+                eq(templateExercises.exerciseId, request.body.toExerciseId),
+              ),
+            )
+            .orderBy(asc(templateExercises.orderIndex), asc(templateExercises.id))
+            .limit(1)
+            .get();
+
+          if (targetTemplateExercise) {
+            const setDrafts = toSnapshotSetDrafts(targetTemplateExercise);
+
+            for (const sourceRow of sourceRows) {
+              tx.delete(scheduledWorkoutExerciseSets)
+                .where(eq(scheduledWorkoutExerciseSets.scheduledWorkoutExerciseId, sourceRow.id))
+                .run();
+
+              if (setDrafts.length > 0) {
+                tx.insert(scheduledWorkoutExerciseSets)
+                  .values(
+                    setDrafts.map((setDraft) => ({
+                      id: randomUUID(),
+                      scheduledWorkoutExerciseId: sourceRow.id,
+                      setNumber: setDraft.setNumber,
+                      repsMin: setDraft.repsMin,
+                      repsMax: setDraft.repsMax,
+                      reps: setDraft.reps,
+                      targetWeight: setDraft.targetWeight,
+                      targetWeightMin: setDraft.targetWeightMin,
+                      targetWeightMax: setDraft.targetWeightMax,
+                      targetSeconds: setDraft.targetSeconds,
+                      targetDistance: setDraft.targetDistance,
+                    })),
+                  )
+                  .run();
+              }
+            }
+          }
+        }
+
+        tx.update(scheduledWorkouts)
+          .set({ updatedAt: Date.now() })
+          .where(eq(scheduledWorkouts.id, scheduledWorkout.id))
+          .run();
+
+        return true;
+      });
+
+      if (!swapSucceeded) {
+        return sendError(
+          reply,
+          404,
+          SCHEDULED_WORKOUT_EXERCISE_NOT_FOUND_RESPONSE.code,
+          SCHEDULED_WORKOUT_EXERCISE_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      const updatedDetail = await buildScheduledWorkoutDetail({
+        scheduledWorkoutId: scheduledWorkout.id,
+        userId: request.userId,
+      });
+      if (!updatedDetail) {
+        throw new Error('Swapped scheduled workout could not be loaded');
+      }
+
+      return reply.send({
+        data: updatedDetail,
+      });
+    },
+  );
+
+  typedApp.patch(
     '/:id',
     {
       schema: {
@@ -373,6 +831,16 @@ export const scheduledWorkoutRoutes: FastifyPluginAsync = async (app) => {
           SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.code,
           SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.message,
         );
+      }
+
+      if (
+        request.body.date !== undefined &&
+        request.body.date !== existingScheduledWorkout.date
+      ) {
+        await markRescheduledAgentNotesAsStale({
+          scheduledWorkoutId: scheduledWorkout.id,
+          newDate: scheduledWorkout.date,
+        });
       }
 
       return reply.send({

--- a/apps/api/src/routes/scheduled-workouts/index.ts
+++ b/apps/api/src/routes/scheduled-workouts/index.ts
@@ -3,16 +3,19 @@ import { randomUUID } from 'node:crypto';
 import {
   apiDataResponseSchema,
   createScheduledWorkoutInputSchema,
+  scheduledWorkoutDetailSchema,
   scheduledWorkoutListItemSchema,
   scheduledWorkoutQueryParamsSchema,
   scheduledWorkoutSchema,
   updateScheduledWorkoutInputSchema,
   workoutTemplateSchema,
 } from '@pulse/shared';
+import { and, eq, inArray } from 'drizzle-orm';
 import type { FastifyPluginAsync } from 'fastify';
 import { type ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 
+import { exercises, scheduledWorkouts, workoutTemplates } from '../../db/schema/index.js';
 import { sendError } from '../../lib/reply.js';
 import { requireAuth } from '../../middleware/auth.js';
 import {
@@ -23,9 +26,13 @@ import {
   successFlagSchema,
 } from '../../openapi.js';
 import { templateBelongsToUser } from '../workout-templates/template-access.js';
-
 import { findWorkoutTemplateById } from '../workout-templates/store.js';
 
+import {
+  computeTemplateVersionForTemplateId,
+  readSnapshot,
+  writeSnapshot,
+} from './snapshot-store.js';
 import {
   createScheduledWorkout,
   deleteScheduledWorkout,
@@ -44,6 +51,166 @@ const WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE = {
   message: 'Workout template not found',
 } as const;
 
+const TEMPLATE_DRIFT_SUMMARY = 'Template has been updated since scheduling.';
+
+const scheduledWorkoutDetailWithTemplateSchema = scheduledWorkoutDetailSchema.extend({
+  template: workoutTemplateSchema.nullable(),
+});
+
+const mapSnapshotExercise = (exercise: Awaited<ReturnType<typeof readSnapshot>>['exercises'][number]) => ({
+  exerciseId: exercise.exerciseId,
+  section: exercise.section,
+  orderIndex: exercise.orderIndex,
+  programmingNotes: exercise.programmingNotes,
+  agentNotes: exercise.agentNotes,
+  agentNotesMeta: exercise.agentNotesMeta,
+  templateCues: exercise.templateCues,
+  supersetGroup: exercise.supersetGroup,
+  tempo: exercise.tempo,
+  restSeconds: exercise.restSeconds,
+  sets: exercise.sets.map((set) => ({
+    setNumber: set.setNumber,
+    repsMin: set.repsMin,
+    repsMax: set.repsMax,
+    reps: set.reps,
+    targetWeight: set.targetWeight,
+    targetWeightMin: set.targetWeightMin,
+    targetWeightMax: set.targetWeightMax,
+    targetSeconds: set.targetSeconds,
+    targetDistance: set.targetDistance,
+  })),
+});
+
+const buildScheduledWorkoutDetail = async ({
+  scheduledWorkoutId,
+  userId,
+}: {
+  scheduledWorkoutId: string;
+  userId: string;
+}) => {
+  const scheduledWorkout = await findScheduledWorkoutById(scheduledWorkoutId, userId);
+  if (!scheduledWorkout) {
+    return null;
+  }
+
+  const { db } = await import('../../db/index.js');
+  const snapshot = await readSnapshot(scheduledWorkout.id, db);
+  const snapshotExercises = snapshot.exercises.map(mapSnapshotExercise);
+  const uniqueSnapshotExerciseIds = [...new Set(snapshotExercises.map((exercise) => exercise.exerciseId))];
+
+  const exerciseRows =
+    uniqueSnapshotExerciseIds.length === 0
+      ? []
+      : db
+          .select({
+            id: exercises.id,
+            userId: exercises.userId,
+            name: exercises.name,
+            deletedAt: exercises.deletedAt,
+          })
+          .from(exercises)
+          .where(inArray(exercises.id, uniqueSnapshotExerciseIds))
+          .all();
+
+  const exercisesById = new Map(exerciseRows.map((row) => [row.id, row]));
+  const staleByExerciseId = new Map<string, { exerciseId: string; snapshotName: string }>();
+
+  for (const snapshotExercise of snapshotExercises) {
+    const exercise = exercisesById.get(snapshotExercise.exerciseId);
+    const isMissing = !exercise;
+    const isSoftDeleted = exercise?.deletedAt !== null;
+    const isOutsideUserScope =
+      exercise !== undefined && exercise.userId !== null && exercise.userId !== userId;
+
+    if (isMissing || isSoftDeleted || isOutsideUserScope) {
+      staleByExerciseId.set(snapshotExercise.exerciseId, {
+        exerciseId: snapshotExercise.exerciseId,
+        snapshotName: exercise?.name ?? snapshotExercise.exerciseId,
+      });
+    }
+  }
+
+  const scheduledWorkoutRecord = db
+    .select({
+      templateVersion: scheduledWorkouts.templateVersion,
+    })
+    .from(scheduledWorkouts)
+    .where(and(eq(scheduledWorkouts.id, scheduledWorkout.id), eq(scheduledWorkouts.userId, userId)))
+    .limit(1)
+    .get();
+
+  let templateDeleted = false;
+  let templateDrift: { changedAt: number; summary: string } | null = null;
+
+  if (scheduledWorkout.templateId) {
+    const sourceTemplate = db
+      .select({
+        id: workoutTemplates.id,
+        deletedAt: workoutTemplates.deletedAt,
+        updatedAt: workoutTemplates.updatedAt,
+      })
+      .from(workoutTemplates)
+      .where(
+        and(
+          eq(workoutTemplates.id, scheduledWorkout.templateId),
+          eq(workoutTemplates.userId, userId),
+        ),
+      )
+      .limit(1)
+      .get();
+
+    templateDeleted = !sourceTemplate || sourceTemplate.deletedAt !== null;
+
+    if (sourceTemplate && sourceTemplate.deletedAt === null && scheduledWorkoutRecord?.templateVersion) {
+      const currentTemplateVersion = await computeTemplateVersionForTemplateId(
+        scheduledWorkout.templateId,
+        db,
+      );
+
+      if (currentTemplateVersion !== scheduledWorkoutRecord.templateVersion) {
+        templateDrift = {
+          changedAt: sourceTemplate.updatedAt,
+          summary: TEMPLATE_DRIFT_SUMMARY,
+        };
+      }
+    }
+  }
+
+  return {
+    ...scheduledWorkout,
+    exercises: snapshotExercises,
+    templateDrift,
+    staleExercises: [...staleByExerciseId.values()],
+    templateDeleted,
+  };
+};
+
+const buildScheduledWorkoutDetailWithTemplate = async ({
+  scheduledWorkoutId,
+  userId,
+}: {
+  scheduledWorkoutId: string;
+  userId: string;
+}) => {
+  const payload = await buildScheduledWorkoutDetail({
+    scheduledWorkoutId,
+    userId,
+  });
+  if (!payload) {
+    return null;
+  }
+
+  const template =
+    payload.templateId && !payload.templateDeleted
+      ? ((await findWorkoutTemplateById(payload.templateId, userId)) ?? null)
+      : null;
+
+  return {
+    ...payload,
+    template,
+  };
+};
+
 export const scheduledWorkoutRoutes: FastifyPluginAsync = async (app) => {
   app.addHook('onRequest', requireAuth);
 
@@ -55,7 +222,7 @@ export const scheduledWorkoutRoutes: FastifyPluginAsync = async (app) => {
       schema: {
         body: createScheduledWorkoutInputSchema,
         response: {
-          201: apiDataResponseSchema(scheduledWorkoutSchema),
+          201: apiDataResponseSchema(scheduledWorkoutDetailSchema),
           400: badRequestResponseSchema,
           401: apiErrorResponseSchema,
           404: apiErrorResponseSchema,
@@ -85,8 +252,21 @@ export const scheduledWorkoutRoutes: FastifyPluginAsync = async (app) => {
         input: request.body,
       });
 
+      await writeSnapshot({
+        scheduledWorkoutId: scheduledWorkout.id,
+        templateId: request.body.templateId,
+      });
+
+      const scheduledWorkoutDetail = await buildScheduledWorkoutDetail({
+        scheduledWorkoutId: scheduledWorkout.id,
+        userId: request.userId,
+      });
+      if (!scheduledWorkoutDetail) {
+        throw new Error('Created scheduled workout could not be loaded');
+      }
+
       return reply.code(201).send({
-        data: scheduledWorkout,
+        data: scheduledWorkoutDetail,
       });
     },
   );
@@ -118,17 +298,13 @@ export const scheduledWorkoutRoutes: FastifyPluginAsync = async (app) => {
     },
   );
 
-  const scheduledWorkoutDetailSchema = scheduledWorkoutSchema.extend({
-    template: workoutTemplateSchema.nullable(),
-  });
-
   typedApp.get(
     '/:id',
     {
       schema: {
         params: idParamsSchema,
         response: {
-          200: apiDataResponseSchema(scheduledWorkoutDetailSchema),
+          200: apiDataResponseSchema(scheduledWorkoutDetailWithTemplateSchema),
           401: apiErrorResponseSchema,
           404: apiErrorResponseSchema,
         },
@@ -148,15 +324,21 @@ export const scheduledWorkoutRoutes: FastifyPluginAsync = async (app) => {
         );
       }
 
-      const template = scheduledWorkout.templateId
-        ? ((await findWorkoutTemplateById(scheduledWorkout.templateId, request.userId)) ?? null)
-        : null;
+      const scheduledWorkoutDetail = await buildScheduledWorkoutDetailWithTemplate({
+        scheduledWorkoutId: scheduledWorkout.id,
+        userId: request.userId,
+      });
+      if (!scheduledWorkoutDetail) {
+        return sendError(
+          reply,
+          404,
+          SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.code,
+          SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.message,
+        );
+      }
 
       return reply.send({
-        data: {
-          ...scheduledWorkout,
-          template,
-        },
+        data: scheduledWorkoutDetail,
       });
     },
   );

--- a/apps/api/src/routes/scheduled-workouts/snapshot-store.test.ts
+++ b/apps/api/src/routes/scheduled-workouts/snapshot-store.test.ts
@@ -1,0 +1,274 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Database from 'better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import * as schema from '../../db/schema/index.js';
+import {
+  exercises,
+  scheduledWorkoutExerciseSets,
+  scheduledWorkoutExercises,
+  scheduledWorkouts,
+  templateExercises,
+  users,
+  workoutTemplates,
+} from '../../db/schema/index.js';
+
+import { deleteSnapshot, readSnapshot, writeSnapshot } from './snapshot-store.js';
+
+type TestDatabase = ReturnType<typeof drizzle<typeof schema>>;
+
+const tempDirs: string[] = [];
+
+const createTestDatabase = () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'pulse-snapshot-store-'));
+  tempDirs.push(tempDir);
+  const dbPath = join(tempDir, 'test.db');
+  const sqlite = new Database(dbPath);
+  sqlite.pragma('foreign_keys = ON');
+  const db = drizzle(sqlite, {
+    schema,
+  });
+  migrate(db, {
+    migrationsFolder: fileURLToPath(new URL('../../../drizzle', import.meta.url)),
+  });
+
+  return { db, sqlite, tempDir };
+};
+
+const seedBaseTemplate = (db: TestDatabase) => {
+  db.insert(users)
+    .values({
+      id: 'user-1',
+      username: 'derek',
+      name: 'Derek',
+      passwordHash: 'hash',
+    })
+    .run();
+
+  db.insert(exercises)
+    .values([
+      {
+        id: 'exercise-warmup',
+        userId: null,
+        name: 'Jump Rope',
+        muscleGroups: ['calves'],
+        equipment: 'none',
+        category: 'cardio',
+        trackingType: 'seconds_only',
+      },
+      {
+        id: 'exercise-main',
+        userId: null,
+        name: 'Kettlebell Swing',
+        muscleGroups: ['hamstrings'],
+        equipment: 'kettlebell',
+        category: 'compound',
+        trackingType: 'weight_reps',
+      },
+      {
+        id: 'exercise-cooldown',
+        userId: null,
+        name: 'Couch Stretch',
+        muscleGroups: ['quads'],
+        equipment: 'none',
+        category: 'mobility',
+        trackingType: 'seconds_only',
+      },
+    ])
+    .run();
+
+  db.insert(workoutTemplates)
+    .values({
+      id: 'template-1',
+      userId: 'user-1',
+      name: 'Lower Body Day',
+      description: null,
+      tags: [],
+      deletedAt: null,
+    })
+    .run();
+
+  db.insert(templateExercises)
+    .values([
+      {
+        id: 'template-ex-main',
+        templateId: 'template-1',
+        exerciseId: 'exercise-main',
+        section: 'main',
+        orderIndex: 1,
+        sets: 2,
+        repsMin: 8,
+        repsMax: 8,
+        restSeconds: 90,
+        supersetGroup: 'A',
+        notes: 'Fallback template note',
+        programmingNotes: null,
+        cues: ['Hinge hips', 'Brace'],
+        setTargets: [
+          {
+            setNumber: 2,
+            targetWeight: 62.5,
+          },
+          {
+            setNumber: 1,
+            targetWeight: 55,
+          },
+        ],
+      },
+      {
+        id: 'template-ex-warmup',
+        templateId: 'template-1',
+        exerciseId: 'exercise-warmup',
+        section: 'warmup',
+        orderIndex: 0,
+        sets: 1,
+        repsMin: null,
+        repsMax: null,
+        restSeconds: 45,
+        notes: null,
+        programmingNotes: 'Keep cadence easy for 3 minutes.',
+        cues: ['Stay relaxed'],
+      },
+      {
+        id: 'template-ex-cooldown',
+        templateId: 'template-1',
+        exerciseId: 'exercise-cooldown',
+        section: 'cooldown',
+        orderIndex: 0,
+        sets: null,
+        repsMin: null,
+        repsMax: null,
+        restSeconds: null,
+        notes: null,
+        programmingNotes: null,
+      },
+    ])
+    .run();
+
+  db.insert(scheduledWorkouts)
+    .values({
+      id: 'scheduled-1',
+      userId: 'user-1',
+      templateId: 'template-1',
+      date: '2026-04-21',
+    })
+    .run();
+};
+
+describe('scheduled workout snapshot store', () => {
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('writeSnapshot copies template exercises, sets, and stores templateVersion hash', async () => {
+    const { db, sqlite } = await createTestDatabase();
+    try {
+      seedBaseTemplate(db);
+
+      const writeResult = await writeSnapshot({
+        scheduledWorkoutId: 'scheduled-1',
+        templateId: 'template-1',
+        database: db,
+      });
+
+      expect(writeResult.exerciseCount).toBe(3);
+      expect(writeResult.setCount).toBe(4);
+      expect(writeResult.templateVersion).toMatch(/^[0-9a-f]{64}$/);
+
+      const scheduledWorkoutRow = db
+        .select({
+          templateVersion: scheduledWorkouts.templateVersion,
+        })
+        .from(scheduledWorkouts)
+        .where(eq(scheduledWorkouts.id, 'scheduled-1'))
+        .limit(1)
+        .get();
+
+      expect(scheduledWorkoutRow?.templateVersion).toBe(writeResult.templateVersion);
+
+      const snapshotRows = db
+        .select({
+          exerciseId: scheduledWorkoutExercises.exerciseId,
+          section: scheduledWorkoutExercises.section,
+          orderIndex: scheduledWorkoutExercises.orderIndex,
+          programmingNotes: scheduledWorkoutExercises.programmingNotes,
+          agentNotes: scheduledWorkoutExercises.agentNotes,
+          templateCues: scheduledWorkoutExercises.templateCues,
+        })
+        .from(scheduledWorkoutExercises)
+        .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, 'scheduled-1'))
+        .all();
+
+      expect(snapshotRows).toHaveLength(3);
+      const mainRow = snapshotRows.find((row) => row.section === 'main');
+      expect(mainRow).toMatchObject({
+        exerciseId: 'exercise-main',
+        orderIndex: 1,
+        programmingNotes: 'Fallback template note',
+        agentNotes: null,
+        templateCues: ['Hinge hips', 'Brace'],
+      });
+
+      const readResult = await readSnapshot('scheduled-1', db);
+      expect(readResult.exercises.map((exercise) => exercise.section)).toEqual([
+        'warmup',
+        'main',
+        'cooldown',
+      ]);
+      expect(readResult.exercises[1]?.sets.map((set) => set.setNumber)).toEqual([1, 2]);
+      expect(readResult.exercises[1]?.sets[0]).toMatchObject({
+        targetWeight: 55,
+        reps: 8,
+      });
+      expect(readResult.exercises[1]?.sets[1]).toMatchObject({
+        targetWeight: 62.5,
+        reps: 8,
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it('deleteSnapshot removes all snapshot rows for a scheduled workout', async () => {
+    const { db, sqlite } = await createTestDatabase();
+    try {
+      seedBaseTemplate(db);
+
+      await writeSnapshot({
+        scheduledWorkoutId: 'scheduled-1',
+        templateId: 'template-1',
+        database: db,
+      });
+
+      const changes = await deleteSnapshot('scheduled-1', db);
+      expect(changes).toBe(3);
+
+      const remainingExercises = db
+        .select({ id: scheduledWorkoutExercises.id })
+        .from(scheduledWorkoutExercises)
+        .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, 'scheduled-1'))
+        .all();
+      expect(remainingExercises).toEqual([]);
+
+      const remainingSets = db
+        .select({ id: scheduledWorkoutExerciseSets.id })
+        .from(scheduledWorkoutExerciseSets)
+        .all();
+      expect(remainingSets).toEqual([]);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/src/routes/scheduled-workouts/snapshot-store.ts
+++ b/apps/api/src/routes/scheduled-workouts/snapshot-store.ts
@@ -252,6 +252,21 @@ export const computeScheduledWorkoutTemplateVersion = (
     .update(JSON.stringify(toTemplateVersionPayload(rows)))
     .digest('hex');
 
+export const computeTemplateVersionForTemplateId = async (
+  templateId: string,
+  database?: PulseDb,
+): Promise<string> => {
+  const db = await resolveDb(database);
+  const templateRows = db
+    .select(templateExerciseSnapshotSelection)
+    .from(templateExercises)
+    .where(eq(templateExercises.templateId, templateId))
+    .all()
+    .sort(compareTemplateExercises);
+
+  return computeScheduledWorkoutTemplateVersion(templateRows);
+};
+
 export const readSnapshot = async (
   scheduledWorkoutId: string,
   database?: PulseDb,

--- a/apps/api/src/routes/scheduled-workouts/snapshot-store.ts
+++ b/apps/api/src/routes/scheduled-workouts/snapshot-store.ts
@@ -1,0 +1,433 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+import { eq, inArray } from 'drizzle-orm';
+
+import type {
+  TemplateExerciseSetTarget,
+  WorkoutTemplateSectionType,
+} from '../../db/schema/index.js';
+import {
+  scheduledWorkoutExerciseSets,
+  scheduledWorkoutExercises,
+  scheduledWorkouts,
+  templateExercises,
+  workoutTemplates,
+} from '../../db/schema/index.js';
+
+type PulseDb = typeof import('../../db/index.js').db;
+
+const SECTION_ORDER: WorkoutTemplateSectionType[] = ['warmup', 'main', 'cooldown', 'supplemental'];
+const SECTION_RANK: Record<WorkoutTemplateSectionType, number> = {
+  warmup: 0,
+  main: 1,
+  cooldown: 2,
+  supplemental: 3,
+};
+
+type TemplateExerciseSnapshotRow = {
+  id: string;
+  exerciseId: string;
+  section: WorkoutTemplateSectionType;
+  orderIndex: number;
+  sets: number | null;
+  repsMin: number | null;
+  repsMax: number | null;
+  tempo: string | null;
+  restSeconds: number | null;
+  supersetGroup: string | null;
+  notes: string | null;
+  programmingNotes: string | null;
+  cues: string[] | null;
+  setTargets: TemplateExerciseSetTarget[] | null;
+};
+
+export type ScheduledWorkoutSnapshotSet = {
+  id: string;
+  scheduledWorkoutExerciseId: string;
+  setNumber: number;
+  repsMin: number | null;
+  repsMax: number | null;
+  reps: number | null;
+  targetWeight: number | null;
+  targetWeightMin: number | null;
+  targetWeightMax: number | null;
+  targetSeconds: number | null;
+  targetDistance: number | null;
+  createdAt: number;
+};
+
+export type ScheduledWorkoutSnapshotExercise = {
+  id: string;
+  scheduledWorkoutId: string;
+  exerciseId: string;
+  section: WorkoutTemplateSectionType;
+  orderIndex: number;
+  programmingNotes: string | null;
+  agentNotes: string | null;
+  agentNotesMeta: {
+    author: string;
+    generatedAt: string;
+    scheduledDateAtGeneration: string;
+    stale?: boolean;
+  } | null;
+  templateCues: string[] | null;
+  supersetGroup: string | null;
+  tempo: string | null;
+  restSeconds: number | null;
+  createdAt: number;
+  updatedAt: number;
+  sets: ScheduledWorkoutSnapshotSet[];
+};
+
+export type ScheduledWorkoutSnapshot = {
+  scheduledWorkoutId: string;
+  exercises: ScheduledWorkoutSnapshotExercise[];
+};
+
+type SnapshotWriteResult = {
+  templateVersion: string;
+  exerciseCount: number;
+  setCount: number;
+};
+
+const resolveDb = async (database?: PulseDb): Promise<PulseDb> => {
+  if (database) {
+    return database;
+  }
+
+  const { db } = await import('../../db/index.js');
+  return db;
+};
+
+const templateExerciseSnapshotSelection = {
+  id: templateExercises.id,
+  exerciseId: templateExercises.exerciseId,
+  section: templateExercises.section,
+  orderIndex: templateExercises.orderIndex,
+  sets: templateExercises.sets,
+  repsMin: templateExercises.repsMin,
+  repsMax: templateExercises.repsMax,
+  tempo: templateExercises.tempo,
+  restSeconds: templateExercises.restSeconds,
+  supersetGroup: templateExercises.supersetGroup,
+  notes: templateExercises.notes,
+  programmingNotes: templateExercises.programmingNotes,
+  cues: templateExercises.cues,
+  setTargets: templateExercises.setTargets,
+};
+
+const scheduledWorkoutExerciseSelection = {
+  id: scheduledWorkoutExercises.id,
+  scheduledWorkoutId: scheduledWorkoutExercises.scheduledWorkoutId,
+  exerciseId: scheduledWorkoutExercises.exerciseId,
+  section: scheduledWorkoutExercises.section,
+  orderIndex: scheduledWorkoutExercises.orderIndex,
+  programmingNotes: scheduledWorkoutExercises.programmingNotes,
+  agentNotes: scheduledWorkoutExercises.agentNotes,
+  agentNotesMeta: scheduledWorkoutExercises.agentNotesMeta,
+  templateCues: scheduledWorkoutExercises.templateCues,
+  supersetGroup: scheduledWorkoutExercises.supersetGroup,
+  tempo: scheduledWorkoutExercises.tempo,
+  restSeconds: scheduledWorkoutExercises.restSeconds,
+  createdAt: scheduledWorkoutExercises.createdAt,
+  updatedAt: scheduledWorkoutExercises.updatedAt,
+};
+
+const scheduledWorkoutExerciseSetSelection = {
+  id: scheduledWorkoutExerciseSets.id,
+  scheduledWorkoutExerciseId: scheduledWorkoutExerciseSets.scheduledWorkoutExerciseId,
+  setNumber: scheduledWorkoutExerciseSets.setNumber,
+  repsMin: scheduledWorkoutExerciseSets.repsMin,
+  repsMax: scheduledWorkoutExerciseSets.repsMax,
+  reps: scheduledWorkoutExerciseSets.reps,
+  targetWeight: scheduledWorkoutExerciseSets.targetWeight,
+  targetWeightMin: scheduledWorkoutExerciseSets.targetWeightMin,
+  targetWeightMax: scheduledWorkoutExerciseSets.targetWeightMax,
+  targetSeconds: scheduledWorkoutExerciseSets.targetSeconds,
+  targetDistance: scheduledWorkoutExerciseSets.targetDistance,
+  createdAt: scheduledWorkoutExerciseSets.createdAt,
+};
+
+const toExerciseProgrammingNotes = (
+  row: Pick<TemplateExerciseSnapshotRow, 'programmingNotes' | 'notes'>,
+) => row.programmingNotes ?? row.notes ?? null;
+
+const compareTemplateExercises = (
+  left: TemplateExerciseSnapshotRow,
+  right: TemplateExerciseSnapshotRow,
+) => {
+  const sectionDelta = SECTION_RANK[left.section] - SECTION_RANK[right.section];
+  if (sectionDelta !== 0) {
+    return sectionDelta;
+  }
+
+  if (left.orderIndex !== right.orderIndex) {
+    return left.orderIndex - right.orderIndex;
+  }
+
+  return left.id.localeCompare(right.id);
+};
+
+const toExactReps = (repsMin: number | null, repsMax: number | null): number | null => {
+  if (repsMin === null || repsMax === null) {
+    return null;
+  }
+
+  return repsMin === repsMax ? repsMin : null;
+};
+
+type SnapshotSetDraft = {
+  setNumber: number;
+  repsMin: number | null;
+  repsMax: number | null;
+  reps: number | null;
+  targetWeight: number | null;
+  targetWeightMin: number | null;
+  targetWeightMax: number | null;
+  targetSeconds: number | null;
+  targetDistance: number | null;
+};
+
+const toSnapshotSetDrafts = (row: TemplateExerciseSnapshotRow): SnapshotSetDraft[] => {
+  const targets = [...(row.setTargets ?? [])].sort(
+    (left, right) => left.setNumber - right.setNumber,
+  );
+  const reps = toExactReps(row.repsMin, row.repsMax);
+
+  if (targets.length > 0) {
+    return targets.map((target) => ({
+      setNumber: target.setNumber,
+      repsMin: row.repsMin,
+      repsMax: row.repsMax,
+      reps,
+      targetWeight: target.targetWeight ?? null,
+      targetWeightMin: target.targetWeightMin ?? null,
+      targetWeightMax: target.targetWeightMax ?? null,
+      targetSeconds: target.targetSeconds ?? null,
+      targetDistance: target.targetDistance ?? null,
+    }));
+  }
+
+  const setCount = Math.max(1, row.sets ?? 1);
+  return Array.from({ length: setCount }, (_, index) => ({
+    setNumber: index + 1,
+    repsMin: row.repsMin,
+    repsMax: row.repsMax,
+    reps,
+    targetWeight: null,
+    targetWeightMin: null,
+    targetWeightMax: null,
+    targetSeconds: null,
+    targetDistance: null,
+  }));
+};
+
+const toTemplateVersionPayload = (rows: TemplateExerciseSnapshotRow[]) =>
+  rows.map((row) => ({
+    exerciseId: row.exerciseId,
+    section: row.section,
+    orderIndex: row.orderIndex,
+    programmingNotes: toExerciseProgrammingNotes(row),
+    templateCues: row.cues ?? null,
+    supersetGroup: row.supersetGroup,
+    tempo: row.tempo,
+    restSeconds: row.restSeconds,
+    sets: toSnapshotSetDrafts(row).map((set) => ({
+      setNumber: set.setNumber,
+      repsMin: set.repsMin,
+      repsMax: set.repsMax,
+      reps: set.reps,
+      targetWeight: set.targetWeight,
+      targetWeightMin: set.targetWeightMin,
+      targetWeightMax: set.targetWeightMax,
+      targetSeconds: set.targetSeconds,
+      targetDistance: set.targetDistance,
+    })),
+  }));
+
+export const computeScheduledWorkoutTemplateVersion = (
+  rows: TemplateExerciseSnapshotRow[],
+): string =>
+  createHash('sha256')
+    .update(JSON.stringify(toTemplateVersionPayload(rows)))
+    .digest('hex');
+
+export const readSnapshot = async (
+  scheduledWorkoutId: string,
+  database?: PulseDb,
+): Promise<ScheduledWorkoutSnapshot> => {
+  const db = await resolveDb(database);
+
+  const exercisesRows = db
+    .select(scheduledWorkoutExerciseSelection)
+    .from(scheduledWorkoutExercises)
+    .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId))
+    .all()
+    .sort((left, right) => {
+      const sectionDelta = SECTION_RANK[left.section] - SECTION_RANK[right.section];
+      if (sectionDelta !== 0) {
+        return sectionDelta;
+      }
+
+      if (left.orderIndex !== right.orderIndex) {
+        return left.orderIndex - right.orderIndex;
+      }
+
+      return left.id.localeCompare(right.id);
+    });
+
+  if (exercisesRows.length === 0) {
+    return {
+      scheduledWorkoutId,
+      exercises: [],
+    };
+  }
+
+  const setRows = db
+    .select(scheduledWorkoutExerciseSetSelection)
+    .from(scheduledWorkoutExerciseSets)
+    .where(
+      inArray(
+        scheduledWorkoutExerciseSets.scheduledWorkoutExerciseId,
+        exercisesRows.map((row) => row.id),
+      ),
+    )
+    .all()
+    .sort((left, right) => {
+      if (left.scheduledWorkoutExerciseId !== right.scheduledWorkoutExerciseId) {
+        return left.scheduledWorkoutExerciseId.localeCompare(right.scheduledWorkoutExerciseId);
+      }
+
+      if (left.setNumber !== right.setNumber) {
+        return left.setNumber - right.setNumber;
+      }
+
+      return left.id.localeCompare(right.id);
+    });
+
+  const setsByExerciseId = new Map<string, ScheduledWorkoutSnapshotSet[]>();
+  for (const setRow of setRows) {
+    const existing = setsByExerciseId.get(setRow.scheduledWorkoutExerciseId) ?? [];
+    existing.push(setRow);
+    setsByExerciseId.set(setRow.scheduledWorkoutExerciseId, existing);
+  }
+
+  return {
+    scheduledWorkoutId,
+    exercises: exercisesRows.map((exerciseRow) => ({
+      ...exerciseRow,
+      sets: setsByExerciseId.get(exerciseRow.id) ?? [],
+    })),
+  };
+};
+
+export const deleteSnapshot = async (
+  scheduledWorkoutId: string,
+  database?: PulseDb,
+): Promise<number> => {
+  const db = await resolveDb(database);
+  const result = db
+    .delete(scheduledWorkoutExercises)
+    .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId))
+    .run();
+
+  return result.changes;
+};
+
+export const writeSnapshot = async ({
+  scheduledWorkoutId,
+  templateId,
+  database,
+}: {
+  scheduledWorkoutId: string;
+  templateId: string;
+  database?: PulseDb;
+}): Promise<SnapshotWriteResult> => {
+  const db = await resolveDb(database);
+
+  return db.transaction((tx) => {
+    const template = tx
+      .select({
+        id: workoutTemplates.id,
+        deletedAt: workoutTemplates.deletedAt,
+      })
+      .from(workoutTemplates)
+      .where(eq(workoutTemplates.id, templateId))
+      .limit(1)
+      .get();
+
+    if (!template || template.deletedAt !== null) {
+      throw new Error(`Cannot snapshot missing or deleted template: ${templateId}`);
+    }
+
+    const templateRows = tx
+      .select(templateExerciseSnapshotSelection)
+      .from(templateExercises)
+      .where(eq(templateExercises.templateId, templateId))
+      .all()
+      .sort(compareTemplateExercises);
+
+    tx.delete(scheduledWorkoutExercises)
+      .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId))
+      .run();
+
+    const templateVersion = computeScheduledWorkoutTemplateVersion(templateRows);
+
+    const exerciseRows = templateRows.map((row) => ({
+      id: randomUUID(),
+      scheduledWorkoutId,
+      exerciseId: row.exerciseId,
+      section: row.section,
+      orderIndex: row.orderIndex,
+      programmingNotes: toExerciseProgrammingNotes(row),
+      agentNotes: null,
+      agentNotesMeta: null,
+      templateCues: row.cues ?? null,
+      supersetGroup: row.supersetGroup,
+      tempo: row.tempo,
+      restSeconds: row.restSeconds,
+    }));
+
+    if (exerciseRows.length > 0) {
+      tx.insert(scheduledWorkoutExercises).values(exerciseRows).run();
+    }
+
+    const setRows = exerciseRows.flatMap((exerciseRow, index) =>
+      toSnapshotSetDrafts(templateRows[index] as TemplateExerciseSnapshotRow).map((setDraft) => ({
+        id: randomUUID(),
+        scheduledWorkoutExerciseId: exerciseRow.id,
+        setNumber: setDraft.setNumber,
+        repsMin: setDraft.repsMin,
+        repsMax: setDraft.repsMax,
+        reps: setDraft.reps,
+        targetWeight: setDraft.targetWeight,
+        targetWeightMin: setDraft.targetWeightMin,
+        targetWeightMax: setDraft.targetWeightMax,
+        targetSeconds: setDraft.targetSeconds,
+        targetDistance: setDraft.targetDistance,
+      })),
+    );
+
+    if (setRows.length > 0) {
+      tx.insert(scheduledWorkoutExerciseSets).values(setRows).run();
+    }
+
+    const updateResult = tx
+      .update(scheduledWorkouts)
+      .set({ templateVersion })
+      .where(eq(scheduledWorkouts.id, scheduledWorkoutId))
+      .run();
+
+    if (updateResult.changes !== 1) {
+      throw new Error(`Scheduled workout not found: ${scheduledWorkoutId}`);
+    }
+
+    return {
+      templateVersion,
+      exerciseCount: exerciseRows.length,
+      setCount: setRows.length,
+    };
+  });
+};
+
+export const getSectionOrder = () => SECTION_ORDER;

--- a/apps/api/src/routes/scheduled-workouts/store.ts
+++ b/apps/api/src/routes/scheduled-workouts/store.ts
@@ -24,6 +24,11 @@ const scheduledWorkoutSelection = {
   updatedAt: scheduledWorkouts.updatedAt,
 };
 
+const scheduledWorkoutSelectionWithTemplateVersion = {
+  ...scheduledWorkoutSelection,
+  templateVersion: scheduledWorkouts.templateVersion,
+};
+
 const scheduledWorkoutListSelection = {
   id: scheduledWorkouts.id,
   date: scheduledWorkouts.date,
@@ -156,10 +161,30 @@ export const findScheduledWorkoutById = async (
   id: string,
   userId: string,
 ): Promise<ScheduledWorkout | undefined> => {
+  const scheduledWorkout = await findScheduledWorkoutByIdWithTemplateVersion(id, userId);
+  if (!scheduledWorkout) {
+    return undefined;
+  }
+
+  return {
+    id: scheduledWorkout.id,
+    userId: scheduledWorkout.userId,
+    templateId: scheduledWorkout.templateId,
+    date: scheduledWorkout.date,
+    sessionId: scheduledWorkout.sessionId,
+    createdAt: scheduledWorkout.createdAt,
+    updatedAt: scheduledWorkout.updatedAt,
+  };
+};
+
+export const findScheduledWorkoutByIdWithTemplateVersion = async (
+  id: string,
+  userId: string,
+): Promise<(ScheduledWorkout & { templateVersion: string | null }) | undefined> => {
   const { db } = await import('../../db/index.js');
 
   return db
-    .select(scheduledWorkoutSelection)
+    .select(scheduledWorkoutSelectionWithTemplateVersion)
     .from(scheduledWorkouts)
     .where(and(eq(scheduledWorkouts.id, id), eq(scheduledWorkouts.userId, userId)))
     .limit(1)

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -3651,6 +3651,52 @@ describe('workout session routes', () => {
     expect(snapshotRows).toHaveLength(1);
   });
 
+  it('cancel endpoint preserves non-scheduled sessions and marks them cancelled', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'session-cancel-endpoint-regular',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      status: 'in-progress',
+      startedAt: Date.parse('2026-03-12T10:00:00.000Z'),
+      timeSegments: [{ start: '2026-03-12T10:00:00.000Z', end: null, section: 'main' }],
+    });
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions/session-cancel-endpoint-regular/cancel',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: {
+        revertedToSchedule: false,
+      },
+    });
+
+    const cancelledSession = context.db
+      .select({
+        status: workoutSessions.status,
+        deletedAt: workoutSessions.deletedAt,
+      })
+      .from(workoutSessions)
+      .where(eq(workoutSessions.id, 'session-cancel-endpoint-regular'))
+      .limit(1)
+      .get();
+
+    expect(cancelledSession).toEqual({
+      status: 'cancelled',
+      deletedAt: null,
+    });
+  });
+
   it('does not open any section segment for legacy in-progress sessions with no time segments', async () => {
     const authToken = context.app.jwt.sign(
       { sub: 'user-1', type: 'session', iss: 'pulse-api' },

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -13,6 +13,8 @@ import {
   agentTokens,
   exercises,
   parseWorkoutSessionTimeSegments,
+  scheduledWorkoutExerciseSets,
+  scheduledWorkoutExercises,
   scheduledWorkouts,
   serializeWorkoutSessionFeedback,
   serializeWorkoutSessionExerciseProgrammingNotes,
@@ -169,6 +171,7 @@ const seedWorkoutSession = (values: {
   id: string;
   userId: string;
   templateId?: string | null;
+  scheduledWorkoutId?: string | null;
   name: string;
   date: string;
   status?: 'scheduled' | 'in-progress' | 'paused' | 'cancelled' | 'completed';
@@ -188,6 +191,16 @@ const seedWorkoutSession = (values: {
     section?: 'warmup' | 'main' | 'cooldown' | 'supplemental';
   }>;
   exerciseProgrammingNotes?: Record<string, string | null>;
+  exerciseAgentNotes?: Record<string, string | null>;
+  exerciseAgentNotesMeta?: Record<
+    string,
+    {
+      author: string;
+      generatedAt: string;
+      scheduledDateAtGeneration: string;
+      stale?: boolean;
+    } | null
+  >;
 }) =>
   context.db
     .insert(workoutSessions)
@@ -195,6 +208,7 @@ const seedWorkoutSession = (values: {
       id: values.id,
       userId: values.userId,
       templateId: values.templateId ?? null,
+      scheduledWorkoutId: values.scheduledWorkoutId ?? null,
       name: values.name,
       date: values.date,
       status: values.status ?? 'in-progress',
@@ -211,6 +225,8 @@ const seedWorkoutSession = (values: {
       exerciseProgrammingNotes: serializeWorkoutSessionExerciseProgrammingNotes(
         values.exerciseProgrammingNotes,
       ),
+      exerciseAgentNotes: values.exerciseAgentNotes ?? null,
+      exerciseAgentNotesMeta: values.exerciseAgentNotesMeta ?? null,
       notes: values.notes ?? null,
     })
     .run();
@@ -272,6 +288,70 @@ const seedScheduledWorkout = (values: {
       templateId: values.templateId ?? null,
       date: values.date,
       sessionId: values.sessionId ?? null,
+    })
+    .run();
+
+const seedScheduledWorkoutExercise = (values: {
+  id: string;
+  scheduledWorkoutId: string;
+  exerciseId: string;
+  section?: 'warmup' | 'main' | 'cooldown' | 'supplemental';
+  orderIndex?: number;
+  programmingNotes?: string | null;
+  agentNotes?: string | null;
+  agentNotesMeta?: {
+    author: string;
+    generatedAt: string;
+    scheduledDateAtGeneration: string;
+    stale?: boolean;
+  } | null;
+  supersetGroup?: string | null;
+}) =>
+  context.db
+    .insert(scheduledWorkoutExercises)
+    .values({
+      id: values.id,
+      scheduledWorkoutId: values.scheduledWorkoutId,
+      exerciseId: values.exerciseId,
+      section: values.section ?? 'main',
+      orderIndex: values.orderIndex ?? 0,
+      programmingNotes: values.programmingNotes ?? null,
+      agentNotes: values.agentNotes ?? null,
+      agentNotesMeta: values.agentNotesMeta ?? null,
+      templateCues: null,
+      supersetGroup: values.supersetGroup ?? null,
+      tempo: null,
+      restSeconds: null,
+    })
+    .run();
+
+const seedScheduledWorkoutExerciseSet = (values: {
+  id: string;
+  scheduledWorkoutExerciseId: string;
+  setNumber: number;
+  reps?: number | null;
+  repsMin?: number | null;
+  repsMax?: number | null;
+  targetWeight?: number | null;
+  targetWeightMin?: number | null;
+  targetWeightMax?: number | null;
+  targetSeconds?: number | null;
+  targetDistance?: number | null;
+}) =>
+  context.db
+    .insert(scheduledWorkoutExerciseSets)
+    .values({
+      id: values.id,
+      scheduledWorkoutExerciseId: values.scheduledWorkoutExerciseId,
+      setNumber: values.setNumber,
+      reps: values.reps ?? null,
+      repsMin: values.repsMin ?? null,
+      repsMax: values.repsMax ?? null,
+      targetWeight: values.targetWeight ?? null,
+      targetWeightMin: values.targetWeightMin ?? null,
+      targetWeightMax: values.targetWeightMax ?? null,
+      targetSeconds: values.targetSeconds ?? null,
+      targetDistance: values.targetDistance ?? null,
     })
     .run();
 
@@ -670,6 +750,16 @@ describe('workout session routes', () => {
         'warmup::global-bench-press': null,
         'main::user-1-lat-pulldown': 'Stay stacked and drive elbows down.',
       },
+      exerciseAgentNotes: {
+        'main::user-1-lat-pulldown': 'This should not round-trip',
+      },
+      exerciseAgentNotesMeta: {
+        'main::user-1-lat-pulldown': {
+          author: 'Coach Agent',
+          generatedAt: '2026-03-11T19:45:00.000Z',
+          scheduledDateAtGeneration: '2026-03-12',
+        },
+      },
     });
 
     seedSessionSet({
@@ -754,6 +844,9 @@ describe('workout session routes', () => {
       persistedTemplateExercises.some(
         (exercise) => exercise.notes === 'User main note that should not round-trip',
       ),
+    ).toBe(false);
+    expect(
+      persistedTemplateExercises.some((exercise) => exercise.notes === 'This should not round-trip'),
     ).toBe(false);
   });
 
@@ -2447,11 +2540,93 @@ describe('workout session routes', () => {
 
     expect(response.statusCode).toBe(201);
     const payload = response.json() as {
-      data: { exercises?: Array<{ exerciseId: string | null; programmingNotes: string | null }> };
+      data: {
+        exercises?: Array<{
+          exerciseId: string | null;
+          programmingNotes: string | null;
+          agentNotes: string | null;
+          agentNotesMeta: unknown;
+        }>;
+      };
     };
 
     expect(payload.data.exercises).toBeDefined();
     expect(payload.data.exercises?.every((exercise) => exercise.programmingNotes === null)).toBe(
+      true,
+    );
+    expect(payload.data.exercises?.every((exercise) => exercise.agentNotes === null)).toBe(true);
+    expect(payload.data.exercises?.every((exercise) => exercise.agentNotesMeta === null)).toBe(
+      true,
+    );
+  });
+
+  it('supports templateId-only and name-only start modes with null session agent notes', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedTemplateExercise({
+      id: 'template-mode-note',
+      templateId: 'template-1',
+      exerciseId: 'global-bench-press',
+      orderIndex: 0,
+      section: 'main',
+      sets: 1,
+      notes: 'Template note for start-mode test',
+    });
+
+    const [templateResponse, adHocResponse] = await Promise.all([
+      context.app.inject({
+        method: 'POST',
+        url: '/api/v1/workout-sessions',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          templateId: 'template-1',
+          date: '2026-03-12',
+          status: 'in-progress',
+          startedAt: 1_700_000_250_000,
+          sets: [],
+        },
+      }),
+      context.app.inject({
+        method: 'POST',
+        url: '/api/v1/workout-sessions',
+        headers: createAuthorizationHeader(authToken),
+        payload: {
+          name: 'Ad-hoc Start Mode',
+          date: '2026-03-12',
+          status: 'in-progress',
+          startedAt: 1_700_000_260_000,
+          sets: [
+            {
+              exerciseId: 'user-1-lat-pulldown',
+              setNumber: 1,
+              section: 'main',
+            },
+          ],
+        },
+      }),
+    ]);
+
+    expect(templateResponse.statusCode).toBe(201);
+    expect(adHocResponse.statusCode).toBe(201);
+
+    const templatePayload = templateResponse.json() as {
+      data: { exercises?: Array<{ agentNotes: string | null; agentNotesMeta: unknown }> };
+    };
+    const adHocPayload = adHocResponse.json() as {
+      data: { exercises?: Array<{ agentNotes: string | null; agentNotesMeta: unknown }> };
+    };
+
+    expect(templatePayload.data.exercises?.every((exercise) => exercise.agentNotes === null)).toBe(
+      true,
+    );
+    expect(templatePayload.data.exercises?.every((exercise) => exercise.agentNotesMeta === null)).toBe(
+      true,
+    );
+    expect(adHocPayload.data.exercises?.every((exercise) => exercise.agentNotes === null)).toBe(true);
+    expect(adHocPayload.data.exercises?.every((exercise) => exercise.agentNotesMeta === null)).toBe(
       true,
     );
   });
@@ -2949,6 +3124,531 @@ describe('workout session routes', () => {
     expect(linkedSchedule).toEqual({
       sessionId,
     });
+  });
+
+  it('starts a session from scheduled-workout snapshot and propagates programming and agent notes', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedScheduledWorkout({
+      id: 'schedule-snapshot-seed',
+      userId: 'user-1',
+      templateId: 'template-1',
+      date: '2026-03-12',
+    });
+    seedScheduledWorkoutExercise({
+      id: 'schedule-snapshot-bench',
+      scheduledWorkoutId: 'schedule-snapshot-seed',
+      exerciseId: 'global-bench-press',
+      section: 'main',
+      orderIndex: 0,
+      programmingNotes: 'Explode through the concentric.',
+      agentNotes: 'Last week moved fast at 185. Start at 190.',
+      agentNotesMeta: {
+        author: 'Coach Agent',
+        generatedAt: '2026-03-11T19:45:00.000Z',
+        scheduledDateAtGeneration: '2026-03-12',
+      },
+    });
+    seedScheduledWorkoutExerciseSet({
+      id: 'schedule-snapshot-bench-set-1',
+      scheduledWorkoutExerciseId: 'schedule-snapshot-bench',
+      setNumber: 1,
+      reps: 6,
+      targetWeight: 190,
+    });
+    seedScheduledWorkoutExerciseSet({
+      id: 'schedule-snapshot-bench-set-2',
+      scheduledWorkoutExerciseId: 'schedule-snapshot-bench',
+      setNumber: 2,
+      reps: 6,
+      targetWeightMin: 190,
+      targetWeightMax: 195,
+    });
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        scheduledWorkoutId: 'schedule-snapshot-seed',
+        date: '2026-03-01',
+        status: 'in-progress',
+        startedAt: 1_700_000_400_000,
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    const payload = response.json() as {
+      data: {
+        id: string;
+        templateId: string | null;
+        date: string;
+        exercises?: Array<{
+          exerciseId: string | null;
+          programmingNotes: string | null;
+          agentNotes: string | null;
+          agentNotesMeta: {
+            author: string;
+            generatedAt: string;
+            scheduledDateAtGeneration: string;
+          } | null;
+        }>;
+        sets: Array<{
+          exerciseId: string | null;
+          setNumber: number;
+          reps: number | null;
+          targetWeight: number | null;
+          targetWeightMin: number | null;
+          targetWeightMax: number | null;
+        }>;
+      };
+    };
+
+    expect(payload.data.templateId).toBe('template-1');
+    expect(payload.data.date).toBe('2026-03-12');
+    expect(payload.data.exercises).toEqual([
+      expect.objectContaining({
+        exerciseId: 'global-bench-press',
+        programmingNotes: 'Explode through the concentric.',
+        agentNotes: 'Last week moved fast at 185. Start at 190.',
+        agentNotesMeta: {
+          author: 'Coach Agent',
+          generatedAt: '2026-03-11T19:45:00.000Z',
+          scheduledDateAtGeneration: '2026-03-12',
+        },
+      }),
+    ]);
+    expect(payload.data.sets).toEqual([
+      expect.objectContaining({
+        exerciseId: 'global-bench-press',
+        setNumber: 1,
+        reps: 6,
+        targetWeight: 190,
+      }),
+      expect.objectContaining({
+        exerciseId: 'global-bench-press',
+        setNumber: 2,
+        reps: 6,
+        targetWeightMin: 190,
+        targetWeightMax: 195,
+      }),
+    ]);
+
+    const linkedSchedule = context.db
+      .select({
+        sessionId: scheduledWorkouts.sessionId,
+      })
+      .from(scheduledWorkouts)
+      .where(eq(scheduledWorkouts.id, 'schedule-snapshot-seed'))
+      .limit(1)
+      .get();
+    expect(linkedSchedule?.sessionId).toBe(payload.data.id);
+
+    const persistedSession = context.db
+      .select({
+        scheduledWorkoutId: workoutSessions.scheduledWorkoutId,
+      })
+      .from(workoutSessions)
+      .where(eq(workoutSessions.id, payload.data.id))
+      .limit(1)
+      .get();
+    expect(persistedSession).toEqual({
+      scheduledWorkoutId: 'schedule-snapshot-seed',
+    });
+  });
+
+  it('returns 409 when scheduled workout is already linked to a live session', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'schedule-live-session',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      status: 'in-progress',
+      startedAt: 1_700_000_400_000,
+    });
+    seedScheduledWorkout({
+      id: 'schedule-consumed',
+      userId: 'user-1',
+      templateId: 'template-1',
+      date: '2026-03-12',
+      sessionId: 'schedule-live-session',
+    });
+    seedScheduledWorkoutExercise({
+      id: 'schedule-consumed-bench',
+      scheduledWorkoutId: 'schedule-consumed',
+      exerciseId: 'global-bench-press',
+      section: 'main',
+      orderIndex: 0,
+    });
+    seedScheduledWorkoutExerciseSet({
+      id: 'schedule-consumed-bench-set-1',
+      scheduledWorkoutExerciseId: 'schedule-consumed-bench',
+      setNumber: 1,
+      reps: 8,
+    });
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        scheduledWorkoutId: 'schedule-consumed',
+        date: '2026-03-12',
+        startedAt: 1_700_000_500_000,
+      },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'SCHEDULED_WORKOUT_ALREADY_STARTED',
+        message: 'Scheduled workout is already linked to an active session',
+        existingSessionId: 'schedule-live-session',
+      },
+    });
+  });
+
+  it('restarts cancelled scheduled sessions by clearing stale links and creating a fresh session', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedScheduledWorkout({
+      id: 'schedule-restart',
+      userId: 'user-1',
+      templateId: 'template-1',
+      date: '2026-03-12',
+    });
+    seedWorkoutSession({
+      id: 'cancelled-linked-session',
+      userId: 'user-1',
+      templateId: 'template-1',
+      scheduledWorkoutId: 'schedule-restart',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      status: 'cancelled',
+      startedAt: 1_700_000_400_000,
+    });
+    context.db
+      .update(scheduledWorkouts)
+      .set({ sessionId: 'cancelled-linked-session' })
+      .where(eq(scheduledWorkouts.id, 'schedule-restart'))
+      .run();
+    seedScheduledWorkoutExercise({
+      id: 'schedule-restart-bench',
+      scheduledWorkoutId: 'schedule-restart',
+      exerciseId: 'global-bench-press',
+      section: 'main',
+      orderIndex: 0,
+      programmingNotes: 'Drive feet into the floor.',
+      agentNotes: 'Add 5 lb if reps stay clean.',
+      agentNotesMeta: {
+        author: 'Coach Agent',
+        generatedAt: '2026-03-11T19:45:00.000Z',
+        scheduledDateAtGeneration: '2026-03-12',
+      },
+    });
+    seedScheduledWorkoutExerciseSet({
+      id: 'schedule-restart-bench-set-1',
+      scheduledWorkoutExerciseId: 'schedule-restart-bench',
+      setNumber: 1,
+      reps: 8,
+      targetWeight: 185,
+    });
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        scheduledWorkoutId: 'schedule-restart',
+        date: '2026-03-12',
+        startedAt: 1_700_000_600_000,
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    const payload = response.json() as { data: { id: string; exercises?: Array<{ agentNotes: string | null }> } };
+    expect(payload.data.id).not.toBe('cancelled-linked-session');
+    expect(payload.data.exercises).toEqual([
+      expect.objectContaining({
+        agentNotes: 'Add 5 lb if reps stay clean.',
+      }),
+    ]);
+
+    const scheduledWorkoutRow = context.db
+      .select({
+        sessionId: scheduledWorkouts.sessionId,
+      })
+      .from(scheduledWorkouts)
+      .where(eq(scheduledWorkouts.id, 'schedule-restart'))
+      .limit(1)
+      .get();
+    expect(scheduledWorkoutRow).toEqual({
+      sessionId: payload.data.id,
+    });
+
+    const cancelledSession = context.db
+      .select({
+        id: workoutSessions.id,
+        status: workoutSessions.status,
+        deletedAt: workoutSessions.deletedAt,
+      })
+      .from(workoutSessions)
+      .where(eq(workoutSessions.id, 'cancelled-linked-session'))
+      .limit(1)
+      .get();
+    expect(cancelledSession).toEqual({
+      id: 'cancelled-linked-session',
+      status: 'cancelled',
+      deletedAt: null,
+    });
+  });
+
+  it('returns stale-exercise 409 when snapshot exercises are deleted', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedScheduledWorkout({
+      id: 'schedule-stale',
+      userId: 'user-1',
+      templateId: 'template-1',
+      date: '2026-03-12',
+    });
+    seedScheduledWorkoutExercise({
+      id: 'schedule-stale-bench',
+      scheduledWorkoutId: 'schedule-stale',
+      exerciseId: 'global-bench-press',
+      section: 'main',
+      orderIndex: 0,
+    });
+    seedScheduledWorkoutExerciseSet({
+      id: 'schedule-stale-bench-set-1',
+      scheduledWorkoutExerciseId: 'schedule-stale-bench',
+      setNumber: 1,
+      reps: 8,
+    });
+
+    context.db
+      .update(exercises)
+      .set({ deletedAt: '2026-03-11T00:00:00.000Z' })
+      .where(eq(exercises.id, 'global-bench-press'))
+      .run();
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        scheduledWorkoutId: 'schedule-stale',
+        date: '2026-03-12',
+        startedAt: 1_700_000_500_000,
+      },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'STALE_SNAPSHOT_EXERCISES',
+        message: 'Scheduled workout snapshot references deleted or unavailable exercises',
+        staleExercises: [
+          {
+            exerciseId: 'global-bench-press',
+            snapshotName: 'Bench Press',
+          },
+        ],
+      },
+    });
+
+    const createdSessions = context.db
+      .select({ id: workoutSessions.id })
+      .from(workoutSessions)
+      .where(eq(workoutSessions.scheduledWorkoutId, 'schedule-stale'))
+      .all();
+    expect(createdSessions).toHaveLength(0);
+  });
+
+  it('skips stale exercises with force=true and includes warnings in the create response', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedScheduledWorkout({
+      id: 'schedule-force-stale',
+      userId: 'user-1',
+      templateId: 'template-1',
+      date: '2026-03-12',
+    });
+    seedScheduledWorkoutExercise({
+      id: 'schedule-force-stale-bench',
+      scheduledWorkoutId: 'schedule-force-stale',
+      exerciseId: 'global-bench-press',
+      section: 'main',
+      orderIndex: 0,
+    });
+    seedScheduledWorkoutExerciseSet({
+      id: 'schedule-force-stale-bench-set-1',
+      scheduledWorkoutExerciseId: 'schedule-force-stale-bench',
+      setNumber: 1,
+      reps: 8,
+    });
+    seedScheduledWorkoutExercise({
+      id: 'schedule-force-stale-lat',
+      scheduledWorkoutId: 'schedule-force-stale',
+      exerciseId: 'user-1-lat-pulldown',
+      section: 'main',
+      orderIndex: 1,
+      programmingNotes: 'Keep torso still.',
+    });
+    seedScheduledWorkoutExerciseSet({
+      id: 'schedule-force-stale-lat-set-1',
+      scheduledWorkoutExerciseId: 'schedule-force-stale-lat',
+      setNumber: 1,
+      reps: 10,
+    });
+
+    context.db
+      .update(exercises)
+      .set({ deletedAt: '2026-03-11T00:00:00.000Z' })
+      .where(eq(exercises.id, 'global-bench-press'))
+      .run();
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        scheduledWorkoutId: 'schedule-force-stale',
+        date: '2026-03-12',
+        startedAt: 1_700_000_700_000,
+        force: true,
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        exercises: [
+          expect.objectContaining({
+            exerciseId: 'user-1-lat-pulldown',
+            programmingNotes: 'Keep torso still.',
+          }),
+        ],
+        sets: [expect.objectContaining({ exerciseId: 'user-1-lat-pulldown', setNumber: 1 })],
+      }),
+      warnings: [
+        {
+          code: 'STALE_EXERCISES_SKIPPED',
+          exercises: [
+            {
+              exerciseId: 'global-bench-press',
+              snapshotName: 'Bench Press',
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('clears scheduled_workouts.sessionId when a linked session is cancelled and preserves snapshot rows', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedScheduledWorkout({
+      id: 'schedule-cancel-linked',
+      userId: 'user-1',
+      templateId: 'template-1',
+      date: '2026-03-12',
+    });
+    seedWorkoutSession({
+      id: 'session-cancel-linked',
+      userId: 'user-1',
+      templateId: 'template-1',
+      scheduledWorkoutId: 'schedule-cancel-linked',
+      name: 'Upper Push',
+      date: '2026-03-12',
+      status: 'in-progress',
+      startedAt: Date.parse('2026-03-12T10:00:00.000Z'),
+      timeSegments: [{ start: '2026-03-12T10:00:00.000Z', end: null, section: 'main' }],
+    });
+    context.db
+      .update(scheduledWorkouts)
+      .set({ sessionId: 'session-cancel-linked' })
+      .where(eq(scheduledWorkouts.id, 'schedule-cancel-linked'))
+      .run();
+    seedScheduledWorkoutExercise({
+      id: 'schedule-cancel-linked-bench',
+      scheduledWorkoutId: 'schedule-cancel-linked',
+      exerciseId: 'global-bench-press',
+      section: 'main',
+      orderIndex: 0,
+      programmingNotes: 'Maintain bar path.',
+      agentNotes: 'Keep it at RPE 7.',
+      agentNotesMeta: {
+        author: 'Coach Agent',
+        generatedAt: '2026-03-11T19:45:00.000Z',
+        scheduledDateAtGeneration: '2026-03-12',
+      },
+    });
+    seedScheduledWorkoutExerciseSet({
+      id: 'schedule-cancel-linked-bench-set-1',
+      scheduledWorkoutExerciseId: 'schedule-cancel-linked-bench',
+      setNumber: 1,
+      reps: 8,
+    });
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-sessions/session-cancel-linked',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        status: 'cancelled',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        id: 'session-cancel-linked',
+        status: 'cancelled',
+      }),
+    });
+
+    const linkedSchedule = context.db
+      .select({
+        sessionId: scheduledWorkouts.sessionId,
+      })
+      .from(scheduledWorkouts)
+      .where(eq(scheduledWorkouts.id, 'schedule-cancel-linked'))
+      .limit(1)
+      .get();
+    expect(linkedSchedule).toEqual({
+      sessionId: null,
+    });
+
+    const snapshotRows = context.db
+      .select({
+        id: scheduledWorkoutExercises.id,
+      })
+      .from(scheduledWorkoutExercises)
+      .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, 'schedule-cancel-linked'))
+      .all();
+    expect(snapshotRows).toHaveLength(1);
   });
 
   it('does not open any section segment for legacy in-progress sessions with no time segments', async () => {

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -5,11 +5,13 @@ import {
   batchUpsertSetsSchema,
   createSetSchema,
   createWorkoutSessionInputSchema,
+  createWorkoutSessionRequestSchema,
   reorderWorkoutSessionExercisesInputSchema,
   sessionCorrectionRequestSchema,
   saveWorkoutSessionAsTemplateInputSchema,
   sessionSetSchema,
   swapWorkoutSessionExerciseInputSchema,
+  type CreateWorkoutSessionRequestInput,
   type CreateWorkoutSessionInput,
   type SessionSetInput,
   updateSetSchema,
@@ -21,10 +23,12 @@ import {
   workoutSessionSchema,
   workoutTemplateSchema,
 } from '@pulse/shared';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
 import { type ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 
+import { exercises, workoutSessions } from '../../db/schema/index.js';
 import { sendError } from '../../lib/reply.js';
 import { isAgentRequest, requireAuth } from '../../middleware/auth.js';
 import {
@@ -44,10 +48,13 @@ import {
 import { allRelatedExercisesOwned } from '../exercises/store.js';
 import {
   deleteScheduledWorkout,
+  findScheduledWorkoutById,
   findScheduledWorkoutBySessionId,
-  linkTodayScheduledWorkoutToSession,
   unlinkScheduledWorkoutSession,
+  linkTodayScheduledWorkoutToSession,
 } from '../scheduled-workouts/store.js';
+import { readSnapshot, type ScheduledWorkoutSnapshot } from '../scheduled-workouts/snapshot-store.js';
+import { findWorkoutTemplateById } from '../workout-templates/store.js';
 import { templateBelongsToUser } from '../workout-templates/template-access.js';
 import {
   applyExerciseNotesToSets,
@@ -66,7 +73,6 @@ import {
   findInvalidSessionExerciseIds,
   findWorkoutSessionAccess,
   findWorkoutSessionById,
-  hardDeleteWorkoutSession,
   InvalidSessionCorrectionSetError,
   listSessionSetGroups,
   listWorkoutSessions,
@@ -121,9 +127,28 @@ const WORKOUT_TEMPLATE_NOT_FOUND_RESPONSE = {
   message: 'Workout template not found',
 } as const;
 
+const SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE = {
+  code: 'SCHEDULED_WORKOUT_NOT_FOUND',
+  message: 'Scheduled workout not found',
+} as const;
+
 const INVALID_SESSION_EXERCISE_RESPONSE = {
   code: 'INVALID_SESSION_EXERCISE',
   message: 'Session references one or more unavailable exercises',
+} as const;
+
+const STALE_SNAPSHOT_EXERCISES_RESPONSE = {
+  code: 'STALE_SNAPSHOT_EXERCISES',
+  message: 'Scheduled workout snapshot references deleted or unavailable exercises',
+} as const;
+
+const SCHEDULED_WORKOUT_ALREADY_STARTED_RESPONSE = {
+  code: 'SCHEDULED_WORKOUT_ALREADY_STARTED',
+  message: 'Scheduled workout is already linked to an active session',
+} as const;
+
+const STALE_EXERCISES_SKIPPED_WARNING = {
+  code: 'STALE_EXERCISES_SKIPPED',
 } as const;
 
 const WORKOUT_SESSION_NOT_ACTIVE_RESPONSE = {
@@ -203,6 +228,36 @@ const UNSUPPORTED_SESSION_CORRECTION_RESPONSE = {
   message:
     'Workout session corrections must include weight or reps. Set-level RPE corrections are not persisted yet',
 } as const;
+
+const staleSnapshotExerciseSchema = z.object({
+  exerciseId: z.string(),
+  snapshotName: z.string(),
+});
+
+const staleSnapshotExercisesErrorResponseSchema = z.object({
+  error: z.object({
+    code: z.literal(STALE_SNAPSHOT_EXERCISES_RESPONSE.code),
+    message: z.string(),
+    staleExercises: z.array(staleSnapshotExerciseSchema),
+  }),
+});
+
+const scheduledWorkoutAlreadyStartedErrorResponseSchema = z.object({
+  error: z.object({
+    code: z.literal(SCHEDULED_WORKOUT_ALREADY_STARTED_RESPONSE.code),
+    message: z.string(),
+    existingSessionId: z.string(),
+  }),
+});
+
+const workoutSessionCreateWarningSchema = z.object({
+  code: z.literal(STALE_EXERCISES_SKIPPED_WARNING.code),
+  exercises: z.array(staleSnapshotExerciseSchema),
+});
+
+const createWorkoutSessionResponseSchema = apiDataResponseSchema(workoutSessionSchema).extend({
+  warnings: z.array(workoutSessionCreateWarningSchema).optional(),
+});
 
 const toCreateWorkoutSessionInput = (
   session: Awaited<ReturnType<typeof findWorkoutSessionById>>,
@@ -295,6 +350,106 @@ const buildInvalidExerciseMessage = (invalidExerciseIds: string[]) => {
   return `${INVALID_SESSION_EXERCISE_RESPONSE.message}: ${preview}${suffix}`;
 };
 
+const listStaleSnapshotExercises = async ({
+  snapshotExercises,
+  userId,
+}: {
+  snapshotExercises: ScheduledWorkoutSnapshot['exercises'];
+  userId: string;
+}) => {
+  const uniqueExerciseIds = [...new Set(snapshotExercises.map((exercise) => exercise.exerciseId))];
+  if (uniqueExerciseIds.length === 0) {
+    return [];
+  }
+
+  const { db } = await import('../../db/index.js');
+  const exerciseRows = db
+    .select({
+      id: exercises.id,
+      userId: exercises.userId,
+      name: exercises.name,
+      deletedAt: exercises.deletedAt,
+    })
+    .from(exercises)
+    .where(inArray(exercises.id, uniqueExerciseIds))
+    .all();
+
+  const exerciseById = new Map(exerciseRows.map((exercise) => [exercise.id, exercise]));
+  const staleExercisesById = new Map<string, { exerciseId: string; snapshotName: string }>();
+
+  for (const snapshotExercise of snapshotExercises) {
+    const resolvedExercise = exerciseById.get(snapshotExercise.exerciseId);
+    const isMissing = !resolvedExercise;
+    const isSoftDeleted = resolvedExercise?.deletedAt != null;
+    const isOutsideUserScope =
+      resolvedExercise !== undefined &&
+      resolvedExercise.userId !== null &&
+      resolvedExercise.userId !== userId;
+
+    if (isMissing || isSoftDeleted || isOutsideUserScope) {
+      staleExercisesById.set(snapshotExercise.exerciseId, {
+        exerciseId: snapshotExercise.exerciseId,
+        snapshotName: resolvedExercise?.name ?? snapshotExercise.exerciseId,
+      });
+    }
+  }
+
+  return [...staleExercisesById.values()];
+};
+
+const buildScheduledSnapshotSessionSeed = ({
+  snapshotExercises,
+  skippedExerciseIds,
+}: {
+  snapshotExercises: ScheduledWorkoutSnapshot['exercises'];
+  skippedExerciseIds: Set<string>;
+}) => {
+  const persistedExercises = snapshotExercises.filter(
+    (exercise) => !skippedExerciseIds.has(exercise.exerciseId),
+  );
+
+  const sets: CreateWorkoutSessionInput['sets'] = persistedExercises.flatMap((exercise) =>
+    exercise.sets.map((set) => ({
+      exerciseId: exercise.exerciseId,
+      orderIndex: exercise.orderIndex,
+      setNumber: set.setNumber,
+      weight: null,
+      reps: set.reps,
+      targetWeight: set.targetWeight,
+      targetWeightMin: set.targetWeightMin,
+      targetWeightMax: set.targetWeightMax,
+      targetSeconds: set.targetSeconds,
+      targetDistance: set.targetDistance,
+      completed: false,
+      skipped: false,
+      supersetGroup: exercise.supersetGroup,
+      section: exercise.section,
+      notes: null,
+    })),
+  );
+
+  const programmingNotesByExerciseSection: Record<string, string | null> = {};
+  const agentNotesByExerciseSection: Record<string, string | null> = {};
+  const agentNotesMetaByExerciseSection: Record<
+    string,
+    NonNullable<ScheduledWorkoutSnapshot['exercises'][number]['agentNotesMeta']> | null
+  > = {};
+
+  for (const exercise of persistedExercises) {
+    const key = `${exercise.section}::${exercise.exerciseId}`;
+    programmingNotesByExerciseSection[key] = exercise.programmingNotes;
+    agentNotesByExerciseSection[key] = exercise.agentNotes;
+    agentNotesMetaByExerciseSection[key] = exercise.agentNotesMeta;
+  }
+
+  return {
+    sets,
+    programmingNotesByExerciseSection,
+    agentNotesByExerciseSection,
+    agentNotesMetaByExerciseSection,
+  };
+};
+
 const ensureOwnedSession = async ({
   sessionId,
   userId,
@@ -364,12 +519,17 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       preHandler: agentRequestTransform,
       onSend: agentEnrichmentOnSend,
       schema: {
-        body: createWorkoutSessionInputSchema,
+        body: createWorkoutSessionRequestSchema,
         response: {
-          201: apiDataResponseSchema(workoutSessionSchema),
+          201: createWorkoutSessionResponseSchema,
           400: badRequestResponseSchema,
           401: apiErrorResponseSchema,
           404: apiErrorResponseSchema,
+          409: z.union([
+            staleSnapshotExercisesErrorResponseSchema,
+            scheduledWorkoutAlreadyStartedErrorResponseSchema,
+            apiErrorResponseSchema,
+          ]),
         },
         tags: ['workout-sessions'],
         summary: 'Create a workout session',
@@ -377,10 +537,35 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       },
     },
     async (request, reply) => {
-      let input: CreateWorkoutSessionInput = request.body;
+      const body: CreateWorkoutSessionRequestInput = request.body;
+      const hasScheduledStart = body.scheduledWorkoutId !== undefined;
+      const hasTemplateStart = body.templateId !== null || body.templateName !== undefined;
+      const hasAdHocStart = body.name !== undefined && !hasScheduledStart && !hasTemplateStart;
+      const requestedStartModes = [hasScheduledStart, hasTemplateStart, hasAdHocStart].filter(
+        Boolean,
+      ).length;
+
+      if (requestedStartModes !== 1) {
+        return sendError(
+          reply,
+          400,
+          'VALIDATION_ERROR',
+          'Provide exactly one session start mode: scheduledWorkoutId, templateId/templateName, or name',
+        );
+      }
+
+      let input: CreateWorkoutSessionInput;
       let programmingNotesByExerciseSection: Record<string, string | null> | undefined;
+      let agentNotesByExerciseSection: Record<string, string | null> | undefined;
+      let agentNotesMetaByExerciseSection:
+        | Record<string, NonNullable<ScheduledWorkoutSnapshot['exercises'][number]['agentNotesMeta']> | null>
+        | undefined;
+      let scheduledWorkoutId: string | undefined;
+      let linkScheduledWorkoutSession = false;
+      let warnings: Array<z.infer<typeof workoutSessionCreateWarningSchema>> | undefined;
+
       // templateName is an AgentToken-only convenience; JWT callers must send templateId.
-      if (request.body.templateName !== undefined && !isAgentRequest(request)) {
+      if (body.templateName !== undefined && !isAgentRequest(request)) {
         return sendError(
           reply,
           400,
@@ -390,7 +575,7 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       }
 
       // AgentToken callers passed templateName, but middleware could not resolve it to templateId.
-      if (request.body.templateName !== undefined && request.body.templateId === null) {
+      if (body.templateName !== undefined && body.templateId === null) {
         return sendError(
           reply,
           404,
@@ -399,9 +584,129 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
         );
       }
 
-      if (request.body.templateId !== null) {
-        const { findWorkoutTemplateById } = await import('../workout-templates/store.js');
-        const template = await findWorkoutTemplateById(request.body.templateId, request.userId);
+      if (hasScheduledStart) {
+        const scheduledWorkoutIdInput = body.scheduledWorkoutId;
+        if (!scheduledWorkoutIdInput) {
+          return sendError(
+            reply,
+            400,
+            'VALIDATION_ERROR',
+            'scheduledWorkoutId is required for scheduled workout starts',
+          );
+        }
+
+        const schedule = await findScheduledWorkoutById(scheduledWorkoutIdInput, request.userId);
+        if (!schedule) {
+          return sendError(
+            reply,
+            404,
+            SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.code,
+            SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.message,
+          );
+        }
+
+        if (schedule.sessionId !== null) {
+          const { db } = await import('../../db/index.js');
+          const linkedSession = db
+            .select({
+              id: workoutSessions.id,
+              status: workoutSessions.status,
+              deletedAt: workoutSessions.deletedAt,
+            })
+            .from(workoutSessions)
+            .where(
+              and(
+                eq(workoutSessions.id, schedule.sessionId),
+                eq(workoutSessions.userId, request.userId),
+              ),
+            )
+            .limit(1)
+            .get();
+
+          const hasLiveLinkedSession =
+            linkedSession !== undefined &&
+            linkedSession.deletedAt === null &&
+            linkedSession.status !== 'cancelled';
+          if (hasLiveLinkedSession) {
+            return reply.code(409).send({
+              error: {
+                code: SCHEDULED_WORKOUT_ALREADY_STARTED_RESPONSE.code,
+                message: SCHEDULED_WORKOUT_ALREADY_STARTED_RESPONSE.message,
+                existingSessionId: linkedSession.id,
+              },
+            });
+          }
+
+          await unlinkScheduledWorkoutSession(schedule.id, request.userId);
+        }
+
+        const snapshot = await readSnapshot(schedule.id);
+        const staleExercises = await listStaleSnapshotExercises({
+          snapshotExercises: snapshot.exercises,
+          userId: request.userId,
+        });
+
+        if (staleExercises.length > 0 && !body.force) {
+          return reply.code(409).send({
+            error: {
+              code: STALE_SNAPSHOT_EXERCISES_RESPONSE.code,
+              message: STALE_SNAPSHOT_EXERCISES_RESPONSE.message,
+              staleExercises,
+            },
+          });
+        }
+
+        const skippedExerciseIds = new Set(
+          body.force ? staleExercises.map((exercise) => exercise.exerciseId) : [],
+        );
+        const scheduledSeed = buildScheduledSnapshotSessionSeed({
+          snapshotExercises: snapshot.exercises,
+          skippedExerciseIds,
+        });
+
+        const template =
+          schedule.templateId !== null
+            ? await findWorkoutTemplateById(schedule.templateId, request.userId)
+            : undefined;
+        input = {
+          templateId: schedule.templateId,
+          name: body.name ?? template?.name ?? `Scheduled Workout ${schedule.date}`,
+          date: schedule.date,
+          status: body.status,
+          startedAt: body.startedAt,
+          completedAt: body.completedAt,
+          duration: body.duration,
+          timeSegments: body.timeSegments,
+          feedback: body.feedback,
+          notes: body.notes,
+          sets: scheduledSeed.sets,
+        };
+        programmingNotesByExerciseSection = scheduledSeed.programmingNotesByExerciseSection;
+        agentNotesByExerciseSection = scheduledSeed.agentNotesByExerciseSection;
+        agentNotesMetaByExerciseSection = scheduledSeed.agentNotesMetaByExerciseSection;
+        scheduledWorkoutId = schedule.id;
+        linkScheduledWorkoutSession = true;
+
+        if (body.force && staleExercises.length > 0) {
+          warnings = [
+            {
+              code: STALE_EXERCISES_SKIPPED_WARNING.code,
+              exercises: staleExercises,
+            },
+          ];
+        }
+      } else if (hasTemplateStart) {
+        const templateIdInput = body.templateId;
+        if (!templateIdInput) {
+          return sendError(
+            reply,
+            400,
+            'VALIDATION_ERROR',
+            'templateId is required for template starts',
+          );
+        }
+
+        const template = await findWorkoutTemplateById(templateIdInput, request.userId);
         if (!template) {
           return sendError(
             reply,
@@ -411,10 +716,19 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
           );
         }
 
-        if (request.body.sets.length === 0) {
+        if (body.sets.length === 0) {
           input = {
-            ...request.body,
+            ...body,
+            name: body.name ?? template.name,
+            templateId: template.id,
             sets: buildInitialSessionSets(template.sections),
+          };
+        } else {
+          input = {
+            ...body,
+            name: body.name ?? template.name,
+            templateId: template.id,
+            sets: body.sets,
           };
         }
 
@@ -422,6 +736,30 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
           templateSections: template.sections,
           sets: input.sets,
         });
+      } else {
+        const adHocName = body.name;
+        if (!adHocName) {
+          return sendError(
+            reply,
+            400,
+            'VALIDATION_ERROR',
+            'name is required for ad-hoc workout starts',
+          );
+        }
+
+        input = {
+          templateId: null,
+          name: adHocName,
+          date: body.date,
+          status: body.status,
+          startedAt: body.startedAt,
+          completedAt: body.completedAt,
+          duration: body.duration,
+          timeSegments: body.timeSegments,
+          feedback: body.feedback,
+          notes: body.notes,
+          sets: body.sets,
+        };
       }
 
       const invalidExerciseIds = await findInvalidSessionExerciseIds({
@@ -442,9 +780,13 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
         userId: request.userId,
         input,
         programmingNotesByExerciseSection,
+        agentNotesByExerciseSection,
+        agentNotesMetaByExerciseSection,
+        scheduledWorkoutId,
+        linkScheduledWorkoutSession,
       });
 
-      if (input.templateId !== null) {
+      if (!hasScheduledStart && input.templateId !== null) {
         await linkTodayScheduledWorkoutToSession({
           userId: request.userId,
           templateId: input.templateId,
@@ -461,6 +803,7 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
 
       return reply.code(201).send({
         data: session,
+        ...(warnings ? { warnings } : {}),
       });
     },
   );
@@ -1340,6 +1683,33 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       );
     }
 
+    if (transitionStatus === 'cancelled' && existingSession.status !== 'cancelled') {
+      const linkedScheduledWorkout = await findScheduledWorkoutBySessionId(params.id, request.userId);
+      if (linkedScheduledWorkout) {
+        await unlinkScheduledWorkoutSession(linkedScheduledWorkout.id, request.userId);
+      } else {
+        const { db } = await import('../../db/index.js');
+        const sourceSession = db
+          .select({
+            scheduledWorkoutId: workoutSessions.scheduledWorkoutId,
+          })
+          .from(workoutSessions)
+          .where(
+            and(
+              eq(workoutSessions.id, params.id),
+              eq(workoutSessions.userId, request.userId),
+              isNull(workoutSessions.deletedAt),
+            ),
+          )
+          .limit(1)
+          .get();
+
+        if (sourceSession?.scheduledWorkoutId) {
+          await unlinkScheduledWorkoutSession(sourceSession.scheduledWorkoutId, request.userId);
+        }
+      }
+    }
+
     setAgentEnrichmentContext(request, {
       endpoint: 'workout-session.mutation',
       action: 'update',
@@ -1780,8 +2150,8 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       },
     },
     async (request, reply) => {
-      const session = await findWorkoutSessionAccess(request.params.id, request.userId);
-      if (!session) {
+      const existingSession = await findWorkoutSessionById(request.params.id, request.userId);
+      if (!existingSession) {
         return sendError(
           reply,
           404,
@@ -1790,7 +2160,7 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
         );
       }
 
-      if (session.status !== 'in-progress' && session.status !== 'paused') {
+      if (existingSession.status !== 'in-progress' && existingSession.status !== 'paused') {
         return sendError(
           reply,
           409,
@@ -1799,6 +2169,51 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
         );
       }
 
+      const basePayload = toCreateWorkoutSessionInput(existingSession);
+      const transitionResult = resolveSessionTransition({
+        existingStatus: existingSession.status,
+        requestedStatus: 'cancelled',
+        currentTimeSegments: basePayload.timeSegments,
+        requestedCompletedAt: basePayload.completedAt,
+        requestedDuration: basePayload.duration,
+        requestedActiveSection: undefined,
+      });
+
+      if (!transitionResult.ok) {
+        return sendError(
+          reply,
+          transitionResult.statusCode,
+          transitionResult.code,
+          transitionResult.message,
+        );
+      }
+
+      const payload = createWorkoutSessionInputSchema.safeParse({
+        ...basePayload,
+        status: 'cancelled',
+        completedAt: transitionResult.completedAt,
+        duration: transitionResult.duration,
+        timeSegments: transitionResult.timeSegments,
+      });
+      if (!payload.success) {
+        return sendError(reply, 400, 'VALIDATION_ERROR', 'Invalid workout session payload');
+      }
+
+      const cancelledSession = await updateWorkoutSession({
+        id: request.params.id,
+        userId: request.userId,
+        input: payload.data,
+      });
+      if (!cancelledSession) {
+        return sendError(
+          reply,
+          404,
+          WORKOUT_SESSION_NOT_FOUND_RESPONSE.code,
+          WORKOUT_SESSION_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      let revertedToSchedule = false;
       const linkedScheduledWorkout = await findScheduledWorkoutBySessionId(
         request.params.id,
         request.userId,
@@ -1806,17 +2221,32 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
 
       if (linkedScheduledWorkout) {
         await unlinkScheduledWorkoutSession(linkedScheduledWorkout.id, request.userId);
-        await hardDeleteWorkoutSession(request.params.id, request.userId);
+        revertedToSchedule = true;
+      } else {
+        const { db } = await import('../../db/index.js');
+        const sourceSession = db
+          .select({
+            scheduledWorkoutId: workoutSessions.scheduledWorkoutId,
+          })
+          .from(workoutSessions)
+          .where(
+            and(
+              eq(workoutSessions.id, request.params.id),
+              eq(workoutSessions.userId, request.userId),
+              isNull(workoutSessions.deletedAt),
+            ),
+          )
+          .limit(1)
+          .get();
 
-        return reply.send({
-          data: { revertedToSchedule: true },
-        });
+        if (sourceSession?.scheduledWorkoutId) {
+          await unlinkScheduledWorkoutSession(sourceSession.scheduledWorkoutId, request.userId);
+          revertedToSchedule = true;
+        }
       }
 
-      await deleteWorkoutSession(request.params.id, request.userId);
-
       return reply.send({
-        data: { revertedToSchedule: false },
+        data: { revertedToSchedule },
       });
     },
   );

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -150,6 +150,7 @@ const SCHEDULED_WORKOUT_ALREADY_STARTED_RESPONSE = {
 const STALE_EXERCISES_SKIPPED_WARNING = {
   code: 'STALE_EXERCISES_SKIPPED',
 } as const;
+const UNKNOWN_SNAPSHOT_EXERCISE_NAME = 'Unknown exercise';
 
 const WORKOUT_SESSION_NOT_ACTIVE_RESPONSE = {
   code: 'WORKOUT_SESSION_NOT_ACTIVE',
@@ -389,7 +390,7 @@ const listStaleSnapshotExercises = async ({
     if (isMissing || isSoftDeleted || isOutsideUserScope) {
       staleExercisesById.set(snapshotExercise.exerciseId, {
         exerciseId: snapshotExercise.exerciseId,
-        snapshotName: resolvedExercise?.name ?? snapshotExercise.exerciseId,
+        snapshotName: resolvedExercise?.name ?? UNKNOWN_SNAPSHOT_EXERCISE_NAME,
       });
     }
   }
@@ -436,7 +437,7 @@ const buildScheduledSnapshotSessionSeed = ({
   > = {};
 
   for (const exercise of persistedExercises) {
-    const key = `${exercise.section}::${exercise.exerciseId}`;
+    const key = `${exercise.section ?? 'main'}::${exercise.exerciseId}`;
     programmingNotesByExerciseSection[key] = exercise.programmingNotes;
     agentNotesByExerciseSection[key] = exercise.agentNotes;
     agentNotesMetaByExerciseSection[key] = exercise.agentNotesMeta;
@@ -448,6 +449,43 @@ const buildScheduledSnapshotSessionSeed = ({
     agentNotesByExerciseSection,
     agentNotesMetaByExerciseSection,
   };
+};
+
+const clearSessionScheduleLink = async ({
+  sessionId,
+  userId,
+}: {
+  sessionId: string;
+  userId: string;
+}) => {
+  const linkedScheduledWorkout = await findScheduledWorkoutBySessionId(sessionId, userId);
+  if (linkedScheduledWorkout) {
+    await unlinkScheduledWorkoutSession(linkedScheduledWorkout.id, userId);
+    return true;
+  }
+
+  const { db } = await import('../../db/index.js');
+  const sourceSession = db
+    .select({
+      scheduledWorkoutId: workoutSessions.scheduledWorkoutId,
+    })
+    .from(workoutSessions)
+    .where(
+      and(
+        eq(workoutSessions.id, sessionId),
+        eq(workoutSessions.userId, userId),
+        isNull(workoutSessions.deletedAt),
+      ),
+    )
+    .limit(1)
+    .get();
+
+  if (sourceSession?.scheduledWorkoutId) {
+    await unlinkScheduledWorkoutSession(sourceSession.scheduledWorkoutId, userId);
+    return true;
+  }
+
+  return false;
 };
 
 const ensureOwnedSession = async ({
@@ -1684,30 +1722,10 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
     }
 
     if (transitionStatus === 'cancelled' && existingSession.status !== 'cancelled') {
-      const linkedScheduledWorkout = await findScheduledWorkoutBySessionId(params.id, request.userId);
-      if (linkedScheduledWorkout) {
-        await unlinkScheduledWorkoutSession(linkedScheduledWorkout.id, request.userId);
-      } else {
-        const { db } = await import('../../db/index.js');
-        const sourceSession = db
-          .select({
-            scheduledWorkoutId: workoutSessions.scheduledWorkoutId,
-          })
-          .from(workoutSessions)
-          .where(
-            and(
-              eq(workoutSessions.id, params.id),
-              eq(workoutSessions.userId, request.userId),
-              isNull(workoutSessions.deletedAt),
-            ),
-          )
-          .limit(1)
-          .get();
-
-        if (sourceSession?.scheduledWorkoutId) {
-          await unlinkScheduledWorkoutSession(sourceSession.scheduledWorkoutId, request.userId);
-        }
-      }
+      await clearSessionScheduleLink({
+        sessionId: params.id,
+        userId: request.userId,
+      });
     }
 
     setAgentEnrichmentContext(request, {
@@ -2213,37 +2231,10 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
         );
       }
 
-      let revertedToSchedule = false;
-      const linkedScheduledWorkout = await findScheduledWorkoutBySessionId(
-        request.params.id,
-        request.userId,
-      );
-
-      if (linkedScheduledWorkout) {
-        await unlinkScheduledWorkoutSession(linkedScheduledWorkout.id, request.userId);
-        revertedToSchedule = true;
-      } else {
-        const { db } = await import('../../db/index.js');
-        const sourceSession = db
-          .select({
-            scheduledWorkoutId: workoutSessions.scheduledWorkoutId,
-          })
-          .from(workoutSessions)
-          .where(
-            and(
-              eq(workoutSessions.id, request.params.id),
-              eq(workoutSessions.userId, request.userId),
-              isNull(workoutSessions.deletedAt),
-            ),
-          )
-          .limit(1)
-          .get();
-
-        if (sourceSession?.scheduledWorkoutId) {
-          await unlinkScheduledWorkoutSession(sourceSession.scheduledWorkoutId, request.userId);
-          revertedToSchedule = true;
-        }
-      }
+      const revertedToSchedule = await clearSessionScheduleLink({
+        sessionId: request.params.id,
+        userId: request.userId,
+      });
 
       return reply.send({
         data: { revertedToSchedule },

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -21,7 +21,9 @@ import {
   parseWorkoutSessionFeedback,
   parseWorkoutSessionExerciseProgrammingNotes,
   parseWorkoutSessionTimeSegments,
+  type WorkoutSessionExerciseAgentNotesMeta,
   sessionSets,
+  scheduledWorkouts,
   serializeWorkoutSessionFeedback,
   serializeWorkoutSessionExerciseProgrammingNotes,
   serializeWorkoutSessionTimeSegments,
@@ -38,6 +40,7 @@ type WorkoutSessionRecord = {
   id: string;
   userId: string;
   templateId: string | null;
+  scheduledWorkoutId: string | null;
   name: string;
   date: string;
   status: WorkoutSession['status'];
@@ -47,6 +50,8 @@ type WorkoutSessionRecord = {
   timeSegments: string;
   feedback: string | null;
   exerciseProgrammingNotes: string | null;
+  exerciseAgentNotes: Record<string, string | null> | null;
+  exerciseAgentNotesMeta: Record<string, WorkoutSessionExerciseAgentNotesMeta | null> | null;
   notes: string | null;
   createdAt: number;
   updatedAt: number;
@@ -87,6 +92,7 @@ const workoutSessionSelection = {
   id: workoutSessions.id,
   userId: workoutSessions.userId,
   templateId: workoutSessions.templateId,
+  scheduledWorkoutId: workoutSessions.scheduledWorkoutId,
   name: workoutSessions.name,
   date: workoutSessions.date,
   status: workoutSessions.status,
@@ -96,6 +102,8 @@ const workoutSessionSelection = {
   timeSegments: workoutSessions.timeSegments,
   feedback: workoutSessions.feedback,
   exerciseProgrammingNotes: workoutSessions.exerciseProgrammingNotes,
+  exerciseAgentNotes: workoutSessions.exerciseAgentNotes,
+  exerciseAgentNotesMeta: workoutSessions.exerciseAgentNotesMeta,
   notes: workoutSessions.notes,
   createdAt: workoutSessions.createdAt,
   updatedAt: workoutSessions.updatedAt,
@@ -238,6 +246,8 @@ const buildWorkoutSession = (
   const programmingNotesByExerciseSection = parseWorkoutSessionExerciseProgrammingNotes(
     session.exerciseProgrammingNotes,
   );
+  const agentNotesByExerciseSection = session.exerciseAgentNotes ?? {};
+  const agentNotesMetaByExerciseSection = session.exerciseAgentNotesMeta ?? {};
   const sectionDurations = calculateSectionDurations(timeSegments);
 
   return {
@@ -258,6 +268,8 @@ const buildWorkoutSession = (
       sets,
       exerciseInfoById,
       programmingNotesByExerciseSection,
+      agentNotesByExerciseSection,
+      agentNotesMetaByExerciseSection,
     ),
     sets: sets.sort(sortSessionSets).map<SessionSet>(buildSessionSet),
     createdAt: session.createdAt,
@@ -279,6 +291,8 @@ const buildWorkoutSessionExercises = (
     }
   >,
   programmingNotesByExerciseSection: Record<string, string | null>,
+  agentNotesByExerciseSection: Record<string, string | null>,
+  agentNotesMetaByExerciseSection: Record<string, WorkoutSessionExerciseAgentNotesMeta | null>,
 ): WorkoutSessionExercise[] => {
   const groupedByExercise = new Map<
     string,
@@ -364,6 +378,17 @@ const buildWorkoutSessionExercises = (
         exercise.exerciseId === null
           ? null
           : (programmingNotesByExerciseSection[
+              `${exercise.section ?? 'main'}::${exercise.exerciseId}`
+            ] ?? null),
+      agentNotes:
+        exercise.exerciseId === null
+          ? null
+          : (agentNotesByExerciseSection[`${exercise.section ?? 'main'}::${exercise.exerciseId}`] ??
+            null),
+      agentNotesMeta:
+        exercise.exerciseId === null
+          ? null
+          : (agentNotesMetaByExerciseSection[
               `${exercise.section ?? 'main'}::${exercise.exerciseId}`
             ] ?? null),
       sets: exercise.sets,
@@ -888,22 +913,31 @@ export const createWorkoutSession = async ({
   userId,
   input,
   programmingNotesByExerciseSection,
+  agentNotesByExerciseSection,
+  agentNotesMetaByExerciseSection,
+  scheduledWorkoutId,
+  linkScheduledWorkoutSession,
 }: {
   id: string;
   userId: string;
   input: CreateWorkoutSessionInput;
   programmingNotesByExerciseSection?: Record<string, string | null>;
+  agentNotesByExerciseSection?: Record<string, string | null>;
+  agentNotesMetaByExerciseSection?: Record<string, WorkoutSessionExerciseAgentNotesMeta | null>;
+  scheduledWorkoutId?: string;
+  linkScheduledWorkoutSession?: boolean;
 }): Promise<WorkoutSession> => {
   const { db } = await import('../../db/index.js');
   const setRows = buildSessionSetRows(id, input.sets);
 
-  const result = db.transaction((tx) => {
+  db.transaction((tx) => {
     const insertResult = tx
       .insert(workoutSessions)
       .values({
         id,
         userId,
         templateId: input.templateId,
+        scheduledWorkoutId: scheduledWorkoutId ?? null,
         name: input.name,
         date: input.date,
         status: input.status,
@@ -915,24 +949,40 @@ export const createWorkoutSession = async ({
         exerciseProgrammingNotes: serializeWorkoutSessionExerciseProgrammingNotes(
           programmingNotesByExerciseSection,
         ),
+        exerciseAgentNotes: agentNotesByExerciseSection ?? null,
+        exerciseAgentNotesMeta: agentNotesMetaByExerciseSection ?? null,
         notes: input.notes,
       })
       .run();
 
     if (insertResult.changes !== 1) {
-      return false;
+      throw new Error('Failed to persist workout session');
     }
 
     if (setRows.length > 0) {
       tx.insert(sessionSets).values(setRows).run();
     }
 
-    return true;
-  });
+    if (linkScheduledWorkoutSession && scheduledWorkoutId) {
+      const linkResult = tx
+        .update(scheduledWorkouts)
+        .set({
+          sessionId: id,
+        })
+        .where(
+          and(
+            eq(scheduledWorkouts.id, scheduledWorkoutId),
+            eq(scheduledWorkouts.userId, userId),
+            isNull(scheduledWorkouts.sessionId),
+          ),
+        )
+        .run();
 
-  if (!result) {
-    throw new Error('Failed to persist workout session');
-  }
+      if (linkResult.changes !== 1) {
+        throw new Error('Failed to link scheduled workout to the new session');
+      }
+    }
+  });
 
   const session = await findWorkoutSessionById(id, userId);
   if (!session) {
@@ -1284,15 +1334,17 @@ const mapSessionSectionToTemplateSection = (
 type SessionExerciseTemplateRoundTripSource = WorkoutSessionExercise & {
   notes?: string | null;
   agentNotes?: string | null;
+  agentNotesMeta?: WorkoutSessionExerciseAgentNotesMeta | null;
 };
 
 const getTemplateNotesFromSessionExercise = (
   exercise: SessionExerciseTemplateRoundTripSource,
 ): string | null => {
   // Agent notes and user notes do not round-trip — they are session-specific.
-  const { programmingNotes, notes, agentNotes } = exercise;
+  const { programmingNotes, notes, agentNotes, agentNotesMeta } = exercise;
   void notes;
   void agentNotes;
+  void agentNotesMeta;
   return programmingNotes ?? null;
 };
 

--- a/apps/web/src/features/workouts/api/workouts.test.tsx
+++ b/apps/web/src/features/workouts/api/workouts.test.tsx
@@ -231,6 +231,8 @@ function createSession(overrides: Partial<WorkoutSession> = {}): WorkoutSession 
         orderIndex: 0,
         section: 'main',
         programmingNotes: null,
+        agentNotes: null,
+        agentNotesMeta: null,
         sets: [
           {
             id: 'set-1',

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -15,7 +15,11 @@ import {
   scheduledWorkoutListItemSchema,
   scheduledWorkoutQueryParamsSchema,
   scheduledWorkoutSchema,
+  swapScheduledWorkoutExerciseInputSchema,
+  swapScheduledWorkoutExerciseResponseSchema,
   reorderWorkoutTemplateExercisesInputSchema,
+  updateScheduledWorkoutExerciseNotesInputSchema,
+  updateScheduledWorkoutExerciseNotesResponseSchema,
   updateWorkoutSessionSectionTimerInputSchema,
   swapWorkoutSessionExerciseInputSchema,
   swapWorkoutTemplateExerciseInputSchema,
@@ -36,6 +40,8 @@ import {
   type WorkoutSessionQueryParams,
   type WorkoutTemplateListQueryParams,
   type WorkoutTemplate,
+  type SwapScheduledWorkoutExerciseInput,
+  type UpdateScheduledWorkoutExerciseNotesInput,
   type SetCorrection,
   type WorkoutTemplateSectionType,
   workoutSessionQueryParamsSchema,
@@ -124,6 +130,14 @@ type UpdateScheduledWorkoutRequest = {
 };
 type DeleteScheduledWorkoutRequest = {
   id: string;
+};
+type UpdateScheduledWorkoutExerciseNotesRequest = {
+  id: string;
+  input: UpdateScheduledWorkoutExerciseNotesInput;
+};
+type SwapScheduledWorkoutExerciseRequest = {
+  id: string;
+  input: SwapScheduledWorkoutExerciseInput;
 };
 type DeleteScheduledWorkoutResponse = {
   data: {
@@ -881,6 +895,30 @@ async function updateScheduledWorkout(input: UpdateScheduledWorkoutRequest) {
   return payload.data;
 }
 
+async function updateScheduledWorkoutExerciseNotes(
+  input: UpdateScheduledWorkoutExerciseNotesRequest,
+) {
+  const parsedInput = updateScheduledWorkoutExerciseNotesInputSchema.parse(input.input);
+  const data = await apiRequest<unknown>(`/api/v1/scheduled-workouts/${input.id}/exercise-notes`, {
+    body: JSON.stringify(parsedInput),
+    method: 'PATCH',
+  });
+  const payload = z.object({ data: updateScheduledWorkoutExerciseNotesResponseSchema }).parse({ data });
+
+  return payload.data;
+}
+
+async function swapScheduledWorkoutExercise(input: SwapScheduledWorkoutExerciseRequest) {
+  const parsedInput = swapScheduledWorkoutExerciseInputSchema.parse(input.input);
+  const data = await apiRequest<unknown>(`/api/v1/scheduled-workouts/${input.id}/exercise-swap`, {
+    body: JSON.stringify(parsedInput),
+    method: 'PATCH',
+  });
+  const payload = z.object({ data: swapScheduledWorkoutExerciseResponseSchema }).parse({ data });
+
+  return payload.data;
+}
+
 async function deleteScheduledWorkout(input: DeleteScheduledWorkoutRequest) {
   const data = await apiRequest<unknown>(`/api/v1/scheduled-workouts/${input.id}`, {
     method: 'DELETE',
@@ -1076,6 +1114,50 @@ export function useUnscheduleWorkout() {
     },
     queryKey: () => workoutQueryKeys.scheduledWorkoutListRoot(),
     updater: (current, variables) => removeScheduledWorkoutFromList(current, variables),
+  });
+}
+
+export function useUpdateScheduledWorkoutExerciseNotes() {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    SharedScheduledWorkoutDetail,
+    Error,
+    UpdateScheduledWorkoutExerciseNotesRequest
+  >({
+    mutationFn: updateScheduledWorkoutExerciseNotes,
+    onSuccess: async (_, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.scheduledWorkout(variables.id),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.scheduledWorkoutListRoot(),
+        }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.scheduledWorkoutMutation()),
+      ]);
+      toast.success('Agent notes updated');
+    },
+  });
+}
+
+export function useSwapScheduledWorkoutExercise() {
+  const queryClient = useQueryClient();
+
+  return useMutation<SharedScheduledWorkoutDetail, Error, SwapScheduledWorkoutExerciseRequest>({
+    mutationFn: swapScheduledWorkoutExercise,
+    onSuccess: async (_, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.scheduledWorkout(variables.id),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.scheduledWorkoutListRoot(),
+        }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.scheduledWorkoutMutation()),
+      ]);
+      toast.success('Exercise updated');
+    },
   });
 }
 

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -11,6 +11,7 @@ import {
   exerciseQueryParamsSchema,
   exerciseSchema,
   sessionCorrectionRequestSchema,
+  scheduledWorkoutDetailSchema,
   scheduledWorkoutListItemSchema,
   scheduledWorkoutQueryParamsSchema,
   scheduledWorkoutSchema,
@@ -26,6 +27,7 @@ import {
   type Exercise,
   type ExerciseQueryParams,
   type CreateScheduledWorkoutInput,
+  type ScheduledWorkoutDetail as SharedScheduledWorkoutDetail,
   type ScheduledWorkout,
   type ScheduledWorkoutListItem,
   type ScheduledWorkoutQueryParams,
@@ -561,11 +563,11 @@ async function getCompletedSessions(signal?: AbortSignal) {
 }
 
 const scheduledWorkoutDetailResponseSchema = z.object({
-  data: scheduledWorkoutSchema.extend({
+  data: scheduledWorkoutDetailSchema.extend({
     template: workoutTemplateSchema.nullable(),
   }),
 }) as unknown as z.ZodType<{
-  data: ScheduledWorkout & { template: WorkoutTemplate | null };
+  data: SharedScheduledWorkoutDetail & { template: WorkoutTemplate | null };
 }>;
 
 async function getScheduledWorkoutDetail(id: string, signal?: AbortSignal) {
@@ -917,7 +919,7 @@ export function useScheduledWorkouts(
   });
 }
 
-export type ScheduledWorkoutDetail = ScheduledWorkout & { template: WorkoutTemplate | null };
+export type ScheduledWorkoutDetail = SharedScheduledWorkoutDetail & { template: WorkoutTemplate | null };
 
 export function useScheduledWorkoutDetail(id: string, options?: { enabled?: boolean }) {
   return useQuery<ScheduledWorkoutDetail>({

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -18,8 +18,6 @@ import {
   swapScheduledWorkoutExerciseInputSchema,
   swapScheduledWorkoutExerciseResponseSchema,
   reorderWorkoutTemplateExercisesInputSchema,
-  updateScheduledWorkoutExerciseNotesInputSchema,
-  updateScheduledWorkoutExerciseNotesResponseSchema,
   updateWorkoutSessionSectionTimerInputSchema,
   swapWorkoutSessionExerciseInputSchema,
   swapWorkoutTemplateExerciseInputSchema,
@@ -41,7 +39,6 @@ import {
   type WorkoutTemplateListQueryParams,
   type WorkoutTemplate,
   type SwapScheduledWorkoutExerciseInput,
-  type UpdateScheduledWorkoutExerciseNotesInput,
   type SetCorrection,
   type WorkoutTemplateSectionType,
   workoutSessionQueryParamsSchema,
@@ -130,10 +127,6 @@ type UpdateScheduledWorkoutRequest = {
 };
 type DeleteScheduledWorkoutRequest = {
   id: string;
-};
-type UpdateScheduledWorkoutExerciseNotesRequest = {
-  id: string;
-  input: UpdateScheduledWorkoutExerciseNotesInput;
 };
 type SwapScheduledWorkoutExerciseRequest = {
   id: string;
@@ -895,19 +888,6 @@ async function updateScheduledWorkout(input: UpdateScheduledWorkoutRequest) {
   return payload.data;
 }
 
-async function updateScheduledWorkoutExerciseNotes(
-  input: UpdateScheduledWorkoutExerciseNotesRequest,
-) {
-  const parsedInput = updateScheduledWorkoutExerciseNotesInputSchema.parse(input.input);
-  const data = await apiRequest<unknown>(`/api/v1/scheduled-workouts/${input.id}/exercise-notes`, {
-    body: JSON.stringify(parsedInput),
-    method: 'PATCH',
-  });
-  const payload = z.object({ data: updateScheduledWorkoutExerciseNotesResponseSchema }).parse({ data });
-
-  return payload.data;
-}
-
 async function swapScheduledWorkoutExercise(input: SwapScheduledWorkoutExerciseRequest) {
   const parsedInput = swapScheduledWorkoutExerciseInputSchema.parse(input.input);
   const data = await apiRequest<unknown>(`/api/v1/scheduled-workouts/${input.id}/exercise-swap`, {
@@ -1114,30 +1094,6 @@ export function useUnscheduleWorkout() {
     },
     queryKey: () => workoutQueryKeys.scheduledWorkoutListRoot(),
     updater: (current, variables) => removeScheduledWorkoutFromList(current, variables),
-  });
-}
-
-export function useUpdateScheduledWorkoutExerciseNotes() {
-  const queryClient = useQueryClient();
-
-  return useMutation<
-    SharedScheduledWorkoutDetail,
-    Error,
-    UpdateScheduledWorkoutExerciseNotesRequest
-  >({
-    mutationFn: updateScheduledWorkoutExerciseNotes,
-    onSuccess: async (_, variables) => {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.scheduledWorkout(variables.id),
-        }),
-        queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.scheduledWorkoutListRoot(),
-        }),
-        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.scheduledWorkoutMutation()),
-      ]);
-      toast.success('Agent notes updated');
-    },
   });
 }
 

--- a/apps/web/src/features/workouts/components/scheduled-workout-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/scheduled-workout-detail.test.tsx
@@ -286,6 +286,35 @@ function createScheduledWorkoutDetailPayload({
   sessionId: null;
   createdAt: number;
   updatedAt: number;
+  exercises: Array<{
+    exerciseId: string;
+    section: 'warmup' | 'main' | 'cooldown' | 'supplemental';
+    orderIndex: number;
+    programmingNotes: string | null;
+    agentNotes: string | null;
+    agentNotesMeta: null;
+    templateCues: string[] | null;
+    supersetGroup: string | null;
+    tempo: string | null;
+    restSeconds: number | null;
+    sets: Array<{
+      setNumber: number;
+      repsMin: number | null;
+      repsMax: number | null;
+      reps: number | null;
+      targetWeight: number | null;
+      targetWeightMin: number | null;
+      targetWeightMax: number | null;
+      targetSeconds: number | null;
+      targetDistance: number | null;
+    }>;
+  }>;
+  templateDrift: null;
+  staleExercises: Array<{
+    exerciseId: string;
+    snapshotName: string;
+  }>;
+  templateDeleted: boolean;
   template: {
     id: string;
     userId: string;
@@ -331,6 +360,36 @@ function createScheduledWorkoutDetailPayload({
     sessionId: null,
     createdAt: 1,
     updatedAt: 1,
+    exercises: [
+      {
+        exerciseId: 'incline-dumbbell-press',
+        section: 'main',
+        orderIndex: 0,
+        programmingNotes: 'Top set first, then reduce load for back-off sets.',
+        agentNotes: null,
+        agentNotesMeta: null,
+        templateCues: ['Drive feet into the floor', 'Keep wrists stacked'],
+        supersetGroup: null,
+        tempo: '3110',
+        restSeconds: 90,
+        sets: [
+          {
+            setNumber: 1,
+            repsMin: 8,
+            repsMax: 10,
+            reps: null,
+            targetWeight: 70,
+            targetWeightMin: null,
+            targetWeightMax: null,
+            targetSeconds: null,
+            targetDistance: null,
+          },
+        ],
+      },
+    ],
+    templateDrift: null,
+    staleExercises: [],
+    templateDeleted: false,
     template: {
       id: 'template-1',
       userId: 'user-1',

--- a/apps/web/src/features/workouts/components/scheduled-workout-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/scheduled-workout-detail.test.tsx
@@ -42,6 +42,29 @@ vi.mock('./schedule-workout-dialog', () => ({
   },
 }));
 
+vi.mock('./swap-exercise-dialog', () => ({
+  SwapExerciseDialog: ({
+    open,
+    sourceExerciseId,
+    sourceExerciseName,
+  }: {
+    open: boolean;
+    sourceExerciseId: string;
+    sourceExerciseName: string;
+  }) => {
+    if (!open) {
+      return null;
+    }
+
+    return (
+      <div data-testid="swap-exercise-dialog">
+        <p>{sourceExerciseName}</p>
+        <p>{sourceExerciseId}</p>
+      </div>
+    );
+  },
+}));
+
 import { ScheduledWorkoutDetail } from './scheduled-workout-detail';
 
 beforeEach(() => {
@@ -232,6 +255,48 @@ describe('ScheduledWorkoutDetail', () => {
         ),
       ).toBe(true);
     });
+  });
+
+  it('opens swap flow from stale recovery modal with the correct stale exercise context', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = new URL(String(input), 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: createScheduledWorkoutDetailPayload({
+              date: toDateKey(new Date()),
+              staleExercises: [
+                {
+                  exerciseId: 'deleted-exercise',
+                  snapshotName: 'Dips',
+                },
+              ],
+            }),
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <ScheduledWorkoutDetail id="scheduled-1" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Review' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Swap' }));
+
+    const swapDialog = await screen.findByTestId('swap-exercise-dialog');
+    expect(swapDialog).toHaveTextContent('Dips');
+    expect(swapDialog).toHaveTextContent('deleted-exercise');
   });
 
   it('opens stale recovery modal when start-session returns STALE_SNAPSHOT_EXERCISES', async () => {

--- a/apps/web/src/features/workouts/components/scheduled-workout-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/scheduled-workout-detail.test.tsx
@@ -54,17 +54,49 @@ afterEach(() => {
 });
 
 describe('ScheduledWorkoutDetail', () => {
-  it('renders shared workout exercise cards and programming notes from scheduled template data', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+  it('renders snapshot exercise cards with programming and agent notes', async () => {
+    const detail = createScheduledWorkoutDetailPayload({
+      date: toDateKey(new Date()),
+      exercises: [
+        {
+          exerciseId: 'incline-dumbbell-press',
+          section: 'main',
+          orderIndex: 0,
+          programmingNotes: 'Top set first, then reduce load for back-off sets.',
+          agentNotes: 'Last session looked smooth; try 62 lb if warmup set is easy.',
+          agentNotesMeta: {
+            author: 'Coach Pulse',
+            generatedAt: '2026-03-16T09:30:00.000Z',
+            scheduledDateAtGeneration: '2026-03-16',
+            stale: false,
+          },
+          templateCues: ['Drive feet into the floor', 'Keep wrists stacked'],
+          supersetGroup: null,
+          tempo: '3110',
+          restSeconds: 90,
+          sets: [
+            {
+              setNumber: 1,
+              repsMin: 8,
+              repsMax: 10,
+              reps: null,
+              targetWeight: 70,
+              targetWeightMin: null,
+              targetWeightMax: null,
+              targetSeconds: null,
+              targetDistance: null,
+            },
+          ],
+        },
+      ],
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
       const url = new URL(String(input), 'https://pulse.test');
       const method = init?.method ?? 'GET';
 
       if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'GET') {
-        return Promise.resolve(
-          jsonResponse({
-            data: createScheduledWorkoutDetailPayload({ date: toDateKey(new Date()) }),
-          }),
-        );
+        return Promise.resolve(jsonResponse({ data: detail }));
       }
 
       if (url.pathname === '/api/v1/workout-sessions' && method === 'GET') {
@@ -81,30 +113,214 @@ describe('ScheduledWorkoutDetail', () => {
     );
 
     expect(await screen.findByRole('heading', { level: 1, name: 'Upper Push' })).toBeInTheDocument();
-    expect(screen.getByTestId('workout-exercise-card-template-exercise-1')).toBeInTheDocument();
-    expect(screen.getByText('Programming notes')).toBeInTheDocument();
-    expect(screen.getByText('Top set first, then reduce load for back-off sets.')).toBeInTheDocument();
-    expect(screen.getByText('Show full set detail')).toBeInTheDocument();
-
     expect(
-      fetchSpy.mock.calls.some(
-        ([input, requestInit]) =>
-          String(input).includes('/api/v1/scheduled-workouts/scheduled-1') &&
-          (requestInit?.method ?? 'GET') === 'GET',
-      ),
-    ).toBe(true);
+      screen.getByTestId('workout-exercise-card-snapshot-main-0-incline-dumbbell-press'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Programming notes')).toBeInTheDocument();
+    expect(screen.getByText('For today')).toBeInTheDocument();
+    expect(screen.getByText('Top set first, then reduce load for back-off sets.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Last session looked smooth; try 62 lb if warmup set is easy.'),
+    ).toBeInTheDocument();
   });
 
-  it('starts the scheduled workout via the start-session mutation', async () => {
+  it('renders template drift, stale exercise, and template deleted banners from marker states', async () => {
+    const detail = createScheduledWorkoutDetailPayload({
+      date: toDateKey(new Date()),
+      staleExercises: [
+        {
+          exerciseId: 'deleted-exercise',
+          snapshotName: 'Dips',
+        },
+      ],
+      templateDeleted: true,
+      templateDrift: {
+        changedAt: Date.UTC(2026, 2, 16, 12, 0, 0),
+        summary: 'Template has been updated since scheduling.',
+      },
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = new URL(String(input), 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: detail }));
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <ScheduledWorkoutDetail id="scheduled-1" />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByTestId('scheduled-template-drift-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('scheduled-stale-exercises-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('scheduled-template-deleted-banner')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Review' })).toBeInTheDocument();
+  });
+
+  it('removes stale snapshot exercises from recovery modal via scheduled swap mutation', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    let currentDetail = createScheduledWorkoutDetailPayload({
+      date: toDateKey(new Date()),
+      staleExercises: [
+        {
+          exerciseId: 'deleted-exercise',
+          snapshotName: 'Dips',
+        },
+      ],
+    });
+
+    fetchSpy.mockImplementation((input, init) => {
+      const url = new URL(String(input), 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: currentDetail }));
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1/exercise-swap' && method === 'PATCH') {
+        const payload = JSON.parse(String(init?.body)) as {
+          fromExerciseId: string;
+          toExerciseId: string | null;
+        };
+
+        expect(payload).toEqual({
+          fromExerciseId: 'deleted-exercise',
+          toExerciseId: null,
+        });
+
+        currentDetail = {
+          ...currentDetail,
+          staleExercises: [],
+          updatedAt: currentDetail.updatedAt + 1,
+        };
+
+        return Promise.resolve(jsonResponse({ data: currentDetail }));
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <ScheduledWorkoutDetail id="scheduled-1" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Review' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(
+          ([input, requestInit]) =>
+            String(input).includes('/api/v1/scheduled-workouts/scheduled-1/exercise-swap') &&
+            (requestInit?.method ?? 'GET') === 'PATCH',
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it('opens stale recovery modal when start-session returns STALE_SNAPSHOT_EXERCISES', async () => {
     const todayKey = toDateKey(new Date());
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
       const url = new URL(String(input), 'https://pulse.test');
       const method = init?.method ?? 'GET';
 
       if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'GET') {
         return Promise.resolve(
           jsonResponse({
-            data: createScheduledWorkoutDetailPayload({ date: todayKey }),
+            data: createScheduledWorkoutDetailPayload({
+              date: todayKey,
+              staleExercises: [
+                {
+                  exerciseId: 'deleted-exercise',
+                  snapshotName: 'Dips',
+                },
+              ],
+            }),
+          }),
+        );
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions' && method === 'POST') {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              error: {
+                code: 'STALE_SNAPSHOT_EXERCISES',
+                message: 'Scheduled workout snapshot references deleted or unavailable exercises',
+                staleExercises: [
+                  {
+                    exerciseId: 'deleted-exercise',
+                    snapshotName: 'Dips',
+                  },
+                ],
+              },
+            }),
+            {
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              status: 409,
+            },
+          ),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <ScheduledWorkoutDetail id="scheduled-1" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Start workout' }));
+
+    expect(await screen.findByRole('heading', { name: 'Resolve unavailable exercises' })).toBeInTheDocument();
+    expect(screen.getByText('Dips')).toBeInTheDocument();
+  });
+
+  it('starts anyway from stale recovery modal by re-posting session start with force true', async () => {
+    const todayKey = toDateKey(new Date());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    fetchSpy.mockImplementation((input, init) => {
+      const url = new URL(String(input), 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            data: createScheduledWorkoutDetailPayload({
+              date: todayKey,
+              staleExercises: [
+                {
+                  exerciseId: 'deleted-exercise',
+                  snapshotName: 'Dips',
+                },
+              ],
+            }),
           }),
         );
       }
@@ -155,7 +371,8 @@ describe('ScheduledWorkoutDetail', () => {
       </MemoryRouter>,
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Start workout' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Review' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Start anyway' }));
 
     await waitFor(() => {
       const startCall = fetchSpy.mock.calls.find(([input, requestInit]) => {
@@ -165,134 +382,37 @@ describe('ScheduledWorkoutDetail', () => {
       });
 
       expect(startCall).toBeDefined();
-    });
-
-    const startCall = fetchSpy.mock.calls.find(([input, requestInit]) => {
-      const requestUrl = String(input);
-      const requestMethod = requestInit?.method ?? 'GET';
-      return requestUrl.includes('/api/v1/workout-sessions') && requestMethod === 'POST';
-    });
-
-    const requestBody = JSON.parse(String(startCall?.[1]?.body));
-    expect(requestBody).toMatchObject({
-      name: 'Upper Push',
-      templateId: 'template-1',
-    });
-  });
-
-  it('keeps reschedule and cancel affordances wired to scheduled-workout mutations', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
-      const url = new URL(String(input), 'https://pulse.test');
-      const method = init?.method ?? 'GET';
-
-      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'GET') {
-        return Promise.resolve(
-          jsonResponse({
-            data: createScheduledWorkoutDetailPayload({ date: toDateKey(new Date()) }),
-          }),
-        );
-      }
-
-      if (url.pathname === '/api/v1/workout-sessions' && method === 'GET') {
-        return Promise.resolve(jsonResponse({ data: [] }));
-      }
-
-      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'PATCH') {
-        return Promise.resolve(
-          jsonResponse({
-            data: {
-              id: 'scheduled-1',
-              userId: 'user-1',
-              templateId: 'template-1',
-              date: '2099-12-31',
-              sessionId: null,
-              createdAt: 1,
-              updatedAt: 2,
-            },
-          }),
-        );
-      }
-
-      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'DELETE') {
-        return Promise.resolve(
-          jsonResponse({
-            data: {
-              success: true,
-            },
-          }),
-        );
-      }
-
-      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
-    });
-
-    renderWithQueryClient(
-      <MemoryRouter>
-        <ScheduledWorkoutDetail id="scheduled-1" />
-      </MemoryRouter>,
-    );
-
-    fireEvent.click(await screen.findByRole('button', { name: 'Reschedule' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Submit reschedule' }));
-
-    await waitFor(() => {
-      const rescheduleCall = fetchSpy.mock.calls.find(([input, requestInit]) => {
-        const requestUrl = String(input);
-        const requestMethod = requestInit?.method ?? 'GET';
-        return (
-          requestUrl.includes('/api/v1/scheduled-workouts/scheduled-1') &&
-          requestMethod === 'PATCH'
-        );
+      const requestBody = JSON.parse(String(startCall?.[1]?.body));
+      expect(requestBody).toMatchObject({
+        force: true,
+        scheduledWorkoutId: 'scheduled-1',
       });
-
-      expect(rescheduleCall).toBeDefined();
-    });
-
-    const rescheduleCall = fetchSpy.mock.calls.find(([input, requestInit]) => {
-      const requestUrl = String(input);
-      const requestMethod = requestInit?.method ?? 'GET';
-      return requestUrl.includes('/api/v1/scheduled-workouts/scheduled-1') && requestMethod === 'PATCH';
-    });
-    const rescheduleBody = JSON.parse(String(rescheduleCall?.[1]?.body));
-    expect(rescheduleBody).toEqual({ date: '2099-12-31' });
-
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Cancel workout' }));
-
-    await waitFor(() => {
-      const cancelCall = fetchSpy.mock.calls.find(([input, requestInit]) => {
-        const requestUrl = String(input);
-        const requestMethod = requestInit?.method ?? 'GET';
-        return (
-          requestUrl.includes('/api/v1/scheduled-workouts/scheduled-1') &&
-          requestMethod === 'DELETE'
-        );
-      });
-
-      expect(cancelCall).toBeDefined();
     });
   });
 });
 
 function createScheduledWorkoutDetailPayload({
   date,
+  exercises,
+  staleExercises,
+  templateDeleted = false,
+  templateDrift = null,
 }: {
   date: string;
-}): {
-  id: string;
-  userId: string;
-  templateId: string;
-  date: string;
-  sessionId: null;
-  createdAt: number;
-  updatedAt: number;
-  exercises: Array<{
+  exercises?: Array<{
     exerciseId: string;
     section: 'warmup' | 'main' | 'cooldown' | 'supplemental';
     orderIndex: number;
     programmingNotes: string | null;
     agentNotes: string | null;
-    agentNotesMeta: null;
+    agentNotesMeta:
+      | {
+          author: string;
+          generatedAt: string;
+          scheduledDateAtGeneration: string;
+          stale: boolean;
+        }
+      | null;
     templateCues: string[] | null;
     supersetGroup: string | null;
     tempo: string | null;
@@ -309,49 +429,18 @@ function createScheduledWorkoutDetailPayload({
       targetDistance: number | null;
     }>;
   }>;
-  templateDrift: null;
-  staleExercises: Array<{
+  staleExercises?: Array<{
     exerciseId: string;
     snapshotName: string;
   }>;
-  templateDeleted: boolean;
-  template: {
-    id: string;
-    userId: string;
-    name: string;
-    description: string;
-    tags: string[];
-    sections: Array<{
-      type: 'warmup' | 'main' | 'cooldown';
-      exercises: Array<{
-        id: string;
-        exerciseId: string;
-        exerciseName: string;
-        trackingType: 'weight_reps';
-        sets: number;
-        repsMin: number;
-        repsMax: number;
-        tempo: '3110';
-        restSeconds: number;
-        supersetGroup: null;
-        notes: string;
-        cues: string[];
-        setTargets: Array<{
-          setNumber: number;
-          targetWeight: number;
-        }>;
-        programmingNotes: string;
-        exercise: {
-          formCues: string[];
-          coachingNotes: string;
-          instructions: string;
-        };
-      }>;
-    }>;
-    createdAt: number;
-    updatedAt: number;
-  };
-} {
+  templateDeleted?: boolean;
+  templateDrift?:
+    | {
+        changedAt: number;
+        summary: string;
+      }
+    | null;
+}) {
   return {
     id: 'scheduled-1',
     userId: 'user-1',
@@ -360,85 +449,89 @@ function createScheduledWorkoutDetailPayload({
     sessionId: null,
     createdAt: 1,
     updatedAt: 1,
-    exercises: [
-      {
-        exerciseId: 'incline-dumbbell-press',
-        section: 'main',
-        orderIndex: 0,
-        programmingNotes: 'Top set first, then reduce load for back-off sets.',
-        agentNotes: null,
-        agentNotesMeta: null,
-        templateCues: ['Drive feet into the floor', 'Keep wrists stacked'],
-        supersetGroup: null,
-        tempo: '3110',
-        restSeconds: 90,
-        sets: [
-          {
-            setNumber: 1,
-            repsMin: 8,
-            repsMax: 10,
-            reps: null,
-            targetWeight: 70,
-            targetWeightMin: null,
-            targetWeightMax: null,
-            targetSeconds: null,
-            targetDistance: null,
-          },
-        ],
-      },
-    ],
-    templateDrift: null,
-    staleExercises: [],
-    templateDeleted: false,
-    template: {
-      id: 'template-1',
-      userId: 'user-1',
-      name: 'Upper Push',
-      description: 'Chest, shoulders, and triceps emphasis.',
-      tags: ['push'],
-      sections: [
+    exercises:
+      exercises ??
+      [
         {
-          type: 'warmup',
-          exercises: [],
-        },
-        {
-          type: 'main',
-          exercises: [
+          exerciseId: 'incline-dumbbell-press',
+          section: 'main',
+          orderIndex: 0,
+          programmingNotes: 'Top set first, then reduce load for back-off sets.',
+          agentNotes: null,
+          agentNotesMeta: null,
+          templateCues: ['Drive feet into the floor', 'Keep wrists stacked'],
+          supersetGroup: null,
+          tempo: '3110',
+          restSeconds: 90,
+          sets: [
             {
-              id: 'template-exercise-1',
-              exerciseId: 'incline-dumbbell-press',
-              exerciseName: 'Incline Dumbbell Press',
-              trackingType: 'weight_reps',
-              sets: 3,
+              setNumber: 1,
               repsMin: 8,
               repsMax: 10,
-              tempo: '3110',
-              restSeconds: 90,
-              supersetGroup: null,
-              notes: 'Drive feet into the floor.',
-              cues: ['Drive feet into the floor', 'Keep wrists stacked'],
-              setTargets: [
-                {
-                  setNumber: 1,
-                  targetWeight: 70,
-                },
-              ],
-              programmingNotes: 'Top set first, then reduce load for back-off sets.',
-              exercise: {
-                formCues: ['Tuck shoulder blades'],
-                coachingNotes: 'Keep your upper back pinned to the bench.',
-                instructions: 'Lower dumbbells with control, then drive straight up.',
-              },
+              reps: null,
+              targetWeight: 70,
+              targetWeightMin: null,
+              targetWeightMax: null,
+              targetSeconds: null,
+              targetDistance: null,
             },
           ],
         },
-        {
-          type: 'cooldown',
-          exercises: [],
-        },
       ],
-      createdAt: 1,
-      updatedAt: 1,
-    },
+    templateDrift,
+    staleExercises: staleExercises ?? [],
+    templateDeleted,
+    template: templateDeleted
+      ? null
+      : {
+          id: 'template-1',
+          userId: 'user-1',
+          name: 'Upper Push',
+          description: 'Chest, shoulders, and triceps emphasis.',
+          tags: ['push'],
+          sections: [
+            {
+              type: 'warmup',
+              exercises: [],
+            },
+            {
+              type: 'main',
+              exercises: [
+                {
+                  id: 'template-exercise-1',
+                  exerciseId: 'incline-dumbbell-press',
+                  exerciseName: 'Incline Dumbbell Press',
+                  trackingType: 'weight_reps',
+                  sets: 3,
+                  repsMin: 8,
+                  repsMax: 10,
+                  tempo: '3110',
+                  restSeconds: 90,
+                  supersetGroup: null,
+                  notes: 'Drive feet into the floor.',
+                  cues: ['Drive feet into the floor', 'Keep wrists stacked'],
+                  setTargets: [
+                    {
+                      setNumber: 1,
+                      targetWeight: 70,
+                    },
+                  ],
+                  programmingNotes: 'Top set first, then reduce load for back-off sets.',
+                  exercise: {
+                    formCues: ['Tuck shoulder blades'],
+                    coachingNotes: 'Keep your upper back pinned to the bench.',
+                    instructions: 'Lower dumbbells with control, then drive straight up.',
+                  },
+                },
+              ],
+            },
+            {
+              type: 'cooldown',
+              exercises: [],
+            },
+          ],
+          createdAt: 1,
+          updatedAt: 1,
+        },
   };
 }

--- a/apps/web/src/features/workouts/components/scheduled-workout-detail.tsx
+++ b/apps/web/src/features/workouts/components/scheduled-workout-detail.tsx
@@ -1,7 +1,8 @@
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
-import { History } from 'lucide-react';
+import { AlertTriangle, History, Info, TriangleAlert } from 'lucide-react';
 import type {
+  ExerciseTrackingType,
   WorkoutTemplate,
   WorkoutTemplateExercise,
   WorkoutTemplateSectionType,
@@ -12,24 +13,36 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useConfirmation } from '@/components/ui/confirmation-dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { useStartSession } from '@/hooks/use-workout-session';
 import { useWeightUnit } from '@/hooks/use-weight-unit';
+import { ApiError } from '@/lib/api-client';
 import { toDateKey } from '@/lib/date-utils';
 import { cn } from '@/lib/utils';
 
 import {
+  type ScheduledWorkoutDetail,
   useRescheduleWorkout,
   useScheduledWorkoutDetail,
+  useSwapScheduledWorkoutExercise,
   useUnscheduleWorkout,
   useWorkoutSessions,
 } from '../api/workouts';
-import { buildInitialSessionSets } from '../lib/workout-session-sets';
-import { ExerciseDetailModal } from './exercise-detail-modal';
 import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
 import { ScheduledWorkoutHeader } from './scheduled-workout-header';
+import { SwapExerciseDialog } from './swap-exercise-dialog';
+import { ExerciseDetailModal } from './exercise-detail-modal';
 import {
   WorkoutExerciseCard,
   type WorkoutExerciseCardScheduledExercise,
+  type WorkoutExerciseSetTarget,
 } from './workout-exercise-card';
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
@@ -58,6 +71,13 @@ type ScheduledWorkoutDetailProps = {
   id: string;
 };
 
+type SnapshotExercise = ScheduledWorkoutDetail['exercises'][number];
+
+type TemplateExerciseLookup = {
+  byExerciseIdBySection: Map<string, WorkoutTemplateExercise>;
+  bySnapshotOrderKey: Map<string, WorkoutTemplateExercise>;
+};
+
 export function ScheduledWorkoutDetail({ bannerSlot, id }: ScheduledWorkoutDetailProps) {
   const navigate = useNavigate();
   const { weightUnit } = useWeightUnit();
@@ -65,35 +85,75 @@ export function ScheduledWorkoutDetail({ bannerSlot, id }: ScheduledWorkoutDetai
   const startSessionMutation = useStartSession();
   const rescheduleWorkoutMutation = useRescheduleWorkout();
   const unscheduleWorkoutMutation = useUnscheduleWorkout();
+  const swapScheduledExerciseMutation = useSwapScheduledWorkoutExercise();
   const { confirm, dialog: confirmDialog } = useConfirmation();
   const activeSessionsQuery = useWorkoutSessions({ status: ['in-progress', 'paused'] });
   const [isRescheduleDialogOpen, setIsRescheduleDialogOpen] = useState(false);
+  const [isRecoveryModalOpen, setIsRecoveryModalOpen] = useState(false);
   const [historyTarget, setHistoryTarget] = useState<{
     exerciseId: string;
     exerciseName: string;
   } | null>(null);
+  const [swapTarget, setSwapTarget] = useState<{
+    exerciseId: string;
+    snapshotName: string;
+  } | null>(null);
 
   const template = scheduledWorkout?.template ?? null;
-  const isTemplateAvailable = template !== null;
+  const staleExercises = useMemo(
+    () => scheduledWorkout?.staleExercises ?? [],
+    [scheduledWorkout?.staleExercises],
+  );
+  const staleExerciseNameById = useMemo(
+    () => new Map(staleExercises.map((exercise) => [exercise.exerciseId, exercise.snapshotName])),
+    [staleExercises],
+  );
+  const templateExerciseLookup = useMemo(
+    () => buildTemplateExerciseLookup(template),
+    [template],
+  );
+  const canStartFromSnapshot = scheduledWorkout !== undefined && scheduledWorkout !== null;
   const isMutating =
     startSessionMutation.isPending ||
     rescheduleWorkoutMutation.isPending ||
-    unscheduleWorkoutMutation.isPending;
+    unscheduleWorkoutMutation.isPending ||
+    swapScheduledExerciseMutation.isPending;
 
-  async function doStart() {
-    if (!scheduledWorkout || !template || !scheduledWorkout.templateId) {
+  async function doStart(options?: { force?: boolean }) {
+    if (!scheduledWorkout) {
       return;
     }
 
     const startedAt = Date.now();
-    const session = await startSessionMutation.mutateAsync({
-      date: toDateKey(new Date(startedAt)),
-      name: template.name,
-      sets: buildInitialSessionSets(template),
-      startedAt,
-      templateId: scheduledWorkout.templateId,
-    });
-    navigate(`/workouts/active?template=${scheduledWorkout.templateId}&sessionId=${session.id}`);
+
+    try {
+      const session = await startSessionMutation.mutateAsync({
+        date: toDateKey(new Date(startedAt)),
+        ...(options?.force ? { force: true } : {}),
+        ...(template?.name ? { name: template.name } : {}),
+        scheduledWorkoutId: scheduledWorkout.id,
+        startedAt,
+      });
+
+      const searchParams = new URLSearchParams({ sessionId: session.id });
+      const templateId = session.templateId ?? scheduledWorkout.templateId;
+      if (templateId) {
+        searchParams.set('template', templateId);
+      }
+
+      navigate(`/workouts/active?${searchParams.toString()}`);
+    } catch (error) {
+      if (
+        error instanceof ApiError &&
+        error.status === 409 &&
+        error.code === 'STALE_SNAPSHOT_EXERCISES'
+      ) {
+        setIsRecoveryModalOpen(true);
+        return;
+      }
+
+      throw error;
+    }
   }
 
   function handleStart() {
@@ -152,6 +212,24 @@ export function ScheduledWorkoutDetail({ bannerSlot, id }: ScheduledWorkoutDetai
     navigate('/workouts');
   }
 
+  async function handleRemoveStaleExercise(exerciseId: string) {
+    if (!scheduledWorkout) {
+      return;
+    }
+
+    await swapScheduledExerciseMutation.mutateAsync({
+      id: scheduledWorkout.id,
+      input: {
+        fromExerciseId: exerciseId,
+        toExerciseId: null,
+      },
+    });
+  }
+
+  async function handleStartAnyway() {
+    await doStart({ force: true });
+  }
+
   function confirmCancel() {
     confirm({
       title: 'Cancel this scheduled workout?',
@@ -188,29 +266,35 @@ export function ScheduledWorkoutDetail({ bannerSlot, id }: ScheduledWorkoutDetai
   return (
     <div className="space-y-4">
       {bannerSlot}
+
+      <ScheduledWorkoutBanners
+        onReviewStale={() => setIsRecoveryModalOpen(true)}
+        scheduledWorkout={scheduledWorkout}
+      />
+
       <ScheduledWorkoutHeader
         isMutating={isMutating}
-        isTemplateAvailable={isTemplateAvailable}
+        isTemplateAvailable={canStartFromSnapshot}
         onCancel={confirmCancel}
         onReschedule={() => setIsRescheduleDialogOpen(true)}
         onStart={handleStart}
         scheduledDateLabel={dateFormatter.format(new Date(`${scheduledWorkout.date}T12:00:00`))}
-        templateId={scheduledWorkout.templateId}
+        templateId={scheduledWorkout.templateDeleted ? null : scheduledWorkout.templateId}
         templateName={template?.name ?? null}
       />
 
-      {template ? (
-        <ScheduledWorkoutSections
-          onOpenHistory={(exercise) =>
-            setHistoryTarget({
-              exerciseId: exercise.exerciseId,
-              exerciseName: exercise.exerciseName,
-            })
-          }
-          template={template}
-          weightUnit={weightUnit}
-        />
-      ) : null}
+      <ScheduledWorkoutSections
+        onOpenHistory={(exercise) =>
+          setHistoryTarget({
+            exerciseId: exercise.exerciseId,
+            exerciseName: exercise.exerciseName,
+          })
+        }
+        scheduledWorkout={scheduledWorkout}
+        staleExerciseNameById={staleExerciseNameById}
+        templateExerciseLookup={templateExerciseLookup}
+        weightUnit={weightUnit}
+      />
 
       <ScheduleWorkoutDialog
         description={`Move ${template?.name ?? 'this workout'} to a new date.`}
@@ -224,6 +308,40 @@ export function ScheduledWorkoutDetail({ bannerSlot, id }: ScheduledWorkoutDetai
         submitLabel="Save"
         title="Reschedule workout"
       />
+
+      <StaleExerciseRecoveryDialog
+        onClose={() => {
+          setIsRecoveryModalOpen(false);
+          setSwapTarget(null);
+        }}
+        onRemoveExercise={handleRemoveStaleExercise}
+        onStartAnyway={handleStartAnyway}
+        onSwapExercise={(exerciseId, snapshotName) => setSwapTarget({ exerciseId, snapshotName })}
+        open={isRecoveryModalOpen && staleExercises.length > 0}
+        pendingExerciseId={
+          swapScheduledExerciseMutation.isPending
+            ? swapScheduledExerciseMutation.variables?.input.fromExerciseId
+            : null
+        }
+        scheduledWorkout={scheduledWorkout}
+        startAnywayPending={startSessionMutation.isPending}
+      />
+
+      {swapTarget ? (
+        <SwapExerciseDialog
+          contextId={scheduledWorkout.id}
+          mode="scheduled"
+          onOpenChange={(open) => {
+            if (!open) {
+              setSwapTarget(null);
+            }
+          }}
+          open={swapTarget != null}
+          sourceExerciseId={swapTarget.exerciseId}
+          sourceExerciseName={swapTarget.snapshotName}
+          sourceLabel="this scheduled workout"
+        />
+      ) : null}
 
       {historyTarget ? (
         <ExerciseDetailModal
@@ -244,20 +362,24 @@ export function ScheduledWorkoutDetail({ bannerSlot, id }: ScheduledWorkoutDetai
 
 function ScheduledWorkoutSections({
   onOpenHistory,
-  template,
+  scheduledWorkout,
+  staleExerciseNameById,
+  templateExerciseLookup,
   weightUnit,
 }: {
-  onOpenHistory: (exercise: WorkoutTemplateExercise) => void;
-  template: WorkoutTemplate;
+  onOpenHistory: (exercise: { exerciseId: string; exerciseName: string }) => void;
+  scheduledWorkout: ScheduledWorkoutDetail;
+  staleExerciseNameById: Map<string, string>;
+  templateExerciseLookup: TemplateExerciseLookup;
   weightUnit: WeightUnit;
 }) {
-  const nonEmptySections = template.sections.filter((section) => section.exercises.length > 0);
+  const nonEmptySections = buildSnapshotSections(scheduledWorkout.exercises);
 
   if (nonEmptySections.length === 0) {
     return (
       <Card>
         <CardContent className="py-6">
-          <p className="text-sm text-muted">No exercises in this template.</p>
+          <p className="text-sm text-muted">No exercises in this scheduled workout.</p>
         </CardContent>
       </Card>
     );
@@ -286,15 +408,30 @@ function ScheduledWorkoutSections({
           </summary>
 
           <div className="space-y-1.5 border-t border-border/80 px-3 py-3 sm:px-4 sm:py-3">
-            {section.exercises.map((exercise, index) => (
-              <ScheduledExerciseCard
-                exercise={exercise}
-                index={index}
-                key={exercise.id}
-                onOpenHistory={() => onOpenHistory(exercise)}
-                weightUnit={weightUnit}
-              />
-            ))}
+            {section.exercises.map((exercise, index) => {
+              const templateExercise = resolveTemplateExercise(exercise, templateExerciseLookup);
+              const resolvedName =
+                templateExercise?.exerciseName ??
+                staleExerciseNameById.get(exercise.exerciseId) ??
+                formatExerciseLabel(exercise.exerciseId);
+
+              return (
+                <ScheduledExerciseCard
+                  exercise={exercise}
+                  exerciseName={resolvedName}
+                  index={index}
+                  key={`${section.type}-${exercise.orderIndex}-${exercise.exerciseId}`}
+                  onOpenHistory={() =>
+                    onOpenHistory({
+                      exerciseId: exercise.exerciseId,
+                      exerciseName: resolvedName,
+                    })
+                  }
+                  templateExercise={templateExercise}
+                  weightUnit={weightUnit}
+                />
+              );
+            })}
           </div>
         </details>
       ))}
@@ -304,24 +441,28 @@ function ScheduledWorkoutSections({
 
 function ScheduledExerciseCard({
   exercise,
+  exerciseName,
   index,
   onOpenHistory,
+  templateExercise,
   weightUnit,
 }: {
-  exercise: WorkoutTemplateExercise;
+  exercise: SnapshotExercise;
+  exerciseName: string;
   index: number;
   onOpenHistory: () => void;
+  templateExercise: WorkoutTemplateExercise | undefined;
   weightUnit: WeightUnit;
 }) {
   return (
     <WorkoutExerciseCard
-      exercise={toWorkoutExerciseCardScheduledExercise(exercise)}
+      exercise={toWorkoutExerciseCardScheduledExercise(exercise, exerciseName, templateExercise)}
       footerSlot={
         <p className="text-[10px] font-semibold tracking-[0.14em] text-muted uppercase">{`Exercise #${index + 1}`}</p>
       }
       headerSlot={
         <Button
-          aria-label={`Open ${exercise.exerciseName} history`}
+          aria-label={`Open ${exerciseName} history`}
           className="size-11 min-h-11 min-w-11"
           onClick={onOpenHistory}
           size="icon"
@@ -338,27 +479,335 @@ function ScheduledExerciseCard({
   );
 }
 
+function ScheduledWorkoutBanners({
+  onReviewStale,
+  scheduledWorkout,
+}: {
+  onReviewStale: () => void;
+  scheduledWorkout: ScheduledWorkoutDetail;
+}) {
+  const hasAnyBanner =
+    scheduledWorkout.templateDrift != null ||
+    scheduledWorkout.staleExercises.length > 0 ||
+    scheduledWorkout.templateDeleted;
+
+  if (!hasAnyBanner) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2" data-testid="scheduled-workout-banners">
+      {scheduledWorkout.templateDrift ? (
+        <BannerCard
+          className="border-amber-500/30 bg-amber-500/12"
+          description="This template has been updated since you scheduled this workout."
+          icon={<TriangleAlert aria-hidden="true" className="size-4 text-amber-700 dark:text-amber-200" />}
+          testId="scheduled-template-drift-banner"
+          title="Template drift"
+        />
+      ) : null}
+
+      {scheduledWorkout.staleExercises.length > 0 ? (
+        <BannerCard
+          action={
+            <Button onClick={onReviewStale} size="sm" type="button" variant="outline">
+              Review
+            </Button>
+          }
+          className="border-amber-500/30 bg-amber-500/10"
+          description="Some exercises have been removed from your library."
+          icon={<AlertTriangle aria-hidden="true" className="size-4 text-amber-700 dark:text-amber-200" />}
+          testId="scheduled-stale-exercises-banner"
+          title="Exercise availability"
+        />
+      ) : null}
+
+      {scheduledWorkout.templateDeleted ? (
+        <BannerCard
+          className="border-border/80 bg-secondary/35"
+          description="Source template was deleted. This snapshot is preserved."
+          icon={<Info aria-hidden="true" className="size-4 text-muted" />}
+          testId="scheduled-template-deleted-banner"
+          title="Template deleted"
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function BannerCard({
+  action,
+  className,
+  description,
+  icon,
+  testId,
+  title,
+}: {
+  action?: ReactNode;
+  className: string;
+  description: string;
+  icon: ReactNode;
+  testId: string;
+  title: string;
+}) {
+  return (
+    <div className={cn('rounded-2xl border px-3 py-2.5', className)} data-testid={testId} role="status">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-2.5">
+          <span className="mt-0.5">{icon}</span>
+          <div>
+            <p className="text-xs font-semibold tracking-[0.16em] text-muted uppercase">{title}</p>
+            <p className="text-sm text-foreground">{description}</p>
+          </div>
+        </div>
+
+        {action}
+      </div>
+    </div>
+  );
+}
+
+function StaleExerciseRecoveryDialog({
+  onClose,
+  onRemoveExercise,
+  onStartAnyway,
+  onSwapExercise,
+  open,
+  pendingExerciseId,
+  scheduledWorkout,
+  startAnywayPending,
+}: {
+  onClose: () => void;
+  onRemoveExercise: (exerciseId: string) => Promise<void>;
+  onStartAnyway: () => Promise<void>;
+  onSwapExercise: (exerciseId: string, snapshotName: string) => void;
+  open: boolean;
+  pendingExerciseId: string | null | undefined;
+  scheduledWorkout: ScheduledWorkoutDetail;
+  startAnywayPending: boolean;
+}) {
+  const staleExercises = scheduledWorkout.staleExercises;
+
+  return (
+    <Dialog
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          onClose();
+        }
+      }}
+      open={open}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Resolve unavailable exercises</DialogTitle>
+          <DialogDescription>
+            Some exercises in this snapshot were removed from your library. Swap or remove each one,
+            or start anyway and skip them.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          {staleExercises.map((staleExercise) => {
+            const isRemoving = pendingExerciseId === staleExercise.exerciseId;
+
+            return (
+              <div
+                className="flex items-center justify-between gap-3 rounded-xl border border-border bg-secondary/20 px-3 py-2"
+                key={staleExercise.exerciseId}
+              >
+                <div>
+                  <p className="text-sm font-medium text-foreground">{staleExercise.snapshotName}</p>
+                  <p className="text-xs text-muted">{staleExercise.exerciseId}</p>
+                </div>
+
+                <div className="flex gap-2">
+                  <Button
+                    disabled={startAnywayPending || isRemoving}
+                    onClick={() => onSwapExercise(staleExercise.exerciseId, staleExercise.snapshotName)}
+                    size="sm"
+                    type="button"
+                    variant="outline"
+                  >
+                    Swap
+                  </Button>
+                  <Button
+                    disabled={startAnywayPending || isRemoving}
+                    onClick={() => {
+                      void onRemoveExercise(staleExercise.exerciseId);
+                    }}
+                    size="sm"
+                    type="button"
+                    variant="outline"
+                  >
+                    {isRemoving ? 'Removing…' : 'Remove'}
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <DialogFooter>
+          <Button disabled={startAnywayPending} onClick={onClose} type="button" variant="ghost">
+            Close
+          </Button>
+          <Button
+            disabled={startAnywayPending || staleExercises.length === 0}
+            onClick={() => {
+              void onStartAnyway();
+            }}
+            type="button"
+          >
+            {startAnywayPending ? 'Starting…' : 'Start anyway'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 function toWorkoutExerciseCardScheduledExercise(
-  exercise: WorkoutTemplateExercise,
+  exercise: SnapshotExercise,
+  exerciseName: string,
+  templateExercise: WorkoutTemplateExercise | undefined,
 ): WorkoutExerciseCardScheduledExercise {
+  const repsMin = maxOrNull(exercise.sets.map((set) => set.repsMin));
+  const repsMax = maxOrNull(exercise.sets.map((set) => set.repsMax));
+
   return {
-    coachingNotes: exercise.exercise?.coachingNotes ?? null,
+    agentNotes: exercise.agentNotes ?? null,
+    agentNotesMeta: exercise.agentNotesMeta ?? null,
+    coachingNotes: templateExercise?.exercise?.coachingNotes ?? null,
     equipment: null,
     exerciseId: exercise.exerciseId,
-    formCues: exercise.exercise?.formCues ?? exercise.formCues ?? [],
-    id: exercise.id,
-    instructions: exercise.exercise?.instructions ?? null,
+    formCues: templateExercise?.exercise?.formCues ?? [],
+    id: `snapshot-${exercise.section}-${exercise.orderIndex}-${exercise.exerciseId}`,
+    instructions: templateExercise?.exercise?.instructions ?? null,
     muscleGroups: [],
-    name: exercise.exerciseName,
-    notes: exercise.notes,
+    name: exerciseName,
+    notes: null,
     programmingNotes: exercise.programmingNotes ?? null,
-    repsMax: exercise.repsMax,
-    repsMin: exercise.repsMin,
+    repsMax,
+    repsMin,
     restSeconds: exercise.restSeconds,
-    setTargets: exercise.setTargets ?? [],
-    sets: exercise.sets,
+    setTargets: toSetTargets(exercise.sets),
+    sets: exercise.sets.length,
+    sessionCues: [],
     tempo: exercise.tempo,
-    templateCues: exercise.cues,
-    trackingType: exercise.trackingType,
+    templateCues: exercise.templateCues ?? [],
+    trackingType: templateExercise?.trackingType ?? inferTrackingType(exercise.sets),
   };
+}
+
+function buildSnapshotSections(snapshotExercises: SnapshotExercise[]) {
+  const grouped = new Map<WorkoutTemplateSectionType, SnapshotExercise[]>([
+    ['warmup', []],
+    ['main', []],
+    ['cooldown', []],
+    ['supplemental', []],
+  ]);
+
+  for (const exercise of snapshotExercises) {
+    const sectionExercises = grouped.get(exercise.section);
+    if (!sectionExercises) {
+      continue;
+    }
+
+    sectionExercises.push(exercise);
+  }
+
+  return (['warmup', 'main', 'cooldown', 'supplemental'] as const)
+    .map((sectionType) => ({
+      type: sectionType,
+      exercises: [...(grouped.get(sectionType) ?? [])].sort(
+        (left, right) => left.orderIndex - right.orderIndex,
+      ),
+    }))
+    .filter((section) => section.exercises.length > 0);
+}
+
+function buildTemplateExerciseLookup(template: WorkoutTemplate | null): TemplateExerciseLookup {
+  const byExerciseIdBySection = new Map<string, WorkoutTemplateExercise>();
+  const bySnapshotOrderKey = new Map<string, WorkoutTemplateExercise>();
+
+  if (!template) {
+    return {
+      byExerciseIdBySection,
+      bySnapshotOrderKey,
+    };
+  }
+
+  for (const section of template.sections) {
+    section.exercises.forEach((exercise, index) => {
+      byExerciseIdBySection.set(`${section.type}::${exercise.exerciseId}`, exercise);
+      bySnapshotOrderKey.set(`${section.type}::${index}::${exercise.exerciseId}`, exercise);
+    });
+  }
+
+  return {
+    byExerciseIdBySection,
+    bySnapshotOrderKey,
+  };
+}
+
+function resolveTemplateExercise(
+  snapshotExercise: SnapshotExercise,
+  lookup: TemplateExerciseLookup,
+): WorkoutTemplateExercise | undefined {
+  const exactKey = `${snapshotExercise.section}::${snapshotExercise.orderIndex}::${snapshotExercise.exerciseId}`;
+  const sectionKey = `${snapshotExercise.section}::${snapshotExercise.exerciseId}`;
+
+  return lookup.bySnapshotOrderKey.get(exactKey) ?? lookup.byExerciseIdBySection.get(sectionKey);
+}
+
+function toSetTargets(snapshotSets: SnapshotExercise['sets']): WorkoutExerciseSetTarget[] {
+  return snapshotSets.map((set) => ({
+    setNumber: set.setNumber,
+    targetDistance: set.targetDistance,
+    targetSeconds: set.targetSeconds,
+    targetWeight: set.targetWeight,
+    targetWeightMax: set.targetWeightMax,
+    targetWeightMin: set.targetWeightMin,
+  }));
+}
+
+function maxOrNull(values: Array<number | null>) {
+  const numbers = values.filter((value): value is number => value !== null);
+  if (numbers.length === 0) {
+    return null;
+  }
+
+  return Math.max(...numbers);
+}
+
+function inferTrackingType(snapshotSets: SnapshotExercise['sets']): ExerciseTrackingType {
+  if (snapshotSets.some((set) => set.targetDistance != null)) {
+    return 'distance';
+  }
+
+  if (snapshotSets.some((set) => set.targetSeconds != null)) {
+    return 'seconds_only';
+  }
+
+  if (
+    snapshotSets.some(
+      (set) => set.targetWeight != null || set.targetWeightMin != null || set.targetWeightMax != null,
+    )
+  ) {
+    return 'weight_reps';
+  }
+
+  if (snapshotSets.some((set) => set.reps != null || set.repsMin != null || set.repsMax != null)) {
+    return 'reps_only';
+  }
+
+  return 'weight_reps';
+}
+
+function formatExerciseLabel(value: string) {
+  return value
+    .split(/[-_ ]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
 }

--- a/apps/web/src/features/workouts/components/scheduled-workout-detail.tsx
+++ b/apps/web/src/features/workouts/components/scheduled-workout-detail.tsx
@@ -336,7 +336,7 @@ export function ScheduledWorkoutDetail({ bannerSlot, id }: ScheduledWorkoutDetai
               setSwapTarget(null);
             }
           }}
-          open={swapTarget != null}
+          open
           sourceExerciseId={swapTarget.exerciseId}
           sourceExerciseName={swapTarget.snapshotName}
           sourceLabel="this scheduled workout"
@@ -617,7 +617,6 @@ function StaleExerciseRecoveryDialog({
               >
                 <div>
                   <p className="text-sm font-medium text-foreground">{staleExercise.snapshotName}</p>
-                  <p className="text-xs text-muted">{staleExercise.exerciseId}</p>
                 </div>
 
                 <div className="flex gap-2">
@@ -671,7 +670,7 @@ function toWorkoutExerciseCardScheduledExercise(
   exerciseName: string,
   templateExercise: WorkoutTemplateExercise | undefined,
 ): WorkoutExerciseCardScheduledExercise {
-  const repsMin = maxOrNull(exercise.sets.map((set) => set.repsMin));
+  const repsMin = minOrNull(exercise.sets.map((set) => set.repsMin));
   const repsMax = maxOrNull(exercise.sets.map((set) => set.repsMax));
 
   return {
@@ -778,6 +777,15 @@ function maxOrNull(values: Array<number | null>) {
   }
 
   return Math.max(...numbers);
+}
+
+function minOrNull(values: Array<number | null>) {
+  const numbers = values.filter((value): value is number => value !== null);
+  if (numbers.length === 0) {
+    return null;
+  }
+
+  return Math.min(...numbers);
 }
 
 function inferTrackingType(snapshotSets: SnapshotExercise['sets']): ExerciseTrackingType {

--- a/apps/web/src/features/workouts/components/session-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.test.tsx
@@ -157,6 +157,8 @@ describe('SessionDetail', () => {
           orderIndex: 0,
           section: 'main',
           programmingNotes: 'Hardstyle, hips snap',
+          agentNotes: null,
+          agentNotesMeta: null,
           sets: [
             createSet({
               id: 'set-programming-note-1',
@@ -235,6 +237,8 @@ describe('SessionDetail', () => {
           orderIndex: 0,
           section: 'main',
           programmingNotes: null,
+          agentNotes: null,
+          agentNotesMeta: null,
           sets: [weightSet],
         },
         {
@@ -246,6 +250,8 @@ describe('SessionDetail', () => {
           orderIndex: 1,
           section: 'main',
           programmingNotes: null,
+          agentNotes: null,
+          agentNotesMeta: null,
           sets: [timeSet],
         },
         {
@@ -257,6 +263,8 @@ describe('SessionDetail', () => {
           orderIndex: 2,
           section: 'main',
           programmingNotes: null,
+          agentNotes: null,
+          agentNotesMeta: null,
           sets: [distanceSet],
         },
       ],
@@ -310,6 +318,8 @@ describe('SessionDetail', () => {
           orderIndex: 0,
           section: 'main',
           programmingNotes: null,
+          agentNotes: null,
+          agentNotesMeta: null,
           sets: [
             createSet({
               id: 'set-no-programming-note-1',
@@ -379,6 +389,8 @@ describe('SessionDetail', () => {
           orderIndex: 0,
           section: 'main',
           programmingNotes: null,
+          agentNotes: null,
+          agentNotesMeta: null,
           sets: [
             createSet({
               id: 'set-deleted-1',
@@ -436,6 +448,8 @@ describe('SessionDetail', () => {
           orderIndex: 0,
           section: 'main',
           programmingNotes: null,
+          agentNotes: null,
+          agentNotesMeta: null,
           sets: [archivedSet],
           exercise: {
             formCues: [],

--- a/apps/web/src/features/workouts/components/session-detail.tsx
+++ b/apps/web/src/features/workouts/components/session-detail.tsx
@@ -703,6 +703,8 @@ function buildSections(
       .map((exercise) => [
         exercise.exerciseId,
         {
+          agentNotes: exercise.agentNotes?.trim() ?? null,
+          agentNotesMeta: exercise.agentNotesMeta ?? null,
           deletedAt: exercise.deletedAt ?? null,
           exerciseName: exercise.exerciseName,
           programmingNotes: exercise.programmingNotes?.trim() ?? null,
@@ -809,6 +811,8 @@ function buildSections(
             muscleGroups: [],
             name,
             notes: null,
+            agentNotes: sessionExerciseMeta?.agentNotes ?? null,
+            agentNotesMeta: sessionExerciseMeta?.agentNotesMeta ?? null,
             phaseBadge: formatLabel(phaseBadge),
             programmingNotes: sessionExerciseMeta?.programmingNotes ?? null,
             repsMax:

--- a/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.test.tsx
@@ -373,6 +373,64 @@ describe('SessionExerciseList', () => {
     ).toHaveTextContent('Hardstyle, hips snap');
   });
 
+  it('renders agent notes inline beneath programming notes on active workout cards', () => {
+    if (!activeTemplate) {
+      throw new Error('Expected upper-push template in mock data.');
+    }
+
+    const session = buildActiveWorkoutSession(
+      activeTemplate,
+      createInitialWorkoutSetDrafts(activeTemplate, new Set()),
+    );
+    const rowErgExercise = session.sections
+      .flatMap((section) => section.exercises)
+      .find((exercise) => exercise.id === 'row-erg');
+
+    if (!rowErgExercise) {
+      throw new Error('Expected Row Erg exercise in active workout session.');
+    }
+
+    rowErgExercise.programmingNotes = 'Hardstyle, hips snap';
+    rowErgExercise.agentNotes = 'Last session was smooth. Increase to 62 lb if set one feels easy.';
+    rowErgExercise.agentNotesMeta = {
+      author: 'Coach Pulse',
+      generatedAt: '2026-03-16T09:30:00.000Z',
+      scheduledDateAtGeneration: '2026-03-16',
+      stale: true,
+    };
+
+    renderWithQueryClient(
+      <SessionExerciseList
+        onAddSet={vi.fn()}
+        onExerciseNotesChange={vi.fn()}
+        onRemoveSet={vi.fn()}
+        onSetUpdate={vi.fn()}
+        session={session}
+      />,
+    );
+
+    const rowErgCard = screen
+      .getByRole('heading', { level: 3, name: 'Row Erg' })
+      .closest('[data-slot="card"]');
+
+    if (!rowErgCard) {
+      throw new Error('Expected Row Erg card.');
+    }
+
+    fireEvent.click(getExercisePanelToggle('Row Erg', 'row-erg'));
+
+    expect(
+      within(rowErgCard as HTMLElement).getByTestId('exercise-programming-notes-row-erg'),
+    ).toHaveTextContent('Hardstyle, hips snap');
+    expect(within(rowErgCard as HTMLElement).getByTestId('exercise-agent-notes-row-erg')).toHaveTextContent(
+      'Last session was smooth. Increase to 62 lb if set one feels easy.',
+    );
+    expect(within(rowErgCard as HTMLElement).getByText(/generated Mar 16/i)).toBeInTheDocument();
+    expect(
+      within(rowErgCard as HTMLElement).getByText(/possibly stale — rescheduled/i),
+    ).toBeInTheDocument();
+  });
+
   it('does not render a programming notes block when programmingNotes is null', () => {
     if (!activeTemplate) {
       throw new Error('Expected upper-push template in mock data.');

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -29,6 +29,7 @@ import {
   ArrowDown,
   ArrowUp,
   ClipboardList,
+  Sparkles,
   Braces,
   ChevronDown,
   Check,
@@ -159,6 +160,10 @@ const phaseBadgeStyles: Record<ActiveWorkoutPhaseBadge, string> = {
 const historyDateFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'short',
   day: 'numeric',
+});
+const agentNotesGeneratedAtFormatter = new Intl.DateTimeFormat('en-US', {
+  day: 'numeric',
+  month: 'short',
 });
 
 const supersetAccentStyles = [
@@ -797,6 +802,8 @@ function ExerciseCardItem({
   const formCues = exercise.formCues;
   const templateCues = exercise.templateCues;
   const programmingNotes = exercise.programmingNotes?.trim() ?? '';
+  const agentNotes = exercise.agentNotes?.trim() ?? '';
+  const agentNotesGeneratedAt = formatAgentNotesGeneratedAt(exercise.agentNotesMeta?.generatedAt);
   const hasInjuryCues = exercise.injuryCues.length > 0;
   const priorityAccentClass = embeddedInSuperset
     ? ''
@@ -1003,6 +1010,30 @@ function ExerciseCardItem({
                     Programming notes
                   </p>
                   <p className="whitespace-pre-wrap text-[13px] italic text-muted">{programmingNotes}</p>
+                </div>
+              </div>
+            ) : null}
+
+            {agentNotes ? (
+              <div
+                className="flex items-start gap-2 rounded-xl border-l-2 border-sky-500/35 bg-sky-500/10 px-3 py-2"
+                data-testid={`exercise-agent-notes-${exercise.id}`}
+              >
+                <Sparkles
+                  aria-hidden="true"
+                  className="mt-0.5 size-3.5 shrink-0 text-sky-700 dark:text-sky-300"
+                />
+                <div className="space-y-0.5">
+                  <p className="text-[10px] font-semibold tracking-[0.16em] text-muted uppercase">
+                    For today
+                  </p>
+                  <p className="whitespace-pre-wrap text-[13px] italic text-muted">{agentNotes}</p>
+                  {agentNotesGeneratedAt || exercise.agentNotesMeta?.stale ? (
+                    <p className="text-[10px] text-muted">
+                      {agentNotesGeneratedAt ? `generated ${agentNotesGeneratedAt}` : 'generated recently'}
+                      {exercise.agentNotesMeta?.stale ? ' • possibly stale — rescheduled' : ''}
+                    </p>
+                  ) : null}
                 </div>
               </div>
             ) : null}
@@ -1577,6 +1608,19 @@ function SessionSupersetManagerDialog({
 
 function formatSupersetGroupLabel(groupId: string) {
   return groupId.replace(/-/g, ' ').replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function formatAgentNotesGeneratedAt(generatedAt: string | undefined) {
+  if (!generatedAt) {
+    return null;
+  }
+
+  const parsed = new Date(generatedAt);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return agentNotesGeneratedAtFormatter.format(parsed);
 }
 
 function groupExercises(exercises: ActiveWorkoutExercise[]) {

--- a/apps/web/src/features/workouts/components/session-summary-exercise-card.tsx
+++ b/apps/web/src/features/workouts/components/session-summary-exercise-card.tsx
@@ -3,8 +3,10 @@ import { cn } from '@/lib/utils';
 
 import { formatSummaryMetricValue, type TrackingSummaryMetricLabel } from '../lib/tracking';
 import { MarkdownNote } from './markdown-note';
+import { AgentNotesBlock } from './workout-exercise-card/agent-notes-block';
 import {
   WorkoutExerciseCard,
+  type WorkoutExerciseCardAgentNotesMeta,
   type WorkoutExerciseCardCompletedExercise,
   type WorkoutExerciseSetListItem,
 } from './workout-exercise-card';
@@ -25,6 +27,8 @@ export type SessionSummaryExerciseResult = {
   metricValue?: number;
   name: string;
   notes?: string | null;
+  agentNotes?: string | null;
+  agentNotesMeta?: WorkoutExerciseCardAgentNotesMeta | null;
   programmingNotes?: string | null;
   reps: number;
   setsCompleted: number;
@@ -50,6 +54,8 @@ export function SessionSummaryExerciseCard({
     name: exercise.name,
     // Notes are intentionally rendered in footerSlot to keep the condensed header clean.
     notes: null,
+    agentNotes: exercise.agentNotes ?? null,
+    agentNotesMeta: exercise.agentNotesMeta ?? null,
     programmingNotes: exercise.programmingNotes ?? null,
     repsMax: null,
     repsMin: null,
@@ -78,6 +84,15 @@ export function SessionSummaryExerciseCard({
               <MetricChip label="Reps" tone="count" value={`${exercise.reps}`} />
             ) : null}
           </div>
+
+          {exercise.agentNotes?.trim() ? (
+            <AgentNotesBlock
+              compact
+              notes={exercise.agentNotes}
+              notesMeta={exercise.agentNotesMeta ?? null}
+              testId={`exercise-agent-notes-${exercise.id}-summary-footer`}
+            />
+          ) : null}
 
           {exercise.notes?.trim() ? (
             <MarkdownNote className="text-xs text-muted" content={exercise.notes.trim()} />

--- a/apps/web/src/features/workouts/components/session-summary.test.tsx
+++ b/apps/web/src/features/workouts/components/session-summary.test.tsx
@@ -33,6 +33,13 @@ describe('SessionSummary', () => {
             ],
             id: 'incline-press',
             name: 'Incline Dumbbell Press',
+            agentNotes: 'Last Saturday: 3x15 at 53 lb. Try 62 lb if warmups feel smooth.',
+            agentNotesMeta: {
+              author: 'Coach Pulse',
+              generatedAt: '2026-03-16T09:30:00.000Z',
+              scheduledDateAtGeneration: '2026-03-16',
+              stale: false,
+            },
             notes: 'Kept shoulder blades pinned and reduced ROM for shoulder comfort.',
             programmingNotes: 'Hardstyle, hips snap',
             reps: 32,
@@ -141,6 +148,9 @@ describe('SessionSummary', () => {
     expect(screen.getByTestId('exercise-programming-notes-incline-press')).toHaveTextContent(
       'Hardstyle, hips snap',
     );
+    expect(
+      screen.getByTestId('exercise-agent-notes-incline-press-summary-footer'),
+    ).toHaveTextContent('Last Saturday: 3x15 at 53 lb. Try 62 lb if warmups feel smooth.');
     expect(
       screen.getByText('Kept shoulder blades pinned and reduced ROM for shoulder comfort.'),
     ).toBeInTheDocument();

--- a/apps/web/src/features/workouts/components/swap-exercise-dialog.tsx
+++ b/apps/web/src/features/workouts/components/swap-exercise-dialog.tsx
@@ -13,12 +13,17 @@ import {
 import { Input } from '@/components/ui/input';
 import { ApiError } from '@/lib/api-client';
 
-import { useExercises, useSwapSessionExercise, useSwapTemplateExercise } from '../api/workouts';
+import {
+  useExercises,
+  useSwapScheduledWorkoutExercise,
+  useSwapSessionExercise,
+  useSwapTemplateExercise,
+} from '../api/workouts';
 import { getTrackingTypeLabel } from '../lib/tracking';
 
 type SwapExerciseDialogProps = {
   contextId: string;
-  mode: 'session' | 'template';
+  mode: 'session' | 'scheduled' | 'template';
   onOpenChange: (open: boolean) => void;
   open: boolean;
   sourceExerciseId: string;
@@ -50,8 +55,11 @@ export function SwapExerciseDialog({
   );
   const swapTemplateExerciseMutation = useSwapTemplateExercise();
   const swapSessionExerciseMutation = useSwapSessionExercise();
+  const swapScheduledExerciseMutation = useSwapScheduledWorkoutExercise();
   const isPending =
-    swapTemplateExerciseMutation.isPending || swapSessionExerciseMutation.isPending;
+    swapTemplateExerciseMutation.isPending ||
+    swapSessionExerciseMutation.isPending ||
+    swapScheduledExerciseMutation.isPending;
   const selectedExerciseId = useMemo(() => {
     if (swapTemplateExerciseMutation.isPending) {
       return swapTemplateExerciseMutation.variables?.newExerciseId ?? null;
@@ -61,8 +69,14 @@ export function SwapExerciseDialog({
       return swapSessionExerciseMutation.variables?.newExerciseId ?? null;
     }
 
+    if (swapScheduledExerciseMutation.isPending) {
+      return swapScheduledExerciseMutation.variables?.input.toExerciseId ?? null;
+    }
+
     return null;
   }, [
+    swapScheduledExerciseMutation.isPending,
+    swapScheduledExerciseMutation.variables?.input.toExerciseId,
     swapSessionExerciseMutation.isPending,
     swapSessionExerciseMutation.variables?.newExerciseId,
     swapTemplateExerciseMutation.isPending,
@@ -121,14 +135,22 @@ export function SwapExerciseDialog({
               exerciseId: sourceExerciseId,
               newExerciseId: targetExercise.id,
             })
-          : await swapSessionExerciseMutation.mutateAsync({
-              sessionId: contextId,
-              exerciseId: sourceExerciseId,
-              newExerciseId: targetExercise.id,
-            });
+          : mode === 'session'
+            ? await swapSessionExerciseMutation.mutateAsync({
+                sessionId: contextId,
+                exerciseId: sourceExerciseId,
+                newExerciseId: targetExercise.id,
+              })
+            : await swapScheduledExerciseMutation.mutateAsync({
+                id: contextId,
+                input: {
+                  fromExerciseId: sourceExerciseId,
+                  toExerciseId: targetExercise.id,
+                },
+              });
 
       toast.success(`Swapped ${sourceExerciseName} → ${targetExercise.name}`);
-      if (payload.meta?.warning) {
+      if ('meta' in payload && payload.meta?.warning) {
         toast.warning(payload.meta.warning);
       }
       onOpenChange(false);

--- a/apps/web/src/features/workouts/components/workout-exercise-card/agent-notes-block.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/agent-notes-block.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { AgentNotesBlock } from './agent-notes-block';
+
+describe('AgentNotesBlock', () => {
+  it('does not render when notes are empty', () => {
+    const { container } = render(<AgentNotesBlock notes="   " />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders trimmed notes with generated timestamp', () => {
+    render(
+      <AgentNotesBlock
+        notes="  Last session looked sharp. Increase weight by 5 lb today.  "
+        notesMeta={{
+          author: 'Coach Pulse',
+          generatedAt: '2026-03-16T09:30:00.000Z',
+          scheduledDateAtGeneration: '2026-03-16',
+          stale: false,
+        }}
+        testId="exercise-agent-notes-id-1"
+      />,
+    );
+
+    expect(screen.getByTestId('exercise-agent-notes-id-1')).toBeInTheDocument();
+    expect(screen.getByText('For today')).toBeInTheDocument();
+    expect(screen.getByText('Last session looked sharp. Increase weight by 5 lb today.')).toBeInTheDocument();
+    expect(screen.getByText('generated Mar 16')).toBeInTheDocument();
+  });
+
+  it('renders stale label when metadata marks the note stale', () => {
+    render(
+      <AgentNotesBlock
+        notes="Keep this session submaximal due to poor sleep."
+        notesMeta={{
+          author: 'Coach Pulse',
+          generatedAt: '2026-03-12T09:30:00.000Z',
+          scheduledDateAtGeneration: '2026-03-12',
+          stale: true,
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/possibly stale — rescheduled/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/workouts/components/workout-exercise-card/agent-notes-block.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/agent-notes-block.tsx
@@ -30,7 +30,7 @@ export function AgentNotesBlock({ compact = false, notes, notesMeta, testId }: A
     <div
       className={cn(
         compact
-          ? 'space-y-1 rounded-lg border border-sky-500/20 bg-sky-500/8 px-2.5 py-2'
+          ? 'flex items-start gap-1.5 rounded-lg border border-sky-500/20 bg-sky-500/8 px-2.5 py-2'
           : 'flex items-start gap-2 rounded-xl border-l-2 border-sky-500/35 bg-sky-500/10 px-3 py-2',
       )}
       data-testid={testId}

--- a/apps/web/src/features/workouts/components/workout-exercise-card/agent-notes-block.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/agent-notes-block.tsx
@@ -1,0 +1,67 @@
+import { Sparkles } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+import { MarkdownNote } from '../markdown-note';
+
+import type { WorkoutExerciseCardAgentNotesMeta } from './types';
+
+type AgentNotesBlockProps = {
+  compact?: boolean;
+  notes: string | null | undefined;
+  notesMeta?: WorkoutExerciseCardAgentNotesMeta | null;
+  testId?: string;
+};
+
+const generatedAtFormatter = new Intl.DateTimeFormat('en-US', {
+  day: 'numeric',
+  month: 'short',
+});
+
+export function AgentNotesBlock({ compact = false, notes, notesMeta, testId }: AgentNotesBlockProps) {
+  const trimmedNotes = notes?.trim() ?? '';
+  if (!trimmedNotes) {
+    return null;
+  }
+
+  const generatedAtLabel = formatGeneratedAt(notesMeta?.generatedAt);
+
+  return (
+    <div
+      className={cn(
+        compact
+          ? 'space-y-1 rounded-lg border border-sky-500/20 bg-sky-500/8 px-2.5 py-2'
+          : 'flex items-start gap-2 rounded-xl border-l-2 border-sky-500/35 bg-sky-500/10 px-3 py-2',
+      )}
+      data-testid={testId}
+    >
+      <Sparkles
+        aria-hidden="true"
+        className={cn('shrink-0 text-sky-700 dark:text-sky-300', compact ? 'size-3.5' : 'mt-0.5 size-3.5')}
+      />
+      <div className="space-y-0.5">
+        <p className="text-[10px] font-semibold tracking-[0.16em] text-muted uppercase">For today</p>
+        <MarkdownNote className="text-[13px] italic text-muted" content={trimmedNotes} />
+        {generatedAtLabel || notesMeta?.stale ? (
+          <p className="text-[10px] text-muted">
+            {generatedAtLabel ? `generated ${generatedAtLabel}` : 'generated recently'}
+            {notesMeta?.stale ? ' • possibly stale — rescheduled' : ''}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function formatGeneratedAt(generatedAt: string | undefined) {
+  if (!generatedAt) {
+    return null;
+  }
+
+  const parsed = new Date(generatedAt);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return generatedAtFormatter.format(parsed);
+}

--- a/apps/web/src/features/workouts/components/workout-exercise-card/index.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/index.test.tsx
@@ -109,11 +109,50 @@ describe('WorkoutExerciseCard', () => {
     expect(screen.getByText('Show set values')).toBeInTheDocument();
   });
 
+  it('renders agent notes in scheduled mode', () => {
+    render(
+      <WorkoutExerciseCard
+        exercise={{
+          agentNotes: 'Last session moved quickly. Increase by 5 lb if warmup feels easy.',
+          agentNotesMeta: {
+            author: 'Coach Pulse',
+            generatedAt: '2026-03-16T09:30:00.000Z',
+            scheduledDateAtGeneration: '2026-03-16',
+            stale: true,
+          },
+          exerciseId: 'exercise-4',
+          id: 'scheduled-exercise-1',
+          name: 'Incline Dumbbell Press',
+          repsMax: 10,
+          repsMin: 8,
+          restSeconds: 90,
+          setTargets: [{ setNumber: 1, targetWeight: 65 }],
+          sets: 3,
+          tempo: '3110',
+          trackingType: 'weight_reps',
+        }}
+        mode="readonly-scheduled"
+      />,
+    );
+
+    expect(screen.getByTestId('exercise-agent-notes-scheduled-exercise-1')).toHaveTextContent(
+      'Last session moved quickly. Increase by 5 lb if warmup feels easy.',
+    );
+    expect(screen.getByText(/possibly stale — rescheduled/i)).toBeInTheDocument();
+  });
+
   it('applies condensed density in readonly-completed mode', () => {
     render(
       <WorkoutExerciseCard
         density="condensed"
         exercise={{
+          agentNotes: 'Keep first set at RPE 7.',
+          agentNotesMeta: {
+            author: 'Coach Pulse',
+            generatedAt: '2026-03-12T09:30:00.000Z',
+            scheduledDateAtGeneration: '2026-03-12',
+            stale: false,
+          },
           completedSets: [
             {
               completed: true,
@@ -138,5 +177,6 @@ describe('WorkoutExerciseCard', () => {
 
     expect(screen.queryByText('Prescription')).not.toBeInTheDocument();
     expect(screen.getByText('Show set values')).toBeInTheDocument();
+    expect(screen.queryByTestId('exercise-agent-notes-completed-exercise-2')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/workouts/components/workout-exercise-card/index.tsx
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/index.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 
+import { AgentNotesBlock } from './agent-notes-block';
 import { ExerciseHeader } from './exercise-header';
 import { buildTemplateSetListItems, formatCompactSetSummary } from './formatters';
 import { FormCuesBlock } from './form-cues-block';
@@ -75,6 +76,12 @@ export function WorkoutExerciseCard(props: WorkoutExerciseCardProps) {
       : (exercise as WorkoutExerciseCardTemplateExercise | WorkoutExerciseCardScheduledExercise);
   const hasProgrammingNotes =
     typeof exercise.programmingNotes === 'string' && exercise.programmingNotes.trim().length > 0;
+  const hasAgentNotes =
+    'agentNotes' in exercise &&
+    typeof exercise.agentNotes === 'string' &&
+    exercise.agentNotes.trim().length > 0;
+  const shouldRenderInlineAgentNotes =
+    hasAgentNotes && !(mode === 'readonly-completed' && isCondensed);
   const shouldShowFormCues =
     !isCondensed &&
     cuesExercise !== null &&
@@ -133,6 +140,14 @@ export function WorkoutExerciseCard(props: WorkoutExerciseCardProps) {
           />
         ) : null}
 
+        {shouldRenderInlineAgentNotes ? (
+          <AgentNotesBlock
+            notes={exercise.agentNotes}
+            notesMeta={exercise.agentNotesMeta}
+            testId={`exercise-agent-notes-${exercise.id}`}
+          />
+        ) : null}
+
         {shouldShowFormCues ? (
           <FormCuesBlock
             coachingNotes={cuesExercise?.coachingNotes}
@@ -167,6 +182,7 @@ export function WorkoutExerciseCard(props: WorkoutExerciseCardProps) {
 
 export type { WorkoutExerciseCardMode };
 export type {
+  WorkoutExerciseCardAgentNotesMeta,
   WorkoutExerciseCardCompletedExercise,
   WorkoutExerciseCardDensity,
   WorkoutExerciseCardScheduledExercise,

--- a/apps/web/src/features/workouts/components/workout-exercise-card/types.ts
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/types.ts
@@ -57,11 +57,22 @@ export type WorkoutExerciseCardTemplateExercise = {
   trackingType: ExerciseTrackingType;
 };
 
+export type WorkoutExerciseCardAgentNotesMeta = {
+  author: string;
+  generatedAt: string;
+  scheduledDateAtGeneration: string;
+  stale?: boolean;
+};
+
 export type WorkoutExerciseCardScheduledExercise = WorkoutExerciseCardTemplateExercise & {
+  agentNotes?: string | null;
+  agentNotesMeta?: WorkoutExerciseCardAgentNotesMeta | null;
   scheduledDateLabel?: string | null;
 };
 
 export type WorkoutExerciseCardCompletedExercise = {
+  agentNotes?: string | null;
+  agentNotesMeta?: WorkoutExerciseCardAgentNotesMeta | null;
   completedSets: WorkoutExerciseSetListItem[];
   equipment?: string | null;
   exerciseId: string;

--- a/apps/web/src/features/workouts/lib/active-session.ts
+++ b/apps/web/src/features/workouts/lib/active-session.ts
@@ -52,6 +52,8 @@ type TemplateExerciseMetadata = {
 };
 
 type WorkoutTemplateExerciseWithMetadata = ActiveWorkoutTemplateExercise & {
+  agentNotes?: string | null;
+  agentNotesMeta?: ActiveWorkoutTemplateExercise['agentNotesMeta'];
   exercise?: TemplateExerciseMetadata | null;
   programmingNotes?: string | null;
 };
@@ -90,6 +92,8 @@ export function buildActiveWorkoutSession(
 
       return {
         badges: templateExercise.badges,
+        agentNotes: templateExerciseWithMetadata.agentNotes ?? null,
+        agentNotesMeta: templateExerciseWithMetadata.agentNotesMeta ?? null,
         category: enhancedExercise?.category ?? 'compound',
         coachingNotes: templateExerciseWithMetadata.exercise?.coachingNotes ?? null,
         completedSets,

--- a/apps/web/src/features/workouts/types.ts
+++ b/apps/web/src/features/workouts/types.ts
@@ -14,7 +14,16 @@ export type WorkoutBadgeType =
   | 'cardio'
   | 'mobility';
 
+export type ActiveWorkoutAgentNotesMeta = {
+  author: string;
+  generatedAt: string;
+  scheduledDateAtGeneration: string;
+  stale?: boolean;
+} | null;
+
 export type ActiveWorkoutTemplateExercise = {
+  agentNotes?: string | null;
+  agentNotesMeta?: ActiveWorkoutAgentNotesMeta;
   badges: WorkoutBadgeType[];
   exercise?: {
     coachingNotes?: string | null;
@@ -135,6 +144,8 @@ export type ActiveWorkoutExerciseHistorySummary = {
 };
 
 export type ActiveWorkoutExerciseMetadata = {
+  agentNotes?: string | null;
+  agentNotesMeta?: ActiveWorkoutAgentNotesMeta;
   badges: WorkoutBadgeType[];
   category: ExerciseCategory;
   coachingNotes?: string | null;

--- a/apps/web/src/hooks/use-workout-session.test.tsx
+++ b/apps/web/src/hooks/use-workout-session.test.tsx
@@ -138,6 +138,26 @@ describe('use-workout-session hooks', () => {
     expect(window.localStorage.getItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY)).toBe('session-1');
   });
 
+  it('invalidates scheduled workout detail cache for scheduled starts', async () => {
+    mockFetch.mockResolvedValueOnce(createJsonResponse(sessionResponse, 201));
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useStartSession(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        date: '2026-03-08',
+        scheduledWorkoutId: 'scheduled-1',
+        startedAt: 100,
+      });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workoutQueryKeys.scheduledWorkout('scheduled-1'),
+    });
+  });
+
   it('patches session start time and refreshes the session query', async () => {
     mockFetch.mockResolvedValueOnce(
       createJsonResponse({

--- a/apps/web/src/hooks/use-workout-session.ts
+++ b/apps/web/src/hooks/use-workout-session.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
-  createWorkoutSessionInputSchema,
+  createWorkoutSessionRequestSchema,
   reorderWorkoutSessionExercisesInputSchema,
   type ReorderWorkoutSessionExercisesInput,
   type WorkoutTemplateSectionType,
@@ -30,7 +30,7 @@ const workoutSessionResponseSchema = z.object({
 
 export { workoutSessionQueryKeys };
 
-type CreateWorkoutSessionRequest = z.input<typeof createWorkoutSessionInputSchema>;
+type CreateWorkoutSessionRequest = z.input<typeof createWorkoutSessionRequestSchema>;
 type UpdateSessionStartTimeRequest = {
   startedAt: number;
 };
@@ -54,7 +54,7 @@ async function getWorkoutSession(sessionId: string) {
 }
 
 async function startSession(input: CreateWorkoutSessionRequest) {
-  const parsedInput = createWorkoutSessionInputSchema.parse(input);
+  const parsedInput = createWorkoutSessionRequestSchema.parse(input);
   const data = await apiRequest<unknown>('/api/v1/workout-sessions', {
     body: JSON.stringify(parsedInput),
     method: 'POST',
@@ -174,7 +174,7 @@ export function useStartSession() {
 
   return useMutation<WorkoutSession, Error, CreateWorkoutSessionRequest>({
     mutationFn: startSession,
-    onSuccess: async (session) => {
+    onSuccess: async (session, variables) => {
       setStoredActiveWorkoutSessionId(session.id);
       queryClient.setQueryData(workoutSessionQueryKeys.detail(session.id), session);
       queryClient.setQueryData(workoutQueryKeys.session(session.id), session);
@@ -195,6 +195,13 @@ export function useStartSession() {
         queryClient.invalidateQueries({
           queryKey: workoutQueryKeys.scheduledWorkoutListRoot(),
         }),
+        ...(variables.scheduledWorkoutId
+          ? [
+              queryClient.invalidateQueries({
+                queryKey: workoutQueryKeys.scheduledWorkout(variables.scheduledWorkoutId),
+              }),
+            ]
+          : []),
         invalidateQueryKeys(
           queryClient,
           crossFeatureInvalidationMap.activeWorkoutSessionMutation(),

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -95,7 +95,7 @@ import { buildSessionSetInputs, extractExerciseNotes } from '@/features/workouts
 import { startCase } from '@/features/workouts/lib/start-case';
 import { ApiError, apiRequest } from '@/lib/api-client';
 import { crossFeatureInvalidationMap, invalidateQueryKeys } from '@/lib/query-invalidation';
-import type { ActiveWorkoutTemplate } from '@/features/workouts/types';
+import type { ActiveWorkoutExercise, ActiveWorkoutTemplate } from '@/features/workouts/types';
 
 const sectionTitleByType: Record<WorkoutTemplateSectionType, string> = {
   warmup: 'Warmup',
@@ -505,6 +505,8 @@ export function ActiveWorkoutPage() {
                 0,
               ),
               name: exercise.name,
+              agentNotes: exercise.agentNotes ?? null,
+              agentNotesMeta: exercise.agentNotesMeta ?? null,
               notes: exercise.notes,
               programmingNotes: exercise.programmingNotes,
               reps: isRepTrackingType(exercise.trackingType)
@@ -2440,6 +2442,8 @@ function toActiveWorkoutTemplate(template: ApiWorkoutTemplate): ActiveWorkoutTem
       type: section.type,
       title: sectionTitleByType[section.type],
       exercises: section.exercises.map((exercise) => ({
+        agentNotes: null,
+        agentNotesMeta: null,
         exerciseId: exercise.exerciseId,
         exerciseName: exercise.exerciseName,
         trackingType: exercise.trackingType,
@@ -2450,6 +2454,7 @@ function toActiveWorkoutTemplate(template: ApiWorkoutTemplate): ActiveWorkoutTem
         restSeconds: exercise.restSeconds ?? 60,
         formCues: exercise.formCues ?? [],
         templateCues: exercise.cues,
+        programmingNotes: exercise.programmingNotes ?? null,
         badges: [],
       })),
     })),
@@ -2534,6 +2539,9 @@ function buildTemplateFromSession(
       restSeconds: fallbackExercise?.restSeconds ?? 60,
       formCues: fallbackExercise?.formCues ?? [],
       templateCues: fallbackExercise?.templateCues ?? [],
+      programmingNotes: sessionExercise.programmingNotes ?? fallbackExercise?.programmingNotes ?? null,
+      agentNotes: sessionExercise.agentNotes ?? fallbackExercise?.agentNotes ?? null,
+      agentNotesMeta: sessionExercise.agentNotesMeta ?? fallbackExercise?.agentNotesMeta ?? null,
       badges: fallbackExercise?.badges ?? [],
     });
   }
@@ -2582,6 +2590,9 @@ function buildSessionExercisesFromSets(session: ApiWorkoutSession) {
       trackingType: ExerciseTrackingType | null;
       section: WorkoutTemplateSectionType | null;
       supersetGroup: string | null;
+      programmingNotes: string | null;
+      agentNotes: string | null;
+      agentNotesMeta: ActiveWorkoutExercise['agentNotesMeta'];
       sets: SessionSet[];
     }
   >();
@@ -2605,6 +2616,9 @@ function buildSessionExercisesFromSets(session: ApiWorkoutSession) {
       trackingType: null,
       section: set.section,
       supersetGroup: null,
+      programmingNotes: null,
+      agentNotes: null,
+      agentNotesMeta: null,
       sets: [set],
     });
   }

--- a/docs/conventions/agent-integration.md
+++ b/docs/conventions/agent-integration.md
@@ -8,6 +8,8 @@ This document defines how external AI agents should authenticate, call unified `
 - Agent-specific conveniences such as name resolution, auto-create behavior, and response hints activate automatically for `Authorization: AgentToken <token>` requests.
 - Convenience request fields (for example `foodName`, `exerciseName`, `templateName`, `reps`) are normalized by middleware; route handlers persist canonical fields.
 - Treat `GET /api/v1/context` as the first call in most agent sessions. It is on the unified route surface but remains AgentToken-only.
+- The second major agent-integrated workflow (after nutrition logging) is scheduled-workout
+  enrichment via per-exercise `agentNotes`.
 
 ## Authentication
 
@@ -361,6 +363,35 @@ Schedules a template for a specific date.
 
 Lists scheduled workouts in the requested date window.
 
+#### `PATCH /api/v1/scheduled-workouts/:id/exercise-notes`
+
+Writes per-exercise scheduled-workout enrichment notes before session start.
+
+Auth note:
+
+- AgentToken-only route. JWT callers receive `403 FORBIDDEN` with
+  `Agent token authentication required`.
+
+Request:
+
+```json
+{
+  "notes": [
+    { "exerciseId": "exercise-1", "agentNotes": "Last session 3x15 @ 53 lb. Try 62 lb today." },
+    { "exerciseId": "exercise-2", "agentNotes": null }
+  ]
+}
+```
+
+Behavior notes:
+
+- Route accepts only exercise ids that exist in the scheduled snapshot.
+- `agentNotes: null` clears an existing note.
+- `agentNotesMeta` is server-authored and returned with this shape:
+  `{ author, generatedAt, scheduledDateAtGeneration, stale }`.
+- `stale` is `false` on fresh writes and may be flipped to `true` by later reschedules that move
+  the scheduled date more than 2 days.
+
 #### `POST /api/v1/workout-sessions`
 
 Starts an in-progress session. AgentToken responses may include `agent.hints`, `agent.suggestedActions`, and `agent.relatedState` describing the next set and remaining work.
@@ -419,8 +450,9 @@ Returns the shared nutrition-summary schema (`date`, `meals`, `actual`, `target`
 2. If `POST /api/v1/exercises` returns `created: false`, review `candidates` before retrying with `force: true`.
 3. Create or update templates with `POST` or `PUT /api/v1/workout-templates`.
 4. Schedule training using `POST /api/v1/scheduled-workouts`, then review the plan with `GET /api/v1/scheduled-workouts`.
-5. Start a session with `POST /api/v1/workout-sessions`.
-6. Continue logging via `PATCH /api/v1/workout-sessions/:id` and use returned `agent` hints to identify the next set.
+5. Enrich the scheduled snapshot with `PATCH /api/v1/scheduled-workouts/:id/exercise-notes`.
+6. Start a session with `POST /api/v1/workout-sessions`.
+7. Continue logging via `PATCH /api/v1/workout-sessions/:id` and use returned `agent` hints to identify the next set.
 
 ## Operational Notes
 

--- a/docs/conventions/api-conventions.md
+++ b/docs/conventions/api-conventions.md
@@ -51,6 +51,26 @@ Unified routes with agent conveniences should use middleware hooks instead of ro
 - `onSend: agentEnrichmentOnSend` appends optional `agent` guidance from request context when available.
 - Handlers should implement one canonical write/read path and avoid `isAgentRequest()` schema branching.
 
+## Unified vs AgentToken-only route pattern
+
+Use one decision rule:
+
+- If the route is user-facing (UI callers and agents both use it), keep it on the unified pattern:
+  `requireAuth`, shared schemas, optional agent middleware (`agentRequestTransform`,
+  `agentEnrichmentOnSend`) where convenience features are needed.
+- If the route is intentionally agent-only (enrichment/ingestion workflow), keep it on `/api/v1/*`
+  but enforce `requireAuth` + `requireAgentOnly`.
+
+Canonical agent-only example:
+
+- `PATCH /api/v1/scheduled-workouts/:id/exercise-notes`
+
+Agent-only invariants:
+
+- JWT callers must receive `403 FORBIDDEN` with `Agent token authentication required`.
+- OpenAPI security should declare only `agentToken`.
+- Do not branch request/response schemas by auth mode for either unified or agent-only routes.
+
 ## Authentication
 
 Three auth hooks are available:

--- a/docs/conventions/api-conventions.md
+++ b/docs/conventions/api-conventions.md
@@ -129,6 +129,23 @@ Error responses return `{ error: { code, message } }`.
 
 Use `apps/api/src/lib/reply.ts` helpers for shared error formatting instead of ad hoc reply bodies.
 
+## Derived Read Markers
+
+When a detail endpoint needs caller-facing lifecycle flags (for example scheduled-workout drift or stale references), compute them server-side on `GET` and return them as read-only marker fields in the response payload.
+
+Guidelines:
+
+- Keep mutation endpoints focused on persisted source-of-truth fields.
+- Compute derived markers at read time from current state plus persisted snapshot/version fields.
+- Prefer nullable object markers for single-state details and empty arrays for zero-or-more marker lists.
+- Keep list endpoints lightweight by default; add only compact summary booleans there when a concrete UI need exists.
+
+Example marker pattern for scheduled workouts:
+
+- `templateDrift: { changedAt, summary } | null`
+- `staleExercises: Array<{ exerciseId, snapshotName }>`
+- `templateDeleted: boolean`
+
 ## Standard Error Codes
 
 These error codes are the base vocabulary across routes:

--- a/docs/conventions/api-conventions.md
+++ b/docs/conventions/api-conventions.md
@@ -65,11 +65,21 @@ Rules:
 - User-account and credential-management routes should use `requireUserAuth`.
 - Agent token CRUD is JWT-only, so `/api/v1/agent-tokens` uses `requireUserAuth`.
 - Agent-only planning routes such as `/api/v1/context` should use `requireAuth` plus `requireAgentOnly`.
+- AgentToken-only mutations on unified resources (for example `/api/v1/scheduled-workouts/:id/exercise-notes`) should still stay on `/api/v1/*` and enforce agent-only access with `preHandler: requireAgentOnly` after the plugin-level `requireAuth`.
 - JWTs issued by Pulse must include `type: "session"` and `iss: "pulse-api"` claims; hand-crafted JWTs without those claims are rejected.
 - Agent tokens are bearer secrets stored only as hashes and validated on every request.
 - After a successful auth hook, handlers may rely on `request.userId`.
 - Agent-token requests may also rely on `request.agentTokenId`.
 - Agent-token `lastUsedAt` updates are best-effort and must not fail an otherwise valid request.
+
+### AgentToken-Only Operations
+
+When a route is intentionally agent-only:
+
+- Keep request/response schemas unified with the rest of the API surface.
+- Enforce auth with `requireAuth` + `requireAgentOnly` (hook or route-level preHandler).
+- Document OpenAPI security as `[{ agentToken: [] }]` instead of the dual auth array.
+- Return `403 FORBIDDEN` for JWT callers with the standard envelope (`Agent token authentication required`).
 
 ## Response Envelope
 

--- a/docs/conventions/data-models.md
+++ b/docs/conventions/data-models.md
@@ -42,6 +42,8 @@ Direct `userId` ownership lives on these root tables:
 Inherited ownership comes from foreign-key chains:
 
 - `template_exercises` through `workout_templates`
+- `scheduled_workout_exercises` through `scheduled_workouts`
+- `scheduled_workout_exercise_sets` through `scheduled_workout_exercises`
 - `session_sets` through `workout_sessions`
 - `meals` through `nutrition_logs`
 - `meal_items` through `meals`
@@ -179,6 +181,7 @@ Constraints:
 - `id`: `text` primary key UUID
 - `userId`: `text`, required, FK -> `users.id`, `ON DELETE CASCADE`, indexed
 - `templateId`: nullable `text`, FK -> `workout_templates.id`, `ON DELETE SET NULL`
+- `scheduledWorkoutId`: nullable `text`, FK -> `scheduled_workouts.id`, `ON DELETE SET NULL`, indexed
 - `name`: `text`, required
 - `date`: `text`, required, `YYYY-MM-DD`, indexed
 - `status`: `text`, required, default `in-progress`, one of `scheduled | in-progress | paused | cancelled | completed`
@@ -188,6 +191,8 @@ Constraints:
 - `timeSegments`: required JSON text array of `{ start: string, end: string | null, section: 'warmup' | 'main' | 'cooldown' | 'supplemental' }`, default `'[]'`
 - `feedback`: nullable JSON text object for post-session ratings and notes
 - `exerciseProgrammingNotes`: nullable JSON text record keyed by `${section}::${exerciseId}` with `string | null` values; snapshots `template_exercises.notes` at session start
+- `exerciseAgentNotes`: nullable JSON text record keyed by `${section}::${exerciseId}` with `string | null` values; snapshots scheduled-workout agent notes at session start
+- `exerciseAgentNotesMeta`: nullable JSON text record keyed by `${section}::${exerciseId}` with metadata values `{ author, generatedAt, scheduledDateAtGeneration, stale? }`
 - `notes`: nullable `text`
 - `deletedAt`: nullable `text` ISO timestamp for soft delete
 - `createdAt`: `integer` Unix ms, required, default now
@@ -230,6 +235,7 @@ Constraints:
 - `id`: `text` primary key UUID
 - `userId`: `text`, required, FK -> `users.id`, `ON DELETE CASCADE`
 - `templateId`: nullable `text`, FK -> `workout_templates.id`, `ON DELETE SET NULL`, indexed
+- `templateVersion`: nullable `text` SHA-256 hex hash of a canonical JSON snapshot of template exercises + set prescriptions + notes at schedule time; used for template drift detection
 - `date`: `text`, required, `YYYY-MM-DD`
 - `sessionId`: nullable `text`, FK -> `workout_sessions.id`, `ON DELETE SET NULL`, indexed
 - `createdAt`: `integer` Unix ms, required, default now
@@ -238,6 +244,7 @@ Constraints:
 Behavior:
 
 - When a workout session is started from a template on the current date, the first matching `scheduled_workouts` row with `sessionId = null` is linked by setting `sessionId` to the created session id.
+- Scheduled workouts can carry a relational exercise snapshot. Backfill is run immediately after schema migration so reads do not need a lazy dual-path fallback.
 
 Indexes and constraints:
 
@@ -245,6 +252,50 @@ Indexes and constraints:
 - `scheduled_workouts_template_id_idx`
 - `scheduled_workouts_session_id_idx`
 - `scheduled_workouts_date_format_check`
+
+#### `scheduled_workout_exercises`
+
+- `id`: `text` primary key UUID
+- `scheduledWorkoutId`: `text`, required, FK -> `scheduled_workouts.id`, `ON DELETE CASCADE`, indexed
+- `exerciseId`: `text`, required, FK -> `exercises.id`, `ON DELETE RESTRICT`, indexed
+- `section`: `text`, required, one of `warmup | main | cooldown | supplemental`
+- `orderIndex`: `integer`, required
+- `programmingNotes`: nullable `text` copied from template exercise programming notes at snapshot time
+- `agentNotes`: nullable `text` used for per-instance agent enrichment
+- `agentNotesMeta`: nullable JSON text object `{ author, generatedAt, scheduledDateAtGeneration, stale? }`
+- `templateCues`: nullable JSON text array copied from template cues
+- `supersetGroup`: nullable `text`
+- `tempo`: nullable `text`
+- `restSeconds`: nullable `integer`
+- `createdAt`: `integer` Unix ms, required, default now
+- `updatedAt`: `integer` Unix ms, required, default now, auto-updates
+
+Constraints and indexes:
+
+- `scheduled_workout_exercises_scheduled_workout_id_idx`
+- `scheduled_workout_exercises_exercise_id_idx`
+- `scheduled_workout_exercises_section_check`
+
+#### `scheduled_workout_exercise_sets`
+
+- `id`: `text` primary key UUID
+- `scheduledWorkoutExerciseId`: `text`, required, FK -> `scheduled_workout_exercises.id`, `ON DELETE CASCADE`, indexed
+- `setNumber`: `integer`, required
+- `repsMin`: nullable `integer`
+- `repsMax`: nullable `integer`
+- `reps`: nullable `integer` for exact-rep prescriptions
+- `targetWeight`: nullable `real`
+- `targetWeightMin`: nullable `real`
+- `targetWeightMax`: nullable `real`
+- `targetSeconds`: nullable `integer`
+- `targetDistance`: nullable `real`
+- `createdAt`: `integer` Unix ms, required, default now
+
+Constraints:
+
+- `scheduled_workout_exercise_sets_set_number_check`
+- `scheduled_workout_exercise_sets_reps_range_check`
+- `scheduled_workout_exercise_sets_target_weight_range_check`
 
 ### Nutrition And Body Metrics
 

--- a/docs/conventions/data-models.md
+++ b/docs/conventions/data-models.md
@@ -192,7 +192,10 @@ Constraints:
 - `feedback`: nullable JSON text object for post-session ratings and notes
 - `exerciseProgrammingNotes`: nullable JSON text record keyed by `${section}::${exerciseId}` with `string | null` values; snapshots `template_exercises.notes` at session start
 - `exerciseAgentNotes`: nullable JSON text record keyed by `${section}::${exerciseId}` with `string | null` values; snapshots scheduled-workout agent notes at session start
-- `exerciseAgentNotesMeta`: nullable JSON text record keyed by `${section}::${exerciseId}` with metadata values `{ author, generatedAt, scheduledDateAtGeneration, stale? }`
+- `exerciseAgentNotesMeta`: nullable JSON text record keyed by `${section}::${exerciseId}` with metadata values `{ author, generatedAt, scheduledDateAtGeneration, stale }` (read-time compatibility defaults missing `stale` to `false`)
+- Session exercise payload field `agentNotes`: projected from `exerciseAgentNotes[${section}::${exerciseId}]`
+- Session exercise payload field `agentNotesMeta`: projected from `exerciseAgentNotesMeta[${section}::${exerciseId}]`
+- There are no physical `workout_sessions.agentNotes` / `workout_sessions.agentNotesMeta` scalar columns; those session exercise fields are projections from the keyed JSON snapshot maps above.
 - `notes`: nullable `text`
 - `deletedAt`: nullable `text` ISO timestamp for soft delete
 - `createdAt`: `integer` Unix ms, required, default now
@@ -262,7 +265,7 @@ Indexes and constraints:
 - `orderIndex`: `integer`, required
 - `programmingNotes`: nullable `text` copied from template exercise programming notes at snapshot time
 - `agentNotes`: nullable `text` used for per-instance agent enrichment
-- `agentNotesMeta`: nullable JSON text object `{ author, generatedAt, scheduledDateAtGeneration, stale? }`
+- `agentNotesMeta`: nullable JSON text object `{ author, generatedAt, scheduledDateAtGeneration, stale }` (`stale` defaults to `false` on server writes)
 - `templateCues`: nullable JSON text array copied from template cues
 - `supersetGroup`: nullable `text`
 - `tempo`: nullable `text`

--- a/docs/conventions/design-system.md
+++ b/docs/conventions/design-system.md
@@ -134,6 +134,9 @@ read-only workout exercises.
   `density="condensed"` for summary surfaces. Condensed cards tighten spacing, hide the
   prescription/form-cue blocks, and relabel the set disclosure as "Show set values" while still
   using the same primitive contract.
+- Notes in condensed mode: keep inline notes minimal. `readonly-completed` condensed cards suppress
+  in-card `AgentNotesBlock`; pass compact free-form notes through `footerSlot` (for example summary
+  metric chips + compact agent notes + user notes).
 
 ## Page Header Pattern
 
@@ -199,6 +202,32 @@ Use this treatment for read-only exercise programming notes sourced from templat
 - Visibility: render only when `programmingNotes` is a non-empty string after trim.
 - Visual pattern: `flex items-start gap-2` container with a subtle left accent (`border-l-2 border-primary/35`) and muted surface (`bg-secondary/35`), plus a small `ClipboardList` icon.
 - Typography: compact uppercase label (`text-[10px] font-semibold tracking-[0.16em] text-muted`) and italic body copy (`text-[13px] italic text-muted`) with `whitespace-pre-wrap`.
+
+## Agent Notes Block
+
+Use this treatment for AI-generated, schedule-aware exercise notes (`agentNotes`) in scheduled,
+active, and completed-session read views.
+
+- Placement: render below `ProgrammingNotesBlock` when shown inline.
+- Visibility: render only when `agentNotes` is a non-empty string after trim.
+- Visual pattern: `Sparkles` icon + distinct sky tone (`border-sky-500/35`, `bg-sky-500/10`) so it
+  is distinguishable from programming and user notes.
+- Footer metadata: render `generated MMM D` from `agentNotesMeta.generatedAt` when present; append
+  `possibly stale — rescheduled` when `agentNotesMeta.stale === true`.
+- Condensed summary rule: in `WorkoutExerciseCard` condensed completed mode, suppress inline
+  rendering and pass a compact `AgentNotesBlock` through `footerSlot`.
+
+## Scheduled Workout Banners
+
+Scheduled-workout detail uses stacked inline status banners above the header for snapshot/template
+state. Prefer `Alert` semantics or equivalent bordered status surfaces with icon + title + body.
+
+- Template drift (non-blocking amber): "This template has been updated since you scheduled this workout."
+- Stale exercises (non-blocking amber): "Some exercises have been removed from your library." Include
+  a `Review` action that opens stale-exercise recovery.
+- Template deleted (informational muted): "Source template was deleted. This snapshot is preserved."
+- Drift banner in this phase is informational-only; do not attach refresh actions until refresh-from-template
+  is implemented server-side.
 
 ## Workout Section Header Controls
 

--- a/docs/conventions/design-system.md
+++ b/docs/conventions/design-system.md
@@ -138,6 +138,11 @@ read-only workout exercises.
   in-card `AgentNotesBlock`; pass compact free-form notes through `footerSlot` (for example summary
   metric chips + compact agent notes + user notes).
 
+Cross-references:
+
+- Primitive file/layout conventions: [feature-structure](./feature-structure.md#shared-primitive-subdirectory-pattern)
+- Workout note lifecycle and ownership: [workout-domain](./workout-domain.md#three-layer-notes-model)
+
 ## Page Header Pattern
 
 Use `PageHeader` (`apps/web/src/components/layout/page-header.tsx`) as the default heading primitive for app routes.
@@ -202,6 +207,7 @@ Use this treatment for read-only exercise programming notes sourced from templat
 - Visibility: render only when `programmingNotes` is a non-empty string after trim.
 - Visual pattern: `flex items-start gap-2` container with a subtle left accent (`border-l-2 border-primary/35`) and muted surface (`bg-secondary/35`), plus a small `ClipboardList` icon.
 - Typography: compact uppercase label (`text-[10px] font-semibold tracking-[0.16em] text-muted`) and italic body copy (`text-[13px] italic text-muted`) with `whitespace-pre-wrap`.
+- Component location: `workout-exercise-card/programming-notes-block.tsx`.
 
 ## Agent Notes Block
 
@@ -216,6 +222,7 @@ active, and completed-session read views.
   `possibly stale — rescheduled` when `agentNotesMeta.stale === true`.
 - Condensed summary rule: in `WorkoutExerciseCard` condensed completed mode, suppress inline
   rendering and pass a compact `AgentNotesBlock` through `footerSlot`.
+- Component location: `workout-exercise-card/agent-notes-block.tsx`.
 
 ## Scheduled Workout Banners
 
@@ -228,6 +235,9 @@ state. Prefer `Alert` semantics or equivalent bordered status surfaces with icon
 - Template deleted (informational muted): "Source template was deleted. This snapshot is preserved."
 - Drift banner in this phase is informational-only; do not attach refresh actions until refresh-from-template
   is implemented server-side.
+
+Cross-reference: lifecycle semantics for these three states are defined in
+[workout-domain](./workout-domain.md#three-layer-notes-model).
 
 ## Workout Section Header Controls
 

--- a/docs/conventions/feature-structure.md
+++ b/docs/conventions/feature-structure.md
@@ -65,6 +65,7 @@ src/features/workouts/components/workout-exercise-card/
   exercise-header.tsx
   prescription-block.tsx
   programming-notes-block.tsx
+  agent-notes-block.tsx
   form-cues-block.tsx
   last-performance-chip.tsx
   workout-exercise-set-list.tsx
@@ -76,6 +77,16 @@ Rules:
 - Keep the orchestrator in `index.tsx`; colocate sub-primitives and their focused tests.
 - Export only the primitive's public surface from `index.tsx`.
 - Reuse this shape for future shared feature primitives instead of introducing one-off flat files.
+
+Final primitive set for `workout-exercise-card/`:
+
+- `exercise-header.tsx`
+- `prescription-block.tsx`
+- `programming-notes-block.tsx`
+- `agent-notes-block.tsx`
+- `form-cues-block.tsx`
+- `last-performance-chip.tsx`
+- `workout-exercise-set-list.tsx`
 
 ## Barrel Export Pattern
 

--- a/docs/conventions/workout-domain.md
+++ b/docs/conventions/workout-domain.md
@@ -29,6 +29,29 @@ The scheduled-workout detail page should mirror template-detail exercise renderi
 - `programmingNotes` shown on scheduled cards comes from the resolved template exercise data.
 - Reserve a page-level `bannerSlot` area above the header for future scheduled-workout warning banners. Leave it empty unless a warning feature explicitly populates it.
 
+### Scheduled Start Lifecycle
+
+`POST /api/v1/workout-sessions` supports three start selectors:
+
+1. `scheduledWorkoutId` (scheduled snapshot start)
+2. `templateId` or `templateName` (template start)
+3. `name` (ad-hoc start)
+
+Scheduled starts seed from `scheduled_workout_exercises` + `scheduled_workout_exercise_sets`, not from live template rows.
+
+- Session set prescriptions copy snapshot targets (`targetWeight*`, `targetSeconds`, `targetDistance`, and exact `reps` when present).
+- Session exercise note snapshots copy `programmingNotes`, `agentNotes`, and `agentNotesMeta` from the scheduled snapshot.
+
+Scheduled-start idempotency:
+
+- If `scheduled_workouts.sessionId` points to a live session (not cancelled and not soft-deleted), start returns `409 SCHEDULED_WORKOUT_ALREADY_STARTED`.
+- If the linked session is cancelled or deleted, the server clears `scheduled_workouts.sessionId` and allows a fresh start from the same snapshot.
+
+Stale snapshot exercises:
+
+- If snapshot exercises reference deleted/unavailable exercises, start returns `409 STALE_SNAPSHOT_EXERCISES` with `staleExercises`.
+- `force: true` allows start to continue by skipping stale snapshot exercises and returns `warnings: [{ code: 'STALE_EXERCISES_SKIPPED', exercises: [...] }]`.
+
 ## Completed Session Detail Surface
 
 The completed-session detail page should render each exercise through shared `WorkoutExerciseCard` primitives in `readonly-completed` mode.
@@ -36,7 +59,7 @@ The completed-session detail page should render each exercise through shared `Wo
 - Exercise rows render through shared `WorkoutExerciseCard` in `readonly-completed` mode.
 - Completed-mode set rows must show logged values (weight/reps/seconds/distance) and must not fall back to template target values.
 - Session-level composition (history button, comparison blocks, correction editors, and exercise-note markdown) should be injected via card slots from `session-detail.tsx`, not reimplemented as a separate card layout.
-- `programmingNotes` on completed cards comes from the session-exercise snapshot (`session_exercises.programmingNotes`) and is rendered by the primitive `ProgrammingNotesBlock`.
+- `programmingNotes` on completed cards comes from the session snapshot map (`workout_sessions.exerciseProgrammingNotes`) and is rendered by the primitive `ProgrammingNotesBlock`.
 
 ## Exercise In Template
 
@@ -105,14 +128,23 @@ Session exercise metadata should preserve `supersetGroup` values so completed re
 
 ### Session Exercise Notes Layers
 
-Session exercises intentionally keep two separate note channels:
+Session exercises intentionally keep three separate note channels:
 
 - `programmingNotes` (read-only): a snapshot of `template_exercises.notes` taken when the session starts from a template. This does not change if the template is edited later.
+- `agentNotes` + `agentNotesMeta` (read-only): snapshot-time session-specific guidance authored through scheduled-workout enrichment (`author`, `generatedAt`, `scheduledDateAtGeneration`, optional `stale`).
 - user exercise notes (editable): the workout-time notes entered during the session via the existing exercise-notes flow.
 
-Do not merge these two layers into one textarea; template prescription context and user observations must remain distinct.
+Do not merge these layers into one textarea; template prescription context, agent context, and user observations must remain distinct.
 
 When a completed session is saved as a new template (`POST /api/v1/workout-sessions/:id/save-as-template`), only `programmingNotes` round-trips onto `template_exercises.notes`. Session-specific note channels (user exercise notes, and agent notes when present) must be dropped so transient workout context is not promoted into reusable programming.
+
+### Cancel Behavior For Scheduled Starts
+
+When a session transitions to `cancelled`, linked schedules are unclaimed but preserved:
+
+- Clear `scheduled_workouts.sessionId` for the linked scheduled workout.
+- Preserve the cancelled session row for history.
+- Preserve scheduled snapshot rows (`scheduled_workout_exercises`, `scheduled_workout_exercise_sets`) so the workout can be started again later.
 
 ## Superset Grouping
 

--- a/docs/conventions/workout-domain.md
+++ b/docs/conventions/workout-domain.md
@@ -26,8 +26,29 @@ The scheduled-workout detail page should mirror template-detail exercise renderi
 
 - Exercise rows render through shared `WorkoutExerciseCard` in `readonly-scheduled` mode.
 - Header controls are schedule-specific: scheduled date, source template link, `Start workout`, `Reschedule`, and `Cancel`.
-- `programmingNotes` shown on scheduled cards comes from the resolved template exercise data.
+- `programmingNotes` shown on scheduled cards comes from the scheduled snapshot exercise row.
 - Reserve a page-level `bannerSlot` area above the header for future scheduled-workout warning banners. Leave it empty unless a warning feature explicitly populates it.
+
+## Three-layer notes model
+
+Workout exercise note content is split into three channels and should stay separate in API,
+storage, and UI rendering.
+
+| Field | Source | Mutable after session-start? | Rendered as |
+| --- | --- | --- | --- |
+| `programmingNotes` | Template, snapshotted on schedule or session-create | No | Read-only "programming" block |
+| `agentNotes` | Agent PATCH between schedule and session-start | No (client) | Read-only "✨ For today" block |
+| `notes` (user) | User textarea on session | Yes | User textarea |
+
+Lifecycle rules:
+
+- Template edit before scheduling applies to future snapshots automatically.
+- Template edit after scheduling does not mutate existing snapshots; scheduled detail computes
+  `templateDrift` and shows the drift banner.
+- Cancelled linked sessions clear `scheduled_workouts.sessionId` so the schedule is startable again
+  from the same snapshot.
+- Reschedule marks existing `agentNotesMeta.stale = true` when the date shift diverges by more than
+  2 days from `scheduledDateAtGeneration`.
 
 ### Scheduled Start Lifecycle
 
@@ -131,7 +152,7 @@ Session exercise metadata should preserve `supersetGroup` values so completed re
 Session exercises intentionally keep three separate note channels:
 
 - `programmingNotes` (read-only): a snapshot of `template_exercises.notes` taken when the session starts from a template. This does not change if the template is edited later.
-- `agentNotes` + `agentNotesMeta` (read-only): snapshot-time session-specific guidance authored through scheduled-workout enrichment (`author`, `generatedAt`, `scheduledDateAtGeneration`, optional `stale`).
+- `agentNotes` + `agentNotesMeta` (read-only): snapshot-time session-specific guidance authored through scheduled-workout enrichment (`author`, `generatedAt`, `scheduledDateAtGeneration`, `stale`).
 - user exercise notes (editable): the workout-time notes entered during the session via the existing exercise-notes flow.
 
 Do not merge these layers into one textarea; template prescription context, agent context, and user observations must remain distinct.

--- a/packages/shared/src/schemas/scheduled-workouts.test.ts
+++ b/packages/shared/src/schemas/scheduled-workouts.test.ts
@@ -126,6 +126,7 @@ describe('scheduledWorkoutDetailSchema', () => {
             author: 'agent',
             generatedAt: '2026-03-12T10:00:00.000Z',
             scheduledDateAtGeneration: '2026-03-13',
+            stale: false,
           },
           templateCues: null,
           supersetGroup: null,

--- a/packages/shared/src/schemas/scheduled-workouts.test.ts
+++ b/packages/shared/src/schemas/scheduled-workouts.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import {
   createScheduledWorkoutInputSchema,
   type CreateScheduledWorkoutInput,
+  scheduledWorkoutDetailSchema,
+  type ScheduledWorkoutDetail,
   scheduledWorkoutListItemSchema,
   scheduledWorkoutQueryParamsSchema,
   scheduledWorkoutSchema,
@@ -35,6 +37,104 @@ describe('scheduledWorkoutSchema', () => {
       sessionId: null,
       createdAt: 1,
       updatedAt: 2,
+    });
+  });
+});
+
+describe('scheduledWorkoutDetailSchema', () => {
+  it('parses snapshot exercises with marker fields', () => {
+    const payload = scheduledWorkoutDetailSchema.parse({
+      id: 'schedule-1',
+      userId: 'user-1',
+      templateId: 'template-1',
+      date: '2026-03-12',
+      sessionId: null,
+      createdAt: 1,
+      updatedAt: 2,
+      exercises: [
+        {
+          exerciseId: 'exercise-1',
+          section: 'main',
+          orderIndex: 0,
+          programmingNotes: 'Keep reps crisp',
+          agentNotes: null,
+          agentNotesMeta: null,
+          templateCues: ['Brace'],
+          supersetGroup: null,
+          tempo: '3010',
+          restSeconds: 90,
+          sets: [
+            {
+              setNumber: 1,
+              repsMin: 8,
+              repsMax: 10,
+              reps: null,
+              targetWeight: null,
+              targetWeightMin: null,
+              targetWeightMax: null,
+              targetSeconds: null,
+              targetDistance: null,
+            },
+          ],
+        },
+      ],
+      templateDrift: null,
+      staleExercises: [],
+      templateDeleted: false,
+    });
+
+    const scheduledWorkout: ScheduledWorkoutDetail = payload;
+
+    expect(scheduledWorkout).toMatchObject({
+      id: 'schedule-1',
+      exercises: [
+        {
+          exerciseId: 'exercise-1',
+          section: 'main',
+          orderIndex: 0,
+          programmingNotes: 'Keep reps crisp',
+          templateCues: ['Brace'],
+        },
+      ],
+      templateDrift: null,
+      staleExercises: [],
+      templateDeleted: false,
+    });
+  });
+
+  it('trims and nulls blank note strings', () => {
+    const payload = scheduledWorkoutDetailSchema.parse({
+      id: 'schedule-2',
+      userId: 'user-1',
+      templateId: 'template-1',
+      date: '2026-03-13',
+      sessionId: null,
+      createdAt: 1,
+      updatedAt: 2,
+      exercises: [
+        {
+          exerciseId: 'exercise-1',
+          section: 'main',
+          orderIndex: 0,
+          programmingNotes: '   ',
+          agentNotes: '  push harder  ',
+          agentNotesMeta: {
+            author: 'agent',
+            generatedAt: '2026-03-12T10:00:00.000Z',
+            scheduledDateAtGeneration: '2026-03-13',
+          },
+          templateCues: null,
+          supersetGroup: null,
+          tempo: null,
+          restSeconds: null,
+          sets: [],
+        },
+      ],
+    });
+
+    expect(payload.exercises[0]).toMatchObject({
+      programmingNotes: null,
+      agentNotes: 'push harder',
     });
   });
 });

--- a/packages/shared/src/schemas/scheduled-workouts.test.ts
+++ b/packages/shared/src/schemas/scheduled-workouts.test.ts
@@ -8,9 +8,13 @@ import {
   scheduledWorkoutListItemSchema,
   scheduledWorkoutQueryParamsSchema,
   scheduledWorkoutSchema,
+  swapScheduledWorkoutExerciseInputSchema,
+  type SwapScheduledWorkoutExerciseInput,
   type ScheduledWorkout,
   type ScheduledWorkoutListItem,
   type ScheduledWorkoutQueryParams,
+  type UpdateScheduledWorkoutExerciseNotesInput,
+  updateScheduledWorkoutExerciseNotesInputSchema,
   type UpdateScheduledWorkoutInput,
   updateScheduledWorkoutInputSchema,
 } from './scheduled-workouts';
@@ -244,5 +248,78 @@ describe('scheduledWorkoutQueryParamsSchema', () => {
         to: '2026-03-10',
       }),
     ).toThrow();
+  });
+});
+
+describe('updateScheduledWorkoutExerciseNotesInputSchema', () => {
+  it('accepts batched exercise note updates and normalizes note strings', () => {
+    const payload: UpdateScheduledWorkoutExerciseNotesInput =
+      updateScheduledWorkoutExerciseNotesInputSchema.parse({
+        notes: [
+          {
+            exerciseId: 'exercise-1',
+            agentNotes: '  Keep first set easy  ',
+          },
+          {
+            exerciseId: 'exercise-2',
+            agentNotes: null,
+          },
+        ],
+      });
+
+    expect(payload).toEqual({
+      notes: [
+        {
+          exerciseId: 'exercise-1',
+          agentNotes: 'Keep first set easy',
+        },
+        {
+          exerciseId: 'exercise-2',
+          agentNotes: null,
+        },
+      ],
+    });
+  });
+
+  it('rejects empty exercise note batches', () => {
+    expect(() =>
+      updateScheduledWorkoutExerciseNotesInputSchema.parse({
+        notes: [],
+      }),
+    ).toThrow();
+  });
+});
+
+describe('swapScheduledWorkoutExerciseInputSchema', () => {
+  it('accepts swap payloads with optional carry-over flags', () => {
+    const payload: SwapScheduledWorkoutExerciseInput = swapScheduledWorkoutExerciseInputSchema.parse(
+      {
+        fromExerciseId: 'exercise-1',
+        toExerciseId: ' exercise-2 ',
+        carryOverProgrammingNotes: true,
+        preserveSets: false,
+      },
+    );
+
+    expect(payload).toEqual({
+      fromExerciseId: 'exercise-1',
+      toExerciseId: 'exercise-2',
+      carryOverProgrammingNotes: true,
+      preserveSets: false,
+    });
+  });
+
+  it('allows remove-style swaps with a null target exercise id', () => {
+    const payload: SwapScheduledWorkoutExerciseInput = swapScheduledWorkoutExerciseInputSchema.parse(
+      {
+        fromExerciseId: 'exercise-1',
+        toExerciseId: null,
+      },
+    );
+
+    expect(payload).toEqual({
+      fromExerciseId: 'exercise-1',
+      toExerciseId: null,
+    });
   });
 });

--- a/packages/shared/src/schemas/scheduled-workouts.test.ts
+++ b/packages/shared/src/schemas/scheduled-workouts.test.ts
@@ -130,6 +130,9 @@ describe('scheduledWorkoutDetailSchema', () => {
           sets: [],
         },
       ],
+      templateDrift: null,
+      staleExercises: [],
+      templateDeleted: false,
     });
 
     expect(payload.exercises[0]).toMatchObject({

--- a/packages/shared/src/schemas/scheduled-workouts.ts
+++ b/packages/shared/src/schemas/scheduled-workouts.ts
@@ -81,7 +81,7 @@ export const scheduledWorkoutExerciseAgentNotesMetaSchema = z.object({
   author: requiredStringSchema,
   generatedAt: z.string().datetime({ offset: true }),
   scheduledDateAtGeneration: dateSchema,
-  stale: z.boolean().optional(),
+  stale: z.boolean(),
 });
 
 export const scheduledWorkoutExerciseSchema = z.object({

--- a/packages/shared/src/schemas/scheduled-workouts.ts
+++ b/packages/shared/src/schemas/scheduled-workouts.ts
@@ -110,9 +110,9 @@ export const scheduledWorkoutStaleExerciseSchema = z.object({
 
 export const scheduledWorkoutDetailSchema = scheduledWorkoutSchema.extend({
   exercises: z.array(scheduledWorkoutExerciseSchema),
-  templateDrift: scheduledWorkoutTemplateDriftSchema.nullable().optional(),
-  staleExercises: z.array(scheduledWorkoutStaleExerciseSchema).optional(),
-  templateDeleted: z.boolean().optional(),
+  templateDrift: scheduledWorkoutTemplateDriftSchema.nullable(),
+  staleExercises: z.array(scheduledWorkoutStaleExerciseSchema),
+  templateDeleted: z.boolean(),
 });
 
 export type ScheduledWorkout = z.infer<typeof scheduledWorkoutSchema>;

--- a/packages/shared/src/schemas/scheduled-workouts.ts
+++ b/packages/shared/src/schemas/scheduled-workouts.ts
@@ -115,6 +115,43 @@ export const scheduledWorkoutDetailSchema = scheduledWorkoutSchema.extend({
   templateDeleted: z.boolean(),
 });
 
+export const updateScheduledWorkoutExerciseNotesInputSchema = z.object({
+  notes: z
+    .array(
+      z.object({
+        exerciseId: requiredStringSchema,
+        agentNotes: nullableLongStringSchema,
+      }),
+    )
+    .min(1)
+    .max(200),
+});
+
+export const updateScheduledWorkoutExerciseNotesResponseSchema = scheduledWorkoutDetailSchema;
+
+export const swapScheduledWorkoutExerciseInputSchema = z.object({
+  fromExerciseId: requiredStringSchema,
+  toExerciseId: z.preprocess(
+    (value) => {
+      if (value === null || value === undefined) {
+        return null;
+      }
+
+      if (typeof value !== 'string') {
+        return value;
+      }
+
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    },
+    requiredStringSchema.nullable(),
+  ),
+  carryOverProgrammingNotes: z.boolean().optional(),
+  preserveSets: z.boolean().optional(),
+});
+
+export const swapScheduledWorkoutExerciseResponseSchema = scheduledWorkoutDetailSchema;
+
 export type ScheduledWorkout = z.infer<typeof scheduledWorkoutSchema>;
 export type ScheduledWorkoutListItem = z.infer<typeof scheduledWorkoutListItemSchema>;
 export type CreateScheduledWorkoutInput = z.infer<typeof createScheduledWorkoutInputSchema>;
@@ -128,3 +165,9 @@ export type ScheduledWorkoutExercise = z.infer<typeof scheduledWorkoutExerciseSc
 export type ScheduledWorkoutTemplateDrift = z.infer<typeof scheduledWorkoutTemplateDriftSchema>;
 export type ScheduledWorkoutStaleExercise = z.infer<typeof scheduledWorkoutStaleExerciseSchema>;
 export type ScheduledWorkoutDetail = z.infer<typeof scheduledWorkoutDetailSchema>;
+export type UpdateScheduledWorkoutExerciseNotesInput = z.infer<
+  typeof updateScheduledWorkoutExerciseNotesInputSchema
+>;
+export type SwapScheduledWorkoutExerciseInput = z.infer<
+  typeof swapScheduledWorkoutExerciseInputSchema
+>;

--- a/packages/shared/src/schemas/scheduled-workouts.ts
+++ b/packages/shared/src/schemas/scheduled-workouts.ts
@@ -2,8 +2,25 @@ import { z } from 'zod';
 
 import { dateSchema } from './common.js';
 import { exerciseTrackingTypeSchema } from './exercises.js';
+import { workoutTemplateSectionTypeSchema } from './workout-templates.js';
 
 const requiredStringSchema = z.string().trim().min(1).max(255);
+const requiredLongStringSchema = z.string().trim().min(1).max(4000);
+const nullableLongStringSchema = z.preprocess(
+  (value) => {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    if (typeof value !== 'string') {
+      return value;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  },
+  requiredLongStringSchema.nullable(),
+);
 
 export const scheduledWorkoutSchema = z.object({
   id: z.string(),
@@ -48,8 +65,66 @@ export const scheduledWorkoutQueryParamsSchema = z
     path: ['to'],
   });
 
+export const scheduledWorkoutExerciseSetSchema = z.object({
+  setNumber: z.number().int().min(1),
+  repsMin: z.number().int().min(1).nullable(),
+  repsMax: z.number().int().min(1).nullable(),
+  reps: z.number().int().min(1).nullable(),
+  targetWeight: z.number().min(0).nullable(),
+  targetWeightMin: z.number().min(0).nullable(),
+  targetWeightMax: z.number().min(0).nullable(),
+  targetSeconds: z.number().int().min(0).nullable(),
+  targetDistance: z.number().min(0).nullable(),
+});
+
+export const scheduledWorkoutExerciseAgentNotesMetaSchema = z.object({
+  author: requiredStringSchema,
+  generatedAt: z.string().datetime({ offset: true }),
+  scheduledDateAtGeneration: dateSchema,
+  stale: z.boolean().optional(),
+});
+
+export const scheduledWorkoutExerciseSchema = z.object({
+  exerciseId: requiredStringSchema,
+  section: workoutTemplateSectionTypeSchema,
+  orderIndex: z.number().int().min(0),
+  programmingNotes: nullableLongStringSchema,
+  agentNotes: nullableLongStringSchema,
+  agentNotesMeta: scheduledWorkoutExerciseAgentNotesMetaSchema.nullable(),
+  templateCues: z.array(requiredStringSchema).max(50).nullable(),
+  supersetGroup: requiredStringSchema.nullable(),
+  tempo: requiredStringSchema.nullable(),
+  restSeconds: z.number().int().min(0).nullable(),
+  sets: z.array(scheduledWorkoutExerciseSetSchema),
+});
+
+export const scheduledWorkoutTemplateDriftSchema = z.object({
+  changedAt: z.number().int(),
+  summary: requiredLongStringSchema,
+});
+
+export const scheduledWorkoutStaleExerciseSchema = z.object({
+  exerciseId: requiredStringSchema,
+  snapshotName: requiredStringSchema,
+});
+
+export const scheduledWorkoutDetailSchema = scheduledWorkoutSchema.extend({
+  exercises: z.array(scheduledWorkoutExerciseSchema),
+  templateDrift: scheduledWorkoutTemplateDriftSchema.nullable().optional(),
+  staleExercises: z.array(scheduledWorkoutStaleExerciseSchema).optional(),
+  templateDeleted: z.boolean().optional(),
+});
+
 export type ScheduledWorkout = z.infer<typeof scheduledWorkoutSchema>;
 export type ScheduledWorkoutListItem = z.infer<typeof scheduledWorkoutListItemSchema>;
 export type CreateScheduledWorkoutInput = z.infer<typeof createScheduledWorkoutInputSchema>;
 export type UpdateScheduledWorkoutInput = z.infer<typeof updateScheduledWorkoutInputSchema>;
 export type ScheduledWorkoutQueryParams = z.infer<typeof scheduledWorkoutQueryParamsSchema>;
+export type ScheduledWorkoutExerciseSet = z.infer<typeof scheduledWorkoutExerciseSetSchema>;
+export type ScheduledWorkoutExerciseAgentNotesMeta = z.infer<
+  typeof scheduledWorkoutExerciseAgentNotesMetaSchema
+>;
+export type ScheduledWorkoutExercise = z.infer<typeof scheduledWorkoutExerciseSchema>;
+export type ScheduledWorkoutTemplateDrift = z.infer<typeof scheduledWorkoutTemplateDriftSchema>;
+export type ScheduledWorkoutStaleExercise = z.infer<typeof scheduledWorkoutStaleExerciseSchema>;
+export type ScheduledWorkoutDetail = z.infer<typeof scheduledWorkoutDetailSchema>;

--- a/packages/shared/src/schemas/workout-sessions.test.ts
+++ b/packages/shared/src/schemas/workout-sessions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   createWorkoutSessionInputSchema,
+  createWorkoutSessionRequestSchema,
   reorderWorkoutSessionExercisesInputSchema,
   sessionCorrectionRequestSchema,
   setCorrectionSchema,
@@ -10,6 +11,7 @@ import {
   saveWorkoutSessionAsTemplateInputSchema,
   sessionSetInputSchema,
   type CreateWorkoutSessionInput,
+  type CreateWorkoutSessionRequestInput,
   type SessionCorrectionRequest,
   type SaveWorkoutSessionAsTemplateInput,
   type SetCorrection,
@@ -336,6 +338,13 @@ describe('workoutSessionSchema', () => {
           orderIndex: 0,
           section: 'main',
           programmingNotes: ' Keep lats tight ',
+          agentNotes: ' Last session was smooth. Add 5 lb if warmups feel sharp. ',
+          agentNotesMeta: {
+            author: 'Coach Pulse',
+            generatedAt: '2026-03-01T09:00:00.000Z',
+            scheduledDateAtGeneration: '2026-03-01',
+            stale: true,
+          },
           sets: [],
         },
         {
@@ -346,6 +355,8 @@ describe('workoutSessionSchema', () => {
           orderIndex: 1,
           section: 'main',
           programmingNotes: null,
+          agentNotes: null,
+          agentNotesMeta: null,
           sets: [],
         },
       ],
@@ -355,7 +366,18 @@ describe('workoutSessionSchema', () => {
     });
 
     expect(session.exercises?.[0]?.programmingNotes).toBe('Keep lats tight');
+    expect(session.exercises?.[0]?.agentNotes).toBe(
+      'Last session was smooth. Add 5 lb if warmups feel sharp.',
+    );
+    expect(session.exercises?.[0]?.agentNotesMeta).toEqual({
+      author: 'Coach Pulse',
+      generatedAt: '2026-03-01T09:00:00.000Z',
+      scheduledDateAtGeneration: '2026-03-01',
+      stale: true,
+    });
     expect(session.exercises?.[1]?.programmingNotes).toBeNull();
+    expect(session.exercises?.[1]?.agentNotes).toBeNull();
+    expect(session.exercises?.[1]?.agentNotesMeta).toBeNull();
   });
 
   it('preserves deleted exercise metadata in historical session responses', () => {
@@ -525,6 +547,8 @@ describe('workoutSessionSchema', () => {
           orderIndex: 0,
           section: 'main',
           programmingNotes: null,
+          agentNotes: null,
+          agentNotesMeta: null,
           sets: [
             {
               id: 'set-1',
@@ -709,6 +733,45 @@ describe('createWorkoutSessionInputSchema', () => {
       notes: null,
       sets: [],
     });
+  });
+});
+
+describe('createWorkoutSessionRequestSchema', () => {
+  it('accepts scheduled-workout starts without templateId or name', () => {
+    const payload: CreateWorkoutSessionRequestInput = createWorkoutSessionRequestSchema.parse({
+      scheduledWorkoutId: ' schedule-1 ',
+      date: '2026-03-12',
+      startedAt: 10,
+      force: true,
+    });
+
+    expect(payload).toEqual({
+      scheduledWorkoutId: 'schedule-1',
+      templateId: null,
+      date: '2026-03-12',
+      status: 'in-progress',
+      startedAt: 10,
+      completedAt: null,
+      duration: null,
+      timeSegments: [],
+      feedback: null,
+      notes: null,
+      sets: [],
+      force: true,
+    });
+  });
+
+  it('rejects payloads that combine multiple start modes', () => {
+    expect(() =>
+      createWorkoutSessionRequestSchema.parse({
+        scheduledWorkoutId: 'schedule-1',
+        templateId: 'template-1',
+        date: '2026-03-12',
+        startedAt: 10,
+      }),
+    ).toThrow(
+      'Provide exactly one session start mode: scheduledWorkoutId, templateId/templateName, or name',
+    );
   });
 });
 

--- a/packages/shared/src/schemas/workout-sessions.ts
+++ b/packages/shared/src/schemas/workout-sessions.ts
@@ -330,6 +330,16 @@ export const workoutSessionExerciseSchema = z.object({
   orderIndex: z.number().int().min(0),
   section: workoutTemplateSectionTypeSchema.nullable(),
   programmingNotes: nullableLongStringSchema.default(null),
+  agentNotes: nullableLongStringSchema.default(null),
+  agentNotesMeta: z
+    .object({
+      author: requiredStringSchema,
+      generatedAt: z.string().datetime({ offset: true }),
+      scheduledDateAtGeneration: dateSchema,
+      stale: z.boolean().optional(),
+    })
+    .nullable()
+    .default(null),
   sets: z.array(sessionSetSchema).max(500),
 });
 
@@ -463,22 +473,47 @@ const workoutSessionExerciseSectionInputSchema = z.object({
   section: workoutTemplateSectionTypeSchema,
 });
 
-export const createWorkoutSessionInputSchema = z
-  .object({
-    templateId: nullableTemplateIdSchema.optional().default(null),
-    templateName: requiredStringSchema.optional(),
-    name: requiredStringSchema,
-    date: dateSchema,
-    status: workoutSessionStatusSchema.optional().default('in-progress'),
-    startedAt: z.number().int(),
-    completedAt: z.number().int().nullable().optional().default(null),
-    duration: nullableIntegerSchema.optional().default(null),
-    timeSegments: validatedTimeSegmentsSchema.optional().default([]),
-    feedback: workoutSessionFeedbackSchema.nullable().optional().default(null),
-    notes: nullableLongStringSchema.optional().default(null),
-    sets: z.array(sessionSetInputSchema).max(500).optional().default([]),
+const createWorkoutSessionInputObjectSchema = z.object({
+  templateId: nullableTemplateIdSchema.optional().default(null),
+  templateName: requiredStringSchema.optional(),
+  name: requiredStringSchema,
+  date: dateSchema,
+  status: workoutSessionStatusSchema.optional().default('in-progress'),
+  startedAt: z.number().int(),
+  completedAt: z.number().int().nullable().optional().default(null),
+  duration: nullableIntegerSchema.optional().default(null),
+  timeSegments: validatedTimeSegmentsSchema.optional().default([]),
+  feedback: workoutSessionFeedbackSchema.nullable().optional().default(null),
+  notes: nullableLongStringSchema.optional().default(null),
+  sets: z.array(sessionSetInputSchema).max(500).optional().default([]),
+});
+
+export const createWorkoutSessionInputSchema =
+  createWorkoutSessionInputObjectSchema.superRefine(validateWorkoutSessionTiming);
+
+export const createWorkoutSessionRequestSchema = createWorkoutSessionInputObjectSchema
+  .extend({
+    scheduledWorkoutId: requiredStringSchema.optional(),
+    force: z.boolean().optional(),
+    name: requiredStringSchema.optional(),
   })
-  .superRefine(validateWorkoutSessionTiming);
+  .superRefine((value, context) => {
+    const hasScheduledStart = value.scheduledWorkoutId !== undefined;
+    const hasTemplateStart = value.templateId !== null || value.templateName !== undefined;
+    const hasAdHocStart = value.name !== undefined && !hasScheduledStart && !hasTemplateStart;
+    const startModes = [hasScheduledStart, hasTemplateStart, hasAdHocStart].filter(Boolean).length;
+
+    if (startModes === 1) {
+      return;
+    }
+
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        'Provide exactly one session start mode: scheduledWorkoutId, templateId/templateName, or name',
+      path: ['scheduledWorkoutId'],
+    });
+  });
 
 export const updateWorkoutSessionInputSchema = z
   .object({
@@ -584,6 +619,7 @@ export type WorkoutSession = z.infer<typeof workoutSessionSchema>;
 export type WorkoutSessionListItem = z.infer<typeof workoutSessionListItemSchema>;
 export type SessionSetInput = z.infer<typeof sessionSetInputSchema>;
 export type CreateWorkoutSessionInput = z.infer<typeof createWorkoutSessionInputSchema>;
+export type CreateWorkoutSessionRequestInput = z.infer<typeof createWorkoutSessionRequestSchema>;
 export type UpdateWorkoutSessionInput = z.infer<typeof updateWorkoutSessionInputSchema>;
 export type UpdateWorkoutSessionTimeSegmentsInput = z.infer<
   typeof updateWorkoutSessionTimeSegmentsInputSchema


### PR DESCRIPTION
## Summary
This PR introduces a full scheduled-workout snapshot pipeline so scheduled plans are preserved as immutable workout content rather than reading live template rows at start time. Scheduling now writes exercise/set snapshots and a template version hash, and session creation can start directly from a scheduled snapshot with clear lifecycle handling for drift, stale exercises, and previously consumed schedules. It also adds an AgentToken-only enrichment step for per-exercise `agentNotes`, with server-authored metadata and stale marking when reschedules move more than two days. On the web side, scheduled workout detail now renders from snapshot data, surfaces drift/stale/deleted banners, and provides stale-exercise recovery (swap/remove/start-anyway). The change also updates conventions and skill docs to formalize the new three-layer notes model (`programmingNotes`, `agentNotes`, user notes).

## Key Changes
- Added new snapshot persistence tables and schema wiring:
  - `scheduled_workout_exercises`
  - `scheduled_workout_exercise_sets`
  - `scheduled_workouts.templateVersion`
  - `workout_sessions.scheduledWorkoutId`, `exerciseAgentNotes`, `exerciseAgentNotesMeta`
- Added snapshot store (`writeSnapshot`, `readSnapshot`, `deleteSnapshot`) and deterministic template version hashing for drift detection.
- Added migration + backfill path for existing scheduled workouts, including a runnable backfill command and tests for processed/skipped scenarios.
- Extended `POST /api/v1/scheduled-workouts` to snapshot template data immediately and return detail payloads with marker fields.
- Extended `GET /api/v1/scheduled-workouts/:id` to return full snapshot plus derived markers:
  - `templateDrift`
  - `staleExercises`
  - `templateDeleted`
- Added `PATCH /api/v1/scheduled-workouts/:id/exercise-notes` (AgentToken-only) for batched per-exercise note upserts/clears with server-authored metadata.
- Added `PATCH /api/v1/scheduled-workouts/:id/exercise-swap` for scheduled snapshot swap/remove flows with validation, duplicate checks, optional carryover, and set reset behavior.
- Extended `POST /api/v1/workout-sessions` with scheduled-start mode via `scheduledWorkoutId`:
  - seeds sets and note maps from snapshot
  - returns `409 SCHEDULED_WORKOUT_ALREADY_STARTED` for active linked sessions
  - returns `409 STALE_SNAPSHOT_EXERCISES` unless `force: true`
  - returns warnings when stale exercises are skipped with force mode
- Updated session cancel lifecycle to clear schedule linkage while preserving cancelled session history and scheduled snapshot rows.
- Updated web workouts UI to render snapshot-based scheduled details, add banners and stale recovery dialog, add agent-note rendering in shared exercise cards/active/completed flows, and invalidate relevant TanStack Query caches on scheduled mutations.
- Updated shared Zod schemas/tests and conventions/agent docs/skill guidance for the new API and note lifecycle.

## Technical Notes
- Drift detection is based on a SHA-256 hash of canonicalized template exercise snapshot payloads (`templateVersion`) rather than direct row timestamps, making comparison stable across ordering and read paths.
- Marker fields (`templateDrift`, `staleExercises`, `templateDeleted`) are computed on read, keeping mutation writes focused on source-of-truth snapshot data.
- Scheduled session-start idempotency is enforced by link-state + session-state checks; stale links to cancelled/deleted sessions are automatically cleared before allowing restart.
- `agentNotesMeta.stale` is intentionally derived from date movement threshold logic (`> 48h` / more than 2 days) during reschedule mutations.
- Save-as-template intentionally drops session-specific channels (`agentNotes`, user notes) and only round-trips programming notes to avoid polluting reusable templates.
- UI now treats scheduled snapshots as the primary rendering source and only uses template rows opportunistically for richer labels/details, which keeps deleted-template schedules usable.

## Commits

- `5349b03 docs(workouts): document three-layer notes and agent enrichment flow`
- `e01f1bc fix(web): address scheduled snapshot review feedback`
- `7a61796 feat(web): render agent notes, drift banners, and recovery flows`
- `1825610 fix(workouts): address commit-11 review feedback`
- `3e36a36 feat(api): seed sessions from scheduled-workout snapshot`
- `b118560 fix(api): resolve scheduled workout swap review feedback`
- `71d37ef feat(api): agent-enrichment endpoints for scheduled workouts`
- `44c12b1 fix(workouts): address commit-9 review feedback`
- `ec845a8 feat(api): snapshot scheduled workouts with drift and lifecycle markers`
- `4daf46f feat(api): add scheduled-workout snapshot tables and backfill`

## Tasks

- **Scheduled-workout snapshot tables + backfill migration**: Add Drizzle schema for scheduled_workout_exercises and scheduled_workout_exercise_sets. Add scheduled_workouts.templateVersion column. Generate Drizzle migration. Backfill script snapshots every existing non-deleted scheduled_workout with a live templateId. Store-layer tests for reads/writes and backfill behavior.
- **Snapshot on schedule + drift/stale/deleted markers**: Extend POST /api/v1/scheduled-workouts/ to snapshot template exercises + sets + programmingNotes + templateVersion. Extend GET /api/v1/scheduled-workouts/:id to return full snapshot plus templateDrift, staleExercises, templateDeleted markers. Route tests covering all marker cases.
- **AgentToken-only exercise-notes + exercise-swap endpoints**: Add PATCH /api/v1/scheduled-workouts/:id/exercise-notes (AgentToken-only, JWT 403) with upsert by (scheduled_workout_id, exerciseId) and server-written metadata (author, generatedAt, scheduledDateAtGeneration). Add PATCH /api/v1/scheduled-workouts/:id/exercise-swap paralleling the session swap. Reschedule path sets stale marker when new date differs > 48h from scheduledDateAtGeneration. Route + auth tests.
- **Seed sessions from scheduled-workout snapshot + lifecycle wiring**: Extend POST /api/v1/workout-sessions/ to accept scheduledWorkoutId and seed the session (programmingNotes, agentNotes, metadata) from the snapshot. Handle idempotency (409 on consumed schedule), stale-exercise 409 with recovery payload, force:true skip-deleted behavior. Cancel-session transition clears scheduled_workouts.sessionId. Save-as-template drops agentNotes + user notes. Route + store tests for every branch.
- **Scheduled-workout UI: agent notes, banners, stale-exercise recovery**: On the shared WorkoutExerciseCard (readonly-scheduled mode), render an agent-notes block visually distinct from programmingNotes, with generatedAt and stale marker. On the scheduled-workout detail page, render three banners (template drift, stale exercises, template deleted) with appropriate actions (refresh from template; stale-exercise recovery modal). TanStack Query cache invalidation on mutations. Component tests.
- **Update pulse-app-usage skill + convention docs**: Update .agents/skills/pulse-app-usage/SKILL.md with the agent enrichment workflow (snapshot → PATCH exercise-notes → surface to user). Update docs/conventions/workout-domain.md with the three-layer notes model. Update docs/conventions/api-conventions.md with the AgentToken-only PATCH endpoint pattern. Update docs/conventions/agent-integration.md. Update docs/conventions/data-models.md with the new tables.

## Diff Stats

```
.agents/skills/pulse-app-usage/SKILL.md            |   39 +
 apps/api/drizzle/0037_vengeful_tigra.sql           |  119 +
 apps/api/drizzle/meta/0037_snapshot.json           | 3326 ++++++++++++++++++++
 apps/api/drizzle/meta/_journal.json                |    7 +
 apps/api/package.json                              |    1 +
 .../src/__tests__/habits-weight-targets.test.ts    |    2 +-
 .../run-scheduled-workout-snapshot-backfill.ts     |   12 +
 .../backfill/scheduled-workout-snapshots.test.ts   |  177 ++
 .../src/db/backfill/scheduled-workout-snapshots.ts |   85 +
 apps/api/src/db/migrations.test.ts                 |   73 +-
 apps/api/src/db/schema.test.ts                     |   99 +-
 apps/api/src/db/schema/index.ts                    |    2 +
 .../db/schema/scheduled-workout-exercise-sets.ts   |   43 +
 .../src/db/schema/scheduled-workout-exercises.ts   |   58 +
 apps/api/src/db/schema/scheduled-workouts.ts       |   11 +-
 apps/api/src/db/schema/workout-sessions.ts         |   36 +-
 .../src/routes/scheduled-workouts/index.test.ts    | 1263 +++++++-
 apps/api/src/routes/scheduled-workouts/index.ts    |  679 +++-
 .../scheduled-workouts/snapshot-store.test.ts      |  274 ++
 .../routes/scheduled-workouts/snapshot-store.ts    |  448 +++
 apps/api/src/routes/scheduled-workouts/store.ts    |   27 +-
 apps/api/src/routes/workout-sessions/index.test.ts |  748 ++++-
 apps/api/src/routes/workout-sessions/index.ts      |  477 ++-
 apps/api/src/routes/workout-sessions/store.ts      |   68 +-
 .../src/features/workouts/api/workouts.test.tsx    |    2 +
 apps/web/src/features/workouts/api/workouts.ts     |   46 +-
 .../components/scheduled-workout-detail.test.tsx   |  617 ++--
 .../components/scheduled-workout-detail.tsx        |  577 +++-
 .../workouts/components/session-detail.test.tsx    |   14 +
 .../workouts/components/session-detail.tsx         |    4 +
 .../components/session-exercise-list.test.tsx      |   58 +
 .../workouts/components/session-exercise-list.tsx  |   44 +
 .../components/session-summary-exercise-card.tsx   |   15 +
 .../workouts/components/session-summary.test.tsx   |   10 +
 .../workouts/components/swap-exercise-dialog.tsx   |   40 +-
 .../agent-notes-block.test.tsx                     |   48 +
 .../workout-exercise-card/agent-notes-block.tsx    |   67 +
 .../workout-exercise-card/index.test.tsx           |   40 +
 .../components/workout-exercise-card/index.tsx     |   16 +
 .../components/workout-exercise-card/types.ts      |   11 +
 .../src/features/workouts/lib/active-session.ts    |    4 +
 apps/web/src/features/workouts/types.ts            |   11 +
 apps/web/src/hooks/use-workout-session.test.tsx    |   20 +
 apps/web/src/hooks/use-workout-session.ts          |   15 +-
 apps/web/src/pages/active-workout.tsx              |   16 +-
 docs/conventions/agent-integration.md              |   36 +-
 docs/conventions/api-conventions.md                |   47 +
 docs/conventions/data-models.md                    |   54 +
 docs/conventions/design-system.md                  |   39 +
 docs/conventions/feature-structure.md              |   11 +
 docs/conventions/workout-domain.md                 |   61 +-
 .../shared/src/schemas/scheduled-workouts.test.ts  |  181 ++
 packages/shared/src/schemas/scheduled-workouts.ts  |  118 +
 .../shared/src/schemas/workout-sessions.test.ts    |   63 +
 packages/shared/src/schemas/workout-sessions.ts    |   66 +-
 55 files changed, 10052 insertions(+), 373 deletions(-)
```