### PR TITLE
fix(workouts): honor payload in bulk sets PATCH + DELETE session set endpoint

### DIFF
--- a/.agents/skills/pulse-app-usage/SKILL.md
+++ b/.agents/skills/pulse-app-usage/SKILL.md
@@ -229,6 +229,7 @@ If no new foods were created, explicitly say that existing food entries were reu
 - **Complete**: set `status: "completed"` in the PATCH body.
 - **Save as template**: `POST /api/v1/workout-sessions/:id/save-as-template`
 - **Set corrections** (completed sessions only): `PATCH /api/v1/workout-sessions/:id/corrections` with `{ corrections: [{ setId, weight?, reps?, rpe? }] }`. Returns 409 on non-completed sessions.
+- **Delete mis-logged in-progress set**: `DELETE /api/v1/workout-sessions/:sessionId/sets/:setId`; once a session is completed/cancelled, use corrections (`PATCH /api/v1/workout-sessions/:id/corrections`) instead of delete.
 - **Time segment correction**: `PATCH /api/v1/workout-sessions/:id/time-segments` — full segment array replacement.
 
 **Status transitions:**

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -846,7 +846,9 @@ describe('workout session routes', () => {
       ),
     ).toBe(false);
     expect(
-      persistedTemplateExercises.some((exercise) => exercise.notes === 'This should not round-trip'),
+      persistedTemplateExercises.some(
+        (exercise) => exercise.notes === 'This should not round-trip',
+      ),
     ).toBe(false);
   });
 
@@ -2622,10 +2624,12 @@ describe('workout session routes', () => {
     expect(templatePayload.data.exercises?.every((exercise) => exercise.agentNotes === null)).toBe(
       true,
     );
-    expect(templatePayload.data.exercises?.every((exercise) => exercise.agentNotesMeta === null)).toBe(
+    expect(
+      templatePayload.data.exercises?.every((exercise) => exercise.agentNotesMeta === null),
+    ).toBe(true);
+    expect(adHocPayload.data.exercises?.every((exercise) => exercise.agentNotes === null)).toBe(
       true,
     );
-    expect(adHocPayload.data.exercises?.every((exercise) => exercise.agentNotes === null)).toBe(true);
     expect(adHocPayload.data.exercises?.every((exercise) => exercise.agentNotesMeta === null)).toBe(
       true,
     );
@@ -2749,8 +2753,6 @@ describe('workout session routes', () => {
             setNumber: 1,
             weight: 185,
             reps: 8,
-            targetWeightMin: 175,
-            targetWeightMax: 185,
             completed: true,
             section: 'main',
             notes: ' Fast bar path ',
@@ -2830,8 +2832,6 @@ describe('workout session routes', () => {
           setNumber: 1,
           weight: 185,
           reps: 8,
-          targetWeightMin: 175,
-          targetWeightMax: 185,
           completed: true,
           skipped: false,
           section: 'main',
@@ -3378,7 +3378,9 @@ describe('workout session routes', () => {
     });
 
     expect(response.statusCode).toBe(201);
-    const payload = response.json() as { data: { id: string; exercises?: Array<{ agentNotes: string | null }> } };
+    const payload = response.json() as {
+      data: { id: string; exercises?: Array<{ agentNotes: string | null }> };
+    };
     expect(payload.data.id).not.toBe('cancelled-linked-session');
     expect(payload.data.exercises).toEqual([
       expect.objectContaining({
@@ -5792,6 +5794,367 @@ describe('workout session routes', () => {
       name: 'Landmine Press',
       userId: 'user-1',
     });
+  });
+
+  it('honors skipped=true in session set patch updates', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'session-skip-bulk-patch',
+      userId: 'user-1',
+      name: 'Skip Bulk Patch',
+      date: '2026-03-12',
+      startedAt: Date.now() - 60_000,
+      status: 'in-progress',
+    });
+    seedSessionSet({
+      id: 'session-skip-bulk-patch-set-1',
+      sessionId: 'session-skip-bulk-patch',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      completed: false,
+      skipped: false,
+      section: 'main',
+    });
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-sessions/session-skip-bulk-patch',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        sets: [{ exerciseId: 'global-bench-press', setNumber: 1, skipped: true }],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const payload = response.json() as {
+      data: {
+        sets: Array<{
+          exerciseId: string | null;
+          setNumber: number;
+          completed: boolean;
+          skipped: boolean;
+        }>;
+      };
+    };
+    expect(payload.data.sets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          exerciseId: 'global-bench-press',
+          setNumber: 1,
+          completed: false,
+          skipped: true,
+        }),
+      ]),
+    );
+  });
+
+  it('honors completed=false in session set patch updates', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'session-completed-bulk-patch',
+      userId: 'user-1',
+      name: 'Completed Bulk Patch',
+      date: '2026-03-12',
+      startedAt: Date.now() - 60_000,
+      status: 'in-progress',
+    });
+    seedSessionSet({
+      id: 'session-completed-bulk-patch-set-1',
+      sessionId: 'session-completed-bulk-patch',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      completed: true,
+      skipped: false,
+      section: 'main',
+    });
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-sessions/session-completed-bulk-patch',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        sets: [{ exerciseId: 'global-bench-press', setNumber: 1, completed: false }],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const payload = response.json() as {
+      data: { sets: Array<{ exerciseId: string | null; setNumber: number; completed: boolean }> };
+    };
+    expect(payload.data.sets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          exerciseId: 'global-bench-press',
+          setNumber: 1,
+          completed: false,
+        }),
+      ]),
+    );
+  });
+
+  it('defaults omitted completed to true for logged set updates', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'session-default-completed-bulk-patch',
+      userId: 'user-1',
+      name: 'Default Completed Bulk Patch',
+      date: '2026-03-12',
+      startedAt: Date.now() - 60_000,
+      status: 'in-progress',
+    });
+    seedSessionSet({
+      id: 'session-default-completed-bulk-patch-set-1',
+      sessionId: 'session-default-completed-bulk-patch',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      weight: 185,
+      reps: 8,
+      completed: false,
+      skipped: false,
+      section: 'main',
+    });
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-sessions/session-default-completed-bulk-patch',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        sets: [{ exerciseId: 'global-bench-press', setNumber: 1, weight: 100, reps: 5 }],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const payload = response.json() as {
+      data: {
+        sets: Array<{
+          exerciseId: string | null;
+          setNumber: number;
+          weight: number | null;
+          reps: number | null;
+          completed: boolean;
+        }>;
+      };
+    };
+    expect(payload.data.sets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          exerciseId: 'global-bench-press',
+          setNumber: 1,
+          weight: 100,
+          reps: 5,
+          completed: true,
+        }),
+      ]),
+    );
+  });
+
+  it('round-trips notes and supersetGroup in session set patch updates', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'session-notes-superset-bulk-patch',
+      userId: 'user-1',
+      name: 'Notes Superset Bulk Patch',
+      date: '2026-03-12',
+      startedAt: Date.now() - 60_000,
+      status: 'in-progress',
+    });
+    seedSessionSet({
+      id: 'session-notes-superset-bulk-patch-set-1',
+      sessionId: 'session-notes-superset-bulk-patch',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      completed: true,
+      skipped: false,
+      supersetGroup: null,
+      notes: null,
+      section: 'main',
+    });
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-sessions/session-notes-superset-bulk-patch',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        sets: [
+          {
+            exerciseId: 'global-bench-press',
+            setNumber: 1,
+            notes: 'left side weak',
+            supersetGroup: 'A',
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const payload = response.json() as {
+      data: {
+        exercises?: Array<{ exerciseId: string | null; supersetGroup: string | null }>;
+        sets: Array<{
+          exerciseId: string | null;
+          setNumber: number;
+          notes: string | null;
+        }>;
+      };
+    };
+    expect(payload.data.sets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          exerciseId: 'global-bench-press',
+          setNumber: 1,
+          notes: 'left side weak',
+        }),
+      ]),
+    );
+    expect(payload.data.exercises).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          exerciseId: 'global-bench-press',
+          supersetGroup: 'A',
+        }),
+      ]),
+    );
+  });
+
+  it('rejects unsupported session set target fields on patch', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'session-target-field-reject',
+      userId: 'user-1',
+      name: 'Target Field Reject',
+      date: '2026-03-12',
+      startedAt: Date.now() - 60_000,
+      status: 'in-progress',
+    });
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-sessions/session-target-field-reject',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        sets: [{ exerciseId: 'global-bench-press', setNumber: 1, targetSeconds: 720 }],
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expectRequestValidationError(
+      response,
+      'PATCH',
+      '/api/v1/workout-sessions/session-target-field-reject',
+    );
+    expect(response.json()).toMatchObject({
+      error: {
+        details: {
+          issues: [
+            expect.objectContaining({
+              keyword: 'unrecognized_keys',
+              params: {
+                issue: expect.objectContaining({
+                  code: 'unrecognized_keys',
+                  keys: expect.arrayContaining(['targetSeconds']),
+                }),
+              },
+            }),
+          ],
+        },
+      },
+    });
+  });
+
+  it('creates missing sets in patch updates and preserves provided structural fields', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'session-new-set-patch',
+      userId: 'user-1',
+      name: 'New Set Patch',
+      date: '2026-03-12',
+      startedAt: Date.now() - 60_000,
+      status: 'in-progress',
+    });
+    seedSessionSet({
+      id: 'session-new-set-patch-set-1',
+      sessionId: 'session-new-set-patch',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      completed: true,
+      skipped: false,
+      section: 'cooldown',
+    });
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-sessions/session-new-set-patch',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        sets: [
+          {
+            exerciseId: 'global-bench-press',
+            setNumber: 2,
+            supersetGroup: 'A',
+            notes: 'left side weak',
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const payload = response.json() as {
+      data: {
+        exercises?: Array<{ exerciseId: string | null; supersetGroup: string | null }>;
+        sets: Array<{
+          exerciseId: string | null;
+          setNumber: number;
+          completed: boolean;
+          skipped: boolean;
+          notes: string | null;
+          section: string | null;
+        }>;
+      };
+    };
+    expect(payload.data.sets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          exerciseId: 'global-bench-press',
+          setNumber: 2,
+          completed: true,
+          skipped: false,
+          notes: 'left side weak',
+          section: 'cooldown',
+        }),
+      ]),
+    );
+    expect(payload.data.exercises).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          exerciseId: 'global-bench-press',
+          supersetGroup: 'A',
+        }),
+      ]),
+    );
   });
 
   it('applies addExercises/removeExercises/reorderExercises for both JWT and AgentToken callers', async () => {

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -1944,7 +1944,48 @@ describe('workout session routes', () => {
     expect(response.json()).toEqual({
       error: {
         code: 'session-not-in-progress',
-        message: 'Workout session must be in progress to delete sets',
+        message: 'Use PATCH /workout-sessions/:id/corrections to edit completed sessions.',
+      },
+    });
+  });
+
+  it('returns 409 when deleting a set from a cancelled session', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'session-delete-cancelled',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Cancelled Session',
+      date: '2026-03-12',
+      status: 'cancelled',
+      startedAt: 1000,
+      completedAt: null,
+      duration: null,
+    });
+    seedSessionSet({
+      id: 'session-delete-cancelled-set-1',
+      sessionId: 'session-delete-cancelled',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      section: 'main',
+      reps: 8,
+    });
+
+    const response = await context.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/workout-sessions/session-delete-cancelled/sets/session-delete-cancelled-set-1',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'session-not-in-progress',
+        message: 'Use PATCH /workout-sessions/:id/corrections to edit completed sessions.',
       },
     });
   });

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -492,6 +492,10 @@ describe('workout session routes', () => {
         },
       }),
       context.app.inject({
+        method: 'DELETE',
+        url: '/api/v1/workout-sessions/session-1/sets/set-1',
+      }),
+      context.app.inject({
         method: 'PATCH',
         url: '/api/v1/workout-sessions/session-1/corrections',
         payload: {
@@ -1804,6 +1808,336 @@ describe('workout session routes', () => {
 
     expect(groupedResponse.statusCode).toBe(200);
     expect(groupedResponse.json()).toEqual(batchResponse.json());
+  });
+
+  it('deletes a set from an in-progress session and renumbers sibling sets', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'session-delete-success',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Delete Set Session',
+      date: '2026-03-12',
+      status: 'in-progress',
+      startedAt: 1000,
+    });
+    seedSessionSet({
+      id: 'session-delete-main-1',
+      sessionId: 'session-delete-success',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      section: 'main',
+      reps: 8,
+    });
+    seedSessionSet({
+      id: 'session-delete-main-2',
+      sessionId: 'session-delete-success',
+      exerciseId: 'global-bench-press',
+      setNumber: 2,
+      section: 'main',
+      reps: 8,
+    });
+    seedSessionSet({
+      id: 'session-delete-main-3',
+      sessionId: 'session-delete-success',
+      exerciseId: 'global-bench-press',
+      setNumber: 3,
+      section: 'main',
+      reps: 8,
+    });
+    seedSessionSet({
+      id: 'session-delete-cooldown-1',
+      sessionId: 'session-delete-success',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      section: 'cooldown',
+      reps: 12,
+    });
+
+    const response = await context.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/workout-sessions/session-delete-success/sets/session-delete-main-2',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const payload = response.json() as {
+      data: {
+        id: string;
+        sets: Array<{
+          id: string;
+          exerciseId: string | null;
+          section: 'warmup' | 'main' | 'cooldown' | 'supplemental' | null;
+          setNumber: number;
+        }>;
+      };
+    };
+    expect(payload.data.id).toBe('session-delete-success');
+
+    const mainBenchSets = payload.data.sets
+      .filter((set) => set.exerciseId === 'global-bench-press' && set.section === 'main')
+      .sort((left, right) => left.setNumber - right.setNumber)
+      .map((set) => ({ id: set.id, setNumber: set.setNumber }));
+    expect(mainBenchSets).toEqual([
+      { id: 'session-delete-main-1', setNumber: 1 },
+      { id: 'session-delete-main-3', setNumber: 2 },
+    ]);
+
+    const cooldownBenchSets = payload.data.sets
+      .filter((set) => set.exerciseId === 'global-bench-press' && set.section === 'cooldown')
+      .map((set) => ({ id: set.id, setNumber: set.setNumber }));
+    expect(cooldownBenchSets).toEqual([{ id: 'session-delete-cooldown-1', setNumber: 1 }]);
+
+    const persistedSets = context.db
+      .select({
+        id: sessionSets.id,
+        setNumber: sessionSets.setNumber,
+      })
+      .from(sessionSets)
+      .where(eq(sessionSets.sessionId, 'session-delete-success'))
+      .all()
+      .sort((left, right) => left.id.localeCompare(right.id));
+    expect(persistedSets).toEqual([
+      { id: 'session-delete-cooldown-1', setNumber: 1 },
+      { id: 'session-delete-main-1', setNumber: 1 },
+      { id: 'session-delete-main-3', setNumber: 2 },
+    ]);
+  });
+
+  it('returns 409 when deleting a set from a completed session', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'session-delete-completed',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Completed Session',
+      date: '2026-03-12',
+      status: 'completed',
+      startedAt: 1000,
+      completedAt: 1100,
+      duration: 100,
+    });
+    seedSessionSet({
+      id: 'session-delete-completed-set-1',
+      sessionId: 'session-delete-completed',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      section: 'main',
+      reps: 8,
+    });
+
+    const response = await context.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/workout-sessions/session-delete-completed/sets/session-delete-completed-set-1',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'session-not-in-progress',
+        message: 'Workout session must be in progress to delete sets',
+      },
+    });
+  });
+
+  it('returns 404 when deleting a set that does not belong to the requested session', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'session-delete-owner-a',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Owner A',
+      date: '2026-03-12',
+      status: 'in-progress',
+      startedAt: 1000,
+    });
+    seedWorkoutSession({
+      id: 'session-delete-owner-b',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Owner B',
+      date: '2026-03-12',
+      status: 'in-progress',
+      startedAt: 1000,
+    });
+    seedSessionSet({
+      id: 'session-delete-owner-b-set-1',
+      sessionId: 'session-delete-owner-b',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      section: 'main',
+      reps: 8,
+    });
+
+    const response = await context.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/workout-sessions/session-delete-owner-a/sets/session-delete-owner-b-set-1',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'SESSION_SET_NOT_FOUND',
+        message: 'Session set not found',
+      },
+    });
+  });
+
+  it('returns 404 when deleting a set from an unknown session', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    const response = await context.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/workout-sessions/session-delete-missing/sets/session-delete-missing-set',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'WORKOUT_SESSION_NOT_FOUND',
+        message: 'Workout session not found',
+      },
+    });
+  });
+
+  it('supports AgentToken auth and returns enrichment when deleting a set', async () => {
+    const agentToken = seedAgentToken('user-1', 'agent-delete-set-token');
+
+    seedWorkoutSession({
+      id: 'session-delete-agent',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Agent Delete Session',
+      date: '2026-03-12',
+      status: 'in-progress',
+      startedAt: 1000,
+    });
+    seedSessionSet({
+      id: 'session-delete-agent-set-1',
+      sessionId: 'session-delete-agent',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      section: 'main',
+      reps: 8,
+    });
+
+    const response = await context.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/workout-sessions/session-delete-agent/sets/session-delete-agent-set-1',
+      headers: createAgentTokenHeader(agentToken),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      data: expect.objectContaining({
+        id: 'session-delete-agent',
+      }),
+      agent: expect.objectContaining({
+        hints: expect.any(Array),
+        suggestedActions: expect.any(Array),
+        relatedState: expect.objectContaining({
+          action: 'set',
+          status: 'in-progress',
+        }),
+      }),
+    });
+  });
+
+  it('returns 401 when deleting a set without auth', async () => {
+    seedWorkoutSession({
+      id: 'session-delete-no-auth',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'No Auth Session',
+      date: '2026-03-12',
+      status: 'in-progress',
+      startedAt: 1000,
+    });
+    seedSessionSet({
+      id: 'session-delete-no-auth-set-1',
+      sessionId: 'session-delete-no-auth',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      section: 'main',
+      reps: 8,
+    });
+
+    const response = await context.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/workout-sessions/session-delete-no-auth/sets/session-delete-no-auth-set-1',
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        message: 'Authentication required',
+      },
+    });
+  });
+
+  it('returns 404 when deleting the same set twice', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'session-delete-idempotent',
+      userId: 'user-1',
+      templateId: 'template-1',
+      name: 'Idempotent Delete Session',
+      date: '2026-03-12',
+      status: 'in-progress',
+      startedAt: 1000,
+    });
+    seedSessionSet({
+      id: 'session-delete-idempotent-set-1',
+      sessionId: 'session-delete-idempotent',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      section: 'main',
+      reps: 8,
+    });
+
+    const firstResponse = await context.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/workout-sessions/session-delete-idempotent/sets/session-delete-idempotent-set-1',
+      headers: createAuthorizationHeader(authToken),
+    });
+    expect(firstResponse.statusCode).toBe(200);
+
+    const secondResponse = await context.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/workout-sessions/session-delete-idempotent/sets/session-delete-idempotent-set-1',
+      headers: createAuthorizationHeader(authToken),
+    });
+
+    expect(secondResponse.statusCode).toBe(404);
+    expect(secondResponse.json()).toEqual({
+      error: {
+        code: 'SESSION_SET_NOT_FOUND',
+        message: 'Session set not found',
+      },
+    });
   });
 
   it('batch-upserted sets inherit an exercise superset group from existing sets', async () => {

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -5960,6 +5960,65 @@ describe('workout session routes', () => {
     );
   });
 
+  it('preserves skipped/completed when patching notes only', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedWorkoutSession({
+      id: 'session-notes-only-state-patch',
+      userId: 'user-1',
+      name: 'Notes Only State Patch',
+      date: '2026-03-12',
+      startedAt: Date.now() - 60_000,
+      status: 'in-progress',
+    });
+    seedSessionSet({
+      id: 'session-notes-only-state-patch-set-1',
+      sessionId: 'session-notes-only-state-patch',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+      completed: false,
+      skipped: true,
+      notes: null,
+      section: 'main',
+    });
+
+    const response = await context.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/workout-sessions/session-notes-only-state-patch',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        sets: [{ exerciseId: 'global-bench-press', setNumber: 1, notes: 'left side weak' }],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const payload = response.json() as {
+      data: {
+        sets: Array<{
+          exerciseId: string | null;
+          setNumber: number;
+          completed: boolean;
+          skipped: boolean;
+          notes: string | null;
+        }>;
+      };
+    };
+    expect(payload.data.sets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          exerciseId: 'global-bench-press',
+          setNumber: 1,
+          completed: false,
+          skipped: true,
+          notes: 'left side weak',
+        }),
+      ]),
+    );
+  });
+
   it('round-trips notes and supersetGroup in session set patch updates', async () => {
     const authToken = context.app.jwt.sign(
       { sub: 'user-1', type: 'session', iss: 'pulse-api' },

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -72,6 +72,7 @@ import {
   batchUpsertSessionSets,
   createSessionSet,
   createWorkoutSession,
+  deleteSessionSet,
   deleteWorkoutSession,
   findInvalidSessionExerciseIds,
   findWorkoutSessionAccess,
@@ -81,6 +82,7 @@ import {
   listWorkoutSessions,
   reorderWorkoutSessionExercises,
   saveCompletedSessionAsTemplate,
+  SESSION_SET_DELETE_NOT_IN_PROGRESS,
   SessionSetNotFoundError,
   swapWorkoutSessionExercise,
   updateSessionSet,
@@ -220,6 +222,11 @@ const WORKOUT_SESSION_EXERCISE_HAS_LOGGED_SETS_RESPONSE = {
 const SESSION_SET_NOT_FOUND_RESPONSE = {
   code: 'SESSION_SET_NOT_FOUND',
   message: 'Session set not found',
+} as const;
+
+const SESSION_SET_NOT_IN_PROGRESS_RESPONSE = {
+  code: SESSION_SET_DELETE_NOT_IN_PROGRESS,
+  message: 'Workout session must be in progress to delete sets',
 } as const;
 
 const INVALID_SESSION_CORRECTION_SET_RESPONSE = {
@@ -977,6 +984,76 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       return reply.send({
         data: set,
       });
+    },
+  );
+
+  typedApp.delete(
+    '/:sessionId/sets/:setId',
+    {
+      preHandler: agentRequestTransform,
+      onSend: agentEnrichmentOnSend,
+      schema: {
+        params: sessionSetParamsSchema,
+        response: {
+          200: apiDataResponseSchema(workoutSessionSchema),
+          401: apiErrorResponseSchema,
+          404: apiErrorResponseSchema,
+          409: apiErrorResponseSchema,
+        },
+        tags: ['workout-sessions'],
+        summary: 'Delete a set from an in-progress workout session',
+        security: authSecurity,
+      },
+    },
+    async (request, reply) => {
+      const session = await ensureOwnedSession({
+        sessionId: request.params.sessionId,
+        userId: request.userId,
+        reply,
+      });
+      if (!session) {
+        return reply;
+      }
+
+      const result = await deleteSessionSet({
+        sessionId: session.id,
+        setId: request.params.setId,
+      });
+      if (!result) {
+        return sendError(
+          reply,
+          404,
+          SESSION_SET_NOT_FOUND_RESPONSE.code,
+          SESSION_SET_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      if ('error' in result && result.error === SESSION_SET_DELETE_NOT_IN_PROGRESS) {
+        return sendError(
+          reply,
+          409,
+          SESSION_SET_NOT_IN_PROGRESS_RESPONSE.code,
+          SESSION_SET_NOT_IN_PROGRESS_RESPONSE.message,
+        );
+      }
+
+      const updatedSession = await findWorkoutSessionById(session.id, request.userId);
+      if (!updatedSession) {
+        return sendError(
+          reply,
+          404,
+          WORKOUT_SESSION_NOT_FOUND_RESPONSE.code,
+          WORKOUT_SESSION_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      return reply.send(
+        buildDataResponse(request, updatedSession, {
+          endpoint: 'workout-session.mutation',
+          action: 'set',
+          session: updatedSession,
+        }),
+      );
     },
   );
 

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -226,7 +226,7 @@ const SESSION_SET_NOT_FOUND_RESPONSE = {
 
 const SESSION_SET_NOT_IN_PROGRESS_RESPONSE = {
   code: SESSION_SET_DELETE_NOT_IN_PROGRESS,
-  message: 'Workout session must be in progress to delete sets',
+  message: 'Use PATCH /workout-sessions/:id/corrections to edit completed sessions.',
 } as const;
 
 const INVALID_SESSION_CORRECTION_SET_RESPONSE = {

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -53,7 +53,10 @@ import {
   unlinkScheduledWorkoutSession,
   linkTodayScheduledWorkoutToSession,
 } from '../scheduled-workouts/store.js';
-import { readSnapshot, type ScheduledWorkoutSnapshot } from '../scheduled-workouts/snapshot-store.js';
+import {
+  readSnapshot,
+  type ScheduledWorkoutSnapshot,
+} from '../scheduled-workouts/snapshot-store.js';
 import { findWorkoutTemplateById } from '../workout-templates/store.js';
 import { templateBelongsToUser } from '../workout-templates/template-access.js';
 import {
@@ -596,7 +599,10 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
       let programmingNotesByExerciseSection: Record<string, string | null> | undefined;
       let agentNotesByExerciseSection: Record<string, string | null> | undefined;
       let agentNotesMetaByExerciseSection:
-        | Record<string, NonNullable<ScheduledWorkoutSnapshot['exercises'][number]['agentNotesMeta']> | null>
+        | Record<
+            string,
+            NonNullable<ScheduledWorkoutSnapshot['exercises'][number]['agentNotesMeta']> | null
+          >
         | undefined;
       let scheduledWorkoutId: string | undefined;
       let linkScheduledWorkoutSession = false;
@@ -1454,17 +1460,27 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
 
           const key = `${exerciseId}:${set.setNumber}`;
           const previous = setMap.get(key);
+          const nextSkipped = set.skipped ?? false;
+          const nextCompleted = set.completed ?? (nextSkipped ? false : true);
 
           if (previous) {
             setMap.set(key, {
               ...previous,
-              weight: set.weight,
-              reps: set.reps,
-              completed: true,
-              skipped: false,
+              weight: set.weight ?? previous.weight,
+              reps: set.reps ?? previous.reps,
+              completed: nextCompleted,
+              skipped: nextSkipped,
+              notes: set.notes ?? previous.notes,
+              supersetGroup: set.supersetGroup ?? previous.supersetGroup,
+              section: set.section ?? previous.section,
             });
             continue;
           }
+
+          const siblingSection =
+            Array.from(setMap.values()).find(
+              (candidate) => candidate.exerciseId === exerciseId && candidate.section !== null,
+            )?.section ?? null;
 
           setMap.set(key, {
             exerciseId,
@@ -1472,11 +1488,11 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
             setNumber: set.setNumber,
             weight: set.weight,
             reps: set.reps,
-            completed: true,
-            skipped: false,
-            supersetGroup: null,
-            section: 'main',
-            notes: null,
+            completed: nextCompleted,
+            skipped: nextSkipped,
+            supersetGroup: set.supersetGroup ?? null,
+            section: set.section ?? siblingSection ?? 'main',
+            notes: set.notes ?? null,
           });
         }
 

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -1446,9 +1446,14 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
           merged.sets.map((set) => [`${set.exerciseId}:${set.setNumber}`, { ...set }]),
         );
         const exerciseOrder = new Map<string, number>();
+        const siblingSectionByExerciseId = new Map<string, SessionSetInput['section']>();
         for (const set of merged.sets) {
           if (!exerciseOrder.has(set.exerciseId)) {
             exerciseOrder.set(set.exerciseId, exerciseOrder.size);
+          }
+
+          if (set.section !== null && !siblingSectionByExerciseId.has(set.exerciseId)) {
+            siblingSectionByExerciseId.set(set.exerciseId, set.section);
           }
         }
 
@@ -1460,10 +1465,26 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
 
           const key = `${exerciseId}:${set.setNumber}`;
           const previous = setMap.get(key);
-          const nextSkipped = set.skipped ?? false;
-          const nextCompleted = set.completed ?? (nextSkipped ? false : true);
+          const hasLoggedFields = set.weight !== null || set.reps !== null;
+          const shouldPreserveCompletionState =
+            previous !== undefined &&
+            set.completed === undefined &&
+            set.skipped === undefined &&
+            !hasLoggedFields;
+
+          const nextSkipped = shouldPreserveCompletionState
+            ? previous.skipped
+            : (set.skipped ?? false);
+          const nextCompleted = shouldPreserveCompletionState
+            ? previous.completed
+            : (set.completed ?? (nextSkipped ? false : true));
 
           if (previous) {
+            const nextSection = set.section ?? previous.section;
+            if (nextSection !== null) {
+              siblingSectionByExerciseId.set(exerciseId, nextSection);
+            }
+
             setMap.set(key, {
               ...previous,
               weight: set.weight ?? previous.weight,
@@ -1472,15 +1493,16 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
               skipped: nextSkipped,
               notes: set.notes ?? previous.notes,
               supersetGroup: set.supersetGroup ?? previous.supersetGroup,
-              section: set.section ?? previous.section,
+              section: nextSection,
             });
             continue;
           }
 
-          const siblingSection =
-            Array.from(setMap.values()).find(
-              (candidate) => candidate.exerciseId === exerciseId && candidate.section !== null,
-            )?.section ?? null;
+          const siblingSection = siblingSectionByExerciseId.get(exerciseId) ?? null;
+          const nextSection = set.section ?? siblingSection ?? 'main';
+          if (nextSection !== null) {
+            siblingSectionByExerciseId.set(exerciseId, nextSection);
+          }
 
           setMap.set(key, {
             exerciseId,
@@ -1491,7 +1513,7 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
             completed: nextCompleted,
             skipped: nextSkipped,
             supersetGroup: set.supersetGroup ?? null,
-            section: set.section ?? siblingSection ?? 'main',
+            section: nextSection,
             notes: set.notes ?? null,
           });
         }

--- a/apps/api/src/routes/workout-sessions/store.test.ts
+++ b/apps/api/src/routes/workout-sessions/store.test.ts
@@ -1,0 +1,383 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { and, eq } from 'drizzle-orm';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { exercises, sessionSets, users, workoutSessions } from '../../db/schema/index.js';
+
+type DatabaseModule = typeof import('../../db/index.js');
+type StoreModule = typeof import('./store.js');
+
+type TestContext = {
+  db: DatabaseModule['db'];
+  sqlite: DatabaseModule['sqlite'];
+  tempDir: string;
+  store: StoreModule;
+};
+
+let context: TestContext;
+
+const seedUser = (values: { id: string; username: string }) =>
+  context.db
+    .insert(users)
+    .values({
+      id: values.id,
+      username: values.username,
+      name: values.username,
+      passwordHash: 'not-used-in-this-suite',
+    })
+    .run();
+
+const seedExercise = (values: { id: string; name: string; userId?: string | null }) =>
+  context.db
+    .insert(exercises)
+    .values({
+      id: values.id,
+      userId: values.userId ?? null,
+      name: values.name,
+      trackingType: 'weight_reps',
+      muscleGroups: ['chest'],
+      equipment: 'barbell',
+      category: 'compound',
+      formCues: [],
+      coachingNotes: null,
+      instructions: null,
+    })
+    .run();
+
+const seedWorkoutSession = (values: {
+  id: string;
+  userId: string;
+  status: 'scheduled' | 'in-progress' | 'paused' | 'cancelled' | 'completed';
+}) =>
+  context.db
+    .insert(workoutSessions)
+    .values({
+      id: values.id,
+      userId: values.userId,
+      templateId: null,
+      scheduledWorkoutId: null,
+      name: `Session ${values.id}`,
+      date: '2026-03-12',
+      status: values.status,
+      startedAt: Date.now() - 60_000,
+      completedAt: values.status === 'completed' ? Date.now() : null,
+      duration: null,
+      timeSegments: '[]',
+      feedback: null,
+      exerciseProgrammingNotes: null,
+      exerciseAgentNotes: null,
+      exerciseAgentNotesMeta: null,
+      notes: null,
+    })
+    .run();
+
+const seedSessionSet = (values: {
+  id: string;
+  sessionId: string;
+  exerciseId: string;
+  section?: 'warmup' | 'main' | 'cooldown' | 'supplemental';
+  setNumber: number;
+}) =>
+  context.db
+    .insert(sessionSets)
+    .values({
+      id: values.id,
+      sessionId: values.sessionId,
+      exerciseId: values.exerciseId,
+      orderIndex: 0,
+      setNumber: values.setNumber,
+      weight: null,
+      reps: null,
+      targetWeight: null,
+      targetWeightMin: null,
+      targetWeightMax: null,
+      targetSeconds: null,
+      targetDistance: null,
+      completed: false,
+      skipped: false,
+      supersetGroup: null,
+      section: values.section ?? 'main',
+      notes: null,
+    })
+    .run();
+
+describe('workout session store deleteSessionSet', () => {
+  beforeAll(async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'pulse-workout-session-store-'));
+
+    process.env.DATABASE_URL = join(tempDir, 'test.db');
+    vi.resetModules();
+
+    const dbModule = await import('../../db/index.js');
+    migrate(dbModule.db, {
+      migrationsFolder: fileURLToPath(new URL('../../../drizzle', import.meta.url)),
+    });
+
+    const store = await import('./store.js');
+
+    context = {
+      db: dbModule.db,
+      sqlite: dbModule.sqlite,
+      tempDir,
+      store,
+    };
+  });
+
+  afterAll(() => {
+    if (context) {
+      context.sqlite.close();
+      rmSync(context.tempDir, { recursive: true, force: true });
+    }
+
+    delete process.env.DATABASE_URL;
+    vi.resetModules();
+  });
+
+  beforeEach(() => {
+    context.db.delete(sessionSets).run();
+    context.db.delete(workoutSessions).run();
+    context.db.delete(exercises).run();
+    context.db.delete(users).run();
+
+    seedUser({ id: 'user-1', username: 'derek' });
+    seedUser({ id: 'user-2', username: 'alex' });
+
+    seedExercise({ id: 'global-bench-press', name: 'Bench Press' });
+    seedExercise({ id: 'global-row', name: 'Row' });
+  });
+
+  it('deletes a middle set and renumbers remaining sets contiguously within the same exercise section', async () => {
+    seedWorkoutSession({ id: 'session-middle-delete', userId: 'user-1', status: 'in-progress' });
+    seedSessionSet({
+      id: 'session-middle-delete-main-1',
+      sessionId: 'session-middle-delete',
+      exerciseId: 'global-bench-press',
+      section: 'main',
+      setNumber: 1,
+    });
+    seedSessionSet({
+      id: 'session-middle-delete-main-2',
+      sessionId: 'session-middle-delete',
+      exerciseId: 'global-bench-press',
+      section: 'main',
+      setNumber: 2,
+    });
+    seedSessionSet({
+      id: 'session-middle-delete-main-3',
+      sessionId: 'session-middle-delete',
+      exerciseId: 'global-bench-press',
+      section: 'main',
+      setNumber: 3,
+    });
+    seedSessionSet({
+      id: 'session-middle-delete-warmup-1',
+      sessionId: 'session-middle-delete',
+      exerciseId: 'global-bench-press',
+      section: 'warmup',
+      setNumber: 1,
+    });
+    seedSessionSet({
+      id: 'session-middle-delete-other-exercise-1',
+      sessionId: 'session-middle-delete',
+      exerciseId: 'global-row',
+      section: 'main',
+      setNumber: 1,
+    });
+
+    const result = await context.store.deleteSessionSet({
+      sessionId: 'session-middle-delete',
+      setId: 'session-middle-delete-main-2',
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({ id: 'session-middle-delete-main-1', setNumber: 1, section: 'main' }),
+      expect.objectContaining({ id: 'session-middle-delete-main-3', setNumber: 2, section: 'main' }),
+    ]);
+
+    const persistedSets = context.db
+      .select({
+        id: sessionSets.id,
+        exerciseId: sessionSets.exerciseId,
+        section: sessionSets.section,
+        setNumber: sessionSets.setNumber,
+      })
+      .from(sessionSets)
+      .where(eq(sessionSets.sessionId, 'session-middle-delete'))
+      .all();
+
+    expect(persistedSets).toEqual(
+      expect.arrayContaining([
+        {
+          id: 'session-middle-delete-main-1',
+          exerciseId: 'global-bench-press',
+          section: 'main',
+          setNumber: 1,
+        },
+        {
+          id: 'session-middle-delete-main-3',
+          exerciseId: 'global-bench-press',
+          section: 'main',
+          setNumber: 2,
+        },
+        {
+          id: 'session-middle-delete-warmup-1',
+          exerciseId: 'global-bench-press',
+          section: 'warmup',
+          setNumber: 1,
+        },
+        {
+          id: 'session-middle-delete-other-exercise-1',
+          exerciseId: 'global-row',
+          section: 'main',
+          setNumber: 1,
+        },
+      ]),
+    );
+    expect(persistedSets).toHaveLength(4);
+  });
+
+  it('deletes the last set without changing existing contiguous numbering', async () => {
+    seedWorkoutSession({ id: 'session-last-delete', userId: 'user-1', status: 'in-progress' });
+    seedSessionSet({
+      id: 'session-last-delete-1',
+      sessionId: 'session-last-delete',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+    });
+    seedSessionSet({
+      id: 'session-last-delete-2',
+      sessionId: 'session-last-delete',
+      exerciseId: 'global-bench-press',
+      setNumber: 2,
+    });
+    seedSessionSet({
+      id: 'session-last-delete-3',
+      sessionId: 'session-last-delete',
+      exerciseId: 'global-bench-press',
+      setNumber: 3,
+    });
+
+    const result = await context.store.deleteSessionSet({
+      sessionId: 'session-last-delete',
+      setId: 'session-last-delete-3',
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({ id: 'session-last-delete-1', setNumber: 1 }),
+      expect.objectContaining({ id: 'session-last-delete-2', setNumber: 2 }),
+    ]);
+
+    const remainingSetNumbers = context.db
+      .select({ setNumber: sessionSets.setNumber })
+      .from(sessionSets)
+      .where(
+        and(
+          eq(sessionSets.sessionId, 'session-last-delete'),
+          eq(sessionSets.exerciseId, 'global-bench-press'),
+          eq(sessionSets.section, 'main'),
+        ),
+      )
+      .all()
+      .map((set) => set.setNumber)
+      .sort((left, right) => left - right);
+
+    expect(remainingSetNumbers).toEqual([1, 2]);
+  });
+
+  it('deletes the only set and leaves the exercise with zero sets', async () => {
+    seedWorkoutSession({ id: 'session-only-delete', userId: 'user-1', status: 'in-progress' });
+    seedSessionSet({
+      id: 'session-only-delete-1',
+      sessionId: 'session-only-delete',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+    });
+
+    const result = await context.store.deleteSessionSet({
+      sessionId: 'session-only-delete',
+      setId: 'session-only-delete-1',
+    });
+
+    expect(result).toEqual([]);
+
+    const remainingSets = context.db
+      .select({ id: sessionSets.id })
+      .from(sessionSets)
+      .where(eq(sessionSets.sessionId, 'session-only-delete'))
+      .all();
+    expect(remainingSets).toEqual([]);
+  });
+
+  it('returns session-not-in-progress for completed sessions without mutating sets', async () => {
+    seedWorkoutSession({ id: 'session-completed-delete', userId: 'user-1', status: 'completed' });
+    seedSessionSet({
+      id: 'session-completed-delete-1',
+      sessionId: 'session-completed-delete',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+    });
+    seedSessionSet({
+      id: 'session-completed-delete-2',
+      sessionId: 'session-completed-delete',
+      exerciseId: 'global-bench-press',
+      setNumber: 2,
+    });
+
+    const beforeSnapshot = context.db
+      .select({ id: sessionSets.id, setNumber: sessionSets.setNumber })
+      .from(sessionSets)
+      .where(eq(sessionSets.sessionId, 'session-completed-delete'))
+      .all();
+
+    const result = await context.store.deleteSessionSet({
+      sessionId: 'session-completed-delete',
+      setId: 'session-completed-delete-1',
+    });
+
+    expect(result).toEqual({
+      error: context.store.SESSION_SET_DELETE_NOT_IN_PROGRESS,
+    });
+
+    const afterSnapshot = context.db
+      .select({ id: sessionSets.id, setNumber: sessionSets.setNumber })
+      .from(sessionSets)
+      .where(eq(sessionSets.sessionId, 'session-completed-delete'))
+      .all();
+
+    expect(afterSnapshot).toEqual(beforeSnapshot);
+  });
+
+  it('returns undefined when setId does not belong to the provided session', async () => {
+    seedWorkoutSession({ id: 'session-scope-a', userId: 'user-1', status: 'in-progress' });
+    seedWorkoutSession({ id: 'session-scope-b', userId: 'user-1', status: 'in-progress' });
+    seedSessionSet({
+      id: 'session-scope-b-set-1',
+      sessionId: 'session-scope-b',
+      exerciseId: 'global-bench-press',
+      setNumber: 1,
+    });
+
+    const result = await context.store.deleteSessionSet({
+      sessionId: 'session-scope-a',
+      setId: 'session-scope-b-set-1',
+    });
+
+    expect(result).toBeUndefined();
+
+    const persistedSet = context.db
+      .select({ id: sessionSets.id, sessionId: sessionSets.sessionId })
+      .from(sessionSets)
+      .where(eq(sessionSets.id, 'session-scope-b-set-1'))
+      .get();
+
+    expect(persistedSet).toEqual({
+      id: 'session-scope-b-set-1',
+      sessionId: 'session-scope-b',
+    });
+  });
+});

--- a/apps/api/src/routes/workout-sessions/store.test.ts
+++ b/apps/api/src/routes/workout-sessions/store.test.ts
@@ -79,7 +79,7 @@ const seedWorkoutSession = (values: {
 const seedSessionSet = (values: {
   id: string;
   sessionId: string;
-  exerciseId: string;
+  exerciseId: string | null;
   section?: 'warmup' | 'main' | 'cooldown' | 'supplemental';
   setNumber: number;
 }) =>
@@ -195,8 +195,16 @@ describe('workout session store deleteSessionSet', () => {
     });
 
     expect(result).toEqual([
-      expect.objectContaining({ id: 'session-middle-delete-main-1', setNumber: 1, section: 'main' }),
-      expect.objectContaining({ id: 'session-middle-delete-main-3', setNumber: 2, section: 'main' }),
+      expect.objectContaining({
+        id: 'session-middle-delete-main-1',
+        setNumber: 1,
+        section: 'main',
+      }),
+      expect.objectContaining({
+        id: 'session-middle-delete-main-3',
+        setNumber: 2,
+        section: 'main',
+      }),
     ]);
 
     const persistedSets = context.db
@@ -379,5 +387,62 @@ describe('workout session store deleteSessionSet', () => {
       id: 'session-scope-b-set-1',
       sessionId: 'session-scope-b',
     });
+  });
+
+  it('renumbers null-exercise rows using IS NULL scope without touching named exercises', async () => {
+    seedWorkoutSession({ id: 'session-null-exercise', userId: 'user-1', status: 'in-progress' });
+    seedSessionSet({
+      id: 'session-null-exercise-null-1',
+      sessionId: 'session-null-exercise',
+      exerciseId: null,
+      setNumber: 1,
+    });
+    seedSessionSet({
+      id: 'session-null-exercise-null-2',
+      sessionId: 'session-null-exercise',
+      exerciseId: null,
+      setNumber: 2,
+    });
+    seedSessionSet({
+      id: 'session-null-exercise-main-1',
+      sessionId: 'session-null-exercise',
+      exerciseId: 'global-row',
+      setNumber: 1,
+    });
+
+    const result = await context.store.deleteSessionSet({
+      sessionId: 'session-null-exercise',
+      setId: 'session-null-exercise-null-1',
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({ id: 'session-null-exercise-null-2', setNumber: 1 }),
+    ]);
+
+    const persistedSets = context.db
+      .select({
+        id: sessionSets.id,
+        exerciseId: sessionSets.exerciseId,
+        setNumber: sessionSets.setNumber,
+      })
+      .from(sessionSets)
+      .where(eq(sessionSets.sessionId, 'session-null-exercise'))
+      .all();
+
+    expect(persistedSets).toEqual(
+      expect.arrayContaining([
+        {
+          id: 'session-null-exercise-null-2',
+          exerciseId: null,
+          setNumber: 1,
+        },
+        {
+          id: 'session-null-exercise-main-1',
+          exerciseId: 'global-row',
+          setNumber: 1,
+        },
+      ]),
+    );
+    expect(persistedSets).toHaveLength(2);
   });
 });

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -396,25 +396,37 @@ const buildWorkoutSessionExercises = (
 };
 
 const buildSessionSetRows = (sessionId: string, sets: CreateWorkoutSessionInput['sets']) =>
-  sets.map((set) => ({
-    id: randomUUID(),
-    sessionId,
-    exerciseId: set.exerciseId,
-    orderIndex: set.orderIndex,
-    setNumber: set.setNumber,
-    weight: set.weight,
-    reps: set.reps,
-    targetWeight: set.targetWeight,
-    targetWeightMin: set.targetWeightMin,
-    targetWeightMax: set.targetWeightMax,
-    targetSeconds: set.targetSeconds,
-    targetDistance: set.targetDistance,
-    supersetGroup: set.supersetGroup,
-    completed: set.completed,
-    skipped: set.skipped,
-    section: set.section ?? 'main',
-    notes: set.notes,
-  }));
+  sets.map((set) => {
+    const setWithTargets = set as typeof set & {
+      targetWeight?: number | null;
+      targetWeightMin?: number | null;
+      targetWeightMax?: number | null;
+      targetSeconds?: number | null;
+      targetDistance?: number | null;
+    };
+
+    return {
+      id: randomUUID(),
+      sessionId,
+      exerciseId: set.exerciseId,
+      orderIndex: set.orderIndex,
+      setNumber: set.setNumber,
+      weight: set.weight,
+      reps: set.reps,
+      // Scheduled-workout snapshot seeding still passes target fields through the
+      // create path even though public session set input does not accept them.
+      targetWeight: setWithTargets.targetWeight ?? null,
+      targetWeightMin: setWithTargets.targetWeightMin ?? null,
+      targetWeightMax: setWithTargets.targetWeightMax ?? null,
+      targetSeconds: setWithTargets.targetSeconds ?? null,
+      targetDistance: setWithTargets.targetDistance ?? null,
+      supersetGroup: set.supersetGroup,
+      completed: set.completed ?? false,
+      skipped: set.skipped ?? false,
+      section: set.section ?? 'main',
+      notes: set.notes,
+    };
+  });
 
 export const findInvalidSessionExerciseIds = async ({
   userId,

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -83,6 +83,14 @@ type SessionSetRecord = {
   createdAt: number;
 };
 
+type SessionSetRowInput = CreateWorkoutSessionInput['sets'][number] & {
+  targetWeight?: number | null;
+  targetWeightMin?: number | null;
+  targetWeightMax?: number | null;
+  targetSeconds?: number | null;
+  targetDistance?: number | null;
+};
+
 export type SessionSetGroup = {
   exerciseId: string | null;
   sets: SessionSet[];
@@ -395,16 +403,8 @@ const buildWorkoutSessionExercises = (
     }));
 };
 
-const buildSessionSetRows = (sessionId: string, sets: CreateWorkoutSessionInput['sets']) =>
+const buildSessionSetRows = (sessionId: string, sets: readonly SessionSetRowInput[]) =>
   sets.map((set) => {
-    const setWithTargets = set as typeof set & {
-      targetWeight?: number | null;
-      targetWeightMin?: number | null;
-      targetWeightMax?: number | null;
-      targetSeconds?: number | null;
-      targetDistance?: number | null;
-    };
-
     return {
       id: randomUUID(),
       sessionId,
@@ -413,13 +413,11 @@ const buildSessionSetRows = (sessionId: string, sets: CreateWorkoutSessionInput[
       setNumber: set.setNumber,
       weight: set.weight,
       reps: set.reps,
-      // Scheduled-workout snapshot seeding still passes target fields through the
-      // create path even though public session set input does not accept them.
-      targetWeight: setWithTargets.targetWeight ?? null,
-      targetWeightMin: setWithTargets.targetWeightMin ?? null,
-      targetWeightMax: setWithTargets.targetWeightMax ?? null,
-      targetSeconds: setWithTargets.targetSeconds ?? null,
-      targetDistance: setWithTargets.targetDistance ?? null,
+      targetWeight: set.targetWeight ?? null,
+      targetWeightMin: set.targetWeightMin ?? null,
+      targetWeightMax: set.targetWeightMax ?? null,
+      targetSeconds: set.targetSeconds ?? null,
+      targetDistance: set.targetDistance ?? null,
       supersetGroup: set.supersetGroup,
       completed: set.completed ?? false,
       skipped: set.skipped ?? false,
@@ -498,6 +496,12 @@ export class InvalidSessionCorrectionSetError extends Error {
     this.setId = setId;
   }
 }
+
+export const SESSION_SET_DELETE_NOT_IN_PROGRESS = 'session-not-in-progress' as const;
+
+export type SessionSetDeleteStatusError = {
+  error: typeof SESSION_SET_DELETE_NOT_IN_PROGRESS;
+};
 
 export const findWorkoutSessionAccess = async (
   id: string,
@@ -626,6 +630,136 @@ export const updateSessionSet = async ({
   }
 
   return buildSessionSet(updatedSet);
+};
+
+const buildSessionSetExerciseScope = (exerciseId: string | null) =>
+  exerciseId === null ? isNull(sessionSets.exerciseId) : eq(sessionSets.exerciseId, exerciseId);
+
+const buildSessionSetSectionScope = (section: WorkoutTemplateSectionType | null) =>
+  section === null ? isNull(sessionSets.section) : eq(sessionSets.section, section);
+
+export const deleteSessionSet = async ({
+  sessionId,
+  setId,
+}: {
+  sessionId: string;
+  setId: string;
+}): Promise<SessionSet[] | SessionSetDeleteStatusError | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  return db.transaction((tx) => {
+    const targetSet = tx
+      .select(sessionSetSelection)
+      .from(sessionSets)
+      .where(and(eq(sessionSets.id, setId), eq(sessionSets.sessionId, sessionId)))
+      .limit(1)
+      .get();
+
+    if (!targetSet) {
+      return undefined;
+    }
+
+    const parentSession = tx
+      .select(workoutSessionAccessSelection)
+      .from(workoutSessions)
+      .where(and(eq(workoutSessions.id, sessionId), isNull(workoutSessions.deletedAt)))
+      .limit(1)
+      .get();
+
+    if (!parentSession) {
+      return undefined;
+    }
+
+    if (parentSession.status === 'completed' || parentSession.status === 'cancelled') {
+      return {
+        error: SESSION_SET_DELETE_NOT_IN_PROGRESS,
+      };
+    }
+
+    const deleteResult = tx
+      .delete(sessionSets)
+      .where(and(eq(sessionSets.id, setId), eq(sessionSets.sessionId, sessionId)))
+      .run();
+
+    if (deleteResult.changes !== 1) {
+      return undefined;
+    }
+
+    const matchingExerciseSets = tx
+      .select(sessionSetSelection)
+      .from(sessionSets)
+      .where(
+        and(
+          eq(sessionSets.sessionId, sessionId),
+          buildSessionSetExerciseScope(targetSet.exerciseId),
+          buildSessionSetSectionScope(targetSet.section),
+        ),
+      )
+      .all()
+      .sort((left, right) => {
+        if (left.setNumber !== right.setNumber) {
+          return left.setNumber - right.setNumber;
+        }
+
+        return left.createdAt - right.createdAt;
+      });
+
+    const renumberUpdates = matchingExerciseSets
+      .map((set, index) => ({
+        id: set.id,
+        currentSetNumber: set.setNumber,
+        nextSetNumber: index + 1,
+      }))
+      .filter((set) => set.currentSetNumber !== set.nextSetNumber);
+
+    if (renumberUpdates.length > 0) {
+      const maxPersistedSetNumber = matchingExerciseSets.reduce(
+        (maxValue, set) => Math.max(maxValue, set.setNumber),
+        0,
+      );
+      const tempOffset = maxPersistedSetNumber + matchingExerciseSets.length + 1_000;
+
+      for (const update of renumberUpdates) {
+        tx.update(sessionSets)
+          .set({ setNumber: update.nextSetNumber + tempOffset })
+          .where(and(eq(sessionSets.id, update.id), eq(sessionSets.sessionId, sessionId)))
+          .run();
+      }
+
+      for (const update of renumberUpdates) {
+        tx.update(sessionSets)
+          .set({ setNumber: update.nextSetNumber })
+          .where(and(eq(sessionSets.id, update.id), eq(sessionSets.sessionId, sessionId)))
+          .run();
+      }
+    }
+
+    tx.update(workoutSessions)
+      .set({ updatedAt: Date.now() })
+      .where(and(eq(workoutSessions.id, sessionId), isNull(workoutSessions.deletedAt)))
+      .run();
+
+    const updatedSets = tx
+      .select(sessionSetSelection)
+      .from(sessionSets)
+      .where(
+        and(
+          eq(sessionSets.sessionId, sessionId),
+          buildSessionSetExerciseScope(targetSet.exerciseId),
+          buildSessionSetSectionScope(targetSet.section),
+        ),
+      )
+      .all()
+      .sort((left, right) => {
+        if (left.setNumber !== right.setNumber) {
+          return left.setNumber - right.setNumber;
+        }
+
+        return left.createdAt - right.createdAt;
+      });
+
+    return updatedSets.map(buildSessionSet);
+  });
 };
 
 export const listSessionSetGroups = async (sessionId: string): Promise<SessionSetGroup[]> => {

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -52,7 +52,10 @@ import { z } from 'zod';
 
 import { ApiError, apiRequest, apiRequestWithMeta } from '@/lib/api-client';
 import { createOptimisticMutation } from '@/lib/optimistic';
-import { syncSessionMutationCache } from '@/features/workouts/lib/session-query-cache';
+import {
+  syncSessionMutationCache,
+  workoutSessionQueryKeys,
+} from '@/features/workouts/lib/session-query-cache';
 import { crossFeatureInvalidationMap, invalidateQueryKeys } from '@/lib/query-invalidation';
 
 const paginationMetaSchema = z.object({
@@ -110,6 +113,10 @@ type SwapSessionExerciseRequest = {
   sessionId: string;
   exerciseId: string;
   newExerciseId: string;
+};
+type DeleteSessionSetRequest = {
+  sessionId: string;
+  setId: string;
 };
 type CorrectSessionSetsRequest = {
   sessionId: string;
@@ -834,6 +841,18 @@ async function swapSessionExercise(input: SwapSessionExerciseRequest) {
   return parsedPayload;
 }
 
+async function deleteSessionSet(input: DeleteSessionSetRequest) {
+  const data = await apiRequest<unknown>(
+    `/api/v1/workout-sessions/${input.sessionId}/sets/${input.setId}`,
+    {
+      method: 'DELETE',
+    },
+  );
+  const payload = workoutSessionResponseSchema.parse({ data });
+
+  return payload.data;
+}
+
 async function correctSessionSets(input: CorrectSessionSetsRequest) {
   const parsedInput = sessionCorrectionRequestSchema.parse({
     corrections: input.corrections,
@@ -1326,6 +1345,148 @@ export function useSwapSessionExercise() {
         }),
       ]);
       toast.success('Exercise swapped');
+    },
+  });
+}
+
+const sortSessionSetsForRenumber = (
+  left: WorkoutSession['sets'][number],
+  right: WorkoutSession['sets'][number],
+) =>
+  (left.orderIndex ?? 0) - (right.orderIndex ?? 0) ||
+  left.setNumber - right.setNumber ||
+  left.createdAt - right.createdAt ||
+  left.id.localeCompare(right.id);
+
+function applyOptimisticSessionSetDelete(session: WorkoutSession, setId: string) {
+  const removedSet = session.sets.find((set) => set.id === setId);
+
+  if (!removedSet || !removedSet.exerciseId) {
+    return session;
+  }
+
+  const nextSessionSets = session.sets.filter((set) => set.id !== setId);
+  const scopedSets = nextSessionSets
+    .filter((set) => set.exerciseId === removedSet.exerciseId)
+    .sort(sortSessionSetsForRenumber);
+  const nextSetNumberById = new Map<string, number>();
+  const scopedSetGroups = new Map<string, WorkoutSession['sets'][number][]>();
+
+  for (const scopedSet of scopedSets) {
+    const section = scopedSet.section ?? 'main';
+    const sectionSets = scopedSetGroups.get(section) ?? [];
+    sectionSets.push(scopedSet);
+    scopedSetGroups.set(section, sectionSets);
+  }
+
+  for (const sectionSets of scopedSetGroups.values()) {
+    sectionSets.forEach((set, index) => {
+      nextSetNumberById.set(set.id, index + 1);
+    });
+  }
+
+  return {
+    ...session,
+    exercises: session.exercises?.map((exercise) => {
+      if (exercise.exerciseId !== removedSet.exerciseId) {
+        return exercise;
+      }
+
+      return {
+        ...exercise,
+        sets: exercise.sets
+          .filter((set) => set.id !== setId)
+          .map((set) => {
+            const nextSetNumber = nextSetNumberById.get(set.id);
+
+            if (nextSetNumber === undefined) {
+              return set;
+            }
+
+            return {
+              ...set,
+              setNumber: nextSetNumber,
+            };
+          }),
+      };
+    }),
+    sets: nextSessionSets.map((set) => {
+      const nextSetNumber = nextSetNumberById.get(set.id);
+
+      if (nextSetNumber === undefined) {
+        return set;
+      }
+
+      return {
+        ...set,
+        setNumber: nextSetNumber,
+      };
+    }),
+  };
+}
+
+export function useDeleteSessionSet() {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    WorkoutSession,
+    Error,
+    DeleteSessionSetRequest,
+    {
+      previousCanonicalSession: WorkoutSession | undefined;
+      previousDetailSession: WorkoutSession | undefined;
+    }
+  >({
+    mutationFn: deleteSessionSet,
+    onMutate: async (variables) => {
+      const detailQueryKey = workoutSessionQueryKeys.detail(variables.sessionId);
+      const canonicalQueryKey = workoutQueryKeys.session(variables.sessionId);
+
+      await Promise.all([
+        queryClient.cancelQueries({
+          queryKey: detailQueryKey,
+        }),
+        queryClient.cancelQueries({
+          queryKey: canonicalQueryKey,
+        }),
+      ]);
+
+      const previousDetailSession = queryClient.getQueryData<WorkoutSession>(detailQueryKey);
+      const previousCanonicalSession = queryClient.getQueryData<WorkoutSession>(canonicalQueryKey);
+      const sessionSnapshot = previousDetailSession ?? previousCanonicalSession;
+
+      if (sessionSnapshot) {
+        const optimisticSession = applyOptimisticSessionSetDelete(sessionSnapshot, variables.setId);
+        queryClient.setQueryData(detailQueryKey, optimisticSession);
+        queryClient.setQueryData(canonicalQueryKey, optimisticSession);
+      }
+
+      return {
+        previousCanonicalSession,
+        previousDetailSession,
+      };
+    },
+    onError: (_error, variables, context) => {
+      queryClient.setQueryData(
+        workoutSessionQueryKeys.detail(variables.sessionId),
+        context?.previousDetailSession,
+      );
+      queryClient.setQueryData(
+        workoutQueryKeys.session(variables.sessionId),
+        context?.previousCanonicalSession,
+      );
+      toast.error('Unable to remove set. Try again.');
+    },
+    onSuccess: async (session) => {
+      queryClient.setQueryData(workoutSessionQueryKeys.detail(session.id), session);
+      queryClient.setQueryData(workoutQueryKeys.session(session.id), session);
+
+      await Promise.all([
+        syncSessionMutationCache(queryClient, session, { invalidateDashboard: true }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.sessionDetailPrefix(),
+        }),
+      ]);
     },
   });
 }

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -1475,18 +1475,12 @@ export function useDeleteSessionSet() {
         workoutQueryKeys.session(variables.sessionId),
         context?.previousCanonicalSession,
       );
-      toast.error('Unable to remove set. Try again.');
     },
     onSuccess: async (session) => {
       queryClient.setQueryData(workoutSessionQueryKeys.detail(session.id), session);
       queryClient.setQueryData(workoutQueryKeys.session(session.id), session);
 
-      await Promise.all([
-        syncSessionMutationCache(queryClient, session, { invalidateDashboard: true }),
-        queryClient.invalidateQueries({
-          queryKey: workoutQueryKeys.sessionDetailPrefix(),
-        }),
-      ]);
+      await syncSessionMutationCache(queryClient, session, { invalidateDashboard: true });
     },
   });
 }

--- a/apps/web/src/features/workouts/lib/session-notes.ts
+++ b/apps/web/src/features/workouts/lib/session-notes.ts
@@ -74,11 +74,6 @@ export function buildSessionSetInputs(
         setNumber: draftSet.number,
         skipped: false,
         supersetGroup: templateExercise?.exercise.supersetGroup ?? null,
-        targetWeight: draftSet.targetWeight,
-        targetWeightMin: draftSet.targetWeightMin,
-        targetWeightMax: draftSet.targetWeightMax,
-        targetSeconds: draftSet.targetSeconds,
-        targetDistance: draftSet.targetDistance,
         weight: isWeightedTrackingType(trackingType) ? draftSet.weight : null,
       });
     }

--- a/apps/web/src/pages/active-workout.remove-set.test.tsx
+++ b/apps/web/src/pages/active-workout.remove-set.test.tsx
@@ -1,0 +1,727 @@
+import type { MouseEvent, ReactNode } from 'react';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast } from 'sonner';
+
+import { workoutQueryKeys } from '@/features/workouts/api/workouts';
+import {
+  ACTIVE_WORKOUT_SESSION_STORAGE_KEY,
+  WORKOUT_EXERCISES_STORAGE_PREFIX,
+  WORKOUT_SECTIONS_STORAGE_PREFIX,
+  getStoredActiveWorkoutDraft,
+} from '@/features/workouts/lib/session-persistence';
+import { workoutSessionQueryKeys } from '@/hooks/use-workout-session';
+import { createAppQueryClient } from '@/lib/query-client';
+import { jsonResponse } from '@/test/test-utils';
+import { renderWithQueryClient } from '@/test/render-with-query-client';
+import { getMockTemplate } from '@/test/fixtures/workouts';
+
+import { ActiveWorkoutPage } from './active-workout';
+
+vi.mock('sonner', () => {
+  const toastMock = vi.fn() as ReturnType<typeof vi.fn> & {
+    success: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+  toastMock.success = vi.fn();
+  toastMock.error = vi.fn();
+
+  return {
+    toast: toastMock,
+  };
+});
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    disabled,
+    onClick,
+  }: {
+    children: ReactNode;
+    disabled?: boolean;
+    onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+  }) => (
+    <button disabled={disabled} onClick={onClick} type="button">
+      {children}
+    </button>
+  ),
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+describe('ActiveWorkoutPage remove-set flow', () => {
+  beforeEach(() => {
+    vi.mocked(toast).mockClear();
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.error).mockClear();
+    vi.useRealTimers();
+    vi.setSystemTime(new Date('2026-03-06T12:00:00.000Z'));
+    vi.stubEnv('VITE_PULSE_DEV_USERNAME', 'dev-user');
+    vi.stubEnv('VITE_PULSE_DEV_PASSWORD', 'dev-pass');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    window.localStorage.removeItem(ACTIVE_WORKOUT_SESSION_STORAGE_KEY);
+    const cleanupPrefixes = [
+      'pulse.active-workout-draft:',
+      `${WORKOUT_SECTIONS_STORAGE_PREFIX}:`,
+      `${WORKOUT_EXERCISES_STORAGE_PREFIX}:`,
+    ];
+    const keysToRemove: string[] = [];
+    for (let index = 0; index < window.localStorage.length; index += 1) {
+      const key = window.localStorage.key(index);
+      if (key && cleanupPrefixes.some((prefix) => key.startsWith(prefix))) {
+        keysToRemove.push(key);
+      }
+    }
+    for (const key of keysToRemove) {
+      window.localStorage.removeItem(key);
+    }
+  });
+
+  it('calls delete with session/set ids, removes optimistically, and stays removed after refetch', async () => {
+    const sessionId = 'session-delete-set-success';
+    const startedAt = Date.parse('2026-03-06T12:00:00.000Z');
+    const deleteDeferred = createDeferredPromise<Response>();
+    let currentSession: MutableInProgressSessionResponse = {
+      ...buildInProgressSessionResponse(sessionId),
+      exercises: [
+        {
+          exerciseId: 'incline-dumbbell-press',
+          exerciseName: 'Incline Dumbbell Press',
+          orderIndex: 0,
+          section: 'main',
+          sets: [
+            buildSessionSet({
+              createdAt: startedAt,
+              exerciseId: 'incline-dumbbell-press',
+              id: 'set-main-1',
+              orderIndex: 0,
+              section: 'main',
+              setNumber: 1,
+            }),
+            buildSessionSet({
+              createdAt: startedAt + 1,
+              exerciseId: 'incline-dumbbell-press',
+              id: 'set-main-2',
+              orderIndex: 0,
+              section: 'main',
+              setNumber: 2,
+            }),
+            buildSessionSet({
+              createdAt: startedAt + 2,
+              exerciseId: 'incline-dumbbell-press',
+              id: 'set-main-3',
+              orderIndex: 0,
+              section: 'main',
+              setNumber: 3,
+            }),
+          ],
+        },
+      ],
+      sets: [
+        buildSessionSet({
+          createdAt: startedAt,
+          exerciseId: 'incline-dumbbell-press',
+          id: 'set-main-1',
+          orderIndex: 0,
+          section: 'main',
+          setNumber: 1,
+        }),
+        buildSessionSet({
+          createdAt: startedAt + 1,
+          exerciseId: 'incline-dumbbell-press',
+          id: 'set-main-2',
+          orderIndex: 0,
+          section: 'main',
+          setNumber: 2,
+        }),
+        buildSessionSet({
+          createdAt: startedAt + 2,
+          exerciseId: 'incline-dumbbell-press',
+          id: 'set-main-3',
+          orderIndex: 0,
+          section: 'main',
+          setNumber: 3,
+        }),
+      ],
+      updatedAt: startedAt,
+    };
+
+    const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.endsWith('/api/v1/auth/register')) {
+        return Promise.resolve(jsonResponse({ data: { token: 'dev-generated-token' } }));
+      }
+
+      if (url.endsWith('/api/v1/workout-templates/upper-push') && (!init?.method || init.method === 'GET')) {
+        const template = buildWorkoutTemplateResponse('upper-push');
+        if (!template) {
+          return Promise.reject(new Error('Expected upper-push template fixture.'));
+        }
+
+        return Promise.resolve(jsonResponse({ data: template }));
+      }
+
+      if (
+        url.endsWith(`/api/v1/workout-sessions/${sessionId}`) &&
+        (!init?.method || init.method === 'GET')
+      ) {
+        return Promise.resolve(jsonResponse({ data: currentSession }));
+      }
+
+      if (
+        url.endsWith(`/api/v1/workout-sessions/${sessionId}/sets/set-main-3`) &&
+        init?.method === 'DELETE'
+      ) {
+        return deleteDeferred.promise;
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch request: ${url}`));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const queryClient = createAppQueryClient();
+    queryClient.clear();
+    const seededTemplate = buildWorkoutTemplateResponse('upper-push');
+    if (!seededTemplate) {
+      throw new Error('Expected upper-push fixture template.');
+    }
+    queryClient.setQueryData(workoutQueryKeys.template('upper-push'), seededTemplate);
+    queryClient.setQueryData(workoutSessionQueryKeys.detail(sessionId), currentSession);
+
+    renderWithQueryClient(
+      <MemoryRouter initialEntries={[`/workouts/active?sessionId=${sessionId}&template=upper-push`]}>
+        <Routes>
+          <Route element={<ActiveWorkoutPage />} path="/workouts/active" />
+          <Route element={<h1>Workouts</h1>} path="/workouts" />
+        </Routes>
+      </MemoryRouter>,
+      { queryClient },
+    );
+
+    await screen.findByRole('heading', { level: 1, name: 'Upper Push' });
+    const inclineCard = getExerciseCard('Incline Dumbbell Press');
+    expect(within(inclineCard).getByLabelText('Reps for set 3')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        getStoredActiveWorkoutDraft(sessionId)?.setDrafts['incline-dumbbell-press']?.map(
+          (set) => set.id,
+        ),
+      ).toEqual(['set-main-1', 'set-main-2', 'set-main-3']);
+    });
+
+    const removeSetButtons = within(inclineCard).getAllByRole('button', {
+      name: 'Remove Last Set',
+    });
+    const removeSetButton = [...removeSetButtons]
+      .reverse()
+      .find((button) => !button.hasAttribute('disabled'));
+    expect(removeSetButton).toBeDefined();
+    fireEvent.click(removeSetButton as HTMLElement);
+
+    await waitFor(() => {
+      expect(within(getExerciseCard('Incline Dumbbell Press')).queryByLabelText('Reps for set 3')).toBeNull();
+    });
+
+    expect(
+      fetchMock.mock.calls.some(
+        ([url, init]) =>
+          String(url).endsWith(`/api/v1/workout-sessions/${sessionId}/sets/set-main-3`) &&
+          init?.method === 'DELETE',
+      ),
+    ).toBe(true);
+    expect(
+      screen.queryByText('Removing sets is local-only right now and may not sync across devices.'),
+    ).toBeNull();
+
+    currentSession = {
+      ...currentSession,
+      exercises: [
+        {
+          ...currentSession.exercises[0],
+          sets: [
+            buildSessionSet({
+              createdAt: startedAt,
+              exerciseId: 'incline-dumbbell-press',
+              id: 'set-main-1',
+              orderIndex: 0,
+              section: 'main',
+              setNumber: 1,
+            }),
+            buildSessionSet({
+              createdAt: startedAt + 1,
+              exerciseId: 'incline-dumbbell-press',
+              id: 'set-main-2',
+              orderIndex: 0,
+              section: 'main',
+              setNumber: 2,
+            }),
+          ],
+        },
+      ],
+      sets: [
+        buildSessionSet({
+          createdAt: startedAt,
+          exerciseId: 'incline-dumbbell-press',
+          id: 'set-main-1',
+          orderIndex: 0,
+          section: 'main',
+          setNumber: 1,
+        }),
+        buildSessionSet({
+          createdAt: startedAt + 1,
+          exerciseId: 'incline-dumbbell-press',
+          id: 'set-main-2',
+          orderIndex: 0,
+          section: 'main',
+          setNumber: 2,
+        }),
+      ],
+      updatedAt: startedAt + 20_000,
+    };
+
+    await act(async () => {
+      deleteDeferred.resolve(jsonResponse({ data: currentSession }));
+      await deleteDeferred.promise;
+    });
+
+    await waitFor(() => {
+      expect(within(getExerciseCard('Incline Dumbbell Press')).queryByLabelText('Reps for set 3')).toBeNull();
+      const draft = getStoredActiveWorkoutDraft(sessionId);
+      expect(draft?.setDrafts['incline-dumbbell-press']?.map((set) => set.number)).toEqual([1, 2]);
+    });
+
+    await act(async () => {
+      await queryClient.invalidateQueries({
+        queryKey: workoutSessionQueryKeys.detail(sessionId),
+      });
+    });
+
+    await waitFor(() => {
+      expect(within(getExerciseCard('Incline Dumbbell Press')).queryByLabelText('Reps for set 3')).toBeNull();
+    });
+  });
+
+  it('rolls back optimistic set removal and shows an error when delete fails', async () => {
+    const sessionId = 'session-delete-set-error';
+    const startedAt = Date.parse('2026-03-06T12:00:00.000Z');
+    const deleteDeferred = createDeferredPromise<Response>();
+    const currentSession: MutableInProgressSessionResponse = {
+      ...buildInProgressSessionResponse(sessionId),
+      exercises: [
+        {
+          exerciseId: 'incline-dumbbell-press',
+          exerciseName: 'Incline Dumbbell Press',
+          orderIndex: 0,
+          section: 'main',
+          sets: [
+            buildSessionSet({
+              createdAt: startedAt,
+              exerciseId: 'incline-dumbbell-press',
+              id: 'set-main-1',
+              orderIndex: 0,
+              section: 'main',
+              setNumber: 1,
+            }),
+            buildSessionSet({
+              createdAt: startedAt + 1,
+              exerciseId: 'incline-dumbbell-press',
+              id: 'set-main-2',
+              orderIndex: 0,
+              section: 'main',
+              setNumber: 2,
+            }),
+            buildSessionSet({
+              createdAt: startedAt + 2,
+              exerciseId: 'incline-dumbbell-press',
+              id: 'set-main-3',
+              orderIndex: 0,
+              section: 'main',
+              setNumber: 3,
+            }),
+          ],
+        },
+      ],
+      sets: [
+        buildSessionSet({
+          createdAt: startedAt,
+          exerciseId: 'incline-dumbbell-press',
+          id: 'set-main-1',
+          orderIndex: 0,
+          section: 'main',
+          setNumber: 1,
+        }),
+        buildSessionSet({
+          createdAt: startedAt + 1,
+          exerciseId: 'incline-dumbbell-press',
+          id: 'set-main-2',
+          orderIndex: 0,
+          section: 'main',
+          setNumber: 2,
+        }),
+        buildSessionSet({
+          createdAt: startedAt + 2,
+          exerciseId: 'incline-dumbbell-press',
+          id: 'set-main-3',
+          orderIndex: 0,
+          section: 'main',
+          setNumber: 3,
+        }),
+      ],
+      updatedAt: startedAt,
+    };
+
+    const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.endsWith('/api/v1/auth/register')) {
+        return Promise.resolve(jsonResponse({ data: { token: 'dev-generated-token' } }));
+      }
+
+      if (url.endsWith('/api/v1/workout-templates/upper-push') && (!init?.method || init.method === 'GET')) {
+        const template = buildWorkoutTemplateResponse('upper-push');
+        if (!template) {
+          return Promise.reject(new Error('Expected upper-push template fixture.'));
+        }
+
+        return Promise.resolve(jsonResponse({ data: template }));
+      }
+
+      if (
+        url.endsWith(`/api/v1/workout-sessions/${sessionId}`) &&
+        (!init?.method || init.method === 'GET')
+      ) {
+        return Promise.resolve(jsonResponse({ data: currentSession }));
+      }
+
+      if (
+        url.endsWith(`/api/v1/workout-sessions/${sessionId}/sets/set-main-3`) &&
+        init?.method === 'DELETE'
+      ) {
+        return deleteDeferred.promise;
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch request: ${url}`));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const queryClient = createAppQueryClient();
+    queryClient.clear();
+    const seededTemplate = buildWorkoutTemplateResponse('upper-push');
+    if (!seededTemplate) {
+      throw new Error('Expected upper-push fixture template.');
+    }
+    queryClient.setQueryData(workoutQueryKeys.template('upper-push'), seededTemplate);
+    queryClient.setQueryData(workoutSessionQueryKeys.detail(sessionId), currentSession);
+
+    renderWithQueryClient(
+      <MemoryRouter initialEntries={[`/workouts/active?sessionId=${sessionId}&template=upper-push`]}>
+        <Routes>
+          <Route element={<ActiveWorkoutPage />} path="/workouts/active" />
+          <Route element={<h1>Workouts</h1>} path="/workouts" />
+        </Routes>
+      </MemoryRouter>,
+      { queryClient },
+    );
+
+    await screen.findByRole('heading', { level: 1, name: 'Upper Push' });
+    const inclineCard = getExerciseCard('Incline Dumbbell Press');
+    expect(within(inclineCard).getByLabelText('Reps for set 3')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        getStoredActiveWorkoutDraft(sessionId)?.setDrafts['incline-dumbbell-press']?.map(
+          (set) => set.id,
+        ),
+      ).toEqual(['set-main-1', 'set-main-2', 'set-main-3']);
+    });
+
+    const removeSetButtons = within(inclineCard).getAllByRole('button', {
+      name: 'Remove Last Set',
+    });
+    const removeSetButton = [...removeSetButtons]
+      .reverse()
+      .find((button) => !button.hasAttribute('disabled'));
+    expect(removeSetButton).toBeDefined();
+    fireEvent.click(removeSetButton as HTMLElement);
+
+    await waitFor(() => {
+      expect(within(getExerciseCard('Incline Dumbbell Press')).queryByLabelText('Reps for set 3')).toBeNull();
+    });
+
+    await act(async () => {
+      deleteDeferred.resolve(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 'INTERNAL',
+              message: 'Delete failed',
+            },
+          }),
+          {
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            status: 500,
+          },
+        ),
+      );
+      await deleteDeferred.promise;
+    });
+
+    await waitFor(() => {
+      expect(within(getExerciseCard('Incline Dumbbell Press')).getByLabelText('Reps for set 3')).toBeInTheDocument();
+      expect(screen.getByText('Unable to remove set. Try again.')).toBeInTheDocument();
+      const draft = getStoredActiveWorkoutDraft(sessionId);
+      expect(draft?.setDrafts['incline-dumbbell-press']?.map((set) => set.number)).toEqual([
+        1,
+        2,
+        3,
+      ]);
+    });
+  });
+});
+
+function createDeferredPromise<T>() {
+  let resolvePromise: ((value: T | PromiseLike<T>) => void) | undefined;
+
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    resolve: (value: T | PromiseLike<T>) => {
+      if (!resolvePromise) {
+        throw new Error('Deferred promise was not initialized.');
+      }
+
+      resolvePromise(value);
+    },
+  };
+}
+
+function buildWorkoutTemplateResponse(templateId: string) {
+  const fixtureTemplate = getMockTemplate(templateId);
+  if (!fixtureTemplate) {
+    return null;
+  }
+
+  let exerciseIndex = 0;
+
+  return {
+    id: fixtureTemplate.id,
+    userId: 'user-1',
+    name: fixtureTemplate.name,
+    description: fixtureTemplate.description,
+    tags: fixtureTemplate.tags,
+    sections: fixtureTemplate.sections.map((section) => ({
+      type: section.type,
+      exercises: section.exercises.map((exercise) => {
+        const reps = parseFixtureReps(exercise.reps);
+        exerciseIndex += 1;
+
+        return {
+          id: `${fixtureTemplate.id}-exercise-${exerciseIndex}`,
+          exerciseId: exercise.exerciseId,
+          exerciseName: exercise.exerciseName ?? startCase(exercise.exerciseId),
+          trackingType: exercise.trackingType ?? null,
+          sets: exercise.sets,
+          repsMin: reps.repsMin,
+          repsMax: reps.repsMax,
+          tempo: exercise.tempo,
+          restSeconds: exercise.restSeconds,
+          supersetGroup: exercise.supersetGroup ?? null,
+          notes: null,
+          cues: exercise.templateCues ?? [],
+          formCues: exercise.formCues,
+        };
+      }),
+    })),
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function parseFixtureReps(value: string): { repsMax: number | null; repsMin: number | null } {
+  const rangeMatch = value.match(/(\d+)\s*-\s*(\d+)/);
+  if (rangeMatch) {
+    return {
+      repsMin: Number(rangeMatch[1]),
+      repsMax: Number(rangeMatch[2]),
+    };
+  }
+
+  const singleMatch = value.match(/\d+/);
+  if (singleMatch) {
+    const reps = Number(singleMatch[0]);
+    return {
+      repsMin: reps,
+      repsMax: reps,
+    };
+  }
+
+  return {
+    repsMin: null,
+    repsMax: null,
+  };
+}
+
+function startCase(value: string) {
+  return value
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function getExerciseCard(name: string) {
+  let heading = screen.queryByRole('heading', { level: 3, name });
+
+  if (!heading) {
+    for (const sectionLabel of ['Warmup', 'Main', 'Cooldown']) {
+      const sectionToggle = screen.queryByRole('button', { name: new RegExp(`^${sectionLabel}`) });
+
+      if (sectionToggle?.getAttribute('aria-expanded') === 'false') {
+        fireEvent.click(sectionToggle);
+      }
+    }
+
+    heading = screen.queryByRole('heading', { level: 3, name });
+  }
+
+  const card = heading?.closest('[data-slot="card"]');
+
+  if (!card) {
+    throw new Error(`Expected exercise card for ${name}.`);
+  }
+
+  const exerciseToggle = within(card as HTMLElement)
+    .queryAllByRole('button')
+    .find((button) => button.getAttribute('aria-controls')?.startsWith('exercise-panel-'));
+  if (exerciseToggle?.getAttribute('aria-expanded') === 'false') {
+    fireEvent.click(exerciseToggle);
+  }
+
+  return card as HTMLElement;
+}
+
+function buildInProgressSessionResponse(sessionId: string): MutableInProgressSessionResponse {
+  return {
+    id: sessionId,
+    userId: 'user-1',
+    templateId: 'upper-push',
+    name: 'Upper Push',
+    date: '2026-03-06',
+    status: 'in-progress',
+    startedAt: Date.parse('2026-03-06T12:00:00.000Z'),
+    completedAt: null,
+    duration: null,
+    timeSegments: [
+      {
+        start: '2026-03-06T12:00:00.000Z',
+        end: null,
+        section: 'main',
+      },
+    ],
+    sectionDurations: {
+      warmup: 0,
+      main: 0,
+      cooldown: 0,
+      supplemental: 0,
+    },
+    feedback: null,
+    notes: null,
+    sets: [],
+    exercises: [],
+    createdAt: Date.parse('2026-03-06T12:00:00.000Z'),
+    updatedAt: Date.parse('2026-03-06T12:00:00.000Z'),
+  };
+}
+
+function buildSessionSet(input: {
+  createdAt: number;
+  exerciseId: string;
+  id: string;
+  orderIndex: number;
+  section: 'warmup' | 'main' | 'cooldown' | 'supplemental';
+  setNumber: number;
+}) {
+  return {
+    id: input.id,
+    exerciseId: input.exerciseId,
+    orderIndex: input.orderIndex,
+    setNumber: input.setNumber,
+    weight: null,
+    reps: null,
+    completed: false,
+    skipped: false,
+    section: input.section,
+    notes: null,
+    createdAt: input.createdAt,
+  };
+}
+
+type MutableInProgressSessionResponse = {
+  id: string;
+  userId: string;
+  templateId: string;
+  name: string;
+  date: string;
+  status: 'in-progress' | 'paused';
+  startedAt: number;
+  completedAt: number | null;
+  duration: number | null;
+  sectionDurations: {
+    warmup: number;
+    main: number;
+    cooldown: number;
+    supplemental: number;
+  };
+  timeSegments: Array<{
+    start: string;
+    end: string | null;
+    section: 'warmup' | 'main' | 'cooldown' | 'supplemental';
+  }>;
+  feedback: null;
+  notes: null;
+  sets: Array<{
+    id: string;
+    exerciseId: string | null;
+    orderIndex: number;
+    setNumber: number;
+    weight: number | null;
+    reps: number | null;
+    completed: boolean;
+    skipped: boolean;
+    section: 'warmup' | 'main' | 'cooldown' | 'supplemental';
+    notes: string | null;
+    createdAt: number;
+  }>;
+  exercises: Array<{
+    exerciseId: string;
+    exerciseName: string | null;
+    orderIndex: number;
+    section: 'warmup' | 'main' | 'cooldown' | 'supplemental' | null;
+    sets: Array<{
+      id: string;
+      exerciseId: string | null;
+      orderIndex: number;
+      setNumber: number;
+      weight: number | null;
+      reps: number | null;
+      completed: boolean;
+      skipped: boolean;
+      section: 'warmup' | 'main' | 'cooldown' | 'supplemental';
+      notes: string | null;
+      createdAt: number;
+    }>;
+  }>;
+  createdAt: number;
+  updatedAt: number;
+};

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -54,6 +54,7 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import {
+  useDeleteSessionSet,
   workoutQueryKeys,
   useUpdateSessionSectionTimer,
   useWorkoutSessions,
@@ -179,6 +180,7 @@ export function ActiveWorkoutPage() {
   const updateSessionStartTimeMutation = useUpdateSessionStartTime(sessionId);
   const updateSessionStatusMutation = useUpdateSessionStatus(sessionId);
   const updateSessionSectionTimerMutation = useUpdateSessionSectionTimer(sessionId);
+  const deleteSessionSetMutation = useDeleteSessionSet();
   const cancelAndRevertSessionMutation = useCancelAndRevertSession(sessionId);
   const updateSessionTimeSegmentsMutation = useUpdateSessionTimeSegments(sessionId);
   const reorderSessionExercisesMutation = useReorderSessionExercises(sessionId);
@@ -1153,23 +1155,66 @@ export function ActiveWorkoutPage() {
       return;
     }
 
-    if (activeSessionId) {
-      // API does not yet expose set deletion for active sessions.
-      setSessionError('Removing sets is local-only right now and may not sync across devices.');
-    }
+    const removedSetId = removedSet.id.trim();
+    const previousRestTimer = restTimer;
+    const previousFocusSetId = focusSetId;
+    const shouldClearRestTimer = restTimer?.setId === removedSet.id;
+    const shouldClearFocus = focusSetId === removedSet.id;
 
     setSetDrafts((current) => ({
       ...current,
       [exerciseId]: nextExerciseSets,
     }));
 
-    if (restTimer?.setId === removedSet.id) {
+    if (shouldClearRestTimer) {
       setRestTimer(null);
     }
 
-    if (focusSetId === removedSet.id) {
+    if (shouldClearFocus) {
       setFocusSetId(null);
     }
+
+    if (!activeSessionId) {
+      return;
+    }
+
+    if (
+      removedSetId.length === 0 ||
+      !activeSession?.sets.some((sessionSet) => sessionSet.id === removedSetId)
+    ) {
+      return;
+    }
+
+    setSessionError(null);
+    deleteSessionSetMutation.mutate(
+      {
+        sessionId: activeSessionId,
+        setId: removedSetId,
+      },
+      {
+        onError: (error) => {
+          if (isSessionNotActiveError(error)) {
+            redirectToCompletedSessionNotice();
+            return;
+          }
+
+          setSetDrafts((current) => ({
+            ...current,
+            [exerciseId]: sortedSets,
+          }));
+
+          if (shouldClearRestTimer && previousRestTimer) {
+            setRestTimer(previousRestTimer);
+          }
+
+          if (shouldClearFocus) {
+            setFocusSetId(previousFocusSetId);
+          }
+
+          setSessionError('Unable to remove set. Try again.');
+        },
+      },
+    );
   }
 
   function removeExerciseFromLocalState(exerciseId: string, section: WorkoutTemplateSectionType) {
@@ -2522,6 +2567,11 @@ function buildTemplateFromSession(
     const fallbackExercise = fallbackExerciseById.get(sessionExercise.exerciseId)?.exercise;
     const defaultReps = fallbackExercise?.reps ?? inferExerciseRepsFromSets(sessionExercise.sets);
 
+    const sessionSetCount = sessionExercise.sets.reduce(
+      (maxValue, set) => Math.max(maxValue, set.setNumber),
+      0,
+    );
+
     targetSection.exercises.push({
       exerciseId: sessionExercise.exerciseId,
       exerciseName:
@@ -2530,10 +2580,7 @@ function buildTemplateFromSession(
         'Unknown Exercise',
       trackingType: fallbackExercise?.trackingType ?? sessionExercise.trackingType ?? undefined,
       supersetGroup: sessionExercise.supersetGroup ?? fallbackExercise?.supersetGroup ?? null,
-      sets: Math.max(
-        fallbackExercise?.sets ?? 0,
-        sessionExercise.sets.reduce((maxValue, set) => Math.max(maxValue, set.setNumber), 0),
-      ),
+      sets: sessionSetCount > 0 ? sessionSetCount : (fallbackExercise?.sets ?? 1),
       reps: defaultReps,
       tempo: fallbackExercise?.tempo ?? '2111',
       restSeconds: fallbackExercise?.restSeconds ?? 60,

--- a/docs/conventions/api-conventions.md
+++ b/docs/conventions/api-conventions.md
@@ -50,6 +50,7 @@ Unified routes with agent conveniences should use middleware hooks instead of ro
 - `preHandler: agentRequestTransform` resolves names, expands shorthand fields, and performs agent auto-create behavior for AgentToken requests.
 - `onSend: agentEnrichmentOnSend` appends optional `agent` guidance from request context when available.
 - Handlers should implement one canonical write/read path and avoid `isAgentRequest()` schema branching.
+- Workout-session set deletion should use `DELETE /api/v1/workout-sessions/:sessionId/sets/:setId` for in-progress sessions and return a `409 session-not-in-progress` conflict for completed/cancelled sessions, where callers can use `PATCH /api/v1/workout-sessions/:id/corrections` to adjust logged values after completion.
 
 ## Unified vs AgentToken-only route pattern
 

--- a/docs/conventions/workout-domain.md
+++ b/docs/conventions/workout-domain.md
@@ -147,6 +147,8 @@ Completed sessions should also store exercise-level set logs and post-workout fe
 
 Session exercise metadata should preserve `supersetGroup` values so completed receipts and history can render grouped supersets consistently.
 
+Set removal is status-scoped: in-progress/paused sessions remove sets through `DELETE /api/v1/workout-sessions/:sessionId/sets/:setId` (with server-side renumbering), while completed sessions are edited only through `PATCH /api/v1/workout-sessions/:id/corrections`.
+
 ### Session Exercise Notes Layers
 
 Session exercises intentionally keep three separate note channels:

--- a/packages/shared/src/schemas/workout-sessions.test.ts
+++ b/packages/shared/src/schemas/workout-sessions.test.ts
@@ -140,8 +140,6 @@ describe('sessionSetInputSchema', () => {
       setNumber: 1,
       weight: null,
       reps: null,
-      completed: false,
-      skipped: false,
       supersetGroup: null,
       section: null,
       notes: null,
@@ -159,7 +157,7 @@ describe('sessionSetInputSchema', () => {
     ).toThrow();
   });
 
-  it('rejects target weight ranges where min exceeds max', () => {
+  it('rejects unsupported target fields for session set input', () => {
     expect(() =>
       sessionSetInputSchema.parse({
         exerciseId: 'bench-press',
@@ -167,7 +165,7 @@ describe('sessionSetInputSchema', () => {
         targetWeightMin: 150,
         targetWeightMax: 100,
       }),
-    ).toThrow('targetWeightMin must be less than or equal to targetWeightMax');
+    ).toThrow("Unrecognized key(s) in object: 'targetWeightMin', 'targetWeightMax'");
   });
 
   it('accepts exerciseName aliases and normalizes to exerciseId', () => {
@@ -183,8 +181,6 @@ describe('sessionSetInputSchema', () => {
       setNumber: 1,
       weight: null,
       reps: 12,
-      completed: false,
-      skipped: false,
       supersetGroup: null,
       section: null,
       notes: null,
@@ -681,7 +677,6 @@ describe('createWorkoutSessionInputSchema', () => {
           reps: 5,
           weight: 275,
           completed: true,
-          skipped: false,
           supersetGroup: null,
           section: 'main',
           notes: 'Fast concentric',
@@ -1021,8 +1016,6 @@ describe('updateWorkoutSessionInputSchema', () => {
           setNumber: 1,
           weight: 95,
           reps: 10,
-          completed: false,
-          skipped: false,
           supersetGroup: null,
           section: null,
           notes: null,

--- a/packages/shared/src/schemas/workout-sessions.ts
+++ b/packages/shared/src/schemas/workout-sessions.ts
@@ -392,24 +392,16 @@ export const sessionSetInputSchema = z
     setNumber: z.number().int().min(1),
     weight: z.number().min(0).nullable().optional().default(null),
     reps: nullableIntegerSchema.optional().default(null),
-    targetWeight: z.number().min(0).nullable().optional(),
-    targetWeightMin: z.number().min(0).nullable().optional(),
-    targetWeightMax: z.number().min(0).nullable().optional(),
-    targetSeconds: nullableIntegerSchema.optional(),
-    targetDistance: z.number().min(0).nullable().optional(),
-    completed: z.boolean().optional().default(false),
-    skipped: z.boolean().optional().default(false),
+    completed: z.boolean().optional(),
+    skipped: z.boolean().optional(),
     supersetGroup: nullableShortStringSchema.optional().default(null),
     section: workoutTemplateSectionTypeSchema.nullable().optional().default(null),
     notes: nullableLongStringSchema.optional().default(null),
   })
+  .strict()
   .refine((value) => !(value.completed && value.skipped), {
     message: 'A set cannot be both completed and skipped',
     path: ['skipped'],
-  })
-  .refine(hasValidTargetWeightRange, {
-    message: 'targetWeightMin must be less than or equal to targetWeightMax',
-    path: ['targetWeightMax'],
   })
   .transform((value, context) => {
     // Fastify validates/transforms request bodies before preHandler hooks run.
@@ -488,8 +480,9 @@ const createWorkoutSessionInputObjectSchema = z.object({
   sets: z.array(sessionSetInputSchema).max(500).optional().default([]),
 });
 
-export const createWorkoutSessionInputSchema =
-  createWorkoutSessionInputObjectSchema.superRefine(validateWorkoutSessionTiming);
+export const createWorkoutSessionInputSchema = createWorkoutSessionInputObjectSchema.superRefine(
+  validateWorkoutSessionTiming,
+);
 
 export const createWorkoutSessionRequestSchema = createWorkoutSessionInputObjectSchema
   .extend({


### PR DESCRIPTION
**Summary**
This PR fixes two session-set correctness gaps in workouts: bulk set PATCH now respects what callers actually send, and in-progress sets can now be deleted through a first-class API route. The bulk merge logic no longer hardcodes `completed/skipped`, and it now carries through payload fields like `notes`, `supersetGroup`, and `section` while preserving existing completion state for non-log-field updates. On the deletion side, the API adds `DELETE /api/v1/workout-sessions/:sessionId/sets/:setId` with proper auth, ownership checks, and a `409 session-not-in-progress` contract for completed/cancelled sessions that redirects clients to corrections. The active workout UI is wired to this endpoint with optimistic removal + rollback so set deletion is no longer local-only.

**Key Changes**
- Fixed bulk set PATCH merge behavior in `workout-sessions` routes:
  - Honors payload `completed`, `skipped`, `notes`, `supersetGroup`, and `section`.
  - Stops forcing `completed: true` / `skipped: false` on every incoming set.
  - Preserves existing completion flags when patching non-log fields only.
- Tightened `sessionSetInputSchema`:
  - Made schema strict for this input path.
  - Removed unsupported target fields from this schema surface.
- Added `deleteSessionSet` store logic:
  - Transactional delete + renumber.
  - Renumbering scoped to same `sessionId` + `exerciseId` + `section` (including `NULL` exercise scope handling).
  - Blocks deletes for completed/cancelled sessions via explicit sentinel error.
- Added `DELETE /workout-sessions/:sessionId/sets/:setId` route:
  - Supports JWT and AgentToken flow with standard response envelope.
  - Returns `404` for missing/mismatched set/session and `409` for non-in-progress sessions with corrections guidance.
- Wired frontend deletion flow:
  - New `useDeleteSessionSet` mutation with optimistic cache updates and rollback on failure.
  - Replaced local-only remove branch in active workout page.
  - Removed local-only warning behavior and aligned error handling.
- Expanded coverage:
  - New store tests for delete/renumber status and null-exercise scope.
  - Route tests for delete auth/ownership/status/error contracts and bulk PATCH payload semantics.
  - New active-workout remove-set tests for optimistic success and rollback.

**Technical Notes**
- Renumbering is intentionally partitioned by exercise and section, so deleting `main` set 2 does not renumber unrelated `warmup/cooldown` or other-exercise sets.
- Store renumber uses a temporary offset phase before final set numbers to avoid in-place collisions during updates.
- The `409 session-not-in-progress` delete contract intentionally points clients to `PATCH /workout-sessions/:id/corrections`, aligning delete/edit behavior after session completion.
- `buildTemplateFromSession` now uses observed session set count (with sane fallback) so deleted sets are not re-inflated from template defaults in active flow refreshes.

## Commits

- `9951391 fix(web): remove duplicate delete-set error toast`
- `5fbbf1d fix(workouts): wire active session set deletion to api`
- `1a080ba fix(workouts): align delete-set 409 contract with corrections guidance`
- `4cff450 fix(workouts): add delete session-set route coverage`
- `d6e3df1 fix(api): cover null exercise delete-set renumber scope`
- `d680151 fix(api): add deleteSessionSet store logic and patch merge safeguards`
- `fafbf8e fix(workouts): honor bulk session set patch payload`

## Tasks

- **Fix bulk sets PATCH handler + trim input schema**: Stop hardcoding completed/skipped in PATCH /workout-sessions/:id sets[] handler (workout-sessions/index.ts:1432-1496). Honor payload completed, skipped, notes, supersetGroup, section with sensible defaults. Trim target fields from sessionSetInputSchema. Route + schema tests.
- **Add deleteSessionSet store function with renumber**: New deleteSessionSet in workout-sessions/store.ts mirroring updateSessionSet. Transaction-wrapped delete + renumber of remaining setNumbers for the same exerciseId. Sentinel for completed/cancelled sessions. Store tests.
- **Add DELETE /workout-sessions/:sessionId/sets/:setId route**: Register DELETE alongside the sibling single-set PATCH. JWT + AgentToken auth. 409 on completed/cancelled sessions pointing at /corrections. Response matches session detail envelope. Route tests.
- **Wire useDeleteSessionSet in active-workout UI**: Add useDeleteSessionSet TanStack mutation. Replace local-only handleRemoveSet branch in active-workout.tsx (lines 1141-1173). Remove 'local-only' warning banner. Optimistic remove + rollback. Update docs/conventions/workout-domain.md + .agents/skills/pulse-app-usage/SKILL.md. Component tests.

## Diff Stats

```
.agents/skills/pulse-app-usage/SKILL.md            |    1 +
 apps/api/src/routes/workout-sessions/index.test.ts | 1841 ++++++++++++++------
 apps/api/src/routes/workout-sessions/index.ts      |  137 +-
 apps/api/src/routes/workout-sessions/store.test.ts |  448 +++++
 apps/api/src/routes/workout-sessions/store.ts      |  186 +-
 apps/web/src/features/workouts/api/workouts.ts     |  157 +-
 .../web/src/features/workouts/lib/session-notes.ts |    5 -
 .../src/pages/active-workout.remove-set.test.tsx   |  727 ++++++++
 apps/web/src/pages/active-workout.tsx              |   67 +-
 docs/conventions/api-conventions.md                |    1 +
 docs/conventions/workout-domain.md                 |    2 +
 .../shared/src/schemas/workout-sessions.test.ts    |   11 +-
 packages/shared/src/schemas/workout-sessions.ts    |   19 +-
 13 files changed, 3011 insertions(+), 591 deletions(-)
```