### PR TITLE
feat(workouts): scheduled-workout structural edit endpoints

### DIFF
--- a/.agents/skills/pulse-app-usage/SKILL.md
+++ b/.agents/skills/pulse-app-usage/SKILL.md
@@ -243,6 +243,29 @@ If no new foods were created, explicitly say that existing food entries were reu
 
 - **Create**: `POST /api/v1/scheduled-workouts/` — schedule a template on calendar date(s).
 - **Review**: `GET /api/v1/scheduled-workouts/?from=<YYYY-MM-DD>&to=<YYYY-MM-DD>`
+- **Reorder snapshot exercises**: `PATCH /api/v1/scheduled-workouts/:id/reorder`
+- **Patch snapshot exercise fields**: `PATCH /api/v1/scheduled-workouts/:id/exercises`
+- **Patch snapshot set targets**: `PATCH /api/v1/scheduled-workouts/:id/exercise-sets`
+- **Write per-exercise agent notes** (AgentToken-only): `PATCH /api/v1/scheduled-workouts/:id/exercise-notes`
+
+Refining tomorrow's workout: read the scheduled workout snapshot first, then use `/reorder` for exercise sequence, `/exercises` for per-exercise structural fields, `/exercise-sets` for target/remove/add set shaping, and optionally `/exercise-notes` for session-specific coaching notes.
+
+Quick request shapes:
+
+```json
+PATCH /api/v1/scheduled-workouts/:id/reorder
+{ "order": ["<exercise-uuid-1>", "<exercise-uuid-2>"] }
+```
+
+```json
+PATCH /api/v1/scheduled-workouts/:id/exercises
+{ "updates": [{ "exerciseId": "<exercise-uuid>", "supersetGroup": "A", "section": "main" }] }
+```
+
+```json
+PATCH /api/v1/scheduled-workouts/:id/exercise-sets
+{ "exerciseId": "<exercise-uuid>", "sets": [{ "setNumber": 2, "remove": true }] }
+```
 
 ### Scheduled-workout enrichment
 

--- a/apps/api/src/middleware/agent-enrichment.ts
+++ b/apps/api/src/middleware/agent-enrichment.ts
@@ -3,6 +3,7 @@ import type {
   BodyWeightEntry,
   HabitEntry,
   HabitTrackingType,
+  ScheduledWorkoutDetail,
   WorkoutSession,
 } from '@pulse/shared';
 import type { FastifyRequest, onSendHookHandler } from 'fastify';
@@ -73,6 +74,10 @@ export type AgentEnrichmentContext =
   | {
       endpoint: 'workout-template.mutation';
       action: 'create' | 'update';
+    }
+  | {
+      endpoint: 'scheduled-workout.mutation';
+      action: 'reorder' | 'exercises' | 'exercise-sets';
     };
 
 const requestEnrichmentContext = new WeakMap<FastifyRequest, AgentEnrichmentContext>();
@@ -99,6 +104,17 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const isWorkoutSession = (value: unknown): value is WorkoutSession =>
   isRecord(value) && Array.isArray(value.sets) && typeof value.status === 'string';
+
+const isScheduledWorkoutDetail = (value: unknown): value is ScheduledWorkoutDetail =>
+  isRecord(value) &&
+  Array.isArray(value.exercises) &&
+  typeof value.date === 'string' &&
+  value.exercises.every(
+    (exercise) =>
+      isRecord(exercise) &&
+      typeof exercise.exerciseId === 'string' &&
+      Array.isArray(exercise.sets),
+  );
 
 const isHabitEntry = (value: unknown): value is HabitEntry =>
   isRecord(value) &&
@@ -511,6 +527,46 @@ const buildWorkoutTemplateEnrichment = (
   };
 };
 
+const buildScheduledWorkoutEnrichment = (
+  responseData: unknown,
+  context: Extract<AgentEnrichmentContext, { endpoint: 'scheduled-workout.mutation' }>,
+): AgentEnrichment | undefined => {
+  if (!isScheduledWorkoutDetail(responseData)) {
+    return undefined;
+  }
+
+  const exerciseCount = responseData.exercises.length;
+  const setCount = responseData.exercises.reduce(
+    (count, exercise) => count + exercise.sets.length,
+    0,
+  );
+  const supersetGroupCount = new Set(
+    responseData.exercises
+      .map((exercise) => exercise.supersetGroup)
+      .filter((group): group is string => typeof group === 'string' && group.length > 0),
+  ).size;
+
+  return {
+    hints: compactStrings([
+      `${pluralize(exerciseCount, 'exercise')} and ${pluralize(setCount, 'planned set')} are configured for ${responseData.date}.`,
+      supersetGroupCount > 0
+        ? `${pluralize(supersetGroupCount, 'superset group')} currently organize this workout.`
+        : 'No supersets are currently configured.',
+    ]),
+    suggestedActions: compactStrings([
+      'Start the scheduled workout when you are ready to train.',
+      'Re-open the scheduled workout detail to confirm the snapshot structure.',
+    ]),
+    relatedState: {
+      action: context.action,
+      date: responseData.date,
+      exerciseCount,
+      setCount,
+      supersetGroupCount,
+    },
+  };
+};
+
 export const buildAgentEnrichment = (
   request: FastifyRequest,
   responseData: unknown,
@@ -538,6 +594,8 @@ export const buildAgentEnrichment = (
       return buildFoodEnrichment(responseData, context);
     case 'workout-template.mutation':
       return buildWorkoutTemplateEnrichment(responseData, context);
+    case 'scheduled-workout.mutation':
+      return buildScheduledWorkoutEnrichment(responseData, context);
     default:
       return undefined;
   }

--- a/apps/api/src/routes/scheduled-workouts/index.test.ts
+++ b/apps/api/src/routes/scheduled-workouts/index.test.ts
@@ -15,6 +15,7 @@ import {
   scheduledWorkoutExerciseSets,
   scheduledWorkoutExercises,
   scheduledWorkouts,
+  sessionSets,
   templateExercises,
   users,
   workoutSessions,
@@ -222,6 +223,110 @@ const seedTemplateExercise = (values: {
       setTargets: values.setTargets ?? null,
     })
     .run();
+
+const STRUCTURAL_EXERCISE_IDS = {
+  first: '11111111-1111-4111-8111-111111111111',
+  second: '22222222-2222-4222-8222-222222222222',
+  third: '33333333-3333-4333-8333-333333333333',
+} as const;
+
+const UNKNOWN_STRUCTURAL_EXERCISE_ID = '44444444-4444-4444-8444-444444444444';
+
+const seedStructuralSnapshotTemplate = ({
+  templateId = 'template-1',
+  userId = 'user-1',
+}: {
+  templateId?: string;
+  userId?: string;
+} = {}) => {
+  seedExercise({
+    id: STRUCTURAL_EXERCISE_IDS.first,
+    userId,
+    name: 'Incline Bench Press',
+    trackingType: 'weight_reps',
+  });
+  seedExercise({
+    id: STRUCTURAL_EXERCISE_IDS.second,
+    userId,
+    name: 'Single-arm Row',
+    trackingType: 'weight_reps',
+  });
+  seedExercise({
+    id: STRUCTURAL_EXERCISE_IDS.third,
+    userId,
+    name: 'Bike Intervals',
+    trackingType: 'seconds_only',
+  });
+
+  seedTemplateExercise({
+    id: 'template-structural-first',
+    templateId,
+    exerciseId: STRUCTURAL_EXERCISE_IDS.first,
+    section: 'main',
+    orderIndex: 0,
+    sets: 3,
+    repsMin: 8,
+    repsMax: 8,
+    setTargets: [
+      { setNumber: 1, targetWeight: 135 },
+      { setNumber: 2, targetWeight: 145 },
+      { setNumber: 3, targetWeight: 150 },
+    ],
+  });
+  seedTemplateExercise({
+    id: 'template-structural-second',
+    templateId,
+    exerciseId: STRUCTURAL_EXERCISE_IDS.second,
+    section: 'main',
+    orderIndex: 1,
+    sets: 3,
+    repsMin: 10,
+    repsMax: 10,
+    setTargets: [
+      { setNumber: 1, targetWeight: 70 },
+      { setNumber: 2, targetWeight: 75 },
+      { setNumber: 3, targetWeight: 80 },
+    ],
+  });
+  seedTemplateExercise({
+    id: 'template-structural-third',
+    templateId,
+    exerciseId: STRUCTURAL_EXERCISE_IDS.third,
+    section: 'main',
+    orderIndex: 2,
+    sets: 3,
+    repsMin: null,
+    repsMax: null,
+    setTargets: [
+      { setNumber: 1, targetSeconds: 60 },
+      { setNumber: 2, targetSeconds: 60 },
+      { setNumber: 3, targetSeconds: 60 },
+    ],
+  });
+};
+
+const createScheduledWorkoutFromTemplate = async ({
+  authToken,
+  templateId = 'template-1',
+  date = '2026-03-12',
+}: {
+  authToken: string;
+  templateId?: string;
+  date?: string;
+}) => {
+  const response = await context.app.inject({
+    method: 'POST',
+    url: '/api/v1/scheduled-workouts',
+    headers: createAuthorizationHeader(authToken),
+    payload: {
+      templateId,
+      date,
+    },
+  });
+  expect(response.statusCode).toBe(201);
+
+  return (response.json() as { data: { id: string } }).data.id;
+};
 
 describe('scheduled workout routes', () => {
   beforeAll(async () => {
@@ -1464,6 +1569,780 @@ describe('scheduled workout routes', () => {
     });
   });
 
+  it('reorders scheduled workout snapshot exercises and is idempotent for JWT callers', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    seedStructuralSnapshotTemplate();
+    const scheduledWorkoutId = await createScheduledWorkoutFromTemplate({ authToken });
+    const reversedOrder = [
+      STRUCTURAL_EXERCISE_IDS.third,
+      STRUCTURAL_EXERCISE_IDS.second,
+      STRUCTURAL_EXERCISE_IDS.first,
+    ];
+
+    const firstResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/reorder`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        order: reversedOrder,
+      },
+    });
+
+    expect(firstResponse.statusCode).toBe(200);
+    const firstPayload = firstResponse.json() as {
+      data: {
+        exercises: Array<{ exerciseId: string; orderIndex: number }>;
+      };
+      agent?: unknown;
+    };
+    expect(firstPayload.agent).toBeUndefined();
+    expect(firstPayload.data.exercises.map((exercise) => exercise.exerciseId)).toEqual(reversedOrder);
+    expect(firstPayload.data.exercises.map((exercise) => exercise.orderIndex)).toEqual([0, 1, 2]);
+
+    const secondResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/reorder`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        order: reversedOrder,
+      },
+    });
+
+    expect(secondResponse.statusCode).toBe(200);
+    expect(secondResponse.json()).toEqual(firstPayload);
+  });
+
+  it('supports AgentToken auth for reorder and rejects missing auth', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    const agentToken = seedAgentToken('user-1', 'scheduled-reorder-agent');
+    seedStructuralSnapshotTemplate();
+    const scheduledWorkoutId = await createScheduledWorkoutFromTemplate({ authToken });
+
+    const authedResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/reorder`,
+      headers: createAgentTokenHeader(agentToken),
+      payload: {
+        order: [
+          STRUCTURAL_EXERCISE_IDS.third,
+          STRUCTURAL_EXERCISE_IDS.second,
+          STRUCTURAL_EXERCISE_IDS.first,
+        ],
+      },
+    });
+
+    expect(authedResponse.statusCode).toBe(200);
+    expect(authedResponse.json()).toEqual({
+      data: expect.objectContaining({ id: scheduledWorkoutId }),
+      agent: expect.objectContaining({
+        hints: expect.any(Array),
+        suggestedActions: expect.any(Array),
+      }),
+    });
+
+    const noAuthResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/reorder`,
+      payload: {
+        order: [
+          STRUCTURAL_EXERCISE_IDS.third,
+          STRUCTURAL_EXERCISE_IDS.second,
+          STRUCTURAL_EXERCISE_IDS.first,
+        ],
+      },
+    });
+
+    expect(noAuthResponse.statusCode).toBe(401);
+    expect(noAuthResponse.json()).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        message: 'Authentication required',
+      },
+    });
+  });
+
+  it('returns validation and invalid-order errors for scheduled-workout reorder', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    seedStructuralSnapshotTemplate();
+    const scheduledWorkoutId = await createScheduledWorkoutFromTemplate({ authToken });
+
+    const invalidBodyResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/reorder`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        order: ['not-a-uuid'],
+      },
+    });
+    expect(invalidBodyResponse.statusCode).toBe(400);
+    expectRequestValidationError(
+      invalidBodyResponse,
+      'PATCH',
+      `/api/v1/scheduled-workouts/${scheduledWorkoutId}/reorder`,
+    );
+
+    const invalidOrderResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/reorder`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        order: [
+          STRUCTURAL_EXERCISE_IDS.first,
+          STRUCTURAL_EXERCISE_IDS.second,
+          UNKNOWN_STRUCTURAL_EXERCISE_ID,
+        ],
+      },
+    });
+    expect(invalidOrderResponse.statusCode).toBe(400);
+    expect(invalidOrderResponse.json()).toEqual({
+      error: {
+        code: 'INVALID_SCHEDULED_WORKOUT_EXERCISE_ORDER',
+        message: 'Order must include each snapshot exercise exactly once',
+        details: {
+          missingExerciseIds: [STRUCTURAL_EXERCISE_IDS.third],
+          extraExerciseIds: [UNKNOWN_STRUCTURAL_EXERCISE_ID],
+          duplicateExerciseIds: [],
+        },
+      },
+    });
+  });
+
+  it('returns 404 for reorder when schedule is missing or outside user scope', async () => {
+    const userOneToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    const userTwoToken = context.app.jwt.sign(
+      { sub: 'user-2', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedStructuralSnapshotTemplate({ templateId: 'template-3', userId: 'user-2' });
+    const otherUserScheduledWorkoutId = await createScheduledWorkoutFromTemplate({
+      authToken: userTwoToken,
+      templateId: 'template-3',
+    });
+
+    const [missingResponse, scopeResponse] = await Promise.all([
+      context.app.inject({
+        method: 'PATCH',
+        url: '/api/v1/scheduled-workouts/schedule-missing/reorder',
+        headers: createAuthorizationHeader(userOneToken),
+        payload: {
+          order: [STRUCTURAL_EXERCISE_IDS.first],
+        },
+      }),
+      context.app.inject({
+        method: 'PATCH',
+        url: `/api/v1/scheduled-workouts/${otherUserScheduledWorkoutId}/reorder`,
+        headers: createAuthorizationHeader(userOneToken),
+        payload: {
+          order: [
+            STRUCTURAL_EXERCISE_IDS.third,
+            STRUCTURAL_EXERCISE_IDS.second,
+            STRUCTURAL_EXERCISE_IDS.first,
+          ],
+        },
+      }),
+    ]);
+
+    for (const response of [missingResponse, scopeResponse]) {
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'SCHEDULED_WORKOUT_NOT_FOUND',
+          message: 'Scheduled workout not found',
+        },
+      });
+    }
+  });
+
+  it('updates scheduled workout exercise fields and is idempotent for JWT callers', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    seedStructuralSnapshotTemplate();
+    const scheduledWorkoutId = await createScheduledWorkoutFromTemplate({ authToken });
+    const payload = {
+      updates: [
+        {
+          exerciseId: STRUCTURAL_EXERCISE_IDS.first,
+          supersetGroup: 'A',
+          section: 'main',
+          tempo: '3011',
+          restSeconds: 75,
+          programmingNotes: 'Keep elbows stacked under wrists.',
+        },
+        {
+          exerciseId: STRUCTURAL_EXERCISE_IDS.second,
+          supersetGroup: 'A',
+          programmingNotes: null,
+        },
+      ],
+    };
+
+    const firstResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercises`,
+      headers: createAuthorizationHeader(authToken),
+      payload,
+    });
+    expect(firstResponse.statusCode).toBe(200);
+    const firstPayload = firstResponse.json() as {
+      data: {
+        exercises: Array<{
+          exerciseId: string;
+          supersetGroup: string | null;
+          section: string;
+          tempo: string | null;
+          restSeconds: number | null;
+          programmingNotes: string | null;
+        }>;
+      };
+      agent?: unknown;
+    };
+    expect(firstPayload.agent).toBeUndefined();
+    expect(firstPayload.data.exercises).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          exerciseId: STRUCTURAL_EXERCISE_IDS.first,
+          supersetGroup: 'A',
+          section: 'main',
+          tempo: '3011',
+          restSeconds: 75,
+          programmingNotes: 'Keep elbows stacked under wrists.',
+        }),
+        expect.objectContaining({
+          exerciseId: STRUCTURAL_EXERCISE_IDS.second,
+          supersetGroup: 'A',
+          programmingNotes: null,
+        }),
+      ]),
+    );
+
+    const secondResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercises`,
+      headers: createAuthorizationHeader(authToken),
+      payload,
+    });
+    expect(secondResponse.statusCode).toBe(200);
+    expect(secondResponse.json()).toEqual(firstPayload);
+  });
+
+  it('supports AgentToken auth for exercise updates and rejects missing auth', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    const agentToken = seedAgentToken('user-1', 'scheduled-exercise-update-agent');
+    seedStructuralSnapshotTemplate();
+    const scheduledWorkoutId = await createScheduledWorkoutFromTemplate({ authToken });
+
+    const authedResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercises`,
+      headers: createAgentTokenHeader(agentToken),
+      payload: {
+        updates: [
+          {
+            exerciseId: STRUCTURAL_EXERCISE_IDS.first,
+            supersetGroup: 'A',
+          },
+        ],
+      },
+    });
+    expect(authedResponse.statusCode).toBe(200);
+    expect(authedResponse.json()).toEqual({
+      data: expect.objectContaining({ id: scheduledWorkoutId }),
+      agent: expect.objectContaining({
+        hints: expect.any(Array),
+        suggestedActions: expect.any(Array),
+      }),
+    });
+
+    const noAuthResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercises`,
+      payload: {
+        updates: [
+          {
+            exerciseId: STRUCTURAL_EXERCISE_IDS.first,
+            supersetGroup: 'A',
+          },
+        ],
+      },
+    });
+    expect(noAuthResponse.statusCode).toBe(401);
+  });
+
+  it('returns validation and unknown-exercise errors for scheduled-workout exercise updates', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    seedStructuralSnapshotTemplate();
+    const scheduledWorkoutId = await createScheduledWorkoutFromTemplate({ authToken });
+
+    const invalidBodyResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercises`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        updates: [
+          {
+            exerciseId: STRUCTURAL_EXERCISE_IDS.first,
+            section: 'supplemental',
+          },
+        ],
+      },
+    });
+    expect(invalidBodyResponse.statusCode).toBe(400);
+    expectRequestValidationError(
+      invalidBodyResponse,
+      'PATCH',
+      `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercises`,
+    );
+
+    const unknownExerciseResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercises`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        updates: [
+          {
+            exerciseId: UNKNOWN_STRUCTURAL_EXERCISE_ID,
+            supersetGroup: 'A',
+          },
+        ],
+      },
+    });
+    expect(unknownExerciseResponse.statusCode).toBe(400);
+    expect(unknownExerciseResponse.json()).toEqual({
+      error: {
+        code: 'UNKNOWN_SCHEDULED_WORKOUT_EXERCISE',
+        message: `Exercise is not present in this scheduled workout snapshot: ${UNKNOWN_STRUCTURAL_EXERCISE_ID}`,
+      },
+    });
+  });
+
+  it('returns 404 for exercise updates when schedule is missing or outside user scope', async () => {
+    const userOneToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    const userTwoToken = context.app.jwt.sign(
+      { sub: 'user-2', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedStructuralSnapshotTemplate({ templateId: 'template-3', userId: 'user-2' });
+    const otherUserScheduledWorkoutId = await createScheduledWorkoutFromTemplate({
+      authToken: userTwoToken,
+      templateId: 'template-3',
+    });
+
+    const [missingResponse, scopeResponse] = await Promise.all([
+      context.app.inject({
+        method: 'PATCH',
+        url: '/api/v1/scheduled-workouts/schedule-missing/exercises',
+        headers: createAuthorizationHeader(userOneToken),
+        payload: {
+          updates: [{ exerciseId: STRUCTURAL_EXERCISE_IDS.first, supersetGroup: 'A' }],
+        },
+      }),
+      context.app.inject({
+        method: 'PATCH',
+        url: `/api/v1/scheduled-workouts/${otherUserScheduledWorkoutId}/exercises`,
+        headers: createAuthorizationHeader(userOneToken),
+        payload: {
+          updates: [{ exerciseId: STRUCTURAL_EXERCISE_IDS.first, supersetGroup: 'A' }],
+        },
+      }),
+    ]);
+
+    for (const response of [missingResponse, scopeResponse]) {
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'SCHEDULED_WORKOUT_NOT_FOUND',
+          message: 'Scheduled workout not found',
+        },
+      });
+    }
+  });
+
+  it('updates scheduled workout set prescriptions and is idempotent for JWT callers', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    seedStructuralSnapshotTemplate();
+    const scheduledWorkoutId = await createScheduledWorkoutFromTemplate({ authToken });
+    const payload = {
+      exerciseId: STRUCTURAL_EXERCISE_IDS.third,
+      sets: [
+        { setNumber: 1, targetSeconds: 120 },
+        { setNumber: 2, remove: true },
+        { setNumber: 3, remove: true },
+      ],
+    };
+
+    const firstResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-sets`,
+      headers: createAuthorizationHeader(authToken),
+      payload,
+    });
+    expect(firstResponse.statusCode).toBe(200);
+    const firstPayload = firstResponse.json() as {
+      data: {
+        exercises: Array<{
+          exerciseId: string;
+          sets: Array<{ setNumber: number; targetSeconds: number | null }>;
+        }>;
+      };
+      agent?: unknown;
+    };
+    expect(firstPayload.agent).toBeUndefined();
+    const updatedExercise = firstPayload.data.exercises.find(
+      (exercise) => exercise.exerciseId === STRUCTURAL_EXERCISE_IDS.third,
+    );
+    expect(updatedExercise).toBeDefined();
+    expect(updatedExercise?.sets).toEqual([
+      expect.objectContaining({
+        setNumber: 1,
+        targetSeconds: 120,
+      }),
+    ]);
+
+    const secondResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-sets`,
+      headers: createAuthorizationHeader(authToken),
+      payload,
+    });
+    expect(secondResponse.statusCode).toBe(200);
+    expect(secondResponse.json()).toEqual(firstPayload);
+  });
+
+  it('supports AgentToken auth for exercise-set updates and rejects missing auth', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    const agentToken = seedAgentToken('user-1', 'scheduled-exercise-sets-agent');
+    seedStructuralSnapshotTemplate();
+    const scheduledWorkoutId = await createScheduledWorkoutFromTemplate({ authToken });
+
+    const authedResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-sets`,
+      headers: createAgentTokenHeader(agentToken),
+      payload: {
+        exerciseId: STRUCTURAL_EXERCISE_IDS.first,
+        sets: [{ setNumber: 1, targetWeight: 155 }],
+      },
+    });
+    expect(authedResponse.statusCode).toBe(200);
+    expect(authedResponse.json()).toEqual({
+      data: expect.objectContaining({ id: scheduledWorkoutId }),
+      agent: expect.objectContaining({
+        hints: expect.any(Array),
+        suggestedActions: expect.any(Array),
+      }),
+    });
+
+    const noAuthResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-sets`,
+      payload: {
+        exerciseId: STRUCTURAL_EXERCISE_IDS.first,
+        sets: [{ setNumber: 1, targetWeight: 155 }],
+      },
+    });
+    expect(noAuthResponse.statusCode).toBe(401);
+  });
+
+  it('returns validation and unknown-exercise errors for scheduled-workout exercise-set updates', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    seedStructuralSnapshotTemplate();
+    const scheduledWorkoutId = await createScheduledWorkoutFromTemplate({ authToken });
+
+    const invalidBodyResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-sets`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        exerciseId: STRUCTURAL_EXERCISE_IDS.third,
+        sets: [{ setNumber: 2, remove: true, targetSeconds: 45 }],
+      },
+    });
+    expect(invalidBodyResponse.statusCode).toBe(400);
+    expectRequestValidationError(
+      invalidBodyResponse,
+      'PATCH',
+      `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-sets`,
+    );
+
+    const unknownExerciseResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-sets`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        exerciseId: UNKNOWN_STRUCTURAL_EXERCISE_ID,
+        sets: [{ setNumber: 1, targetSeconds: 60 }],
+      },
+    });
+    expect(unknownExerciseResponse.statusCode).toBe(400);
+    expect(unknownExerciseResponse.json()).toEqual({
+      error: {
+        code: 'UNKNOWN_SCHEDULED_WORKOUT_EXERCISE',
+        message: `Exercise is not present in this scheduled workout snapshot: ${UNKNOWN_STRUCTURAL_EXERCISE_ID}`,
+      },
+    });
+  });
+
+  it('returns 404 for exercise-set updates when schedule is missing or outside user scope', async () => {
+    const userOneToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    const userTwoToken = context.app.jwt.sign(
+      { sub: 'user-2', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedStructuralSnapshotTemplate({ templateId: 'template-3', userId: 'user-2' });
+    const otherUserScheduledWorkoutId = await createScheduledWorkoutFromTemplate({
+      authToken: userTwoToken,
+      templateId: 'template-3',
+    });
+
+    const [missingResponse, scopeResponse] = await Promise.all([
+      context.app.inject({
+        method: 'PATCH',
+        url: '/api/v1/scheduled-workouts/schedule-missing/exercise-sets',
+        headers: createAuthorizationHeader(userOneToken),
+        payload: {
+          exerciseId: STRUCTURAL_EXERCISE_IDS.first,
+          sets: [{ setNumber: 1, targetWeight: 155 }],
+        },
+      }),
+      context.app.inject({
+        method: 'PATCH',
+        url: `/api/v1/scheduled-workouts/${otherUserScheduledWorkoutId}/exercise-sets`,
+        headers: createAuthorizationHeader(userOneToken),
+        payload: {
+          exerciseId: STRUCTURAL_EXERCISE_IDS.first,
+          sets: [{ setNumber: 1, targetWeight: 155 }],
+        },
+      }),
+    ]);
+
+    for (const response of [missingResponse, scopeResponse]) {
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toEqual({
+        error: {
+          code: 'SCHEDULED_WORKOUT_NOT_FOUND',
+          message: 'Scheduled workout not found',
+        },
+      });
+    }
+  });
+
+  it('seeds new sessions from edited scheduled snapshots and leaves the template unchanged', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    seedStructuralSnapshotTemplate();
+    const templateBefore = context.db
+      .select({
+        id: templateExercises.id,
+        exerciseId: templateExercises.exerciseId,
+        section: templateExercises.section,
+        orderIndex: templateExercises.orderIndex,
+        supersetGroup: templateExercises.supersetGroup,
+        tempo: templateExercises.tempo,
+        restSeconds: templateExercises.restSeconds,
+        programmingNotes: templateExercises.programmingNotes,
+        setTargets: templateExercises.setTargets,
+      })
+      .from(templateExercises)
+      .where(eq(templateExercises.templateId, 'template-1'))
+      .all()
+      .sort((left, right) => left.orderIndex - right.orderIndex);
+
+    const scheduledWorkoutId = await createScheduledWorkoutFromTemplate({
+      authToken,
+      date: '2026-03-20',
+    });
+
+    const reorderResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/reorder`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        order: [
+          STRUCTURAL_EXERCISE_IDS.third,
+          STRUCTURAL_EXERCISE_IDS.second,
+          STRUCTURAL_EXERCISE_IDS.first,
+        ],
+      },
+    });
+    expect(reorderResponse.statusCode).toBe(200);
+
+    const updateExercisesResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercises`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        updates: [
+          { exerciseId: STRUCTURAL_EXERCISE_IDS.third, supersetGroup: 'A' },
+          { exerciseId: STRUCTURAL_EXERCISE_IDS.second, supersetGroup: 'A' },
+        ],
+      },
+    });
+    expect(updateExercisesResponse.statusCode).toBe(200);
+    expect(updateExercisesResponse.json()).toEqual({
+      data: expect.objectContaining({
+        exercises: expect.arrayContaining([
+          expect.objectContaining({
+            exerciseId: STRUCTURAL_EXERCISE_IDS.third,
+            supersetGroup: 'A',
+          }),
+          expect.objectContaining({
+            exerciseId: STRUCTURAL_EXERCISE_IDS.second,
+            supersetGroup: 'A',
+          }),
+        ]),
+      }),
+    });
+
+    const updateSetsResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-sets`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        exerciseId: STRUCTURAL_EXERCISE_IDS.third,
+        sets: [
+          { setNumber: 2, remove: true },
+          { setNumber: 3, remove: true },
+        ],
+      },
+    });
+    expect(updateSetsResponse.statusCode).toBe(200);
+
+    const startSessionResponse = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        scheduledWorkoutId,
+        date: '2026-03-20',
+        startedAt: Date.parse('2026-03-20T06:30:00.000Z'),
+      },
+    });
+    expect(startSessionResponse.statusCode).toBe(201);
+    const sessionPayload = startSessionResponse.json() as {
+      data: {
+        id: string;
+        sets: Array<{
+          exerciseId: string;
+          orderIndex: number | null;
+          setNumber: number;
+        }>;
+      };
+    };
+
+    const sortedSessionSets = context.db
+      .select({
+        exerciseId: sessionSets.exerciseId,
+        orderIndex: sessionSets.orderIndex,
+        setNumber: sessionSets.setNumber,
+        supersetGroup: sessionSets.supersetGroup,
+      })
+      .from(sessionSets)
+      .where(eq(sessionSets.sessionId, sessionPayload.data.id))
+      .all()
+      .sort((left, right) => {
+        const leftOrderIndex = left.orderIndex ?? Number.MAX_SAFE_INTEGER;
+        const rightOrderIndex = right.orderIndex ?? Number.MAX_SAFE_INTEGER;
+        if (leftOrderIndex !== rightOrderIndex) {
+          return leftOrderIndex - rightOrderIndex;
+        }
+
+        return left.setNumber - right.setNumber;
+      });
+
+    const exerciseOrder = [...new Set(sortedSessionSets.map((set) => set.exerciseId))];
+    expect(exerciseOrder).toEqual([
+      STRUCTURAL_EXERCISE_IDS.third,
+      STRUCTURAL_EXERCISE_IDS.second,
+      STRUCTURAL_EXERCISE_IDS.first,
+    ]);
+
+    const setsByExerciseId = sortedSessionSets.reduce<Record<string, typeof sortedSessionSets>>(
+      (accumulator, set) => {
+        if (!set.exerciseId) {
+          return accumulator;
+        }
+        const existing = accumulator[set.exerciseId] ?? [];
+        accumulator[set.exerciseId] = [...existing, set];
+        return accumulator;
+      },
+      {},
+    );
+
+    expect(setsByExerciseId[STRUCTURAL_EXERCISE_IDS.third]).toHaveLength(1);
+    expect(setsByExerciseId[STRUCTURAL_EXERCISE_IDS.second]).toHaveLength(3);
+    expect(setsByExerciseId[STRUCTURAL_EXERCISE_IDS.first]).toHaveLength(3);
+
+    expect(
+      setsByExerciseId[STRUCTURAL_EXERCISE_IDS.third]?.every((set) => set.supersetGroup === 'A'),
+    ).toBe(true);
+    expect(
+      setsByExerciseId[STRUCTURAL_EXERCISE_IDS.second]?.every((set) => set.supersetGroup === 'A'),
+    ).toBe(true);
+    expect(
+      setsByExerciseId[STRUCTURAL_EXERCISE_IDS.first]?.every((set) => set.supersetGroup === null),
+    ).toBe(true);
+
+    const templateAfter = context.db
+      .select({
+        id: templateExercises.id,
+        exerciseId: templateExercises.exerciseId,
+        section: templateExercises.section,
+        orderIndex: templateExercises.orderIndex,
+        supersetGroup: templateExercises.supersetGroup,
+        tempo: templateExercises.tempo,
+        restSeconds: templateExercises.restSeconds,
+        programmingNotes: templateExercises.programmingNotes,
+        setTargets: templateExercises.setTargets,
+      })
+      .from(templateExercises)
+      .where(eq(templateExercises.templateId, 'template-1'))
+      .all()
+      .sort((left, right) => left.orderIndex - right.orderIndex);
+
+    expect(templateAfter).toEqual(templateBefore);
+  });
+
   it('marks agent notes stale when rescheduling by more than two days', async () => {
     const authToken = context.app.jwt.sign(
       { sub: 'user-1', type: 'session', iss: 'pulse-api' },
@@ -1610,7 +2489,7 @@ describe('scheduled workout routes', () => {
     });
   });
 
-  it('documents scheduled workout exercise-note and swap paths in OpenAPI with correct security', async () => {
+  it('documents scheduled workout snapshot mutation paths in OpenAPI with correct security', async () => {
     const response = await context.app.inject({
       method: 'GET',
       url: '/api/docs/json',
@@ -1635,6 +2514,18 @@ describe('scheduled workout routes', () => {
     });
     expect(body.paths['/api/v1/scheduled-workouts/{id}/exercise-swap']?.patch).toMatchObject({
       summary: 'Swap or remove an exercise in a scheduled workout snapshot',
+      security: [{ bearerAuth: [] }, { agentToken: [] }],
+    });
+    expect(body.paths['/api/v1/scheduled-workouts/{id}/reorder']?.patch).toMatchObject({
+      summary: 'Reorder exercises in a scheduled workout snapshot',
+      security: [{ bearerAuth: [] }, { agentToken: [] }],
+    });
+    expect(body.paths['/api/v1/scheduled-workouts/{id}/exercises']?.patch).toMatchObject({
+      summary: 'Update exercise-level snapshot fields on a scheduled workout',
+      security: [{ bearerAuth: [] }, { agentToken: [] }],
+    });
+    expect(body.paths['/api/v1/scheduled-workouts/{id}/exercise-sets']?.patch).toMatchObject({
+      summary: 'Update snapshot set prescriptions on a scheduled workout exercise',
       security: [{ bearerAuth: [] }, { agentToken: [] }],
     });
   });

--- a/apps/api/src/routes/scheduled-workouts/index.ts
+++ b/apps/api/src/routes/scheduled-workouts/index.ts
@@ -3,14 +3,17 @@ import { randomUUID } from 'node:crypto';
 import {
   apiDataResponseSchema,
   createScheduledWorkoutInputSchema,
+  reorderScheduledWorkoutInputSchema,
   scheduledWorkoutDetailSchema,
   scheduledWorkoutListItemSchema,
   scheduledWorkoutQueryParamsSchema,
   scheduledWorkoutSchema,
   swapScheduledWorkoutExerciseInputSchema,
   swapScheduledWorkoutExerciseResponseSchema,
+  updateScheduledWorkoutExerciseSetsInputSchema,
   updateScheduledWorkoutExerciseNotesInputSchema,
   updateScheduledWorkoutExerciseNotesResponseSchema,
+  updateScheduledWorkoutExercisesInputSchema,
   updateScheduledWorkoutInputSchema,
   workoutTemplateSchema,
 } from '@pulse/shared';
@@ -31,6 +34,10 @@ import {
 } from '../../db/schema/index.js';
 import { sendError } from '../../lib/reply.js';
 import { requireAgentOnly, requireAuth } from '../../middleware/auth.js';
+import {
+  agentEnrichmentOnSend,
+  setAgentEnrichmentContext,
+} from '../../middleware/agent-enrichment.js';
 import {
   apiErrorResponseSchema,
   agentTokenSecurity,
@@ -54,6 +61,9 @@ import {
   findScheduledWorkoutById,
   findScheduledWorkoutByIdWithTemplateVersion,
   listScheduledWorkouts,
+  reorderScheduledWorkoutExercises,
+  updateScheduledWorkoutExerciseSets,
+  updateScheduledWorkoutExercises,
   updateScheduledWorkout,
 } from './store.js';
 
@@ -80,6 +90,16 @@ const SCHEDULED_WORKOUT_DUPLICATE_EXERCISE_RESPONSE = {
 const INVALID_SCHEDULED_WORKOUT_EXERCISE_RESPONSE = {
   code: 'INVALID_SCHEDULED_WORKOUT_EXERCISE',
   message: 'Exercise is not available for this user',
+} as const;
+
+const INVALID_SCHEDULED_WORKOUT_EXERCISE_ORDER_RESPONSE = {
+  code: 'INVALID_SCHEDULED_WORKOUT_EXERCISE_ORDER',
+  message: 'Order must include each snapshot exercise exactly once',
+} as const;
+
+const UNKNOWN_SCHEDULED_WORKOUT_EXERCISE_RESPONSE = {
+  code: 'UNKNOWN_SCHEDULED_WORKOUT_EXERCISE',
+  message: 'Exercise is not present in this scheduled workout snapshot',
 } as const;
 
 const TEMPLATE_DRIFT_SUMMARY = 'Template has been updated since scheduling.';
@@ -803,6 +823,174 @@ export const scheduledWorkoutRoutes: FastifyPluginAsync = async (app) => {
       if (!updatedDetail) {
         throw new Error('Swapped scheduled workout could not be loaded');
       }
+
+      return reply.send({
+        data: updatedDetail,
+      });
+    },
+  );
+
+  typedApp.patch(
+    '/:id/reorder',
+    {
+      onSend: agentEnrichmentOnSend,
+      schema: {
+        params: idParamsSchema,
+        body: reorderScheduledWorkoutInputSchema,
+        response: {
+          200: apiDataResponseSchema(scheduledWorkoutDetailSchema),
+          400: badRequestResponseSchema,
+          401: apiErrorResponseSchema,
+          404: apiErrorResponseSchema,
+        },
+        tags: ['scheduled-workouts'],
+        summary: 'Reorder exercises in a scheduled workout snapshot',
+        security: authSecurity,
+      },
+    },
+    async (request, reply) => {
+      const reordered = await reorderScheduledWorkoutExercises({
+        userId: request.userId,
+        scheduledWorkoutId: request.params.id,
+        order: request.body.order,
+      });
+      if (!reordered) {
+        return sendError(
+          reply,
+          404,
+          SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.code,
+          SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      if ('error' in reordered) {
+        return reply.code(400).send({
+          error: {
+            code: INVALID_SCHEDULED_WORKOUT_EXERCISE_ORDER_RESPONSE.code,
+            message: INVALID_SCHEDULED_WORKOUT_EXERCISE_ORDER_RESPONSE.message,
+            details: {
+              missingExerciseIds: reordered.missingExerciseIds,
+              extraExerciseIds: reordered.extraExerciseIds,
+              duplicateExerciseIds: reordered.duplicateExerciseIds,
+            },
+          },
+        });
+      }
+
+      const reorderedDetail = reordered;
+      setAgentEnrichmentContext(request, {
+        endpoint: 'scheduled-workout.mutation',
+        action: 'reorder',
+      });
+
+      return reply.send({
+        data: reorderedDetail,
+      });
+    },
+  );
+
+  typedApp.patch(
+    '/:id/exercises',
+    {
+      onSend: agentEnrichmentOnSend,
+      schema: {
+        params: idParamsSchema,
+        body: updateScheduledWorkoutExercisesInputSchema,
+        response: {
+          200: apiDataResponseSchema(scheduledWorkoutDetailSchema),
+          400: badRequestResponseSchema,
+          401: apiErrorResponseSchema,
+          404: apiErrorResponseSchema,
+        },
+        tags: ['scheduled-workouts'],
+        summary: 'Update exercise-level snapshot fields on a scheduled workout',
+        security: authSecurity,
+      },
+    },
+    async (request, reply) => {
+      const updated = await updateScheduledWorkoutExercises({
+        userId: request.userId,
+        scheduledWorkoutId: request.params.id,
+        updates: request.body.updates,
+      });
+      if (!updated) {
+        return sendError(
+          reply,
+          404,
+          SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.code,
+          SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      if ('error' in updated) {
+        return sendError(
+          reply,
+          400,
+          UNKNOWN_SCHEDULED_WORKOUT_EXERCISE_RESPONSE.code,
+          `${UNKNOWN_SCHEDULED_WORKOUT_EXERCISE_RESPONSE.message}: ${updated.exerciseId}`,
+        );
+      }
+
+      const updatedDetail = updated;
+      setAgentEnrichmentContext(request, {
+        endpoint: 'scheduled-workout.mutation',
+        action: 'exercises',
+      });
+
+      return reply.send({
+        data: updatedDetail,
+      });
+    },
+  );
+
+  typedApp.patch(
+    '/:id/exercise-sets',
+    {
+      onSend: agentEnrichmentOnSend,
+      schema: {
+        params: idParamsSchema,
+        body: updateScheduledWorkoutExerciseSetsInputSchema,
+        response: {
+          200: apiDataResponseSchema(scheduledWorkoutDetailSchema),
+          400: badRequestResponseSchema,
+          401: apiErrorResponseSchema,
+          404: apiErrorResponseSchema,
+        },
+        tags: ['scheduled-workouts'],
+        summary: 'Update snapshot set prescriptions on a scheduled workout exercise',
+        security: authSecurity,
+      },
+    },
+    async (request, reply) => {
+      const updated = await updateScheduledWorkoutExerciseSets({
+        userId: request.userId,
+        scheduledWorkoutId: request.params.id,
+        exerciseId: request.body.exerciseId,
+        sets: request.body.sets,
+      });
+      if (!updated) {
+        return sendError(
+          reply,
+          404,
+          SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.code,
+          SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE.message,
+        );
+      }
+
+      if ('error' in updated) {
+        return sendError(
+          reply,
+          400,
+          UNKNOWN_SCHEDULED_WORKOUT_EXERCISE_RESPONSE.code,
+          `${UNKNOWN_SCHEDULED_WORKOUT_EXERCISE_RESPONSE.message}: ${updated.exerciseId}`,
+        );
+      }
+
+      const updatedDetail = updated;
+      setAgentEnrichmentContext(request, {
+        endpoint: 'scheduled-workout.mutation',
+        action: 'exercise-sets',
+      });
 
       return reply.send({
         data: updatedDetail,

--- a/apps/api/src/routes/scheduled-workouts/store.test.ts
+++ b/apps/api/src/routes/scheduled-workouts/store.test.ts
@@ -351,9 +351,7 @@ describe('scheduled workout structural mutation store functions', () => {
     expect(readExerciseRows().find((row) => row.exerciseId === EXERCISE_MAIN_ID)?.supersetGroup).toBe(
       null,
     );
-    const updatedAtAfterFirstRun = readExerciseRows().find(
-      (row) => row.exerciseId === EXERCISE_MAIN_ID,
-    )?.updatedAt;
+    const updatedAtAfterFirstRun = readScheduledWorkoutUpdatedAt();
 
     const secondRun = await context.store.updateScheduledWorkoutExercises({
       userId: USER_ID,
@@ -369,9 +367,7 @@ describe('scheduled workout structural mutation store functions', () => {
     expect(secondRun).toMatchObject({
       id: SCHEDULED_WORKOUT_ID,
     });
-    expect(
-      readExerciseRows().find((row) => row.exerciseId === EXERCISE_MAIN_ID)?.updatedAt,
-    ).toBe(updatedAtAfterFirstRun);
+    expect(readScheduledWorkoutUpdatedAt()).toBe(updatedAtAfterFirstRun);
   });
 
   it('returns unknown-exercise sentinel for exercise updates without mutating rows', async () => {

--- a/apps/api/src/routes/scheduled-workouts/store.test.ts
+++ b/apps/api/src/routes/scheduled-workouts/store.test.ts
@@ -1,0 +1,664 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { eq } from 'drizzle-orm';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  exercises,
+  scheduledWorkoutExerciseSets,
+  scheduledWorkoutExercises,
+  scheduledWorkouts,
+  users,
+} from '../../db/schema/index.js';
+
+type DatabaseModule = typeof import('../../db/index.js');
+type StoreModule = typeof import('./store.js');
+
+type TestContext = {
+  db: DatabaseModule['db'];
+  sqlite: DatabaseModule['sqlite'];
+  tempDir: string;
+  store: StoreModule;
+};
+
+const USER_ID = 'user-1';
+const OTHER_USER_ID = 'user-2';
+const SCHEDULED_WORKOUT_ID = 'scheduled-1';
+const EXERCISE_WARMUP_ID = 'exercise-warmup';
+const EXERCISE_MAIN_ID = 'exercise-main';
+const EXERCISE_COOLDOWN_ID = 'exercise-cooldown';
+const UNKNOWN_EXERCISE_ID = 'exercise-unknown';
+const MAIN_SNAPSHOT_EXERCISE_ID = 'snapshot-main';
+
+let context: TestContext;
+
+const seedUser = (values: { id: string; username: string }) =>
+  context.db
+    .insert(users)
+    .values({
+      id: values.id,
+      username: values.username,
+      name: values.username,
+      passwordHash: 'not-used-in-this-suite',
+    })
+    .run();
+
+const seedExercise = (values: { id: string; name: string; userId?: string | null }) =>
+  context.db
+    .insert(exercises)
+    .values({
+      id: values.id,
+      userId: values.userId ?? null,
+      name: values.name,
+      trackingType: 'weight_reps',
+      muscleGroups: ['legs'],
+      equipment: 'barbell',
+      category: 'compound',
+      formCues: [],
+      coachingNotes: null,
+      instructions: null,
+    })
+    .run();
+
+const seedSnapshotWorkout = () => {
+  context.db
+    .insert(scheduledWorkouts)
+    .values({
+      id: SCHEDULED_WORKOUT_ID,
+      userId: USER_ID,
+      templateId: null,
+      date: '2026-04-21',
+      sessionId: null,
+      templateVersion: null,
+    })
+    .run();
+
+  context.db
+    .insert(scheduledWorkoutExercises)
+    .values([
+      {
+        id: 'snapshot-warmup',
+        scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+        exerciseId: EXERCISE_WARMUP_ID,
+        section: 'warmup',
+        orderIndex: 0,
+        supersetGroup: null,
+        tempo: 'controlled',
+        restSeconds: 45,
+        programmingNotes: 'Prime the movement pattern.',
+      },
+      {
+        id: MAIN_SNAPSHOT_EXERCISE_ID,
+        scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+        exerciseId: EXERCISE_MAIN_ID,
+        section: 'main',
+        orderIndex: 1,
+        supersetGroup: 'A',
+        tempo: '3-1-1',
+        restSeconds: 90,
+        programmingNotes: 'Drive hard through lockout.',
+      },
+      {
+        id: 'snapshot-cooldown',
+        scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+        exerciseId: EXERCISE_COOLDOWN_ID,
+        section: 'cooldown',
+        orderIndex: 2,
+        supersetGroup: null,
+        tempo: null,
+        restSeconds: null,
+        programmingNotes: 'Slow breathing.',
+      },
+    ])
+    .run();
+
+  context.db
+    .insert(scheduledWorkoutExerciseSets)
+    .values([
+      {
+        id: 'snapshot-main-set-1',
+        scheduledWorkoutExerciseId: MAIN_SNAPSHOT_EXERCISE_ID,
+        setNumber: 1,
+        repsMin: 5,
+        repsMax: 5,
+        reps: 5,
+        targetWeight: 100,
+        targetWeightMin: null,
+        targetWeightMax: null,
+        targetSeconds: null,
+        targetDistance: null,
+      },
+      {
+        id: 'snapshot-main-set-2',
+        scheduledWorkoutExerciseId: MAIN_SNAPSHOT_EXERCISE_ID,
+        setNumber: 2,
+        repsMin: 5,
+        repsMax: 5,
+        reps: 5,
+        targetWeight: 105,
+        targetWeightMin: null,
+        targetWeightMax: null,
+        targetSeconds: null,
+        targetDistance: null,
+      },
+      {
+        id: 'snapshot-main-set-3',
+        scheduledWorkoutExerciseId: MAIN_SNAPSHOT_EXERCISE_ID,
+        setNumber: 3,
+        repsMin: 5,
+        repsMax: 5,
+        reps: 5,
+        targetWeight: 110,
+        targetWeightMin: null,
+        targetWeightMax: null,
+        targetSeconds: null,
+        targetDistance: null,
+      },
+    ])
+    .run();
+};
+
+const readExerciseRows = () =>
+  context.db
+    .select({
+      exerciseId: scheduledWorkoutExercises.exerciseId,
+      section: scheduledWorkoutExercises.section,
+      orderIndex: scheduledWorkoutExercises.orderIndex,
+      supersetGroup: scheduledWorkoutExercises.supersetGroup,
+      tempo: scheduledWorkoutExercises.tempo,
+      restSeconds: scheduledWorkoutExercises.restSeconds,
+      programmingNotes: scheduledWorkoutExercises.programmingNotes,
+      updatedAt: scheduledWorkoutExercises.updatedAt,
+    })
+    .from(scheduledWorkoutExercises)
+    .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, SCHEDULED_WORKOUT_ID))
+    .all();
+
+const readMainSetRows = () =>
+  context.db
+    .select({
+      id: scheduledWorkoutExerciseSets.id,
+      setNumber: scheduledWorkoutExerciseSets.setNumber,
+      targetWeight: scheduledWorkoutExerciseSets.targetWeight,
+      repsMin: scheduledWorkoutExerciseSets.repsMin,
+      repsMax: scheduledWorkoutExerciseSets.repsMax,
+      reps: scheduledWorkoutExerciseSets.reps,
+    })
+    .from(scheduledWorkoutExerciseSets)
+    .where(eq(scheduledWorkoutExerciseSets.scheduledWorkoutExerciseId, MAIN_SNAPSHOT_EXERCISE_ID))
+    .all()
+    .sort((left, right) => left.setNumber - right.setNumber);
+
+const readScheduledWorkoutUpdatedAt = () => {
+  const row = context.db
+    .select({ updatedAt: scheduledWorkouts.updatedAt })
+    .from(scheduledWorkouts)
+    .where(eq(scheduledWorkouts.id, SCHEDULED_WORKOUT_ID))
+    .limit(1)
+    .get();
+
+  if (!row) {
+    throw new Error('Scheduled workout missing in test fixture');
+  }
+
+  return row.updatedAt;
+};
+
+describe('scheduled workout structural mutation store functions', () => {
+  beforeAll(async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'pulse-scheduled-workout-store-'));
+
+    process.env.DATABASE_URL = join(tempDir, 'test.db');
+    vi.resetModules();
+
+    const dbModule = await import('../../db/index.js');
+    migrate(dbModule.db, {
+      migrationsFolder: fileURLToPath(new URL('../../../drizzle', import.meta.url)),
+    });
+
+    const store = await import('./store.js');
+
+    context = {
+      db: dbModule.db,
+      sqlite: dbModule.sqlite,
+      tempDir,
+      store,
+    };
+  });
+
+  afterAll(() => {
+    if (context) {
+      context.sqlite.close();
+      rmSync(context.tempDir, { recursive: true, force: true });
+    }
+
+    delete process.env.DATABASE_URL;
+    vi.resetModules();
+  });
+
+  beforeEach(() => {
+    context.db.delete(scheduledWorkoutExerciseSets).run();
+    context.db.delete(scheduledWorkoutExercises).run();
+    context.db.delete(scheduledWorkouts).run();
+    context.db.delete(exercises).run();
+    context.db.delete(users).run();
+
+    seedUser({ id: USER_ID, username: 'derek' });
+    seedUser({ id: OTHER_USER_ID, username: 'alex' });
+    seedExercise({ id: EXERCISE_WARMUP_ID, name: 'Jump Rope' });
+    seedExercise({ id: EXERCISE_MAIN_ID, name: 'Back Squat' });
+    seedExercise({ id: EXERCISE_COOLDOWN_ID, name: 'Hip Flexor Stretch' });
+    seedSnapshotWorkout();
+  });
+
+  it('reorders snapshot exercises, keeps sections intact, and is idempotent on rerun', async () => {
+    const result = await context.store.reorderScheduledWorkoutExercises({
+      userId: USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      order: [EXERCISE_MAIN_ID, EXERCISE_COOLDOWN_ID, EXERCISE_WARMUP_ID],
+    });
+
+    expect(result).toMatchObject({
+      id: SCHEDULED_WORKOUT_ID,
+      exercises: expect.any(Array),
+    });
+
+    const reorderedRows = readExerciseRows();
+    const rowByExerciseId = new Map(reorderedRows.map((row) => [row.exerciseId, row]));
+    expect(rowByExerciseId.get(EXERCISE_MAIN_ID)?.orderIndex).toBe(0);
+    expect(rowByExerciseId.get(EXERCISE_COOLDOWN_ID)?.orderIndex).toBe(1);
+    expect(rowByExerciseId.get(EXERCISE_WARMUP_ID)?.orderIndex).toBe(2);
+    expect(rowByExerciseId.get(EXERCISE_MAIN_ID)?.section).toBe('main');
+    expect(rowByExerciseId.get(EXERCISE_COOLDOWN_ID)?.section).toBe('cooldown');
+    expect(rowByExerciseId.get(EXERCISE_WARMUP_ID)?.section).toBe('warmup');
+
+    const updatedAtAfterFirstRun = readScheduledWorkoutUpdatedAt();
+
+    const rerun = await context.store.reorderScheduledWorkoutExercises({
+      userId: USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      order: [EXERCISE_MAIN_ID, EXERCISE_COOLDOWN_ID, EXERCISE_WARMUP_ID],
+    });
+
+    expect(rerun).toMatchObject({
+      id: SCHEDULED_WORKOUT_ID,
+    });
+    expect(readScheduledWorkoutUpdatedAt()).toBe(updatedAtAfterFirstRun);
+  });
+
+  it('returns invalid-order sentinel for missing or extra exercise ids without mutating rows', async () => {
+    const beforeRows = readExerciseRows();
+
+    const result = await context.store.reorderScheduledWorkoutExercises({
+      userId: USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      order: [EXERCISE_WARMUP_ID, EXERCISE_MAIN_ID, UNKNOWN_EXERCISE_ID],
+    });
+
+    expect(result).toEqual({
+      error: context.store.SCHEDULED_WORKOUT_REORDER_INVALID_ORDER,
+      missingExerciseIds: [EXERCISE_COOLDOWN_ID],
+      extraExerciseIds: [UNKNOWN_EXERCISE_ID],
+      duplicateExerciseIds: [],
+    });
+    expect(readExerciseRows()).toEqual(beforeRows);
+  });
+
+  it('updates scheduled workout exercise fields partially and keeps unspecified fields unchanged', async () => {
+    const result = await context.store.updateScheduledWorkoutExercises({
+      userId: USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      updates: [
+        {
+          exerciseId: EXERCISE_MAIN_ID,
+          tempo: '2-0-2',
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      id: SCHEDULED_WORKOUT_ID,
+    });
+
+    const mainRow = readExerciseRows().find((row) => row.exerciseId === EXERCISE_MAIN_ID);
+    expect(mainRow).toMatchObject({
+      tempo: '2-0-2',
+      supersetGroup: 'A',
+      restSeconds: 90,
+      programmingNotes: 'Drive hard through lockout.',
+    });
+  });
+
+  it('clears nullable exercise fields and is idempotent when rerun with the same payload', async () => {
+    const firstRun = await context.store.updateScheduledWorkoutExercises({
+      userId: USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      updates: [
+        {
+          exerciseId: EXERCISE_MAIN_ID,
+          supersetGroup: null,
+        },
+      ],
+    });
+
+    expect(firstRun).toMatchObject({
+      id: SCHEDULED_WORKOUT_ID,
+    });
+    expect(readExerciseRows().find((row) => row.exerciseId === EXERCISE_MAIN_ID)?.supersetGroup).toBe(
+      null,
+    );
+    const updatedAtAfterFirstRun = readExerciseRows().find(
+      (row) => row.exerciseId === EXERCISE_MAIN_ID,
+    )?.updatedAt;
+
+    const secondRun = await context.store.updateScheduledWorkoutExercises({
+      userId: USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      updates: [
+        {
+          exerciseId: EXERCISE_MAIN_ID,
+          supersetGroup: null,
+        },
+      ],
+    });
+
+    expect(secondRun).toMatchObject({
+      id: SCHEDULED_WORKOUT_ID,
+    });
+    expect(
+      readExerciseRows().find((row) => row.exerciseId === EXERCISE_MAIN_ID)?.updatedAt,
+    ).toBe(updatedAtAfterFirstRun);
+  });
+
+  it('returns unknown-exercise sentinel for exercise updates without mutating rows', async () => {
+    const beforeRows = readExerciseRows();
+
+    const result = await context.store.updateScheduledWorkoutExercises({
+      userId: USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      updates: [
+        {
+          exerciseId: UNKNOWN_EXERCISE_ID,
+          tempo: 'explosive',
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      error: context.store.SCHEDULED_WORKOUT_UNKNOWN_EXERCISE,
+      exerciseId: UNKNOWN_EXERCISE_ID,
+    });
+    expect(readExerciseRows()).toEqual(beforeRows);
+  });
+
+  it('upserts set targets idempotently and removes a set with contiguous renumbering', async () => {
+    const upsertResult = await context.store.updateScheduledWorkoutExerciseSets({
+      userId: USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      exerciseId: EXERCISE_MAIN_ID,
+      sets: [
+        {
+          setNumber: 1,
+          targetWeight: 125,
+        },
+      ],
+    });
+
+    expect(upsertResult).toMatchObject({
+      id: SCHEDULED_WORKOUT_ID,
+    });
+    expect(readMainSetRows()[0]).toMatchObject({
+      setNumber: 1,
+      targetWeight: 125,
+    });
+
+    const updatedAtAfterUpsert = readScheduledWorkoutUpdatedAt();
+    const upsertRerun = await context.store.updateScheduledWorkoutExerciseSets({
+      userId: USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      exerciseId: EXERCISE_MAIN_ID,
+      sets: [
+        {
+          setNumber: 1,
+          targetWeight: 125,
+        },
+      ],
+    });
+
+    expect(upsertRerun).toMatchObject({
+      id: SCHEDULED_WORKOUT_ID,
+    });
+    expect(readScheduledWorkoutUpdatedAt()).toBe(updatedAtAfterUpsert);
+
+    const removeResult = await context.store.updateScheduledWorkoutExerciseSets({
+      userId: USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      exerciseId: EXERCISE_MAIN_ID,
+      sets: [
+        {
+          setNumber: 2,
+          remove: true,
+        },
+      ],
+    });
+
+    expect(removeResult).toMatchObject({
+      id: SCHEDULED_WORKOUT_ID,
+    });
+
+    const renumberedRows = readMainSetRows();
+    expect(renumberedRows.map((row) => row.setNumber)).toEqual([1, 2]);
+    expect(renumberedRows).toHaveLength(2);
+  });
+
+  it('returns unknown-exercise sentinel for set updates without mutating rows', async () => {
+    const beforeRows = readMainSetRows();
+
+    const result = await context.store.updateScheduledWorkoutExerciseSets({
+      userId: USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      exerciseId: UNKNOWN_EXERCISE_ID,
+      sets: [
+        {
+          setNumber: 1,
+          targetWeight: 140,
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      error: context.store.SCHEDULED_WORKOUT_UNKNOWN_EXERCISE,
+      exerciseId: UNKNOWN_EXERCISE_ID,
+    });
+    expect(readMainSetRows()).toEqual(beforeRows);
+  });
+
+  it('returns not-found/undefined for cross-user scope on all structural mutation functions', async () => {
+    const beforeExerciseRows = readExerciseRows();
+    const beforeSetRows = readMainSetRows();
+
+    const reorderResult = await context.store.reorderScheduledWorkoutExercises({
+      userId: OTHER_USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      order: [EXERCISE_MAIN_ID, EXERCISE_WARMUP_ID, EXERCISE_COOLDOWN_ID],
+    });
+    const exerciseUpdateResult = await context.store.updateScheduledWorkoutExercises({
+      userId: OTHER_USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      updates: [
+        {
+          exerciseId: EXERCISE_MAIN_ID,
+          tempo: '1-0-1',
+        },
+      ],
+    });
+    const setUpdateResult = await context.store.updateScheduledWorkoutExerciseSets({
+      userId: OTHER_USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      exerciseId: EXERCISE_MAIN_ID,
+      sets: [
+        {
+          setNumber: 1,
+          targetWeight: 999,
+        },
+      ],
+    });
+
+    expect(reorderResult).toBeUndefined();
+    expect(exerciseUpdateResult).toBeUndefined();
+    expect(setUpdateResult).toBeUndefined();
+    expect(readExerciseRows()).toEqual(beforeExerciseRows);
+    expect(readMainSetRows()).toEqual(beforeSetRows);
+  });
+
+  it('reorder detects duplicate ids in the payload as invalid-order', async () => {
+    const result = await context.store.reorderScheduledWorkoutExercises({
+      userId: USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      order: [EXERCISE_MAIN_ID, EXERCISE_MAIN_ID, EXERCISE_COOLDOWN_ID],
+    });
+
+    expect(result).toEqual({
+      error: context.store.SCHEDULED_WORKOUT_REORDER_INVALID_ORDER,
+      missingExerciseIds: [EXERCISE_WARMUP_ID],
+      extraExerciseIds: [],
+      duplicateExerciseIds: [EXERCISE_MAIN_ID],
+    });
+  });
+
+  it('set updates treat undefined as no-op and null as explicit clear', async () => {
+    const targetBefore = readMainSetRows().find((row) => row.setNumber === 1)?.targetWeight;
+    expect(targetBefore).toBe(100);
+
+    const noOpResult = await context.store.updateScheduledWorkoutExerciseSets({
+      userId: USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      exerciseId: EXERCISE_MAIN_ID,
+      sets: [
+        {
+          setNumber: 1,
+        },
+      ],
+    });
+    expect(noOpResult).toMatchObject({ id: SCHEDULED_WORKOUT_ID });
+    expect(readMainSetRows().find((row) => row.setNumber === 1)?.targetWeight).toBe(100);
+
+    const clearResult = await context.store.updateScheduledWorkoutExerciseSets({
+      userId: USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      exerciseId: EXERCISE_MAIN_ID,
+      sets: [
+        {
+          setNumber: 1,
+          targetWeight: null,
+        },
+      ],
+    });
+    expect(clearResult).toMatchObject({ id: SCHEDULED_WORKOUT_ID });
+    expect(readMainSetRows().find((row) => row.setNumber === 1)?.targetWeight).toBeNull();
+  });
+
+  it('exercise updates treat undefined as leave-alone and null as explicit clear', async () => {
+    const before = readExerciseRows().find((row) => row.exerciseId === EXERCISE_MAIN_ID);
+    expect(before?.programmingNotes).toBe('Drive hard through lockout.');
+
+    const unchangedResult = await context.store.updateScheduledWorkoutExercises({
+      userId: USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      updates: [
+        {
+          exerciseId: EXERCISE_MAIN_ID,
+        },
+      ],
+    });
+    expect(unchangedResult).toMatchObject({ id: SCHEDULED_WORKOUT_ID });
+    expect(
+      readExerciseRows().find((row) => row.exerciseId === EXERCISE_MAIN_ID)?.programmingNotes,
+    ).toBe('Drive hard through lockout.');
+
+    const clearedResult = await context.store.updateScheduledWorkoutExercises({
+      userId: USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      updates: [
+        {
+          exerciseId: EXERCISE_MAIN_ID,
+          programmingNotes: null,
+        },
+      ],
+    });
+    expect(clearedResult).toMatchObject({ id: SCHEDULED_WORKOUT_ID });
+    expect(
+      readExerciseRows().find((row) => row.exerciseId === EXERCISE_MAIN_ID)?.programmingNotes,
+    ).toBeNull();
+  });
+
+  it('set delete renumbering remains transactional when another update in payload is invalid no-op', async () => {
+    const beforeSetRows = readMainSetRows();
+
+    const result = await context.store.updateScheduledWorkoutExerciseSets({
+      userId: USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      exerciseId: EXERCISE_MAIN_ID,
+      sets: [
+        { setNumber: 2, remove: true },
+        { setNumber: 50, remove: true },
+      ],
+    });
+
+    expect(result).toMatchObject({ id: SCHEDULED_WORKOUT_ID });
+    const afterSetRows = readMainSetRows();
+    expect(afterSetRows).not.toEqual(beforeSetRows);
+    expect(afterSetRows.map((row) => row.setNumber)).toEqual([1, 2]);
+  });
+
+  it('scope guard leaves row counts unchanged for non-owner calls', async () => {
+    const beforeCounts = {
+      exercises: context.db
+        .select({ id: scheduledWorkoutExercises.id })
+        .from(scheduledWorkoutExercises)
+        .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, SCHEDULED_WORKOUT_ID))
+        .all().length,
+      sets: context.db
+        .select({ id: scheduledWorkoutExerciseSets.id })
+        .from(scheduledWorkoutExerciseSets)
+        .where(eq(scheduledWorkoutExerciseSets.scheduledWorkoutExerciseId, MAIN_SNAPSHOT_EXERCISE_ID))
+        .all().length,
+    };
+
+    await context.store.reorderScheduledWorkoutExercises({
+      userId: OTHER_USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      order: [EXERCISE_MAIN_ID, EXERCISE_COOLDOWN_ID, EXERCISE_WARMUP_ID],
+    });
+    await context.store.updateScheduledWorkoutExercises({
+      userId: OTHER_USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      updates: [{ exerciseId: EXERCISE_MAIN_ID, restSeconds: 120 }],
+    });
+    await context.store.updateScheduledWorkoutExerciseSets({
+      userId: OTHER_USER_ID,
+      scheduledWorkoutId: SCHEDULED_WORKOUT_ID,
+      exerciseId: EXERCISE_MAIN_ID,
+      sets: [{ setNumber: 1, reps: 6 }],
+    });
+
+    const afterCounts = {
+      exercises: context.db
+        .select({ id: scheduledWorkoutExercises.id })
+        .from(scheduledWorkoutExercises)
+        .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, SCHEDULED_WORKOUT_ID))
+        .all().length,
+      sets: context.db
+        .select({ id: scheduledWorkoutExerciseSets.id })
+        .from(scheduledWorkoutExerciseSets)
+        .where(eq(scheduledWorkoutExerciseSets.scheduledWorkoutExerciseId, MAIN_SNAPSHOT_EXERCISE_ID))
+        .all().length,
+    };
+
+    expect(afterCounts).toEqual(beforeCounts);
+  });
+});

--- a/apps/api/src/routes/scheduled-workouts/store.ts
+++ b/apps/api/src/routes/scheduled-workouts/store.ts
@@ -1,18 +1,37 @@
+import { randomUUID } from 'node:crypto';
+
 import { and, asc, eq, gte, inArray, isNull, lte, or } from 'drizzle-orm';
 import type {
   CreateScheduledWorkoutInput,
   ExerciseTrackingType,
+  ReorderScheduledWorkoutInput,
+  ScheduledWorkoutDetail,
   ScheduledWorkout,
   ScheduledWorkoutListItem,
+  UpdateScheduledWorkoutExercisesInput,
+  UpdateScheduledWorkoutExerciseSetsInput,
   UpdateScheduledWorkoutInput,
 } from '@pulse/shared';
 
 import {
   exercises,
+  type WorkoutTemplateSectionType,
+  scheduledWorkoutExerciseSets,
+  scheduledWorkoutExercises,
   scheduledWorkouts,
   templateExercises,
   workoutTemplates,
 } from '../../db/schema/index.js';
+import { computeTemplateVersionForTemplateId, readSnapshot } from './snapshot-store.js';
+
+const SECTION_RANK: Record<WorkoutTemplateSectionType, number> = {
+  warmup: 0,
+  main: 1,
+  cooldown: 2,
+  supplemental: 3,
+};
+const TEMPLATE_DRIFT_SUMMARY = 'Template has been updated since scheduling.';
+const UNKNOWN_SNAPSHOT_EXERCISE_NAME = 'Unknown exercise';
 
 const scheduledWorkoutSelection = {
   id: scheduledWorkouts.id,
@@ -36,6 +55,326 @@ const scheduledWorkoutListSelection = {
   templateName: workoutTemplates.name,
   sessionId: scheduledWorkouts.sessionId,
   createdAt: scheduledWorkouts.createdAt,
+};
+
+const scheduledWorkoutExerciseMutationSelection = {
+  id: scheduledWorkoutExercises.id,
+  exerciseId: scheduledWorkoutExercises.exerciseId,
+  section: scheduledWorkoutExercises.section,
+  orderIndex: scheduledWorkoutExercises.orderIndex,
+  supersetGroup: scheduledWorkoutExercises.supersetGroup,
+  tempo: scheduledWorkoutExercises.tempo,
+  restSeconds: scheduledWorkoutExercises.restSeconds,
+  programmingNotes: scheduledWorkoutExercises.programmingNotes,
+};
+
+const scheduledWorkoutExerciseSetMutationSelection = {
+  id: scheduledWorkoutExerciseSets.id,
+  scheduledWorkoutExerciseId: scheduledWorkoutExerciseSets.scheduledWorkoutExerciseId,
+  setNumber: scheduledWorkoutExerciseSets.setNumber,
+  targetWeight: scheduledWorkoutExerciseSets.targetWeight,
+  targetWeightMin: scheduledWorkoutExerciseSets.targetWeightMin,
+  targetWeightMax: scheduledWorkoutExerciseSets.targetWeightMax,
+  targetSeconds: scheduledWorkoutExerciseSets.targetSeconds,
+  targetDistance: scheduledWorkoutExerciseSets.targetDistance,
+  repsMin: scheduledWorkoutExerciseSets.repsMin,
+  repsMax: scheduledWorkoutExerciseSets.repsMax,
+  reps: scheduledWorkoutExerciseSets.reps,
+  createdAt: scheduledWorkoutExerciseSets.createdAt,
+};
+
+type ScheduledWorkoutExerciseMutationRow = {
+  id: string;
+  exerciseId: string;
+  section: WorkoutTemplateSectionType;
+  orderIndex: number;
+  supersetGroup: string | null;
+  tempo: string | null;
+  restSeconds: number | null;
+  programmingNotes: string | null;
+};
+
+type ScheduledWorkoutExerciseSetMutationRow = {
+  id: string;
+  scheduledWorkoutExerciseId: string;
+  setNumber: number;
+  targetWeight: number | null;
+  targetWeightMin: number | null;
+  targetWeightMax: number | null;
+  targetSeconds: number | null;
+  targetDistance: number | null;
+  repsMin: number | null;
+  repsMax: number | null;
+  reps: number | null;
+  createdAt: number;
+};
+
+type ScheduledWorkoutExercisePatch = Partial<
+  Pick<
+    ScheduledWorkoutExerciseMutationRow,
+    'supersetGroup' | 'section' | 'tempo' | 'restSeconds' | 'programmingNotes'
+  >
+>;
+
+const mapSnapshotExercise = (
+  exercise: Awaited<ReturnType<typeof readSnapshot>>['exercises'][number],
+  exerciseName: string,
+) => ({
+  exerciseId: exercise.exerciseId,
+  exerciseName,
+  section: exercise.section,
+  orderIndex: exercise.orderIndex,
+  programmingNotes: exercise.programmingNotes,
+  agentNotes: exercise.agentNotes,
+  agentNotesMeta: exercise.agentNotesMeta
+    ? {
+        ...exercise.agentNotesMeta,
+        stale: exercise.agentNotesMeta.stale ?? false,
+      }
+    : null,
+  templateCues: exercise.templateCues,
+  supersetGroup: exercise.supersetGroup,
+  tempo: exercise.tempo,
+  restSeconds: exercise.restSeconds,
+  sets: exercise.sets.map((set) => ({
+    setNumber: set.setNumber,
+    repsMin: set.repsMin,
+    repsMax: set.repsMax,
+    reps: set.reps,
+    targetWeight: set.targetWeight,
+    targetWeightMin: set.targetWeightMin,
+    targetWeightMax: set.targetWeightMax,
+    targetSeconds: set.targetSeconds,
+    targetDistance: set.targetDistance,
+  })),
+});
+
+const buildScheduledWorkoutDetail = async ({
+  scheduledWorkoutId,
+  userId,
+}: {
+  scheduledWorkoutId: string;
+  userId: string;
+}): Promise<ScheduledWorkoutDetail | null> => {
+  const scheduledWorkout = await findScheduledWorkoutByIdWithTemplateVersion(
+    scheduledWorkoutId,
+    userId,
+  );
+  if (!scheduledWorkout) {
+    return null;
+  }
+
+  const { db } = await import('../../db/index.js');
+  const snapshot = await readSnapshot(scheduledWorkout.id, db);
+  const uniqueSnapshotExerciseIds = [
+    ...new Set(snapshot.exercises.map((exercise) => exercise.exerciseId)),
+  ];
+
+  const exerciseRows =
+    uniqueSnapshotExerciseIds.length === 0
+      ? []
+      : db
+          .select({
+            id: exercises.id,
+            userId: exercises.userId,
+            name: exercises.name,
+            deletedAt: exercises.deletedAt,
+          })
+          .from(exercises)
+          .where(inArray(exercises.id, uniqueSnapshotExerciseIds))
+          .all();
+
+  const exercisesById = new Map(exerciseRows.map((row) => [row.id, row]));
+  const snapshotExercises = snapshot.exercises.map((exercise) =>
+    mapSnapshotExercise(
+      exercise,
+      exercisesById.get(exercise.exerciseId)?.name ?? UNKNOWN_SNAPSHOT_EXERCISE_NAME,
+    ),
+  );
+  const staleByExerciseId = new Map<string, { exerciseId: string; snapshotName: string }>();
+
+  for (const snapshotExercise of snapshotExercises) {
+    const exercise = exercisesById.get(snapshotExercise.exerciseId);
+    const isMissing = !exercise;
+    const isSoftDeleted = exercise?.deletedAt != null;
+    const isOutsideUserScope =
+      exercise !== undefined && exercise.userId !== null && exercise.userId !== userId;
+
+    if (isMissing || isSoftDeleted || isOutsideUserScope) {
+      staleByExerciseId.set(snapshotExercise.exerciseId, {
+        exerciseId: snapshotExercise.exerciseId,
+        snapshotName: exercise?.name ?? UNKNOWN_SNAPSHOT_EXERCISE_NAME,
+      });
+    }
+  }
+
+  let templateDeleted = false;
+  let templateDrift: { changedAt: number; summary: string } | null = null;
+
+  if (scheduledWorkout.templateId) {
+    const sourceTemplate = db
+      .select({
+        id: workoutTemplates.id,
+        deletedAt: workoutTemplates.deletedAt,
+        updatedAt: workoutTemplates.updatedAt,
+      })
+      .from(workoutTemplates)
+      .where(
+        and(
+          eq(workoutTemplates.id, scheduledWorkout.templateId),
+          eq(workoutTemplates.userId, userId),
+        ),
+      )
+      .limit(1)
+      .get();
+
+    templateDeleted = !sourceTemplate || sourceTemplate.deletedAt !== null;
+
+    if (sourceTemplate && sourceTemplate.deletedAt === null && scheduledWorkout.templateVersion) {
+      const currentTemplateVersion = await computeTemplateVersionForTemplateId(
+        scheduledWorkout.templateId,
+        db,
+      );
+
+      if (currentTemplateVersion !== scheduledWorkout.templateVersion) {
+        templateDrift = {
+          changedAt: sourceTemplate.updatedAt,
+          summary: TEMPLATE_DRIFT_SUMMARY,
+        };
+      }
+    }
+  }
+
+  return {
+    ...scheduledWorkout,
+    exercises: snapshotExercises,
+    templateDrift,
+    staleExercises: [...staleByExerciseId.values()],
+    templateDeleted,
+  };
+};
+
+const sortSnapshotExercises = (
+  left: {
+    section: WorkoutTemplateSectionType;
+    orderIndex: number;
+    id: string;
+  },
+  right: {
+    section: WorkoutTemplateSectionType;
+    orderIndex: number;
+    id: string;
+  },
+) => {
+  const sectionDelta = SECTION_RANK[left.section] - SECTION_RANK[right.section];
+  if (sectionDelta !== 0) {
+    return sectionDelta;
+  }
+
+  if (left.orderIndex !== right.orderIndex) {
+    return left.orderIndex - right.orderIndex;
+  }
+
+  return left.id.localeCompare(right.id);
+};
+
+const sortSnapshotSets = (
+  left: {
+    setNumber: number;
+    createdAt: number;
+    id: string;
+  },
+  right: {
+    setNumber: number;
+    createdAt: number;
+    id: string;
+  },
+) => {
+  if (left.setNumber !== right.setNumber) {
+    return left.setNumber - right.setNumber;
+  }
+
+  if (left.createdAt !== right.createdAt) {
+    return left.createdAt - right.createdAt;
+  }
+
+  return left.id.localeCompare(right.id);
+};
+
+const getDuplicateIds = (values: string[]) => {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) {
+      duplicates.add(value);
+      continue;
+    }
+
+    seen.add(value);
+  }
+
+  return [...duplicates];
+};
+
+const buildSetUpdatePayload = (
+  current: ScheduledWorkoutExerciseSetMutationRow,
+  input: Omit<UpdateScheduledWorkoutExerciseSetsInput['sets'][number], 'setNumber' | 'remove'>,
+) => {
+  const payload: Partial<
+    Pick<
+      ScheduledWorkoutExerciseSetMutationRow,
+      | 'targetWeight'
+      | 'targetWeightMin'
+      | 'targetWeightMax'
+      | 'targetSeconds'
+      | 'targetDistance'
+      | 'repsMin'
+      | 'repsMax'
+      | 'reps'
+    >
+  > = {};
+
+  if (input.targetWeight !== undefined && input.targetWeight !== current.targetWeight) {
+    payload.targetWeight = input.targetWeight;
+  }
+  if (input.targetWeightMin !== undefined && input.targetWeightMin !== current.targetWeightMin) {
+    payload.targetWeightMin = input.targetWeightMin;
+  }
+  if (input.targetWeightMax !== undefined && input.targetWeightMax !== current.targetWeightMax) {
+    payload.targetWeightMax = input.targetWeightMax;
+  }
+  if (input.targetSeconds !== undefined && input.targetSeconds !== current.targetSeconds) {
+    payload.targetSeconds = input.targetSeconds;
+  }
+  if (input.targetDistance !== undefined && input.targetDistance !== current.targetDistance) {
+    payload.targetDistance = input.targetDistance;
+  }
+  if (input.repsMin !== undefined && input.repsMin !== current.repsMin) {
+    payload.repsMin = input.repsMin;
+  }
+  if (input.repsMax !== undefined && input.repsMax !== current.repsMax) {
+    payload.repsMax = input.repsMax;
+  }
+  if (input.reps !== undefined && input.reps !== current.reps) {
+    payload.reps = input.reps;
+  }
+
+  return payload;
+};
+
+export const SCHEDULED_WORKOUT_REORDER_INVALID_ORDER = 'invalid-order' as const;
+export const SCHEDULED_WORKOUT_UNKNOWN_EXERCISE = 'unknown-exercise' as const;
+
+export type ReorderScheduledWorkoutExercisesValidationError = {
+  error: typeof SCHEDULED_WORKOUT_REORDER_INVALID_ORDER;
+  missingExerciseIds: string[];
+  extraExerciseIds: string[];
+  duplicateExerciseIds: string[];
+};
+
+export type UpdateScheduledWorkoutExercisesValidationError = {
+  error: typeof SCHEDULED_WORKOUT_UNKNOWN_EXERCISE;
+  exerciseId: string;
 };
 
 export const createScheduledWorkout = async ({
@@ -300,4 +639,373 @@ export const linkTodayScheduledWorkoutToSession = async ({
     .run();
 
   return result.changes === 1;
+};
+
+export const reorderScheduledWorkoutExercises = async ({
+  userId,
+  scheduledWorkoutId,
+  order,
+}: {
+  userId: string;
+  scheduledWorkoutId: string;
+  order: ReorderScheduledWorkoutInput['order'];
+}): Promise<ScheduledWorkoutDetail | ReorderScheduledWorkoutExercisesValidationError | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  const scheduledWorkout = await findScheduledWorkoutById(scheduledWorkoutId, userId);
+  if (!scheduledWorkout) {
+    return undefined;
+  }
+
+  const snapshotRows = db
+    .select(scheduledWorkoutExerciseMutationSelection)
+    .from(scheduledWorkoutExercises)
+    .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId))
+    .all()
+    .sort(sortSnapshotExercises);
+
+  const existingExerciseIds = new Set(snapshotRows.map((row) => row.exerciseId));
+  const missingExerciseIds = [...existingExerciseIds].filter((exerciseId) => !order.includes(exerciseId));
+  const extraExerciseIds = order.filter((exerciseId) => !existingExerciseIds.has(exerciseId));
+  const duplicateExerciseIds = getDuplicateIds(order);
+
+  if (
+    order.length !== snapshotRows.length ||
+    missingExerciseIds.length > 0 ||
+    extraExerciseIds.length > 0 ||
+    duplicateExerciseIds.length > 0
+  ) {
+    return {
+      error: SCHEDULED_WORKOUT_REORDER_INVALID_ORDER,
+      missingExerciseIds,
+      extraExerciseIds,
+      duplicateExerciseIds,
+    };
+  }
+
+  const nextOrderByExerciseId = new Map(order.map((exerciseId, index) => [exerciseId, index]));
+  const rowsNeedingUpdate = snapshotRows.filter(
+    (row) => row.orderIndex !== nextOrderByExerciseId.get(row.exerciseId),
+  );
+
+  if (rowsNeedingUpdate.length > 0) {
+    db.transaction((tx) => {
+      for (const [index, row] of rowsNeedingUpdate.entries()) {
+        tx.update(scheduledWorkoutExercises)
+          .set({ orderIndex: -1 * (index + 1) })
+          .where(
+            and(
+              eq(scheduledWorkoutExercises.id, row.id),
+              eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId),
+            ),
+          )
+          .run();
+      }
+
+      for (const row of rowsNeedingUpdate) {
+        tx.update(scheduledWorkoutExercises)
+          .set({ orderIndex: nextOrderByExerciseId.get(row.exerciseId) ?? row.orderIndex })
+          .where(
+            and(
+              eq(scheduledWorkoutExercises.id, row.id),
+              eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId),
+            ),
+          )
+          .run();
+      }
+
+      tx.update(scheduledWorkouts)
+        .set({ updatedAt: Date.now() })
+        .where(eq(scheduledWorkouts.id, scheduledWorkoutId))
+        .run();
+    });
+  }
+
+  const detail = await buildScheduledWorkoutDetail({
+    scheduledWorkoutId,
+    userId,
+  });
+  if (!detail) {
+    throw new Error('Updated scheduled workout could not be loaded');
+  }
+
+  return detail;
+};
+
+export const updateScheduledWorkoutExercises = async ({
+  userId,
+  scheduledWorkoutId,
+  updates,
+}: {
+  userId: string;
+  scheduledWorkoutId: string;
+  updates: UpdateScheduledWorkoutExercisesInput['updates'];
+}): Promise<ScheduledWorkoutDetail | UpdateScheduledWorkoutExercisesValidationError | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  const scheduledWorkout = await findScheduledWorkoutById(scheduledWorkoutId, userId);
+  if (!scheduledWorkout) {
+    return undefined;
+  }
+
+  const snapshotRows = db
+    .select(scheduledWorkoutExerciseMutationSelection)
+    .from(scheduledWorkoutExercises)
+    .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId))
+    .all()
+    .sort(sortSnapshotExercises);
+
+  const rowsByExerciseId = new Map(snapshotRows.map((row) => [row.exerciseId, { ...row }]));
+  const updatesToPersist: Array<{
+    id: string;
+    payload: ScheduledWorkoutExercisePatch;
+  }> = [];
+
+  for (const update of updates) {
+    const row = rowsByExerciseId.get(update.exerciseId);
+    if (!row) {
+      return {
+        error: SCHEDULED_WORKOUT_UNKNOWN_EXERCISE,
+        exerciseId: update.exerciseId,
+      };
+    }
+
+    const payload: ScheduledWorkoutExercisePatch = {};
+
+    if (update.supersetGroup !== undefined && update.supersetGroup !== row.supersetGroup) {
+      payload.supersetGroup = update.supersetGroup;
+      row.supersetGroup = update.supersetGroup;
+    }
+    if (update.section !== undefined && update.section !== row.section) {
+      payload.section = update.section;
+      row.section = update.section;
+    }
+    if (update.tempo !== undefined && update.tempo !== row.tempo) {
+      payload.tempo = update.tempo;
+      row.tempo = update.tempo;
+    }
+    if (update.restSeconds !== undefined && update.restSeconds !== row.restSeconds) {
+      payload.restSeconds = update.restSeconds;
+      row.restSeconds = update.restSeconds;
+    }
+    if (
+      update.programmingNotes !== undefined &&
+      update.programmingNotes !== row.programmingNotes
+    ) {
+      payload.programmingNotes = update.programmingNotes;
+      row.programmingNotes = update.programmingNotes;
+    }
+
+    if (Object.keys(payload).length > 0) {
+      updatesToPersist.push({
+        id: row.id,
+        payload,
+      });
+    }
+  }
+
+  if (updatesToPersist.length > 0) {
+    db.transaction((tx) => {
+      for (const update of updatesToPersist) {
+        tx.update(scheduledWorkoutExercises)
+          .set(update.payload)
+          .where(
+            and(
+              eq(scheduledWorkoutExercises.id, update.id),
+              eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId),
+            ),
+          )
+          .run();
+      }
+
+      tx.update(scheduledWorkouts)
+        .set({ updatedAt: Date.now() })
+        .where(eq(scheduledWorkouts.id, scheduledWorkoutId))
+        .run();
+    });
+  }
+
+  const detail = await buildScheduledWorkoutDetail({
+    scheduledWorkoutId,
+    userId,
+  });
+  if (!detail) {
+    throw new Error('Updated scheduled workout could not be loaded');
+  }
+
+  return detail;
+};
+
+export const updateScheduledWorkoutExerciseSets = async ({
+  userId,
+  scheduledWorkoutId,
+  exerciseId,
+  sets,
+}: {
+  userId: string;
+  scheduledWorkoutId: string;
+  exerciseId: UpdateScheduledWorkoutExerciseSetsInput['exerciseId'];
+  sets: UpdateScheduledWorkoutExerciseSetsInput['sets'];
+}): Promise<ScheduledWorkoutDetail | UpdateScheduledWorkoutExercisesValidationError | undefined> => {
+  const { db } = await import('../../db/index.js');
+
+  const scheduledWorkout = await findScheduledWorkoutById(scheduledWorkoutId, userId);
+  if (!scheduledWorkout) {
+    return undefined;
+  }
+
+  const snapshotExercises = db
+    .select({
+      id: scheduledWorkoutExercises.id,
+      exerciseId: scheduledWorkoutExercises.exerciseId,
+      section: scheduledWorkoutExercises.section,
+      orderIndex: scheduledWorkoutExercises.orderIndex,
+    })
+    .from(scheduledWorkoutExercises)
+    .where(eq(scheduledWorkoutExercises.scheduledWorkoutId, scheduledWorkoutId))
+    .all()
+    .sort(sortSnapshotExercises);
+
+  const snapshotExercise = snapshotExercises.find((row) => row.exerciseId === exerciseId);
+  if (!snapshotExercise) {
+    return {
+      error: SCHEDULED_WORKOUT_UNKNOWN_EXERCISE,
+      exerciseId,
+    };
+  }
+
+  const didMutate = db.transaction((tx) => {
+    let mutated = false;
+
+    let persistedRows = tx
+      .select(scheduledWorkoutExerciseSetMutationSelection)
+      .from(scheduledWorkoutExerciseSets)
+      .where(eq(scheduledWorkoutExerciseSets.scheduledWorkoutExerciseId, snapshotExercise.id))
+      .all()
+      .sort(sortSnapshotSets);
+
+    const persistedBySetNumber = new Map(persistedRows.map((row) => [row.setNumber, row]));
+
+    for (const setUpdate of sets) {
+      const existing = persistedBySetNumber.get(setUpdate.setNumber);
+      if (setUpdate.remove === true) {
+        if (!existing) {
+          continue;
+        }
+
+        tx.delete(scheduledWorkoutExerciseSets)
+          .where(eq(scheduledWorkoutExerciseSets.id, existing.id))
+          .run();
+        persistedBySetNumber.delete(setUpdate.setNumber);
+        mutated = true;
+        continue;
+      }
+
+      if (existing) {
+        const payload = buildSetUpdatePayload(existing, setUpdate);
+        if (Object.keys(payload).length === 0) {
+          continue;
+        }
+
+        tx.update(scheduledWorkoutExerciseSets)
+          .set(payload)
+          .where(eq(scheduledWorkoutExerciseSets.id, existing.id))
+          .run();
+
+        persistedBySetNumber.set(setUpdate.setNumber, {
+          ...existing,
+          ...payload,
+        });
+        mutated = true;
+        continue;
+      }
+
+      tx.insert(scheduledWorkoutExerciseSets)
+        .values({
+          id: randomUUID(),
+          scheduledWorkoutExerciseId: snapshotExercise.id,
+          setNumber: setUpdate.setNumber,
+          targetWeight: setUpdate.targetWeight ?? null,
+          targetWeightMin: setUpdate.targetWeightMin ?? null,
+          targetWeightMax: setUpdate.targetWeightMax ?? null,
+          targetSeconds: setUpdate.targetSeconds ?? null,
+          targetDistance: setUpdate.targetDistance ?? null,
+          repsMin: setUpdate.repsMin ?? null,
+          repsMax: setUpdate.repsMax ?? null,
+          reps: setUpdate.reps ?? null,
+        })
+        .run();
+      mutated = true;
+    }
+
+    persistedRows = tx
+      .select(scheduledWorkoutExerciseSetMutationSelection)
+      .from(scheduledWorkoutExerciseSets)
+      .where(eq(scheduledWorkoutExerciseSets.scheduledWorkoutExerciseId, snapshotExercise.id))
+      .all()
+      .sort(sortSnapshotSets);
+
+    const renumberUpdates = persistedRows
+      .map((row, index) => ({
+        id: row.id,
+        currentSetNumber: row.setNumber,
+        nextSetNumber: index + 1,
+      }))
+      .filter((row) => row.currentSetNumber !== row.nextSetNumber);
+
+    if (renumberUpdates.length > 0) {
+      const maxPersistedSetNumber = persistedRows.reduce(
+        (maxValue, row) => Math.max(maxValue, row.setNumber),
+        0,
+      );
+      const tempOffset = maxPersistedSetNumber + persistedRows.length + 1_000;
+
+      for (const update of renumberUpdates) {
+        tx.update(scheduledWorkoutExerciseSets)
+          .set({ setNumber: update.nextSetNumber + tempOffset })
+          .where(eq(scheduledWorkoutExerciseSets.id, update.id))
+          .run();
+      }
+
+      for (const update of renumberUpdates) {
+        tx.update(scheduledWorkoutExerciseSets)
+          .set({ setNumber: update.nextSetNumber })
+          .where(eq(scheduledWorkoutExerciseSets.id, update.id))
+          .run();
+      }
+
+      mutated = true;
+    }
+
+    if (mutated) {
+      tx.update(scheduledWorkouts)
+        .set({ updatedAt: Date.now() })
+        .where(eq(scheduledWorkouts.id, scheduledWorkoutId))
+        .run();
+    }
+
+    return mutated;
+  });
+
+  if (didMutate) {
+    const detail = await buildScheduledWorkoutDetail({
+      scheduledWorkoutId,
+      userId,
+    });
+    if (!detail) {
+      throw new Error('Updated scheduled workout could not be loaded');
+    }
+
+    return detail;
+  }
+
+  const detail = await buildScheduledWorkoutDetail({
+    scheduledWorkoutId,
+    userId,
+  });
+  if (!detail) {
+    throw new Error('Updated scheduled workout could not be loaded');
+  }
+
+  return detail;
 };

--- a/apps/api/src/routes/scheduled-workouts/store.ts
+++ b/apps/api/src/routes/scheduled-workouts/store.ts
@@ -24,6 +24,8 @@ import {
 } from '../../db/schema/index.js';
 import { computeTemplateVersionForTemplateId, readSnapshot } from './snapshot-store.js';
 
+// Supplemental is retained for deterministic ordering of legacy snapshot rows.
+// Structural edit input schemas prevent callers from assigning supplemental.
 const SECTION_RANK: Record<WorkoutTemplateSectionType, number> = {
   warmup: 0,
   main: 1,
@@ -874,7 +876,7 @@ export const updateScheduledWorkoutExerciseSets = async ({
     };
   }
 
-  const didMutate = db.transaction((tx) => {
+  db.transaction((tx) => {
     let mutated = false;
 
     let persistedRows = tx
@@ -986,18 +988,6 @@ export const updateScheduledWorkoutExerciseSets = async ({
 
     return mutated;
   });
-
-  if (didMutate) {
-    const detail = await buildScheduledWorkoutDetail({
-      scheduledWorkoutId,
-      userId,
-    });
-    if (!detail) {
-      throw new Error('Updated scheduled workout could not be loaded');
-    }
-
-    return detail;
-  }
 
   const detail = await buildScheduledWorkoutDetail({
     scheduledWorkoutId,

--- a/apps/web/src/features/workouts/api/workouts.ts
+++ b/apps/web/src/features/workouts/api/workouts.ts
@@ -10,6 +10,7 @@ import {
   createWorkoutSessionInputSchema,
   exerciseQueryParamsSchema,
   exerciseSchema,
+  reorderScheduledWorkoutInputSchema,
   sessionCorrectionRequestSchema,
   scheduledWorkoutDetailSchema,
   scheduledWorkoutListItemSchema,
@@ -18,6 +19,8 @@ import {
   swapScheduledWorkoutExerciseInputSchema,
   swapScheduledWorkoutExerciseResponseSchema,
   reorderWorkoutTemplateExercisesInputSchema,
+  updateScheduledWorkoutExerciseSetsInputSchema,
+  updateScheduledWorkoutExercisesInputSchema,
   updateWorkoutSessionSectionTimerInputSchema,
   swapWorkoutSessionExerciseInputSchema,
   swapWorkoutTemplateExerciseInputSchema,
@@ -38,8 +41,11 @@ import {
   type WorkoutSessionQueryParams,
   type WorkoutTemplateListQueryParams,
   type WorkoutTemplate,
+  type ReorderScheduledWorkoutInput,
   type SwapScheduledWorkoutExerciseInput,
   type SetCorrection,
+  type UpdateScheduledWorkoutExerciseSetsInput,
+  type UpdateScheduledWorkoutExercisesInput,
   type WorkoutTemplateSectionType,
   workoutSessionQueryParamsSchema,
   workoutSessionListItemSchema,
@@ -138,6 +144,18 @@ type DeleteScheduledWorkoutRequest = {
 type SwapScheduledWorkoutExerciseRequest = {
   id: string;
   input: SwapScheduledWorkoutExerciseInput;
+};
+type ReorderScheduledWorkoutRequest = {
+  id: string;
+  input: ReorderScheduledWorkoutInput;
+};
+type UpdateScheduledWorkoutExercisesRequest = {
+  id: string;
+  input: UpdateScheduledWorkoutExercisesInput;
+};
+type UpdateScheduledWorkoutExerciseSetsRequest = {
+  id: string;
+  input: UpdateScheduledWorkoutExerciseSetsInput;
 };
 type DeleteScheduledWorkoutResponse = {
   data: {
@@ -548,6 +566,69 @@ const removeScheduledWorkoutFromList = (
   request: DeleteScheduledWorkoutRequest,
 ) => current?.filter((item) => item.id !== request.id);
 
+const reorderScheduledWorkoutInDetail = <T extends SharedScheduledWorkoutDetail>(
+  current: T | undefined,
+  order: ReorderScheduledWorkoutInput['order'],
+) => {
+  if (!current) {
+    return current;
+  }
+
+  const existingExerciseIds = current.exercises.map((exercise) => exercise.exerciseId);
+  const existingExerciseIdSet = new Set(existingExerciseIds);
+  const nextExerciseIdSet = new Set(order);
+
+  if (
+    existingExerciseIds.length !== order.length ||
+    existingExerciseIdSet.size !== nextExerciseIdSet.size ||
+    !existingExerciseIds.every((exerciseId) => nextExerciseIdSet.has(exerciseId))
+  ) {
+    return current;
+  }
+
+  const orderIndexByExerciseId = new Map(order.map((exerciseId, index) => [exerciseId, index]));
+
+  return {
+    ...current,
+    exercises: current.exercises.map((exercise) => ({
+      ...exercise,
+      orderIndex: orderIndexByExerciseId.get(exercise.exerciseId) ?? exercise.orderIndex,
+    })),
+  };
+};
+
+const updateScheduledWorkoutExercisesInDetail = <T extends SharedScheduledWorkoutDetail>(
+  current: T | undefined,
+  updates: UpdateScheduledWorkoutExercisesInput['updates'],
+) => {
+  if (!current) {
+    return current;
+  }
+
+  const updatesByExerciseId = new Map(updates.map((update) => [update.exerciseId, update]));
+
+  return {
+    ...current,
+    exercises: current.exercises.map((exercise) => {
+      const update = updatesByExerciseId.get(exercise.exerciseId);
+      if (!update) {
+        return exercise;
+      }
+
+      return {
+        ...exercise,
+        ...(update.supersetGroup !== undefined ? { supersetGroup: update.supersetGroup } : {}),
+        ...(update.section !== undefined ? { section: update.section } : {}),
+        ...(update.tempo !== undefined ? { tempo: update.tempo } : {}),
+        ...(update.restSeconds !== undefined ? { restSeconds: update.restSeconds } : {}),
+        ...(update.programmingNotes !== undefined
+          ? { programmingNotes: update.programmingNotes }
+          : {}),
+      };
+    }),
+  };
+};
+
 async function getWorkoutTemplates(params: Partial<WorkoutTemplateListQueryParams> = {}) {
   const parsedParams = workoutTemplateListQueryParamsSchema.parse(params);
   const searchParams = new URLSearchParams({
@@ -918,6 +999,39 @@ async function swapScheduledWorkoutExercise(input: SwapScheduledWorkoutExerciseR
   return payload.data;
 }
 
+async function reorderScheduledWorkout(input: ReorderScheduledWorkoutRequest) {
+  const parsedInput = reorderScheduledWorkoutInputSchema.parse(input.input);
+  const data = await apiRequest<unknown>(`/api/v1/scheduled-workouts/${input.id}/reorder`, {
+    body: JSON.stringify(parsedInput),
+    method: 'PATCH',
+  });
+  const payload = z.object({ data: scheduledWorkoutDetailSchema }).parse({ data });
+
+  return payload.data;
+}
+
+async function updateScheduledWorkoutExercises(input: UpdateScheduledWorkoutExercisesRequest) {
+  const parsedInput = updateScheduledWorkoutExercisesInputSchema.parse(input.input);
+  const data = await apiRequest<unknown>(`/api/v1/scheduled-workouts/${input.id}/exercises`, {
+    body: JSON.stringify(parsedInput),
+    method: 'PATCH',
+  });
+  const payload = z.object({ data: scheduledWorkoutDetailSchema }).parse({ data });
+
+  return payload.data;
+}
+
+async function updateScheduledWorkoutExerciseSets(input: UpdateScheduledWorkoutExerciseSetsRequest) {
+  const parsedInput = updateScheduledWorkoutExerciseSetsInputSchema.parse(input.input);
+  const data = await apiRequest<unknown>(`/api/v1/scheduled-workouts/${input.id}/exercise-sets`, {
+    body: JSON.stringify(parsedInput),
+    method: 'PATCH',
+  });
+  const payload = z.object({ data: scheduledWorkoutDetailSchema }).parse({ data });
+
+  return payload.data;
+}
+
 async function deleteScheduledWorkout(input: DeleteScheduledWorkoutRequest) {
   const data = await apiRequest<unknown>(`/api/v1/scheduled-workouts/${input.id}`, {
     method: 'DELETE',
@@ -1132,6 +1246,112 @@ export function useSwapScheduledWorkoutExercise() {
         invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.scheduledWorkoutMutation()),
       ]);
       toast.success('Exercise updated');
+    },
+  });
+}
+
+export function useReorderScheduledWorkout() {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    SharedScheduledWorkoutDetail,
+    Error,
+    ReorderScheduledWorkoutRequest,
+    { previousDetail?: ScheduledWorkoutDetail }
+  >({
+    mutationFn: reorderScheduledWorkout,
+    onMutate: async (variables) => {
+      const queryKey = workoutQueryKeys.scheduledWorkout(variables.id);
+      await queryClient.cancelQueries({ queryKey });
+      const previousDetail = queryClient.getQueryData<ScheduledWorkoutDetail>(queryKey);
+
+      queryClient.setQueryData<ScheduledWorkoutDetail>(queryKey, (current) =>
+        reorderScheduledWorkoutInDetail(current, variables.input.order),
+      );
+
+      return { previousDetail };
+    },
+    onError: (_error, variables, context) => {
+      if (!context?.previousDetail) {
+        return;
+      }
+
+      queryClient.setQueryData(workoutQueryKeys.scheduledWorkout(variables.id), context.previousDetail);
+    },
+    onSuccess: async (_, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.scheduledWorkout(variables.id),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.scheduledWorkoutListRoot(),
+        }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.scheduledWorkoutMutation()),
+      ]);
+      toast.success('Exercise order updated');
+    },
+  });
+}
+
+export function useUpdateScheduledWorkoutExercises() {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    SharedScheduledWorkoutDetail,
+    Error,
+    UpdateScheduledWorkoutExercisesRequest,
+    { previousDetail?: ScheduledWorkoutDetail }
+  >({
+    mutationFn: updateScheduledWorkoutExercises,
+    onMutate: async (variables) => {
+      const queryKey = workoutQueryKeys.scheduledWorkout(variables.id);
+      await queryClient.cancelQueries({ queryKey });
+      const previousDetail = queryClient.getQueryData<ScheduledWorkoutDetail>(queryKey);
+
+      queryClient.setQueryData<ScheduledWorkoutDetail>(queryKey, (current) =>
+        updateScheduledWorkoutExercisesInDetail(current, variables.input.updates),
+      );
+
+      return { previousDetail };
+    },
+    onError: (_error, variables, context) => {
+      if (!context?.previousDetail) {
+        return;
+      }
+
+      queryClient.setQueryData(workoutQueryKeys.scheduledWorkout(variables.id), context.previousDetail);
+    },
+    onSuccess: async (_, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.scheduledWorkout(variables.id),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.scheduledWorkoutListRoot(),
+        }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.scheduledWorkoutMutation()),
+      ]);
+      toast.success('Exercise updated');
+    },
+  });
+}
+
+export function useUpdateScheduledWorkoutExerciseSets() {
+  const queryClient = useQueryClient();
+
+  return useMutation<SharedScheduledWorkoutDetail, Error, UpdateScheduledWorkoutExerciseSetsRequest>({
+    mutationFn: updateScheduledWorkoutExerciseSets,
+    onSuccess: async (_, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.scheduledWorkout(variables.id),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workoutQueryKeys.scheduledWorkoutListRoot(),
+        }),
+        invalidateQueryKeys(queryClient, crossFeatureInvalidationMap.scheduledWorkoutMutation()),
+      ]);
+      toast.success('Set targets updated');
     },
   });
 }

--- a/apps/web/src/features/workouts/components/scheduled-workout-detail.test.tsx
+++ b/apps/web/src/features/workouts/components/scheduled-workout-detail.test.tsx
@@ -7,6 +7,12 @@ import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
 import { renderWithQueryClient } from '@/test/render-with-query-client';
 import { jsonResponse } from '@/test/test-utils';
 
+const SCHEDULED_EXERCISE_IDS = {
+  first: '11111111-1111-4111-8111-111111111111',
+  second: '22222222-2222-4222-8222-222222222222',
+  third: '33333333-3333-4333-8333-333333333333',
+};
+
 vi.mock('./schedule-workout-dialog', () => ({
   ScheduleWorkoutDialog: ({
     onOpenChange,
@@ -464,6 +470,400 @@ describe('ScheduledWorkoutDetail', () => {
       });
     });
   });
+
+  it('reorders scheduled exercises with move controls and sends the expected order payload', async () => {
+    let currentDetail = createScheduledWorkoutDetailPayload({
+      date: toDateKey(new Date()),
+      exercises: [
+        buildSnapshotExercise({
+          exerciseId: SCHEDULED_EXERCISE_IDS.first,
+          exerciseName: 'Front Squat',
+          orderIndex: 0,
+        }),
+        buildSnapshotExercise({
+          exerciseId: SCHEDULED_EXERCISE_IDS.second,
+          exerciseName: 'Bench Press',
+          orderIndex: 1,
+        }),
+        buildSnapshotExercise({
+          exerciseId: SCHEDULED_EXERCISE_IDS.third,
+          exerciseName: 'Romanian Deadlift',
+          orderIndex: 2,
+        }),
+      ],
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = new URL(String(input), 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: currentDetail }));
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1/reorder' && method === 'PATCH') {
+        const payload = JSON.parse(String(init?.body)) as { order: string[] };
+        const orderIndexByExerciseId = new Map(
+          payload.order.map((exerciseId, index) => [exerciseId, index]),
+        );
+
+        currentDetail = {
+          ...currentDetail,
+          exercises: currentDetail.exercises.map((exercise) => ({
+            ...exercise,
+            orderIndex: orderIndexByExerciseId.get(exercise.exerciseId) ?? exercise.orderIndex,
+          })),
+          updatedAt: currentDetail.updatedAt + 1,
+        };
+
+        return Promise.resolve(jsonResponse({ data: currentDetail }));
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <ScheduledWorkoutDetail id="scheduled-1" />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Romanian Deadlift')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Move Romanian Deadlift up' }));
+
+    await waitFor(() => {
+      const reorderCall = fetchSpy.mock.calls.find(
+        ([input, requestInit]) =>
+          String(input).includes('/api/v1/scheduled-workouts/scheduled-1/reorder') &&
+          (requestInit?.method ?? 'GET') === 'PATCH',
+      );
+      expect(reorderCall).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move Romanian Deadlift up' }));
+
+    await waitFor(() => {
+      const reorderCall = fetchSpy.mock.calls.find(
+        ([input, requestInit]) =>
+          String(input).includes('/api/v1/scheduled-workouts/scheduled-1/reorder') &&
+          (requestInit?.method ?? 'GET') === 'PATCH' &&
+          JSON.parse(String(requestInit?.body)).order[0] === SCHEDULED_EXERCISE_IDS.third,
+      );
+
+      expect(reorderCall).toBeDefined();
+      expect(JSON.parse(String(reorderCall?.[1]?.body))).toEqual({
+        order: [
+          SCHEDULED_EXERCISE_IDS.third,
+          SCHEDULED_EXERCISE_IDS.first,
+          SCHEDULED_EXERCISE_IDS.second,
+        ],
+      });
+    });
+
+    await waitFor(() => {
+      const cards = Array.from(
+        document.querySelectorAll('[data-testid^="workout-exercise-card-snapshot-main"]'),
+      );
+      expect(cards[0]).toHaveAttribute(
+        'data-testid',
+        `workout-exercise-card-snapshot-main-0-${SCHEDULED_EXERCISE_IDS.third}`,
+      );
+    });
+  });
+
+  it('updates superset group from the chip popover', async () => {
+    const exerciseId = SCHEDULED_EXERCISE_IDS.first;
+    let currentDetail = createScheduledWorkoutDetailPayload({
+      date: toDateKey(new Date()),
+      exercises: [
+        buildSnapshotExercise({
+          exerciseId,
+          exerciseName: 'Incline Dumbbell Press',
+          orderIndex: 0,
+          supersetGroup: null,
+        }),
+      ],
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = new URL(String(input), 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: currentDetail }));
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (
+        url.pathname === '/api/v1/scheduled-workouts/scheduled-1/exercises' &&
+        method === 'PATCH'
+      ) {
+        const payload = JSON.parse(String(init?.body)) as {
+          updates: Array<{ exerciseId: string; supersetGroup: string | null }>;
+        };
+        expect(payload).toEqual({
+          updates: [{ exerciseId, supersetGroup: 'A' }],
+        });
+
+        currentDetail = {
+          ...currentDetail,
+          exercises: currentDetail.exercises.map((exercise) =>
+            exercise.exerciseId === exerciseId ? { ...exercise, supersetGroup: 'A' } : exercise,
+          ),
+          updatedAt: currentDetail.updatedAt + 1,
+        };
+
+        return Promise.resolve(jsonResponse({ data: currentDetail }));
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <ScheduledWorkoutDetail id="scheduled-1" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Superset —' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Superset A' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Superset A' })).toBeInTheDocument();
+    });
+  });
+
+  it('edits set targets through the set editor modal and saves to exercise-sets', async () => {
+    const exerciseId = SCHEDULED_EXERCISE_IDS.first;
+    let currentDetail = createScheduledWorkoutDetailPayload({
+      date: toDateKey(new Date()),
+      exercises: [
+        buildSnapshotExercise({
+          exerciseId,
+          exerciseName: 'Bike Sprint',
+          orderIndex: 0,
+          sets: [
+            buildSnapshotSet({ setNumber: 1, targetSeconds: 600 }),
+            buildSnapshotSet({ setNumber: 2, targetSeconds: null }),
+          ],
+        }),
+      ],
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = new URL(String(input), 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: currentDetail }));
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (
+        url.pathname === '/api/v1/scheduled-workouts/scheduled-1/exercise-sets' &&
+        method === 'PATCH'
+      ) {
+        const payload = JSON.parse(String(init?.body)) as {
+          exerciseId: string;
+          sets: Array<{ setNumber: number; targetSeconds?: number }>;
+        };
+        expect(payload).toEqual({
+          exerciseId,
+          sets: [{ setNumber: 2, targetSeconds: 720 }],
+        });
+
+        currentDetail = {
+          ...currentDetail,
+          exercises: currentDetail.exercises.map((exercise) =>
+            exercise.exerciseId === exerciseId
+              ? {
+                  ...exercise,
+                  sets: exercise.sets.map((set) =>
+                    set.setNumber === 2 ? { ...set, targetSeconds: 720 } : set,
+                  ),
+                }
+              : exercise,
+          ),
+          updatedAt: currentDetail.updatedAt + 1,
+        };
+
+        return Promise.resolve(jsonResponse({ data: currentDetail }));
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <ScheduledWorkoutDetail id="scheduled-1" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /Set 2:/ }));
+    fireEvent.change(screen.getByLabelText('Target seconds'), {
+      target: { value: '720' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save set' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Set 2: 720 sec/ })).toBeInTheDocument();
+    });
+  });
+
+  it('removes a set and shows the updated set count after success', async () => {
+    const exerciseId = SCHEDULED_EXERCISE_IDS.first;
+    let currentDetail = createScheduledWorkoutDetailPayload({
+      date: toDateKey(new Date()),
+      exercises: [
+        buildSnapshotExercise({
+          exerciseId,
+          exerciseName: 'Leg Press',
+          orderIndex: 0,
+          sets: [
+            buildSnapshotSet({ setNumber: 1, repsMin: 10, repsMax: 12 }),
+            buildSnapshotSet({ setNumber: 2, repsMin: 10, repsMax: 12 }),
+            buildSnapshotSet({ setNumber: 3, repsMin: 10, repsMax: 12 }),
+          ],
+        }),
+      ],
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = new URL(String(input), 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: currentDetail }));
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (
+        url.pathname === '/api/v1/scheduled-workouts/scheduled-1/exercise-sets' &&
+        method === 'PATCH'
+      ) {
+        const payload = JSON.parse(String(init?.body)) as {
+          exerciseId: string;
+          sets: Array<{ remove?: true; setNumber: number }>;
+        };
+        expect(payload).toEqual({
+          exerciseId,
+          sets: [{ remove: true, setNumber: 2 }],
+        });
+
+        currentDetail = {
+          ...currentDetail,
+          exercises: currentDetail.exercises.map((exercise) =>
+            exercise.exerciseId === exerciseId
+              ? {
+                  ...exercise,
+                  sets: exercise.sets
+                    .filter((set) => set.setNumber !== 2)
+                    .map((set, index) => ({ ...set, setNumber: index + 1 })),
+                }
+              : exercise,
+          ),
+          updatedAt: currentDetail.updatedAt + 1,
+        };
+
+        return Promise.resolve(jsonResponse({ data: currentDetail }));
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <ScheduledWorkoutDetail id="scheduled-1" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove set 2' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /Set 3:/ })).not.toBeInTheDocument();
+      expect(screen.getAllByRole('button', { name: /Set \d:/ })).toHaveLength(2);
+    });
+  });
+
+  it('shows mutation errors and rolls optimistic superset updates back', async () => {
+    const exerciseId = SCHEDULED_EXERCISE_IDS.first;
+    const currentDetail = createScheduledWorkoutDetailPayload({
+      date: toDateKey(new Date()),
+      exercises: [
+        buildSnapshotExercise({
+          exerciseId,
+          exerciseName: 'Overhead Press',
+          orderIndex: 0,
+          supersetGroup: null,
+        }),
+      ],
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = new URL(String(input), 'https://pulse.test');
+      const method = init?.method ?? 'GET';
+
+      if (url.pathname === '/api/v1/scheduled-workouts/scheduled-1' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: currentDetail }));
+      }
+
+      if (url.pathname === '/api/v1/workout-sessions' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+
+      if (
+        url.pathname === '/api/v1/scheduled-workouts/scheduled-1/exercises' &&
+        method === 'PATCH'
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              error: {
+                code: 'UNKNOWN_SCHEDULED_WORKOUT_EXERCISE',
+                message: 'Failed to update superset group',
+              },
+            }),
+            {
+              headers: { 'Content-Type': 'application/json' },
+              status: 500,
+            },
+          ),
+        );
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url.pathname}`);
+    });
+
+    renderWithQueryClient(
+      <MemoryRouter>
+        <ScheduledWorkoutDetail id="scheduled-1" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Superset —' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Superset A' }));
+
+    expect(
+      await screen.findByTestId('scheduled-workout-structure-error-banner'),
+    ).toHaveTextContent('Failed to update superset group');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Superset —' })).toBeInTheDocument();
+    });
+  });
 });
 
 function createScheduledWorkoutDetailPayload({
@@ -604,5 +1004,43 @@ function createScheduledWorkoutDetailPayload({
           createdAt: 1,
           updatedAt: 1,
         },
+  };
+}
+
+type SnapshotExerciseFixture = NonNullable<
+  Parameters<typeof createScheduledWorkoutDetailPayload>[0]['exercises']
+>[number];
+type SnapshotSetFixture = SnapshotExerciseFixture['sets'][number];
+
+function buildSnapshotSet(overrides: Partial<SnapshotSetFixture>): SnapshotSetFixture {
+  return {
+    setNumber: 1,
+    repsMin: 8,
+    repsMax: 10,
+    reps: null,
+    targetWeight: null,
+    targetWeightMin: null,
+    targetWeightMax: null,
+    targetSeconds: null,
+    targetDistance: null,
+    ...overrides,
+  };
+}
+
+function buildSnapshotExercise(overrides: Partial<SnapshotExerciseFixture>): SnapshotExerciseFixture {
+  return {
+    exerciseId: SCHEDULED_EXERCISE_IDS.first,
+    exerciseName: 'Incline Dumbbell Press',
+    section: 'main',
+    orderIndex: 0,
+    programmingNotes: null,
+    agentNotes: null,
+    agentNotesMeta: null,
+    templateCues: null,
+    supersetGroup: null,
+    tempo: null,
+    restSeconds: 90,
+    sets: [buildSnapshotSet({ setNumber: 1 })],
+    ...overrides,
   };
 }

--- a/apps/web/src/features/workouts/components/scheduled-workout-detail.tsx
+++ b/apps/web/src/features/workouts/components/scheduled-workout-detail.tsx
@@ -1,8 +1,34 @@
-import { type ReactNode, useMemo, useState } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 import { useNavigate } from 'react-router';
-import { AlertTriangle, History, Info, TriangleAlert } from 'lucide-react';
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import {
+  AlertTriangle,
+  ArrowDown,
+  ArrowUp,
+  GripVertical,
+  History,
+  Info,
+  Plus,
+  TriangleAlert,
+} from 'lucide-react';
 import type {
   ExerciseTrackingType,
+  UpdateScheduledWorkoutExerciseSetsInput,
   WorkoutTemplate,
   WorkoutTemplateExercise,
   WorkoutTemplateSectionType,
@@ -21,17 +47,24 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { useStartSession } from '@/hooks/use-workout-session';
 import { useWeightUnit } from '@/hooks/use-weight-unit';
 import { ApiError } from '@/lib/api-client';
 import { toDateKey } from '@/lib/date-utils';
+import { useDebouncedCallback } from '@/lib/use-debounced-callback';
 import { cn } from '@/lib/utils';
 
 import {
   type ScheduledWorkoutDetail,
+  useReorderScheduledWorkout,
   useRescheduleWorkout,
   useScheduledWorkoutDetail,
   useSwapScheduledWorkoutExercise,
+  useUpdateScheduledWorkoutExercises,
+  useUpdateScheduledWorkoutExerciseSets,
   useUnscheduleWorkout,
   useWorkoutSessions,
 } from '../api/workouts';
@@ -66,12 +99,76 @@ const sectionAccentStyles: Record<WorkoutTemplateSectionType, string> = {
   supplemental: 'border-l-[var(--color-accent-cream)]',
 };
 
+const sectionOrder: WorkoutTemplateSectionType[] = ['warmup', 'main', 'cooldown', 'supplemental'];
+const supersetOptions = ['A', 'B', 'C'] as const;
+
+type EditableSetFieldDefinition = {
+  inputMode: 'decimal' | 'numeric';
+  key: Exclude<keyof UpdateScheduledWorkoutExerciseSetsInput['sets'][number], 'setNumber' | 'remove'>;
+  label: string;
+  step: string;
+  suffix?: string;
+};
+
+const editableSetFields: EditableSetFieldDefinition[] = [
+  {
+    inputMode: 'decimal',
+    key: 'targetWeight',
+    label: 'Target weight',
+    step: '0.5',
+  },
+  {
+    inputMode: 'decimal',
+    key: 'targetWeightMin',
+    label: 'Target weight min',
+    step: '0.5',
+  },
+  {
+    inputMode: 'decimal',
+    key: 'targetWeightMax',
+    label: 'Target weight max',
+    step: '0.5',
+  },
+  {
+    inputMode: 'numeric',
+    key: 'targetSeconds',
+    label: 'Target seconds',
+    step: '1',
+    suffix: 'sec',
+  },
+  {
+    inputMode: 'decimal',
+    key: 'targetDistance',
+    label: 'Target distance',
+    step: '0.1',
+  },
+  {
+    inputMode: 'numeric',
+    key: 'repsMin',
+    label: 'Reps min',
+    step: '1',
+  },
+  {
+    inputMode: 'numeric',
+    key: 'repsMax',
+    label: 'Reps max',
+    step: '1',
+  },
+  {
+    inputMode: 'numeric',
+    key: 'reps',
+    label: 'Reps',
+    step: '1',
+  },
+];
+
 type ScheduledWorkoutDetailProps = {
   bannerSlot?: ReactNode;
   id: string;
 };
 
 type SnapshotExercise = ScheduledWorkoutDetail['exercises'][number];
+type SnapshotExerciseSet = SnapshotExercise['sets'][number];
 
 type TemplateExerciseLookup = {
   byExerciseIdBySection: Map<string, WorkoutTemplateExercise>;
@@ -86,10 +183,14 @@ export function ScheduledWorkoutDetail({ bannerSlot, id }: ScheduledWorkoutDetai
   const rescheduleWorkoutMutation = useRescheduleWorkout();
   const unscheduleWorkoutMutation = useUnscheduleWorkout();
   const swapScheduledExerciseMutation = useSwapScheduledWorkoutExercise();
+  const reorderScheduledWorkoutMutation = useReorderScheduledWorkout();
+  const updateScheduledWorkoutExercisesMutation = useUpdateScheduledWorkoutExercises();
+  const updateScheduledWorkoutExerciseSetsMutation = useUpdateScheduledWorkoutExerciseSets();
   const { confirm, dialog: confirmDialog } = useConfirmation();
   const activeSessionsQuery = useWorkoutSessions({ status: ['in-progress', 'paused'] });
   const [isRescheduleDialogOpen, setIsRescheduleDialogOpen] = useState(false);
   const [isRecoveryModalOpen, setIsRecoveryModalOpen] = useState(false);
+  const [mutationErrorMessage, setMutationErrorMessage] = useState<string | null>(null);
   const [historyTarget, setHistoryTarget] = useState<{
     exerciseId: string;
     exerciseName: string;
@@ -106,11 +207,43 @@ export function ScheduledWorkoutDetail({ bannerSlot, id }: ScheduledWorkoutDetai
   );
   const templateExerciseLookup = useMemo(() => buildTemplateExerciseLookup(template), [template]);
   const canStartFromSnapshot = scheduledWorkout !== undefined && scheduledWorkout !== null;
+  const isPlanLocked = scheduledWorkout?.sessionId != null;
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 6,
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+  const queueReorderMutation = useDebouncedCallback((order: string[]) => {
+    if (!scheduledWorkout || isPlanLocked) {
+      return;
+    }
+
+    setMutationErrorMessage(null);
+    reorderScheduledWorkoutMutation.mutate(
+      {
+        id: scheduledWorkout.id,
+        input: { order },
+      },
+      {
+        onError: (error) => {
+          setMutationErrorMessage(getMutationErrorMessage(error, 'Unable to reorder exercises.'));
+        },
+      },
+    );
+  }, 250);
   const isMutating =
     startSessionMutation.isPending ||
     rescheduleWorkoutMutation.isPending ||
     unscheduleWorkoutMutation.isPending ||
-    swapScheduledExerciseMutation.isPending;
+    swapScheduledExerciseMutation.isPending ||
+    reorderScheduledWorkoutMutation.isPending ||
+    updateScheduledWorkoutExercisesMutation.isPending ||
+    updateScheduledWorkoutExerciseSetsMutation.isPending;
 
   async function doStart(options?: { force?: boolean }) {
     if (!scheduledWorkout) {
@@ -219,6 +352,63 @@ export function ScheduledWorkoutDetail({ bannerSlot, id }: ScheduledWorkoutDetai
     });
   }
 
+  async function handleUpdateSupersetGroup(exerciseId: string, supersetGroup: string | null) {
+    if (!scheduledWorkout || isPlanLocked) {
+      return;
+    }
+
+    setMutationErrorMessage(null);
+
+    try {
+      await updateScheduledWorkoutExercisesMutation.mutateAsync({
+        id: scheduledWorkout.id,
+        input: {
+          updates: [{ exerciseId, supersetGroup }],
+        },
+      });
+    } catch (error) {
+      setMutationErrorMessage(getMutationErrorMessage(error, 'Unable to update superset group.'));
+    }
+  }
+
+  async function handleUpdateSet(
+    exerciseId: string,
+    setUpdate: UpdateScheduledWorkoutExerciseSetsInput['sets'][number],
+  ) {
+    if (!scheduledWorkout || isPlanLocked) {
+      return;
+    }
+
+    setMutationErrorMessage(null);
+
+    try {
+      await updateScheduledWorkoutExerciseSetsMutation.mutateAsync({
+        id: scheduledWorkout.id,
+        input: {
+          exerciseId,
+          sets: [setUpdate],
+        },
+      });
+    } catch (error) {
+      setMutationErrorMessage(
+        getMutationErrorMessage(error, 'Unable to update scheduled workout set targets.'),
+      );
+    }
+  }
+
+  async function handleRemoveSet(exerciseId: string, setNumber: number) {
+    await handleUpdateSet(exerciseId, {
+      remove: true,
+      setNumber,
+    });
+  }
+
+  async function handleAddSet(exerciseId: string, setNumber: number) {
+    await handleUpdateSet(exerciseId, {
+      setNumber,
+    });
+  }
+
   async function handleStartAnyway() {
     await doStart({ force: true });
   }
@@ -276,14 +466,46 @@ export function ScheduledWorkoutDetail({ bannerSlot, id }: ScheduledWorkoutDetai
         templateName={template?.name ?? null}
       />
 
+      {mutationErrorMessage ? (
+        <BannerCard
+          className="border-destructive/35 bg-destructive/10"
+          description={mutationErrorMessage}
+          icon={<AlertTriangle aria-hidden="true" className="size-4 text-destructive" />}
+          testId="scheduled-workout-structure-error-banner"
+          title="Unable to apply edit"
+        />
+      ) : null}
+
+      {isPlanLocked ? (
+        <BannerCard
+          className="border-border/80 bg-secondary/40"
+          description="This workout already has a started session. Structural edits are read-only here."
+          icon={<Info aria-hidden="true" className="size-4 text-muted" />}
+          testId="scheduled-workout-readonly-banner"
+          title="Session in progress"
+        />
+      ) : null}
+
       <ScheduledWorkoutSections
+        isEditLocked={isPlanLocked}
+        isMutating={isMutating}
+        onAddSet={handleAddSet}
         onOpenHistory={(exercise) =>
           setHistoryTarget({
             exerciseId: exercise.exerciseId,
             exerciseName: exercise.exerciseName,
           })
         }
+        onRemoveSet={handleRemoveSet}
+        onReorder={(order) => queueReorderMutation.run(order)}
+        onReorderImmediate={(order) => {
+          queueReorderMutation.run(order);
+          queueReorderMutation.flush();
+        }}
+        onUpdateSet={handleUpdateSet}
+        onUpdateSupersetGroup={handleUpdateSupersetGroup}
         scheduledWorkout={scheduledWorkout}
+        sensors={sensors}
         templateExerciseLookup={templateExerciseLookup}
         weightUnit={weightUnit}
       />
@@ -353,17 +575,39 @@ export function ScheduledWorkoutDetail({ bannerSlot, id }: ScheduledWorkoutDetai
 }
 
 function ScheduledWorkoutSections({
+  isEditLocked,
+  isMutating,
+  onAddSet,
   onOpenHistory,
+  onRemoveSet,
+  onReorder,
+  onReorderImmediate,
+  onUpdateSet,
+  onUpdateSupersetGroup,
   scheduledWorkout,
+  sensors,
   templateExerciseLookup,
   weightUnit,
 }: {
+  isEditLocked: boolean;
+  isMutating: boolean;
+  onAddSet: (exerciseId: string, setNumber: number) => Promise<void>;
   onOpenHistory: (exercise: { exerciseId: string; exerciseName: string }) => void;
+  onRemoveSet: (exerciseId: string, setNumber: number) => Promise<void>;
+  onReorder: (order: string[]) => void;
+  onReorderImmediate: (order: string[]) => void;
+  onUpdateSet: (
+    exerciseId: string,
+    setUpdate: UpdateScheduledWorkoutExerciseSetsInput['sets'][number],
+  ) => Promise<void>;
+  onUpdateSupersetGroup: (exerciseId: string, supersetGroup: string | null) => Promise<void>;
   scheduledWorkout: ScheduledWorkoutDetail;
+  sensors: ReturnType<typeof useSensors>;
   templateExerciseLookup: TemplateExerciseLookup;
   weightUnit: WeightUnit;
 }) {
   const nonEmptySections = buildSnapshotSections(scheduledWorkout.exercises);
+  const isInteractionDisabled = isEditLocked || isMutating;
 
   if (nonEmptySections.length === 0) {
     return (
@@ -374,6 +618,23 @@ function ScheduledWorkoutSections({
       </Card>
     );
   }
+
+  const buildReorderPayload = (
+    sectionType: WorkoutTemplateSectionType,
+    reorderedSectionExerciseIds: string[],
+  ) =>
+    sectionOrder.flatMap((candidateSectionType) => {
+      const section = nonEmptySections.find((entry) => entry.type === candidateSectionType);
+      if (!section) {
+        return [];
+      }
+
+      if (candidateSectionType === sectionType) {
+        return reorderedSectionExerciseIds;
+      }
+
+      return section.exercises.map((exercise) => exercise.exerciseId);
+    });
 
   return (
     <div className="space-y-3">
@@ -401,27 +662,87 @@ function ScheduledWorkoutSections({
           </summary>
 
           <div className="space-y-1.5 border-t border-border/80 px-3 py-3 sm:px-4 sm:py-3">
-            {section.exercises.map((exercise, index) => {
-              const templateExercise = resolveTemplateExercise(exercise, templateExerciseLookup);
-              const resolvedName = exercise.exerciseName;
+            <DndContext
+              collisionDetection={closestCenter}
+              onDragEnd={({ active, over }) => {
+                if (isInteractionDisabled || !over || active.id === over.id) {
+                  return;
+                }
 
-              return (
-                <ScheduledExerciseCard
-                  exercise={exercise}
-                  exerciseName={resolvedName}
-                  index={index}
-                  key={`${section.type}-${exercise.orderIndex}-${exercise.exerciseId}`}
-                  onOpenHistory={() =>
-                    onOpenHistory({
-                      exerciseId: exercise.exerciseId,
-                      exerciseName: resolvedName,
-                    })
-                  }
-                  templateExercise={templateExercise}
-                  weightUnit={weightUnit}
-                />
-              );
-            })}
+                const exerciseIds = section.exercises.map((exercise) => exercise.exerciseId);
+                const currentIndex = exerciseIds.findIndex((exerciseId) => exerciseId === active.id);
+                const nextIndex = exerciseIds.findIndex((exerciseId) => exerciseId === over.id);
+
+                if (currentIndex === -1 || nextIndex === -1) {
+                  return;
+                }
+
+                const reorderedExerciseIds = arrayMove(exerciseIds, currentIndex, nextIndex);
+                onReorder(buildReorderPayload(section.type, reorderedExerciseIds));
+              }}
+              sensors={sensors}
+            >
+              <SortableContext
+                items={section.exercises.map((exercise) => exercise.exerciseId)}
+                strategy={verticalListSortingStrategy}
+              >
+                {section.exercises.map((exercise, index) => {
+                  const templateExercise = resolveTemplateExercise(exercise, templateExerciseLookup);
+                  const resolvedName = exercise.exerciseName;
+
+                  return (
+                    <ScheduledExerciseCard
+                      exercise={exercise}
+                      exerciseName={resolvedName}
+                      index={index}
+                      isEditLocked={isEditLocked}
+                      isMoveDownDisabled={
+                        index === section.exercises.length - 1 || isInteractionDisabled
+                      }
+                      isMoveUpDisabled={index === 0 || isInteractionDisabled}
+                      isMutating={isMutating}
+                      key={`${section.type}-${exercise.orderIndex}-${exercise.exerciseId}`}
+                      onAddSet={onAddSet}
+                      onMoveDown={() => {
+                        if (index >= section.exercises.length - 1 || isInteractionDisabled) {
+                          return;
+                        }
+
+                        const reorderedExerciseIds = arrayMove(
+                          section.exercises.map((entry) => entry.exerciseId),
+                          index,
+                          index + 1,
+                        );
+                        onReorderImmediate(buildReorderPayload(section.type, reorderedExerciseIds));
+                      }}
+                      onMoveUp={() => {
+                        if (index <= 0 || isInteractionDisabled) {
+                          return;
+                        }
+
+                        const reorderedExerciseIds = arrayMove(
+                          section.exercises.map((entry) => entry.exerciseId),
+                          index,
+                          index - 1,
+                        );
+                        onReorderImmediate(buildReorderPayload(section.type, reorderedExerciseIds));
+                      }}
+                      onOpenHistory={() =>
+                        onOpenHistory({
+                          exerciseId: exercise.exerciseId,
+                          exerciseName: resolvedName,
+                        })
+                      }
+                      onRemoveSet={onRemoveSet}
+                      onUpdateSet={onUpdateSet}
+                      onUpdateSupersetGroup={onUpdateSupersetGroup}
+                      templateExercise={templateExercise}
+                      weightUnit={weightUnit}
+                    />
+                  );
+                })}
+              </SortableContext>
+            </DndContext>
           </div>
         </details>
       ))}
@@ -433,39 +754,343 @@ function ScheduledExerciseCard({
   exercise,
   exerciseName,
   index,
+  isEditLocked,
+  isMoveDownDisabled,
+  isMoveUpDisabled,
+  isMutating,
+  onAddSet,
+  onMoveDown,
+  onMoveUp,
   onOpenHistory,
+  onRemoveSet,
+  onUpdateSet,
+  onUpdateSupersetGroup,
   templateExercise,
   weightUnit,
 }: {
   exercise: SnapshotExercise;
   exerciseName: string;
   index: number;
+  isEditLocked: boolean;
+  isMoveDownDisabled: boolean;
+  isMoveUpDisabled: boolean;
+  isMutating: boolean;
+  onAddSet: (exerciseId: string, setNumber: number) => Promise<void>;
+  onMoveDown: () => void;
+  onMoveUp: () => void;
   onOpenHistory: () => void;
+  onRemoveSet: (exerciseId: string, setNumber: number) => Promise<void>;
+  onUpdateSet: (
+    exerciseId: string,
+    setUpdate: UpdateScheduledWorkoutExerciseSetsInput['sets'][number],
+  ) => Promise<void>;
+  onUpdateSupersetGroup: (exerciseId: string, supersetGroup: string | null) => Promise<void>;
   templateExercise: WorkoutTemplateExercise | undefined;
   weightUnit: WeightUnit;
 }) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: exercise.exerciseId,
+    disabled: isEditLocked || isMutating,
+  });
+  const [setEditTarget, setSetEditTarget] = useState<SnapshotExerciseSet | null>(null);
+  const nextSetNumber = exercise.sets.reduce((maxValue, set) => Math.max(maxValue, set.setNumber), 0) + 1;
+  const supersetLabel = formatSupersetGroupLabel(exercise.supersetGroup);
+
   return (
-    <WorkoutExerciseCard
-      exercise={toWorkoutExerciseCardScheduledExercise(exercise, exerciseName, templateExercise)}
-      footerSlot={
-        <p className="text-[10px] font-semibold tracking-[0.14em] text-muted uppercase">{`Exercise #${index + 1}`}</p>
-      }
-      headerSlot={
+    <>
+      <WorkoutExerciseCard
+        cardRef={setNodeRef}
+        exercise={toWorkoutExerciseCardScheduledExercise(exercise, exerciseName, templateExercise)}
+        footerSlot={
+        <div className="space-y-2.5">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-[10px] font-semibold tracking-[0.14em] text-muted uppercase">{`Exercise #${index + 1}`}</p>
+            {isEditLocked ? (
+              <Badge className="border-border/80 bg-secondary/60" variant="outline">
+                {`Superset ${supersetLabel}`}
+              </Badge>
+            ) : (
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    className="h-7 rounded-full px-2 text-[11px]"
+                    disabled={isMutating}
+                    size="sm"
+                    type="button"
+                    variant="outline"
+                  >
+                    {`Superset ${supersetLabel}`}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent align="start" className="w-40 p-2">
+                  <div className="space-y-1">
+                    {supersetOptions.map((option) => (
+                      <Button
+                        className="w-full justify-start"
+                        key={option}
+                        onClick={() => {
+                          void onUpdateSupersetGroup(exercise.exerciseId, option);
+                        }}
+                        size="sm"
+                        type="button"
+                        variant="ghost"
+                      >
+                        {`Superset ${option}`}
+                      </Button>
+                    ))}
+                    <Button
+                      className="w-full justify-start"
+                      onClick={() => {
+                        void onUpdateSupersetGroup(exercise.exerciseId, null);
+                      }}
+                      size="sm"
+                      type="button"
+                      variant="ghost"
+                    >
+                      Clear grouping
+                    </Button>
+                  </div>
+                </PopoverContent>
+              </Popover>
+            )}
+          </div>
+
+          <div className="space-y-1.5 rounded-xl border border-border/80 bg-secondary/20 p-2.5">
+            {exercise.sets
+              .slice()
+              .sort((left, right) => left.setNumber - right.setNumber)
+              .map((set) => (
+                <div className="flex items-center justify-between gap-2" key={set.setNumber}>
+                  <Button
+                    className="h-auto min-h-9 flex-1 justify-start px-2 py-1.5 text-left"
+                    disabled={isEditLocked || isMutating}
+                    onClick={() => setSetEditTarget(set)}
+                    type="button"
+                    variant="ghost"
+                  >
+                    <span className="text-xs text-foreground">
+                      {`Set ${set.setNumber}: ${formatSetTargetSummary(set)}`}
+                    </span>
+                  </Button>
+                  {!isEditLocked ? (
+                    <Button
+                      className="h-8 px-2 text-xs"
+                      disabled={isMutating}
+                      onClick={() => {
+                        void onRemoveSet(exercise.exerciseId, set.setNumber);
+                      }}
+                      size="sm"
+                      type="button"
+                      variant="outline"
+                    >
+                      {`Remove set ${set.setNumber}`}
+                    </Button>
+                  ) : null}
+                </div>
+              ))}
+
+            {!isEditLocked ? (
+              <Button
+                className="w-full justify-center"
+                disabled={isMutating}
+                onClick={() => {
+                  void onAddSet(exercise.exerciseId, nextSetNumber);
+                }}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                <Plus aria-hidden="true" className="size-4" />
+                Add set
+              </Button>
+            ) : null}
+          </div>
+        </div>
+        }
+        headerSlot={
+        <>
+          <Button
+            aria-label={`Open ${exerciseName} history`}
+            className="size-11 min-h-11 min-w-11"
+            onClick={onOpenHistory}
+            size="icon"
+            type="button"
+            variant="ghost"
+          >
+            <History aria-hidden="true" className="size-4" />
+          </Button>
+          <Button
+            aria-label={`Move ${exerciseName} up`}
+            className="size-11 min-h-11 min-w-11"
+            disabled={isMoveUpDisabled}
+            onClick={onMoveUp}
+            size="icon"
+            type="button"
+            variant="ghost"
+          >
+            <ArrowUp aria-hidden="true" className="size-4" />
+          </Button>
+          <Button
+            aria-label={`Move ${exerciseName} down`}
+            className="size-11 min-h-11 min-w-11"
+            disabled={isMoveDownDisabled}
+            onClick={onMoveDown}
+            size="icon"
+            type="button"
+            variant="ghost"
+          >
+            <ArrowDown aria-hidden="true" className="size-4" />
+          </Button>
+        </>
+        }
+        leadingSlot={
         <Button
-          aria-label={`Open ${exerciseName} history`}
-          className="size-11 min-h-11 min-w-11"
-          onClick={onOpenHistory}
+          aria-label={`Drag handle for ${exerciseName}`}
+          className="-ml-1 mt-0.5 size-11 min-h-11 min-w-11 touch-none"
+          disabled={isEditLocked || isMutating}
           size="icon"
           type="button"
           variant="ghost"
+          {...attributes}
+          {...listeners}
         >
-          <History aria-hidden="true" className="size-4" />
+          <GripVertical aria-hidden="true" className="size-4" />
         </Button>
-      }
-      mode="readonly-scheduled"
-      onOpenDetails={onOpenHistory}
-      weightUnit={weightUnit}
-    />
+        }
+        mode="editable-scheduled"
+        onOpenDetails={onOpenHistory}
+        showSetList={false}
+        style={{
+          transform: CSS.Transform.toString(transform),
+          transition,
+        }}
+        weightUnit={weightUnit}
+      />
+      {setEditTarget ? (
+        <EditScheduledSetDialog
+          exerciseName={exerciseName}
+          isPending={isMutating}
+          onClose={() => setSetEditTarget(null)}
+          onSave={async (setUpdate) => {
+            await onUpdateSet(exercise.exerciseId, setUpdate);
+            setSetEditTarget(null);
+          }}
+          set={setEditTarget}
+        />
+      ) : null}
+    </>
+  );
+}
+
+type ScheduledSetEditorDraft = Record<EditableSetFieldDefinition['key'], string>;
+
+const integerSetFieldKeys = new Set<EditableSetFieldDefinition['key']>([
+  'targetSeconds',
+  'repsMin',
+  'repsMax',
+  'reps',
+]);
+
+function EditScheduledSetDialog({
+  exerciseName,
+  isPending,
+  onClose,
+  onSave,
+  set,
+}: {
+  exerciseName: string;
+  isPending: boolean;
+  onClose: () => void;
+  onSave: (setUpdate: UpdateScheduledWorkoutExerciseSetsInput['sets'][number]) => Promise<void>;
+  set: SnapshotExerciseSet;
+}) {
+  const [fieldDraft, setFieldDraft] = useState<ScheduledSetEditorDraft>(() => createSetEditorDraft(set));
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    const parsed = parseSetEditorDraft({
+      draft: fieldDraft,
+      set,
+    });
+
+    if (parsed.error) {
+      setValidationError(parsed.error);
+      return;
+    }
+
+    if (Object.keys(parsed.setUpdate).length === 1) {
+      onClose();
+      return;
+    }
+
+    await onSave(parsed.setUpdate);
+  };
+
+  return (
+    <Dialog onOpenChange={(open) => (!open ? onClose() : undefined)} open>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{`Edit ${exerciseName} set ${set.setNumber}`}</DialogTitle>
+          <DialogDescription>
+            Update target values for this set. Leave a field blank to clear it.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          {editableSetFields.map((field) => {
+            const inputId = `${exerciseName}-${set.setNumber}-${field.key}`;
+
+            return (
+              <div className="space-y-1.5" key={field.key}>
+                <Label className="text-xs font-semibold text-muted" htmlFor={inputId}>
+                  {field.label}
+                </Label>
+                <div className="relative">
+                  <Input
+                    className={field.suffix ? 'pr-12' : undefined}
+                    id={inputId}
+                    inputMode={field.inputMode}
+                    min={0}
+                    onChange={(event) => {
+                      setValidationError(null);
+                      setFieldDraft((current) => ({
+                        ...current,
+                        [field.key]: event.currentTarget.value,
+                      }));
+                    }}
+                    step={field.step}
+                    type="number"
+                    value={fieldDraft[field.key]}
+                  />
+                  {field.suffix ? (
+                    <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-[10px] font-semibold uppercase text-muted">
+                      {field.suffix}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {validationError ? <p className="text-sm text-destructive">{validationError}</p> : null}
+
+        <DialogFooter>
+          <Button disabled={isPending} onClick={onClose} type="button" variant="ghost">
+            Cancel
+          </Button>
+          <Button
+            disabled={isPending}
+            onClick={() => {
+              void handleSave();
+            }}
+            type="button"
+          >
+            {isPending ? 'Saving…' : 'Save set'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -569,6 +1194,151 @@ function BannerCard({
       </div>
     </div>
   );
+}
+
+function createSetEditorDraft(set: SnapshotExerciseSet): ScheduledSetEditorDraft {
+  return editableSetFields.reduce((draft, field) => {
+    const value = set[field.key];
+
+    return {
+      ...draft,
+      [field.key]: value == null ? '' : `${value}`,
+    };
+  }, {} as ScheduledSetEditorDraft);
+}
+
+function parseSetEditorDraft({
+  draft,
+  set,
+}: {
+  draft: ScheduledSetEditorDraft;
+  set: SnapshotExerciseSet;
+}) {
+  const setUpdate: UpdateScheduledWorkoutExerciseSetsInput['sets'][number] = {
+    setNumber: set.setNumber,
+  };
+
+  for (const field of editableSetFields) {
+    const rawValue = draft[field.key].trim();
+    const currentValue = set[field.key] ?? null;
+    let nextValue: number | null;
+
+    if (rawValue.length === 0) {
+      nextValue = null;
+    } else {
+      const parsedValue = Number(rawValue);
+      if (!Number.isFinite(parsedValue)) {
+        return {
+          error: `${field.label} must be a valid number.`,
+          setUpdate,
+        };
+      }
+
+      if (parsedValue < 0) {
+        return {
+          error: `${field.label} must be zero or greater.`,
+          setUpdate,
+        };
+      }
+
+      if (integerSetFieldKeys.has(field.key) && !Number.isInteger(parsedValue)) {
+        return {
+          error: `${field.label} must be a whole number.`,
+          setUpdate,
+        };
+      }
+
+      nextValue = parsedValue;
+    }
+
+    if (nextValue !== currentValue) {
+      assignSetUpdateField(setUpdate, field.key, nextValue);
+    }
+  }
+
+  return {
+    setUpdate,
+  };
+}
+
+function assignSetUpdateField(
+  setUpdate: UpdateScheduledWorkoutExerciseSetsInput['sets'][number],
+  key: EditableSetFieldDefinition['key'],
+  value: number | null,
+) {
+  switch (key) {
+    case 'targetWeight':
+      setUpdate.targetWeight = value;
+      break;
+    case 'targetWeightMin':
+      setUpdate.targetWeightMin = value;
+      break;
+    case 'targetWeightMax':
+      setUpdate.targetWeightMax = value;
+      break;
+    case 'targetSeconds':
+      setUpdate.targetSeconds = value;
+      break;
+    case 'targetDistance':
+      setUpdate.targetDistance = value;
+      break;
+    case 'repsMin':
+      setUpdate.repsMin = value;
+      break;
+    case 'repsMax':
+      setUpdate.repsMax = value;
+      break;
+    case 'reps':
+      setUpdate.reps = value;
+      break;
+  }
+}
+
+function formatSetTargetSummary(set: SnapshotExerciseSet) {
+  const values: string[] = [];
+
+  if (set.targetWeight != null) {
+    values.push(`wt ${set.targetWeight}`);
+  } else if (set.targetWeightMin != null || set.targetWeightMax != null) {
+    values.push(`wt ${set.targetWeightMin ?? '—'}-${set.targetWeightMax ?? '—'}`);
+  }
+
+  if (set.targetSeconds != null) {
+    values.push(`${set.targetSeconds} sec`);
+  }
+
+  if (set.targetDistance != null) {
+    values.push(`dist ${set.targetDistance}`);
+  }
+
+  if (set.reps != null) {
+    values.push(`${set.reps} reps`);
+  } else if (set.repsMin != null || set.repsMax != null) {
+    values.push(`reps ${set.repsMin ?? '—'}-${set.repsMax ?? '—'}`);
+  }
+
+  return values.length > 0 ? values.join(' • ') : 'No targets';
+}
+
+function formatSupersetGroupLabel(value: string | null) {
+  if (!value) {
+    return '—';
+  }
+
+  const normalized = value
+    .replace(/^superset[-\s]*/i, '')
+    .trim()
+    .toUpperCase();
+
+  return normalized.length > 0 ? normalized : '—';
+}
+
+function getMutationErrorMessage(error: unknown, fallbackMessage: string) {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return fallbackMessage;
 }
 
 function StaleExerciseRecoveryDialog({
@@ -723,7 +1493,7 @@ function buildSnapshotSections(snapshotExercises: SnapshotExercise[]) {
     sectionExercises.push(exercise);
   }
 
-  return (['warmup', 'main', 'cooldown', 'supplemental'] as const)
+  return sectionOrder
     .map((sectionType) => ({
       type: sectionType,
       exercises: [...(grouped.get(sectionType) ?? [])].sort(

--- a/apps/web/src/features/workouts/components/workout-exercise-card/types.ts
+++ b/apps/web/src/features/workouts/components/workout-exercise-card/types.ts
@@ -4,6 +4,7 @@ import type { ExerciseTrackingType, WeightUnit } from '@pulse/shared';
 export type WorkoutExerciseCardMode =
   | 'readonly-template'
   | 'readonly-scheduled'
+  | 'editable-scheduled'
   | 'readonly-completed';
 // Reserved for a later migration round.
 // | 'in-progress'
@@ -111,7 +112,7 @@ export type WorkoutExerciseCardTemplateProps = WorkoutExerciseCardCommonProps & 
 
 export type WorkoutExerciseCardScheduledProps = WorkoutExerciseCardCommonProps & {
   exercise: WorkoutExerciseCardScheduledExercise;
-  mode: 'readonly-scheduled';
+  mode: 'readonly-scheduled' | 'editable-scheduled';
 };
 
 export type WorkoutExerciseCardCompletedProps = WorkoutExerciseCardCommonProps & {

--- a/docs/conventions/agent-integration.md
+++ b/docs/conventions/agent-integration.md
@@ -363,6 +363,21 @@ Schedules a template for a specific date.
 
 Lists scheduled workouts in the requested date window.
 
+#### `PATCH /api/v1/scheduled-workouts/:id/reorder`
+
+Reorders the scheduled snapshot exercises. Body uses `reorderScheduledWorkoutInputSchema`
+(`{ order: string[] }` of snapshot exercise ids).
+
+#### `PATCH /api/v1/scheduled-workouts/:id/exercises`
+
+Patches exercise-level snapshot fields (`supersetGroup`, `section`, `tempo`, `restSeconds`,
+`programmingNotes`). Body uses `updateScheduledWorkoutExercisesInputSchema`.
+
+#### `PATCH /api/v1/scheduled-workouts/:id/exercise-sets`
+
+Patches per-set snapshot targets for one exercise, including `remove: true` or add-by-set-number
+operations. Body uses `updateScheduledWorkoutExerciseSetsInputSchema`.
+
 #### `PATCH /api/v1/scheduled-workouts/:id/exercise-notes`
 
 Writes per-exercise scheduled-workout enrichment notes before session start.
@@ -450,9 +465,10 @@ Returns the shared nutrition-summary schema (`date`, `meals`, `actual`, `target`
 2. If `POST /api/v1/exercises` returns `created: false`, review `candidates` before retrying with `force: true`.
 3. Create or update templates with `POST` or `PUT /api/v1/workout-templates`.
 4. Schedule training using `POST /api/v1/scheduled-workouts`, then review the plan with `GET /api/v1/scheduled-workouts`.
-5. Enrich the scheduled snapshot with `PATCH /api/v1/scheduled-workouts/:id/exercise-notes`.
-6. Start a session with `POST /api/v1/workout-sessions`.
-7. Continue logging via `PATCH /api/v1/workout-sessions/:id` and use returned `agent` hints to identify the next set.
+5. Refine the scheduled snapshot structure as needed with `PATCH /api/v1/scheduled-workouts/:id/reorder`, `PATCH /api/v1/scheduled-workouts/:id/exercises`, and `PATCH /api/v1/scheduled-workouts/:id/exercise-sets`.
+6. Enrich per-exercise notes with `PATCH /api/v1/scheduled-workouts/:id/exercise-notes` (AgentToken only).
+7. Start a session with `POST /api/v1/workout-sessions`.
+8. Continue logging via `PATCH /api/v1/workout-sessions/:id` and use returned `agent` hints to identify the next set.
 
 ## Operational Notes
 

--- a/docs/conventions/api-conventions.md
+++ b/docs/conventions/api-conventions.md
@@ -102,6 +102,52 @@ When a route is intentionally agent-only:
 - Document OpenAPI security as `[{ agentToken: [] }]` instead of the dual auth array.
 - Return `403 FORBIDDEN` for JWT callers with the standard envelope (`Agent token authentication required`).
 
+## Scheduled-workout Structural Edit Endpoints
+
+Scheduled-workout structural edits use the unified route surface and shared Zod schemas from
+`@pulse/shared`. All three endpoints mutate only scheduled snapshot rows and return
+`{ data: ScheduledWorkoutDetail, agent? }`.
+
+### `PATCH /api/v1/scheduled-workouts/:id/reorder`
+
+- Auth: unified `requireAuth` (`Bearer` JWT or `AgentToken`).
+- Body schema: `reorderScheduledWorkoutInputSchema` (`{ order: string[] }` UUID exercise ids).
+- Error codes:
+  - `400 VALIDATION_ERROR` for malformed payload shape.
+  - `400 INVALID_SCHEDULED_WORKOUT_EXERCISE_ORDER` when `order` does not contain each snapshot
+    exercise exactly once (with `details.missingExerciseIds|extraExerciseIds|duplicateExerciseIds`).
+  - `404 SCHEDULED_WORKOUT_NOT_FOUND` when id is missing or outside caller scope.
+- Idempotency: sending the same complete `order` again is a no-op update and returns the same
+  detail payload shape.
+
+### `PATCH /api/v1/scheduled-workouts/:id/exercises`
+
+- Auth: unified `requireAuth` (`Bearer` JWT or `AgentToken`).
+- Body schema: `updateScheduledWorkoutExercisesInputSchema`
+  (`updates[]` for per-exercise `supersetGroup`, `section`, `tempo`, `restSeconds`,
+  `programmingNotes`).
+- Error codes:
+  - `400 VALIDATION_ERROR` for malformed payload shape.
+  - `400 UNKNOWN_SCHEDULED_WORKOUT_EXERCISE` when an update references an exercise id not present
+    in the scheduled snapshot.
+  - `404 SCHEDULED_WORKOUT_NOT_FOUND` when id is missing or outside caller scope.
+- Idempotency: unchanged field values are ignored; replaying the same update payload is safe and
+  returns the same snapshot detail shape.
+
+### `PATCH /api/v1/scheduled-workouts/:id/exercise-sets`
+
+- Auth: unified `requireAuth` (`Bearer` JWT or `AgentToken`).
+- Body schema: `updateScheduledWorkoutExerciseSetsInputSchema`
+  (`exerciseId` + `sets[]` with target-field edits, `remove: true`, and optional new set inserts).
+- Error codes:
+  - `400 VALIDATION_ERROR` for malformed payload shape (for example invalid field combos such as
+    `remove` plus target edits).
+  - `400 UNKNOWN_SCHEDULED_WORKOUT_EXERCISE` when `exerciseId` is not present in the scheduled
+    snapshot.
+  - `404 SCHEDULED_WORKOUT_NOT_FOUND` when id is missing or outside caller scope.
+- Idempotency: remove/update/add operations are replay-safe; set numbers are re-compacted to
+  contiguous ordering on each successful mutation.
+
 ## Response Envelope
 
 Base success responses return `{ data: T }`.

--- a/docs/conventions/workout-domain.md
+++ b/docs/conventions/workout-domain.md
@@ -29,7 +29,24 @@ The scheduled-workout detail page should mirror template-detail exercise renderi
 - `programmingNotes` shown on scheduled cards comes from the scheduled snapshot exercise row.
 - Reserve a page-level `bannerSlot` area above the header for future scheduled-workout warning banners. Leave it empty unless a warning feature explicitly populates it.
 
-Scheduled-workout structural edits (reorder, superset grouping, exercise-level fields, and set-level targets) mutate only the planned snapshot and are intended to seed future session starts. Once a session exists for that schedule, the session becomes the live run and must be edited through workout-session endpoints rather than by mutating the scheduled snapshot structure.
+### Scheduled Workout Structural Edits
+
+Scheduled-workout structural edits are plan-time snapshot edits and never mutate the source
+template.
+
+- `PATCH /api/v1/scheduled-workouts/:id/reorder`: reorder snapshot exercises while preserving the
+  existing exercise set.
+- `PATCH /api/v1/scheduled-workouts/:id/exercises`: patch per-exercise snapshot fields
+  (`supersetGroup`, `section`, `tempo`, `restSeconds`, `programmingNotes`).
+- `PATCH /api/v1/scheduled-workouts/:id/exercise-sets`: patch per-set target fields for one
+  snapshot exercise, including `remove: true` and add-by-setNumber behavior.
+
+Plan vs live run invariant:
+
+- Scheduled workouts are the editable plan snapshot that seeds session start.
+- Once a session is started/linked for that schedule, the session is the live run and further live
+  edits must use workout-session endpoints (for example set logging/deletion/corrections), not
+  scheduled-workout structural mutation routes.
 
 ## Three-layer notes model
 

--- a/docs/conventions/workout-domain.md
+++ b/docs/conventions/workout-domain.md
@@ -29,6 +29,8 @@ The scheduled-workout detail page should mirror template-detail exercise renderi
 - `programmingNotes` shown on scheduled cards comes from the scheduled snapshot exercise row.
 - Reserve a page-level `bannerSlot` area above the header for future scheduled-workout warning banners. Leave it empty unless a warning feature explicitly populates it.
 
+Scheduled-workout structural edits (reorder, superset grouping, exercise-level fields, and set-level targets) mutate only the planned snapshot and are intended to seed future session starts. Once a session exists for that schedule, the session becomes the live run and must be edited through workout-session endpoints rather than by mutating the scheduled snapshot structure.
+
 ## Three-layer notes model
 
 Workout exercise note content is split into three channels and should stay separate in API,

--- a/packages/shared/src/schemas/scheduled-workouts.test.ts
+++ b/packages/shared/src/schemas/scheduled-workouts.test.ts
@@ -405,6 +405,19 @@ describe('updateScheduledWorkoutExercisesInputSchema', () => {
       }),
     ).toThrow();
   });
+
+  it("rejects section values outside warmup/main/cooldown (e.g. 'supplemental')", () => {
+    expect(() =>
+      updateScheduledWorkoutExercisesInputSchema.parse({
+        updates: [
+          {
+            exerciseId: 'de111111-1111-4111-8111-111111111111',
+            section: 'supplemental',
+          },
+        ],
+      }),
+    ).toThrow();
+  });
 });
 
 describe('updateScheduledWorkoutExerciseSetsInputSchema', () => {

--- a/packages/shared/src/schemas/scheduled-workouts.test.ts
+++ b/packages/shared/src/schemas/scheduled-workouts.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createScheduledWorkoutInputSchema,
   type CreateScheduledWorkoutInput,
+  type ReorderScheduledWorkoutInput,
   scheduledWorkoutDetailSchema,
   type ScheduledWorkoutDetail,
   scheduledWorkoutListItemSchema,
@@ -13,7 +14,12 @@ import {
   type ScheduledWorkout,
   type ScheduledWorkoutListItem,
   type ScheduledWorkoutQueryParams,
+  type UpdateScheduledWorkoutExercisesInput,
+  type UpdateScheduledWorkoutExerciseSetsInput,
   type UpdateScheduledWorkoutExerciseNotesInput,
+  reorderScheduledWorkoutInputSchema,
+  updateScheduledWorkoutExercisesInputSchema,
+  updateScheduledWorkoutExerciseSetsInputSchema,
   updateScheduledWorkoutExerciseNotesInputSchema,
   type UpdateScheduledWorkoutInput,
   updateScheduledWorkoutInputSchema,
@@ -322,5 +328,142 @@ describe('swapScheduledWorkoutExerciseInputSchema', () => {
       fromExerciseId: 'exercise-1',
       toExerciseId: null,
     });
+  });
+});
+
+describe('reorderScheduledWorkoutInputSchema', () => {
+  it('parses valid reorder payloads', () => {
+    const payload: ReorderScheduledWorkoutInput = reorderScheduledWorkoutInputSchema.parse({
+      order: ['de111111-1111-4111-8111-111111111111', 'de222222-2222-4222-8222-222222222222'],
+    });
+
+    expect(payload).toEqual({
+      order: ['de111111-1111-4111-8111-111111111111', 'de222222-2222-4222-8222-222222222222'],
+    });
+  });
+
+  it('rejects empty order arrays', () => {
+    expect(() =>
+      reorderScheduledWorkoutInputSchema.parse({
+        order: [],
+      }),
+    ).toThrow();
+  });
+
+  it('rejects order entries that are not UUIDs', () => {
+    expect(() =>
+      reorderScheduledWorkoutInputSchema.parse({
+        order: ['exercise-1'],
+      }),
+    ).toThrow();
+  });
+});
+
+describe('updateScheduledWorkoutExercisesInputSchema', () => {
+  it('parses partial exercise metadata updates', () => {
+    const payload: UpdateScheduledWorkoutExercisesInput =
+      updateScheduledWorkoutExercisesInputSchema.parse({
+        updates: [
+          {
+            exerciseId: 'de111111-1111-4111-8111-111111111111',
+            supersetGroup: 'A',
+            section: 'main',
+          },
+          {
+            exerciseId: 'de222222-2222-4222-8222-222222222222',
+            restSeconds: 75,
+            programmingNotes: null,
+          },
+        ],
+      });
+
+    expect(payload).toEqual({
+      updates: [
+        {
+          exerciseId: 'de111111-1111-4111-8111-111111111111',
+          supersetGroup: 'A',
+          section: 'main',
+        },
+        {
+          exerciseId: 'de222222-2222-4222-8222-222222222222',
+          restSeconds: 75,
+          programmingNotes: null,
+        },
+      ],
+    });
+  });
+
+  it('rejects unknown fields inside update items', () => {
+    expect(() =>
+      updateScheduledWorkoutExercisesInputSchema.parse({
+        updates: [
+          {
+            exerciseId: 'de111111-1111-4111-8111-111111111111',
+            unknown: 'value',
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+});
+
+describe('updateScheduledWorkoutExerciseSetsInputSchema', () => {
+  it('parses mixed target updates and remove operations', () => {
+    const payload: UpdateScheduledWorkoutExerciseSetsInput =
+      updateScheduledWorkoutExerciseSetsInputSchema.parse({
+        exerciseId: 'de111111-1111-4111-8111-111111111111',
+        sets: [
+          {
+            setNumber: 1,
+            targetSeconds: 720,
+            repsMin: 8,
+            repsMax: 10,
+          },
+          {
+            setNumber: 2,
+            remove: true,
+          },
+        ],
+      });
+
+    expect(payload).toEqual({
+      exerciseId: 'de111111-1111-4111-8111-111111111111',
+      sets: [
+        {
+          setNumber: 1,
+          targetSeconds: 720,
+          repsMin: 8,
+          repsMax: 10,
+        },
+        {
+          setNumber: 2,
+          remove: true,
+        },
+      ],
+    });
+  });
+
+  it('rejects remove operations combined with target fields', () => {
+    expect(() =>
+      updateScheduledWorkoutExerciseSetsInputSchema.parse({
+        exerciseId: 'de111111-1111-4111-8111-111111111111',
+        sets: [
+          {
+            setNumber: 2,
+            remove: true,
+            targetSeconds: 600,
+          },
+        ],
+      }),
+    ).toThrow('remove cannot be combined with target fields');
+  });
+
+  it('rejects empty set update payloads', () => {
+    expect(() =>
+      updateScheduledWorkoutExerciseSetsInputSchema.parse({
+        exerciseId: 'de111111-1111-4111-8111-111111111111',
+        sets: [],
+      }),
+    ).toThrow();
   });
 });

--- a/packages/shared/src/schemas/scheduled-workouts.ts
+++ b/packages/shared/src/schemas/scheduled-workouts.ts
@@ -62,16 +62,20 @@ export const scheduledWorkoutQueryParamsSchema = z
     path: ['to'],
   });
 
-export const scheduledWorkoutExerciseSetSchema = z.object({
-  setNumber: z.number().int().min(1),
-  repsMin: z.number().int().min(1).nullable(),
-  repsMax: z.number().int().min(1).nullable(),
-  reps: z.number().int().min(1).nullable(),
+const scheduledWorkoutExerciseSetTargetFieldSchemas = {
   targetWeight: z.number().min(0).nullable(),
   targetWeightMin: z.number().min(0).nullable(),
   targetWeightMax: z.number().min(0).nullable(),
   targetSeconds: z.number().int().min(0).nullable(),
   targetDistance: z.number().min(0).nullable(),
+};
+
+export const scheduledWorkoutExerciseSetSchema = z.object({
+  setNumber: z.number().int().min(1),
+  repsMin: z.number().int().min(1).nullable(),
+  repsMax: z.number().int().min(1).nullable(),
+  reps: z.number().int().min(1).nullable(),
+  ...scheduledWorkoutExerciseSetTargetFieldSchemas,
 });
 
 export const scheduledWorkoutExerciseAgentNotesMetaSchema = z.object({
@@ -147,6 +151,85 @@ export const swapScheduledWorkoutExerciseInputSchema = z.object({
 
 export const swapScheduledWorkoutExerciseResponseSchema = scheduledWorkoutDetailSchema;
 
+const scheduledWorkoutEditableSectionSchema = workoutTemplateSectionTypeSchema.refine(
+  (section) => section !== 'supplemental',
+  {
+    message: 'Section must be warmup, main, or cooldown',
+  },
+);
+
+export const reorderScheduledWorkoutInputSchema = z
+  .object({
+    order: z.array(z.string().uuid()).min(1),
+  })
+  .strict();
+
+export const updateScheduledWorkoutExercisesInputSchema = z
+  .object({
+    updates: z
+      .array(
+        z
+          .object({
+            exerciseId: z.string().uuid(),
+            supersetGroup: z.string().nullable().optional(),
+            section: scheduledWorkoutEditableSectionSchema.optional(),
+            tempo: z.string().nullable().optional(),
+            restSeconds: z.number().int().nonnegative().nullable().optional(),
+            programmingNotes: z.string().nullable().optional(),
+          })
+          .strict(),
+      )
+      .min(1),
+  })
+  .strict();
+
+const editableSetTargetFields = [
+  'targetWeight',
+  'targetWeightMin',
+  'targetWeightMax',
+  'targetSeconds',
+  'targetDistance',
+  'repsMin',
+  'repsMax',
+  'reps',
+] as const;
+
+export const updateScheduledWorkoutExerciseSetsInputSchema = z
+  .object({
+    exerciseId: z.string().uuid(),
+    sets: z
+      .array(
+        z
+          .object({
+            setNumber: z.number().int().positive(),
+            targetWeight: scheduledWorkoutExerciseSetTargetFieldSchemas.targetWeight.optional(),
+            targetWeightMin:
+              scheduledWorkoutExerciseSetTargetFieldSchemas.targetWeightMin.optional(),
+            targetWeightMax:
+              scheduledWorkoutExerciseSetTargetFieldSchemas.targetWeightMax.optional(),
+            targetSeconds: scheduledWorkoutExerciseSetTargetFieldSchemas.targetSeconds.optional(),
+            targetDistance: scheduledWorkoutExerciseSetTargetFieldSchemas.targetDistance.optional(),
+            repsMin: z.number().int().nonnegative().nullable().optional(),
+            repsMax: z.number().int().nonnegative().nullable().optional(),
+            reps: z.number().int().nonnegative().nullable().optional(),
+            remove: z.literal(true).optional(),
+          })
+          .strict()
+          .refine(
+            (setUpdate) =>
+              !(
+                setUpdate.remove &&
+                editableSetTargetFields.some((field) => setUpdate[field] != null)
+              ),
+            {
+              message: 'remove cannot be combined with target fields',
+            },
+          ),
+      )
+      .min(1),
+  })
+  .strict();
+
 export type ScheduledWorkout = z.infer<typeof scheduledWorkoutSchema>;
 export type ScheduledWorkoutListItem = z.infer<typeof scheduledWorkoutListItemSchema>;
 export type CreateScheduledWorkoutInput = z.infer<typeof createScheduledWorkoutInputSchema>;
@@ -165,4 +248,11 @@ export type UpdateScheduledWorkoutExerciseNotesInput = z.infer<
 >;
 export type SwapScheduledWorkoutExerciseInput = z.infer<
   typeof swapScheduledWorkoutExerciseInputSchema
+>;
+export type ReorderScheduledWorkoutInput = z.infer<typeof reorderScheduledWorkoutInputSchema>;
+export type UpdateScheduledWorkoutExercisesInput = z.infer<
+  typeof updateScheduledWorkoutExercisesInputSchema
+>;
+export type UpdateScheduledWorkoutExerciseSetsInput = z.infer<
+  typeof updateScheduledWorkoutExerciseSetsInputSchema
 >;

--- a/packages/shared/src/schemas/scheduled-workouts.ts
+++ b/packages/shared/src/schemas/scheduled-workouts.ts
@@ -151,12 +151,7 @@ export const swapScheduledWorkoutExerciseInputSchema = z.object({
 
 export const swapScheduledWorkoutExerciseResponseSchema = scheduledWorkoutDetailSchema;
 
-const scheduledWorkoutEditableSectionSchema = workoutTemplateSectionTypeSchema.refine(
-  (section) => section !== 'supplemental',
-  {
-    message: 'Section must be warmup, main, or cooldown',
-  },
-);
+const scheduledWorkoutEditableSectionSchema = z.enum(['warmup', 'main', 'cooldown']);
 
 export const reorderScheduledWorkoutInputSchema = z
   .object({
@@ -183,7 +178,7 @@ export const updateScheduledWorkoutExercisesInputSchema = z
   })
   .strict();
 
-const editableSetTargetFields = [
+const editableSetFields = [
   'targetWeight',
   'targetWeightMin',
   'targetWeightMax',
@@ -219,7 +214,7 @@ export const updateScheduledWorkoutExerciseSetsInputSchema = z
             (setUpdate) =>
               !(
                 setUpdate.remove &&
-                editableSetTargetFields.some((field) => setUpdate[field] != null)
+                editableSetFields.some((field) => setUpdate[field] != null)
               ),
             {
               message: 'remove cannot be combined with target fields',


### PR DESCRIPTION
## Summary
This PR adds full structural editing for scheduled workout snapshots, so users and agents can refine a planned workout before starting a live session. It introduces three new scheduled-workout PATCH routes (`/reorder`, `/exercises`, `/exercise-sets`) backed by shared strict Zod input schemas and new store mutation operations. The scheduled workout detail UI now supports exercise reordering, superset-group editing, and per-set target add/edit/remove flows using new React Query mutations. The changes preserve the plan-vs-live-run boundary: edits apply to the scheduled snapshot, and tests confirm edited snapshots seed new sessions while the source template remains unchanged.

## Key Changes
- Added shared input schemas and types in `@pulse/shared` for:
  - Reordering snapshot exercises
  - Updating exercise-level snapshot fields (`supersetGroup`, `section`, `tempo`, `restSeconds`, `programmingNotes`)
  - Updating per-set targets with add/remove semantics
- Added store-layer structural mutation functions for scheduled snapshots:
  - `reorderScheduledWorkoutExercises`
  - `updateScheduledWorkoutExercises`
  - `updateScheduledWorkoutExerciseSets`
- Added API routes on scheduled workouts:
  - `PATCH /api/v1/scheduled-workouts/:id/reorder`
  - `PATCH /api/v1/scheduled-workouts/:id/exercises`
  - `PATCH /api/v1/scheduled-workouts/:id/exercise-sets`
- Extended agent enrichment to include scheduled-workout mutation context and mutation-specific hints for AgentToken callers.
- Implemented scheduled-workout detail editing UI:
  - DnD and move up/down reorder controls
  - Superset chip popover edits
  - Set editor dialog with validation
  - Add/remove set actions
  - Read-only lock banner when a session is already linked
- Added/expanded tests across shared schemas, store functions, API routes, and component behavior, including idempotency, auth/scope, validation errors, and session-seeding continuity.
- Updated conventions and skill docs to document the new endpoints and the “refine plan before live run” workflow.

## Technical Notes
- Structural edit schemas intentionally restrict editable section values to `warmup | main | cooldown`; `supplemental` is preserved for legacy snapshot ordering but cannot be assigned by these new patch inputs.
- Store mutations are idempotent and scoped by `userId`; tests verify replay safety and cross-user no-op behavior.
- Field semantics are explicit: `undefined` means “leave unchanged,” while `null` means “clear value.”
- Reorder and set-renumber flows use temporary index/number values inside transactions to avoid collisions during in-place updates, then normalize to final contiguous ordering.
- Route responses follow the standard `{ data, agent? }` envelope and include typed error handling for invalid order payloads and unknown snapshot exercise references.

## Commits

- `af2a59f docs(workouts): document scheduled snapshot structural edit endpoints`
- `da68e43 feat(workouts): add scheduled workout structural edit controls`
- `2163396 feat(api): add scheduled workout structural patch routes`
- `1d2e4b8 fix(api): resolve commit-6 review feedback`
- `72679b3 feat(api): add scheduled workout snapshot mutation store ops`
- `61ba5ae fix(shared): narrow editable scheduled section enum`
- `88a91a1 feat(shared): add scheduled workout structural edit input schemas`

## Tasks

- **Shared zod schemas for scheduled-workout structural edits**: Add reorderScheduledWorkoutInputSchema, updateScheduledWorkoutExercisesInputSchema, updateScheduledWorkoutExerciseSetsInputSchema in @pulse/shared. Reuse section enum + target-field helpers. Strict objects reject unknown fields. Schema parse tests.
- **Store functions for scheduled-workout snapshot mutations**: reorderScheduledWorkoutExercises, updateScheduledWorkoutExercises, updateScheduledWorkoutExerciseSets in scheduled-workouts/store.ts. Transaction-wrapped, idempotent, scoped to userId. Distinguish null-clear from undefined-leave-alone. Renumber after set delete. Store tests.
- **Three new PATCH routes for scheduled-workout snapshot edits**: Register PATCH /reorder, /exercises, /exercise-sets on scheduled-workouts/index.ts. JWT + AgentToken via shared middleware. Standard envelope + agent enrichment. Snapshot-to-session continuity regression test verifies buildScheduledSnapshotSessionSeed picks up edited structure.
- **Scheduled-workout detail UI for reorder, superset, per-set targets**: useReorderScheduledWorkout, useUpdateScheduledWorkoutExercises, useUpdateScheduledWorkoutExerciseSets mutations. Reorder drag / up-down affordance, superset chip popover, per-set target editor, add/remove set on scheduled-workout-detail.tsx. Reuse WorkoutExerciseCard primitives. Component tests + browser verification.
- **Docs + pulse-app-usage skill updates for new endpoints**: Update docs/conventions/api-conventions.md and docs/conventions/workout-domain.md with the three endpoints and plan-vs-live-run distinction. Update .agents/skills/pulse-app-usage/SKILL.md with a 'refining tomorrow's workout' workflow + endpoint references.

## Diff Stats

```
.agents/skills/pulse-app-usage/SKILL.md            |  23 +
 apps/api/src/middleware/agent-enrichment.ts        |  58 ++
 .../src/routes/scheduled-workouts/index.test.ts    | 893 ++++++++++++++++++++-
 apps/api/src/routes/scheduled-workouts/index.ts    | 188 +++++
 .../src/routes/scheduled-workouts/store.test.ts    | 660 +++++++++++++++
 apps/api/src/routes/scheduled-workouts/store.ts    | 698 ++++++++++++++++
 apps/web/src/features/workouts/api/workouts.ts     | 220 +++++
 .../components/scheduled-workout-detail.test.tsx   | 438 ++++++++++
 .../components/scheduled-workout-detail.tsx        | 850 +++++++++++++++++++-
 .../components/workout-exercise-card/types.ts      |   3 +-
 docs/conventions/agent-integration.md              |  22 +-
 docs/conventions/api-conventions.md                |  46 ++
 docs/conventions/workout-domain.md                 |  19 +
 .../shared/src/schemas/scheduled-workouts.test.ts  | 156 ++++
 packages/shared/src/schemas/scheduled-workouts.ts  |  95 ++-
 15 files changed, 4319 insertions(+), 50 deletions(-)
```