### PR TITLE
fix(workouts): merge localStorage draft with server state on session load

### DIFF
--- a/apps/web/src/features/workouts/lib/session-persistence.test.ts
+++ b/apps/web/src/features/workouts/lib/session-persistence.test.ts
@@ -13,9 +13,31 @@ import {
   getWorkoutExerciseStorageKey,
   getWorkoutSectionStorageKey,
   getStoredActiveWorkoutDraft,
+  mergeExerciseNotes,
+  mergeServerSetDrafts,
   setStoredActiveWorkoutDraft,
   setStoredActiveWorkoutSessionId,
 } from './session-persistence';
+
+type MergeDraftSet = ActiveWorkoutSetDrafts[string][number] & {
+  orderIndex?: number;
+  section?: string | null;
+  skipped?: boolean;
+  supersetGroup?: string | null;
+};
+
+function createDraftSet(overrides: Partial<MergeDraftSet> = {}): MergeDraftSet {
+  return {
+    completed: false,
+    distance: null,
+    id: 'set-1',
+    number: 1,
+    reps: 8,
+    seconds: null,
+    weight: 100,
+    ...overrides,
+  };
+}
 
 describe('session-persistence', () => {
   afterEach(() => {
@@ -117,5 +139,139 @@ describe('session-persistence', () => {
 
     expect(window.localStorage.getItem(`${WORKOUT_SECTIONS_STORAGE_PREFIX}:session-a`)).toBeNull();
     expect(window.localStorage.getItem(`${WORKOUT_EXERCISES_STORAGE_PREFIX}:session-a`)).toBeNull();
+  });
+});
+
+describe('mergeServerSetDrafts', () => {
+  it('uses server values for completed sets even when local has in-progress edits', () => {
+    const local: ActiveWorkoutSetDrafts = {
+      squat: [createDraftSet({ reps: 5, weight: 225 })],
+    };
+    const server: ActiveWorkoutSetDrafts = {
+      squat: [createDraftSet({ completed: true, reps: 8, weight: 245 })],
+    };
+
+    expect(mergeServerSetDrafts(local, server)).toEqual(server);
+  });
+
+  it('uses server values for skipped sets', () => {
+    const local: ActiveWorkoutSetDrafts = {
+      squat: [createDraftSet({ reps: 5, weight: 225 })],
+    };
+    const server: ActiveWorkoutSetDrafts = {
+      squat: [createDraftSet({ completed: true, reps: null, skipped: true, weight: null })],
+    };
+
+    expect(mergeServerSetDrafts(local, server)).toEqual(server);
+  });
+
+  it('keeps local editable fields for in-progress sets while syncing structural server fields', () => {
+    const local: ActiveWorkoutSetDrafts = {
+      squat: [
+        createDraftSet({
+          distance: 0.25,
+          reps: 6,
+          seconds: 45,
+          targetWeight: 205,
+          targetWeightMax: 215,
+          targetWeightMin: 195,
+          weight: 185,
+        }),
+      ],
+    };
+    const server: ActiveWorkoutSetDrafts = {
+      squat: [
+        createDraftSet({
+          distance: null,
+          orderIndex: 3,
+          reps: 10,
+          section: 'main',
+          supersetGroup: 'A',
+          targetWeight: 205,
+          targetWeightMax: 215,
+          targetWeightMin: 195,
+          weight: 135,
+        }),
+      ],
+    };
+
+    expect(mergeServerSetDrafts(local, server)).toEqual({
+      squat: [
+        createDraftSet({
+          distance: 0.25,
+          orderIndex: 3,
+          reps: 6,
+          seconds: 45,
+          section: 'main',
+          supersetGroup: 'A',
+          targetWeight: 205,
+          targetWeightMax: 215,
+          targetWeightMin: 195,
+          weight: 185,
+        }),
+      ],
+    });
+  });
+
+  it('drops local exercises that are missing from the server payload', () => {
+    const local: ActiveWorkoutSetDrafts = {
+      carry: [createDraftSet({ id: 'carry-1' })],
+    };
+
+    expect(mergeServerSetDrafts(local, {})).toEqual({});
+  });
+
+  it('initializes exercises present only on the server', () => {
+    const server: ActiveWorkoutSetDrafts = {
+      row: [createDraftSet({ id: 'row-1', reps: 12 })],
+    };
+
+    expect(mergeServerSetDrafts({}, server)).toEqual(server);
+  });
+
+  it('passes through all server data when local drafts are empty', () => {
+    const server: ActiveWorkoutSetDrafts = {
+      row: [createDraftSet({ id: 'row-1', reps: 12 })],
+    };
+
+    expect(mergeServerSetDrafts({}, server)).toEqual(server);
+  });
+
+  it('is total when the server payload is empty', () => {
+    const local: ActiveWorkoutSetDrafts = {
+      row: [createDraftSet({ id: 'row-1', reps: 12 })],
+    };
+
+    expect(mergeServerSetDrafts(local, {})).toEqual({});
+  });
+});
+
+describe('mergeExerciseNotes', () => {
+  it('prefers non-empty server notes over local notes', () => {
+    expect(
+      mergeExerciseNotes(
+        { squat: 'Local note' },
+        { squat: 'Server note', deadlift: 'Deadlift cue' },
+      ),
+    ).toEqual({
+      deadlift: 'Deadlift cue',
+      squat: 'Server note',
+    });
+  });
+
+  it('keeps local notes when server note is empty', () => {
+    expect(mergeExerciseNotes({ squat: 'Local note' }, { squat: '' })).toEqual({
+      squat: 'Local note',
+    });
+  });
+
+  it('keeps server-only exercise notes', () => {
+    expect(mergeExerciseNotes({}, { squat: 'Server note' })).toEqual({
+      squat: 'Server note',
+    });
+  });
+
+  it('drops local-only exercise notes that are not in server payload', () => {
+    expect(mergeExerciseNotes({ squat: 'Local note' }, {})).toEqual({});
   });
 });

--- a/apps/web/src/features/workouts/lib/session-persistence.ts
+++ b/apps/web/src/features/workouts/lib/session-persistence.ts
@@ -13,6 +13,73 @@ type ActiveWorkoutDraft = {
   setDrafts: ActiveWorkoutSetDrafts;
 };
 
+export function mergeServerSetDrafts(
+  currentSetDrafts: ActiveWorkoutSetDrafts,
+  serverSetDrafts: ActiveWorkoutSetDrafts,
+) {
+  const nextDrafts: ActiveWorkoutSetDrafts = {};
+
+  for (const [exerciseId, serverExerciseDrafts] of Object.entries(serverSetDrafts)) {
+    const currentExerciseDrafts = currentSetDrafts[exerciseId] ?? [];
+
+    nextDrafts[exerciseId] = serverExerciseDrafts.map((serverSetDraft) => {
+      const currentDraft = currentExerciseDrafts.find(
+        (set) => set.number === serverSetDraft.number,
+      );
+
+      if (!currentDraft) {
+        return serverSetDraft;
+      }
+
+      if (currentDraft.completed || serverSetDraft.completed) {
+        // Completed sets are server-authoritative; this may replace uncommitted local input if
+        // an external actor completed the set between poll intervals.
+        return serverSetDraft;
+      }
+
+      return {
+        ...serverSetDraft,
+        distance: currentDraft.distance,
+        reps: currentDraft.reps,
+        seconds: currentDraft.seconds,
+        targetDistance: currentDraft.targetDistance,
+        targetSeconds: currentDraft.targetSeconds,
+        targetWeight: currentDraft.targetWeight,
+        targetWeightMax: currentDraft.targetWeightMax,
+        targetWeightMin: currentDraft.targetWeightMin,
+        weight: currentDraft.weight,
+      };
+    });
+  }
+
+  return nextDrafts;
+}
+
+export function mergeExerciseNotes(
+  local: Record<string, string>,
+  server: Record<string, string>,
+): Record<string, string> {
+  const mergedNotes: Record<string, string> = {};
+
+  for (const [exerciseId, serverNote] of Object.entries(server)) {
+    const localNote = local[exerciseId];
+
+    if (typeof serverNote === 'string' && serverNote.trim().length > 0) {
+      mergedNotes[exerciseId] = serverNote;
+      continue;
+    }
+
+    if (typeof localNote === 'string' && localNote.trim().length > 0) {
+      mergedNotes[exerciseId] = localNote;
+      continue;
+    }
+
+    mergedNotes[exerciseId] = serverNote;
+  }
+
+  return mergedNotes;
+}
+
 function canUseLocalStorage() {
   return typeof window !== 'undefined';
 }

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -11,6 +11,7 @@ import { renderWithQueryClient } from '@/test/render-with-query-client';
 import { jsonResponse } from '@/test/test-utils';
 import { buildSessionSetInputs, extractExerciseNotes } from '@/features/workouts/lib/session-notes';
 import {
+  ACTIVE_WORKOUT_DRAFT_STORAGE_PREFIX,
   ACTIVE_WORKOUT_SESSION_STORAGE_KEY,
   WORKOUT_EXERCISES_STORAGE_PREFIX,
   WORKOUT_SECTIONS_STORAGE_PREFIX,
@@ -463,6 +464,340 @@ describe('ActiveWorkoutPage', () => {
     expect(window.localStorage.getItem(exerciseStateKey)).toBeNull();
   });
 
+  it('hydrates completed server sets over empty autosaved draft values on session switch', async () => {
+    vi.useRealTimers();
+    const sessionId = 'session-merge-completed';
+    seedActiveWorkoutDraft(sessionId, {
+      exerciseNotes: {},
+      sessionCuesByExercise: {},
+      setDrafts: {
+        'incline-dumbbell-press': [
+          createStoredDraftSet({
+            completed: false,
+            id: 'set-1',
+            number: 1,
+            reps: null,
+            weight: null,
+          }),
+        ],
+      },
+    });
+    mockActiveSessionFetch(
+      sessionId,
+      buildHydrationSessionResponse(sessionId, {
+        exercises: [
+          createHydrationSessionExercise({
+            exerciseId: 'incline-dumbbell-press',
+            exerciseName: 'Incline Dumbbell Press',
+            orderIndex: 0,
+            section: 'main',
+            sets: [
+              createHydrationSessionSet({
+                completed: true,
+                exerciseId: 'incline-dumbbell-press',
+                id: 'set-1',
+                orderIndex: 0,
+                reps: 8,
+                section: 'main',
+                setNumber: 1,
+              }),
+            ],
+          }),
+        ],
+        sets: [
+          createHydrationSessionSet({
+            completed: true,
+            exerciseId: 'incline-dumbbell-press',
+            id: 'set-1',
+            orderIndex: 0,
+            reps: 8,
+            section: 'main',
+            setNumber: 1,
+          }),
+        ],
+      }),
+    );
+
+    renderActiveWorkoutPage(`/workouts/active?sessionId=${sessionId}&template=upper-push`);
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Upper Push' })).toBeVisible();
+    expect(
+      within(getExerciseCard('Incline Dumbbell Press')).getByLabelText('Reps for set 1'),
+    ).toHaveValue(8);
+  });
+
+  it('preserves in-progress local set values when the server set is still incomplete', async () => {
+    vi.useRealTimers();
+    const sessionId = 'session-merge-local-in-progress';
+    seedActiveWorkoutDraft(sessionId, {
+      exerciseNotes: {},
+      sessionCuesByExercise: {},
+      setDrafts: {
+        'incline-dumbbell-press': [
+          createStoredDraftSet({
+            completed: false,
+            id: 'set-1',
+            number: 1,
+            reps: null,
+            weight: 42,
+          }),
+        ],
+      },
+    });
+    mockActiveSessionFetch(
+      sessionId,
+      buildHydrationSessionResponse(sessionId, {
+        exercises: [
+          createHydrationSessionExercise({
+            exerciseId: 'incline-dumbbell-press',
+            exerciseName: 'Incline Dumbbell Press',
+            orderIndex: 0,
+            section: 'main',
+            sets: [
+              createHydrationSessionSet({
+                completed: false,
+                exerciseId: 'incline-dumbbell-press',
+                id: 'set-1',
+                orderIndex: 0,
+                reps: null,
+                section: 'main',
+                setNumber: 1,
+                weight: null,
+              }),
+            ],
+          }),
+        ],
+        sets: [
+          createHydrationSessionSet({
+            completed: false,
+            exerciseId: 'incline-dumbbell-press',
+            id: 'set-1',
+            orderIndex: 0,
+            reps: null,
+            section: 'main',
+            setNumber: 1,
+            weight: null,
+          }),
+        ],
+      }),
+    );
+
+    renderActiveWorkoutPage(`/workouts/active?sessionId=${sessionId}&template=upper-push`);
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Upper Push' })).toBeVisible();
+    expect(
+      within(getExerciseCard('Incline Dumbbell Press')).getByLabelText('Weight for set 1'),
+    ).toHaveValue(42);
+  });
+
+  it('drops local-only exercises that are missing from server session payloads', async () => {
+    vi.useRealTimers();
+    const sessionId = 'session-merge-drop-local-only-exercise';
+    seedActiveWorkoutDraft(sessionId, {
+      exerciseNotes: {},
+      sessionCuesByExercise: {},
+      setDrafts: {
+        'incline-dumbbell-press': [
+          createStoredDraftSet({
+            completed: false,
+            id: 'local-only-set-1',
+            number: 1,
+            reps: 6,
+            weight: 40,
+          }),
+        ],
+      },
+    });
+    mockActiveSessionFetch(
+      sessionId,
+      buildHydrationSessionResponse(sessionId, {
+        exercises: [
+          createHydrationSessionExercise({
+            exerciseId: 'seated-dumbbell-shoulder-press',
+            exerciseName: 'Seated Dumbbell Shoulder Press',
+            orderIndex: 0,
+            section: 'main',
+            sets: [
+              createHydrationSessionSet({
+                completed: false,
+                exerciseId: 'seated-dumbbell-shoulder-press',
+                id: 'set-1',
+                orderIndex: 0,
+                reps: 10,
+                section: 'main',
+                setNumber: 1,
+              }),
+            ],
+          }),
+        ],
+        sets: [
+          createHydrationSessionSet({
+            completed: false,
+            exerciseId: 'seated-dumbbell-shoulder-press',
+            id: 'set-1',
+            orderIndex: 0,
+            reps: 10,
+            section: 'main',
+            setNumber: 1,
+          }),
+        ],
+      }),
+    );
+
+    renderActiveWorkoutPage(`/workouts/active?sessionId=${sessionId}&template=upper-push`);
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Upper Push' })).toBeVisible();
+    expect(
+      screen.queryByRole('heading', { level: 3, name: 'Incline Dumbbell Press' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Seated Dumbbell Shoulder Press' }),
+    ).toBeVisible();
+  });
+
+  it('prefers server exercise notes when local and server notes differ', async () => {
+    vi.useRealTimers();
+    const sessionId = 'session-merge-notes-server-wins';
+    seedActiveWorkoutDraft(sessionId, {
+      exerciseNotes: {
+        'seated-dumbbell-shoulder-press': 'Local note',
+      },
+      sessionCuesByExercise: {},
+      setDrafts: {
+        'seated-dumbbell-shoulder-press': [
+          createStoredDraftSet({
+            completed: false,
+            id: 'set-1',
+            number: 1,
+            reps: 9,
+            weight: 35,
+          }),
+        ],
+      },
+    });
+    mockActiveSessionFetch(
+      sessionId,
+      buildHydrationSessionResponse(sessionId, {
+        exercises: [
+          createHydrationSessionExercise({
+            exerciseId: 'seated-dumbbell-shoulder-press',
+            exerciseName: 'Seated Dumbbell Shoulder Press',
+            orderIndex: 0,
+            section: 'main',
+            sets: [
+              createHydrationSessionSet({
+                completed: true,
+                exerciseId: 'seated-dumbbell-shoulder-press',
+                id: 'set-1',
+                notes: 'Server note',
+                orderIndex: 0,
+                reps: 9,
+                section: 'main',
+                setNumber: 1,
+                weight: 35,
+              }),
+            ],
+          }),
+        ],
+        sets: [
+          createHydrationSessionSet({
+            completed: true,
+            exerciseId: 'seated-dumbbell-shoulder-press',
+            id: 'set-1',
+            notes: 'Server note',
+            orderIndex: 0,
+            reps: 9,
+            section: 'main',
+            setNumber: 1,
+            weight: 35,
+          }),
+        ],
+      }),
+    );
+
+    renderActiveWorkoutPage(`/workouts/active?sessionId=${sessionId}&template=upper-push`);
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Upper Push' })).toBeVisible();
+    const seatedCard = getExerciseCard('Seated Dumbbell Shoulder Press');
+    fireEvent.click(within(seatedCard).getByText('Session notes'));
+    expect(within(seatedCard).getByDisplayValue('Server note')).toBeVisible();
+  });
+
+  it('preserves local session cues during session hydration', async () => {
+    vi.useRealTimers();
+    const sessionId = 'session-merge-preserve-cues';
+    seedActiveWorkoutDraft(sessionId, {
+      exerciseNotes: {},
+      sessionCuesByExercise: {
+        'seated-dumbbell-shoulder-press': ['Drive elbows under wrists'],
+      },
+      setDrafts: {
+        'seated-dumbbell-shoulder-press': [
+          createStoredDraftSet({
+            completed: false,
+            id: 'set-1',
+            number: 1,
+            reps: 10,
+            weight: 35,
+          }),
+        ],
+      },
+    });
+    mockActiveSessionFetch(
+      sessionId,
+      buildHydrationSessionResponse(sessionId, {
+        exercises: [
+          createHydrationSessionExercise({
+            exerciseId: 'seated-dumbbell-shoulder-press',
+            exerciseName: 'Seated Dumbbell Shoulder Press',
+            orderIndex: 0,
+            section: 'main',
+            sets: [
+              createHydrationSessionSet({
+                completed: false,
+                exerciseId: 'seated-dumbbell-shoulder-press',
+                id: 'set-1',
+                orderIndex: 0,
+                reps: 10,
+                section: 'main',
+                setNumber: 1,
+                weight: 35,
+              }),
+            ],
+          }),
+        ],
+        sets: [
+          createHydrationSessionSet({
+            completed: false,
+            exerciseId: 'seated-dumbbell-shoulder-press',
+            id: 'set-1',
+            orderIndex: 0,
+            reps: 10,
+            section: 'main',
+            setNumber: 1,
+            weight: 35,
+          }),
+        ],
+      }),
+    );
+
+    renderActiveWorkoutPage(`/workouts/active?sessionId=${sessionId}&template=upper-push`);
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Upper Push' })).toBeVisible();
+    await waitFor(() => {
+      const storedDraft = window.localStorage.getItem(
+        `${ACTIVE_WORKOUT_DRAFT_STORAGE_PREFIX}:${sessionId}`,
+      );
+      expect(storedDraft).not.toBeNull();
+
+      expect(JSON.parse(storedDraft ?? '{}')).toMatchObject({
+        sessionCuesByExercise: {
+          'seated-dumbbell-shoulder-press': ['Drive elbows under wrists'],
+        },
+      });
+    });
+  });
+
   it('uses the selected template from the route query string', () => {
     renderActiveWorkoutPage('/workouts/active?template=lower-quad-dominant');
 
@@ -782,7 +1117,10 @@ describe('ActiveWorkoutPage', () => {
           currentSession = {
             ...currentSession,
             sectionDurations: nextSectionDurations,
-            timeSegments: [...nextTimeSegments, { start: nowIso, end: null, section: payload.section }],
+            timeSegments: [
+              ...nextTimeSegments,
+              { start: nowIso, end: null, section: payload.section },
+            ],
           };
         } else {
           currentSession = {
@@ -807,7 +1145,10 @@ describe('ActiveWorkoutPage', () => {
     expect(screen.getByRole('button', { name: 'Start' })).toBeInTheDocument();
 
     const getSectionTimerButton = (sectionTitle: 'Warmup' | 'Main', buttonName: string) => {
-      const heading = screen.getByRole('heading', { level: 2, name: new RegExp(`^${sectionTitle}`) });
+      const heading = screen.getByRole('heading', {
+        level: 2,
+        name: new RegExp(`^${sectionTitle}`),
+      });
       const sectionElement = heading.closest('section');
 
       expect(sectionElement).not.toBeNull();
@@ -2418,6 +2759,154 @@ function getRestTimerRemainingSeconds() {
   throw new Error(`Unable to parse rest timer text: ${timerText}`);
 }
 
+function seedActiveWorkoutDraft(
+  sessionId: string,
+  draft: {
+    exerciseNotes: Record<string, string>;
+    sessionCuesByExercise: Record<string, string[]>;
+    setDrafts: Record<string, Array<ReturnType<typeof createStoredDraftSet>>>;
+  },
+) {
+  window.localStorage.setItem(
+    `${ACTIVE_WORKOUT_DRAFT_STORAGE_PREFIX}:${sessionId}`,
+    JSON.stringify(draft),
+  );
+}
+
+function mockActiveSessionFetch(sessionId: string, session: MutableInProgressSessionResponse) {
+  const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+
+    if (url.endsWith('/api/v1/auth/register')) {
+      return Promise.resolve(jsonResponse({ data: { token: 'dev-generated-token' } }));
+    }
+
+    if (url.includes('/api/v1/workout-sessions?status=completed&limit=3')) {
+      return Promise.resolve(jsonResponse({ data: [] }));
+    }
+
+    if (url.includes('/api/v1/workout-sessions?status=in-progress&status=paused')) {
+      return Promise.resolve(
+        jsonResponse({
+          data: [
+            buildWorkoutSessionListItem({
+              id: sessionId,
+              name: session.name,
+              status: session.status,
+              templateId: session.templateId,
+              templateName: session.name,
+            }),
+          ],
+        }),
+      );
+    }
+
+    if (
+      url.endsWith('/api/v1/workout-templates/upper-push') &&
+      (!init?.method || init.method === 'GET')
+    ) {
+      const template = buildWorkoutTemplateResponse('upper-push');
+      if (!template) {
+        return Promise.reject(new Error('Expected upper-push fixture template to exist.'));
+      }
+
+      return Promise.resolve(jsonResponse({ data: template }));
+    }
+
+    if (
+      url.endsWith(`/api/v1/workout-sessions/${sessionId}`) &&
+      (!init?.method || init.method === 'GET')
+    ) {
+      return Promise.resolve(jsonResponse({ data: session }));
+    }
+
+    if (url.includes('/api/v1/exercises/') && url.includes('/history')) {
+      return Promise.resolve(jsonResponse({ data: [] }));
+    }
+
+    if (url.endsWith(`/api/v1/workout-sessions/${sessionId}`) && init?.method === 'PATCH') {
+      return Promise.resolve(jsonResponse({ data: session }));
+    }
+
+    return Promise.reject(new Error(`Unexpected fetch request: ${url}`));
+  });
+
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function createStoredDraftSet(
+  overrides: Partial<{
+    completed: boolean;
+    distance: number | null;
+    id: string;
+    number: number;
+    reps: number | null;
+    seconds: number | null;
+    weight: number | null;
+  }> = {},
+) {
+  return {
+    completed: false,
+    distance: null,
+    id: 'stored-set-1',
+    number: 1,
+    reps: null,
+    seconds: null,
+    weight: null,
+    ...overrides,
+  };
+}
+
+function createHydrationSessionSet(
+  overrides: Partial<MutableInProgressSessionResponse['sets'][number]> = {},
+): MutableInProgressSessionResponse['sets'][number] {
+  return {
+    completed: false,
+    createdAt: Date.parse('2026-03-06T12:00:00.000Z'),
+    exerciseId: 'incline-dumbbell-press',
+    id: 'session-set-1',
+    notes: null,
+    orderIndex: 0,
+    reps: null,
+    section: 'main',
+    setNumber: 1,
+    skipped: false,
+    weight: null,
+    ...overrides,
+  };
+}
+
+function createHydrationSessionExercise(
+  overrides: Partial<MutableInProgressSessionResponse['exercises'][number]> = {},
+): MutableInProgressSessionResponse['exercises'][number] {
+  return {
+    exerciseId: 'incline-dumbbell-press',
+    exerciseName: 'Incline Dumbbell Press',
+    orderIndex: 0,
+    section: 'main',
+    sets: [createHydrationSessionSet()],
+    ...overrides,
+  };
+}
+
+function buildHydrationSessionResponse(
+  sessionId: string,
+  overrides: {
+    exercises: MutableInProgressSessionResponse['exercises'];
+    sets: MutableInProgressSessionResponse['sets'];
+  },
+): MutableInProgressSessionResponse {
+  const baseSession = buildInProgressSessionResponse(sessionId);
+
+  return {
+    ...baseSession,
+    exercises: overrides.exercises,
+    sets: overrides.sets,
+    updatedAt: Date.parse('2026-03-06T12:00:05.000Z'),
+  };
+}
+
 function buildCompletedSessionResponse() {
   return {
     id: 'created-session-id',
@@ -2450,7 +2939,7 @@ function buildCompletedSessionResponse() {
   };
 }
 
-function buildInProgressSessionResponse(sessionId: string) {
+function buildInProgressSessionResponse(sessionId: string): MutableInProgressSessionResponse {
   return {
     id: sessionId,
     userId: 'user-1',
@@ -2476,6 +2965,7 @@ function buildInProgressSessionResponse(sessionId: string) {
     },
     feedback: null,
     notes: null,
+    exercises: [],
     sets: [],
     createdAt: Date.parse('2026-03-06T12:00:00.000Z'),
     updatedAt: Date.parse('2026-03-06T12:00:00.000Z'),

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -89,6 +89,7 @@ import {
   clearStoredActiveWorkoutSessionId,
   clearStoredWorkoutSessionUiState,
   getStoredActiveWorkoutDraft,
+  mergeExerciseNotes,
   mergeServerSetDrafts,
   setStoredActiveWorkoutSessionId,
   setStoredActiveWorkoutDraft,
@@ -323,14 +324,14 @@ export function ActiveWorkoutPage() {
 
     if (isSessionSwitch) {
       const autosavedDraft = getStoredActiveWorkoutDraft(activeSession.id);
-      const shouldUseAutosavedDraft =
-        autosavedDraft &&
-        (!hasDraftStructure(serverSetDrafts) || hasDraftStructure(autosavedDraft.setDrafts));
-      setSetDrafts(shouldUseAutosavedDraft ? autosavedDraft.setDrafts : serverSetDrafts);
+      const mergedSetDrafts = autosavedDraft
+        ? mergeServerSetDrafts(autosavedDraft.setDrafts, serverSetDrafts)
+        : serverSetDrafts;
+      setSetDrafts(mergedSetDrafts);
       setExerciseNotes(
-        shouldUseAutosavedDraft ? autosavedDraft.exerciseNotes : serverExerciseNotes,
+        mergeExerciseNotes(autosavedDraft?.exerciseNotes ?? {}, serverExerciseNotes),
       );
-      setSessionCuesByExercise(shouldUseAutosavedDraft ? autosavedDraft.sessionCuesByExercise : {});
+      setSessionCuesByExercise(autosavedDraft?.sessionCuesByExercise ?? {});
       setExerciseOrderBySection(serverExerciseOrder);
       hydratedSessionIdRef.current = activeSession.id;
       hydratedDraftKeyRef.current = activeSession.id;
@@ -395,13 +396,13 @@ export function ActiveWorkoutPage() {
 
     const initialSetDrafts = createInitialWorkoutSetDrafts(template, new Set<string>());
     const autosavedDraft = getStoredActiveWorkoutDraft(activeWorkoutDraftId);
-    const shouldUseAutosavedDraft =
+    const preferAutosavedDraft =
       autosavedDraft &&
       (!hasDraftStructure(initialSetDrafts) || hasDraftStructure(autosavedDraft.setDrafts));
 
-    setSetDrafts(shouldUseAutosavedDraft ? autosavedDraft.setDrafts : initialSetDrafts);
-    setExerciseNotes(shouldUseAutosavedDraft ? autosavedDraft.exerciseNotes : {});
-    setSessionCuesByExercise(shouldUseAutosavedDraft ? autosavedDraft.sessionCuesByExercise : {});
+    setSetDrafts(preferAutosavedDraft ? autosavedDraft.setDrafts : initialSetDrafts);
+    setExerciseNotes(preferAutosavedDraft ? autosavedDraft.exerciseNotes : {});
+    setSessionCuesByExercise(preferAutosavedDraft ? autosavedDraft.sessionCuesByExercise : {});
     setExerciseOrderBySection(buildExerciseOrderFromTemplate(template));
     hydratedSessionIdRef.current = null;
     hydratedDraftKeyRef.current = activeWorkoutDraftId;

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -89,6 +89,7 @@ import {
   clearStoredActiveWorkoutSessionId,
   clearStoredWorkoutSessionUiState,
   getStoredActiveWorkoutDraft,
+  mergeServerSetDrafts,
   setStoredActiveWorkoutSessionId,
   setStoredActiveWorkoutDraft,
 } from '@/features/workouts/lib/session-persistence';
@@ -1893,48 +1894,6 @@ function createSessionSetDrafts(
   return drafts;
 }
 
-function mergeServerSetDrafts(
-  currentSetDrafts: ActiveWorkoutSetDrafts,
-  serverSetDrafts: ActiveWorkoutSetDrafts,
-) {
-  const nextDrafts: ActiveWorkoutSetDrafts = {};
-
-  for (const [exerciseId, serverExerciseDrafts] of Object.entries(serverSetDrafts)) {
-    const currentExerciseDrafts = currentSetDrafts[exerciseId] ?? [];
-
-    nextDrafts[exerciseId] = serverExerciseDrafts.map((serverSetDraft) => {
-      const currentDraft = currentExerciseDrafts.find(
-        (set) => set.number === serverSetDraft.number,
-      );
-
-      if (!currentDraft) {
-        return serverSetDraft;
-      }
-
-      if (currentDraft.completed || serverSetDraft.completed) {
-        // Completed sets are server-authoritative; this may replace uncommitted local input if
-        // an external actor completed the set between poll intervals.
-        return serverSetDraft;
-      }
-
-      return {
-        ...serverSetDraft,
-        distance: currentDraft.distance,
-        reps: currentDraft.reps,
-        seconds: currentDraft.seconds,
-        targetDistance: currentDraft.targetDistance,
-        targetSeconds: currentDraft.targetSeconds,
-        targetWeight: currentDraft.targetWeight,
-        targetWeightMax: currentDraft.targetWeightMax,
-        targetWeightMin: currentDraft.targetWeightMin,
-        weight: currentDraft.weight,
-      };
-    });
-  }
-
-  return nextDrafts;
-}
-
 function hasDraftStructure(setDrafts: ActiveWorkoutSetDrafts) {
   return Object.values(setDrafts).some((exerciseDrafts) => exerciseDrafts.length > 0);
 }
@@ -2586,7 +2545,8 @@ function buildTemplateFromSession(
       restSeconds: fallbackExercise?.restSeconds ?? 60,
       formCues: fallbackExercise?.formCues ?? [],
       templateCues: fallbackExercise?.templateCues ?? [],
-      programmingNotes: sessionExercise.programmingNotes ?? fallbackExercise?.programmingNotes ?? null,
+      programmingNotes:
+        sessionExercise.programmingNotes ?? fallbackExercise?.programmingNotes ?? null,
       agentNotes: sessionExercise.agentNotes ?? fallbackExercise?.agentNotes ?? null,
       agentNotesMeta: sessionExercise.agentNotesMeta ?? fallbackExercise?.agentNotesMeta ?? null,
       badges: fallbackExercise?.badges ?? [],


### PR DESCRIPTION
## Summary
This PR fixes active workout hydration so local `localStorage` drafts are merged with fresh server session state instead of choosing one source wholesale. The main bug was that cross-device updates (for example, a set completed elsewhere) could be masked by stale or partial local drafts when loading a session. On session switch, set drafts now merge per exercise/set with server-authoritative completion semantics, while in-progress editable fields are preserved locally. Exercise notes now also merge deterministically, and local session cues remain local-only during hydration.

## Key Changes
- Extracted `mergeServerSetDrafts` from `active-workout.tsx` into `apps/web/src/features/workouts/lib/session-persistence.ts` as a shared pure helper.
- Added `mergeExerciseNotes(local, server)` to centralize note merge behavior:
  - non-empty server note wins,
  - empty server note falls back to non-empty local note,
  - exercise IDs not present in server payload are dropped.
- Updated session-switch hydration in `apps/web/src/pages/active-workout.tsx` to use:
  - `mergeServerSetDrafts(autosavedDraft.setDrafts, serverSetDrafts)`,
  - `mergeExerciseNotes(autosavedDraft.exerciseNotes, serverExerciseNotes)`,
  - local-only `sessionCuesByExercise` preservation from autosave.
- Removed the previous session-switch “either local or server” draft selection path and related branching.
- Added focused unit coverage in `session-persistence.test.ts` for merge rules (completed/skipped authority, in-progress local preservation, server-only init, local-only drop, note precedence).
- Added Active Workout page component tests that exercise hydration/session-switch scenarios, including cross-device completion, in-progress local preservation, dropping local-only exercises, server-note precedence, and cue persistence.

## Technical Notes
- Set merge is keyed by `exerciseId` and set `number`, and only iterates server exercises, which intentionally prunes local-only exercises no longer present in the canonical session payload.
- Completed/skipped states are treated as server-authoritative to avoid showing stale local edits after external updates.
- For non-completed sets, structural server fields (e.g. order/section/superset metadata) are retained while editable input values (reps/weight/distance/seconds and targets) are preserved from local draft.
- `sessionCuesByExercise` is intentionally not server-merged in this change; it remains local draft state by design.

## Commits

- `955aa28 fix(web): merge session hydration drafts with server`
- `60d1473 refactor(web): extract session draft merge helpers`

## Tasks

- **Extract mergeServerSetDrafts + add mergeExerciseNotes**: Move mergeServerSetDrafts from active-workout.tsx (line 1896) into apps/web/src/features/workouts/lib/session-persistence.ts. Add mergeExerciseNotes helper (server non-empty wins; server-removed exerciseIds dropped). Pure-function unit tests on the merge rules.
- **Apply merge on initial load / session-switch branch**: Replace wholesale either/or at active-workout.tsx:323-343 with mergeServerSetDrafts + mergeExerciseNotes calls. Preserve sessionCuesByExercise as local-only. Remove hasDraftStructure if unused. Component tests for cross-device scenarios + browser verification against real API.

## Diff Stats

```
.../workouts/lib/session-persistence.test.ts       | 156 +++++++
 .../features/workouts/lib/session-persistence.ts   |  67 +++
 apps/web/src/pages/active-workout.test.tsx         | 496 ++++++++++++++++++++-
 apps/web/src/pages/active-workout.tsx              |  67 +--
 4 files changed, 730 insertions(+), 56 deletions(-)
```