### PR TITLE
fix(workouts): honor supplemental section in session sort + UI visibility

### DIFF
--- a/.agents/skills/pulse-app-usage/SKILL.md
+++ b/.agents/skills/pulse-app-usage/SKILL.md
@@ -221,6 +221,7 @@ If no new foods were created, explicitly say that existing food entries were reu
 ### Sessions
 
 - **Start**: `POST /api/v1/workout-sessions/` with `{ "templateId": "<id>" }` or `{ "name": "Ad hoc" }`.
+- Session responses order sections as `warmup → main → cooldown → supplemental → null`. Supplemental exercises added to a template after session creation appear in the active-workout UI via a template fallback, but only become real session rows once the user logs against them.
 - **Log sets**: `PATCH /api/v1/workout-sessions/:id` with `sets: [{ exerciseName, setNumber, weight, reps }]` (middleware resolves `exerciseName` to canonical `exerciseId`).
 - **Add exercises mid-session**: `addExercises: [{ name, sets, reps, section }]`
 - **Remove unstarted exercises**: `removeExercises: [exerciseId]` — returns 409 if exercise has logged sets.

--- a/apps/api/src/routes/workout-sessions/store.test.ts
+++ b/apps/api/src/routes/workout-sessions/store.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -5,14 +6,23 @@ import { fileURLToPath } from 'node:url';
 
 import { and, eq } from 'drizzle-orm';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import type { FastifyInstance } from 'fastify';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkoutTemplateSectionType } from '@pulse/shared';
 
-import { exercises, sessionSets, users, workoutSessions } from '../../db/schema/index.js';
+import {
+  agentTokens,
+  exercises,
+  sessionSets,
+  users,
+  workoutSessions,
+} from '../../db/schema/index.js';
 
 type DatabaseModule = typeof import('../../db/index.js');
 type StoreModule = typeof import('./store.js');
 
 type TestContext = {
+  app: FastifyInstance;
   db: DatabaseModule['db'];
   sqlite: DatabaseModule['sqlite'];
   tempDir: string;
@@ -31,6 +41,24 @@ const seedUser = (values: { id: string; username: string }) =>
       passwordHash: 'not-used-in-this-suite',
     })
     .run();
+
+const createAgentTokenHeader = (token: string) => ({
+  authorization: `AgentToken ${token}`,
+});
+
+const seedAgentToken = (userId: string, token = 'plain-agent-token') => {
+  context.db
+    .insert(agentTokens)
+    .values({
+      id: `agent-token-${userId}`,
+      userId,
+      name: `Agent ${userId}`,
+      tokenHash: createHash('sha256').update(token).digest('hex'),
+    })
+    .run();
+
+  return token;
+};
 
 const seedExercise = (values: { id: string; name: string; userId?: string | null }) =>
   context.db
@@ -80,7 +108,8 @@ const seedSessionSet = (values: {
   id: string;
   sessionId: string;
   exerciseId: string | null;
-  section?: 'warmup' | 'main' | 'cooldown' | 'supplemental';
+  section?: WorkoutTemplateSectionType;
+  orderIndex?: number;
   setNumber: number;
 }) =>
   context.db
@@ -89,7 +118,7 @@ const seedSessionSet = (values: {
       id: values.id,
       sessionId: values.sessionId,
       exerciseId: values.exerciseId,
-      orderIndex: 0,
+      orderIndex: values.orderIndex ?? 0,
       setNumber: values.setNumber,
       weight: null,
       reps: null,
@@ -113,14 +142,20 @@ describe('workout session store deleteSessionSet', () => {
     process.env.DATABASE_URL = join(tempDir, 'test.db');
     vi.resetModules();
 
-    const dbModule = await import('../../db/index.js');
+    const [{ buildServer }, dbModule] = await Promise.all([
+      import('../../index.js'),
+      import('../../db/index.js'),
+    ]);
     migrate(dbModule.db, {
       migrationsFolder: fileURLToPath(new URL('../../../drizzle', import.meta.url)),
     });
 
     const store = await import('./store.js');
+    const app = buildServer();
+    await app.ready();
 
     context = {
+      app,
       db: dbModule.db,
       sqlite: dbModule.sqlite,
       tempDir,
@@ -128,8 +163,9 @@ describe('workout session store deleteSessionSet', () => {
     };
   });
 
-  afterAll(() => {
+  afterAll(async () => {
     if (context) {
+      await context.app.close();
       context.sqlite.close();
       rmSync(context.tempDir, { recursive: true, force: true });
     }
@@ -141,6 +177,7 @@ describe('workout session store deleteSessionSet', () => {
   beforeEach(() => {
     context.db.delete(sessionSets).run();
     context.db.delete(workoutSessions).run();
+    context.db.delete(agentTokens).run();
     context.db.delete(exercises).run();
     context.db.delete(users).run();
 
@@ -149,6 +186,171 @@ describe('workout session store deleteSessionSet', () => {
 
     seedExercise({ id: 'global-bench-press', name: 'Bench Press' });
     seedExercise({ id: 'global-row', name: 'Row' });
+  });
+
+  it('sortSessionSets orders warmup/main/cooldown/supplemental/null/unknown', () => {
+    type SortableSetRecord = Parameters<StoreModule['sortSessionSets']>[0];
+    const baseCreatedAt = Date.now();
+
+    const buildSortableSet = (
+      id: string,
+      section: WorkoutTemplateSectionType | null,
+      createdAtOffset: number,
+    ): SortableSetRecord => ({
+      id,
+      sessionId: 'session-sort',
+      exerciseId: `${id}-exercise`,
+      orderIndex: 0,
+      setNumber: 1,
+      weight: null,
+      reps: null,
+      targetWeight: null,
+      targetWeightMin: null,
+      targetWeightMax: null,
+      targetSeconds: null,
+      targetDistance: null,
+      supersetGroup: null,
+      completed: false,
+      skipped: false,
+      section,
+      notes: null,
+      createdAt: baseCreatedAt + createdAtOffset,
+    });
+
+    const unknownSection = 'legacy' as unknown as WorkoutTemplateSectionType;
+    const rows: SortableSetRecord[] = [
+      buildSortableSet('unknown', unknownSection, 5),
+      buildSortableSet('supplemental', 'supplemental', 4),
+      buildSortableSet('main', 'main', 2),
+      buildSortableSet('null', null, 6),
+      buildSortableSet('cooldown', 'cooldown', 3),
+      buildSortableSet('warmup', 'warmup', 1),
+    ];
+
+    const sortedSections = rows.sort(context.store.sortSessionSets).map((row) => row.section);
+    expect(sortedSections).toEqual([
+      'warmup',
+      'main',
+      'cooldown',
+      'supplemental',
+      null,
+      unknownSection,
+    ]);
+  });
+
+  it('returns GET /workout-sessions/:id sets in warmup/main/cooldown/supplemental order', async () => {
+    seedExercise({ id: 'global-squat', name: 'Squat' });
+    seedExercise({ id: 'global-press', name: 'Press' });
+    seedWorkoutSession({ id: 'session-get-order', userId: 'user-1', status: 'in-progress' });
+    seedSessionSet({
+      id: 'session-get-order-supplemental',
+      sessionId: 'session-get-order',
+      exerciseId: 'global-press',
+      section: 'supplemental',
+      orderIndex: 0,
+      setNumber: 1,
+    });
+    seedSessionSet({
+      id: 'session-get-order-main',
+      sessionId: 'session-get-order',
+      exerciseId: 'global-row',
+      section: 'main',
+      orderIndex: 0,
+      setNumber: 1,
+    });
+    seedSessionSet({
+      id: 'session-get-order-cooldown',
+      sessionId: 'session-get-order',
+      exerciseId: 'global-squat',
+      section: 'cooldown',
+      orderIndex: 0,
+      setNumber: 1,
+    });
+    seedSessionSet({
+      id: 'session-get-order-warmup',
+      sessionId: 'session-get-order',
+      exerciseId: 'global-bench-press',
+      section: 'warmup',
+      orderIndex: 0,
+      setNumber: 1,
+    });
+
+    const response = await context.app.inject({
+      method: 'GET',
+      url: '/api/v1/workout-sessions/session-get-order',
+      headers: createAgentTokenHeader(seedAgentToken('user-1')),
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const payload = response.json() as {
+      data: {
+        sets: Array<{ section: WorkoutTemplateSectionType }>;
+      };
+    };
+
+    expect(payload.data.sets.map((set) => set.section)).toEqual([
+      'warmup',
+      'main',
+      'cooldown',
+      'supplemental',
+    ]);
+  });
+
+  it('orders exercises by section as warmup/main/cooldown/supplemental', async () => {
+    seedExercise({ id: 'global-squat', name: 'Squat' });
+    seedExercise({ id: 'global-press', name: 'Press' });
+    seedWorkoutSession({
+      id: 'session-exercise-order',
+      userId: 'user-1',
+      status: 'in-progress',
+    });
+    seedSessionSet({
+      id: 'session-exercise-order-supplemental',
+      sessionId: 'session-exercise-order',
+      exerciseId: 'global-press',
+      section: 'supplemental',
+      orderIndex: 0,
+      setNumber: 1,
+    });
+    seedSessionSet({
+      id: 'session-exercise-order-main',
+      sessionId: 'session-exercise-order',
+      exerciseId: 'global-row',
+      section: 'main',
+      orderIndex: 0,
+      setNumber: 1,
+    });
+    seedSessionSet({
+      id: 'session-exercise-order-cooldown',
+      sessionId: 'session-exercise-order',
+      exerciseId: 'global-squat',
+      section: 'cooldown',
+      orderIndex: 0,
+      setNumber: 1,
+    });
+    seedSessionSet({
+      id: 'session-exercise-order-warmup',
+      sessionId: 'session-exercise-order',
+      exerciseId: 'global-bench-press',
+      section: 'warmup',
+      orderIndex: 0,
+      setNumber: 1,
+    });
+
+    const session = await context.store.findWorkoutSessionById('session-exercise-order', 'user-1');
+    expect(session).toBeDefined();
+    if (!session) {
+      throw new Error('Expected seeded session to exist');
+    }
+
+    const exercises = session.exercises ?? [];
+    expect(exercises.map((exercise) => exercise.section)).toEqual([
+      'warmup',
+      'main',
+      'cooldown',
+      'supplemental',
+    ]);
   });
 
   it('deletes a middle set and renumbers remaining sets contiguously within the same exercise section', async () => {

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -34,7 +34,16 @@ import {
 import { findWorkoutTemplateById } from '../workout-templates/store.js';
 import { backfillTimeSegmentSections, calculateSectionDurations } from './time-segments.js';
 
-const SECTION_ORDER: WorkoutTemplateSectionType[] = ['warmup', 'main', 'cooldown'];
+const SECTION_ORDER: WorkoutTemplateSectionType[] = ['warmup', 'main', 'cooldown', 'supplemental'];
+
+export const sectionRank = (section: WorkoutTemplateSectionType | null): number => {
+  if (section === null) {
+    return SECTION_ORDER.length;
+  }
+
+  const index = SECTION_ORDER.indexOf(section);
+  return index === -1 ? SECTION_ORDER.length + 1 : index;
+};
 
 type WorkoutSessionRecord = {
   id: string;
@@ -162,11 +171,9 @@ const sessionSetSelection = {
   createdAt: sessionSets.createdAt,
 };
 
-const sortSessionSets = (left: SessionSetRecord, right: SessionSetRecord) => {
-  const leftSectionIndex =
-    left.section === null ? SECTION_ORDER.length : SECTION_ORDER.indexOf(left.section);
-  const rightSectionIndex =
-    right.section === null ? SECTION_ORDER.length : SECTION_ORDER.indexOf(right.section);
+export const sortSessionSets = (left: SessionSetRecord, right: SessionSetRecord) => {
+  const leftSectionIndex = sectionRank(left.section);
+  const rightSectionIndex = sectionRank(right.section);
 
   if (leftSectionIndex !== rightSectionIndex) {
     return leftSectionIndex - rightSectionIndex;
@@ -354,10 +361,8 @@ const buildWorkoutSessionExercises = (
 
   return Array.from(groupedByExercise.values())
     .sort((left, right) => {
-      const leftSectionIndex =
-        left.section === null ? SECTION_ORDER.length : SECTION_ORDER.indexOf(left.section);
-      const rightSectionIndex =
-        right.section === null ? SECTION_ORDER.length : SECTION_ORDER.indexOf(right.section);
+      const leftSectionIndex = sectionRank(left.section);
+      const rightSectionIndex = sectionRank(right.section);
 
       if (leftSectionIndex !== rightSectionIndex) {
         return leftSectionIndex - rightSectionIndex;

--- a/apps/api/src/scripts/migrate-static.ts
+++ b/apps/api/src/scripts/migrate-static.ts
@@ -107,7 +107,7 @@ export type ParsedDailyLog = {
   bodyWeight: number | null;
 };
 
-type WorkoutTemplateSectionType = 'warmup' | 'main' | 'cooldown';
+type WorkoutTemplateSectionType = 'warmup' | 'main' | 'cooldown' | 'supplemental';
 type ExerciseCategory = 'compound' | 'isolation' | 'cardio' | 'mobility';
 
 type ParsedTemplateExercise = {
@@ -174,7 +174,8 @@ type ExerciseCreateDefaults = {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
-const normalizeLookupKey = (value: string) => value.trim().toLowerCase().replace(WHITESPACE_PATTERN, ' ');
+const normalizeLookupKey = (value: string) =>
+  value.trim().toLowerCase().replace(WHITESPACE_PATTERN, ' ');
 
 const normalizeText = (value: unknown): string | null => {
   if (typeof value !== 'string') {
@@ -296,7 +297,8 @@ const toTwentyFourHourTime = (value: unknown): string | null => {
     return null;
   }
 
-  const normalizedHours = meridiem === 'AM' ? (hours === 12 ? 0 : hours) : hours === 12 ? 12 : hours + 12;
+  const normalizedHours =
+    meridiem === 'AM' ? (hours === 12 ? 0 : hours) : hours === 12 ? 12 : hours + 12;
 
   return `${String(normalizedHours).padStart(2, '0')}:${minutes}`;
 };
@@ -443,7 +445,9 @@ const parseMealItem = (value: unknown): ParsedMealItem | null => {
 
 const parseMeal = (value: unknown, fallbackName: string | null): ParsedMeal | null => {
   if (Array.isArray(value)) {
-    const items = value.map((item) => parseMealItem(item)).filter((item): item is ParsedMealItem => item !== null);
+    const items = value
+      .map((item) => parseMealItem(item))
+      .filter((item): item is ParsedMealItem => item !== null);
 
     if (items.length === 0) {
       return null;
@@ -729,7 +733,10 @@ export const extractBodyWeightFromDailyLog = (raw: unknown): number | null => {
     return null;
   }
 
-  const candidateSources: unknown[] = [getNestedField(raw, 'bodyWeight'), getNestedField(raw, 'weight')];
+  const candidateSources: unknown[] = [
+    getNestedField(raw, 'bodyWeight'),
+    getNestedField(raw, 'weight'),
+  ];
 
   const metrics = getNestedField(raw, 'metrics');
   if (isRecord(metrics)) {
@@ -782,7 +789,10 @@ const listJsonFiles = async (directoryPath: string): Promise<string[]> => {
   return files;
 };
 
-export const loadDailyLogRecords = async (dataRoot: string, logger: Logger): Promise<Map<string, ParsedDailyLog>> => {
+export const loadDailyLogRecords = async (
+  dataRoot: string,
+  logger: Logger,
+): Promise<Map<string, ParsedDailyLog>> => {
   const dailyRoot = join(dataRoot, 'daily');
 
   let dailyFiles: string[];
@@ -832,7 +842,10 @@ const addWeightEntry = (entries: DateWeightMap, date: string | null, weight: num
   entries.set(date, weight);
 };
 
-const parseWeightRecord = (raw: Record<string, unknown>, fallbackDate: string | null): [string | null, number | null] => {
+const parseWeightRecord = (
+  raw: Record<string, unknown>,
+  fallbackDate: string | null,
+): [string | null, number | null] => {
   const date =
     fallbackDate ??
     toDateKey(getNestedField(raw, 'date')) ??
@@ -908,7 +921,10 @@ const loadBodyWeightHistory = async (dataRoot: string, logger: Logger): Promise<
   return parseBodyWeightHistory(payload);
 };
 
-export const mergeWeightEntries = (dailyWeights: DateWeightMap, bodyWeightHistory: DateWeightMap): DateWeightMap => {
+export const mergeWeightEntries = (
+  dailyWeights: DateWeightMap,
+  bodyWeightHistory: DateWeightMap,
+): DateWeightMap => {
   const merged = new Map<string, number>(dailyWeights);
 
   for (const [date, weight] of bodyWeightHistory) {
@@ -949,7 +965,12 @@ const buildHabitLookup = (
   return lookup;
 };
 
-const WORKOUT_SECTION_ORDER: WorkoutTemplateSectionType[] = ['warmup', 'main', 'cooldown'];
+const WORKOUT_SECTION_ORDER: WorkoutTemplateSectionType[] = [
+  'warmup',
+  'main',
+  'cooldown',
+  'supplemental',
+];
 const SESSION_TIMELESS_FALLBACK_SUFFIX = 'T00:00:00.000Z';
 const MIGRATION_ID_HASH_LENGTH = 24;
 
@@ -1047,6 +1068,10 @@ const toSectionType = (value: unknown): WorkoutTemplateSectionType => {
     return 'cooldown';
   }
 
+  if (normalized.includes('supplement') || normalized.includes('accessory')) {
+    return 'supplemental';
+  }
+
   return 'main';
 };
 
@@ -1066,7 +1091,11 @@ const toExerciseCategory = (value: unknown): ExerciseCategory | null => {
     return 'cardio';
   }
 
-  if (normalized.includes('mobility') || normalized.includes('stretch') || normalized.includes('warmup')) {
+  if (
+    normalized.includes('mobility') ||
+    normalized.includes('stretch') ||
+    normalized.includes('warmup')
+  ) {
     return 'mobility';
   }
 
@@ -1395,7 +1424,9 @@ const loadWorkoutTemplateRecords = async (
   try {
     files = await listJsonFiles(templatesRoot);
   } catch (error) {
-    logger.warn(`Workout template directory not found or unreadable at ${templatesRoot}: ${String(error)}`);
+    logger.warn(
+      `Workout template directory not found or unreadable at ${templatesRoot}: ${String(error)}`,
+    );
     return [];
   }
 
@@ -1513,7 +1544,8 @@ const parseSessionSet = (
     toPositiveInteger(getNestedField(value, 'number'));
   const indexSetNumber = toNonnegativeInteger(getNestedField(value, 'index'));
 
-  const setNumber = explicitSetNumber ?? (indexSetNumber !== null ? indexSetNumber + 1 : fallbackSetNumber);
+  const setNumber =
+    explicitSetNumber ?? (indexSetNumber !== null ? indexSetNumber + 1 : fallbackSetNumber);
 
   const skipped = toBoolean(getNestedField(value, 'skipped')) ?? false;
   const completed = skipped ? false : (toBoolean(getNestedField(value, 'completed')) ?? true);
@@ -1719,12 +1751,16 @@ const loadWorkoutSessionRecords = async (
   try {
     files = await listJsonFiles(sessionsRoot);
   } catch (error) {
-    logger.warn(`Workout session directory not found or unreadable at ${sessionsRoot}: ${String(error)}`);
+    logger.warn(
+      `Workout session directory not found or unreadable at ${sessionsRoot}: ${String(error)}`,
+    );
     return [];
   }
 
   const sortedFiles = files
-    .filter((filePath) => !relative(sessionsRoot, filePath).replace(/\\/gu, '/').startsWith('templates/'))
+    .filter(
+      (filePath) => !relative(sessionsRoot, filePath).replace(/\\/gu, '/').startsWith('templates/'),
+    )
     .sort((left, right) => left.localeCompare(right));
   const records: ParsedWorkoutSessionRecord[] = [];
 
@@ -1946,7 +1982,9 @@ export const migrateWorkoutTemplatesAndSessions = async ({
         const rows = template.exercises.flatMap((exercise) => {
           const exerciseLookupEntry = exerciseLookup.get(normalizeLookupKey(exercise.name));
           if (!exerciseLookupEntry) {
-            logger.warn(`Template "${template.name}" references missing exercise "${exercise.name}"; skipping.`);
+            logger.warn(
+              `Template "${template.name}" references missing exercise "${exercise.name}"; skipping.`,
+            );
             return [];
           }
 
@@ -1990,7 +2028,9 @@ export const migrateWorkoutTemplatesAndSessions = async ({
         templateNameLookup.set(templateNameKey, templateId);
       }
 
-      logger.info(`Imported workout template "${template.name}" with ${insertedExerciseCount} exercise(s).`);
+      logger.info(
+        `Imported workout template "${template.name}" with ${insertedExerciseCount} exercise(s).`,
+      );
     } catch (error) {
       summary.failedTemplates += 1;
       logger.error(`Failed importing workout template "${template.name}": ${String(error)}`);
@@ -2179,7 +2219,9 @@ export const migrateFoodsDatabase = async ({
     const dedupeKey = normalizeLookupKey(`${name}|${brand ?? ''}`);
 
     if (existingSet.has(dedupeKey)) {
-      logger.info(`Skipping duplicate food "${name}"${brand ? ` (${brand})` : ''} for user ${userId}.`);
+      logger.info(
+        `Skipping duplicate food "${name}"${brand ? ` (${brand})` : ''} for user ${userId}.`,
+      );
       summary.skipped += 1;
       continue;
     }

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { toast } from 'sonner';
+import type { WorkoutSession as ApiWorkoutSession } from '@pulse/shared';
 
 import { API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
 import { workoutQueryKeys } from '@/features/workouts/api/workouts';
@@ -16,8 +17,9 @@ import {
   WORKOUT_EXERCISES_STORAGE_PREFIX,
   WORKOUT_SECTIONS_STORAGE_PREFIX,
 } from '@/features/workouts/lib/session-persistence';
+import type { ActiveWorkoutTemplate, ActiveWorkoutTemplateExercise } from '@/features/workouts/types';
 
-import { ActiveWorkoutPage } from './active-workout';
+import { ActiveWorkoutPage, buildTemplateFromSession } from './active-workout';
 
 vi.mock('sonner', () => {
   const toastMock = vi.fn() as ReturnType<typeof vi.fn> & {
@@ -2575,6 +2577,103 @@ describe('ActiveWorkoutPage', () => {
   });
 });
 
+describe('buildTemplateFromSession', () => {
+  it('keeps session supplemental exercises when the snapshot already has supplemental rows', () => {
+    const fallbackTemplate = createTemplateForBuildTemplateTests({
+      supplementalExercises: [
+        createTemplateExerciseForBuildTemplateTests({
+          exerciseId: 'fallback-supplemental-exercise',
+          exerciseName: 'Fallback Supplemental Exercise',
+          reps: '12-15',
+        }),
+      ],
+    });
+    const session = createSessionForBuildTemplateTests({
+      exercises: [
+        createSessionExerciseForBuildTemplateTests({
+          exerciseId: 'main-exercise',
+          exerciseName: 'Main Exercise',
+          orderIndex: 0,
+          section: 'main',
+          sets: [createSessionSetForBuildTemplateTests({ exerciseId: 'main-exercise', section: 'main' })],
+        }),
+        createSessionExerciseForBuildTemplateTests({
+          exerciseId: 'session-supplemental-exercise',
+          exerciseName: 'Session Supplemental Exercise',
+          orderIndex: 1,
+          section: 'supplemental',
+          sets: [
+            createSessionSetForBuildTemplateTests({
+              exerciseId: 'session-supplemental-exercise',
+              id: 'supplemental-session-set-1',
+              orderIndex: 1,
+              section: 'supplemental',
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const result = buildTemplateFromSession(session, fallbackTemplate);
+    const supplementalSection = result.sections.find((section) => section.type === 'supplemental');
+
+    expect(supplementalSection?.exercises.map((exercise) => exercise.exerciseId)).toEqual([
+      'session-supplemental-exercise',
+    ]);
+  });
+
+  it('uses template supplemental exercises when the snapshot has no supplemental rows', () => {
+    const fallbackTemplate = createTemplateForBuildTemplateTests({
+      supplementalExercises: [
+        createTemplateExerciseForBuildTemplateTests({
+          exerciseId: 'fallback-supplemental-exercise',
+          exerciseName: 'Fallback Supplemental Exercise',
+          reps: '15-20',
+        }),
+      ],
+    });
+    const session = createSessionForBuildTemplateTests({
+      exercises: [
+        createSessionExerciseForBuildTemplateTests({
+          exerciseId: 'main-exercise',
+          exerciseName: 'Main Exercise',
+          orderIndex: 0,
+          section: 'main',
+          sets: [createSessionSetForBuildTemplateTests({ exerciseId: 'main-exercise', section: 'main' })],
+        }),
+      ],
+    });
+
+    const result = buildTemplateFromSession(session, fallbackTemplate);
+    const supplementalSection = result.sections.find((section) => section.type === 'supplemental');
+
+    expect(supplementalSection?.exercises.map((exercise) => exercise.exerciseId)).toEqual([
+      'fallback-supplemental-exercise',
+    ]);
+  });
+
+  it('omits supplemental when neither snapshot nor template has supplemental exercises', () => {
+    const fallbackTemplate = createTemplateForBuildTemplateTests({
+      supplementalExercises: [],
+    });
+    const session = createSessionForBuildTemplateTests({
+      exercises: [
+        createSessionExerciseForBuildTemplateTests({
+          exerciseId: 'main-exercise',
+          exerciseName: 'Main Exercise',
+          orderIndex: 0,
+          section: 'main',
+          sets: [createSessionSetForBuildTemplateTests({ exerciseId: 'main-exercise', section: 'main' })],
+        }),
+      ],
+    });
+
+    const result = buildTemplateFromSession(session, fallbackTemplate);
+
+    expect(result.sections.find((section) => section.type === 'supplemental')).toBeUndefined();
+  });
+});
+
 function buildWorkoutTemplateResponse(templateId: string) {
   const fixtureTemplate = getMockTemplate(templateId);
   if (!fixtureTemplate) {
@@ -2614,6 +2713,129 @@ function buildWorkoutTemplateResponse(templateId: string) {
     })),
     createdAt: 1,
     updatedAt: 1,
+  };
+}
+
+function createTemplateExerciseForBuildTemplateTests(
+  overrides: Partial<ActiveWorkoutTemplateExercise> = {},
+): ActiveWorkoutTemplateExercise {
+  return {
+    badges: [],
+    exerciseId: 'main-exercise',
+    exerciseName: 'Main Exercise',
+    formCues: [],
+    reps: '8-10',
+    restSeconds: 90,
+    sets: 3,
+    tempo: '2111',
+    ...overrides,
+  };
+}
+
+function createTemplateForBuildTemplateTests({
+  supplementalExercises,
+}: {
+  supplementalExercises: ActiveWorkoutTemplateExercise[];
+}): ActiveWorkoutTemplate {
+  return {
+    description: '',
+    id: 'template-build-helper',
+    name: 'Template Build Helper',
+    sections: [
+      {
+        type: 'main',
+        title: 'Main',
+        exercises: [
+          createTemplateExerciseForBuildTemplateTests({
+            exerciseId: 'main-exercise',
+            exerciseName: 'Main Exercise',
+          }),
+        ],
+      },
+      {
+        type: 'supplemental',
+        title: 'Supplemental',
+        exercises: supplementalExercises,
+      },
+    ],
+    tags: [],
+  };
+}
+
+function createSessionSetForBuildTemplateTests(
+  overrides: Partial<ApiWorkoutSession['sets'][number]> = {},
+): ApiWorkoutSession['sets'][number] {
+  return {
+    completed: false,
+    createdAt: Date.parse('2026-03-06T12:00:00.000Z'),
+    exerciseId: 'main-exercise',
+    id: 'main-set-1',
+    notes: null,
+    orderIndex: 0,
+    reps: 10,
+    section: 'main',
+    setNumber: 1,
+    skipped: false,
+    weight: 50,
+    ...overrides,
+  };
+}
+
+function createSessionExerciseForBuildTemplateTests(
+  overrides: Partial<NonNullable<ApiWorkoutSession['exercises']>[number]> = {},
+): NonNullable<ApiWorkoutSession['exercises']>[number] {
+  return {
+    agentNotes: null,
+    agentNotesMeta: null,
+    exerciseId: 'main-exercise',
+    exerciseName: 'Main Exercise',
+    orderIndex: 0,
+    programmingNotes: null,
+    section: 'main',
+    sets: [createSessionSetForBuildTemplateTests()],
+    supersetGroup: null,
+    trackingType: 'weight_reps',
+    ...overrides,
+  };
+}
+
+function createSessionForBuildTemplateTests(
+  overrides: Partial<ApiWorkoutSession> = {},
+): ApiWorkoutSession {
+  const { exercises: overrideExercises, sets: overrideSets, ...restOverrides } = overrides;
+  const exercises = overrideExercises ?? [createSessionExerciseForBuildTemplateTests()];
+  const sets = overrideSets ?? exercises.flatMap((exercise) => exercise.sets);
+
+  return {
+    completedAt: null,
+    createdAt: Date.parse('2026-03-06T12:00:00.000Z'),
+    date: '2026-03-06',
+    duration: null,
+    feedback: null,
+    id: 'build-template-session',
+    name: 'Build Template Session',
+    notes: null,
+    sectionDurations: {
+      cooldown: 0,
+      main: 0,
+      supplemental: 0,
+      warmup: 0,
+    },
+    startedAt: Date.parse('2026-03-06T12:00:00.000Z'),
+    status: 'in-progress',
+    templateId: 'template-build-helper',
+    timeSegments: [
+      {
+        end: null,
+        section: 'main',
+        start: '2026-03-06T12:00:00.000Z',
+      },
+    ],
+    updatedAt: Date.parse('2026-03-06T12:00:00.000Z'),
+    userId: 'user-1',
+    ...restOverrides,
+    exercises,
+    sets,
   };
 }
 

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -2482,7 +2482,7 @@ function formatTemplateExerciseReps(repsMin: number | null, repsMax: number | nu
   return '';
 }
 
-function buildTemplateFromSession(
+export function buildTemplateFromSession(
   activeSession: ApiWorkoutSession | undefined,
   fallbackTemplate: ActiveWorkoutTemplate,
 ): ActiveWorkoutTemplate {
@@ -2552,6 +2552,16 @@ function buildTemplateFromSession(
       agentNotesMeta: sessionExercise.agentNotesMeta ?? fallbackExercise?.agentNotesMeta ?? null,
       badges: fallbackExercise?.badges ?? [],
     });
+  }
+
+  const supplementalSection = sectionsByType.get('supplemental');
+  if (supplementalSection && supplementalSection.exercises.length === 0) {
+    const fallbackSupplemental = fallbackTemplate.sections.find(
+      (section) => section.type === 'supplemental',
+    );
+    if (fallbackSupplemental && fallbackSupplemental.exercises.length > 0) {
+      sectionsByType.set('supplemental', fallbackSupplemental);
+    }
   }
 
   for (const section of sectionsByType.values()) {

--- a/docs/conventions/workout-domain.md
+++ b/docs/conventions/workout-domain.md
@@ -147,6 +147,15 @@ A workout session is the user-specific execution record of a template.
 - `sectionDurations`: derived server response field with per-section elapsed milliseconds:
   `{ warmup, main, cooldown, supplemental }`
 
+### Section Ordering And Supplemental Fallback
+
+- API response ordering: `GET /api/v1/workout-sessions/:id` must return both `sets[]` and `exercises[]` ordered as `warmup → main → cooldown → supplemental → null-section orphans → unknown`. This is enforced by `sectionRank` in `apps/api/src/routes/workout-sessions/store.ts`.
+- Unknown section values always sort to the end. If a new section type is introduced, add it to `SECTION_ORDER` in `apps/api/src/routes/workout-sessions/store.ts` so it sorts in the intended position.
+- Session snapshot rule: section membership is snapshotted at session creation via `buildInitialSessionSets` in `apps/api/src/routes/workout-sessions/session-set-utils.ts`. Later template edits do not backfill an in-flight session. To modify upcoming workouts, edit the scheduled-workout snapshot endpoints instead of the template source.
+- Supplemental UI fallback: `buildTemplateFromSession` in `apps/web/src/pages/active-workout.tsx` unions in fallback-template supplemental exercises when the session snapshot has zero supplemental rows.
+- Logging against a fallback-sourced supplemental exercise writes a real supplemental session-set row through the existing bulk `PATCH /api/v1/workout-sessions/:id` path; once logged, that row is part of the session snapshot.
+- Warmup/main/cooldown are not unioned from fallback templates. If those sections are empty in a session response, treat it as data corruption, not expected product behavior.
+
 Timer transition rules:
 
 - `PATCH /api/v1/workout-sessions/:id` transitions to `in-progress` from `scheduled` or `paused` must provide `activeSection` so the server can open a section-specific segment.


### PR DESCRIPTION
## Summary
This PR fixes supplemental-section behavior end-to-end so session data and the active workout UI stay consistent. On the API side, supplemental is now part of the canonical session ordering, and section sorting is centralized through a shared rank helper that handles `null` and unknown section values deterministically. On the web side, active workout rendering now restores a supplemental section from the fallback template only when the session snapshot has no supplemental rows, so newly added supplemental work is visible during in-progress sessions. The result is correct ordering in responses, predictable UI visibility, and clearer domain rules around snapshot authority versus fallback rendering.

## Key Changes
- Added `supplemental` to canonical section order in:
  - `apps/api/src/routes/workout-sessions/store.ts` (`SECTION_ORDER`)
  - `apps/api/src/scripts/migrate-static.ts` (`WORKOUT_SECTION_ORDER`)
- Introduced `sectionRank` in workout session store and reused it in both set sorting and exercise sorting so ordering logic is consistent and unknown sections sort last.
- Updated `buildTemplateFromSession` in `apps/web/src/pages/active-workout.tsx` to union fallback-template supplemental exercises only when session supplemental is empty.
- Kept existing non-supplemental behavior intact: warmup/main/cooldown are not backfilled from template fallback.
- Added regression coverage for:
  - API/store section ordering (`warmup -> main -> cooldown -> supplemental -> null -> unknown`)
  - session GET response ordering
  - active-workout snapshot-wins / fallback-union / neither-has-supplemental scenarios.
- Documented the invariant and fallback rules in `docs/conventions/workout-domain.md`, plus a concise note in `.agents/skills/pulse-app-usage/SKILL.md`.

## Technical Notes
- `sectionRank` intentionally places `null` sections after known sections and unknown values after `null`, which keeps legacy/invalid section data from interleaving with canonical sections.
- Comparator logic is now shared rather than duplicated, reducing drift risk between `sets[]` and `exercises[]` ordering paths.
- Supplemental fallback in UI is intentionally narrow: it preserves session snapshot semantics for primary sections while allowing supplemental discoverability for templates updated after session creation.
- Static migration section parsing now maps “supplement”/“accessory” semantics into `supplemental`, aligning imported data with runtime ordering expectations.

## Commits

- `0845478 docs(workouts): document supplemental section ordering conventions`
- `f256acb fix(web): restore supplemental fallback in active workout`
- `86a18d3 fix(api): fix supplemental session section sorting`

## Tasks

- **Honor supplemental in session-domain sort order + robust comparator**: Add 'supplemental' to SECTION_ORDER in workout-sessions/store.ts and WORKOUT_SECTION_ORDER in migrate-static.ts. Extract sectionRank helper so unknown sections sort to the end. Update sortSessionSets + buildWorkoutSessionExercises comparator. Regression tests in store.test.ts.
- **Surface supplemental slot in active-workout UI when snapshot lacks it**: In buildTemplateFromSession (active-workout.tsx), union in the fallback template's supplemental section when the session snapshot has zero supplemental rows. Keep the existing empty-section filter intact for warmup/main/cooldown. Three regression tests covering snapshot-wins, fallback-union, and neither-has-supplemental.
- **Document supplemental section handling in workout-domain conventions**: Update docs/conventions/workout-domain.md with the four-section ordering invariant, the session snapshot rule, and the supplemental UI fallback. Add a one-line blurb to .agents/skills/pulse-app-usage/SKILL.md for agent context.

## Diff Stats

```
.agents/skills/pulse-app-usage/SKILL.md            |   1 +
 apps/api/src/routes/workout-sessions/store.test.ts | 212 ++++++++++++++++++-
 apps/api/src/routes/workout-sessions/store.ts      |  25 ++-
 apps/api/src/scripts/migrate-static.ts             |  76 +++++--
 apps/web/src/pages/active-workout.test.tsx         | 224 ++++++++++++++++++++-
 apps/web/src/pages/active-workout.tsx              |  12 +-
 docs/conventions/workout-domain.md                 |   9 +
 7 files changed, 525 insertions(+), 34 deletions(-)
```