### PR TITLE
feat: add data quality trust calendar

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -20,6 +20,7 @@ import { habitEntryCollectionRoutes } from './routes/habit-entries/index.js';
 import { habitRoutes } from './routes/habits/index.js';
 import { mealRoutes } from './routes/meals/index.js';
 import { nutritionRoutes } from './routes/nutrition/index.js';
+import { dataQualityRoutes } from './routes/data-quality/index.js';
 import { nutritionTargetRoutes } from './routes/nutrition-targets/index.js';
 import { scheduledWorkoutRoutes } from './routes/scheduled-workouts/index.js';
 import { trashRoutes } from './routes/trash/index.js';
@@ -230,6 +231,7 @@ export const buildServer = () => {
 
   app.get('/health', async () => ({ status: 'ok' }));
   app.register(authRoutes, { prefix: '/api/v1/auth' });
+  app.register(dataQualityRoutes, { prefix: '/api/v1/data-quality' });
   app.register(adaptiveNutritionRoutes, { prefix: '/api/v1/adaptive-nutrition' });
   app.register(agentTokenRoutes, { prefix: '/api/v1/agent-tokens' });
   app.register(exerciseRoutes, { prefix: '/api/v1/exercises' });

--- a/apps/api/src/routes/adaptive-nutrition/analytics-store.ts
+++ b/apps/api/src/routes/adaptive-nutrition/analytics-store.ts
@@ -124,7 +124,9 @@ export const resolveEffectiveProgramRevisions = (
 const acceptedExpenditureEffectiveDate = (checkIn: AdaptiveCheckInDetail) =>
   checkIn.proposedTargets?.effectiveDate ?? checkIn.localDate;
 
-const stateForCheckIn = (checkIn: AdaptiveCheckInDetail): EnergyBalanceState | null => {
+export const adaptiveAnalyticsStateForCheckIn = (
+  checkIn: Pick<AdaptiveCheckInDetail, 'status' | 'calculationState'>,
+): EnergyBalanceState | null => {
   if (checkIn.status === 'pending') return 'review_needed';
   if (checkIn.status === 'held' || checkIn.calculationState === 'holding') return 'holding';
   if (checkIn.status !== 'accepted') return null;
@@ -132,11 +134,11 @@ const stateForCheckIn = (checkIn: AdaptiveCheckInDetail): EnergyBalanceState | n
   return 'learning';
 };
 
-const stateForPoint = (
-  checkIn: AdaptiveCheckInDetail | null,
+export const adaptiveAnalyticsStateForPoint = (
+  checkIn: Pick<AdaptiveCheckInDetail, 'status' | 'calculationState'> | null,
   calculationState: AdaptiveCheckInDetail['calculationState'],
 ): EnergyBalanceState => {
-  if (checkIn) return stateForCheckIn(checkIn) ?? 'learning';
+  if (checkIn) return adaptiveAnalyticsStateForCheckIn(checkIn) ?? 'learning';
   if (calculationState === 'holding') return 'holding';
   if (calculationState === 'updating') return 'updating';
   return 'learning';
@@ -459,7 +461,7 @@ export const createAdaptiveAnalyticsStore = (dependencies: {
           nutritionStatus = 'complete';
         }
 
-        let pointState = stateForPoint(stateSource, calculationState);
+        let pointState = adaptiveAnalyticsStateForPoint(stateSource, calculationState);
         let pointCalculationState = calculationState;
         let pointCalculationReasonCodes = stateSource?.reasonCodes ?? [];
         if (pointProgram?.status === 'paused') {
@@ -698,7 +700,7 @@ export const createAdaptiveAnalyticsStore = (dependencies: {
             inputFingerprint: checkIn.dataFingerprint,
             goalId: checkIn.goalId,
             goalRevisionId: checkIn.goalRevisionId,
-            state: stateForCheckIn(checkIn),
+            state: adaptiveAnalyticsStateForCheckIn(checkIn),
           })),
         ...revisions
           .filter((revision) => revision.effectiveLocalDate >= range.startDate)

--- a/apps/api/src/routes/adaptive-nutrition/review-store.ts
+++ b/apps/api/src/routes/adaptive-nutrition/review-store.ts
@@ -425,9 +425,32 @@ export const createAdaptiveWeeklyReviewStore = (options: {
         .all() as ActionRow[]
     ).map(parseAction);
 
-  const hydrateReview = (row: ReviewRow): AdaptiveWeeklyReview => {
+  const loadProjectionActions = (reviewId: string, userId: string): AdaptiveReviewAction[] =>
+    (
+      db
+        .select(actionSelection)
+        .from(adaptiveNutritionReviewActions)
+        .where(
+          and(
+            eq(adaptiveNutritionReviewActions.reviewId, reviewId),
+            eq(adaptiveNutritionReviewActions.userId, userId),
+            sql`${adaptiveNutritionReviewActions.sequence} in (
+              coalesce((select max(a.sequence) from adaptive_nutrition_review_actions a where a.review_id = ${reviewId} and a.user_id = ${userId}), -1),
+              coalesce((select max(a.sequence) from adaptive_nutrition_review_actions a where a.review_id = ${reviewId} and a.user_id = ${userId} and a.type in ('accept', 'decline', 'supersede')), -1),
+              coalesce((select max(a.sequence) from adaptive_nutrition_review_actions a where a.review_id = ${reviewId} and a.user_id = ${userId} and a.type = 'edit'), -1),
+              coalesce((select max(a.sequence) from adaptive_nutrition_review_actions a where a.review_id = ${reviewId} and a.user_id = ${userId} and a.type = 'defer'), -1)
+            )`,
+          ),
+        )
+        .orderBy(asc(adaptiveNutritionReviewActions.sequence))
+        .all() as ActionRow[]
+    ).map(parseAction);
+
+  const hydrateReview = (
+    row: ReviewRow,
+    actions: AdaptiveReviewAction[] = loadActions(row.id, row.userId),
+  ): AdaptiveWeeklyReview => {
     const snapshot = adaptiveWeeklyReviewSnapshotSchema.parse(row.snapshot);
-    const actions = loadActions(row.id, row.userId);
     const state = stateFromActions(actions);
     const recommendation = snapshot.modules.find((module) => module.kind === 'recommendation');
     const outcome = recommendation?.kind === 'recommendation' ? recommendation.outcome : 'defer';
@@ -1504,8 +1527,11 @@ export const createAdaptiveWeeklyReviewStore = (options: {
       .limit(1)
       .get() as ReviewRow | undefined) ?? null;
 
-  const projectCurrentReview = (row: ReviewRow): AdaptiveWeeklyReview => {
-    const hydrated = hydrateReview(row);
+  const projectCurrentReview = (
+    row: ReviewRow,
+    actions?: AdaptiveReviewAction[],
+  ): AdaptiveWeeklyReview => {
+    const hydrated = hydrateReview(row, actions);
     if (['accepted', 'declined', 'superseded'].includes(hydrated.state)) return hydrated;
     const checkIn = adaptiveStore.findCheckInDetail(row.userId, row.checkInId);
     const fresh =
@@ -1553,8 +1579,21 @@ export const createAdaptiveWeeklyReviewStore = (options: {
     const rows = db
       .select(reviewRowSelection)
       .from(adaptiveNutritionReviews)
-      .where(eq(adaptiveNutritionReviews.userId, userId))
+      .where(
+        and(
+          eq(adaptiveNutritionReviews.userId, userId),
+          sql`coalesce((
+            select latest.type
+              from adaptive_nutrition_review_actions latest
+             where latest.review_id = ${adaptiveNutritionReviews.id}
+               and latest.user_id = ${userId}
+             order by latest.sequence desc
+             limit 1
+          ), 'pending') in ('pending', 'edit', 'ask_agent', 'answer', 'defer')`,
+        ),
+      )
       .orderBy(desc(adaptiveNutritionReviews.createdAt))
+      .limit(64)
       .all() as ReviewRow[];
     return (
       rows
@@ -1575,6 +1614,46 @@ export const createAdaptiveWeeklyReviewStore = (options: {
         .find((review) => ['pending', 'awaiting_clarification', 'stale'].includes(review.state)) ??
       null
     );
+  };
+
+  const getPendingProjection = (
+    userId: string,
+  ): Pick<AdaptiveWeeklyReview, 'id' | 'snapshot' | 'state'> | null => {
+    const rows = db
+      .select(reviewRowSelection)
+      .from(adaptiveNutritionReviews)
+      .where(
+        and(
+          eq(adaptiveNutritionReviews.userId, userId),
+          sql`coalesce((
+            select latest.type
+              from adaptive_nutrition_review_actions latest
+             where latest.review_id = ${adaptiveNutritionReviews.id}
+               and latest.user_id = ${userId}
+             order by latest.sequence desc
+             limit 1
+          ), 'pending') in ('pending', 'edit', 'ask_agent', 'answer', 'defer')`,
+        ),
+      )
+      .orderBy(desc(adaptiveNutritionReviews.createdAt))
+      .limit(64)
+      .all() as ReviewRow[];
+    for (const row of rows) {
+      const current = projectCurrentReview(row, loadProjectionActions(row.id, row.userId));
+      if (current.state === 'deferred') continue;
+      const sourceStatus = adaptiveStore.findCheckInDetail(row.userId, row.checkInId)?.status;
+      if (
+        current.state === 'stale' &&
+        sourceStatus !== undefined &&
+        ['accepted', 'declined', 'held', 'superseded'].includes(sourceStatus)
+      ) {
+        continue;
+      }
+      if (['pending', 'awaiting_clarification', 'stale'].includes(current.state)) {
+        return { id: current.id, snapshot: current.snapshot, state: current.state };
+      }
+    }
+    return null;
   };
 
   const get = (userId: string, reviewId: string) => {
@@ -1599,7 +1678,7 @@ export const createAdaptiveWeeklyReviewStore = (options: {
         .from(adaptiveNutritionReviews)
         .where(eq(adaptiveNutritionReviews.userId, userId))
         .get()?.value ?? 0;
-    return { data: rows.map(projectCurrentReview), meta: { ...query, total } };
+    return { data: rows.map((row) => projectCurrentReview(row)), meta: { ...query, total } };
   };
 
   const appendAction = (
@@ -1994,6 +2073,7 @@ export const createAdaptiveWeeklyReviewStore = (options: {
     deleteContext,
     get,
     getPending,
+    getPendingProjection,
     list,
     preview,
     refresh,

--- a/apps/api/src/routes/data-quality/index.test.ts
+++ b/apps/api/src/routes/data-quality/index.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { DataQualityCalendar } from '@pulse/shared';
+
+import { buildServer } from '../../index.js';
+import { findAgentTokenByHash, updateAgentTokenLastUsedAt } from '../../middleware/store.js';
+import { getDataQualityCalendar } from './store.js';
+
+vi.mock('./store.js', () => ({ getDataQualityCalendar: vi.fn() }));
+vi.mock('../../middleware/store.js', () => ({
+  findAgentTokenByHash: vi.fn(),
+  findUserAuthById: vi.fn(),
+  updateAgentTokenLastUsedAt: vi.fn(),
+}));
+
+const calendar: DataQualityCalendar = {
+  range: { startDate: '2026-08-18', endDate: '2026-08-18' },
+  timeZone: 'America/Detroit',
+  days: [
+    {
+      date: '2026-08-18',
+      isToday: true,
+      nutrition: {
+        qualityState: 'no_records',
+        evidenceState: 'missing',
+        logId: null,
+        explicitStatus: null,
+        totals: null,
+        mealCount: null,
+        itemCount: null,
+        statusUpdatedAt: null,
+        updatedAt: null,
+        reasonCodes: [],
+        actions: [],
+      },
+      weight: {
+        evidenceState: 'missing',
+        entryId: null,
+        weight: null,
+        unit: null,
+        trendWeight: null,
+        corrected: false,
+        suspect: false,
+        stale: false,
+        createdAt: null,
+        updatedAt: null,
+        reasonCodes: [],
+        actions: [],
+      },
+      workouts: [],
+      algorithm: {
+        state: 'no_program',
+        nutritionEvidenceState: 'not_applicable',
+        weightEvidenceState: 'not_applicable',
+        reasonCodes: [],
+        events: [],
+      },
+      contexts: [],
+    },
+  ],
+  summary: {
+    nutrition: { complete: 0, partial: 0, unknown: 0, missing: 1, pending: 0, excluded: 0 },
+    weight: { logged: 0, missing: 1, pending: 0, excluded: 0, corrected: 0 },
+    workout: { planned: 0, active: 0, completed: 0, cancelled: 0, corrected: 0 },
+    algorithm: { learning: 0, updating: 0, holding: 0, pendingReview: 0 },
+    contextDays: 0,
+  },
+};
+
+beforeEach(() => {
+  vi.mocked(getDataQualityCalendar).mockReset();
+  vi.mocked(findAgentTokenByHash).mockReset();
+  vi.mocked(updateAgentTokenLastUsedAt).mockReset();
+});
+
+describe('Data Quality calendar route', () => {
+  it('returns identical strict data for JWT and AgentToken callers', async () => {
+    vi.mocked(getDataQualityCalendar).mockResolvedValue(calendar);
+    vi.mocked(findAgentTokenByHash).mockResolvedValue({ id: 'agent-1', userId: 'user-1' });
+    const app = buildServer();
+    try {
+      await app.ready();
+      const token = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
+      const url =
+        '/api/v1/data-quality/calendar?start=2026-08-18&end=2026-08-18&timeZone=America%2FDetroit';
+      const [jwtResponse, agentResponse] = await Promise.all([
+        app.inject({ method: 'GET', url, headers: { authorization: `Bearer ${token}` } }),
+        app.inject({ method: 'GET', url, headers: { authorization: 'AgentToken agent-secret' } }),
+      ]);
+
+      expect(jwtResponse.statusCode).toBe(200);
+      expect(agentResponse.statusCode).toBe(200);
+      expect(jwtResponse.json().data).toEqual(calendar);
+      expect(agentResponse.json().data).toEqual(jwtResponse.json().data);
+      expect(vi.mocked(getDataQualityCalendar)).toHaveBeenNthCalledWith(1, 'user-1', {
+        start: '2026-08-18',
+        end: '2026-08-18',
+        timeZone: 'America/Detroit',
+      });
+      expect(vi.mocked(getDataQualityCalendar)).toHaveBeenNthCalledWith(2, 'user-1', {
+        start: '2026-08-18',
+        end: '2026-08-18',
+        timeZone: 'America/Detroit',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects invalid ranges before calling the store', async () => {
+    const app = buildServer();
+    try {
+      await app.ready();
+      const token = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/data-quality/calendar?start=2026-08-20&end=2026-08-18',
+        headers: { authorization: `Bearer ${token}` },
+      });
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toMatchObject({ error: { code: 'VALIDATION_ERROR' } });
+      expect(getDataQualityCalendar).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apps/api/src/routes/data-quality/index.test.ts
+++ b/apps/api/src/routes/data-quality/index.test.ts
@@ -15,6 +15,7 @@ vi.mock('../../middleware/store.js', () => ({
 
 const calendar: DataQualityCalendar = {
   range: { startDate: '2026-08-18', endDate: '2026-08-18' },
+  today: '2026-08-18',
   timeZone: 'America/Detroit',
   days: [
     {
@@ -28,8 +29,15 @@ const calendar: DataQualityCalendar = {
         totals: null,
         mealCount: null,
         itemCount: null,
+        createdAt: null,
         statusUpdatedAt: null,
         updatedAt: null,
+        provenance: {
+          type: 'not_recorded',
+          label: 'Not recorded',
+          agentTokenId: null,
+          limitation: 'No record.',
+        },
         reasonCodes: [],
         actions: [],
       },
@@ -39,11 +47,17 @@ const calendar: DataQualityCalendar = {
         weight: null,
         unit: null,
         trendWeight: null,
-        corrected: false,
+        correctionState: 'not_applicable',
         suspect: false,
         stale: false,
         createdAt: null,
         updatedAt: null,
+        provenance: {
+          type: 'not_recorded',
+          label: 'Not recorded',
+          agentTokenId: null,
+          limitation: 'No record.',
+        },
         reasonCodes: [],
         actions: [],
       },
@@ -54,8 +68,11 @@ const calendar: DataQualityCalendar = {
         weightEvidenceState: 'not_applicable',
         reasonCodes: [],
         events: [],
+        omittedEventCount: 0,
       },
       contexts: [],
+      omittedWorkoutCount: 0,
+      omittedContextCount: 0,
     },
   ],
   summary: {
@@ -64,6 +81,7 @@ const calendar: DataQualityCalendar = {
     workout: { planned: 0, active: 0, completed: 0, cancelled: 0, corrected: 0 },
     algorithm: { learning: 0, updating: 0, holding: 0, pendingReview: 0 },
     contextDays: 0,
+    intervalLabel: 'Visible calendar grid',
   },
 };
 
@@ -126,6 +144,27 @@ describe('Data Quality calendar route', () => {
       expect(response.statusCode).toBe(400);
       expect(response.json()).toMatchObject({ error: { code: 'VALIDATION_ERROR' } });
       expect(getDataQualityCalendar).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('allows an empty query so the server can bootstrap the authoritative local month', async () => {
+    vi.mocked(getDataQualityCalendar).mockResolvedValue(calendar);
+    const app = buildServer();
+    try {
+      await app.ready();
+      const token = app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      );
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/data-quality/calendar',
+        headers: { authorization: `Bearer ${token}` },
+      });
+      expect(response.statusCode).toBe(200);
+      expect(vi.mocked(getDataQualityCalendar)).toHaveBeenCalledWith('user-1', {});
     } finally {
       await app.close();
     }

--- a/apps/api/src/routes/data-quality/index.test.ts
+++ b/apps/api/src/routes/data-quality/index.test.ts
@@ -77,8 +77,8 @@ const calendar: DataQualityCalendar = {
   ],
   summary: {
     nutrition: { complete: 0, partial: 0, unknown: 0, missing: 1, pending: 0, excluded: 0 },
-    weight: { logged: 0, missing: 1, pending: 0, excluded: 0, corrected: 0 },
-    workout: { planned: 0, active: 0, completed: 0, cancelled: 0, corrected: 0 },
+    weight: { logged: 0, missing: 1, pending: 0, excluded: 0 },
+    workout: { planned: 0, active: 0, completed: 0, cancelled: 0 },
     algorithm: { learning: 0, updating: 0, holding: 0, pendingReview: 0 },
     contextDays: 0,
     intervalLabel: 'Visible calendar grid',

--- a/apps/api/src/routes/data-quality/index.ts
+++ b/apps/api/src/routes/data-quality/index.ts
@@ -1,0 +1,40 @@
+import {
+  apiDataResponseSchema,
+  dataQualityCalendarQuerySchema,
+  dataQualityCalendarSchema,
+} from '@pulse/shared';
+import type { FastifyPluginAsync } from 'fastify';
+import { type ZodTypeProvider } from 'fastify-type-provider-zod';
+
+import { buildDataResponse } from '../../middleware/agent-enrichment.js';
+import { requireAuth } from '../../middleware/auth.js';
+import { apiErrorResponseSchema, authSecurity, badRequestResponseSchema } from '../../openapi.js';
+import { getDataQualityCalendar } from './store.js';
+
+export const dataQualityRoutes: FastifyPluginAsync = async (app) => {
+  const typedApp = app.withTypeProvider<ZodTypeProvider>();
+
+  typedApp.get(
+    '/calendar',
+    {
+      onRequest: requireAuth,
+      schema: {
+        querystring: dataQualityCalendarQuerySchema,
+        response: {
+          200: apiDataResponseSchema(dataQualityCalendarSchema),
+          400: badRequestResponseSchema,
+          401: apiErrorResponseSchema,
+        },
+        tags: ['data-quality'],
+        summary: 'Get a bounded cross-domain Data Quality calendar',
+        description:
+          'Composes nutrition, weight, workout, Adaptive TDEE, weekly-review, and bounded context truth for an inclusive range without mutating or duplicating the source domains.',
+        security: authSecurity,
+      },
+    },
+    async (request, reply) => {
+      const calendar = await getDataQualityCalendar(request.userId, request.query);
+      return reply.send(buildDataResponse(request, calendar));
+    },
+  );
+};

--- a/apps/api/src/routes/data-quality/store.integration.test.ts
+++ b/apps/api/src/routes/data-quality/store.integration.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import Database from 'better-sqlite3';
+import { eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -12,6 +13,9 @@ import { dataQualityCalendarSchema, type AdaptiveProgramMutation } from '@pulse/
 
 import * as schema from '../../db/schema/index.js';
 import {
+  adaptiveNutritionCheckIns,
+  adaptiveNutritionReviewActions,
+  adaptiveNutritionReviews,
   adaptiveNutritionReviewContexts,
   bodyWeight,
   mealItems,
@@ -21,6 +25,7 @@ import {
   users,
   workoutSessions,
 } from '../../db/schema/index.js';
+import { createAdaptiveWeeklyReviewStore } from '../adaptive-nutrition/review-store.js';
 import { createAdaptiveNutritionStore } from '../adaptive-nutrition/store.js';
 import { createDataQualityCalendarStore } from './store.js';
 
@@ -103,6 +108,30 @@ const seedWeight = (userId: string, date: string, weightKg: number, corrected = 
       updatedAt: corrected ? createdAt + 1 : createdAt,
     })
     .run();
+};
+
+const addDate = (date: string, days: number) => {
+  const value = new Date(`${date}T00:00:00.000Z`);
+  value.setUTCDate(value.getUTCDate() + days);
+  return value.toISOString().slice(0, 10);
+};
+
+const seedEligibleReviewProgram = () => {
+  const lifecycle = createAdaptiveNutritionStore({
+    db,
+    sqlite,
+    now: () => new Date('2026-07-20T16:00:00.000Z'),
+  });
+  lifecycle.upsertProgram('user-1', programInput());
+  const baseline = lifecycle.getState('user-1').pendingCheckIn;
+  if (!baseline) throw new Error('Expected baseline check-in');
+  lifecycle.acceptCheckIn('user-1', baseline.id, { replaceSameDateTarget: false });
+  for (let offset = 0; offset < 21; offset += 1) {
+    seedNutrition('user-1', addDate('2026-07-28', offset), 'complete', 2500);
+  }
+  for (const date of ['2026-07-28', '2026-08-04', '2026-08-11', '2026-08-17']) {
+    seedWeight('user-1', date, 80, false);
+  }
 };
 
 beforeEach(() => {
@@ -205,10 +234,11 @@ describe('Data Quality calendar store', () => {
         .prepare('select count(*) as value from adaptive_nutrition_review_contexts')
         .get(),
     };
-    const calendar = createDataQualityCalendarStore({ db, now: () => new Date(nowMs) }).getCalendar(
-      'user-1',
-      { start: '2026-08-17', end: '2026-08-18' },
-    );
+    const calendar = createDataQualityCalendarStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    }).getCalendar('user-1', { start: '2026-08-17', end: '2026-08-18' });
     expect(dataQualityCalendarSchema.parse(calendar)).toEqual(calendar);
     expect(calendar.timeZone).toBe('America/Detroit');
 
@@ -222,12 +252,16 @@ describe('Data Quality calendar store', () => {
     });
     expect(august17.weight).toMatchObject({
       entryId: 'user-1-weight-2026-08-17',
-      corrected: true,
+      correctionState: 'history_unavailable',
       unit: 'lbs',
     });
     expect(august17.weight.weight).toBeCloseTo(176.81, 1);
     expect(august17.workouts).toEqual([
-      expect.objectContaining({ id: 'session-1', state: 'corrected' }),
+      expect.objectContaining({
+        id: 'session-1',
+        state: 'completed',
+        correctionState: 'history_unavailable',
+      }),
     ]);
     expect(august17.contexts).toEqual([
       expect.objectContaining({
@@ -252,8 +286,8 @@ describe('Data Quality calendar store', () => {
     ]);
     expect(calendar.summary).toMatchObject({
       nutrition: { complete: 1, missing: 1 },
-      weight: { logged: 2, corrected: 2, pending: 1 },
-      workout: { planned: 1, corrected: 1 },
+      weight: { logged: 2, corrected: 0, pending: 1 },
+      workout: { planned: 1, corrected: 0 },
       contextDays: 1,
     });
 
@@ -278,6 +312,7 @@ describe('Data Quality calendar store', () => {
     seedWeight('user-2', '2026-08-19', 72, false);
     const calendar = createDataQualityCalendarStore({
       db,
+      sqlite,
       now: () => new Date('2026-08-18T16:00:00.000Z'),
     }).getCalendar('user-2', {
       start: '2026-08-18',
@@ -302,6 +337,45 @@ describe('Data Quality calendar store', () => {
     });
   });
 
+  it('labels and summarizes the complete adjacent-month bootstrap grid', () => {
+    seedNutrition('user-2', '2026-08-19', 'complete', 2100);
+    const calendar = createDataQualityCalendarStore({
+      db,
+      sqlite,
+      now: () => new Date('2026-08-18T16:00:00.000Z'),
+    }).getCalendar('user-2', {});
+
+    expect(calendar).toMatchObject({
+      today: '2026-08-19',
+      timeZone: 'Asia/Tokyo',
+      range: { startDate: '2026-07-27', endDate: '2026-09-06' },
+      summary: {
+        intervalLabel: 'Visible calendar grid',
+        nutrition: { complete: 1, missing: 41 },
+      },
+    });
+    expect(calendar.days).toHaveLength(42);
+    expect(calendar.days[0]?.date).toBe('2026-07-27');
+    expect(calendar.days.at(-1)?.date).toBe('2026-09-06');
+  });
+
+  it('does not reinterpret a notes-only weight edit as a measurement correction', () => {
+    seedWeight('user-1', '2026-08-17', 80, false);
+    db.update(bodyWeight)
+      .set({ notes: 'Same measurement, clarified note.', updatedAt: nowMs + 1 })
+      .where(eq(bodyWeight.id, 'user-1-weight-2026-08-17'))
+      .run();
+    const weight = createDataQualityCalendarStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    }).getCalendar('user-1', { start: '2026-08-17', end: '2026-08-17' }).days[0]?.weight;
+    expect(weight).toMatchObject({
+      weight: expect.any(Number),
+      correctionState: 'history_unavailable',
+    });
+  });
+
   it('uses a fixed number of selects for a dense 42-day range', () => {
     for (let offset = 0; offset < 42; offset += 1) {
       const date = new Date(Date.UTC(2026, 6, 8 + offset)).toISOString().slice(0, 10);
@@ -311,6 +385,7 @@ describe('Data Quality calendar store', () => {
     const queriedSources: string[] = [];
     createDataQualityCalendarStore({
       db,
+      sqlite,
       now: () => new Date(nowMs),
       onQuery: (source) => queriedSources.push(source),
     }).getCalendar('user-1', { start: '2026-07-08', end: '2026-08-18' });
@@ -333,6 +408,7 @@ describe('Data Quality calendar store', () => {
     adaptiveStore.upsertProgram('user-1', programInput());
     const calendar = createDataQualityCalendarStore({
       db,
+      sqlite,
       now: () => new Date(nowMs),
     }).getCalendar('user-1', { start: '2026-08-18', end: '2026-08-19' });
 
@@ -342,5 +418,385 @@ describe('Data Quality calendar store', () => {
       weightEvidenceState: 'not_applicable',
       reasonCodes: ['FUTURE_DATE_NOT_EVALUATED'],
     });
+  });
+
+  it('follows accepted Adaptive state history instead of treating eligibility as an update', () => {
+    seedEligibleReviewProgram();
+    const lifecycle = createAdaptiveNutritionStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    });
+    const calendarStore = () =>
+      createDataQualityCalendarStore({ db, sqlite, now: () => new Date(nowMs) });
+
+    const eligibleBeforeUpdate = calendarStore().getCalendar('user-1', {
+      start: '2026-08-17',
+      end: '2026-08-18',
+    });
+    expect(eligibleBeforeUpdate.days[0]?.algorithm.state).toBe('learning');
+
+    const pendingUpdate = lifecycle.previewCheckIn('user-1', {
+      kind: 'manual',
+      includeToday: false,
+    });
+    expect(pendingUpdate.calculationState).toBe('updating');
+    const whilePending = calendarStore().getCalendar('user-1', {
+      start: '2026-08-18',
+      end: '2026-08-18',
+    });
+    expect(whilePending.days[0]?.algorithm).toMatchObject({
+      state: 'learning',
+      events: [expect.objectContaining({ id: pendingUpdate.id, state: 'pending' })],
+    });
+
+    lifecycle.acceptCheckIn('user-1', pendingUpdate.id, { replaceSameDateTarget: false });
+    expect(
+      calendarStore().getCalendar('user-1', {
+        start: '2026-08-18',
+        end: '2026-08-18',
+      }).days[0]?.algorithm,
+    ).toMatchObject({
+      state: 'updating',
+      events: [expect.objectContaining({ id: pendingUpdate.id, state: 'accepted' })],
+    });
+
+    lifecycle.upsertProgram('user-1', {
+      ...programInput(),
+      status: 'paused',
+      currentWeight: null,
+    });
+    expect(
+      calendarStore().getCalendar('user-1', {
+        start: '2026-08-18',
+        end: '2026-08-18',
+      }).days[0]?.algorithm.state,
+    ).toBe('holding');
+  });
+
+  it('projects nutrition and weight corrections as stale through the authoritative review store', () => {
+    seedEligibleReviewProgram();
+    const reviewStore = createAdaptiveWeeklyReviewStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    });
+    const original = reviewStore.preview('user-1', { kind: 'weekly' });
+    const targetCountBefore = sqlite
+      .prepare('select count(*) as value from nutrition_targets')
+      .get();
+
+    db.update(mealItems)
+      .set({ calories: 2100 })
+      .where(eq(mealItems.id, 'user-1-item-2026-08-10'))
+      .run();
+    const staleNutrition = createDataQualityCalendarStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    }).getCalendar('user-1', { start: '2026-08-01', end: '2026-08-18' });
+    expect(
+      staleNutrition.days
+        .flatMap((day) => day.algorithm.events)
+        .find((event) => event.id === original.id),
+    ).toMatchObject({
+      state: 'stale',
+      actions: expect.arrayContaining([expect.objectContaining({ kind: 'refresh_review' })]),
+    });
+
+    const refreshedNutrition = reviewStore.refresh('user-1', original.id);
+    db.update(bodyWeight)
+      .set({ weightKg: 79.5, weight: poundsFromKg(79.5), updatedAt: nowMs + 1 })
+      .where(eq(bodyWeight.id, 'user-1-weight-2026-08-17'))
+      .run();
+    const staleWeight = createDataQualityCalendarStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    }).getCalendar('user-1', { start: '2026-08-01', end: '2026-08-18' });
+    expect(
+      staleWeight.days
+        .flatMap((day) => day.algorithm.events)
+        .find((event) => event.id === refreshedNutrition.id),
+    ).toMatchObject({ state: 'stale' });
+
+    const regenerated = reviewStore.refresh('user-1', refreshedNutrition.id);
+    const declined = reviewStore.act(
+      'user-1',
+      regenerated.id,
+      {
+        type: 'decline',
+        expectedFingerprint: regenerated.sourceFingerprint,
+        expectedActionSequence: regenerated.actionSequence,
+        reason: 'Keep the current plan.',
+      },
+      { type: 'user', label: 'You' },
+    );
+    expect(declined.state).toBe('declined');
+    expect(sqlite.prepare('select count(*) as value from nutrition_targets').get()).toEqual(
+      targetCountBefore,
+    );
+    expect(db.select().from(adaptiveNutritionReviews).all()).toHaveLength(3);
+    expect(db.select().from(adaptiveNutritionReviewActions).all()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ reviewId: original.id, type: 'supersede' }),
+        expect.objectContaining({ reviewId: refreshedNutrition.id, type: 'supersede' }),
+        expect.objectContaining({ reviewId: regenerated.id, type: 'decline' }),
+      ]),
+    );
+  });
+
+  it('retains linked workout plan and session dates across range boundaries without inventing movement or correction history', () => {
+    db.insert(scheduledWorkouts)
+      .values({
+        id: 'boundary-plan',
+        userId: 'user-1',
+        templateId: null,
+        date: '2026-08-31',
+        createdAt: nowMs - 10_000,
+        updatedAt: nowMs - 10_000,
+      })
+      .run();
+    db.insert(workoutSessions)
+      .values({
+        id: 'boundary-session',
+        userId: 'user-1',
+        scheduledWorkoutId: 'boundary-plan',
+        name: 'Boundary workout',
+        date: '2026-09-01',
+        status: 'scheduled',
+        startedAt: nowMs,
+        createdAt: nowMs,
+        updatedAt: nowMs,
+      })
+      .run();
+    db.update(scheduledWorkouts)
+      .set({ sessionId: 'boundary-session' })
+      .where(eq(scheduledWorkouts.id, 'boundary-plan'))
+      .run();
+
+    const store = createDataQualityCalendarStore({ db, sqlite, now: () => new Date(nowMs) });
+    const originalOnly = store.getCalendar('user-1', {
+      start: '2026-08-31',
+      end: '2026-08-31',
+    });
+    expect(originalOnly.days[0]?.workouts).toEqual([
+      expect.objectContaining({
+        id: 'boundary-plan',
+        state: 'moved',
+        plannedDate: '2026-08-31',
+        sessionDate: '2026-09-01',
+        relation: 'linked_different_date',
+      }),
+    ]);
+
+    const destinationOnly = store.getCalendar('user-1', {
+      start: '2026-09-01',
+      end: '2026-09-01',
+    });
+    expect(destinationOnly.days[0]?.workouts).toEqual([
+      expect.objectContaining({
+        id: 'boundary-session',
+        state: 'scheduled',
+        plannedDate: '2026-08-31',
+        sessionDate: '2026-09-01',
+        relation: 'linked_different_date',
+      }),
+    ]);
+
+    db.update(workoutSessions)
+      .set({ status: 'completed', completedAt: nowMs + 1_000, updatedAt: nowMs + 2_000 })
+      .where(eq(workoutSessions.id, 'boundary-session'))
+      .run();
+    const bothDates = store.getCalendar('user-1', {
+      start: '2026-08-31',
+      end: '2026-09-01',
+    });
+    expect(bothDates.days.flatMap((day) => day.workouts)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'boundary-plan', state: 'moved' }),
+        expect.objectContaining({
+          id: 'boundary-session',
+          state: 'completed',
+          correctionState: 'history_unavailable',
+        }),
+      ]),
+    );
+  });
+
+  it('places accepted check-ins on retained effective dates across month and year boundaries', () => {
+    const lifecycle = createAdaptiveNutritionStore({
+      db,
+      sqlite,
+      now: () => new Date('2026-08-31T16:00:00.000Z'),
+    });
+    lifecycle.upsertProgram('user-1', programInput());
+    const baseline = lifecycle.getState('user-1').pendingCheckIn;
+    if (!baseline) throw new Error('Expected baseline check-in');
+    lifecycle.acceptCheckIn('user-1', baseline.id, { replaceSameDateTarget: false });
+    const accepted = db
+      .select()
+      .from(adaptiveNutritionCheckIns)
+      .where(eq(adaptiveNutritionCheckIns.id, baseline.id))
+      .get();
+    if (!accepted) throw new Error('Expected accepted check-in row');
+    db.insert(adaptiveNutritionCheckIns)
+      .values([
+        {
+          ...accepted,
+          id: 'month-boundary-check-in',
+          localDate: '2026-08-31',
+          proposedTargets: { ...accepted.proposedTargets, effectiveDate: '2026-09-01' },
+          acceptedNutritionTargetId: accepted.acceptedNutritionTargetId,
+          createdAt: accepted.createdAt + 1,
+        },
+        {
+          ...accepted,
+          id: 'year-boundary-check-in',
+          localDate: '2026-12-31',
+          proposedTargets: { ...accepted.proposedTargets, effectiveDate: '2027-01-01' },
+          acceptedNutritionTargetId: accepted.acceptedNutritionTargetId,
+          createdAt: accepted.createdAt + 2,
+        },
+        {
+          ...accepted,
+          id: 'declined-check-in',
+          localDate: '2026-09-02',
+          status: 'declined',
+          acceptedNutritionTargetId: null,
+          proposedTargets: null,
+          createdAt: accepted.createdAt + 3,
+        },
+        {
+          ...accepted,
+          id: 'held-check-in',
+          localDate: '2026-09-03',
+          status: 'held',
+          calculationState: 'holding',
+          acceptedNutritionTargetId: null,
+          proposedTargets: null,
+          createdAt: accepted.createdAt + 4,
+        },
+        {
+          ...accepted,
+          id: 'superseded-check-in',
+          localDate: '2026-09-04',
+          status: 'superseded',
+          acceptedNutritionTargetId: null,
+          proposedTargets: null,
+          createdAt: accepted.createdAt + 5,
+        },
+      ])
+      .run();
+
+    const store = createDataQualityCalendarStore({
+      db,
+      sqlite,
+      now: () => new Date('2027-01-02T16:00:00.000Z'),
+    });
+    const september = store.getCalendar('user-1', {
+      start: '2026-09-01',
+      end: '2026-09-04',
+    });
+    expect(september.days.flatMap((day) => day.algorithm.events)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'month-boundary-check-in',
+          effectiveDate: '2026-09-01',
+          state: 'accepted',
+        }),
+        expect.objectContaining({ id: 'declined-check-in', state: 'declined' }),
+        expect.objectContaining({ id: 'held-check-in', state: 'held' }),
+        expect.objectContaining({ id: 'superseded-check-in', state: 'superseded' }),
+      ]),
+    );
+    expect(
+      store.getCalendar('user-1', { start: '2027-01-01', end: '2027-01-01' }).days[0]?.algorithm
+        .events,
+    ).toEqual([
+      expect.objectContaining({
+        id: 'year-boundary-check-in',
+        effectiveDate: '2027-01-01',
+        state: 'accepted',
+      }),
+    ]);
+  });
+
+  it('returns deterministic bounded truth instead of failing strict response caps on dense days', () => {
+    const lifecycle = createAdaptiveNutritionStore({ db, sqlite, now: () => new Date(nowMs) });
+    lifecycle.upsertProgram('user-1', programInput());
+    const program = lifecycle.getState('user-1').program;
+    const baseline = lifecycle.getState('user-1').pendingCheckIn;
+    if (!program || !baseline) throw new Error('Expected program and baseline');
+    lifecycle.acceptCheckIn('user-1', baseline.id, { replaceSameDateTarget: false });
+    const source = db
+      .select()
+      .from(adaptiveNutritionCheckIns)
+      .where(eq(adaptiveNutritionCheckIns.id, baseline.id))
+      .get();
+    if (!source) throw new Error('Expected accepted source check-in');
+
+    db.insert(workoutSessions)
+      .values(
+        Array.from({ length: 55 }, (_, index) => ({
+          id: `dense-session-${String(index).padStart(2, '0')}`,
+          userId: 'user-1',
+          name: `Dense session ${index}`,
+          date: '2026-08-18',
+          status: 'scheduled' as const,
+          startedAt: nowMs + index,
+          createdAt: nowMs + index,
+          updatedAt: nowMs + index,
+        })),
+      )
+      .run();
+    db.insert(adaptiveNutritionReviewContexts)
+      .values(
+        Array.from({ length: 105 }, (_, index) => ({
+          id: `dense-context-${String(index).padStart(3, '0')}`,
+          userId: 'user-1',
+          programId: program.id,
+          subjectType: 'date' as const,
+          subject: { kind: 'date' as const, localDate: '2026-08-18' },
+          category: 'other' as const,
+          note: `Dense context ${index}`,
+          resolution: null,
+          resolutionKind: null,
+          createdBy: 'user' as const,
+          agentTokenId: null,
+          actorLabel: 'You',
+          revision: 1,
+          createdAt: nowMs + index,
+          updatedAt: nowMs + index,
+        })),
+      )
+      .run();
+    db.insert(adaptiveNutritionCheckIns)
+      .values(
+        Array.from({ length: 55 }, (_, index) => ({
+          ...source,
+          id: `dense-check-in-${String(index).padStart(2, '0')}`,
+          localDate: '2026-08-18',
+          createdAt: source.createdAt + index + 1,
+        })),
+      )
+      .run();
+
+    const calendar = createDataQualityCalendarStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    }).getCalendar('user-1', { start: '2026-08-18', end: '2026-08-18' });
+    const day = calendar.days[0];
+    expect(day?.workouts).toHaveLength(50);
+    expect(day?.omittedWorkoutCount).toBe(5);
+    expect(day?.contexts).toHaveLength(100);
+    expect(day?.omittedContextCount).toBe(5);
+    expect(day?.algorithm.events).toHaveLength(50);
+    expect(day?.algorithm.omittedEventCount).toBe(6);
+    expect(day?.workouts.map((item) => item.id)).toEqual(
+      [...(day?.workouts ?? [])].map((item) => item.id).sort(),
+    );
+    expect(dataQualityCalendarSchema.parse(calendar)).toEqual(calendar);
   });
 });

--- a/apps/api/src/routes/data-quality/store.integration.test.ts
+++ b/apps/api/src/routes/data-quality/store.integration.test.ts
@@ -1,0 +1,346 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { dataQualityCalendarSchema, type AdaptiveProgramMutation } from '@pulse/shared';
+
+import * as schema from '../../db/schema/index.js';
+import {
+  adaptiveNutritionReviewContexts,
+  bodyWeight,
+  mealItems,
+  meals,
+  nutritionLogs,
+  scheduledWorkouts,
+  users,
+  workoutSessions,
+} from '../../db/schema/index.js';
+import { createAdaptiveNutritionStore } from '../adaptive-nutrition/store.js';
+import { createDataQualityCalendarStore } from './store.js';
+
+const migrationsFolder = fileURLToPath(new URL('../../../drizzle', import.meta.url));
+const nowMs = Date.parse('2026-08-18T16:00:00.000Z');
+const poundsFromKg = (weightKg: number) => weightKg / 0.45359237;
+
+let tempDir = '';
+let sqlite: Database.Database;
+let db: ReturnType<typeof drizzle<typeof schema>>;
+
+const programInput = (): AdaptiveProgramMutation => ({
+  status: 'active',
+  timeZone: 'America/Detroit',
+  heightCm: null,
+  birthDate: null,
+  rmrEquation: 'manual_tdee',
+  activityLevel: null,
+  manualBaselineTdeeKcal: 2500,
+  goalType: 'maintain',
+  targetWeightKg: null,
+  goalRatePctPerWeek: 0,
+  proteinGrams: 180,
+  fatAllocationPct: 30,
+  currentWeight: { weight: 80, unit: 'kg' },
+  rebaseline: false,
+  supersedePending: false,
+});
+
+const seedNutrition = (
+  userId: string,
+  date: string,
+  status: 'unknown' | 'partial' | 'complete',
+  calories: number,
+) => {
+  const logId = `${userId}-log-${date}`;
+  const mealId = `${userId}-meal-${date}`;
+  db.insert(nutritionLogs)
+    .values({
+      id: logId,
+      userId,
+      date,
+      status,
+      statusUpdatedAt: nowMs - 10,
+      createdAt: nowMs - 20,
+      updatedAt: nowMs - 10,
+    })
+    .run();
+  db.insert(meals)
+    .values({ id: mealId, nutritionLogId: logId, name: 'Daily total', createdAt: nowMs - 19 })
+    .run();
+  db.insert(mealItems)
+    .values({
+      id: `${userId}-item-${date}`,
+      mealId,
+      name: 'Recorded food',
+      amount: 1,
+      unit: 'serving',
+      calories,
+      protein: 160,
+      carbs: 220,
+      fat: 70,
+      createdAt: nowMs - 18,
+    })
+    .run();
+  return logId;
+};
+
+const seedWeight = (userId: string, date: string, weightKg: number, corrected = false) => {
+  const createdAt = nowMs - 100;
+  db.insert(bodyWeight)
+    .values({
+      id: `${userId}-weight-${date}`,
+      userId,
+      date,
+      weight: poundsFromKg(weightKg),
+      weightKg,
+      unitAtEntry: 'kg',
+      createdAt,
+      updatedAt: corrected ? createdAt + 1 : createdAt,
+    })
+    .run();
+};
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'pulse-data-quality-'));
+  sqlite = new Database(join(tempDir, 'test.db'));
+  sqlite.pragma('foreign_keys = ON');
+  db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder });
+  db.insert(users)
+    .values([
+      {
+        id: 'user-1',
+        username: 'quality-one',
+        passwordHash: 'hash',
+        weightUnit: 'lbs',
+        preferences: { timeZone: 'America/Detroit' },
+      },
+      {
+        id: 'user-2',
+        username: 'quality-two',
+        passwordHash: 'hash',
+        weightUnit: 'kg',
+        preferences: { timeZone: 'Asia/Tokyo' },
+      },
+    ])
+    .run();
+});
+
+afterEach(() => {
+  sqlite.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('Data Quality calendar store', () => {
+  it('composes logged, pending, workout, algorithm, and bounded context truth without writes', () => {
+    const nutritionLogId = seedNutrition('user-1', '2026-08-17', 'complete', 2400);
+    seedWeight('user-1', '2026-08-17', 80.2, true);
+    seedWeight('user-1', '2026-08-18', 80, false);
+    seedNutrition('user-2', '2026-08-17', 'complete', 9999);
+    seedWeight('user-2', '2026-08-17', 120, false);
+
+    const adaptiveStore = createAdaptiveNutritionStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    });
+    adaptiveStore.upsertProgram('user-1', programInput());
+    const program = adaptiveStore.getState('user-1').program;
+    expect(program).not.toBeNull();
+    if (!program) throw new Error('Expected an Adaptive Nutrition program');
+
+    db.insert(scheduledWorkouts)
+      .values({
+        id: 'schedule-1',
+        userId: 'user-1',
+        templateId: null,
+        date: '2026-08-18',
+        createdAt: nowMs - 1000,
+        updatedAt: nowMs - 1000,
+      })
+      .run();
+    db.insert(workoutSessions)
+      .values({
+        id: 'session-1',
+        userId: 'user-1',
+        scheduledWorkoutId: null,
+        name: 'Upper body',
+        date: '2026-08-17',
+        status: 'completed',
+        startedAt: nowMs - 10_000,
+        completedAt: nowMs - 5_000,
+        updatedAt: nowMs - 4_000,
+      })
+      .run();
+    db.insert(adaptiveNutritionReviewContexts)
+      .values({
+        id: 'context-1',
+        userId: 'user-1',
+        programId: program.id,
+        subjectType: 'nutrition_log',
+        subject: { kind: 'nutrition_log', id: nutritionLogId },
+        category: 'illness',
+        note: 'Recovering from a cold',
+        resolution: null,
+        resolutionKind: null,
+        createdBy: 'user',
+        agentTokenId: null,
+        actorLabel: 'You',
+        revision: 1,
+        createdAt: nowMs - 500,
+        updatedAt: nowMs - 500,
+      })
+      .run();
+
+    const sourceCountsBefore = {
+      nutrition: sqlite.prepare('select count(*) as value from nutrition_logs').get(),
+      weights: sqlite.prepare('select count(*) as value from body_weight').get(),
+      checkIns: sqlite.prepare('select count(*) as value from adaptive_nutrition_checkins').get(),
+      contexts: sqlite
+        .prepare('select count(*) as value from adaptive_nutrition_review_contexts')
+        .get(),
+    };
+    const calendar = createDataQualityCalendarStore({ db, now: () => new Date(nowMs) }).getCalendar(
+      'user-1',
+      { start: '2026-08-17', end: '2026-08-18' },
+    );
+    expect(dataQualityCalendarSchema.parse(calendar)).toEqual(calendar);
+    expect(calendar.timeZone).toBe('America/Detroit');
+
+    const august17 = calendar.days.find((day) => day.date === '2026-08-17');
+    expect(august17).toBeDefined();
+    if (!august17) throw new Error('Expected August 17 calendar day');
+    expect(august17.nutrition).toMatchObject({
+      qualityState: 'complete',
+      logId: nutritionLogId,
+      totals: { calories: 2400 },
+    });
+    expect(august17.weight).toMatchObject({
+      entryId: 'user-1-weight-2026-08-17',
+      corrected: true,
+      unit: 'lbs',
+    });
+    expect(august17.weight.weight).toBeCloseTo(176.81, 1);
+    expect(august17.workouts).toEqual([
+      expect.objectContaining({ id: 'session-1', state: 'corrected' }),
+    ]);
+    expect(august17.contexts).toEqual([
+      expect.objectContaining({
+        id: 'context-1',
+        category: 'illness',
+        provenance: { type: 'user', agentTokenId: null, label: 'You' },
+      }),
+    ]);
+    expect(august17.algorithm.state).toBe('pre_program');
+
+    const august18 = calendar.days.find((day) => day.date === '2026-08-18');
+    expect(august18).toBeDefined();
+    if (!august18) throw new Error('Expected August 18 calendar day');
+    expect(august18.isToday).toBe(true);
+    expect(august18.algorithm.state).toBe('learning');
+    expect(august18.weight).toMatchObject({
+      evidenceState: 'pending_cutoff',
+      weight: expect.any(Number),
+    });
+    expect(august18.workouts).toEqual([
+      expect.objectContaining({ id: 'schedule-1', state: 'planned' }),
+    ]);
+    expect(calendar.summary).toMatchObject({
+      nutrition: { complete: 1, missing: 1 },
+      weight: { logged: 2, corrected: 2, pending: 1 },
+      workout: { planned: 1, corrected: 1 },
+      contextDays: 1,
+    });
+
+    expect({
+      nutrition: sqlite.prepare('select count(*) as value from nutrition_logs').get(),
+      weights: sqlite.prepare('select count(*) as value from body_weight').get(),
+      checkIns: sqlite.prepare('select count(*) as value from adaptive_nutrition_checkins').get(),
+      contexts: sqlite
+        .prepare('select count(*) as value from adaptive_nutrition_review_contexts')
+        .get(),
+    }).toEqual(sourceCountsBefore);
+    expect(calendar.days.map((day) => day.nutrition.logId).filter(Boolean)).not.toContain(
+      'user-2-log-2026-08-17',
+    );
+    expect(calendar.days.map((day) => day.weight.entryId).filter(Boolean)).not.toContain(
+      'user-2-weight-2026-08-17',
+    );
+  });
+
+  it('returns honest no-program state and caller-zone today across a UTC/local boundary', () => {
+    seedNutrition('user-2', '2026-08-19', 'partial', 900);
+    seedWeight('user-2', '2026-08-19', 72, false);
+    const calendar = createDataQualityCalendarStore({
+      db,
+      now: () => new Date('2026-08-18T16:00:00.000Z'),
+    }).getCalendar('user-2', {
+      start: '2026-08-18',
+      end: '2026-08-19',
+      timeZone: 'Asia/Tokyo',
+    });
+
+    expect(calendar.timeZone).toBe('Asia/Tokyo');
+    expect(calendar.days.map((day) => [day.date, day.isToday])).toEqual([
+      ['2026-08-18', false],
+      ['2026-08-19', true],
+    ]);
+    expect(calendar.days[1]).toMatchObject({
+      nutrition: { qualityState: 'partial', evidenceState: 'pending_cutoff' },
+      weight: { evidenceState: 'pending_cutoff' },
+      algorithm: {
+        state: 'no_program',
+        nutritionEvidenceState: 'not_applicable',
+        weightEvidenceState: 'not_applicable',
+      },
+      contexts: [],
+    });
+  });
+
+  it('uses a fixed number of selects for a dense 42-day range', () => {
+    for (let offset = 0; offset < 42; offset += 1) {
+      const date = new Date(Date.UTC(2026, 6, 8 + offset)).toISOString().slice(0, 10);
+      seedNutrition('user-1', date, offset % 3 === 0 ? 'partial' : 'complete', 2000 + offset);
+      seedWeight('user-1', date, 80 - offset * 0.02, false);
+    }
+    const queriedSources: string[] = [];
+    createDataQualityCalendarStore({
+      db,
+      now: () => new Date(nowMs),
+      onQuery: (source) => queriedSources.push(source),
+    }).getCalendar('user-1', { start: '2026-07-08', end: '2026-08-18' });
+    expect(queriedSources).toEqual([
+      'user',
+      'program',
+      'nutrition',
+      'weight',
+      'scheduled-workouts',
+      'workout-sessions',
+    ]);
+  });
+
+  it('does not forecast future algorithm eligibility for an active program', () => {
+    const adaptiveStore = createAdaptiveNutritionStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    });
+    adaptiveStore.upsertProgram('user-1', programInput());
+    const calendar = createDataQualityCalendarStore({
+      db,
+      now: () => new Date(nowMs),
+    }).getCalendar('user-1', { start: '2026-08-18', end: '2026-08-19' });
+
+    expect(calendar.days.find((day) => day.date === '2026-08-19')?.algorithm).toMatchObject({
+      state: 'future',
+      nutritionEvidenceState: 'not_applicable',
+      weightEvidenceState: 'not_applicable',
+      reasonCodes: ['FUTURE_DATE_NOT_EVALUATED'],
+    });
+  });
+});

--- a/apps/api/src/routes/data-quality/store.integration.test.ts
+++ b/apps/api/src/routes/data-quality/store.integration.test.ts
@@ -394,9 +394,143 @@ describe('Data Quality calendar store', () => {
       'program',
       'nutrition',
       'weight',
+      'latest-weight',
       'scheduled-workouts',
       'workout-sessions',
+      'workout-counts',
     ]);
+  });
+
+  it('does not call the fulfilled same-date plan outstanding after its linked session completes', () => {
+    db.insert(scheduledWorkouts)
+      .values({
+        id: 'fulfilled-plan',
+        userId: 'user-1',
+        templateId: null,
+        date: '2026-08-17',
+        createdAt: nowMs - 10_000,
+        updatedAt: nowMs - 10_000,
+      })
+      .run();
+    db.insert(workoutSessions)
+      .values({
+        id: 'fulfilled-session',
+        userId: 'user-1',
+        scheduledWorkoutId: 'fulfilled-plan',
+        name: 'Fulfilled workout',
+        date: '2026-08-17',
+        status: 'completed',
+        startedAt: nowMs - 8_000,
+        completedAt: nowMs - 4_000,
+        createdAt: nowMs - 9_000,
+        updatedAt: nowMs - 4_000,
+      })
+      .run();
+    db.update(scheduledWorkouts)
+      .set({ sessionId: 'fulfilled-session' })
+      .where(eq(scheduledWorkouts.id, 'fulfilled-plan'))
+      .run();
+
+    const calendar = createDataQualityCalendarStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    }).getCalendar('user-1', { start: '2026-08-17', end: '2026-08-17' });
+
+    expect(calendar.days[0]?.workouts).toEqual([
+      expect.objectContaining({
+        id: 'fulfilled-session',
+        state: 'completed',
+        relation: 'linked_same_date',
+      }),
+    ]);
+    expect(calendar.summary.workout).toEqual({
+      planned: 0,
+      active: 0,
+      completed: 1,
+      cancelled: 0,
+    });
+  });
+
+  it('projects every fulfilled same-date lifecycle without a duplicate plan', () => {
+    const cases = [
+      { date: '2026-08-14', status: 'scheduled' as const },
+      { date: '2026-08-15', status: 'in-progress' as const },
+      { date: '2026-08-16', status: 'paused' as const },
+      { date: '2026-08-17', status: 'cancelled' as const },
+    ];
+    db.insert(scheduledWorkouts)
+      .values(
+        cases.map(({ date, status }, index) => ({
+          id: `matrix-plan-${status}`,
+          userId: 'user-1',
+          templateId: null,
+          date,
+          createdAt: nowMs - 20_000 + index,
+          updatedAt: nowMs - 20_000 + index,
+        })),
+      )
+      .run();
+    db.insert(workoutSessions)
+      .values(
+        cases.map(({ date, status }, index) => ({
+          id: `matrix-session-${status}`,
+          userId: 'user-1',
+          scheduledWorkoutId: `matrix-plan-${status}`,
+          name: `Matrix ${status}`,
+          date,
+          status,
+          startedAt: nowMs - 10_000 + index,
+          createdAt: nowMs - 10_000 + index,
+          updatedAt: nowMs - 10_000 + index,
+        })),
+      )
+      .run();
+    for (const { status } of cases) {
+      db.update(scheduledWorkouts)
+        .set({ sessionId: `matrix-session-${status}` })
+        .where(eq(scheduledWorkouts.id, `matrix-plan-${status}`))
+        .run();
+    }
+
+    const calendar = createDataQualityCalendarStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    }).getCalendar('user-1', { start: '2026-08-14', end: '2026-08-17' });
+
+    expect(calendar.days.flatMap((day) => day.workouts).map((item) => item.kind)).toEqual([
+      'workout_session',
+      'workout_session',
+      'workout_session',
+      'workout_session',
+    ]);
+    expect(calendar.days.flatMap((day) => day.workouts).map((item) => item.state)).toEqual([
+      'scheduled',
+      'in_progress',
+      'paused',
+      'cancelled',
+    ]);
+    expect(calendar.summary.workout).toEqual({
+      planned: 1,
+      active: 2,
+      completed: 0,
+      cancelled: 1,
+    });
+  });
+
+  it('derives current staleness from the user latest weight, not the requested range endpoint', () => {
+    seedWeight('user-1', '2026-08-01', 80, false);
+    seedWeight('user-1', '2026-08-10', 79.8, false);
+    seedWeight('user-1', '2026-08-17', 79.5, false);
+
+    const historical = createDataQualityCalendarStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    }).getCalendar('user-1', { start: '2026-08-01', end: '2026-08-10' });
+
+    expect(historical.days.find((day) => day.date === '2026-08-10')?.weight.stale).toBe(false);
   });
 
   it('does not forecast future algorithm eligibility for an active program', () => {
@@ -605,6 +739,17 @@ describe('Data Quality calendar store', () => {
     ]);
 
     db.update(workoutSessions)
+      .set({ status: 'cancelled', updatedAt: nowMs + 500 })
+      .where(eq(workoutSessions.id, 'boundary-session'))
+      .run();
+    expect(
+      store.getCalendar('user-1', {
+        start: '2026-09-01',
+        end: '2026-09-01',
+      }).days[0]?.workouts,
+    ).toEqual([expect.objectContaining({ id: 'boundary-session', state: 'cancelled' })]);
+
+    db.update(workoutSessions)
       .set({ status: 'completed', completedAt: nowMs + 1_000, updatedAt: nowMs + 2_000 })
       .where(eq(workoutSessions.id, 'boundary-session'))
       .run();
@@ -722,6 +867,143 @@ describe('Data Quality calendar store', () => {
     ]);
   });
 
+  it('keeps a deferred weekly review on its retained review date', () => {
+    seedEligibleReviewProgram();
+    const reviewStore = createAdaptiveWeeklyReviewStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    });
+    const review = reviewStore.preview('user-1', { kind: 'weekly' });
+    const deferred = reviewStore.act(
+      'user-1',
+      review.id,
+      {
+        type: 'defer',
+        expectedFingerprint: review.sourceFingerprint,
+        expectedActionSequence: review.actionSequence,
+        condition: { kind: 'until_date', localDate: '2026-08-21' },
+        reason: 'Wait for one more measurement.',
+      },
+      { type: 'user', label: 'You' },
+    );
+    expect(deferred.state).toBe('deferred');
+
+    const event = createDataQualityCalendarStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    })
+      .getCalendar('user-1', {
+        start: review.snapshot.reviewLocalDate,
+        end: review.snapshot.reviewLocalDate,
+      })
+      .days[0]?.algorithm.events.find((item) => item.id === review.id);
+    expect(event).toMatchObject({
+      effectiveDate: review.snapshot.reviewLocalDate,
+      state: 'deferred',
+    });
+  });
+
+  it('reduces large revision and action histories before Data Quality materialization', () => {
+    seedEligibleReviewProgram();
+    const reviewStore = createAdaptiveWeeklyReviewStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    });
+    const review = reviewStore.preview('user-1', { kind: 'weekly' });
+    reviewStore.act(
+      'user-1',
+      review.id,
+      {
+        type: 'ask_agent',
+        expectedActionSequence: review.actionSequence,
+        question: 'What evidence should be clarified?',
+      },
+      { type: 'user', label: 'You' },
+    );
+
+    const programRevision = sqlite
+      .prepare(
+        `select program_id as programId, user_id as userId, effective_at as effectiveAt,
+                snapshot, source, created_at as createdAt
+           from adaptive_nutrition_program_revisions
+          where user_id = 'user-1'
+          order by sequence desc limit 1`,
+      )
+      .get() as {
+      programId: string;
+      userId: string;
+      effectiveAt: number;
+      snapshot: string;
+      source: string;
+      createdAt: number;
+    };
+    const action = sqlite
+      .prepare(
+        `select user_id as userId, payload, actor_type as actorType,
+                agent_token_id as agentTokenId, actor_label as actorLabel, created_at as createdAt
+           from adaptive_nutrition_review_actions
+          where review_id = ? order by sequence desc limit 1`,
+      )
+      .get(review.id) as {
+      userId: string;
+      payload: string;
+      actorType: string;
+      agentTokenId: string | null;
+      actorLabel: string;
+      createdAt: number;
+    };
+    const insertRevision = sqlite.prepare(
+      `insert into adaptive_nutrition_program_revisions
+        (id, program_id, user_id, sequence, effective_at, snapshot, source, created_at)
+       values (?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const insertAction = sqlite.prepare(
+      `insert into adaptive_nutrition_review_actions
+        (id, review_id, user_id, sequence, type, payload, actor_type, agent_token_id, actor_label, created_at)
+       values (?, ?, ?, ?, 'ask_agent', ?, ?, ?, ?, ?)`,
+    );
+    sqlite.transaction(() => {
+      for (let sequence = 2; sequence <= 5_001; sequence += 1) {
+        insertRevision.run(
+          `large-revision-${sequence}`,
+          programRevision.programId,
+          programRevision.userId,
+          sequence,
+          programRevision.effectiveAt + sequence,
+          programRevision.snapshot,
+          programRevision.source,
+          programRevision.createdAt + sequence,
+        );
+        insertAction.run(
+          `large-action-${sequence}`,
+          review.id,
+          action.userId,
+          sequence,
+          action.payload,
+          action.actorType,
+          action.agentTokenId,
+          action.actorLabel,
+          action.createdAt + sequence,
+        );
+      }
+    })();
+
+    const event = createDataQualityCalendarStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    })
+      .getCalendar('user-1', {
+        start: review.snapshot.reviewLocalDate,
+        end: review.snapshot.reviewLocalDate,
+      })
+      .days[0]?.algorithm.events.find((item) => item.id === review.id);
+    expect(event).toMatchObject({ state: 'awaiting_clarification' });
+  });
+
   it('returns deterministic bounded truth instead of failing strict response caps on dense days', () => {
     const lifecycle = createAdaptiveNutritionStore({ db, sqlite, now: () => new Date(nowMs) });
     lifecycle.upsertProgram('user-1', programInput());
@@ -798,5 +1080,105 @@ describe('Data Quality calendar store', () => {
       [...(day?.workouts ?? [])].map((item) => item.id).sort(),
     );
     expect(dataQualityCalendarSchema.parse(calendar)).toEqual(calendar);
+  });
+
+  it('preserves every date cap and exact omission count across a fully dense 42-day range', () => {
+    const start = '2026-07-08';
+    db.insert(workoutSessions)
+      .values(
+        Array.from({ length: 42 }, (_, dayIndex) =>
+          Array.from({ length: 51 }, (_, itemIndex) => ({
+            id: `dense-range-${String(dayIndex).padStart(2, '0')}-${String(itemIndex).padStart(2, '0')}`,
+            userId: 'user-1',
+            name: `Dense range ${dayIndex}-${itemIndex}`,
+            date: addDate(start, dayIndex),
+            status: 'scheduled' as const,
+            startedAt: nowMs + dayIndex * 100 + itemIndex,
+            createdAt: nowMs + dayIndex * 100 + itemIndex,
+            updatedAt: nowMs + dayIndex * 100 + itemIndex,
+          })),
+        ).flat(),
+      )
+      .run();
+
+    const calendar = createDataQualityCalendarStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    }).getCalendar('user-1', { start, end: addDate(start, 41) });
+
+    expect(calendar.days).toHaveLength(42);
+    for (const day of calendar.days) {
+      expect(day.workouts, day.date).toHaveLength(50);
+      expect(day.omittedWorkoutCount, day.date).toBe(1);
+    }
+  });
+
+  it('preserves per-date context and event caps across a fully dense 42-day range', () => {
+    const start = '2026-06-01';
+    const lifecycle = createAdaptiveNutritionStore({ db, sqlite, now: () => new Date(nowMs) });
+    lifecycle.upsertProgram('user-1', programInput());
+    const program = lifecycle.getState('user-1').program;
+    const baseline = lifecycle.getState('user-1').pendingCheckIn;
+    if (!program || !baseline) throw new Error('Expected program and baseline');
+    lifecycle.acceptCheckIn('user-1', baseline.id, { replaceSameDateTarget: false });
+    const source = db
+      .select()
+      .from(adaptiveNutritionCheckIns)
+      .where(eq(adaptiveNutritionCheckIns.id, baseline.id))
+      .get();
+    if (!source) throw new Error('Expected accepted check-in source');
+
+    for (let dayIndex = 0; dayIndex < 42; dayIndex += 1) {
+      const date = addDate(start, dayIndex);
+      db.insert(adaptiveNutritionReviewContexts)
+        .values(
+          Array.from({ length: 101 }, (_, itemIndex) => ({
+            id: `dense-context-range-${String(dayIndex).padStart(2, '0')}-${String(itemIndex).padStart(3, '0')}`,
+            userId: 'user-1',
+            programId: program.id,
+            subjectType: 'date' as const,
+            subject: { kind: 'date' as const, localDate: date },
+            category: 'other' as const,
+            note: `Dense context ${dayIndex}-${itemIndex}`,
+            resolution: null,
+            resolutionKind: null,
+            createdBy: 'user' as const,
+            agentTokenId: null,
+            actorLabel: 'You',
+            revision: 1,
+            createdAt: nowMs + dayIndex * 1_000 + itemIndex,
+            updatedAt: nowMs + dayIndex * 1_000 + itemIndex,
+          })),
+        )
+        .run();
+      db.insert(adaptiveNutritionCheckIns)
+        .values(
+          Array.from({ length: 51 }, (_, itemIndex) => ({
+            ...source,
+            id: `dense-event-range-${String(dayIndex).padStart(2, '0')}-${String(itemIndex).padStart(2, '0')}`,
+            localDate: date,
+            status: 'declined' as const,
+            acceptedNutritionTargetId: null,
+            proposedTargets: null,
+            resolvedAt: source.resolvedAt,
+            createdAt: source.createdAt + dayIndex * 100 + itemIndex + 1,
+          })),
+        )
+        .run();
+    }
+
+    const calendar = createDataQualityCalendarStore({
+      db,
+      sqlite,
+      now: () => new Date(nowMs),
+    }).getCalendar('user-1', { start, end: addDate(start, 41) });
+
+    for (const day of calendar.days) {
+      expect(day.contexts, day.date).toHaveLength(100);
+      expect(day.omittedContextCount, day.date).toBe(1);
+      expect(day.algorithm.events, day.date).toHaveLength(50);
+      expect(day.algorithm.omittedEventCount, day.date).toBe(1);
+    }
   });
 });

--- a/apps/api/src/routes/data-quality/store.integration.test.ts
+++ b/apps/api/src/routes/data-quality/store.integration.test.ts
@@ -286,8 +286,8 @@ describe('Data Quality calendar store', () => {
     ]);
     expect(calendar.summary).toMatchObject({
       nutrition: { complete: 1, missing: 1 },
-      weight: { logged: 2, corrected: 0, pending: 1 },
-      workout: { planned: 1, corrected: 0 },
+      weight: { logged: 2, pending: 1 },
+      workout: { planned: 1 },
       contextDays: 1,
     });
 

--- a/apps/api/src/routes/data-quality/store.ts
+++ b/apps/api/src/routes/data-quality/store.ts
@@ -178,7 +178,6 @@ const summaryFor = (days: DataQualityCalendarDay[]): DataQualityCalendar['summar
     missing: days.filter((day) => day.weight.entryId === null).length,
     pending: days.filter((day) => day.weight.evidenceState === 'pending_cutoff').length,
     excluded: days.filter((day) => day.weight.evidenceState === 'excluded').length,
-    corrected: days.filter((day) => day.weight.correctionState === 'confirmed').length,
   },
   workout: {
     planned: days.flatMap((day) => day.workouts).filter((item) => item.state === 'planned').length,
@@ -188,8 +187,6 @@ const summaryFor = (days: DataQualityCalendarDay[]): DataQualityCalendar['summar
     completed: days.flatMap((day) => day.workouts).filter((item) => item.state === 'completed')
       .length,
     cancelled: days.flatMap((day) => day.workouts).filter((item) => item.state === 'cancelled')
-      .length,
-    corrected: days.flatMap((day) => day.workouts).filter((item) => item.state === 'corrected')
       .length,
   },
   algorithm: {

--- a/apps/api/src/routes/data-quality/store.ts
+++ b/apps/api/src/routes/data-quality/store.ts
@@ -1,0 +1,904 @@
+import {
+  adaptiveProgramCalculationSchema,
+  adaptiveRecommendationSchema,
+  adaptiveWeeklyReviewSnapshotSchema,
+  calculateAdaptiveDateBoundaries,
+  calculateCanonicalTrendWeightSeries,
+  convertWeightFromKg,
+  dataQualityCalendarQuerySchema,
+  dataQualityCalendarSchema,
+  evaluateEligibility,
+  type AdaptiveNutritionDay,
+  type AdaptiveWeightEntry,
+  type DataQualityCalendar,
+  type DataQualityCalendarDay,
+  type DataQualityCalendarQuery,
+  type DataQualityEvidenceState,
+  type WeightUnit,
+} from '@pulse/shared';
+import { and, asc, eq, gte, inArray, isNull, lte, or, sql } from 'drizzle-orm';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+import * as schema from '../../db/schema/index.js';
+import {
+  adaptiveNutritionCheckIns,
+  adaptiveNutritionProgramRevisions,
+  adaptiveNutritionPrograms,
+  adaptiveNutritionReviewActions,
+  adaptiveNutritionReviewContexts,
+  adaptiveNutritionReviews,
+  bodyWeight,
+  mealItems,
+  meals,
+  nutritionLogs,
+  scheduledWorkouts,
+  users,
+  workoutSessions,
+  workoutTemplates,
+} from '../../db/schema/index.js';
+import {
+  getDateKeyInTimeZone,
+  resolveEffectiveProgramRevisions,
+  type EffectiveProgramRevision,
+} from '../adaptive-nutrition/analytics-store.js';
+
+type DataQualityDatabase = BetterSQLite3Database<typeof schema>;
+
+const addDays = (date: string, days: number) => {
+  const value = new Date(`${date}T00:00:00.000Z`);
+  value.setUTCDate(value.getUTCDate() + days);
+  return value.toISOString().slice(0, 10);
+};
+
+const datesBetween = (start: string, end: string) => {
+  const dates: string[] = [];
+  for (let current = start; current <= end; current = addDays(current, 1)) dates.push(current);
+  return dates;
+};
+
+const isSupportedTimeZone = (value: unknown): value is string => {
+  if (typeof value !== 'string' || value.trim().length === 0) return false;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: value }).format(0);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const preferenceTimeZone = (preferences: unknown) => {
+  if (!preferences || typeof preferences !== 'object') return null;
+  const value = preferences as { timeZone?: unknown; timezone?: unknown };
+  const candidate = value.timeZone ?? value.timezone;
+  return isSupportedTimeZone(candidate) ? candidate : null;
+};
+
+const unique = <T>(values: readonly T[]) => [...new Set(values)];
+
+const nutritionStatusAction = (date: string) => ({
+  kind: 'set_nutrition_status' as const,
+  label: 'Review nutrition day status',
+  href: `/nutrition?date=${date}`,
+  method: 'navigate' as const,
+});
+
+const addContextAction = (date: string) => ({
+  kind: 'add_context' as const,
+  label: 'Add bounded context',
+  href: `/data-quality?date=${date}&action=context`,
+  method: 'navigate' as const,
+});
+
+const reviewActionState = (
+  actions: Array<{ type: string }>,
+): DataQualityCalendarDay['algorithm']['events'][number]['state'] => {
+  const latest = actions.at(-1)?.type;
+  if (latest === 'accept') return 'accepted';
+  if (latest === 'decline') return 'declined';
+  if (latest === 'defer') return 'deferred';
+  if (latest === 'ask_agent') return 'awaiting_clarification';
+  if (latest === 'supersede') return 'superseded';
+  return 'pending';
+};
+
+const programRevisionForDate = (
+  revisions: EffectiveProgramRevision[],
+  date: string,
+): EffectiveProgramRevision | null =>
+  [...revisions].reverse().find((revision) => revision.effectiveLocalDate <= date) ?? null;
+
+const algorithmStateForDate = (
+  date: string,
+  revisions: EffectiveProgramRevision[],
+  checkIns: Array<{
+    localDate: string;
+    calculationState: 'baseline' | 'learning' | 'updating' | 'holding';
+    status: 'pending' | 'accepted' | 'declined' | 'superseded' | 'held';
+    createdAt: number;
+  }>,
+  eligible: boolean,
+): DataQualityCalendarDay['algorithm']['state'] => {
+  const revision = programRevisionForDate(revisions, date);
+  if (!revision) return revisions.length === 0 ? 'no_program' : 'pre_program';
+  if (revision.snapshot.status === 'paused') return 'holding';
+  if (eligible) return 'updating';
+  const latest = checkIns
+    .filter((checkIn) => checkIn.localDate <= date)
+    .sort(
+      (left, right) =>
+        left.localDate.localeCompare(right.localDate) || left.createdAt - right.createdAt,
+    )
+    .at(-1);
+  if (!latest) return 'learning';
+  if (latest.status === 'held' || latest.calculationState === 'holding') return 'holding';
+  if (latest.status === 'accepted' && latest.calculationState === 'updating') return 'holding';
+  return 'learning';
+};
+
+const summaryFor = (days: DataQualityCalendarDay[]): DataQualityCalendar['summary'] => ({
+  nutrition: {
+    complete: days.filter((day) => day.nutrition.qualityState === 'complete').length,
+    partial: days.filter((day) => day.nutrition.qualityState === 'partial').length,
+    unknown: days.filter((day) => day.nutrition.qualityState === 'unknown').length,
+    missing: days.filter((day) => day.nutrition.qualityState === 'no_records').length,
+    pending: days.filter((day) => day.nutrition.evidenceState === 'pending_cutoff').length,
+    excluded: days.filter((day) => day.nutrition.evidenceState === 'excluded').length,
+  },
+  weight: {
+    logged: days.filter((day) => day.weight.entryId !== null).length,
+    missing: days.filter((day) => day.weight.entryId === null).length,
+    pending: days.filter((day) => day.weight.evidenceState === 'pending_cutoff').length,
+    excluded: days.filter((day) => day.weight.evidenceState === 'excluded').length,
+    corrected: days.filter((day) => day.weight.corrected).length,
+  },
+  workout: {
+    planned: days.flatMap((day) => day.workouts).filter((item) => item.state === 'planned').length,
+    active: days
+      .flatMap((day) => day.workouts)
+      .filter((item) => item.state === 'in_progress' || item.state === 'paused').length,
+    completed: days.flatMap((day) => day.workouts).filter((item) => item.state === 'completed')
+      .length,
+    cancelled: days.flatMap((day) => day.workouts).filter((item) => item.state === 'cancelled')
+      .length,
+    corrected: days.flatMap((day) => day.workouts).filter((item) => item.state === 'corrected')
+      .length,
+  },
+  algorithm: {
+    learning: days.filter((day) => day.algorithm.state === 'learning').length,
+    updating: days.filter((day) => day.algorithm.state === 'updating').length,
+    holding: days.filter((day) => day.algorithm.state === 'holding').length,
+    pendingReview: days.filter((day) =>
+      day.algorithm.events.some((event) =>
+        ['pending', 'awaiting_clarification', 'deferred', 'stale'].includes(event.state),
+      ),
+    ).length,
+  },
+  contextDays: days.filter((day) => day.contexts.length > 0).length,
+});
+
+export const createDataQualityCalendarStore = (dependencies: {
+  db: DataQualityDatabase;
+  now?: () => Date;
+  onQuery?: (source: string) => void;
+}) => {
+  const { db } = dependencies;
+  const now = dependencies.now ?? (() => new Date());
+  const observe = dependencies.onQuery ?? (() => undefined);
+
+  const getCalendar = (userId: string, rawQuery: DataQualityCalendarQuery): DataQualityCalendar => {
+    const query = dataQualityCalendarQuerySchema.parse(rawQuery);
+    observe('user');
+    const user = db
+      .select({ weightUnit: users.weightUnit, preferences: users.preferences })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1)
+      .get();
+    if (!user) throw new Error('Authenticated user not found while loading Data Quality calendar');
+
+    observe('program');
+    const program = db
+      .select({ id: adaptiveNutritionPrograms.id })
+      .from(adaptiveNutritionPrograms)
+      .where(eq(adaptiveNutritionPrograms.userId, userId))
+      .limit(1)
+      .get();
+    const programRevisions = program
+      ? (observe('program-revisions'),
+        resolveEffectiveProgramRevisions(
+          db
+            .select({
+              id: adaptiveNutritionProgramRevisions.id,
+              sequence: adaptiveNutritionProgramRevisions.sequence,
+              effectiveAt: adaptiveNutritionProgramRevisions.effectiveAt,
+              snapshot: adaptiveNutritionProgramRevisions.snapshot,
+            })
+            .from(adaptiveNutritionProgramRevisions)
+            .where(
+              and(
+                eq(adaptiveNutritionProgramRevisions.userId, userId),
+                eq(adaptiveNutritionProgramRevisions.programId, program.id),
+              ),
+            )
+            .orderBy(asc(adaptiveNutritionProgramRevisions.sequence))
+            .all()
+            .map((revision) => ({
+              ...revision,
+              snapshot: adaptiveProgramCalculationSchema.parse(revision.snapshot),
+            })),
+        ))
+      : [];
+    const timeZone =
+      query.timeZone ??
+      programRevisions.at(-1)?.snapshot.timeZone ??
+      preferenceTimeZone(user.preferences) ??
+      'UTC';
+    const today = getDateKeyInTimeZone(now(), timeZone);
+    const dates = datesBetween(query.start, query.end);
+    const evidenceStart = calculateAdaptiveDateBoundaries(query.start, false).analysisStart;
+
+    observe('nutrition');
+    const nutritionRows = db
+      .select({
+        id: nutritionLogs.id,
+        date: nutritionLogs.date,
+        status: nutritionLogs.status,
+        statusUpdatedAt: nutritionLogs.statusUpdatedAt,
+        updatedAt: nutritionLogs.updatedAt,
+        calories: sql<number>`coalesce(sum(${mealItems.calories}), 0)`,
+        protein: sql<number>`coalesce(sum(${mealItems.protein}), 0)`,
+        carbs: sql<number>`coalesce(sum(${mealItems.carbs}), 0)`,
+        fat: sql<number>`coalesce(sum(${mealItems.fat}), 0)`,
+        mealCount: sql<number>`count(distinct ${meals.id})`,
+        itemCount: sql<number>`count(${mealItems.id})`,
+      })
+      .from(nutritionLogs)
+      .leftJoin(meals, eq(meals.nutritionLogId, nutritionLogs.id))
+      .leftJoin(mealItems, eq(mealItems.mealId, meals.id))
+      .where(
+        and(
+          eq(nutritionLogs.userId, userId),
+          gte(nutritionLogs.date, evidenceStart),
+          lte(nutritionLogs.date, query.end),
+        ),
+      )
+      .groupBy(nutritionLogs.id)
+      .orderBy(asc(nutritionLogs.date))
+      .all();
+    const visibleNutritionRows = nutritionRows.filter((row) => row.date >= query.start);
+    const nutritionByDate = new Map(visibleNutritionRows.map((row) => [row.date, row]));
+
+    observe('weight');
+    const allWeightRows = db
+      .select({
+        id: bodyWeight.id,
+        date: bodyWeight.date,
+        weightKg: bodyWeight.weightKg,
+        unitAtEntry: bodyWeight.unitAtEntry,
+        createdAt: bodyWeight.createdAt,
+        updatedAt: bodyWeight.updatedAt,
+      })
+      .from(bodyWeight)
+      .where(and(eq(bodyWeight.userId, userId), lte(bodyWeight.date, query.end)))
+      .orderBy(asc(bodyWeight.date), asc(bodyWeight.id))
+      .all()
+      .map((row) => ({ ...row, weightKg: Number(row.weightKg) }));
+    const visibleWeightRows = allWeightRows.filter(
+      (row) => row.date >= query.start && row.date <= query.end,
+    );
+    const weightByDate = new Map(visibleWeightRows.map((row) => [row.date, row]));
+    const trendByDate = new Map(
+      calculateCanonicalTrendWeightSeries(allWeightRows, query.start, query.end).map((point) => [
+        point.date,
+        point.trendWeightKg,
+      ]),
+    );
+    const eligibilityByDate = new Map(
+      dates.map((date) => [
+        date,
+        evaluateEligibility({
+          boundaries: calculateAdaptiveDateBoundaries(date, false),
+          nutritionDays: nutritionRows as AdaptiveNutritionDay[],
+          weightEntries: allWeightRows as AdaptiveWeightEntry[],
+        }),
+      ]),
+    );
+
+    observe('scheduled-workouts');
+    const scheduledRows = db
+      .select({
+        id: scheduledWorkouts.id,
+        date: scheduledWorkouts.date,
+        sessionId: scheduledWorkouts.sessionId,
+        templateName: workoutTemplates.name,
+        createdAt: scheduledWorkouts.createdAt,
+        updatedAt: scheduledWorkouts.updatedAt,
+      })
+      .from(scheduledWorkouts)
+      .leftJoin(workoutTemplates, eq(workoutTemplates.id, scheduledWorkouts.templateId))
+      .where(
+        and(
+          eq(scheduledWorkouts.userId, userId),
+          gte(scheduledWorkouts.date, query.start),
+          lte(scheduledWorkouts.date, query.end),
+        ),
+      )
+      .orderBy(asc(scheduledWorkouts.date), asc(scheduledWorkouts.createdAt))
+      .all();
+    observe('workout-sessions');
+    const sessionRows = db
+      .select({
+        id: workoutSessions.id,
+        scheduledWorkoutId: workoutSessions.scheduledWorkoutId,
+        name: workoutSessions.name,
+        date: workoutSessions.date,
+        status: workoutSessions.status,
+        startedAt: workoutSessions.startedAt,
+        completedAt: workoutSessions.completedAt,
+        createdAt: workoutSessions.createdAt,
+        updatedAt: workoutSessions.updatedAt,
+      })
+      .from(workoutSessions)
+      .where(
+        and(
+          eq(workoutSessions.userId, userId),
+          isNull(workoutSessions.deletedAt),
+          gte(workoutSessions.date, query.start),
+          lte(workoutSessions.date, query.end),
+        ),
+      )
+      .orderBy(asc(workoutSessions.date), asc(workoutSessions.startedAt))
+      .all();
+    const sessionsByDate = new Map<string, typeof sessionRows>();
+    for (const row of sessionRows) {
+      const existing = sessionsByDate.get(row.date) ?? [];
+      existing.push(row);
+      sessionsByDate.set(row.date, existing);
+    }
+    const schedulesByDate = new Map<string, typeof scheduledRows>();
+    for (const row of scheduledRows) {
+      const existing = schedulesByDate.get(row.date) ?? [];
+      existing.push(row);
+      schedulesByDate.set(row.date, existing);
+    }
+
+    const priorCheckIn = program
+      ? (observe('prior-check-in'),
+        db
+          .select()
+          .from(adaptiveNutritionCheckIns)
+          .where(
+            and(
+              eq(adaptiveNutritionCheckIns.userId, userId),
+              eq(adaptiveNutritionCheckIns.programId, program.id),
+              lte(adaptiveNutritionCheckIns.localDate, query.start),
+            ),
+          )
+          .orderBy(
+            sql`${adaptiveNutritionCheckIns.localDate} desc`,
+            sql`${adaptiveNutritionCheckIns.createdAt} desc`,
+          )
+          .limit(1)
+          .get())
+      : undefined;
+    const rangeCheckIns = program
+      ? (observe('range-check-ins'),
+        db
+          .select()
+          .from(adaptiveNutritionCheckIns)
+          .where(
+            and(
+              eq(adaptiveNutritionCheckIns.userId, userId),
+              eq(adaptiveNutritionCheckIns.programId, program.id),
+              gte(adaptiveNutritionCheckIns.localDate, query.start),
+              lte(adaptiveNutritionCheckIns.localDate, query.end),
+            ),
+          )
+          .orderBy(
+            asc(adaptiveNutritionCheckIns.localDate),
+            asc(adaptiveNutritionCheckIns.createdAt),
+          )
+          .all())
+      : [];
+    const checkIns = priorCheckIn
+      ? [priorCheckIn, ...rangeCheckIns.filter((row) => row.id !== priorCheckIn.id)]
+      : rangeCheckIns;
+
+    const overlappingReviews = program
+      ? (observe('overlapping-reviews'),
+        db
+          .select()
+          .from(adaptiveNutritionReviews)
+          .where(
+            and(
+              eq(adaptiveNutritionReviews.userId, userId),
+              eq(adaptiveNutritionReviews.programId, program.id),
+              lte(adaptiveNutritionReviews.analysisStart, query.end),
+              gte(adaptiveNutritionReviews.analysisEnd, query.start),
+            ),
+          )
+          .orderBy(asc(adaptiveNutritionReviews.createdAt))
+          .all())
+      : [];
+    const reviewIds = overlappingReviews.map((review) => review.id);
+    const reviewActions =
+      reviewIds.length > 0
+        ? (observe('review-actions'),
+          db
+            .select()
+            .from(adaptiveNutritionReviewActions)
+            .where(
+              and(
+                eq(adaptiveNutritionReviewActions.userId, userId),
+                inArray(adaptiveNutritionReviewActions.reviewId, reviewIds),
+              ),
+            )
+            .orderBy(
+              asc(adaptiveNutritionReviewActions.reviewId),
+              asc(adaptiveNutritionReviewActions.sequence),
+            )
+            .all())
+        : [];
+    const actionsByReview = new Map<string, typeof reviewActions>();
+    for (const action of reviewActions) {
+      const existing = actionsByReview.get(action.reviewId) ?? [];
+      existing.push(action);
+      actionsByReview.set(action.reviewId, existing);
+    }
+
+    const nutritionEvidence = new Map<
+      string,
+      { state: DataQualityEvidenceState; reasonCodes: string[]; suspectedPartial: boolean }
+    >();
+    const weightEvidence = new Map<
+      string,
+      { state: DataQualityEvidenceState; reasonCodes: string[]; suspect: boolean }
+    >();
+    for (const eligibility of eligibilityByDate.values()) {
+      for (const day of eligibility.usableNutritionDays) {
+        if (day.date >= query.start && day.date <= query.end) {
+          nutritionEvidence.set(day.date, {
+            state: 'usable',
+            reasonCodes: [],
+            suspectedPartial: false,
+          });
+        }
+      }
+      for (const date of eligibility.excludedNutritionDates) {
+        if (date >= query.start && date <= query.end && !nutritionEvidence.has(date)) {
+          nutritionEvidence.set(date, {
+            state: 'excluded',
+            reasonCodes: ['INCOMPLETE_NUTRITION_EXCLUDED'],
+            suspectedPartial: false,
+          });
+        }
+      }
+      const suspectIds = new Set(eligibility.suspectWeightEntryIds);
+      for (const weight of eligibility.actualWeights) {
+        if (weight.date < query.start || weight.date > query.end) continue;
+        const suspect = suspectIds.has(weight.id);
+        weightEvidence.set(weight.date, {
+          state: suspect ? 'excluded' : 'usable',
+          reasonCodes: suspect ? ['SUSPECT_WEIGHT'] : [],
+          suspect,
+        });
+      }
+    }
+    for (const review of overlappingReviews) {
+      const snapshot = adaptiveWeeklyReviewSnapshotSchema.parse(review.snapshot);
+      const recommendation = snapshot.modules.find((module) => module.kind === 'recommendation');
+      if (recommendation?.kind === 'recommendation') {
+        for (const date of recommendation.causalBreakdown.includedNutritionDates) {
+          nutritionEvidence.set(date, {
+            state: 'usable',
+            reasonCodes: [],
+            suspectedPartial: false,
+          });
+        }
+        for (const item of recommendation.causalBreakdown.excludedNutrition) {
+          nutritionEvidence.set(item.localDate, {
+            state: 'excluded',
+            reasonCodes: item.reasonCodes,
+            suspectedPartial: false,
+          });
+        }
+        for (const date of recommendation.causalBreakdown.includedWeightDates) {
+          weightEvidence.set(date, { state: 'usable', reasonCodes: [], suspect: false });
+        }
+        for (const item of recommendation.causalBreakdown.excludedWeight) {
+          weightEvidence.set(item.localDate, {
+            state: 'excluded',
+            reasonCodes: item.reasonCodes,
+            suspect: item.reasonCodes.some((code) => code.includes('SUSPECT')),
+          });
+        }
+      }
+      const dataQuality = snapshot.modules.find((module) => module.kind === 'data_quality');
+      if (dataQuality?.kind === 'data_quality') {
+        for (const evidence of dataQuality.evidence) {
+          if (evidence.kind !== 'nutrition') continue;
+          const current = nutritionEvidence.get(evidence.localDate) ?? {
+            state: evidence.state,
+            reasonCodes: [],
+            suspectedPartial: false,
+          };
+          nutritionEvidence.set(evidence.localDate, {
+            ...current,
+            reasonCodes: unique([...current.reasonCodes, ...evidence.reasonCodes]),
+            suspectedPartial:
+              current.suspectedPartial || evidence.reasonCodes.includes('LIKELY_PARTIAL_NUTRITION'),
+          });
+        }
+      }
+    }
+    for (const checkIn of checkIns) {
+      const calculation = adaptiveRecommendationSchema.parse(checkIn.calculationSnapshot);
+      for (const date of calculation.excludedNutritionDates) {
+        if (!nutritionEvidence.has(date)) {
+          nutritionEvidence.set(date, {
+            state: 'excluded',
+            reasonCodes: calculation.reasonCodes,
+            suspectedPartial: false,
+          });
+        }
+      }
+      for (const entry of calculation.suspectWeightEntries) {
+        if (!weightEvidence.has(entry.date)) {
+          weightEvidence.set(entry.date, {
+            state: 'excluded',
+            reasonCodes: ['SUSPECT_WEIGHT'],
+            suspect: true,
+          });
+        }
+      }
+    }
+
+    const boundedEntityIds = unique([
+      ...visibleNutritionRows.map((row) => row.id),
+      ...visibleWeightRows.map((row) => row.id),
+      ...scheduledRows.map((row) => row.id),
+      ...sessionRows.map((row) => row.id),
+      ...rangeCheckIns.map((row) => row.id),
+    ]);
+    const contexts = program
+      ? (observe('contexts'),
+        db
+          .select()
+          .from(adaptiveNutritionReviewContexts)
+          .where(
+            and(
+              eq(adaptiveNutritionReviewContexts.userId, userId),
+              eq(adaptiveNutritionReviewContexts.programId, program.id),
+              isNull(adaptiveNutritionReviewContexts.deletedAt),
+              or(
+                and(
+                  eq(adaptiveNutritionReviewContexts.subjectType, 'date'),
+                  sql`json_extract(${adaptiveNutritionReviewContexts.subject}, '$.localDate') between ${query.start} and ${query.end}`,
+                ),
+                and(
+                  eq(adaptiveNutritionReviewContexts.subjectType, 'date_range'),
+                  sql`json_extract(${adaptiveNutritionReviewContexts.subject}, '$.startDate') <= ${query.end}`,
+                  sql`json_extract(${adaptiveNutritionReviewContexts.subject}, '$.endDate') >= ${query.start}`,
+                ),
+                ...(boundedEntityIds.length > 0
+                  ? [
+                      sql`json_extract(${adaptiveNutritionReviewContexts.subject}, '$.id') in ${boundedEntityIds}`,
+                    ]
+                  : []),
+                and(
+                  eq(adaptiveNutritionReviewContexts.subjectType, 'upcoming_check_in'),
+                  sql`json_extract(${adaptiveNutritionReviewContexts.subject}, '$.targetReviewLocalDate') between ${query.start} and ${query.end}`,
+                ),
+              ),
+            ),
+          )
+          .orderBy(
+            asc(adaptiveNutritionReviewContexts.createdAt),
+            asc(adaptiveNutritionReviewContexts.id),
+          )
+          .all())
+      : [];
+
+    const contextDates = (context: (typeof contexts)[number]) => {
+      const subject = context.subject;
+      if (subject.kind === 'date') return [subject.localDate];
+      if (subject.kind === 'date_range') {
+        return datesBetween(
+          subject.startDate < query.start ? query.start : subject.startDate,
+          subject.endDate > query.end ? query.end : subject.endDate,
+        );
+      }
+      if (subject.kind === 'upcoming_check_in') return [subject.targetReviewLocalDate];
+      const rowDate =
+        subject.kind === 'nutrition_log'
+          ? visibleNutritionRows.find((row) => row.id === subject.id)?.date
+          : subject.kind === 'weigh_in'
+            ? visibleWeightRows.find((row) => row.id === subject.id)?.date
+            : subject.kind === 'scheduled_workout'
+              ? scheduledRows.find((row) => row.id === subject.id)?.date
+              : subject.kind === 'workout_session'
+                ? sessionRows.find((row) => row.id === subject.id)?.date
+                : rangeCheckIns.find((row) => row.id === subject.id)?.localDate;
+      return rowDate ? [rowDate] : [];
+    };
+    const contextsByDate = new Map<string, typeof contexts>();
+    for (const context of contexts) {
+      for (const date of contextDates(context)) {
+        const existing = contextsByDate.get(date) ?? [];
+        existing.push(context);
+        contextsByDate.set(date, existing);
+      }
+    }
+
+    const reviewsByDate = new Map<string, typeof overlappingReviews>();
+    for (const review of overlappingReviews.filter(
+      (item) => item.reviewLocalDate >= query.start && item.reviewLocalDate <= query.end,
+    )) {
+      const existing = reviewsByDate.get(review.reviewLocalDate) ?? [];
+      existing.push(review);
+      reviewsByDate.set(review.reviewLocalDate, existing);
+    }
+
+    const days: DataQualityCalendarDay[] = dates.map((date) => {
+      const nutrition = nutritionByDate.get(date);
+      const recordedNutritionState = nutritionEvidence.get(date);
+      const nutritionEvidenceState: DataQualityEvidenceState =
+        date === today && nutrition
+          ? 'pending_cutoff'
+          : (recordedNutritionState?.state ?? (nutrition ? 'logged' : 'missing'));
+      const qualityState = !nutrition
+        ? ('no_records' as const)
+        : recordedNutritionState?.suspectedPartial && nutrition.status === 'complete'
+          ? ('suspected_partial' as const)
+          : nutrition.status;
+
+      const weight = weightByDate.get(date);
+      const recordedWeightState = weightEvidence.get(date);
+      const weightEvidenceState: DataQualityEvidenceState =
+        date === today && weight
+          ? 'pending_cutoff'
+          : (recordedWeightState?.state ?? (weight ? 'logged' : 'missing'));
+      const trendWeightKg = trendByDate.get(date) ?? null;
+      const unit = user.weightUnit as WeightUnit;
+
+      const sessions = sessionsByDate.get(date) ?? [];
+      const sessionIds = new Set(sessions.map((session) => session.id));
+      const workoutItems: DataQualityCalendarDay['workouts'] = [
+        ...(schedulesByDate.get(date) ?? [])
+          .filter((schedule) => schedule.sessionId === null || !sessionIds.has(schedule.sessionId))
+          .map((schedule) => ({
+            id: schedule.id,
+            kind: 'scheduled_workout' as const,
+            state: 'planned' as const,
+            name: schedule.templateName ?? 'Unavailable scheduled workout',
+            sessionStatus: null,
+            scheduledWorkoutId: schedule.id,
+            sessionId: schedule.sessionId,
+            startedAt: null,
+            completedAt: null,
+            createdAt: schedule.createdAt,
+            updatedAt: schedule.updatedAt,
+            reasonCodes: [],
+            actions: [
+              {
+                kind: 'correct_workout' as const,
+                label: 'Review scheduled workout',
+                href: `/workouts/scheduled/${schedule.id}`,
+                method: 'navigate' as const,
+              },
+            ],
+          })),
+        ...sessions.map((session) => {
+          const corrected =
+            session.status === 'completed' &&
+            session.completedAt !== null &&
+            session.updatedAt > session.completedAt;
+          const state = corrected
+            ? ('corrected' as const)
+            : session.status === 'completed'
+              ? ('completed' as const)
+              : session.status === 'cancelled'
+                ? ('cancelled' as const)
+                : session.status === 'paused'
+                  ? ('paused' as const)
+                  : ('in_progress' as const);
+          return {
+            id: session.id,
+            kind: 'workout_session' as const,
+            state,
+            name: session.name,
+            sessionStatus: session.status,
+            scheduledWorkoutId: session.scheduledWorkoutId,
+            sessionId: session.id,
+            startedAt: session.startedAt,
+            completedAt: session.completedAt,
+            createdAt: session.createdAt,
+            updatedAt: session.updatedAt,
+            reasonCodes: corrected ? ['SESSION_CORRECTED_AFTER_COMPLETION'] : [],
+            actions: [
+              {
+                kind: 'correct_workout' as const,
+                label: corrected ? 'Review corrected workout' : 'Review workout',
+                href: `/workouts/session/${session.id}`,
+                method: 'navigate' as const,
+              },
+            ],
+          };
+        }),
+      ];
+
+      const checkInEvents: DataQualityCalendarDay['algorithm']['events'] = rangeCheckIns
+        .filter((checkIn) => {
+          const proposedTargets = checkIn.proposedTargets as { effectiveDate?: unknown } | null;
+          const effectiveDate =
+            checkIn.status === 'accepted' && typeof proposedTargets?.effectiveDate === 'string'
+              ? proposedTargets.effectiveDate
+              : checkIn.localDate;
+          return effectiveDate === date;
+        })
+        .map((checkIn) => {
+          const proposedTargets = checkIn.proposedTargets as { effectiveDate?: unknown } | null;
+          const effectiveDate =
+            checkIn.status === 'accepted' && typeof proposedTargets?.effectiveDate === 'string'
+              ? proposedTargets.effectiveDate
+              : checkIn.localDate;
+          return {
+            id: checkIn.id,
+            kind: 'check_in' as const,
+            state: checkIn.status,
+            effectiveDate,
+            createdAt: checkIn.createdAt,
+            reasonCodes: checkIn.reasonCodes,
+            actions: [
+              {
+                kind: 'view_check_in' as const,
+                label: 'Open Nutrition Coach',
+                href: '/nutrition?view=coach',
+                method: 'navigate' as const,
+              },
+            ],
+          };
+        });
+      const reviewEvents: DataQualityCalendarDay['algorithm']['events'] = (
+        reviewsByDate.get(date) ?? []
+      ).map((review) => {
+        const state = reviewActionState(actionsByReview.get(review.id) ?? []);
+        return {
+          id: review.id,
+          kind: 'weekly_review' as const,
+          state,
+          effectiveDate: review.reviewLocalDate,
+          createdAt: review.createdAt,
+          reasonCodes: [],
+          actions: [
+            {
+              kind: 'view_review' as const,
+              label: 'View weekly review',
+              href: `/nutrition/reviews/${review.id}`,
+              method: 'navigate' as const,
+            },
+          ],
+        };
+      });
+      const eligibility = eligibilityByDate.get(date);
+      const state =
+        date > today && programRevisions.length > 0
+          ? ('future' as const)
+          : algorithmStateForDate(date, programRevisions, checkIns, eligibility?.eligible ?? false);
+      const algorithmNutritionState =
+        state === 'no_program' || state === 'pre_program' || state === 'future'
+          ? 'not_applicable'
+          : nutritionEvidenceState;
+      const algorithmWeightState =
+        state === 'no_program' || state === 'pre_program' || state === 'future'
+          ? 'not_applicable'
+          : weightEvidenceState;
+
+      return {
+        date,
+        isToday: date === today,
+        nutrition: {
+          qualityState,
+          evidenceState: nutritionEvidenceState,
+          logId: nutrition?.id ?? null,
+          explicitStatus: nutrition?.status ?? null,
+          totals: nutrition
+            ? {
+                calories: Number(nutrition.calories),
+                protein: Number(nutrition.protein),
+                carbs: Number(nutrition.carbs),
+                fat: Number(nutrition.fat),
+              }
+            : null,
+          mealCount: nutrition ? Number(nutrition.mealCount) : null,
+          itemCount: nutrition ? Number(nutrition.itemCount) : null,
+          statusUpdatedAt: nutrition?.statusUpdatedAt ?? null,
+          updatedAt: nutrition?.updatedAt ?? null,
+          reasonCodes: recordedNutritionState?.reasonCodes ?? [],
+          actions: [nutritionStatusAction(date), addContextAction(date)],
+        },
+        weight: {
+          evidenceState: weightEvidenceState,
+          entryId: weight?.id ?? null,
+          weight: weight ? convertWeightFromKg(weight.weightKg, unit) : null,
+          unit: weight ? unit : null,
+          trendWeight: trendWeightKg === null ? null : convertWeightFromKg(trendWeightKg, unit),
+          corrected: weight ? weight.updatedAt > weight.createdAt : false,
+          suspect: recordedWeightState?.suspect ?? false,
+          stale:
+            weight !== undefined &&
+            date < addDays(today, -7) &&
+            visibleWeightRows.at(-1)?.date === date,
+          createdAt: weight?.createdAt ?? null,
+          updatedAt: weight?.updatedAt ?? null,
+          reasonCodes: recordedWeightState?.reasonCodes ?? [],
+          actions: weight
+            ? [
+                {
+                  kind: 'correct_weight' as const,
+                  label: 'Review weight measurement',
+                  href: `/weight/history?date=${date}`,
+                  method: 'navigate' as const,
+                },
+                addContextAction(date),
+              ]
+            : [addContextAction(date)],
+        },
+        workouts: workoutItems,
+        algorithm: {
+          state,
+          nutritionEvidenceState: algorithmNutritionState,
+          weightEvidenceState: algorithmWeightState,
+          reasonCodes: unique([
+            ...(state === 'future' ? ['FUTURE_DATE_NOT_EVALUATED'] : []),
+            ...(state === 'learning' || state === 'holding'
+              ? (eligibility?.holdReasons ?? [])
+              : []),
+            ...(recordedNutritionState?.reasonCodes ?? []),
+            ...(recordedWeightState?.reasonCodes ?? []),
+          ]),
+          events: [...checkInEvents, ...reviewEvents].sort(
+            (left, right) => left.createdAt - right.createdAt || left.id.localeCompare(right.id),
+          ),
+        },
+        contexts: (contextsByDate.get(date) ?? []).map((context) => ({
+          id: context.id,
+          category: context.category,
+          note: context.note,
+          resolution: context.resolution,
+          provenance: {
+            type: context.createdBy,
+            agentTokenId: context.agentTokenId,
+            label: context.actorLabel,
+          },
+          subjectKind: context.subject.kind,
+          revision: context.revision,
+          createdAt: context.createdAt,
+          updatedAt: context.updatedAt,
+          actions: [
+            {
+              kind: 'add_context' as const,
+              label: 'Review context in Nutrition Coach',
+              href: '/nutrition?view=coach',
+              method: 'navigate' as const,
+            },
+          ],
+        })),
+      };
+    });
+
+    return dataQualityCalendarSchema.parse({
+      range: { startDate: query.start, endDate: query.end },
+      timeZone,
+      days,
+      summary: summaryFor(days),
+    });
+  };
+
+  return { getCalendar };
+};
+
+export const getDataQualityCalendar = async (userId: string, query: DataQualityCalendarQuery) => {
+  const { db } = await import('../../db/index.js');
+  return createDataQualityCalendarStore({ db }).getCalendar(userId, query);
+};

--- a/apps/api/src/routes/data-quality/store.ts
+++ b/apps/api/src/routes/data-quality/store.ts
@@ -16,7 +16,7 @@ import {
   type WeightUnit,
 } from '@pulse/shared';
 import type Database from 'better-sqlite3';
-import { and, asc, eq, gte, inArray, isNull, lte, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, inArray, isNull, lte, max, or, sql } from 'drizzle-orm';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
 import * as schema from '../../db/schema/index.js';
@@ -39,7 +39,6 @@ import {
 import {
   adaptiveAnalyticsStateForPoint,
   getDateKeyInTimeZone,
-  resolveEffectiveProgramRevisions,
   type EffectiveProgramRevision,
 } from '../adaptive-nutrition/analytics-store.js';
 import { createAdaptiveWeeklyReviewStore } from '../adaptive-nutrition/review-store.js';
@@ -180,7 +179,9 @@ const summaryFor = (days: DataQualityCalendarDay[]): DataQualityCalendar['summar
     excluded: days.filter((day) => day.weight.evidenceState === 'excluded').length,
   },
   workout: {
-    planned: days.flatMap((day) => day.workouts).filter((item) => item.state === 'planned').length,
+    planned: days
+      .flatMap((day) => day.workouts)
+      .filter((item) => item.state === 'planned' || item.state === 'scheduled').length,
     active: days
       .flatMap((day) => day.workouts)
       .filter((item) => item.state === 'in_progress' || item.state === 'paused').length,
@@ -205,16 +206,20 @@ const summaryFor = (days: DataQualityCalendarDay[]): DataQualityCalendar['summar
 
 export const createDataQualityCalendarStore = (dependencies: {
   db: DataQualityDatabase;
-  sqlite?: Database.Database;
+  sqlite: Database.Database;
   now?: () => Date;
   onQuery?: (source: string) => void;
 }) => {
   const { db } = dependencies;
   const now = dependencies.now ?? (() => new Date());
   const observe = dependencies.onQuery ?? (() => undefined);
-  const reviewStore = dependencies.sqlite
-    ? createAdaptiveWeeklyReviewStore({ db, sqlite: dependencies.sqlite, now })
-    : null;
+  dependencies.sqlite.function(
+    'pulse_date_key',
+    { deterministic: true },
+    (effectiveAt: number, timeZone: string) =>
+      getDateKeyInTimeZone(new Date(Number(effectiveAt)), String(timeZone)),
+  );
+  const reviewStore = createAdaptiveWeeklyReviewStore({ db, sqlite: dependencies.sqlite, now });
 
   const getCalendar = (userId: string, rawQuery: DataQualityCalendarQuery): DataQualityCalendar => {
     const parsedQuery = dataQualityCalendarQuerySchema.parse(rawQuery);
@@ -234,34 +239,33 @@ export const createDataQualityCalendarStore = (dependencies: {
       .where(eq(adaptiveNutritionPrograms.userId, userId))
       .limit(1)
       .get();
-    const programRevisions = program
-      ? (observe('program-revisions'),
-        resolveEffectiveProgramRevisions(
-          db
-            .select({
-              id: adaptiveNutritionProgramRevisions.id,
-              sequence: adaptiveNutritionProgramRevisions.sequence,
-              effectiveAt: adaptiveNutritionProgramRevisions.effectiveAt,
-              snapshot: adaptiveNutritionProgramRevisions.snapshot,
-            })
-            .from(adaptiveNutritionProgramRevisions)
-            .where(
-              and(
-                eq(adaptiveNutritionProgramRevisions.userId, userId),
-                eq(adaptiveNutritionProgramRevisions.programId, program.id),
-              ),
-            )
-            .orderBy(asc(adaptiveNutritionProgramRevisions.sequence))
-            .all()
-            .map((revision) => ({
-              ...revision,
-              snapshot: adaptiveProgramCalculationSchema.parse(revision.snapshot),
-            })),
-        ))
-      : [];
+    const revisionSelection = {
+      id: adaptiveNutritionProgramRevisions.id,
+      sequence: adaptiveNutritionProgramRevisions.sequence,
+      effectiveAt: adaptiveNutritionProgramRevisions.effectiveAt,
+      snapshot: adaptiveNutritionProgramRevisions.snapshot,
+    };
+    const latestRevisionRow = program
+      ? (observe('latest-program-revision'),
+        db
+          .select(revisionSelection)
+          .from(adaptiveNutritionProgramRevisions)
+          .where(
+            and(
+              eq(adaptiveNutritionProgramRevisions.userId, userId),
+              eq(adaptiveNutritionProgramRevisions.programId, program.id),
+            ),
+          )
+          .orderBy(desc(adaptiveNutritionProgramRevisions.sequence))
+          .limit(1)
+          .get())
+      : undefined;
+    const latestRevisionSnapshot = latestRevisionRow
+      ? adaptiveProgramCalculationSchema.parse(latestRevisionRow.snapshot)
+      : null;
     const timeZone =
       parsedQuery.timeZone ??
-      programRevisions.at(-1)?.snapshot.timeZone ??
+      latestRevisionSnapshot?.timeZone ??
       preferenceTimeZone(user.preferences) ??
       'UTC';
     const today = getDateKeyInTimeZone(now(), timeZone);
@@ -271,6 +275,83 @@ export const createDataQualityCalendarStore = (dependencies: {
       end: parsedQuery.end ?? bootstrapRange.end,
       timeZone: parsedQuery.timeZone,
     };
+    type RevisionDateRow = {
+      id: string;
+      sequence: number;
+      effectiveAt: number;
+      snapshot: string | unknown;
+      effectiveLocalDate: string;
+    };
+    const programRevisions = program
+      ? (observe('range-program-revisions'),
+        (
+          dependencies.sqlite
+            .prepare(
+              `with recursive resolved(id, sequence, effectiveAt, snapshot, effectiveLocalDate) as (
+               select r.id,
+                      r.sequence,
+                      r.effective_at,
+                      r.snapshot,
+                      pulse_date_key(r.effective_at, json_extract(r.snapshot, '$.timeZone'))
+                 from adaptive_nutrition_program_revisions r
+                where r.user_id = @userId
+                  and r.program_id = @programId
+                  and r.sequence = (
+                    select min(first.sequence)
+                      from adaptive_nutrition_program_revisions first
+                     where first.user_id = @userId and first.program_id = @programId
+                  )
+               union all
+               select next.id,
+                      next.sequence,
+                      next.effective_at,
+                      next.snapshot,
+                      max(
+                        resolved.effectiveLocalDate,
+                        pulse_date_key(next.effective_at, json_extract(next.snapshot, '$.timeZone')),
+                        pulse_date_key(next.effective_at, json_extract(resolved.snapshot, '$.timeZone'))
+                      )
+                 from resolved
+                 join adaptive_nutrition_program_revisions next
+                   on next.user_id = @userId
+                  and next.program_id = @programId
+                  and next.sequence = resolved.sequence + 1
+             ), in_range as (
+               select *,
+                      row_number() over (
+                        partition by effectiveLocalDate order by sequence desc
+                      ) as dateRank
+                 from resolved
+                where effectiveLocalDate between @start and @end
+             ), prior as (
+               select *
+                 from resolved
+                where effectiveLocalDate < @start
+                order by sequence desc
+                limit 1
+             )
+             select id, sequence, effectiveAt, snapshot, effectiveLocalDate from prior
+             union all
+             select id, sequence, effectiveAt, snapshot, effectiveLocalDate
+               from in_range
+              where dateRank = 1
+             order by sequence`,
+            )
+            .all({
+              userId,
+              programId: program.id,
+              start: query.start,
+              end: query.end,
+            }) as RevisionDateRow[]
+        ).map((revision) => ({
+          ...revision,
+          snapshot: adaptiveProgramCalculationSchema.parse(
+            typeof revision.snapshot === 'string'
+              ? JSON.parse(revision.snapshot)
+              : revision.snapshot,
+          ),
+        })))
+      : [];
     const dates = datesBetween(query.start, query.end);
     const earliestBoundaries = calculateAdaptiveDateBoundaries(query.start, false);
     const evidenceStart = earliestBoundaries.analysisStart;
@@ -337,6 +418,12 @@ export const createDataQualityCalendarStore = (dependencies: {
       (row) => row.date >= query.start && row.date <= query.end,
     );
     const weightByDate = new Map(visibleWeightRows.map((row) => [row.date, row]));
+    observe('latest-weight');
+    const latestWeightDate = db
+      .select({ date: max(bodyWeight.date) })
+      .from(bodyWeight)
+      .where(and(eq(bodyWeight.userId, userId), lte(bodyWeight.date, today)))
+      .get()?.date;
     const trendByDate = new Map(
       calculateCanonicalTrendWeightSeries(allWeightRows, query.start, query.end).map((point) => [
         point.date,
@@ -373,7 +460,10 @@ export const createDataQualityCalendarStore = (dependencies: {
           lte(scheduledWorkouts.date, query.end),
         ),
       )
-      .orderBy(asc(scheduledWorkouts.date), asc(scheduledWorkouts.createdAt))
+      .orderBy(
+        sql`row_number() over (partition by ${scheduledWorkouts.date} order by ${scheduledWorkouts.createdAt}, ${scheduledWorkouts.id})`,
+        asc(scheduledWorkouts.date),
+      )
       .limit(2_100)
       .all();
     observe('workout-sessions');
@@ -398,9 +488,58 @@ export const createDataQualityCalendarStore = (dependencies: {
           lte(workoutSessions.date, query.end),
         ),
       )
-      .orderBy(asc(workoutSessions.date), asc(workoutSessions.startedAt))
+      .orderBy(
+        sql`row_number() over (partition by ${workoutSessions.date} order by ${workoutSessions.createdAt}, ${workoutSessions.id})`,
+        asc(workoutSessions.date),
+      )
       .limit(2_100)
       .all();
+    observe('workout-counts');
+    const visibleScheduleCounts = db
+      .select({
+        date: scheduledWorkouts.date,
+        count: sql<number>`count(*)`,
+      })
+      .from(scheduledWorkouts)
+      .leftJoin(
+        workoutSessions,
+        and(
+          eq(workoutSessions.id, scheduledWorkouts.sessionId),
+          eq(workoutSessions.userId, userId),
+          isNull(workoutSessions.deletedAt),
+        ),
+      )
+      .where(
+        and(
+          eq(scheduledWorkouts.userId, userId),
+          gte(scheduledWorkouts.date, query.start),
+          lte(scheduledWorkouts.date, query.end),
+          or(
+            isNull(scheduledWorkouts.sessionId),
+            isNull(workoutSessions.id),
+            sql`${workoutSessions.date} <> ${scheduledWorkouts.date}`,
+          ),
+        ),
+      )
+      .groupBy(scheduledWorkouts.date)
+      .all();
+    const visibleSessionCounts = db
+      .select({ date: workoutSessions.date, count: sql<number>`count(*)` })
+      .from(workoutSessions)
+      .where(
+        and(
+          eq(workoutSessions.userId, userId),
+          isNull(workoutSessions.deletedAt),
+          gte(workoutSessions.date, query.start),
+          lte(workoutSessions.date, query.end),
+        ),
+      )
+      .groupBy(workoutSessions.date)
+      .all();
+    const workoutCountByDate = new Map<string, number>();
+    for (const row of [...visibleScheduleCounts, ...visibleSessionCounts]) {
+      workoutCountByDate.set(row.date, (workoutCountByDate.get(row.date) ?? 0) + Number(row.count));
+    }
     const linkedScheduleIds = unique(
       visibleSessionRows
         .map((session) => session.scheduledWorkoutId)
@@ -525,18 +664,47 @@ export const createDataQualityCalendarStore = (dependencies: {
             ),
           )
           .orderBy(
+            sql`row_number() over (
+              partition by case
+                when ${adaptiveNutritionCheckIns.status} = 'accepted'
+                  then coalesce(json_extract(${adaptiveNutritionCheckIns.proposedTargets}, '$.effectiveDate'), ${adaptiveNutritionCheckIns.localDate})
+                else ${adaptiveNutritionCheckIns.localDate}
+              end
+              order by ${adaptiveNutritionCheckIns.createdAt}, ${adaptiveNutritionCheckIns.id}
+            )`,
             asc(adaptiveNutritionCheckIns.localDate),
-            asc(adaptiveNutritionCheckIns.createdAt),
           )
           .limit(2_100)
           .all())
+      : [];
+    const checkInCounts = program
+      ? (observe('check-in-counts'),
+        dependencies.sqlite
+          .prepare(
+            `select case
+                      when status = 'accepted'
+                        then coalesce(json_extract(proposed_targets, '$.effectiveDate'), local_date)
+                      else local_date
+                    end as localDate,
+                    count(*) as totalCount
+               from adaptive_nutrition_checkins
+              where user_id = @userId
+                and program_id = @programId
+                and (local_date between @start and @end
+                  or json_extract(proposed_targets, '$.effectiveDate') between @start and @end)
+              group by localDate`,
+          )
+          .all({ userId, programId: program.id, start: query.start, end: query.end }) as Array<{
+          localDate: string;
+          totalCount: number;
+        }>)
       : [];
     const checkIns = priorCheckIn
       ? [priorCheckIn, ...rangeCheckIns.filter((row) => row.id !== priorCheckIn.id)]
       : rangeCheckIns;
 
     const overlappingReviews = program
-      ? (observe('overlapping-reviews'),
+      ? (observe('range-reviews'),
         db
           .select()
           .from(adaptiveNutritionReviews)
@@ -544,11 +712,37 @@ export const createDataQualityCalendarStore = (dependencies: {
             and(
               eq(adaptiveNutritionReviews.userId, userId),
               eq(adaptiveNutritionReviews.programId, program.id),
-              lte(adaptiveNutritionReviews.analysisStart, query.end),
-              gte(adaptiveNutritionReviews.analysisEnd, query.start),
+              gte(adaptiveNutritionReviews.reviewLocalDate, query.start),
+              lte(adaptiveNutritionReviews.reviewLocalDate, query.end),
             ),
           )
-          .orderBy(asc(adaptiveNutritionReviews.createdAt))
+          .orderBy(
+            sql`row_number() over (
+              partition by ${adaptiveNutritionReviews.reviewLocalDate}
+              order by ${adaptiveNutritionReviews.createdAt}, ${adaptiveNutritionReviews.id}
+            )`,
+            asc(adaptiveNutritionReviews.reviewLocalDate),
+          )
+          .limit(2_100)
+          .all())
+      : [];
+    const reviewCounts = program
+      ? (observe('review-counts'),
+        db
+          .select({
+            localDate: adaptiveNutritionReviews.reviewLocalDate,
+            totalCount: sql<number>`count(*)`,
+          })
+          .from(adaptiveNutritionReviews)
+          .where(
+            and(
+              eq(adaptiveNutritionReviews.userId, userId),
+              eq(adaptiveNutritionReviews.programId, program.id),
+              gte(adaptiveNutritionReviews.reviewLocalDate, query.start),
+              lte(adaptiveNutritionReviews.reviewLocalDate, query.end),
+            ),
+          )
+          .groupBy(adaptiveNutritionReviews.reviewLocalDate)
           .all())
       : [];
     const reviewIds = overlappingReviews.map((review) => review.id);
@@ -562,12 +756,15 @@ export const createDataQualityCalendarStore = (dependencies: {
               and(
                 eq(adaptiveNutritionReviewActions.userId, userId),
                 inArray(adaptiveNutritionReviewActions.reviewId, reviewIds),
+                sql`${adaptiveNutritionReviewActions.sequence} = (
+                  select max(latest.sequence)
+                    from adaptive_nutrition_review_actions latest
+                   where latest.review_id = ${adaptiveNutritionReviewActions.reviewId}
+                     and latest.user_id = ${userId}
+                )`,
               ),
             )
-            .orderBy(
-              asc(adaptiveNutritionReviewActions.reviewId),
-              asc(adaptiveNutritionReviewActions.sequence),
-            )
+            .orderBy(asc(adaptiveNutritionReviewActions.reviewId))
             .all())
         : [];
     const actionsByReview = new Map<string, typeof reviewActions>();
@@ -576,17 +773,13 @@ export const createDataQualityCalendarStore = (dependencies: {
       existing.push(action);
       actionsByReview.set(action.reviewId, existing);
     }
-    const projectedReview = reviewStore
-      ? ([...overlappingReviews]
-          .reverse()
-          .filter((review) =>
-            ['pending', 'awaiting_clarification', 'deferred'].includes(
-              reviewActionState(actionsByReview.get(review.id) ?? []),
-            ),
-          )
-          .slice(0, 1)
-          .map((review) => reviewStore.get(userId, review.id))[0] ?? null)
-      : null;
+    const pendingReview = program ? reviewStore.getPendingProjection(userId) : null;
+    const projectedReview =
+      pendingReview &&
+      pendingReview.snapshot.analysisStart <= query.end &&
+      pendingReview.snapshot.analysisEnd >= query.start
+        ? pendingReview
+        : null;
 
     const nutritionEvidence = new Map<
       string,
@@ -669,82 +862,104 @@ export const createDataQualityCalendarStore = (dependencies: {
       }
     }
 
-    const boundedEntityIds = unique([
-      ...visibleNutritionRows.map((row) => row.id),
-      ...visibleWeightRows.map((row) => row.id),
-      ...scheduledRows.map((row) => row.id),
-      ...sessionRows.map((row) => row.id),
-      ...rangeCheckIns.map((row) => row.id),
-    ]);
-    const contexts = program
+    type ContextDateRow = { contextId: string; localDate: string; totalCount: number };
+    const contextDateRows = program
       ? (observe('contexts'),
-        db
-          .select()
-          .from(adaptiveNutritionReviewContexts)
-          .where(
-            and(
-              eq(adaptiveNutritionReviewContexts.userId, userId),
-              eq(adaptiveNutritionReviewContexts.programId, program.id),
-              isNull(adaptiveNutritionReviewContexts.deletedAt),
-              or(
-                and(
-                  eq(adaptiveNutritionReviewContexts.subjectType, 'date'),
-                  sql`json_extract(${adaptiveNutritionReviewContexts.subject}, '$.localDate') between ${query.start} and ${query.end}`,
-                ),
-                and(
-                  eq(adaptiveNutritionReviewContexts.subjectType, 'date_range'),
-                  sql`json_extract(${adaptiveNutritionReviewContexts.subject}, '$.startDate') <= ${query.end}`,
-                  sql`json_extract(${adaptiveNutritionReviewContexts.subject}, '$.endDate') >= ${query.start}`,
-                ),
-                ...(boundedEntityIds.length > 0
-                  ? [
-                      sql`json_extract(${adaptiveNutritionReviewContexts.subject}, '$.id') in ${boundedEntityIds}`,
-                    ]
-                  : []),
-                and(
-                  eq(adaptiveNutritionReviewContexts.subjectType, 'upcoming_check_in'),
-                  sql`json_extract(${adaptiveNutritionReviewContexts.subject}, '$.targetReviewLocalDate') between ${query.start} and ${query.end}`,
-                ),
-              ),
-            ),
+        dependencies.sqlite
+          .prepare(
+            `with recursive requested_dates(local_date) as (
+               select @start
+               union all
+               select date(local_date, '+1 day') from requested_dates where local_date < @end
+             ), mapped as (
+               select c.id as contextId,
+                      d.local_date as localDate,
+                      row_number() over (
+                        partition by d.local_date order by c.created_at, c.id
+                      ) as rowNumber,
+                      count(*) over (partition by d.local_date) as totalCount
+                 from adaptive_nutrition_review_contexts c
+                 cross join requested_dates d
+                where c.user_id = @userId
+                  and c.program_id = @programId
+                  and c.deleted_at is null
+                  and (
+                    (c.subject_type = 'date'
+                      and json_extract(c.subject, '$.localDate') = d.local_date)
+                    or (c.subject_type = 'date_range'
+                      and json_extract(c.subject, '$.startDate') <= d.local_date
+                      and json_extract(c.subject, '$.endDate') >= d.local_date)
+                    or (c.subject_type = 'upcoming_check_in'
+                      and json_extract(c.subject, '$.targetReviewLocalDate') = d.local_date)
+                    or (c.subject_type = 'nutrition_log' and exists (
+                      select 1 from nutrition_logs n
+                       where n.id = json_extract(c.subject, '$.id')
+                         and n.user_id = @userId and n.date = d.local_date
+                    ))
+                    or (c.subject_type = 'weigh_in' and exists (
+                      select 1 from body_weight w
+                       where w.id = json_extract(c.subject, '$.id')
+                         and w.user_id = @userId and w.date = d.local_date
+                    ))
+                    or (c.subject_type = 'scheduled_workout' and exists (
+                      select 1 from scheduled_workouts sw
+                       where sw.id = json_extract(c.subject, '$.id')
+                         and sw.user_id = @userId and sw.date = d.local_date
+                    ))
+                    or (c.subject_type = 'workout_session' and exists (
+                      select 1 from workout_sessions ws
+                       where ws.id = json_extract(c.subject, '$.id')
+                         and ws.user_id = @userId and ws.deleted_at is null
+                         and ws.date = d.local_date
+                    ))
+                    or (c.subject_type = 'check_in' and exists (
+                      select 1 from adaptive_nutrition_checkins ci
+                       where ci.id = json_extract(c.subject, '$.id')
+                         and ci.user_id = @userId and ci.local_date = d.local_date
+                    ))
+                  )
+             )
+             select contextId, localDate, totalCount
+               from mapped
+              where rowNumber <= 100
+              order by localDate, rowNumber`,
           )
-          .orderBy(
-            asc(adaptiveNutritionReviewContexts.createdAt),
-            asc(adaptiveNutritionReviewContexts.id),
-          )
-          .limit(4_201)
-          .all())
+          .all({
+            start: query.start,
+            end: query.end,
+            userId,
+            programId: program.id,
+          }) as ContextDateRow[])
       : [];
-
-    const contextDates = (context: (typeof contexts)[number]) => {
-      const subject = context.subject;
-      if (subject.kind === 'date') return [subject.localDate];
-      if (subject.kind === 'date_range') {
-        return datesBetween(
-          subject.startDate < query.start ? query.start : subject.startDate,
-          subject.endDate > query.end ? query.end : subject.endDate,
-        );
-      }
-      if (subject.kind === 'upcoming_check_in') return [subject.targetReviewLocalDate];
-      const rowDate =
-        subject.kind === 'nutrition_log'
-          ? visibleNutritionRows.find((row) => row.id === subject.id)?.date
-          : subject.kind === 'weigh_in'
-            ? visibleWeightRows.find((row) => row.id === subject.id)?.date
-            : subject.kind === 'scheduled_workout'
-              ? scheduledRows.find((row) => row.id === subject.id)?.date
-              : subject.kind === 'workout_session'
-                ? sessionRows.find((row) => row.id === subject.id)?.date
-                : rangeCheckIns.find((row) => row.id === subject.id)?.localDate;
-      return rowDate ? [rowDate] : [];
-    };
+    const selectedContextIds = unique(contextDateRows.map((row) => row.contextId));
+    const contexts =
+      selectedContextIds.length > 0
+        ? db
+            .select()
+            .from(adaptiveNutritionReviewContexts)
+            .where(
+              and(
+                eq(adaptiveNutritionReviewContexts.userId, userId),
+                isNull(adaptiveNutritionReviewContexts.deletedAt),
+                inArray(adaptiveNutritionReviewContexts.id, selectedContextIds),
+              ),
+            )
+            .orderBy(
+              asc(adaptiveNutritionReviewContexts.createdAt),
+              asc(adaptiveNutritionReviewContexts.id),
+            )
+            .all()
+        : [];
+    const contextById = new Map(contexts.map((context) => [context.id, context]));
     const contextsByDate = new Map<string, typeof contexts>();
-    for (const context of contexts) {
-      for (const date of contextDates(context)) {
-        const existing = contextsByDate.get(date) ?? [];
-        existing.push(context);
-        contextsByDate.set(date, existing);
-      }
+    const contextCountByDate = new Map<string, number>();
+    for (const row of contextDateRows) {
+      const context = contextById.get(row.contextId);
+      if (!context) continue;
+      const existing = contextsByDate.get(row.localDate) ?? [];
+      existing.push(context);
+      contextsByDate.set(row.localDate, existing);
+      contextCountByDate.set(row.localDate, Number(row.totalCount));
     }
 
     const reviewsByDate = new Map<string, typeof overlappingReviews>();
@@ -754,6 +969,13 @@ export const createDataQualityCalendarStore = (dependencies: {
       const existing = reviewsByDate.get(review.reviewLocalDate) ?? [];
       existing.push(review);
       reviewsByDate.set(review.reviewLocalDate, existing);
+    }
+    const algorithmEventCountByDate = new Map<string, number>();
+    for (const row of [...checkInCounts, ...reviewCounts]) {
+      algorithmEventCountByDate.set(
+        row.localDate,
+        (algorithmEventCountByDate.get(row.localDate) ?? 0) + Number(row.totalCount),
+      );
     }
     const scheduleById = new Map(scheduledRows.map((row) => [row.id, row]));
     const sessionById = new Map(sessionRows.map((row) => [row.id, row]));
@@ -782,49 +1004,55 @@ export const createDataQualityCalendarStore = (dependencies: {
 
       const sessions = sessionsByDate.get(date) ?? [];
       const allWorkoutItems: DataQualityCalendarDay['workouts'] = [
-        ...(schedulesByDate.get(date) ?? []).map((schedule) => {
-          const linkedSession = schedule.sessionId
-            ? sessionById.get(schedule.sessionId)
-            : undefined;
-          const moved = linkedSession !== undefined && linkedSession.date !== schedule.date;
-          return {
-            id: schedule.id,
-            kind: 'scheduled_workout' as const,
-            state: moved ? ('moved' as const) : ('planned' as const),
-            name: schedule.templateName ?? 'Unavailable scheduled workout',
-            sessionStatus: linkedSession?.status ?? null,
-            scheduledWorkoutId: schedule.id,
-            sessionId: schedule.sessionId,
-            plannedDate: schedule.date,
-            sessionDate: linkedSession?.date ?? null,
-            relation:
-              linkedSession === undefined
-                ? ('unlinked' as const)
-                : moved
-                  ? ('linked_different_date' as const)
-                  : ('linked_same_date' as const),
-            relationLimitation: moved
-              ? 'Pulse retains the linked plan and session dates, but no immutable movement event is recorded.'
-              : null,
-            correctionState: 'not_applicable' as const,
-            startedAt: null,
-            completedAt: null,
-            createdAt: schedule.createdAt,
-            updatedAt: schedule.updatedAt,
-            provenance: notRecordedProvenance(
-              'Historical creator provenance is not retained for scheduled workouts.',
-            ),
-            reasonCodes: [],
-            actions: [
-              {
-                kind: 'correct_workout' as const,
-                label: 'Review scheduled workout',
-                href: `/workouts/scheduled/${schedule.id}`,
-                method: 'navigate' as const,
-              },
-            ],
-          };
-        }),
+        ...(schedulesByDate.get(date) ?? [])
+          .filter((schedule) => {
+            if (!schedule.sessionId) return true;
+            const linkedSession = sessionById.get(schedule.sessionId);
+            return linkedSession === undefined || linkedSession.date !== schedule.date;
+          })
+          .map((schedule) => {
+            const linkedSession = schedule.sessionId
+              ? sessionById.get(schedule.sessionId)
+              : undefined;
+            const moved = linkedSession !== undefined && linkedSession.date !== schedule.date;
+            return {
+              id: schedule.id,
+              kind: 'scheduled_workout' as const,
+              state: moved ? ('moved' as const) : ('planned' as const),
+              name: schedule.templateName ?? 'Unavailable scheduled workout',
+              sessionStatus: linkedSession?.status ?? null,
+              scheduledWorkoutId: schedule.id,
+              sessionId: schedule.sessionId,
+              plannedDate: schedule.date,
+              sessionDate: linkedSession?.date ?? null,
+              relation:
+                linkedSession === undefined
+                  ? ('unlinked' as const)
+                  : moved
+                    ? ('linked_different_date' as const)
+                    : ('linked_same_date' as const),
+              relationLimitation: moved
+                ? 'Pulse retains the linked plan and session dates, but no immutable movement event is recorded.'
+                : null,
+              correctionState: 'not_applicable' as const,
+              startedAt: null,
+              completedAt: null,
+              createdAt: schedule.createdAt,
+              updatedAt: schedule.updatedAt,
+              provenance: notRecordedProvenance(
+                'Historical creator provenance is not retained for scheduled workouts.',
+              ),
+              reasonCodes: [],
+              actions: [
+                {
+                  kind: 'correct_workout' as const,
+                  label: 'Review scheduled workout',
+                  href: `/workouts/scheduled/${schedule.id}`,
+                  method: 'navigate' as const,
+                },
+              ],
+            };
+          }),
         ...sessions.map((session) => {
           const linkedSchedule = session.scheduledWorkoutId
             ? scheduleById.get(session.scheduledWorkoutId)
@@ -1006,10 +1234,7 @@ export const createDataQualityCalendarStore = (dependencies: {
           trendWeight: trendWeightKg === null ? null : convertWeightFromKg(trendWeightKg, unit),
           correctionState: weight ? 'history_unavailable' : 'not_applicable',
           suspect: recordedWeightState?.suspect ?? false,
-          stale:
-            weight !== undefined &&
-            date < addDays(today, -7) &&
-            visibleWeightRows.at(-1)?.date === date,
+          stale: weight !== undefined && date < addDays(today, -7) && latestWeightDate === date,
           createdAt: weight?.createdAt ?? null,
           updatedAt: weight?.updatedAt ?? null,
           provenance: weight
@@ -1044,7 +1269,10 @@ export const createDataQualityCalendarStore = (dependencies: {
             ...(recordedWeightState?.reasonCodes ?? []),
           ]),
           events: allAlgorithmEvents.slice(0, 50),
-          omittedEventCount: Math.max(0, allAlgorithmEvents.length - 50),
+          omittedEventCount: Math.max(
+            0,
+            (algorithmEventCountByDate.get(date) ?? allAlgorithmEvents.length) - 50,
+          ),
         },
         contexts: (contextsByDate.get(date) ?? []).slice(0, 100).map((context) => ({
           id: context.id,
@@ -1069,8 +1297,14 @@ export const createDataQualityCalendarStore = (dependencies: {
             },
           ],
         })),
-        omittedWorkoutCount: Math.max(0, allWorkoutItems.length - workoutItems.length),
-        omittedContextCount: Math.max(0, (contextsByDate.get(date) ?? []).length - 100),
+        omittedWorkoutCount: Math.max(
+          0,
+          (workoutCountByDate.get(date) ?? allWorkoutItems.length) - workoutItems.length,
+        ),
+        omittedContextCount: Math.max(
+          0,
+          (contextCountByDate.get(date) ?? (contextsByDate.get(date) ?? []).length) - 100,
+        ),
       };
     });
 

--- a/apps/api/src/routes/data-quality/store.ts
+++ b/apps/api/src/routes/data-quality/store.ts
@@ -1,7 +1,6 @@
 import {
   adaptiveProgramCalculationSchema,
   adaptiveRecommendationSchema,
-  adaptiveWeeklyReviewSnapshotSchema,
   calculateAdaptiveDateBoundaries,
   calculateCanonicalTrendWeightSeries,
   convertWeightFromKg,
@@ -16,6 +15,7 @@ import {
   type DataQualityEvidenceState,
   type WeightUnit,
 } from '@pulse/shared';
+import type Database from 'better-sqlite3';
 import { and, asc, eq, gte, inArray, isNull, lte, or, sql } from 'drizzle-orm';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
@@ -37,10 +37,12 @@ import {
   workoutTemplates,
 } from '../../db/schema/index.js';
 import {
+  adaptiveAnalyticsStateForPoint,
   getDateKeyInTimeZone,
   resolveEffectiveProgramRevisions,
   type EffectiveProgramRevision,
 } from '../adaptive-nutrition/analytics-store.js';
+import { createAdaptiveWeeklyReviewStore } from '../adaptive-nutrition/review-store.js';
 
 type DataQualityDatabase = BetterSQLite3Database<typeof schema>;
 
@@ -75,6 +77,20 @@ const preferenceTimeZone = (preferences: unknown) => {
 
 const unique = <T>(values: readonly T[]) => [...new Set(values)];
 
+const notRecordedProvenance = (limitation: string) => ({
+  type: 'not_recorded' as const,
+  label: 'Not recorded',
+  agentTokenId: null,
+  limitation,
+});
+
+const systemProvenance = {
+  type: 'system_derived' as const,
+  label: 'Pulse algorithm',
+  agentTokenId: null,
+  limitation: null,
+};
+
 const nutritionStatusAction = (date: string) => ({
   kind: 'set_nutrition_status' as const,
   label: 'Review nutrition day status',
@@ -101,6 +117,16 @@ const reviewActionState = (
   return 'pending';
 };
 
+const monthGridRange = (date: string) => {
+  const monthStart = `${date.slice(0, 7)}-01`;
+  const first = new Date(`${monthStart}T00:00:00.000Z`);
+  const start = addDays(monthStart, -((first.getUTCDay() + 6) % 7));
+  const next = new Date(first);
+  next.setUTCMonth(next.getUTCMonth() + 1);
+  const last = addDays(next.toISOString().slice(0, 10), -1);
+  return { start, end: addDays(last, (7 - new Date(`${last}T00:00:00.000Z`).getUTCDay()) % 7) };
+};
+
 const programRevisionForDate = (
   revisions: EffectiveProgramRevision[],
   date: string,
@@ -121,17 +147,20 @@ const algorithmStateForDate = (
   const revision = programRevisionForDate(revisions, date);
   if (!revision) return revisions.length === 0 ? 'no_program' : 'pre_program';
   if (revision.snapshot.status === 'paused') return 'holding';
-  if (eligible) return 'updating';
   const latest = checkIns
-    .filter((checkIn) => checkIn.localDate <= date)
+    .filter(
+      (checkIn) =>
+        checkIn.localDate <= date && ['accepted', 'held', 'pending'].includes(checkIn.status),
+    )
     .sort(
       (left, right) =>
         left.localDate.localeCompare(right.localDate) || left.createdAt - right.createdAt,
     )
     .at(-1);
   if (!latest) return 'learning';
-  if (latest.status === 'held' || latest.calculationState === 'holding') return 'holding';
-  if (latest.status === 'accepted' && latest.calculationState === 'updating') return 'holding';
+  const state = adaptiveAnalyticsStateForPoint(latest, latest.calculationState);
+  if (state === 'holding') return 'holding';
+  if (state === 'updating') return eligible ? 'updating' : 'holding';
   return 'learning';
 };
 
@@ -149,7 +178,7 @@ const summaryFor = (days: DataQualityCalendarDay[]): DataQualityCalendar['summar
     missing: days.filter((day) => day.weight.entryId === null).length,
     pending: days.filter((day) => day.weight.evidenceState === 'pending_cutoff').length,
     excluded: days.filter((day) => day.weight.evidenceState === 'excluded').length,
-    corrected: days.filter((day) => day.weight.corrected).length,
+    corrected: days.filter((day) => day.weight.correctionState === 'confirmed').length,
   },
   workout: {
     planned: days.flatMap((day) => day.workouts).filter((item) => item.state === 'planned').length,
@@ -174,19 +203,24 @@ const summaryFor = (days: DataQualityCalendarDay[]): DataQualityCalendar['summar
     ).length,
   },
   contextDays: days.filter((day) => day.contexts.length > 0).length,
+  intervalLabel: 'Visible calendar grid',
 });
 
 export const createDataQualityCalendarStore = (dependencies: {
   db: DataQualityDatabase;
+  sqlite?: Database.Database;
   now?: () => Date;
   onQuery?: (source: string) => void;
 }) => {
   const { db } = dependencies;
   const now = dependencies.now ?? (() => new Date());
   const observe = dependencies.onQuery ?? (() => undefined);
+  const reviewStore = dependencies.sqlite
+    ? createAdaptiveWeeklyReviewStore({ db, sqlite: dependencies.sqlite, now })
+    : null;
 
   const getCalendar = (userId: string, rawQuery: DataQualityCalendarQuery): DataQualityCalendar => {
-    const query = dataQualityCalendarQuerySchema.parse(rawQuery);
+    const parsedQuery = dataQualityCalendarQuerySchema.parse(rawQuery);
     observe('user');
     const user = db
       .select({ weightUnit: users.weightUnit, preferences: users.preferences })
@@ -229,13 +263,25 @@ export const createDataQualityCalendarStore = (dependencies: {
         ))
       : [];
     const timeZone =
-      query.timeZone ??
+      parsedQuery.timeZone ??
       programRevisions.at(-1)?.snapshot.timeZone ??
       preferenceTimeZone(user.preferences) ??
       'UTC';
     const today = getDateKeyInTimeZone(now(), timeZone);
+    const bootstrapRange = monthGridRange(today);
+    const query = {
+      start: parsedQuery.start ?? bootstrapRange.start,
+      end: parsedQuery.end ?? bootstrapRange.end,
+      timeZone: parsedQuery.timeZone,
+    };
     const dates = datesBetween(query.start, query.end);
-    const evidenceStart = calculateAdaptiveDateBoundaries(query.start, false).analysisStart;
+    const earliestBoundaries = calculateAdaptiveDateBoundaries(query.start, false);
+    const evidenceStart = earliestBoundaries.analysisStart;
+    const canonicalTrendStart = addDays(query.start, -29);
+    const weightEvidenceStart =
+      earliestBoundaries.warmupStart < canonicalTrendStart
+        ? earliestBoundaries.warmupStart
+        : canonicalTrendStart;
 
     observe('nutrition');
     const nutritionRows = db
@@ -243,6 +289,7 @@ export const createDataQualityCalendarStore = (dependencies: {
         id: nutritionLogs.id,
         date: nutritionLogs.date,
         status: nutritionLogs.status,
+        createdAt: nutritionLogs.createdAt,
         statusUpdatedAt: nutritionLogs.statusUpdatedAt,
         updatedAt: nutritionLogs.updatedAt,
         calories: sql<number>`coalesce(sum(${mealItems.calories}), 0)`,
@@ -279,7 +326,13 @@ export const createDataQualityCalendarStore = (dependencies: {
         updatedAt: bodyWeight.updatedAt,
       })
       .from(bodyWeight)
-      .where(and(eq(bodyWeight.userId, userId), lte(bodyWeight.date, query.end)))
+      .where(
+        and(
+          eq(bodyWeight.userId, userId),
+          gte(bodyWeight.date, weightEvidenceStart),
+          lte(bodyWeight.date, query.end),
+        ),
+      )
       .orderBy(asc(bodyWeight.date), asc(bodyWeight.id))
       .all()
       .map((row) => ({ ...row, weightKg: Number(row.weightKg) }));
@@ -305,7 +358,7 @@ export const createDataQualityCalendarStore = (dependencies: {
     );
 
     observe('scheduled-workouts');
-    const scheduledRows = db
+    const visibleScheduledRows = db
       .select({
         id: scheduledWorkouts.id,
         date: scheduledWorkouts.date,
@@ -324,9 +377,10 @@ export const createDataQualityCalendarStore = (dependencies: {
         ),
       )
       .orderBy(asc(scheduledWorkouts.date), asc(scheduledWorkouts.createdAt))
+      .limit(2_100)
       .all();
     observe('workout-sessions');
-    const sessionRows = db
+    const visibleSessionRows = db
       .select({
         id: workoutSessions.id,
         scheduledWorkoutId: workoutSessions.scheduledWorkoutId,
@@ -348,15 +402,89 @@ export const createDataQualityCalendarStore = (dependencies: {
         ),
       )
       .orderBy(asc(workoutSessions.date), asc(workoutSessions.startedAt))
+      .limit(2_100)
       .all();
+    const linkedScheduleIds = unique(
+      visibleSessionRows
+        .map((session) => session.scheduledWorkoutId)
+        .filter((value): value is string => value !== null),
+    );
+    const relatedScheduledRows = linkedScheduleIds.length
+      ? (observe('related-scheduled-workouts'),
+        db
+          .select({
+            id: scheduledWorkouts.id,
+            date: scheduledWorkouts.date,
+            sessionId: scheduledWorkouts.sessionId,
+            templateName: workoutTemplates.name,
+            createdAt: scheduledWorkouts.createdAt,
+            updatedAt: scheduledWorkouts.updatedAt,
+          })
+          .from(scheduledWorkouts)
+          .leftJoin(workoutTemplates, eq(workoutTemplates.id, scheduledWorkouts.templateId))
+          .where(
+            and(
+              eq(scheduledWorkouts.userId, userId),
+              inArray(scheduledWorkouts.id, linkedScheduleIds),
+            ),
+          )
+          .orderBy(asc(scheduledWorkouts.date), asc(scheduledWorkouts.createdAt))
+          .limit(2_100)
+          .all())
+      : [];
+    const linkedSessionIds = unique(
+      visibleScheduledRows
+        .map((schedule) => schedule.sessionId)
+        .filter((value): value is string => value !== null),
+    );
+    const relatedSessionRows = linkedSessionIds.length
+      ? (observe('related-workout-sessions'),
+        db
+          .select({
+            id: workoutSessions.id,
+            scheduledWorkoutId: workoutSessions.scheduledWorkoutId,
+            name: workoutSessions.name,
+            date: workoutSessions.date,
+            status: workoutSessions.status,
+            startedAt: workoutSessions.startedAt,
+            completedAt: workoutSessions.completedAt,
+            createdAt: workoutSessions.createdAt,
+            updatedAt: workoutSessions.updatedAt,
+          })
+          .from(workoutSessions)
+          .where(
+            and(
+              eq(workoutSessions.userId, userId),
+              isNull(workoutSessions.deletedAt),
+              inArray(workoutSessions.id, linkedSessionIds),
+            ),
+          )
+          .orderBy(
+            asc(workoutSessions.date),
+            asc(workoutSessions.startedAt),
+            asc(workoutSessions.id),
+          )
+          .limit(2_100)
+          .all())
+      : [];
+    const scheduledRows = [
+      ...new Map(
+        [...visibleScheduledRows, ...relatedScheduledRows].map((row) => [row.id, row]),
+      ).values(),
+    ];
+    const sessionRows = [
+      ...new Map(
+        [...visibleSessionRows, ...relatedSessionRows].map((row) => [row.id, row]),
+      ).values(),
+    ];
     const sessionsByDate = new Map<string, typeof sessionRows>();
-    for (const row of sessionRows) {
+    for (const row of visibleSessionRows) {
       const existing = sessionsByDate.get(row.date) ?? [];
       existing.push(row);
       sessionsByDate.set(row.date, existing);
     }
     const schedulesByDate = new Map<string, typeof scheduledRows>();
-    for (const row of scheduledRows) {
+    for (const row of visibleScheduledRows) {
       const existing = schedulesByDate.get(row.date) ?? [];
       existing.push(row);
       schedulesByDate.set(row.date, existing);
@@ -390,14 +518,20 @@ export const createDataQualityCalendarStore = (dependencies: {
             and(
               eq(adaptiveNutritionCheckIns.userId, userId),
               eq(adaptiveNutritionCheckIns.programId, program.id),
-              gte(adaptiveNutritionCheckIns.localDate, query.start),
-              lte(adaptiveNutritionCheckIns.localDate, query.end),
+              or(
+                and(
+                  gte(adaptiveNutritionCheckIns.localDate, query.start),
+                  lte(adaptiveNutritionCheckIns.localDate, query.end),
+                ),
+                sql`json_extract(${adaptiveNutritionCheckIns.proposedTargets}, '$.effectiveDate') between ${query.start} and ${query.end}`,
+              ),
             ),
           )
           .orderBy(
             asc(adaptiveNutritionCheckIns.localDate),
             asc(adaptiveNutritionCheckIns.createdAt),
           )
+          .limit(2_100)
           .all())
       : [];
     const checkIns = priorCheckIn
@@ -445,6 +579,17 @@ export const createDataQualityCalendarStore = (dependencies: {
       existing.push(action);
       actionsByReview.set(action.reviewId, existing);
     }
+    const projectedReview = reviewStore
+      ? ([...overlappingReviews]
+          .reverse()
+          .filter((review) =>
+            ['pending', 'awaiting_clarification', 'deferred'].includes(
+              reviewActionState(actionsByReview.get(review.id) ?? []),
+            ),
+          )
+          .slice(0, 1)
+          .map((review) => reviewStore.get(userId, review.id))[0] ?? null)
+      : null;
 
     const nutritionEvidence = new Map<
       string,
@@ -484,36 +629,10 @@ export const createDataQualityCalendarStore = (dependencies: {
         });
       }
     }
-    for (const review of overlappingReviews) {
-      const snapshot = adaptiveWeeklyReviewSnapshotSchema.parse(review.snapshot);
-      const recommendation = snapshot.modules.find((module) => module.kind === 'recommendation');
-      if (recommendation?.kind === 'recommendation') {
-        for (const date of recommendation.causalBreakdown.includedNutritionDates) {
-          nutritionEvidence.set(date, {
-            state: 'usable',
-            reasonCodes: [],
-            suspectedPartial: false,
-          });
-        }
-        for (const item of recommendation.causalBreakdown.excludedNutrition) {
-          nutritionEvidence.set(item.localDate, {
-            state: 'excluded',
-            reasonCodes: item.reasonCodes,
-            suspectedPartial: false,
-          });
-        }
-        for (const date of recommendation.causalBreakdown.includedWeightDates) {
-          weightEvidence.set(date, { state: 'usable', reasonCodes: [], suspect: false });
-        }
-        for (const item of recommendation.causalBreakdown.excludedWeight) {
-          weightEvidence.set(item.localDate, {
-            state: 'excluded',
-            reasonCodes: item.reasonCodes,
-            suspect: item.reasonCodes.some((code) => code.includes('SUSPECT')),
-          });
-        }
-      }
-      const dataQuality = snapshot.modules.find((module) => module.kind === 'data_quality');
+    if (projectedReview && projectedReview.state !== 'stale') {
+      const dataQuality = projectedReview.snapshot.modules.find(
+        (module) => module.kind === 'data_quality',
+      );
       if (dataQuality?.kind === 'data_quality') {
         for (const evidence of dataQuality.evidence) {
           if (evidence.kind !== 'nutrition') continue;
@@ -596,6 +715,7 @@ export const createDataQualityCalendarStore = (dependencies: {
             asc(adaptiveNutritionReviewContexts.createdAt),
             asc(adaptiveNutritionReviewContexts.id),
           )
+          .limit(4_201)
           .all())
       : [];
 
@@ -638,6 +758,8 @@ export const createDataQualityCalendarStore = (dependencies: {
       existing.push(review);
       reviewsByDate.set(review.reviewLocalDate, existing);
     }
+    const scheduleById = new Map(scheduledRows.map((row) => [row.id, row]));
+    const sessionById = new Map(sessionRows.map((row) => [row.id, row]));
 
     const days: DataQualityCalendarDay[] = dates.map((date) => {
       const nutrition = nutritionByDate.get(date);
@@ -662,22 +784,39 @@ export const createDataQualityCalendarStore = (dependencies: {
       const unit = user.weightUnit as WeightUnit;
 
       const sessions = sessionsByDate.get(date) ?? [];
-      const sessionIds = new Set(sessions.map((session) => session.id));
-      const workoutItems: DataQualityCalendarDay['workouts'] = [
-        ...(schedulesByDate.get(date) ?? [])
-          .filter((schedule) => schedule.sessionId === null || !sessionIds.has(schedule.sessionId))
-          .map((schedule) => ({
+      const allWorkoutItems: DataQualityCalendarDay['workouts'] = [
+        ...(schedulesByDate.get(date) ?? []).map((schedule) => {
+          const linkedSession = schedule.sessionId
+            ? sessionById.get(schedule.sessionId)
+            : undefined;
+          const moved = linkedSession !== undefined && linkedSession.date !== schedule.date;
+          return {
             id: schedule.id,
             kind: 'scheduled_workout' as const,
-            state: 'planned' as const,
+            state: moved ? ('moved' as const) : ('planned' as const),
             name: schedule.templateName ?? 'Unavailable scheduled workout',
-            sessionStatus: null,
+            sessionStatus: linkedSession?.status ?? null,
             scheduledWorkoutId: schedule.id,
             sessionId: schedule.sessionId,
+            plannedDate: schedule.date,
+            sessionDate: linkedSession?.date ?? null,
+            relation:
+              linkedSession === undefined
+                ? ('unlinked' as const)
+                : moved
+                  ? ('linked_different_date' as const)
+                  : ('linked_same_date' as const),
+            relationLimitation: moved
+              ? 'Pulse retains the linked plan and session dates, but no immutable movement event is recorded.'
+              : null,
+            correctionState: 'not_applicable' as const,
             startedAt: null,
             completedAt: null,
             createdAt: schedule.createdAt,
             updatedAt: schedule.updatedAt,
+            provenance: notRecordedProvenance(
+              'Historical creator provenance is not retained for scheduled workouts.',
+            ),
             reasonCodes: [],
             actions: [
               {
@@ -687,21 +826,22 @@ export const createDataQualityCalendarStore = (dependencies: {
                 method: 'navigate' as const,
               },
             ],
-          })),
+          };
+        }),
         ...sessions.map((session) => {
-          const corrected =
-            session.status === 'completed' &&
-            session.completedAt !== null &&
-            session.updatedAt > session.completedAt;
-          const state = corrected
-            ? ('corrected' as const)
-            : session.status === 'completed'
+          const linkedSchedule = session.scheduledWorkoutId
+            ? scheduleById.get(session.scheduledWorkoutId)
+            : undefined;
+          const state =
+            session.status === 'completed'
               ? ('completed' as const)
               : session.status === 'cancelled'
                 ? ('cancelled' as const)
                 : session.status === 'paused'
                   ? ('paused' as const)
-                  : ('in_progress' as const);
+                  : session.status === 'scheduled'
+                    ? ('scheduled' as const)
+                    : ('in_progress' as const);
           return {
             id: session.id,
             kind: 'workout_session' as const,
@@ -710,15 +850,34 @@ export const createDataQualityCalendarStore = (dependencies: {
             sessionStatus: session.status,
             scheduledWorkoutId: session.scheduledWorkoutId,
             sessionId: session.id,
+            plannedDate: linkedSchedule?.date ?? null,
+            sessionDate: session.date,
+            relation:
+              linkedSchedule === undefined
+                ? ('unlinked' as const)
+                : linkedSchedule.date === session.date
+                  ? ('linked_same_date' as const)
+                  : ('linked_different_date' as const),
+            relationLimitation:
+              linkedSchedule && linkedSchedule.date !== session.date
+                ? 'Pulse retains the linked plan and session dates, but no immutable movement event is recorded.'
+                : null,
+            correctionState:
+              session.status === 'completed'
+                ? ('history_unavailable' as const)
+                : ('not_applicable' as const),
             startedAt: session.startedAt,
             completedAt: session.completedAt,
             createdAt: session.createdAt,
             updatedAt: session.updatedAt,
-            reasonCodes: corrected ? ['SESSION_CORRECTED_AFTER_COMPLETION'] : [],
+            provenance: notRecordedProvenance(
+              'Historical creator provenance is not retained for workout sessions.',
+            ),
+            reasonCodes: [],
             actions: [
               {
                 kind: 'correct_workout' as const,
-                label: corrected ? 'Review corrected workout' : 'Review workout',
+                label: 'Review workout',
                 href: `/workouts/session/${session.id}`,
                 method: 'navigate' as const,
               },
@@ -726,6 +885,9 @@ export const createDataQualityCalendarStore = (dependencies: {
           };
         }),
       ];
+      const workoutItems = allWorkoutItems
+        .sort((left, right) => left.createdAt - right.createdAt || left.id.localeCompare(right.id))
+        .slice(0, 50);
 
       const checkInEvents: DataQualityCalendarDay['algorithm']['events'] = rangeCheckIns
         .filter((checkIn) => {
@@ -749,6 +911,7 @@ export const createDataQualityCalendarStore = (dependencies: {
             effectiveDate,
             createdAt: checkIn.createdAt,
             reasonCodes: checkIn.reasonCodes,
+            provenance: systemProvenance,
             actions: [
               {
                 kind: 'view_check_in' as const,
@@ -762,7 +925,8 @@ export const createDataQualityCalendarStore = (dependencies: {
       const reviewEvents: DataQualityCalendarDay['algorithm']['events'] = (
         reviewsByDate.get(date) ?? []
       ).map((review) => {
-        const state = reviewActionState(actionsByReview.get(review.id) ?? []);
+        const current = projectedReview?.id === review.id ? projectedReview : null;
+        const state = current?.state ?? reviewActionState(actionsByReview.get(review.id) ?? []);
         return {
           id: review.id,
           kind: 'weekly_review' as const,
@@ -770,6 +934,7 @@ export const createDataQualityCalendarStore = (dependencies: {
           effectiveDate: review.reviewLocalDate,
           createdAt: review.createdAt,
           reasonCodes: [],
+          provenance: systemProvenance,
           actions: [
             {
               kind: 'view_review' as const,
@@ -777,9 +942,22 @@ export const createDataQualityCalendarStore = (dependencies: {
               href: `/nutrition/reviews/${review.id}`,
               method: 'navigate' as const,
             },
+            ...(state === 'stale'
+              ? [
+                  {
+                    kind: 'refresh_review' as const,
+                    label: 'Refresh stale weekly review',
+                    href: `/nutrition/reviews/${review.id}`,
+                    method: 'navigate' as const,
+                  },
+                ]
+              : []),
           ],
         };
       });
+      const allAlgorithmEvents = [...checkInEvents, ...reviewEvents].sort(
+        (left, right) => left.createdAt - right.createdAt || left.id.localeCompare(right.id),
+      );
       const eligibility = eligibilityByDate.get(date);
       const state =
         date > today && programRevisions.length > 0
@@ -812,8 +990,14 @@ export const createDataQualityCalendarStore = (dependencies: {
             : null,
           mealCount: nutrition ? Number(nutrition.mealCount) : null,
           itemCount: nutrition ? Number(nutrition.itemCount) : null,
+          createdAt: nutrition?.createdAt ?? null,
           statusUpdatedAt: nutrition?.statusUpdatedAt ?? null,
           updatedAt: nutrition?.updatedAt ?? null,
+          provenance: nutrition
+            ? notRecordedProvenance(
+                'Historical creator provenance is not retained for nutrition logs.',
+              )
+            : notRecordedProvenance('No nutrition source record exists for this date.'),
           reasonCodes: recordedNutritionState?.reasonCodes ?? [],
           actions: [nutritionStatusAction(date), addContextAction(date)],
         },
@@ -823,7 +1007,7 @@ export const createDataQualityCalendarStore = (dependencies: {
           weight: weight ? convertWeightFromKg(weight.weightKg, unit) : null,
           unit: weight ? unit : null,
           trendWeight: trendWeightKg === null ? null : convertWeightFromKg(trendWeightKg, unit),
-          corrected: weight ? weight.updatedAt > weight.createdAt : false,
+          correctionState: weight ? 'history_unavailable' : 'not_applicable',
           suspect: recordedWeightState?.suspect ?? false,
           stale:
             weight !== undefined &&
@@ -831,6 +1015,11 @@ export const createDataQualityCalendarStore = (dependencies: {
             visibleWeightRows.at(-1)?.date === date,
           createdAt: weight?.createdAt ?? null,
           updatedAt: weight?.updatedAt ?? null,
+          provenance: weight
+            ? notRecordedProvenance(
+                'Historical creator provenance is not retained for weight measurements.',
+              )
+            : notRecordedProvenance('No weight source record exists for this date.'),
           reasonCodes: recordedWeightState?.reasonCodes ?? [],
           actions: weight
             ? [
@@ -857,11 +1046,10 @@ export const createDataQualityCalendarStore = (dependencies: {
             ...(recordedNutritionState?.reasonCodes ?? []),
             ...(recordedWeightState?.reasonCodes ?? []),
           ]),
-          events: [...checkInEvents, ...reviewEvents].sort(
-            (left, right) => left.createdAt - right.createdAt || left.id.localeCompare(right.id),
-          ),
+          events: allAlgorithmEvents.slice(0, 50),
+          omittedEventCount: Math.max(0, allAlgorithmEvents.length - 50),
         },
-        contexts: (contextsByDate.get(date) ?? []).map((context) => ({
+        contexts: (contextsByDate.get(date) ?? []).slice(0, 100).map((context) => ({
           id: context.id,
           category: context.category,
           note: context.note,
@@ -884,11 +1072,14 @@ export const createDataQualityCalendarStore = (dependencies: {
             },
           ],
         })),
+        omittedWorkoutCount: Math.max(0, allWorkoutItems.length - workoutItems.length),
+        omittedContextCount: Math.max(0, (contextsByDate.get(date) ?? []).length - 100),
       };
     });
 
     return dataQualityCalendarSchema.parse({
       range: { startDate: query.start, endDate: query.end },
+      today,
       timeZone,
       days,
       summary: summaryFor(days),
@@ -899,6 +1090,6 @@ export const createDataQualityCalendarStore = (dependencies: {
 };
 
 export const getDataQualityCalendar = async (userId: string, query: DataQualityCalendarQuery) => {
-  const { db } = await import('../../db/index.js');
-  return createDataQualityCalendarStore({ db }).getCalendar(userId, query);
+  const { db, sqlite } = await import('../../db/index.js');
+  return createDataQualityCalendarStore({ db, sqlite }).getCalendar(userId, query);
 };

--- a/apps/api/src/routes/weight/trend-store.integration.test.ts
+++ b/apps/api/src/routes/weight/trend-store.integration.test.ts
@@ -365,7 +365,7 @@ describe('Trend Weight analytics store', () => {
     expect(second.timeZone).toBe('America/Detroit');
   });
 
-  it('recomputes corrections and deletions while preserving correction provenance', async () => {
+  it('recomputes edits and deletions without fabricating correction provenance', async () => {
     seedWeight('user-1', '2026-08-01', 180);
     seedWeight('user-1', '2026-08-10', 179);
     seedWeight('user-1', '2026-08-19', 178);
@@ -384,18 +384,29 @@ describe('Trend Weight analytics store', () => {
     const corrected = store.getAnalytics('user-1', { range: '1m', end: '2026-08-19' });
 
     expect(corrected.current.trendWeight).not.toBe(original.current.trendWeight);
-    expect(corrected.markers).toContainEqual({
-      id: 'correction-user-1-2026-08-19',
-      date: '2026-08-19',
-      kind: 'correction',
-      label: 'Corrected weigh-in',
-    });
-    expect(corrected.points.at(-1)?.corrected).toBe(true);
+    expect(corrected.markers.filter((marker) => marker.kind === 'correction')).toEqual([]);
+    expect(corrected.points.at(-1)).toMatchObject({ corrected: false, annotation: null });
 
     dbModule.db.delete(bodyWeight).where(eq(bodyWeight.id, 'user-1-2026-08-19')).run();
     const deleted = store.getAnalytics('user-1', { range: '1m', end: '2026-08-19' });
     expect(deleted.points.map((point) => point.date)).not.toContain('2026-08-19');
     expect(deleted.current.latestScale?.date).toBe('2026-08-10');
+  });
+
+  it('keeps a notes-only edit out of Trend Weight correction markers', async () => {
+    seedWeight('user-1', '2026-08-10', 179);
+    seedWeight('user-1', '2026-08-19', 178);
+    const store = await getStore();
+    const before = store.getAnalytics('user-1', { range: '1m', end: '2026-08-19' });
+    dbModule.db
+      .update(bodyWeight)
+      .set({ notes: 'Clarified note only.', updatedAt: Date.parse('2026-08-20T12:00:00.000Z') })
+      .where(eq(bodyWeight.id, 'user-1-2026-08-19'))
+      .run();
+    const after = store.getAnalytics('user-1', { range: '1m', end: '2026-08-19' });
+    expect(after.current.trendWeight).toBe(before.current.trendWeight);
+    expect(after.markers.filter((marker) => marker.kind === 'correction')).toEqual([]);
+    expect(after.points.at(-1)).toMatchObject({ corrected: false, annotation: null });
   });
 
   it('returns explicit no-data and scale-only states without trend precision', async () => {

--- a/apps/api/src/routes/weight/trend-store.ts
+++ b/apps/api/src/routes/weight/trend-store.ts
@@ -275,14 +275,6 @@ export const createTrendWeightStore = (dependencies: { db: TrendDatabase; now?: 
       ...checkIns
         .filter((checkIn) => checkIn.date >= startDate)
         .map((checkIn) => ({ ...checkIn, kind: 'check_in' as const, label: 'Check-in' })),
-      ...entries
-        .filter((entry) => entry.date >= startDate && entry.updatedAt > entry.createdAt)
-        .map((entry) => ({
-          id: `correction-${entry.id}`,
-          date: entry.date,
-          kind: 'correction' as const,
-          label: 'Corrected weigh-in',
-        })),
     ].sort(
       (left, right) =>
         left.date.localeCompare(right.date) ||

--- a/apps/api/src/scripts/seed-adaptive-tdee-preview.test.ts
+++ b/apps/api/src/scripts/seed-adaptive-tdee-preview.test.ts
@@ -133,6 +133,7 @@ describe('Adaptive TDEE preview fixtures', () => {
     if (!dataQualityFixture) throw new Error('Missing Data Quality calendar fixture');
     const qualityCalendar = createDataQualityCalendarStore({
       db,
+      sqlite,
       now: () => new Date('2026-08-13T16:30:00.000Z'),
     }).getCalendar(dataQualityFixture.userId, {
       start: '2026-08-09',
@@ -158,15 +159,15 @@ describe('Adaptive TDEE preview fixtures', () => {
         provenance: expect.objectContaining({ type: 'agent_token', label: 'Preview Coach' }),
       }),
     ]);
-    expect(qualityCalendar.days[1]?.weight.corrected).toBe(true);
+    expect(qualityCalendar.days[1]?.weight.correctionState).toBe('history_unavailable');
     expect(qualityCalendar.days[2]?.workouts).toEqual([
       expect.objectContaining({ state: 'planned' }),
     ]);
     expect(qualityCalendar.days[3]?.workouts).toEqual([
-      expect.objectContaining({ state: 'corrected' }),
+      expect.objectContaining({ state: 'completed', correctionState: 'history_unavailable' }),
     ]);
     expect(qualityCalendar.days[4]?.algorithm).toMatchObject({
-      state: 'updating',
+      state: 'learning',
       nutritionEvidenceState: 'pending_cutoff',
       weightEvidenceState: 'pending_cutoff',
     });

--- a/apps/api/src/scripts/seed-adaptive-tdee-preview.test.ts
+++ b/apps/api/src/scripts/seed-adaptive-tdee-preview.test.ts
@@ -19,6 +19,7 @@ import {
 import { createAdaptiveNutritionStore } from '../routes/adaptive-nutrition/store.js';
 import { createAdaptiveWeeklyReviewStore } from '../routes/adaptive-nutrition/review-store.js';
 import { createAdaptiveGoalReadStore } from '../routes/adaptive-nutrition/goal-store.js';
+import { createDataQualityCalendarStore } from '../routes/data-quality/store.js';
 
 import {
   ADAPTIVE_PREVIEW_USERNAME_PREFIX,
@@ -123,10 +124,52 @@ describe('Adaptive TDEE preview fixtures', () => {
       'trajectory-maintenance-above': 'updating',
       'trajectory-scale-only': 'updating',
       'trajectory-historical': 'updating',
+      'data-quality-calendar': 'updating',
     });
     for (const fixture of first) {
       expect(store.getState(fixture.userId).state).toBe(fixture.expectedState);
     }
+    const dataQualityFixture = first.find((fixture) => fixture.fixture === 'data-quality-calendar');
+    if (!dataQualityFixture) throw new Error('Missing Data Quality calendar fixture');
+    const qualityCalendar = createDataQualityCalendarStore({
+      db,
+      now: () => new Date('2026-08-13T16:30:00.000Z'),
+    }).getCalendar(dataQualityFixture.userId, {
+      start: '2026-08-09',
+      end: '2026-08-13',
+    });
+    expect(qualityCalendar.days.map((day) => day.nutrition.qualityState)).toEqual([
+      'partial',
+      'unknown',
+      'no_records',
+      'complete',
+      'complete',
+    ]);
+    expect(qualityCalendar.days.map((day) => day.nutrition.evidenceState)).toEqual([
+      'excluded',
+      'excluded',
+      'missing',
+      'usable',
+      'pending_cutoff',
+    ]);
+    expect(qualityCalendar.days[0]?.contexts).toEqual([
+      expect.objectContaining({
+        category: 'illness',
+        provenance: expect.objectContaining({ type: 'agent_token', label: 'Preview Coach' }),
+      }),
+    ]);
+    expect(qualityCalendar.days[1]?.weight.corrected).toBe(true);
+    expect(qualityCalendar.days[2]?.workouts).toEqual([
+      expect.objectContaining({ state: 'planned' }),
+    ]);
+    expect(qualityCalendar.days[3]?.workouts).toEqual([
+      expect.objectContaining({ state: 'corrected' }),
+    ]);
+    expect(qualityCalendar.days[4]?.algorithm).toMatchObject({
+      state: 'updating',
+      nutritionEvidenceState: 'pending_cutoff',
+      weightEvidenceState: 'pending_cutoff',
+    });
     const reviewStore = createAdaptiveWeeklyReviewStore({
       db,
       sqlite,

--- a/apps/api/src/scripts/seed-adaptive-tdee-preview.ts
+++ b/apps/api/src/scripts/seed-adaptive-tdee-preview.ts
@@ -23,7 +23,9 @@ import {
   nutritionLogs,
   nutritionTargetEvents,
   nutritionTargets,
+  scheduledWorkouts,
   users,
+  workoutSessions,
 } from '../db/schema/index.js';
 import { createAdaptiveNutritionStore } from '../routes/adaptive-nutrition/store.js';
 import { createAdaptiveWeeklyReviewStore } from '../routes/adaptive-nutrition/review-store.js';
@@ -69,7 +71,8 @@ export type AdaptivePreviewFixtureName =
   | 'trajectory-maintenance-below'
   | 'trajectory-maintenance-above'
   | 'trajectory-scale-only'
-  | 'trajectory-historical';
+  | 'trajectory-historical'
+  | 'data-quality-calendar';
 
 export type AdaptivePreviewFixtureRecord = {
   fixture: AdaptivePreviewFixtureName;
@@ -374,6 +377,14 @@ const FIXTURES: Array<
     expectedState: 'updating',
     note: 'A dedicated replaced goal proves historical trajectory copy and immutable context.',
   },
+  {
+    fixture: 'data-quality-calendar',
+    usernameSuffix: 'dq-calendar',
+    idSuffix: '0038',
+    name: 'Data Quality · Cross-domain Calendar',
+    expectedState: 'updating',
+    note: 'A dedicated read-only month combines complete, partial, unknown, missing, pending, corrected, workout, algorithm, and agent-context evidence.',
+  },
 ];
 
 const datePlus = (date: string, days: number) => {
@@ -438,6 +449,7 @@ const seedWeightDay = (
       weight: poundsFromKg(weightKg),
       weightKg,
       unitAtEntry: 'kg',
+      createdAt: timestamp,
       updatedAt: timestamp,
     })
     .onConflictDoUpdate({
@@ -550,6 +562,7 @@ const seedEligibleHistory = (
         weight: poundsFromKg(weightKg),
         weightKg,
         unitAtEntry: 'kg',
+        createdAt: timestamp + index,
         updatedAt: timestamp + index,
       })
       .onConflictDoUpdate({
@@ -994,6 +1007,77 @@ export function seedAdaptiveTdeePreviewFixtures(options: {
     .where(like(mealItems.id, `${adjustReview.userId}-item-%`))
     .run();
   reviewStore.preview(adjustReview.userId, { kind: 'weekly' });
+
+  const dataQuality = createHistoricalBaseline('data-quality-calendar');
+  seedEligibleHistory(db, dataQuality.userId, anchorDate, clock);
+  db.update(nutritionLogs)
+    .set({ status: 'partial', statusUpdatedAt: clock + 1, updatedAt: clock + 1 })
+    .where(
+      and(
+        eq(nutritionLogs.userId, dataQuality.userId),
+        eq(nutritionLogs.date, datePlus(anchorDate, -4)),
+      ),
+    )
+    .run();
+  db.update(nutritionLogs)
+    .set({ status: 'unknown', statusUpdatedAt: clock + 2, updatedAt: clock + 2 })
+    .where(
+      and(
+        eq(nutritionLogs.userId, dataQuality.userId),
+        eq(nutritionLogs.date, datePlus(anchorDate, -3)),
+      ),
+    )
+    .run();
+  db.delete(nutritionLogs)
+    .where(
+      and(
+        eq(nutritionLogs.userId, dataQuality.userId),
+        eq(nutritionLogs.date, datePlus(anchorDate, -2)),
+      ),
+    )
+    .run();
+  seedCompleteNutritionDay(db, dataQuality.userId, anchorDate, clock + 3);
+  seedWeightDay(db, dataQuality.userId, anchorDate, 81.55, clock + 4);
+  db.update(bodyWeight)
+    .set({ weightKg: 81.5, weight: poundsFromKg(81.5), updatedAt: clock + 50 })
+    .where(
+      and(eq(bodyWeight.userId, dataQuality.userId), eq(bodyWeight.date, datePlus(anchorDate, -3))),
+    )
+    .run();
+  db.insert(scheduledWorkouts)
+    .values({
+      id: `${dataQuality.userId}-schedule-${datePlus(anchorDate, -2)}`,
+      userId: dataQuality.userId,
+      templateId: null,
+      date: datePlus(anchorDate, -2),
+      createdAt: clock + 6,
+      updatedAt: clock + 6,
+    })
+    .run();
+  db.insert(workoutSessions)
+    .values({
+      id: `${dataQuality.userId}-session-${datePlus(anchorDate, -1)}`,
+      userId: dataQuality.userId,
+      scheduledWorkoutId: null,
+      name: 'Cross-domain strength session',
+      date: datePlus(anchorDate, -1),
+      status: 'completed',
+      startedAt: clock + 7,
+      completedAt: clock + 8,
+      updatedAt: clock + 9,
+    })
+    .run();
+  reviewStore.createContext(
+    dataQuality.userId,
+    {
+      subject: { kind: 'date', localDate: datePlus(anchorDate, -4) },
+      category: 'illness',
+      note: 'Migraine reduced appetite and changed the planned training day.',
+      resolution: null,
+    },
+    { type: 'agent_token', agentTokenId: 'preview-agent', label: 'Preview Coach' },
+  );
+  clock += 1000;
 
   for (const fixture of records) {
     const state = store.getState(fixture.userId);

--- a/apps/web/e2e/chart-exploration.spec.ts
+++ b/apps/web/e2e/chart-exploration.spec.ts
@@ -74,14 +74,18 @@ function monitorPage(page: Page) {
 }
 
 async function expectNoOverflow(page: Page) {
-  expect(
-    await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1),
-  ).toBeTruthy();
-  for (const frame of await page.locator('[data-slot="chart-frame"]').all()) {
-    expect(await frame.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(
-      true,
-    );
-  }
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1))
+    .toBe(true);
+  await expect
+    .poll(() =>
+      page
+        .locator('[data-slot="chart-frame"]')
+        .evaluateAll((frames) =>
+          frames.every((frame) => frame.scrollWidth <= frame.clientWidth + 1),
+        ),
+    )
+    .toBe(true);
 }
 
 async function expectRangeTargets(page: Page, label: string) {

--- a/apps/web/e2e/data-quality-calendar.spec.ts
+++ b/apps/web/e2e/data-quality-calendar.spec.ts
@@ -152,8 +152,8 @@ test.describe.serial('Data Quality calendar', () => {
     await expect(
       page.getByText('Migraine reduced appetite and changed the planned training day.'),
     ).toBeVisible();
-    await expect(page.getByText('Preview Coach')).toBeVisible();
-    await expect(page.getByText('agent token · revision 1', { exact: false })).toBeVisible();
+    await expect(page.getByText('AgentToken · Preview Coach')).toBeVisible();
+    await expect(page.getByText('date · revision 1', { exact: false })).toBeVisible();
     await expect(page.getByText('partial', { exact: true }).first()).toBeVisible();
     await expect(
       page.getByText(
@@ -170,7 +170,7 @@ test.describe.serial('Data Quality calendar', () => {
     expect(agentResponse.ok(), await agentResponse.text()).toBeTruthy();
     expect((await agentResponse.json()).data).toEqual((await jwtResponse.json()).data);
 
-    const weightFilter = page.getByRole('button', { name: 'Weight' });
+    const weightFilter = page.getByRole('button', { exact: true, name: 'Weight' });
     await weightFilter.focus();
     await page.keyboard.press('Space');
     await expect(weightFilter).toHaveAttribute('aria-pressed', 'false');
@@ -193,21 +193,42 @@ test.describe.serial('Data Quality calendar', () => {
 
     await selectDay(page, addDays(today, -3));
     await expect(page.getByText('Retained row was corrected')).toBeVisible();
-    await expect(page.getByText('Corrected', { exact: true }).first()).toBeVisible();
+    await expect(
+      page.getByRole('region', { name: 'Weight' }).getByText('Corrected', { exact: true }),
+    ).toBeVisible();
 
     await selectDay(page, addDays(today, -2));
     await expect(page.getByText('No record', { exact: true })).toBeVisible();
-    await expect(page.getByText('No weigh-in', { exact: true }).first()).toBeVisible();
-    await expect(page.getByText('planned', { exact: true }).first()).toBeVisible();
+    await expect(
+      page
+        .getByRole('region', { name: 'Weight' })
+        .getByText('No weigh-in', { exact: true })
+        .first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('region', { name: 'Workout' }).getByText('planned', { exact: true }).first(),
+    ).toBeVisible();
 
     await selectDay(page, addDays(today, -1));
     await expect(page.getByText('Cross-domain strength session')).toBeVisible();
-    await expect(page.getByText('corrected', { exact: true }).first()).toBeVisible();
+    await expect(
+      page.getByRole('region', { name: 'Workout' }).getByText('corrected', { exact: true }).first(),
+    ).toBeVisible();
     await capture(page, 'data-quality-workout-430.png');
 
     await selectDay(page, today);
-    await expect(page.getAllByText('Pending cutoff', { exact: true })).toHaveLength(2);
-    await expect(page.getByText(/pending completed day cutoff/i)).toBeVisible();
+    await expect(
+      page
+        .getByRole('region', { name: 'Nutrition' })
+        .getByText('Pending cutoff', { exact: true })
+        .first(),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByRole('region', { name: 'Weight' })
+        .getByText('Pending cutoff', { exact: true })
+        .first(),
+    ).toBeVisible();
     diagnostics();
   });
 

--- a/apps/web/e2e/data-quality-calendar.spec.ts
+++ b/apps/web/e2e/data-quality-calendar.spec.ts
@@ -43,6 +43,16 @@ function uiDate(date: string) {
   }).format(new Date(`${date}T00:00:00.000Z`));
 }
 
+function monthGridRange(date: string) {
+  const first = `${date.slice(0, 7)}-01`;
+  const firstValue = new Date(`${first}T00:00:00.000Z`);
+  const start = addDays(first, -((firstValue.getUTCDay() + 6) % 7));
+  const next = new Date(firstValue);
+  next.setUTCMonth(next.getUTCMonth() + 1);
+  const last = addDays(next.toISOString().slice(0, 10), -1);
+  return { start, end: addDays(last, (7 - new Date(`${last}T00:00:00.000Z`).getUTCDay()) % 7) };
+}
+
 function monitorPage(page: Page) {
   const failures: string[] = [];
   page.on('console', (message) => {
@@ -98,11 +108,39 @@ async function capture(page: Page, filename: string) {
 }
 
 async function expectNoOverflowAndTouchTargets(page: Page, width: number) {
+  const calendarAncestors = await page
+    .getByTestId('data-quality-calendar-scroller')
+    .evaluate((element) => {
+      const values: Array<Record<string, unknown>> = [];
+      for (let current: HTMLElement | null = element; current; current = current.parentElement) {
+        const style = getComputedStyle(current);
+        values.push({
+          className: current.className,
+          overflowX: style.overflowX,
+          rect: current.getBoundingClientRect().toJSON(),
+          scrollWidth: current.scrollWidth,
+          tag: current.tagName,
+        });
+      }
+      return values;
+    });
+  const overflowingElements = await page.evaluate(() => {
+    const viewportWidth = document.documentElement.clientWidth;
+    return [...document.body.querySelectorAll<HTMLElement>('*')]
+      .map((element) => ({
+        className: element.className,
+        name: element.getAttribute('aria-label') ?? element.textContent?.trim().slice(0, 80),
+        rect: element.getBoundingClientRect().toJSON(),
+        tag: element.tagName,
+      }))
+      .filter(({ rect }) => rect.left < -1 || rect.right > viewportWidth + 1)
+      .slice(0, 10);
+  });
   expect(
     await page.evaluate(
       () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
     ),
-    `${width}px page overflow`,
+    `${width}px page overflow: ${JSON.stringify({ calendarAncestors, overflowingElements })}`,
   ).toBe(true);
   const domainGroup = page.getByRole('group', { name: 'Calendar domains' });
   for (const control of await domainGroup.getByRole('button').all()) {
@@ -111,6 +149,12 @@ async function expectNoOverflowAndTouchTargets(page: Page, width: number) {
       box?.height ?? 0,
       `${width}px ${await control.textContent()} touch target`,
     ).toBeGreaterThanOrEqual(44);
+  }
+  for (const day of await page.locator('button[data-date]').all()) {
+    const box = await day.boundingBox();
+    if (!box || box.x + box.width <= 0 || box.x >= width) continue;
+    expect(box.width, `${width}px visible day width`).toBeGreaterThanOrEqual(44);
+    expect(box.height, `${width}px visible day height`).toBeGreaterThanOrEqual(44);
   }
 }
 
@@ -183,7 +227,7 @@ test.describe.serial('Data Quality calendar', () => {
     diagnostics();
   });
 
-  test('keeps missing, cutoff, corrected, planned, and completed evidence distinct', async ({
+  test('keeps missing, cutoff, correction limitations, planned, and completed evidence distinct', async ({
     page,
   }) => {
     const diagnostics = monitorPage(page);
@@ -192,9 +236,9 @@ test.describe.serial('Data Quality calendar', () => {
     const today = calendar.days.find((day) => day.isToday)?.date ?? dateKeyInDetroit();
 
     await selectDay(page, addDays(today, -3));
-    await expect(page.getByText('Retained row was corrected')).toBeVisible();
+    await expect(page.getByText('Correction history unavailable').first()).toBeVisible();
     await expect(
-      page.getByRole('region', { name: 'Weight' }).getByText('Corrected', { exact: true }),
+      page.getByRole('region', { name: 'Weight' }).getByText('Logged', { exact: true }),
     ).toBeVisible();
 
     await selectDay(page, addDays(today, -2));
@@ -212,7 +256,10 @@ test.describe.serial('Data Quality calendar', () => {
     await selectDay(page, addDays(today, -1));
     await expect(page.getByText('Cross-domain strength session')).toBeVisible();
     await expect(
-      page.getByRole('region', { name: 'Workout' }).getByText('corrected', { exact: true }).first(),
+      page.getByRole('region', { name: 'Workout' }).getByText('completed', { exact: true }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('region', { name: 'Workout' }).getByText('Correction history unavailable'),
     ).toBeVisible();
     await capture(page, 'data-quality-workout-430.png');
 
@@ -284,11 +331,68 @@ test.describe.serial('Data Quality calendar', () => {
     const calendar = await openCalendar(page);
     const today = calendar.days.find((day) => day.isToday)?.date ?? dateKeyInDetroit();
     await selectDay(page, today);
-    for (const width of [768, 1280]) {
+    for (const width of [320, 390, 430, 768, 1280]) {
       await page.setViewportSize({ height: 1000, width });
       await expectNoOverflowAndTouchTargets(page, width);
       await capture(page, `data-quality-calendar-${width}.png`);
     }
     diagnostics();
+  });
+
+  test('bootstraps the authoritative program-local month in opposite browser zones and DST boundaries', async ({
+    browser,
+  }) => {
+    const cases = [
+      { timezoneId: 'Pacific/Kiritimati', today: '2026-08-31' },
+      { timezoneId: 'Etc/GMT+12', today: '2027-01-01' },
+      { timezoneId: 'Asia/Tokyo', today: '2026-03-08' },
+      { timezoneId: 'America/Detroit', today: '2026-11-01' },
+    ] as const;
+    const webBaseURL = process.env.BASE_URL ?? `http://127.0.0.1:${process.env.E2E_PORT ?? '4173'}`;
+
+    for (const testCase of cases) {
+      const range = monthGridRange(testCase.today);
+      const sourceResponse = await api.get(
+        `/api/v1/data-quality/calendar?start=${range.start}&end=${range.end}`,
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+      expect(sourceResponse.ok(), await sourceResponse.text()).toBeTruthy();
+      const fixed = ((await sourceResponse.json()) as { data: DataQualityCalendar }).data;
+      fixed.today = testCase.today;
+      fixed.days = fixed.days.map((day) => ({ ...day, isToday: day.date === testCase.today }));
+
+      const context = await browser.newContext({
+        baseURL: webBaseURL,
+        timezoneId: testCase.timezoneId,
+      });
+      const page = await context.newPage();
+      const diagnostics = monitorPage(page);
+      const requestUrls: string[] = [];
+      await page.route('**/api/v1/data-quality/calendar*', async (route) => {
+        requestUrls.push(route.request().url());
+        await route.fulfill({ status: 200, json: { data: fixed } });
+      });
+      try {
+        await setAuthenticatedSession(page, token);
+        await page.goto('/data-quality', { waitUntil: 'domcontentloaded' });
+        await expect(
+          page.getByRole('heading', {
+            name: new Intl.DateTimeFormat('en-US', {
+              month: 'long',
+              timeZone: 'UTC',
+              year: 'numeric',
+            }).format(new Date(`${testCase.today.slice(0, 7)}-01T00:00:00.000Z`)),
+          }),
+        ).toBeVisible();
+        await expect(page.getByLabel('Jump to date')).toHaveValue(testCase.today);
+        await page.waitForLoadState('networkidle');
+        expect(new URL(requestUrls[0] ?? '').searchParams.has('start')).toBe(false);
+        expect(requestUrls).toHaveLength(1);
+        expect(fixed.range).toEqual({ startDate: range.start, endDate: range.end });
+        diagnostics();
+      } finally {
+        await context.close();
+      }
+    }
   });
 });

--- a/apps/web/e2e/data-quality-calendar.spec.ts
+++ b/apps/web/e2e/data-quality-calendar.spec.ts
@@ -1,0 +1,273 @@
+import { mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import type { DataQualityCalendar } from '@pulse/shared';
+import { expect, request, test, type APIRequestContext, type Page } from '@playwright/test';
+
+import { setAuthenticatedSession } from './auth-session';
+import { apiBaseURL } from './test-env';
+
+test.use({ timezoneId: 'America/Detroit' });
+
+const username = 'adaptive-preview-dq-calendar';
+const password = 'adaptive-preview-only';
+let api: APIRequestContext;
+let token: string;
+let agentToken: { id: string; token: string };
+
+function dateKeyInDetroit() {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    day: '2-digit',
+    month: '2-digit',
+    timeZone: 'America/Detroit',
+    year: 'numeric',
+  }).formatToParts(new Date());
+  const part = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((value) => value.type === type)?.value ?? '';
+  return `${part('year')}-${part('month')}-${part('day')}`;
+}
+
+function addDays(date: string, amount: number) {
+  const value = new Date(`${date}T00:00:00.000Z`);
+  value.setUTCDate(value.getUTCDate() + amount);
+  return value.toISOString().slice(0, 10);
+}
+
+function uiDate(date: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    day: 'numeric',
+    month: 'long',
+    timeZone: 'UTC',
+    weekday: 'long',
+    year: 'numeric',
+  }).format(new Date(`${date}T00:00:00.000Z`));
+}
+
+function monitorPage(page: Page) {
+  const failures: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() === 'warning' || message.type() === 'error') {
+      failures.push(`${message.type()}: ${message.text()}`);
+    }
+  });
+  page.on('pageerror', (error) => failures.push(`pageerror: ${error.message}`));
+  page.on('requestfailed', (failed) =>
+    failures.push(
+      `requestfailed: ${failed.method()} ${failed.url()} ${failed.failure()?.errorText ?? ''}`,
+    ),
+  );
+  page.on('response', (response) => {
+    if (response.status() >= 400) failures.push(`http ${response.status()}: ${response.url()}`);
+  });
+  return () => expect(failures, 'browser diagnostics').toEqual([]);
+}
+
+async function openCalendar(page: Page, throughNavigation = false) {
+  await setAuthenticatedSession(page, token);
+  const calendarResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/v1/data-quality/calendar?') && response.status() === 200,
+  );
+  if (throughNavigation) {
+    await page.goto('/', { waitUntil: 'networkidle' });
+    await page.getByRole('button', { name: 'More' }).click();
+    await page.getByRole('menuitem', { name: 'Data Quality' }).click();
+  } else {
+    await page.goto('/data-quality', { waitUntil: 'domcontentloaded' });
+  }
+  const response = await calendarResponse;
+  const payload = (await response.json()) as { data: DataQualityCalendar };
+  await expect(page.getByRole('heading', { level: 1, name: 'Data Quality & Trust' })).toBeVisible();
+  await expect(page.getByText('Audit, not score')).toBeVisible();
+  await page.waitForLoadState('networkidle');
+  return payload.data;
+}
+
+async function selectDay(page: Page, date: string) {
+  const day = page.getByRole('button', { name: new RegExp(`^${uiDate(date)}[.]`) });
+  await day.focus();
+  await page.keyboard.press('Enter');
+  await expect(day).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByRole('heading', { name: uiDate(date) })).toBeVisible();
+}
+
+async function capture(page: Page, filename: string) {
+  const directory = resolve(process.cwd(), '../../artifacts/issue-111');
+  mkdirSync(directory, { recursive: true });
+  await page.screenshot({ fullPage: true, path: resolve(directory, filename) });
+}
+
+async function expectNoOverflowAndTouchTargets(page: Page, width: number) {
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+    ),
+    `${width}px page overflow`,
+  ).toBe(true);
+  const domainGroup = page.getByRole('group', { name: 'Calendar domains' });
+  for (const control of await domainGroup.getByRole('button').all()) {
+    const box = await control.boundingBox();
+    expect(
+      box?.height ?? 0,
+      `${width}px ${await control.textContent()} touch target`,
+    ).toBeGreaterThanOrEqual(44);
+  }
+}
+
+test.describe.serial('Data Quality calendar', () => {
+  test.beforeAll(async () => {
+    api = await request.newContext({ baseURL: apiBaseURL });
+    const login = await api.post('/api/v1/auth/login', { data: { password, username } });
+    expect(login.ok(), await login.text()).toBeTruthy();
+    token = ((await login.json()) as { data: { token: string } }).data.token;
+    const created = await api.post('/api/v1/agent-tokens', {
+      data: { name: 'Data Quality browser parity' },
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(created.status(), await created.text()).toBe(201);
+    agentToken = ((await created.json()) as { data: { id: string; token: string } }).data;
+  });
+
+  test.afterAll(async () => {
+    if (agentToken) {
+      const removed = await api.delete(`/api/v1/agent-tokens/${agentToken.id}`, {
+        headers: { authorization: `Bearer ${token}` },
+      });
+      expect(removed.ok(), await removed.text()).toBeTruthy();
+    }
+    await api.dispose();
+  });
+
+  test('navigates from More and audits cross-domain facts with exact AgentToken parity', async ({
+    page,
+  }) => {
+    const diagnostics = monitorPage(page);
+    await page.setViewportSize({ height: 1000, width: 390 });
+    const calendar = await openCalendar(page, true);
+    const today = calendar.days.find((day) => day.isToday)?.date ?? dateKeyInDetroit();
+    const contextDate = addDays(today, -4);
+    await selectDay(page, contextDate);
+
+    await expect(page.getByRole('heading', { name: 'Nutrition' })).toBeVisible();
+    await expect(
+      page.getByText('Migraine reduced appetite and changed the planned training day.'),
+    ).toBeVisible();
+    await expect(page.getByText('Preview Coach')).toBeVisible();
+    await expect(page.getByText('agent token · revision 1', { exact: false })).toBeVisible();
+    await expect(page.getByText('partial', { exact: true }).first()).toBeVisible();
+    await expect(
+      page.getByText(
+        'Context explains evidence but never changes status or calculations by itself.',
+      ),
+    ).toBeVisible();
+
+    const url = `/api/v1/data-quality/calendar?start=${calendar.range.startDate}&end=${calendar.range.endDate}`;
+    const [jwtResponse, agentResponse] = await Promise.all([
+      api.get(url, { headers: { authorization: `Bearer ${token}` } }),
+      api.get(url, { headers: { authorization: `AgentToken ${agentToken.token}` } }),
+    ]);
+    expect(jwtResponse.ok(), await jwtResponse.text()).toBeTruthy();
+    expect(agentResponse.ok(), await agentResponse.text()).toBeTruthy();
+    expect((await agentResponse.json()).data).toEqual((await jwtResponse.json()).data);
+
+    const weightFilter = page.getByRole('button', { name: 'Weight' });
+    await weightFilter.focus();
+    await page.keyboard.press('Space');
+    await expect(weightFilter).toHaveAttribute('aria-pressed', 'false');
+    await expect(page.getByRole('heading', { name: 'Weight' })).toHaveCount(0);
+    await page.keyboard.press('Space');
+    await expect(weightFilter).toHaveAttribute('aria-pressed', 'true');
+
+    await expectNoOverflowAndTouchTargets(page, 390);
+    await capture(page, 'data-quality-context-390.png');
+    diagnostics();
+  });
+
+  test('keeps missing, cutoff, corrected, planned, and completed evidence distinct', async ({
+    page,
+  }) => {
+    const diagnostics = monitorPage(page);
+    await page.setViewportSize({ height: 1000, width: 430 });
+    const calendar = await openCalendar(page);
+    const today = calendar.days.find((day) => day.isToday)?.date ?? dateKeyInDetroit();
+
+    await selectDay(page, addDays(today, -3));
+    await expect(page.getByText('Retained row was corrected')).toBeVisible();
+    await expect(page.getByText('Corrected', { exact: true }).first()).toBeVisible();
+
+    await selectDay(page, addDays(today, -2));
+    await expect(page.getByText('No record', { exact: true })).toBeVisible();
+    await expect(page.getByText('No weigh-in', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('planned', { exact: true }).first()).toBeVisible();
+
+    await selectDay(page, addDays(today, -1));
+    await expect(page.getByText('Cross-domain strength session')).toBeVisible();
+    await expect(page.getByText('corrected', { exact: true }).first()).toBeVisible();
+    await capture(page, 'data-quality-workout-430.png');
+
+    await selectDay(page, today);
+    await expect(page.getAllByText('Pending cutoff', { exact: true })).toHaveLength(2);
+    await expect(page.getByText(/pending completed day cutoff/i)).toBeVisible();
+    diagnostics();
+  });
+
+  test('creates bounded context without changing the selected date algorithm state', async ({
+    page,
+  }) => {
+    const diagnostics = monitorPage(page);
+    await page.setViewportSize({ height: 1000, width: 320 });
+    const calendar = await openCalendar(page);
+    const today = calendar.days.find((day) => day.isToday)?.date ?? dateKeyInDetroit();
+    const date = addDays(today, -1);
+    await selectDay(page, date);
+    const originalProgramState = await page
+      .getByText('Program state')
+      .locator('..')
+      .locator('dd')
+      .textContent();
+
+    const contextResponse = page.waitForResponse(
+      (response) =>
+        response.url().endsWith('/api/v1/adaptive-nutrition/review-context') &&
+        response.request().method() === 'POST' &&
+        response.status() === 201,
+    );
+    await page.getByRole('button', { name: 'Add context' }).click();
+    await page.getByLabel('Context type').selectOption('recovery');
+    await page
+      .getByLabel('What should Pulse know?')
+      .fill('Recovery session was intentionally lighter.');
+    await page.getByRole('dialog').getByRole('button', { name: 'Add context' }).click();
+    const created = (await (await contextResponse).json()) as {
+      data: { id: string; revision: number };
+    };
+    try {
+      await expect(page.getByText('Recovery session was intentionally lighter.')).toBeVisible();
+      await expect(page.getByText('Program state').locator('..').locator('dd')).toHaveText(
+        originalProgramState ?? '',
+      );
+      await expectNoOverflowAndTouchTargets(page, 320);
+      await capture(page, 'data-quality-context-created-320.png');
+    } finally {
+      const removed = await api.delete(
+        `/api/v1/adaptive-nutrition/review-context/${created.data.id}?expectedRevision=${created.data.revision}`,
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+      expect(removed.ok(), await removed.text()).toBeTruthy();
+    }
+    diagnostics();
+  });
+
+  test('stays usable without overflow at tablet and desktop widths', async ({ page }) => {
+    const diagnostics = monitorPage(page);
+    const calendar = await openCalendar(page);
+    const today = calendar.days.find((day) => day.isToday)?.date ?? dateKeyInDetroit();
+    await selectDay(page, today);
+    for (const width of [768, 1280]) {
+      await page.setViewportSize({ height: 1000, width });
+      await expectNoOverflowAndTouchTargets(page, width);
+      await capture(page, `data-quality-calendar-${width}.png`);
+    }
+    diagnostics();
+  });
+});

--- a/apps/web/e2e/trend-weight-analytics.spec.ts
+++ b/apps/web/e2e/trend-weight-analytics.spec.ts
@@ -155,16 +155,6 @@ async function reviseGoal(api: APIRequestContext, authorization: string) {
   expect(response.ok(), await response.text()).toBeTruthy();
 }
 
-async function chartDotX(dot: ReturnType<Page['locator']>) {
-  const path = dot.locator('path');
-  const coordinate = await path.getAttribute('cx');
-  if (coordinate !== null) return Number(coordinate);
-  const transform = await path.getAttribute('transform');
-  const match = transform?.match(/^translate\(([-\d.]+)/);
-  if (!match) throw new Error('Trend Weight point did not expose an x coordinate');
-  return Number(match[1]);
-}
-
 async function trendWeightAxisLabels(page: Page) {
   return page
     .locator('.recharts-xAxis-tick-labels .recharts-cartesian-axis-tick-value')
@@ -362,7 +352,7 @@ test('shows server-owned Trend Weight, raw spike, exact table, ranges, and respo
     const updatePayload = (await updateHttpResponse.json()) as { data: { updatedAt: number } };
     await expect(page.getByText('Weight entry updated')).toBeVisible();
     await expect(page.locator('[data-slot="trend-weight-latest-scale"]')).toHaveText('188 lbs');
-    await expect(page.getByText(/Corrected weigh-in/).first()).toBeVisible();
+    await expect(page.getByText(/Corrected weigh-in/)).toHaveCount(0);
     await expect(
       page.getByText(uiUpdatedAt(updatePayload.data.updatedAt), { exact: true }),
     ).toBeVisible();
@@ -912,7 +902,7 @@ for (const scenario of dateZoneCases) {
 test.describe('Trend Weight literal dates across Detroit DST', () => {
   test.use({ timezoneId: 'America/Detroit' });
 
-  test('keeps spring-forward points and a correction marker on their literal dates', async ({
+  test('keeps spring-forward points literal without fabricating a correction marker', async ({
     page,
   }) => {
     const endDate = dateKeyInDetroit();
@@ -958,6 +948,7 @@ test.describe('Trend Weight literal dates across Detroit DST', () => {
       await expectLiteralAxisRange(page, analytics.range);
       const marchDates = ['2026-03-07', '2026-03-08', '2026-03-09'];
       expect(analytics.points.slice(0, 3).map((point) => point.date)).toEqual(marchDates);
+      expect(analytics.markers.filter((marker) => marker.kind === 'correction')).toEqual([]);
 
       const march8Index = analytics.points.findIndex((point) => point.date === '2026-03-08');
       expect(march8Index).toBeGreaterThanOrEqual(0);
@@ -977,13 +968,8 @@ test.describe('Trend Weight literal dates across Detroit DST', () => {
       const correctionMarker = page.locator(
         '[data-slot="trend-weight-marker-lane"] [data-date="2026-03-08"]',
       );
-      await expect(correctionMarker).toContainText('Mar 8, 2026');
-      await expect(correctionMarker).toContainText('Corrected weigh-in');
-
-      const correctionLine = page.locator('.trend-weight-marker-line line').first();
-      const correctionX = Number(await correctionLine.getAttribute('x1'));
-      const dotX = await chartDotX(march8Dot);
-      expect(Math.abs(correctionX - dotX)).toBeLessThanOrEqual(0.5);
+      await expect(correctionMarker).toHaveCount(0);
+      await expect(page.getByText(/Corrected weigh-in/)).toHaveCount(0);
 
       await page.setViewportSize({ width: 430, height: 900 });
       expect(

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -26,6 +26,11 @@ const DashboardPage = lazy(async () => {
   return { default: module.DashboardPage };
 });
 
+const DataQualityPage = lazy(async () => {
+  const module = await import('./pages/data-quality');
+  return { default: module.DataQualityPage };
+});
+
 const DesignSystemPage = lazy(async () => {
   const module = await import('./pages/design-system');
   return { default: module.DesignSystemPage };
@@ -164,6 +169,7 @@ function AppRoutes() {
         path="/"
       >
         <Route element={renderWithPageFallback(<DashboardPage />)} index />
+        <Route element={renderWithPageFallback(<DataQualityPage />)} path="data-quality" />
         <Route element={renderWithPageFallback(<DesignSystemPage />)} path="design-system" />
         <Route element={renderWithPageFallback(<WorkoutsPage />)} path="workouts" />
         <Route element={renderWithPageFallback(<ActiveWorkoutPage />)} path="workouts/active" />

--- a/apps/web/src/components/layout/bottom-nav.test.tsx
+++ b/apps/web/src/components/layout/bottom-nav.test.tsx
@@ -63,6 +63,7 @@ function renderBottomNav(initialPath = '/', store = createAuthStore()) {
         <Route element={<h1>Workouts Route</h1>} path="/workouts" />
         <Route element={<h1>Nutrition Route</h1>} path="/nutrition" />
         <Route element={<h1>Habits Route</h1>} path="/habits" />
+        <Route element={<h1>Data Quality Route</h1>} path="/data-quality" />
         <Route element={<h1>Activity Route</h1>} path="/activity" />
         <Route element={<h1>Journal Route</h1>} path="/journal" />
         <Route element={<h1>Profile Route</h1>} path="/profile" />
@@ -76,7 +77,7 @@ describe('BottomNav', () => {
     vi.clearAllMocks();
   });
 
-  it('opens the More menu with activity, journal, and profile links', () => {
+  it('opens the More menu with data-quality, activity, journal, and profile links', () => {
     renderBottomNav('/');
 
     const nav = screen.getByRole('navigation', { name: 'Mobile navigation' });
@@ -94,6 +95,10 @@ describe('BottomNav', () => {
 
     expect(screen.getByRole('menu')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Dashboard' })).toHaveClass('cursor-pointer');
+    expect(screen.getByRole('menuitem', { name: 'Data Quality' })).toHaveAttribute(
+      'href',
+      '/data-quality',
+    );
     expect(screen.getByRole('menuitem', { name: 'Activity' })).toHaveAttribute('href', '/activity');
     expect(screen.getByRole('menuitem', { name: 'Activity' })).toHaveClass('cursor-pointer');
     expect(screen.getByRole('menuitem', { name: 'Journal' })).toHaveAttribute('href', '/journal');

--- a/apps/web/src/components/layout/nav-items.ts
+++ b/apps/web/src/components/layout/nav-items.ts
@@ -1,6 +1,7 @@
 import type { LucideIcon } from 'lucide-react';
 import {
   Activity,
+  ShieldCheck,
   Dumbbell,
   Ellipsis,
   NotebookPen,
@@ -42,6 +43,11 @@ export const primaryNavItems: NavItem[] = [
 ];
 
 export const moreNavItems: NavItem[] = [
+  {
+    icon: ShieldCheck,
+    label: 'Data Quality',
+    to: '/data-quality',
+  },
   {
     icon: Activity,
     label: 'Activity',

--- a/apps/web/src/features/data-quality/api/data-quality.ts
+++ b/apps/web/src/features/data-quality/api/data-quality.ts
@@ -15,12 +15,14 @@ export const dataQualityQueryKeys = {
     [
       ...dataQualityQueryKeys.all,
       'calendar',
-      { start: query.start, end: query.end, timeZone: query.timeZone ?? null },
+      { start: query.start ?? null, end: query.end ?? null, timeZone: query.timeZone ?? null },
     ] as const,
 };
 
 const fetchDataQualityCalendar = (query: DataQualityCalendarQuery, signal?: AbortSignal) => {
-  const params = new URLSearchParams({ start: query.start, end: query.end });
+  const params = new URLSearchParams();
+  if (query.start) params.set('start', query.start);
+  if (query.end) params.set('end', query.end);
   if (query.timeZone) params.set('timeZone', query.timeZone);
   return apiRequest<unknown>(`/api/v1/data-quality/calendar?${params.toString()}`, {
     signal,

--- a/apps/web/src/features/data-quality/api/data-quality.ts
+++ b/apps/web/src/features/data-quality/api/data-quality.ts
@@ -1,0 +1,52 @@
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  adaptiveReviewContextSchema,
+  dataQualityCalendarSchema,
+  type AdaptiveReviewContextCreateInput,
+  type DataQualityCalendarQuery,
+} from '@pulse/shared';
+import { toast } from 'sonner';
+
+import { apiRequest } from '@/lib/api-client';
+
+export const dataQualityQueryKeys = {
+  all: ['data-quality'] as const,
+  calendar: (query: DataQualityCalendarQuery) =>
+    [
+      ...dataQualityQueryKeys.all,
+      'calendar',
+      { start: query.start, end: query.end, timeZone: query.timeZone ?? null },
+    ] as const,
+};
+
+const fetchDataQualityCalendar = (query: DataQualityCalendarQuery, signal?: AbortSignal) => {
+  const params = new URLSearchParams({ start: query.start, end: query.end });
+  if (query.timeZone) params.set('timeZone', query.timeZone);
+  return apiRequest<unknown>(`/api/v1/data-quality/calendar?${params.toString()}`, {
+    signal,
+  }).then((value) => dataQualityCalendarSchema.parse(value));
+};
+
+export const useDataQualityCalendar = (query: DataQualityCalendarQuery) =>
+  useQuery({
+    queryKey: dataQualityQueryKeys.calendar(query),
+    queryFn: ({ signal }) => fetchDataQualityCalendar(query, signal),
+    placeholderData: keepPreviousData,
+  });
+
+const createDateContext = (input: AdaptiveReviewContextCreateInput) =>
+  apiRequest<unknown>('/api/v1/adaptive-nutrition/review-context', {
+    method: 'POST',
+    body: input,
+  }).then((value) => adaptiveReviewContextSchema.parse(value));
+
+export const useCreateDataQualityContext = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createDateContext,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: dataQualityQueryKeys.all });
+      toast.success('Context added without changing algorithm eligibility');
+    },
+  });
+};

--- a/apps/web/src/features/data-quality/components/data-quality-calendar-workspace.test.tsx
+++ b/apps/web/src/features/data-quality/components/data-quality-calendar-workspace.test.tsx
@@ -35,8 +35,15 @@ const emptyDay = (date: string): DataQualityCalendarDay => ({
     totals: null,
     mealCount: null,
     itemCount: null,
+    createdAt: null,
     statusUpdatedAt: null,
     updatedAt: null,
+    provenance: {
+      type: 'not_recorded',
+      label: 'Not recorded',
+      agentTokenId: null,
+      limitation: 'No record.',
+    },
     reasonCodes: [],
     actions: [],
   },
@@ -46,11 +53,17 @@ const emptyDay = (date: string): DataQualityCalendarDay => ({
     weight: null,
     unit: null,
     trendWeight: null,
-    corrected: false,
+    correctionState: 'not_applicable',
     suspect: false,
     stale: false,
     createdAt: null,
     updatedAt: null,
+    provenance: {
+      type: 'not_recorded',
+      label: 'Not recorded',
+      agentTokenId: null,
+      limitation: 'No record.',
+    },
     reasonCodes: [],
     actions: [],
   },
@@ -61,8 +74,11 @@ const emptyDay = (date: string): DataQualityCalendarDay => ({
     weightEvidenceState: 'missing',
     reasonCodes: ['INSUFFICIENT_NUTRITION'],
     events: [],
+    omittedEventCount: 0,
   },
   contexts: [],
+  omittedWorkoutCount: 0,
+  omittedContextCount: 0,
 });
 
 const calendar = (): DataQualityCalendar => {
@@ -77,8 +93,15 @@ const calendar = (): DataQualityCalendar => {
     totals: { calories: 2410, protein: 168, carbs: 265, fat: 71 },
     mealCount: 4,
     itemCount: 12,
+    createdAt: 1_777_000_000_000,
     statusUpdatedAt: 1_777_000_000_000,
     updatedAt: 1_777_000_000_000,
+    provenance: {
+      type: 'not_recorded',
+      label: 'Not recorded',
+      agentTokenId: null,
+      limitation: 'Unavailable.',
+    },
     reasonCodes: ['COMPLETE_NUTRITION_PENDING_COMPLETED_DAY_CUTOFF'],
     actions: [],
   };
@@ -88,11 +111,17 @@ const calendar = (): DataQualityCalendar => {
     weight: 176.8,
     unit: 'lbs',
     trendWeight: 175.9,
-    corrected: true,
+    correctionState: 'history_unavailable',
     suspect: false,
     stale: false,
     createdAt: 1_777_000_000_000,
     updatedAt: 1_777_000_001_000,
+    provenance: {
+      type: 'not_recorded',
+      label: 'Not recorded',
+      agentTokenId: null,
+      limitation: 'Unavailable.',
+    },
     reasonCodes: ['WEIGH_INS_PENDING_COMPLETED_DAY_CUTOFF'],
     actions: [],
   };
@@ -101,14 +130,25 @@ const calendar = (): DataQualityCalendar => {
       id: 'workout-18',
       kind: 'workout_session',
       name: 'Upper strength',
-      state: 'corrected',
+      state: 'completed',
       scheduledWorkoutId: null,
       sessionId: 'workout-18',
       sessionStatus: 'completed',
+      plannedDate: null,
+      sessionDate: '2026-08-18',
+      relation: 'unlinked',
+      relationLimitation: null,
+      correctionState: 'history_unavailable',
       startedAt: 1_777_000_000_000,
       completedAt: 1_777_000_000_500,
       createdAt: 1_777_000_000_000,
       updatedAt: 1_777_000_001_000,
+      provenance: {
+        type: 'not_recorded',
+        label: 'Not recorded',
+        agentTokenId: null,
+        limitation: 'Unavailable.',
+      },
       reasonCodes: ['WORKOUT_RECORD_CORRECTED'],
       actions: [],
     },
@@ -126,9 +166,16 @@ const calendar = (): DataQualityCalendar => {
         effectiveDate: '2026-08-18',
         createdAt: 1_777_000_000_000,
         reasonCodes: [],
+        provenance: {
+          type: 'system_derived',
+          label: 'Pulse algorithm',
+          agentTokenId: null,
+          limitation: null,
+        },
         actions: [],
       },
     ],
+    omittedEventCount: 0,
   };
   selected.contexts = [
     {
@@ -146,6 +193,7 @@ const calendar = (): DataQualityCalendar => {
   ];
   return {
     range: { startDate: '2026-07-27', endDate: '2026-09-06' },
+    today: '2026-08-18',
     timeZone: 'America/Detroit',
     days,
     summary: {
@@ -154,6 +202,7 @@ const calendar = (): DataQualityCalendar => {
       workout: { planned: 0, active: 0, completed: 0, cancelled: 0, corrected: 1 },
       algorithm: { learning: 41, updating: 0, holding: 1, pendingReview: 1 },
       contextDays: 1,
+      intervalLabel: 'Visible calendar grid',
     },
   };
 };
@@ -187,12 +236,38 @@ const renderWorkspace = () =>
   );
 
 describe('DataQualityCalendarWorkspace', () => {
+  it('renders the authoritative bootstrap month without a browser-local range request', async () => {
+    const tokyo = calendar();
+    tokyo.today = '2027-01-01';
+    tokyo.timeZone = 'Asia/Tokyo';
+    vi.mocked(useDataQualityCalendar).mockReturnValue({
+      data: tokyo,
+      isPending: false,
+      isError: false,
+      isFetching: false,
+      refetch,
+    } as unknown as ReturnType<typeof useDataQualityCalendar>);
+
+    render(
+      <MemoryRouter initialEntries={['/data-quality']}>
+        <DataQualityCalendarWorkspace />
+      </MemoryRouter>,
+    );
+
+    expect(vi.mocked(useDataQualityCalendar).mock.calls[0]?.[0]).toEqual({});
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'January 2027' })).toBeInTheDocument(),
+    );
+    expect(screen.getByLabelText('Jump to date')).toHaveValue('2027-01-01');
+    expect(vi.mocked(useDataQualityCalendar)).toHaveBeenCalledTimes(1);
+  });
+
   it('renders honest cross-domain facts, provenance, and exact algorithm treatment', () => {
     renderWorkspace();
 
     expect(screen.getByRole('heading', { name: 'August 2026' })).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /Tuesday, August 18, 2026.*Pending cutoff.*Corrected/i }),
+      screen.getByRole('button', { name: /Tuesday, August 18, 2026.*Pending cutoff/i }),
     ).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByText('2410 kcal')).toBeInTheDocument();
     expect(screen.getByText('176.8 lbs')).toBeInTheDocument();
@@ -215,6 +290,43 @@ describe('DataQualityCalendarWorkspace', () => {
     expect(screen.queryByRole('heading', { name: 'Context' })).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Nutrition' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Tuesday, August 18, 2026/ })).toBeInTheDocument();
+  });
+
+  it('shows the authoritative refresh path for stale review evidence', () => {
+    const stale = calendar();
+    const today = stale.days.find((day) => day.date === stale.today);
+    if (!today) throw new Error('Expected today fixture');
+    const review = today.algorithm.events[0];
+    if (!review) throw new Error('Expected review fixture');
+    review.state = 'stale';
+    review.actions = [
+      {
+        kind: 'view_review',
+        label: 'View weekly review',
+        href: `/nutrition/reviews/${review.id}`,
+        method: 'navigate',
+      },
+      {
+        kind: 'refresh_review',
+        label: 'Refresh stale weekly review',
+        href: `/nutrition/reviews/${review.id}`,
+        method: 'navigate',
+      },
+    ];
+    vi.mocked(useDataQualityCalendar).mockReturnValue({
+      data: stale,
+      isPending: false,
+      isError: false,
+      isFetching: false,
+      refetch,
+    } as unknown as ReturnType<typeof useDataQualityCalendar>);
+
+    renderWorkspace();
+    expect(screen.getByText('weekly review · stale')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Refresh stale weekly review' })).toHaveAttribute(
+      'href',
+      `/nutrition/reviews/${review.id}`,
+    );
   });
 
   it('submits bounded date context through the shared form schema', async () => {

--- a/apps/web/src/features/data-quality/components/data-quality-calendar-workspace.test.tsx
+++ b/apps/web/src/features/data-quality/components/data-quality-calendar-workspace.test.tsx
@@ -198,8 +198,8 @@ const calendar = (): DataQualityCalendar => {
     days,
     summary: {
       nutrition: { complete: 1, partial: 0, unknown: 0, missing: 41, pending: 1, excluded: 1 },
-      weight: { logged: 1, missing: 41, pending: 1, excluded: 1, corrected: 1 },
-      workout: { planned: 0, active: 0, completed: 0, cancelled: 0, corrected: 1 },
+      weight: { logged: 1, missing: 41, pending: 1, excluded: 1 },
+      workout: { planned: 0, active: 0, completed: 0, cancelled: 0 },
       algorithm: { learning: 41, updating: 0, holding: 1, pendingReview: 1 },
       contextDays: 1,
       intervalLabel: 'Visible calendar grid',

--- a/apps/web/src/features/data-quality/components/data-quality-calendar-workspace.test.tsx
+++ b/apps/web/src/features/data-quality/components/data-quality-calendar-workspace.test.tsx
@@ -199,7 +199,7 @@ describe('DataQualityCalendarWorkspace', () => {
     expect(screen.getByText('Upper strength')).toBeInTheDocument();
     expect(screen.getByText('weekly review · deferred')).toBeInTheDocument();
     expect(screen.getByText('Recovery day after a cold')).toBeInTheDocument();
-    expect(screen.getByText('Coach Agent')).toBeInTheDocument();
+    expect(screen.getByText('AgentToken · Coach Agent')).toBeInTheDocument();
     expect(screen.getByTestId('nutrition-status-control')).toHaveTextContent('2026-08-18');
     expect(screen.getAllByText('pending cutoff').length).toBeGreaterThan(0);
   });

--- a/apps/web/src/features/data-quality/components/data-quality-calendar-workspace.test.tsx
+++ b/apps/web/src/features/data-quality/components/data-quality-calendar-workspace.test.tsx
@@ -1,0 +1,259 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { DataQualityCalendar, DataQualityCalendarDay } from '@pulse/shared';
+
+import { useCreateDataQualityContext, useDataQualityCalendar } from '../api/data-quality';
+import { DataQualityCalendarWorkspace } from './data-quality-calendar-workspace';
+
+vi.mock('../api/data-quality', () => ({
+  useCreateDataQualityContext: vi.fn(),
+  useDataQualityCalendar: vi.fn(),
+}));
+
+vi.mock('@/features/adaptive-nutrition/components/nutrition-day-status-control', () => ({
+  NutritionDayStatusControl: ({ date }: { date: string }) => (
+    <div data-testid="nutrition-status-control">Status control for {date}</div>
+  ),
+}));
+
+const addDays = (date: string, amount: number) => {
+  const value = new Date(`${date}T00:00:00.000Z`);
+  value.setUTCDate(value.getUTCDate() + amount);
+  return value.toISOString().slice(0, 10);
+};
+
+const emptyDay = (date: string): DataQualityCalendarDay => ({
+  date,
+  isToday: date === '2026-08-18',
+  nutrition: {
+    qualityState: 'no_records',
+    evidenceState: 'missing',
+    logId: null,
+    explicitStatus: null,
+    totals: null,
+    mealCount: null,
+    itemCount: null,
+    statusUpdatedAt: null,
+    updatedAt: null,
+    reasonCodes: [],
+    actions: [],
+  },
+  weight: {
+    evidenceState: 'missing',
+    entryId: null,
+    weight: null,
+    unit: null,
+    trendWeight: null,
+    corrected: false,
+    suspect: false,
+    stale: false,
+    createdAt: null,
+    updatedAt: null,
+    reasonCodes: [],
+    actions: [],
+  },
+  workouts: [],
+  algorithm: {
+    state: 'learning',
+    nutritionEvidenceState: 'missing',
+    weightEvidenceState: 'missing',
+    reasonCodes: ['INSUFFICIENT_NUTRITION'],
+    events: [],
+  },
+  contexts: [],
+});
+
+const calendar = (): DataQualityCalendar => {
+  const days = Array.from({ length: 42 }, (_, index) => emptyDay(addDays('2026-07-27', index)));
+  const selected = days.find((day) => day.date === '2026-08-18');
+  if (!selected) throw new Error('Expected selected day fixture');
+  selected.nutrition = {
+    qualityState: 'complete',
+    evidenceState: 'pending_cutoff',
+    logId: 'nutrition-18',
+    explicitStatus: 'complete',
+    totals: { calories: 2410, protein: 168, carbs: 265, fat: 71 },
+    mealCount: 4,
+    itemCount: 12,
+    statusUpdatedAt: 1_777_000_000_000,
+    updatedAt: 1_777_000_000_000,
+    reasonCodes: ['COMPLETE_NUTRITION_PENDING_COMPLETED_DAY_CUTOFF'],
+    actions: [],
+  };
+  selected.weight = {
+    evidenceState: 'pending_cutoff',
+    entryId: 'weight-18',
+    weight: 176.8,
+    unit: 'lbs',
+    trendWeight: 175.9,
+    corrected: true,
+    suspect: false,
+    stale: false,
+    createdAt: 1_777_000_000_000,
+    updatedAt: 1_777_000_001_000,
+    reasonCodes: ['WEIGH_INS_PENDING_COMPLETED_DAY_CUTOFF'],
+    actions: [],
+  };
+  selected.workouts = [
+    {
+      id: 'workout-18',
+      kind: 'workout_session',
+      name: 'Upper strength',
+      state: 'corrected',
+      scheduledWorkoutId: null,
+      sessionId: 'workout-18',
+      sessionStatus: 'completed',
+      startedAt: 1_777_000_000_000,
+      completedAt: 1_777_000_000_500,
+      createdAt: 1_777_000_000_000,
+      updatedAt: 1_777_000_001_000,
+      reasonCodes: ['WORKOUT_RECORD_CORRECTED'],
+      actions: [],
+    },
+  ];
+  selected.algorithm = {
+    state: 'holding',
+    nutritionEvidenceState: 'pending_cutoff',
+    weightEvidenceState: 'pending_cutoff',
+    reasonCodes: ['INSUFFICIENT_NUTRITION'],
+    events: [
+      {
+        id: 'review-18',
+        kind: 'weekly_review',
+        state: 'deferred',
+        effectiveDate: '2026-08-18',
+        createdAt: 1_777_000_000_000,
+        reasonCodes: [],
+        actions: [],
+      },
+    ],
+  };
+  selected.contexts = [
+    {
+      id: 'context-18',
+      subjectKind: 'date',
+      category: 'illness',
+      note: 'Recovery day after a cold',
+      resolution: null,
+      provenance: { type: 'agent_token', agentTokenId: 'agent-1', label: 'Coach Agent' },
+      revision: 2,
+      createdAt: 1_777_000_000_000,
+      updatedAt: 1_777_000_001_000,
+      actions: [],
+    },
+  ];
+  return {
+    range: { startDate: '2026-07-27', endDate: '2026-09-06' },
+    timeZone: 'America/Detroit',
+    days,
+    summary: {
+      nutrition: { complete: 1, partial: 0, unknown: 0, missing: 41, pending: 1, excluded: 1 },
+      weight: { logged: 1, missing: 41, pending: 1, excluded: 1, corrected: 1 },
+      workout: { planned: 0, active: 0, completed: 0, cancelled: 0, corrected: 1 },
+      algorithm: { learning: 41, updating: 0, holding: 1, pendingReview: 1 },
+      contextDays: 1,
+    },
+  };
+};
+
+const mutateAsync = vi.fn();
+const refetch = vi.fn();
+
+beforeEach(() => {
+  mutateAsync.mockReset();
+  refetch.mockReset();
+  vi.mocked(useDataQualityCalendar).mockReturnValue({
+    data: calendar(),
+    isPending: false,
+    isError: false,
+    isFetching: false,
+    refetch,
+  } as unknown as ReturnType<typeof useDataQualityCalendar>);
+  vi.mocked(useCreateDataQualityContext).mockReturnValue({
+    mutateAsync,
+    isPending: false,
+    isError: false,
+    error: null,
+  } as unknown as ReturnType<typeof useCreateDataQualityContext>);
+});
+
+const renderWorkspace = () =>
+  render(
+    <MemoryRouter initialEntries={['/data-quality?date=2026-08-18']}>
+      <DataQualityCalendarWorkspace />
+    </MemoryRouter>,
+  );
+
+describe('DataQualityCalendarWorkspace', () => {
+  it('renders honest cross-domain facts, provenance, and exact algorithm treatment', () => {
+    renderWorkspace();
+
+    expect(screen.getByRole('heading', { name: 'August 2026' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Tuesday, August 18, 2026.*Pending cutoff.*Corrected/i }),
+    ).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('2410 kcal')).toBeInTheDocument();
+    expect(screen.getByText('176.8 lbs')).toBeInTheDocument();
+    expect(screen.getByText('Upper strength')).toBeInTheDocument();
+    expect(screen.getByText('weekly review · deferred')).toBeInTheDocument();
+    expect(screen.getByText('Recovery day after a cold')).toBeInTheDocument();
+    expect(screen.getByText('Coach Agent')).toBeInTheDocument();
+    expect(screen.getByTestId('nutrition-status-control')).toHaveTextContent('2026-08-18');
+    expect(screen.getAllByText('pending cutoff').length).toBeGreaterThan(0);
+  });
+
+  it('supports keyboard domain filtering without removing the calendar date truth', () => {
+    renderWorkspace();
+    const contextFilter = screen.getByRole('button', { name: 'Context' });
+    contextFilter.focus();
+    fireEvent.keyDown(contextFilter, { key: 'Enter' });
+    fireEvent.click(contextFilter);
+
+    expect(contextFilter).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.queryByRole('heading', { name: 'Context' })).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Nutrition' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Tuesday, August 18, 2026/ })).toBeInTheDocument();
+  });
+
+  it('submits bounded date context through the shared form schema', async () => {
+    mutateAsync.mockResolvedValue({ id: 'context-created' });
+    renderWorkspace();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add context' }));
+    const dialog = screen.getByRole('dialog');
+    fireEvent.change(within(dialog).getByLabelText('Context type'), {
+      target: { value: 'illness' },
+    });
+    fireEvent.change(within(dialog).getByLabelText('What should Pulse know?'), {
+      target: { value: 'Migraine affected appetite and training.' },
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Add context' }));
+
+    await waitFor(() =>
+      expect(mutateAsync).toHaveBeenCalledWith({
+        subject: { kind: 'date', localDate: '2026-08-18' },
+        category: 'illness',
+        note: 'Migraine affected appetite and training.',
+        resolution: undefined,
+        resolutionKind: undefined,
+      }),
+    );
+  });
+
+  it('keeps retry available when the read-only request fails', () => {
+    vi.mocked(useDataQualityCalendar).mockReturnValue({
+      data: undefined,
+      isPending: false,
+      isError: true,
+      isFetching: false,
+      refetch,
+    } as unknown as ReturnType<typeof useDataQualityCalendar>);
+
+    renderWorkspace();
+    expect(screen.getByRole('alert')).toHaveTextContent('Your source records are safe');
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/data-quality/components/data-quality-calendar-workspace.tsx
+++ b/apps/web/src/features/data-quality/components/data-quality-calendar-workspace.tsx
@@ -73,14 +73,6 @@ const monthGridRange = (date: string) => {
   const sundayOffset = (7 - parseDateKey(last).getUTCDay()) % 7;
   return { start, end: addDays(last, sundayOffset) };
 };
-const browserToday = () => {
-  const parts = new Intl.DateTimeFormat('en-CA', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).formatToParts(new Date());
-  return `${parts.find((part) => part.type === 'year')?.value}-${parts.find((part) => part.type === 'month')?.value}-${parts.find((part) => part.type === 'day')?.value}`;
-};
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   timeZone: 'UTC',
   weekday: 'long',
@@ -101,6 +93,12 @@ const formatTimestamp = (value: number, timeZone: string) =>
     timeStyle: 'short',
   }).format(new Date(value));
 const humanize = (value: string) => value.replaceAll('_', ' ');
+const provenanceLabel = (value: { label: string; limitation: string | null }) => (
+  <>
+    {value.label}
+    {value.limitation ? ` · ${value.limitation}` : ''}
+  </>
+);
 
 const nutritionLabel = (day: DataQualityCalendarDay) => {
   if (day.nutrition.evidenceState === 'pending_cutoff') return 'Pending cutoff';
@@ -111,7 +109,7 @@ const weightLabel = (day: DataQualityCalendarDay) => {
   if (day.weight.evidenceState === 'pending_cutoff') return 'Pending cutoff';
   if (day.weight.suspect) return 'Suspect';
   if (day.weight.evidenceState === 'excluded') return 'Excluded';
-  if (day.weight.corrected) return 'Corrected';
+  if (day.weight.correctionState === 'confirmed') return 'Corrected';
   return day.weight.entryId ? 'Logged' : 'No weigh-in';
 };
 const workoutLabel = (day: DataQualityCalendarDay) => {
@@ -326,17 +324,22 @@ export function DataQualityCalendarWorkspace() {
   const [searchParams, setSearchParams] = useSearchParams();
   const requestedDate = searchParams.get('date');
   const initialDate =
-    requestedDate && /^\d{4}-\d{2}-\d{2}$/.test(requestedDate) ? requestedDate : browserToday();
-  const [visibleMonth, setVisibleMonth] = useState(() => monthStart(initialDate));
-  const [selectedDate, setSelectedDate] = useState(initialDate);
+    requestedDate && /^\d{4}-\d{2}-\d{2}$/.test(requestedDate) ? requestedDate : null;
+  const [visibleMonth, setVisibleMonth] = useState<string | null>(() =>
+    initialDate ? monthStart(initialDate) : null,
+  );
+  const [selectedDate, setSelectedDate] = useState<string | null>(initialDate);
   const [domains, setDomains] = useState<Set<Domain>>(
     () => new Set(['nutrition', 'weight', 'workout', 'algorithm', 'context']),
   );
   const [contextOpen, setContextOpen] = useState(searchParams.get('action') === 'context');
-  const range = useMemo(() => monthGridRange(visibleMonth), [visibleMonth]);
-  const calendarQuery = useDataQualityCalendar({ start: range.start, end: range.end });
+  const range = useMemo(() => (visibleMonth ? monthGridRange(visibleMonth) : null), [visibleMonth]);
+  const calendarQuery = useDataQualityCalendar(range ? { start: range.start, end: range.end } : {});
   const calendar = calendarQuery.data;
-  const selectedDay = calendar?.days.find((day) => day.date === selectedDate) ?? calendar?.days[0];
+  const resolvedVisibleMonth = visibleMonth ?? (calendar ? monthStart(calendar.today) : null);
+  const resolvedSelectedDate = selectedDate ?? calendar?.today ?? null;
+  const selectedDay =
+    calendar?.days.find((day) => day.date === resolvedSelectedDate) ?? calendar?.days[0];
 
   const selectDate = (date: string) => {
     setSelectedDate(date);
@@ -347,7 +350,8 @@ export function DataQualityCalendarWorkspace() {
   };
 
   const changeMonth = (amount: number) => {
-    const nextMonth = addMonths(visibleMonth, amount);
+    if (!resolvedVisibleMonth) return;
+    const nextMonth = addMonths(resolvedVisibleMonth, amount);
     setVisibleMonth(nextMonth);
     selectDate(nextMonth);
   };
@@ -396,6 +400,7 @@ export function DataQualityCalendarWorkspace() {
               <Button
                 aria-label="Previous month"
                 className="min-h-11 min-w-11"
+                disabled={!resolvedVisibleMonth}
                 onClick={() => changeMonth(-1)}
                 size="icon"
                 type="button"
@@ -407,11 +412,14 @@ export function DataQualityCalendarWorkspace() {
                 className="min-w-40 text-center text-lg font-semibold"
                 id="data-quality-month-heading"
               >
-                {monthFormatter.format(parseDateKey(visibleMonth))}
+                {resolvedVisibleMonth
+                  ? monthFormatter.format(parseDateKey(resolvedVisibleMonth))
+                  : 'Loading…'}
               </h2>
               <Button
                 aria-label="Next month"
                 className="min-h-11 min-w-11"
+                disabled={!resolvedVisibleMonth}
                 onClick={() => changeMonth(1)}
                 size="icon"
                 type="button"
@@ -429,7 +437,7 @@ export function DataQualityCalendarWorkspace() {
                 id="data-quality-jump-date"
                 onChange={(event) => jumpTo(event.target.value)}
                 type="date"
-                value={selectedDate}
+                value={resolvedSelectedDate ?? ''}
               />
             </div>
           </div>
@@ -486,9 +494,13 @@ export function DataQualityCalendarWorkspace() {
           </div>
         ) : calendar ? (
           <CardContent className="space-y-5 p-3 sm:p-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              {calendar.summary.intervalLabel} summary · {formatDate(calendar.range.startDate)}–
+              {formatDate(calendar.range.endDate)}
+            </p>
             <div
               className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-6"
-              aria-label="Month summary"
+              aria-label={calendar.summary.intervalLabel}
             >
               {[
                 ['Complete nutrition', calendar.summary.nutrition.complete],
@@ -517,67 +529,77 @@ export function DataQualityCalendarWorkspace() {
             <section
               aria-labelledby="data-quality-month-heading"
               aria-busy={calendarQuery.isFetching}
+              className="min-w-0 max-w-full overflow-hidden [contain:inline-size_layout_paint]"
             >
-              <div className="grid grid-cols-7 gap-1 sm:gap-2">
-                {DAY_LABELS.map((label) => (
-                  <p
-                    className="py-1 text-center text-[0.65rem] font-bold uppercase tracking-[0.16em] text-muted-foreground"
-                    key={label}
-                  >
-                    {label}
-                  </p>
-                ))}
-                {calendar.days.map((day) => {
-                  const inMonth = day.date.slice(0, 7) === visibleMonth.slice(0, 7);
-                  const selected = day.date === selectedDay?.date;
-                  return (
-                    <button
-                      aria-current={day.isToday ? 'date' : undefined}
-                      aria-label={`${formatDate(day.date)}. Nutrition ${nutritionLabel(day)}. Weight ${weightLabel(day)}. Workout ${workoutLabel(day)}. Algorithm ${algorithmLabel(day)}. ${day.contexts.length} context record${day.contexts.length === 1 ? '' : 's'}.`}
-                      aria-pressed={selected}
-                      className={cn(
-                        'min-h-20 min-w-0 rounded-xl border border-border/70 p-1.5 text-left transition-colors sm:min-h-28 sm:p-2',
-                        inMonth ? 'bg-card hover:border-primary/45' : 'bg-secondary/20 opacity-55',
-                        selected && 'border-primary bg-primary/8 ring-2 ring-primary/20',
-                        day.isToday && 'outline outline-2 outline-offset-1 outline-primary/35',
-                      )}
-                      data-date={day.date}
-                      key={day.date}
-                      onClick={() => selectDate(day.date)}
-                      type="button"
+              <div
+                className="w-full min-w-0 max-w-full overflow-x-auto pb-2"
+                data-testid="data-quality-calendar-scroller"
+              >
+                <div className="grid min-w-[336px] grid-cols-7 gap-1 sm:min-w-0 sm:gap-2">
+                  {DAY_LABELS.map((label) => (
+                    <p
+                      className="py-1 text-center text-[0.65rem] font-bold uppercase tracking-[0.16em] text-muted-foreground"
+                      key={label}
                     >
-                      <span className="block text-xs font-semibold tabular-nums sm:text-sm">
-                        {Number(day.date.slice(-2))}
-                      </span>
-                      <span className="mt-1 flex flex-col items-start gap-0.5 sm:gap-1">
-                        {domains.has('nutrition') ? (
-                          <Indicator domain="nutrition" label={nutritionLabel(day)} />
-                        ) : null}
-                        {domains.has('weight') ? (
-                          <Indicator domain="weight" label={weightLabel(day)} />
-                        ) : null}
-                        {domains.has('workout') ? (
-                          <Indicator domain="workout" label={workoutLabel(day)} />
-                        ) : null}
-                        {domains.has('algorithm') ? (
-                          <Indicator domain="algorithm" label={algorithmLabel(day)} />
-                        ) : null}
-                        {domains.has('context') && day.contexts.length > 0 ? (
-                          <Indicator
-                            domain="context"
-                            label={`${day.contexts.length} note${day.contexts.length === 1 ? '' : 's'}`}
-                          />
-                        ) : null}
-                      </span>
-                    </button>
-                  );
-                })}
+                      {label}
+                    </p>
+                  ))}
+                  {calendar.days.map((day) => {
+                    const inMonth = day.date.slice(0, 7) === resolvedVisibleMonth?.slice(0, 7);
+                    const selected = day.date === selectedDay?.date;
+                    return (
+                      <button
+                        aria-current={day.isToday ? 'date' : undefined}
+                        aria-label={`${formatDate(day.date)}. Nutrition ${nutritionLabel(day)}. Weight ${weightLabel(day)}. Workout ${workoutLabel(day)}. Algorithm ${algorithmLabel(day)}. ${day.contexts.length} context record${day.contexts.length === 1 ? '' : 's'}.`}
+                        aria-pressed={selected}
+                        className={cn(
+                          'min-h-20 min-w-11 rounded-xl border border-border/70 p-1.5 text-left transition-colors sm:min-h-28 sm:p-2',
+                          inMonth
+                            ? 'bg-card hover:border-primary/45'
+                            : 'bg-secondary/20 opacity-55',
+                          selected && 'border-primary bg-primary/8 ring-2 ring-primary/20',
+                          day.isToday && 'outline outline-2 outline-offset-1 outline-primary/35',
+                        )}
+                        data-date={day.date}
+                        key={day.date}
+                        onClick={() => selectDate(day.date)}
+                        type="button"
+                      >
+                        <span className="block text-xs font-semibold tabular-nums sm:text-sm">
+                          {Number(day.date.slice(-2))}
+                        </span>
+                        <span className="mt-1 flex flex-col items-start gap-0.5 sm:gap-1">
+                          {domains.has('nutrition') ? (
+                            <Indicator domain="nutrition" label={nutritionLabel(day)} />
+                          ) : null}
+                          {domains.has('weight') ? (
+                            <Indicator domain="weight" label={weightLabel(day)} />
+                          ) : null}
+                          {domains.has('workout') ? (
+                            <Indicator domain="workout" label={workoutLabel(day)} />
+                          ) : null}
+                          {domains.has('algorithm') ? (
+                            <Indicator domain="algorithm" label={algorithmLabel(day)} />
+                          ) : null}
+                          {domains.has('context') && day.contexts.length > 0 ? (
+                            <Indicator
+                              domain="context"
+                              label={`${day.contexts.length} note${day.contexts.length === 1 ? '' : 's'}`}
+                            />
+                          ) : null}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
               </div>
               <p className="mt-3 text-sm text-muted-foreground" aria-live="polite">
                 {calendar.timeZone} · {calendar.days.length} dates ·{' '}
                 {calendarQuery.isFetching
                   ? 'Checking for updates…'
-                  : `Selected ${formatDate(selectedDay?.date ?? selectedDate)}`}
+                  : selectedDay
+                    ? `Selected ${formatDate(selectedDay.date)}`
+                    : 'No date selected'}
               </p>
             </section>
           </CardContent>
@@ -646,6 +668,21 @@ export function DataQualityCalendarWorkspace() {
                         : 'Not available',
                     },
                     {
+                      label: 'Nutrition log ID',
+                      value: selectedDay.nutrition.logId ?? 'Not recorded',
+                    },
+                    {
+                      label: 'Source',
+                      value: provenanceLabel(selectedDay.nutrition.provenance),
+                    },
+                    {
+                      label: 'Recorded',
+                      value:
+                        selectedDay.nutrition.createdAt === null
+                          ? 'Not available'
+                          : formatTimestamp(selectedDay.nutrition.createdAt, calendar.timeZone),
+                    },
+                    {
                       label: 'Last updated',
                       value:
                         selectedDay.nutrition.updatedAt === null
@@ -686,10 +723,19 @@ export function DataQualityCalendarWorkspace() {
                       value: humanize(selectedDay.weight.evidenceState),
                     },
                     {
+                      label: 'Weight entry ID',
+                      value: selectedDay.weight.entryId ?? 'Not recorded',
+                    },
+                    {
+                      label: 'Source',
+                      value: provenanceLabel(selectedDay.weight.provenance),
+                    },
+                    {
                       label: 'Correction state',
-                      value: selectedDay.weight.corrected
-                        ? 'Retained row was corrected'
-                        : 'No retained correction',
+                      value:
+                        selectedDay.weight.correctionState === 'history_unavailable'
+                          ? 'Correction history unavailable'
+                          : humanize(selectedDay.weight.correctionState),
                     },
                     {
                       label: 'Suspect / stale',
@@ -735,6 +781,39 @@ export function DataQualityCalendarWorkspace() {
                             ? ` · Updated ${formatTimestamp(workout.updatedAt, calendar.timeZone)}`
                             : ''}
                         </p>
+                        <dl className="mt-2 grid gap-1 text-xs text-muted-foreground">
+                          <div>
+                            <dt className="inline font-medium text-foreground">Relation IDs:</dt>{' '}
+                            <dd className="inline">
+                              plan {workout.scheduledWorkoutId ?? 'Not recorded'} · session{' '}
+                              {workout.sessionId ?? 'Not recorded'}
+                            </dd>
+                          </div>
+                          <div>
+                            <dt className="inline font-medium text-foreground">Dates:</dt>{' '}
+                            <dd className="inline">
+                              planned {workout.plannedDate ?? 'Not recorded'} · session{' '}
+                              {workout.sessionDate ?? 'Not recorded'}
+                            </dd>
+                          </div>
+                          <div>
+                            <dt className="inline font-medium text-foreground">Source:</dt>{' '}
+                            <dd className="inline">{provenanceLabel(workout.provenance)}</dd>
+                          </div>
+                          <div>
+                            <dt className="inline font-medium text-foreground">Correction:</dt>{' '}
+                            <dd className="inline">
+                              {workout.correctionState === 'history_unavailable'
+                                ? 'Correction history unavailable'
+                                : humanize(workout.correctionState)}
+                            </dd>
+                          </div>
+                        </dl>
+                        {workout.relationLimitation ? (
+                          <p className="mt-2 text-xs text-muted-foreground">
+                            {workout.relationLimitation}
+                          </p>
+                        ) : null}
                         <ReasonList codes={workout.reasonCodes} />
                         <Button asChild className="mt-3 min-h-11" size="sm" variant="outline">
                           <Link
@@ -751,6 +830,12 @@ export function DataQualityCalendarWorkspace() {
                     ))}
                   </ul>
                 )}
+                {selectedDay.omittedWorkoutCount > 0 ? (
+                  <p className="text-muted-foreground">
+                    {selectedDay.omittedWorkoutCount} additional workout records are omitted from
+                    this bounded view.
+                  </p>
+                ) : null}
               </DomainSection>
             ) : null}
 
@@ -771,7 +856,12 @@ export function DataQualityCalendarWorkspace() {
                       label: 'Weight evidence',
                       value: humanize(selectedDay.algorithm.weightEvidenceState),
                     },
-                    { label: 'Decision events', value: selectedDay.algorithm.events.length },
+                    {
+                      label: 'Decision events',
+                      value:
+                        selectedDay.algorithm.events.length +
+                        selectedDay.algorithm.omittedEventCount,
+                    },
                   ]}
                 />
                 <ReasonList codes={selectedDay.algorithm.reasonCodes} />
@@ -787,20 +877,23 @@ export function DataQualityCalendarWorkspace() {
                             {humanize(event.kind)} · {humanize(event.state)}
                           </p>
                           <p className="text-xs text-muted-foreground">
-                            Effective {formatDate(event.effectiveDate)}
+                            ID {event.id} · Effective {formatDate(event.effectiveDate)} · Source{' '}
+                            {event.provenance.label}
                           </p>
                         </div>
-                        <Button asChild className="min-h-11" size="sm" variant="outline">
-                          <Link
-                            to={
-                              event.kind === 'weekly_review'
-                                ? `/nutrition/reviews/${event.id}`
-                                : '/nutrition?view=coach'
-                            }
-                          >
-                            View evidence
-                          </Link>
-                        </Button>
+                        <div className="flex flex-wrap gap-2">
+                          {event.actions.map((action) => (
+                            <Button
+                              asChild
+                              className="min-h-11"
+                              key={`${event.id}-${action.kind}`}
+                              size="sm"
+                              variant="outline"
+                            >
+                              <Link to={action.href}>{action.label}</Link>
+                            </Button>
+                          ))}
+                        </div>
                       </li>
                     ))}
                   </ul>
@@ -809,6 +902,12 @@ export function DataQualityCalendarWorkspace() {
                     No check-in or weekly-review decision is effective on this date.
                   </p>
                 )}
+                {selectedDay.algorithm.omittedEventCount > 0 ? (
+                  <p className="text-muted-foreground">
+                    {selectedDay.algorithm.omittedEventCount} additional decision events are omitted
+                    from this bounded view.
+                  </p>
+                ) : null}
               </DomainSection>
             ) : null}
 
@@ -856,6 +955,12 @@ export function DataQualityCalendarWorkspace() {
                     ))}
                   </ul>
                 )}
+                {selectedDay.omittedContextCount > 0 ? (
+                  <p className="text-muted-foreground">
+                    {selectedDay.omittedContextCount} additional context records are omitted from
+                    this bounded view.
+                  </p>
+                ) : null}
               </DomainSection>
             ) : null}
           </CardContent>

--- a/apps/web/src/features/data-quality/components/data-quality-calendar-workspace.tsx
+++ b/apps/web/src/features/data-quality/components/data-quality-calendar-workspace.tsx
@@ -1,0 +1,871 @@
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  adaptiveReviewContextCreateInputSchema,
+  type AdaptiveReviewContextCreateInput,
+  type DataQualityCalendarDay,
+} from '@pulse/shared';
+import {
+  BrainCircuit,
+  ChevronLeft,
+  ChevronRight,
+  Clock3,
+  Dumbbell,
+  MessageSquareText,
+  RefreshCw,
+  Scale,
+  ShieldCheck,
+  UtensilsCrossed,
+} from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import { Link, useSearchParams } from 'react-router';
+
+import { NutritionDayStatusControl } from '@/features/adaptive-nutrition/components/nutrition-day-status-control';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+import { useCreateDataQualityContext, useDataQualityCalendar } from '../api/data-quality';
+
+type Domain = 'nutrition' | 'weight' | 'workout' | 'algorithm' | 'context';
+
+const DOMAIN_META = {
+  nutrition: { label: 'Nutrition', icon: UtensilsCrossed, short: 'N' },
+  weight: { label: 'Weight', icon: Scale, short: 'W' },
+  workout: { label: 'Workout', icon: Dumbbell, short: 'X' },
+  algorithm: { label: 'Algorithm', icon: BrainCircuit, short: 'A' },
+  context: { label: 'Context', icon: MessageSquareText, short: 'C' },
+} as const;
+
+const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
+
+const parseDateKey = (date: string) => new Date(`${date}T00:00:00.000Z`);
+const toDateKey = (date: Date) => date.toISOString().slice(0, 10);
+const addDays = (date: string, amount: number) => {
+  const value = parseDateKey(date);
+  value.setUTCDate(value.getUTCDate() + amount);
+  return toDateKey(value);
+};
+const addMonths = (date: string, amount: number) => {
+  const value = parseDateKey(date);
+  value.setUTCDate(1);
+  value.setUTCMonth(value.getUTCMonth() + amount);
+  return toDateKey(value);
+};
+const monthStart = (date: string) => `${date.slice(0, 7)}-01`;
+const monthGridRange = (date: string) => {
+  const first = parseDateKey(monthStart(date));
+  const mondayOffset = (first.getUTCDay() + 6) % 7;
+  const start = addDays(toDateKey(first), -mondayOffset);
+  const nextMonth = parseDateKey(addMonths(toDateKey(first), 1));
+  const last = addDays(toDateKey(nextMonth), -1);
+  const sundayOffset = (7 - parseDateKey(last).getUTCDay()) % 7;
+  return { start, end: addDays(last, sundayOffset) };
+};
+const browserToday = () => {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date());
+  return `${parts.find((part) => part.type === 'year')?.value}-${parts.find((part) => part.type === 'month')?.value}-${parts.find((part) => part.type === 'day')?.value}`;
+};
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'UTC',
+  weekday: 'long',
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+});
+const monthFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'UTC',
+  month: 'long',
+  year: 'numeric',
+});
+const formatDate = (date: string) => dateFormatter.format(parseDateKey(date));
+const formatTimestamp = (value: number, timeZone: string) =>
+  new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+const humanize = (value: string) => value.replaceAll('_', ' ');
+
+const nutritionLabel = (day: DataQualityCalendarDay) => {
+  if (day.nutrition.evidenceState === 'pending_cutoff') return 'Pending cutoff';
+  if (day.nutrition.evidenceState === 'excluded') return 'Excluded';
+  return humanize(day.nutrition.qualityState);
+};
+const weightLabel = (day: DataQualityCalendarDay) => {
+  if (day.weight.evidenceState === 'pending_cutoff') return 'Pending cutoff';
+  if (day.weight.suspect) return 'Suspect';
+  if (day.weight.evidenceState === 'excluded') return 'Excluded';
+  if (day.weight.corrected) return 'Corrected';
+  return day.weight.entryId ? 'Logged' : 'No weigh-in';
+};
+const workoutLabel = (day: DataQualityCalendarDay) => {
+  if (day.workouts.length === 0) return 'No workout';
+  const states = [...new Set(day.workouts.map((item) => item.state))];
+  return states.length === 1 && states[0] ? humanize(states[0]) : `${day.workouts.length} records`;
+};
+const algorithmLabel = (day: DataQualityCalendarDay) => humanize(day.algorithm.state);
+
+function Indicator({ domain, label }: { domain: Domain; label: string }) {
+  const meta = DOMAIN_META[domain];
+  return (
+    <span
+      className={cn(
+        'inline-flex max-w-full items-center gap-1 rounded-md border border-border/70 bg-background/80 px-1 py-0.5 text-[0.58rem] font-semibold leading-tight text-foreground sm:text-[0.65rem]',
+        (label.includes('Missing') || label.includes('No ')) &&
+          'border-dashed text-muted-foreground',
+        (label.includes('Pending') || label.includes('partial')) &&
+          'border-amber-500/60 bg-amber-500/10',
+        (label.includes('Excluded') || label.includes('Suspect')) &&
+          'border-rose-500/60 bg-rose-500/10',
+      )}
+      title={`${meta.label}: ${label}`}
+    >
+      <span aria-hidden="true">{meta.short}</span>
+      <span className="hidden truncate sm:inline">{label}</span>
+      <span className="sr-only">{meta.label}: </span>
+    </span>
+  );
+}
+
+function DomainSection({
+  children,
+  icon: Icon,
+  label,
+  status,
+}: {
+  children: ReactNode;
+  icon: typeof UtensilsCrossed;
+  label: string;
+  status: string;
+}) {
+  const id = `data-quality-${label.toLowerCase().replaceAll(' ', '-')}`;
+  return (
+    <section
+      aria-labelledby={id}
+      className="rounded-2xl border border-border/70 bg-background/65 p-4"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="flex items-center gap-2 text-base font-semibold" id={id}>
+          <Icon aria-hidden="true" className="size-4 text-primary" />
+          {label}
+        </h3>
+        <Badge variant="outline">{status}</Badge>
+      </div>
+      <div className="mt-3 space-y-3 text-sm">{children}</div>
+    </section>
+  );
+}
+
+function FactList({ facts }: { facts: Array<{ label: string; value: ReactNode }> }) {
+  return (
+    <dl className="grid gap-2 sm:grid-cols-2">
+      {facts.map((fact) => (
+        <div className="min-w-0 rounded-xl bg-secondary/45 px-3 py-2" key={fact.label}>
+          <dt className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+            {fact.label}
+          </dt>
+          <dd className="mt-1 break-words font-medium text-foreground">{fact.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function ReasonList({ codes }: { codes: string[] }) {
+  if (codes.length === 0) return null;
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+        Recorded reasons
+      </p>
+      <ul className="mt-2 flex flex-wrap gap-2">
+        {codes.map((code) => (
+          <li key={code}>
+            <Badge className="whitespace-normal text-left" variant="secondary">
+              {humanize(code)}
+            </Badge>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ContextDialog({
+  date,
+  open,
+  onOpenChange,
+}: {
+  date: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const mutation = useCreateDataQualityContext();
+  const form = useForm<AdaptiveReviewContextCreateInput>({
+    resolver: zodResolver(adaptiveReviewContextCreateInputSchema),
+    defaultValues: {
+      subject: { kind: 'date', localDate: date },
+      category: 'other',
+      note: '',
+      resolution: undefined,
+      resolutionKind: undefined,
+    },
+  });
+
+  useEffect(() => {
+    form.reset({
+      subject: { kind: 'date', localDate: date },
+      category: 'other',
+      note: '',
+      resolution: undefined,
+      resolutionKind: undefined,
+    });
+  }, [date, form]);
+
+  const submit = form.handleSubmit(async (input) => {
+    await mutation.mutateAsync(input);
+    onOpenChange(false);
+    form.reset({
+      subject: { kind: 'date', localDate: date },
+      category: 'other',
+      note: '',
+      resolution: undefined,
+      resolutionKind: undefined,
+    });
+  });
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add context for {formatDate(date)}</DialogTitle>
+          <DialogDescription>
+            Context helps explain the record. It does not change calories, status, eligibility, or
+            algorithm calculations.
+          </DialogDescription>
+        </DialogHeader>
+        <form className="space-y-4" onSubmit={submit}>
+          <div className="space-y-2">
+            <Label htmlFor="data-quality-context-category">Context type</Label>
+            <select
+              className="flex min-h-11 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+              disabled={mutation.isPending}
+              id="data-quality-context-category"
+              {...form.register('category')}
+            >
+              <option value="illness">Illness</option>
+              <option value="recovery">Recovery</option>
+              <option value="pain_injury">Pain or injury</option>
+              <option value="travel">Travel</option>
+              <option value="nutrition_exception">Nutrition exception</option>
+              <option value="training_change">Training change</option>
+              <option value="schedule_change">Schedule constraint</option>
+              <option value="clarification">Clarification</option>
+              <option value="other">Other</option>
+            </select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="data-quality-context-note">What should Pulse know?</Label>
+            <Textarea
+              aria-describedby={
+                form.formState.errors.note ? 'data-quality-context-error' : undefined
+              }
+              aria-invalid={Boolean(form.formState.errors.note)}
+              disabled={mutation.isPending}
+              id="data-quality-context-note"
+              placeholder="Bounded context for this date"
+              {...form.register('note')}
+            />
+            {form.formState.errors.note ? (
+              <p className="text-sm text-destructive" id="data-quality-context-error" role="alert">
+                {form.formState.errors.note.message}
+              </p>
+            ) : null}
+          </div>
+          {mutation.isError ? (
+            <p className="text-sm text-destructive" role="alert">
+              {mutation.error instanceof Error ? mutation.error.message : 'Unable to add context.'}
+            </p>
+          ) : null}
+          <DialogFooter>
+            <Button
+              disabled={mutation.isPending}
+              onClick={() => onOpenChange(false)}
+              type="button"
+              variant="outline"
+            >
+              Cancel
+            </Button>
+            <Button disabled={mutation.isPending} type="submit">
+              {mutation.isPending ? 'Adding context…' : 'Add context'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function DataQualityCalendarWorkspace() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const requestedDate = searchParams.get('date');
+  const initialDate =
+    requestedDate && /^\d{4}-\d{2}-\d{2}$/.test(requestedDate) ? requestedDate : browserToday();
+  const [visibleMonth, setVisibleMonth] = useState(() => monthStart(initialDate));
+  const [selectedDate, setSelectedDate] = useState(initialDate);
+  const [domains, setDomains] = useState<Set<Domain>>(
+    () => new Set(['nutrition', 'weight', 'workout', 'algorithm', 'context']),
+  );
+  const [contextOpen, setContextOpen] = useState(searchParams.get('action') === 'context');
+  const range = useMemo(() => monthGridRange(visibleMonth), [visibleMonth]);
+  const calendarQuery = useDataQualityCalendar({ start: range.start, end: range.end });
+  const calendar = calendarQuery.data;
+  const selectedDay = calendar?.days.find((day) => day.date === selectedDate) ?? calendar?.days[0];
+
+  const selectDate = (date: string) => {
+    setSelectedDate(date);
+    const next = new URLSearchParams(searchParams);
+    next.set('date', date);
+    next.delete('action');
+    setSearchParams(next, { replace: true });
+  };
+
+  const changeMonth = (amount: number) => {
+    const nextMonth = addMonths(visibleMonth, amount);
+    setVisibleMonth(nextMonth);
+    selectDate(nextMonth);
+  };
+
+  const jumpTo = (date: string) => {
+    if (!date) return;
+    setVisibleMonth(monthStart(date));
+    selectDate(date);
+  };
+
+  const toggleDomain = (domain: Domain) => {
+    setDomains((current) => {
+      const next = new Set(current);
+      if (next.has(domain)) {
+        if (next.size > 1) next.delete(domain);
+      } else {
+        next.add(domain);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="space-y-5">
+      <Card className="overflow-hidden border-primary/20 bg-gradient-to-br from-primary/12 via-card to-[var(--color-accent-mint)]/35">
+        <CardContent className="grid gap-4 p-5 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center sm:p-6">
+          <div className="flex size-14 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-lg shadow-primary/20">
+            <ShieldCheck aria-hidden="true" className="size-7" />
+          </div>
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.2em] text-primary">
+              Audit, not score
+            </p>
+            <p className="mt-1 max-w-3xl text-sm leading-6 text-foreground/85">
+              See what Pulse recorded, what is still pending, and what the algorithms could actually
+              use. Missing and excluded records stay distinct; context never silently rewrites data.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="overflow-hidden">
+        <CardHeader className="gap-4 border-b border-border/70 bg-secondary/25 p-4 sm:p-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center justify-between gap-2 sm:justify-start">
+              <Button
+                aria-label="Previous month"
+                className="min-h-11 min-w-11"
+                onClick={() => changeMonth(-1)}
+                size="icon"
+                type="button"
+                variant="outline"
+              >
+                <ChevronLeft aria-hidden="true" />
+              </Button>
+              <h2
+                className="min-w-40 text-center text-lg font-semibold"
+                id="data-quality-month-heading"
+              >
+                {monthFormatter.format(parseDateKey(visibleMonth))}
+              </h2>
+              <Button
+                aria-label="Next month"
+                className="min-h-11 min-w-11"
+                onClick={() => changeMonth(1)}
+                size="icon"
+                type="button"
+                variant="outline"
+              >
+                <ChevronRight aria-hidden="true" />
+              </Button>
+            </div>
+            <div className="flex items-center gap-2">
+              <Label className="sr-only" htmlFor="data-quality-jump-date">
+                Jump to date
+              </Label>
+              <Input
+                className="min-h-11 min-w-0"
+                id="data-quality-jump-date"
+                onChange={(event) => jumpTo(event.target.value)}
+                type="date"
+                value={selectedDate}
+              />
+            </div>
+          </div>
+          <div aria-label="Calendar domains" className="flex flex-wrap gap-2" role="group">
+            {(Object.keys(DOMAIN_META) as Domain[]).map((domain) => {
+              const meta = DOMAIN_META[domain];
+              const Icon = meta.icon;
+              return (
+                <Button
+                  aria-pressed={domains.has(domain)}
+                  className="min-h-11"
+                  key={domain}
+                  onClick={() => toggleDomain(domain)}
+                  type="button"
+                  variant={domains.has(domain) ? 'secondary' : 'outline'}
+                >
+                  <Icon aria-hidden="true" className="size-4" />
+                  {meta.label}
+                </Button>
+              );
+            })}
+          </div>
+        </CardHeader>
+
+        {calendarQuery.isPending && !calendar ? (
+          <div
+            aria-live="polite"
+            className="flex min-h-80 items-center justify-center gap-2 p-6 text-muted-foreground"
+            role="status"
+          >
+            <RefreshCw
+              aria-hidden="true"
+              className="size-5 animate-spin motion-reduce:animate-none"
+            />
+            Loading Data Quality calendar
+          </div>
+        ) : calendarQuery.isError && !calendar ? (
+          <div
+            className="m-4 rounded-2xl border border-destructive/40 bg-destructive/5 p-5"
+            role="alert"
+          >
+            <h2 className="font-semibold">Data Quality calendar could not be loaded</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Your source records are safe. Retry the read-only calendar request.
+            </p>
+            <Button
+              className="mt-4 min-h-11"
+              onClick={() => calendarQuery.refetch()}
+              type="button"
+              variant="outline"
+            >
+              Retry
+            </Button>
+          </div>
+        ) : calendar ? (
+          <CardContent className="space-y-5 p-3 sm:p-5">
+            <div
+              className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-6"
+              aria-label="Month summary"
+            >
+              {[
+                ['Complete nutrition', calendar.summary.nutrition.complete],
+                ['Partial nutrition', calendar.summary.nutrition.partial],
+                [
+                  'Pending dates',
+                  calendar.summary.nutrition.pending + calendar.summary.weight.pending,
+                ],
+                [
+                  'Excluded evidence',
+                  calendar.summary.nutrition.excluded + calendar.summary.weight.excluded,
+                ],
+                ['Missing nutrition', calendar.summary.nutrition.missing],
+                ['Context days', calendar.summary.contextDays],
+              ].map(([label, value]) => (
+                <div
+                  className="rounded-xl border border-border/60 bg-secondary/35 px-3 py-2"
+                  key={label}
+                >
+                  <p className="text-lg font-semibold tabular-nums">{value}</p>
+                  <p className="text-xs text-muted-foreground">{label}</p>
+                </div>
+              ))}
+            </div>
+
+            <section
+              aria-labelledby="data-quality-month-heading"
+              aria-busy={calendarQuery.isFetching}
+            >
+              <div className="grid grid-cols-7 gap-1 sm:gap-2">
+                {DAY_LABELS.map((label) => (
+                  <p
+                    className="py-1 text-center text-[0.65rem] font-bold uppercase tracking-[0.16em] text-muted-foreground"
+                    key={label}
+                  >
+                    {label}
+                  </p>
+                ))}
+                {calendar.days.map((day) => {
+                  const inMonth = day.date.slice(0, 7) === visibleMonth.slice(0, 7);
+                  const selected = day.date === selectedDay?.date;
+                  return (
+                    <button
+                      aria-current={day.isToday ? 'date' : undefined}
+                      aria-label={`${formatDate(day.date)}. Nutrition ${nutritionLabel(day)}. Weight ${weightLabel(day)}. Workout ${workoutLabel(day)}. Algorithm ${algorithmLabel(day)}. ${day.contexts.length} context record${day.contexts.length === 1 ? '' : 's'}.`}
+                      aria-pressed={selected}
+                      className={cn(
+                        'min-h-20 min-w-0 rounded-xl border border-border/70 p-1.5 text-left transition-colors sm:min-h-28 sm:p-2',
+                        inMonth ? 'bg-card hover:border-primary/45' : 'bg-secondary/20 opacity-55',
+                        selected && 'border-primary bg-primary/8 ring-2 ring-primary/20',
+                        day.isToday && 'outline outline-2 outline-offset-1 outline-primary/35',
+                      )}
+                      data-date={day.date}
+                      key={day.date}
+                      onClick={() => selectDate(day.date)}
+                      type="button"
+                    >
+                      <span className="block text-xs font-semibold tabular-nums sm:text-sm">
+                        {Number(day.date.slice(-2))}
+                      </span>
+                      <span className="mt-1 flex flex-col items-start gap-0.5 sm:gap-1">
+                        {domains.has('nutrition') ? (
+                          <Indicator domain="nutrition" label={nutritionLabel(day)} />
+                        ) : null}
+                        {domains.has('weight') ? (
+                          <Indicator domain="weight" label={weightLabel(day)} />
+                        ) : null}
+                        {domains.has('workout') ? (
+                          <Indicator domain="workout" label={workoutLabel(day)} />
+                        ) : null}
+                        {domains.has('algorithm') ? (
+                          <Indicator domain="algorithm" label={algorithmLabel(day)} />
+                        ) : null}
+                        {domains.has('context') && day.contexts.length > 0 ? (
+                          <Indicator
+                            domain="context"
+                            label={`${day.contexts.length} note${day.contexts.length === 1 ? '' : 's'}`}
+                          />
+                        ) : null}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+              <p className="mt-3 text-sm text-muted-foreground" aria-live="polite">
+                {calendar.timeZone} · {calendar.days.length} dates ·{' '}
+                {calendarQuery.isFetching
+                  ? 'Checking for updates…'
+                  : `Selected ${formatDate(selectedDay?.date ?? selectedDate)}`}
+              </p>
+            </section>
+          </CardContent>
+        ) : null}
+      </Card>
+
+      {selectedDay && calendar ? (
+        <Card id="data-quality-date-detail">
+          <CardHeader className="border-b border-border/70">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <CardTitle>{formatDate(selectedDay.date)}</CardTitle>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Exact source facts and algorithm treatment in {calendar.timeZone}.
+                </p>
+              </div>
+              <Button
+                className="min-h-11"
+                disabled={
+                  selectedDay.algorithm.state === 'no_program' ||
+                  selectedDay.algorithm.state === 'pre_program'
+                }
+                onClick={() => setContextOpen(true)}
+                type="button"
+                variant="outline"
+              >
+                <MessageSquareText aria-hidden="true" className="size-4" />
+                Add context
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="grid gap-4 p-4 lg:grid-cols-2 lg:p-5">
+            {domains.has('nutrition') ? (
+              <DomainSection
+                icon={UtensilsCrossed}
+                label="Nutrition"
+                status={nutritionLabel(selectedDay)}
+              >
+                <FactList
+                  facts={[
+                    {
+                      label: 'Recorded status',
+                      value: selectedDay.nutrition.explicitStatus ?? 'No record',
+                    },
+                    {
+                      label: 'Algorithm treatment',
+                      value: humanize(selectedDay.nutrition.evidenceState),
+                    },
+                    {
+                      label: 'Meals / items',
+                      value:
+                        selectedDay.nutrition.mealCount === null
+                          ? 'Not available'
+                          : `${selectedDay.nutrition.mealCount} / ${selectedDay.nutrition.itemCount}`,
+                    },
+                    {
+                      label: 'Calories',
+                      value: selectedDay.nutrition.totals
+                        ? `${Math.round(selectedDay.nutrition.totals.calories)} kcal`
+                        : 'Not available',
+                    },
+                    {
+                      label: 'Protein / carbs / fat',
+                      value: selectedDay.nutrition.totals
+                        ? `${Math.round(selectedDay.nutrition.totals.protein)}g / ${Math.round(selectedDay.nutrition.totals.carbs)}g / ${Math.round(selectedDay.nutrition.totals.fat)}g`
+                        : 'Not available',
+                    },
+                    {
+                      label: 'Last updated',
+                      value:
+                        selectedDay.nutrition.updatedAt === null
+                          ? 'Not available'
+                          : formatTimestamp(selectedDay.nutrition.updatedAt, calendar.timeZone),
+                    },
+                  ]}
+                />
+                <ReasonList codes={selectedDay.nutrition.reasonCodes} />
+                <NutritionDayStatusControl
+                  date={selectedDay.date}
+                  isToday={selectedDay.isToday}
+                  status={selectedDay.nutrition.explicitStatus}
+                />
+              </DomainSection>
+            ) : null}
+
+            {domains.has('weight') ? (
+              <DomainSection icon={Scale} label="Weight" status={weightLabel(selectedDay)}>
+                <FactList
+                  facts={[
+                    {
+                      label: 'Scale weight',
+                      value:
+                        selectedDay.weight.weight === null
+                          ? 'No weigh-in'
+                          : `${selectedDay.weight.weight.toFixed(1)} ${selectedDay.weight.unit}`,
+                    },
+                    {
+                      label: 'Product Trend Weight',
+                      value:
+                        selectedDay.weight.trendWeight === null
+                          ? 'Not available'
+                          : `${selectedDay.weight.trendWeight.toFixed(1)} ${selectedDay.weight.unit}`,
+                    },
+                    {
+                      label: 'Algorithm treatment',
+                      value: humanize(selectedDay.weight.evidenceState),
+                    },
+                    {
+                      label: 'Correction state',
+                      value: selectedDay.weight.corrected
+                        ? 'Retained row was corrected'
+                        : 'No retained correction',
+                    },
+                    {
+                      label: 'Suspect / stale',
+                      value: `${selectedDay.weight.suspect ? 'Suspect' : 'Not flagged suspect'} · ${selectedDay.weight.stale ? 'Stale' : 'Not stale'}`,
+                    },
+                    {
+                      label: 'Recorded',
+                      value:
+                        selectedDay.weight.createdAt === null
+                          ? 'Not available'
+                          : formatTimestamp(selectedDay.weight.createdAt, calendar.timeZone),
+                    },
+                  ]}
+                />
+                <ReasonList codes={selectedDay.weight.reasonCodes} />
+                {selectedDay.weight.entryId ? (
+                  <Button asChild className="min-h-11" variant="outline">
+                    <Link to={`/weight/history?date=${selectedDay.date}`}>
+                      Review weight measurement
+                    </Link>
+                  </Button>
+                ) : null}
+              </DomainSection>
+            ) : null}
+
+            {domains.has('workout') ? (
+              <DomainSection icon={Dumbbell} label="Workout" status={workoutLabel(selectedDay)}>
+                {selectedDay.workouts.length === 0 ? (
+                  <p className="text-muted-foreground">
+                    No workout plan or session is recorded for this date.
+                  </p>
+                ) : (
+                  <ul className="space-y-2">
+                    {selectedDay.workouts.map((workout) => (
+                      <li className="rounded-xl border border-border/60 p-3" key={workout.id}>
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <p className="font-medium">{workout.name}</p>
+                          <Badge variant="outline">{humanize(workout.state)}</Badge>
+                        </div>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          Recorded {formatTimestamp(workout.createdAt, calendar.timeZone)}
+                          {workout.updatedAt > workout.createdAt
+                            ? ` · Updated ${formatTimestamp(workout.updatedAt, calendar.timeZone)}`
+                            : ''}
+                        </p>
+                        <ReasonList codes={workout.reasonCodes} />
+                        <Button asChild className="mt-3 min-h-11" size="sm" variant="outline">
+                          <Link
+                            to={
+                              workout.kind === 'workout_session'
+                                ? `/workouts/session/${workout.id}`
+                                : `/workouts/scheduled/${workout.id}`
+                            }
+                          >
+                            Review workout
+                          </Link>
+                        </Button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </DomainSection>
+            ) : null}
+
+            {domains.has('algorithm') ? (
+              <DomainSection
+                icon={BrainCircuit}
+                label="Algorithm"
+                status={algorithmLabel(selectedDay)}
+              >
+                <FactList
+                  facts={[
+                    { label: 'Program state', value: humanize(selectedDay.algorithm.state) },
+                    {
+                      label: 'Nutrition evidence',
+                      value: humanize(selectedDay.algorithm.nutritionEvidenceState),
+                    },
+                    {
+                      label: 'Weight evidence',
+                      value: humanize(selectedDay.algorithm.weightEvidenceState),
+                    },
+                    { label: 'Decision events', value: selectedDay.algorithm.events.length },
+                  ]}
+                />
+                <ReasonList codes={selectedDay.algorithm.reasonCodes} />
+                {selectedDay.algorithm.events.length > 0 ? (
+                  <ul className="space-y-2">
+                    {selectedDay.algorithm.events.map((event) => (
+                      <li
+                        className="flex flex-col gap-2 rounded-xl border border-border/60 p-3 sm:flex-row sm:items-center sm:justify-between"
+                        key={`${event.kind}-${event.id}`}
+                      >
+                        <div>
+                          <p className="font-medium">
+                            {humanize(event.kind)} · {humanize(event.state)}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            Effective {formatDate(event.effectiveDate)}
+                          </p>
+                        </div>
+                        <Button asChild className="min-h-11" size="sm" variant="outline">
+                          <Link
+                            to={
+                              event.kind === 'weekly_review'
+                                ? `/nutrition/reviews/${event.id}`
+                                : '/nutrition?view=coach'
+                            }
+                          >
+                            View evidence
+                          </Link>
+                        </Button>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-muted-foreground">
+                    No check-in or weekly-review decision is effective on this date.
+                  </p>
+                )}
+              </DomainSection>
+            ) : null}
+
+            {domains.has('context') ? (
+              <DomainSection
+                icon={MessageSquareText}
+                label="Context"
+                status={
+                  selectedDay.contexts.length
+                    ? `${selectedDay.contexts.length} recorded`
+                    : 'No context'
+                }
+              >
+                {selectedDay.contexts.length === 0 ? (
+                  <p className="text-muted-foreground">
+                    No bounded context is recorded. Absence of context does not imply that nothing
+                    happened.
+                  </p>
+                ) : (
+                  <ul className="space-y-2">
+                    {selectedDay.contexts.map((context) => (
+                      <li className="rounded-xl border border-border/60 p-3" key={context.id}>
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <p className="font-medium capitalize">{humanize(context.category)}</p>
+                          <Badge variant="outline">{context.provenance.label}</Badge>
+                        </div>
+                        <p className="mt-2 leading-6">{context.note}</p>
+                        {context.resolution ? (
+                          <p className="mt-2 text-sm">
+                            <span className="font-medium">Resolution:</span> {context.resolution}
+                          </p>
+                        ) : null}
+                        <p className="mt-2 text-xs text-muted-foreground">
+                          {humanize(context.subjectKind)} · revision {context.revision} · updated{' '}
+                          {formatTimestamp(context.updatedAt, calendar.timeZone)}
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </DomainSection>
+            ) : null}
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <div className="flex items-start gap-2 rounded-2xl border border-border/70 bg-secondary/30 p-4 text-sm text-muted-foreground">
+        <Clock3 aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
+        <p>
+          Completed-day cutoff and algorithm inclusion use the response time zone. Context explains
+          evidence but never changes status or calculations by itself.
+        </p>
+      </div>
+
+      {selectedDay ? (
+        <ContextDialog date={selectedDay.date} onOpenChange={setContextOpen} open={contextOpen} />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/data-quality/components/data-quality-calendar-workspace.tsx
+++ b/apps/web/src/features/data-quality/components/data-quality-calendar-workspace.tsx
@@ -23,7 +23,7 @@ import { Link, useSearchParams } from 'react-router';
 import { NutritionDayStatusControl } from '@/features/adaptive-nutrition/components/nutrition-day-status-control';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import {
   Dialog,
   DialogContent,
@@ -589,7 +589,7 @@ export function DataQualityCalendarWorkspace() {
           <CardHeader className="border-b border-border/70">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div>
-                <CardTitle>{formatDate(selectedDay.date)}</CardTitle>
+                <h2 className="text-xl font-semibold">{formatDate(selectedDay.date)}</h2>
                 <p className="mt-1 text-sm text-muted-foreground">
                   Exact source facts and algorithm treatment in {calendar.timeZone}.
                 </p>
@@ -833,7 +833,14 @@ export function DataQualityCalendarWorkspace() {
                       <li className="rounded-xl border border-border/60 p-3" key={context.id}>
                         <div className="flex flex-wrap items-center justify-between gap-2">
                           <p className="font-medium capitalize">{humanize(context.category)}</p>
-                          <Badge variant="outline">{context.provenance.label}</Badge>
+                          <Badge variant="outline">
+                            {context.provenance.type === 'agent_token'
+                              ? 'AgentToken'
+                              : context.provenance.type === 'system'
+                                ? 'Pulse system'
+                                : 'You'}{' '}
+                            · {context.provenance.label}
+                          </Badge>
                         </div>
                         <p className="mt-2 leading-6">{context.note}</p>
                         {context.resolution ? (

--- a/apps/web/src/features/data-quality/components/data-quality-calendar-workspace.tsx
+++ b/apps/web/src/features/data-quality/components/data-quality-calendar-workspace.tsx
@@ -109,7 +109,6 @@ const weightLabel = (day: DataQualityCalendarDay) => {
   if (day.weight.evidenceState === 'pending_cutoff') return 'Pending cutoff';
   if (day.weight.suspect) return 'Suspect';
   if (day.weight.evidenceState === 'excluded') return 'Excluded';
-  if (day.weight.correctionState === 'confirmed') return 'Corrected';
   return day.weight.entryId ? 'Logged' : 'No weigh-in';
 };
 const workoutLabel = (day: DataQualityCalendarDay) => {

--- a/apps/web/src/features/nutrition/api/nutrition.ts
+++ b/apps/web/src/features/nutrition/api/nutrition.ts
@@ -13,6 +13,7 @@ import { toast } from 'sonner';
 import {
   adaptiveNutritionQueryKey,
   crossFeatureInvalidationMap,
+  dataQualityQueryKey,
   invalidateQueryKeys,
 } from '@/lib/query-invalidation';
 import { apiRequest } from '@/lib/api-client';
@@ -233,6 +234,7 @@ export const useUpdateNutritionStatus = () => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: nutritionQueryKeys.day(variables.date) }),
         queryClient.invalidateQueries({ queryKey: adaptiveNutritionQueryKey }),
+        queryClient.invalidateQueries({ queryKey: dataQualityQueryKey }),
       ]);
     },
   });

--- a/apps/web/src/lib/query-invalidation.test.ts
+++ b/apps/web/src/lib/query-invalidation.test.ts
@@ -11,6 +11,7 @@ import { nutritionQueryKeys } from '@/features/nutrition/api/keys';
 import {
   adaptiveNutritionQueryKey,
   crossFeatureInvalidationMap,
+  dataQualityQueryKey,
   nutritionTargetQueryKey,
 } from './query-invalidation';
 
@@ -18,6 +19,7 @@ describe('crossFeatureInvalidationMap', () => {
   it('returns the expected workout-session invalidations', () => {
     expect(crossFeatureInvalidationMap.workoutSessionChange()).toEqual([
       dashboardSnapshotQueryKeys.all,
+      dataQualityQueryKey,
       recentWorkoutQueryKeys.all,
       habitQueryKeys.list(),
       habitQueryKeys.entryList(),
@@ -28,6 +30,7 @@ describe('crossFeatureInvalidationMap', () => {
   it('returns the expected meal invalidations', () => {
     expect(crossFeatureInvalidationMap.mealMutation()).toEqual([
       adaptiveNutritionQueryKey,
+      dataQualityQueryKey,
       dashboardSnapshotQueryKeys.all,
       macroTrendQueryKeys.all,
       habitQueryKeys.list(),
@@ -39,6 +42,7 @@ describe('crossFeatureInvalidationMap', () => {
   it('returns all target-dependent invalidations', () => {
     expect(crossFeatureInvalidationMap.nutritionTargetMutation()).toEqual([
       adaptiveNutritionQueryKey,
+      dataQualityQueryKey,
       nutritionQueryKeys.all,
       dashboardSnapshotQueryKeys.all,
       macroTrendQueryKeys.all,
@@ -55,6 +59,7 @@ describe('crossFeatureInvalidationMap', () => {
   it('returns the expected weight invalidations', () => {
     expect(crossFeatureInvalidationMap.weightMutation()).toEqual([
       adaptiveNutritionQueryKey,
+      dataQualityQueryKey,
       dashboardSnapshotQueryKeys.all,
       dashboardWeightTrendQueryKeys.all,
       habitQueryKeys.list(),
@@ -66,13 +71,19 @@ describe('crossFeatureInvalidationMap', () => {
   it('returns complete adaptive lifecycle invalidations', () => {
     expect(crossFeatureInvalidationMap.adaptiveProgramMutation()).toEqual([
       adaptiveNutritionQueryKey,
+      dataQualityQueryKey,
     ]);
-    expect(crossFeatureInvalidationMap.adaptiveGoalMutation()).toEqual([adaptiveNutritionQueryKey]);
+    expect(crossFeatureInvalidationMap.adaptiveGoalMutation()).toEqual([
+      adaptiveNutritionQueryKey,
+      dataQualityQueryKey,
+    ]);
     expect(crossFeatureInvalidationMap.adaptivePreviewMutation()).toEqual([
       adaptiveNutritionQueryKey,
+      dataQualityQueryKey,
     ]);
     expect(crossFeatureInvalidationMap.adaptiveResolutionMutation()).toEqual([
       adaptiveNutritionQueryKey,
+      dataQualityQueryKey,
       nutritionTargetQueryKey,
       nutritionQueryKeys.all,
       dashboardSnapshotQueryKeys.all,

--- a/apps/web/src/lib/query-invalidation.ts
+++ b/apps/web/src/lib/query-invalidation.ts
@@ -9,6 +9,7 @@ import { dashboardWeightTrendQueryKeys } from '@/hooks/use-weight-trend';
 import { nutritionQueryKeys } from '@/features/nutrition/api/keys';
 
 export const adaptiveNutritionQueryKey = ['adaptive-nutrition'] as const;
+export const dataQualityQueryKey = ['data-quality'] as const;
 export const nutritionTargetQueryKey = ['nutrition-targets'] as const;
 
 /**
@@ -28,13 +29,17 @@ export const nutritionTargetQueryKey = ['nutrition-targets'] as const;
  */
 export const crossFeatureInvalidationMap = {
   activeWorkoutSessionMutation: () =>
-    [dashboardSnapshotQueryKeys.all] as const satisfies readonly QueryKey[],
-  adaptiveProgramMutation: () => [adaptiveNutritionQueryKey] as const satisfies readonly QueryKey[],
-  adaptiveGoalMutation: () => [adaptiveNutritionQueryKey] as const satisfies readonly QueryKey[],
-  adaptivePreviewMutation: () => [adaptiveNutritionQueryKey] as const satisfies readonly QueryKey[],
+    [dashboardSnapshotQueryKeys.all, dataQualityQueryKey] as const satisfies readonly QueryKey[],
+  adaptiveProgramMutation: () =>
+    [adaptiveNutritionQueryKey, dataQualityQueryKey] as const satisfies readonly QueryKey[],
+  adaptiveGoalMutation: () =>
+    [adaptiveNutritionQueryKey, dataQualityQueryKey] as const satisfies readonly QueryKey[],
+  adaptivePreviewMutation: () =>
+    [adaptiveNutritionQueryKey, dataQualityQueryKey] as const satisfies readonly QueryKey[],
   adaptiveResolutionMutation: () =>
     [
       adaptiveNutritionQueryKey,
+      dataQualityQueryKey,
       nutritionTargetQueryKey,
       nutritionQueryKeys.all,
       dashboardSnapshotQueryKeys.all,
@@ -50,6 +55,7 @@ export const crossFeatureInvalidationMap = {
   mealMutation: () =>
     [
       adaptiveNutritionQueryKey,
+      dataQualityQueryKey,
       dashboardSnapshotQueryKeys.all,
       macroTrendQueryKeys.all,
       habitQueryKeys.list(),
@@ -59,6 +65,7 @@ export const crossFeatureInvalidationMap = {
   nutritionTargetMutation: () =>
     [
       adaptiveNutritionQueryKey,
+      dataQualityQueryKey,
       nutritionQueryKeys.all,
       dashboardSnapshotQueryKeys.all,
       macroTrendQueryKeys.all,
@@ -66,6 +73,7 @@ export const crossFeatureInvalidationMap = {
   weightMutation: () =>
     [
       adaptiveNutritionQueryKey,
+      dataQualityQueryKey,
       dashboardSnapshotQueryKeys.all,
       dashboardWeightTrendQueryKeys.all,
       habitQueryKeys.list(),
@@ -73,12 +81,13 @@ export const crossFeatureInvalidationMap = {
       habitChainQueryKeys.all,
     ] as const satisfies readonly QueryKey[],
   scheduledWorkoutMutation: () =>
-    [dashboardSnapshotQueryKeys.all] as const satisfies readonly QueryKey[],
+    [dashboardSnapshotQueryKeys.all, dataQualityQueryKey] as const satisfies readonly QueryKey[],
   workoutTemplateMutation: () =>
     [dashboardSnapshotQueryKeys.all] as const satisfies readonly QueryKey[],
   workoutSessionChange: () =>
     [
       dashboardSnapshotQueryKeys.all,
+      dataQualityQueryKey,
       recentWorkoutQueryKeys.all,
       habitQueryKeys.list(),
       habitQueryKeys.entryList(),

--- a/apps/web/src/pages/data-quality.tsx
+++ b/apps/web/src/pages/data-quality.tsx
@@ -1,0 +1,21 @@
+import { ShieldCheck } from 'lucide-react';
+
+import { PageHeader } from '@/components/layout/page-header';
+import { DataQualityCalendarWorkspace } from '@/features/data-quality/components/data-quality-calendar-workspace';
+
+export function DataQualityPage() {
+  return (
+    <main className="space-y-5">
+      <PageHeader
+        description="Audit what Pulse recorded, what is pending or excluded, and how each date affects coaching—without turning your data into a score."
+        icon={
+          <div className="rounded-2xl bg-primary/12 p-3 text-primary">
+            <ShieldCheck aria-hidden="true" className="size-6" />
+          </div>
+        }
+        title="Data Quality & Trust"
+      />
+      <DataQualityCalendarWorkspace />
+    </main>
+  );
+}

--- a/docs/specs/data-quality-calendar-v1.md
+++ b/docs/specs/data-quality-calendar-v1.md
@@ -1,0 +1,113 @@
+# Data Quality & Algorithm Trust Calendar v1
+
+## Purpose
+
+The Data Quality calendar is a bounded, read-only composition of Pulse's existing nutrition,
+weight, workout, Adaptive TDEE, weekly-review, and context records. It explains what was recorded,
+what the algorithms could use, and why evidence was pending or excluded. It does not grade the
+user, infer an unrecorded fact, or persist a parallel cross-domain truth.
+
+Domain mutations remain authoritative. Nutrition status changes use the nutrition status route,
+weight and workout corrections use their existing correction routes, weekly-review refresh uses
+the review route, and context creation/editing/deletion uses the existing bounded review-context
+routes. The calendar may link to those actions but does not replace them.
+
+## Endpoint and bounds
+
+`GET /api/v1/data-quality/calendar?start=YYYY-MM-DD&end=YYYY-MM-DD&timeZone=IANA`
+
+- JWT and AgentToken callers receive the same strict `data` payload for the same user and query.
+- The range is inclusive and limited to 42 calendar days. `start` must be on or before `end`.
+- An explicitly supplied, `Intl`-supported IANA time zone controls today and completed-day cutoff.
+  Otherwise the latest effective Adaptive program time zone is used, followed by the user
+  preference and then UTC.
+- Date-only keys are authoritative local calendar dates. Clients must not reinterpret them through
+  the browser time zone.
+- The store performs a fixed set of bounded range queries and batched relation queries. Query count
+  must not grow with the number of dates or records.
+- The endpoint is read-only. A GET must not change any source, review, action, target, or context row.
+
+## Composition sources
+
+### Nutrition
+
+`nutrition_logs`, `meals`, and `meal_items` are the recorded source. The explicit log status remains
+`unknown`, `partial`, or `complete`; a missing row remains `no_records`. Calories and macros are
+nullable summaries and are never converted to zero when the log is absent.
+
+Algorithm evidence is separate from the recorded status:
+
+- today's record is `pending_cutoff` in a live view;
+- the existing #103 eligibility evaluator classifies current source rows as `usable` or `excluded`
+  for each completed local-date boundary; immutable calculation/review snapshots retain the reason
+  codes and treatment that supported past decisions;
+- a complete low day is `suspected_partial` only when an existing immutable weekly-review
+  data-quality module says so. The calendar does not run a second anomaly heuristic.
+
+### Weight
+
+`body_weight` is canonical and already contains one selected measurement per user/local date. The
+calendar returns that exact row, its entry unit, recorded/updated timestamps, and a `corrected`
+flag when the retained row was updated after creation. Product Trend Weight and Adaptive snapshots
+supply derived inclusion, suspect, stale, and pending-cutoff facts. Missing measurements and missing
+trend estimates stay null.
+
+Pulse currently has no deleted-weight event ledger, so the calendar does not claim to reconstruct a
+deleted measurement. If such a ledger is added later, it may be composed without changing this
+source-of-truth rule.
+
+### Workout
+
+`scheduled_workouts` and non-deleted `workout_sessions` provide planned, active, paused, completed,
+and cancelled facts. A completed session is `corrected` only when its retained update timestamp is
+later than completion. `schedule_change` or `training_change` context is displayed as context; it is
+not treated as proof that a schedule moved.
+
+Pulse currently has no immutable schedule-movement ledger. The calendar therefore uses `moved`
+only when an authoritative future schedule-event source exists; v1 otherwise reports the retained
+plan/session state and any bounded context honestly.
+
+### Algorithm and decisions
+
+Append-only program revisions, immutable check-in calculation snapshots, weekly-review snapshots,
+and review actions provide the algorithm history. The calendar distinguishes `no_program`,
+`pre_program`, `learning`, `updating`, and `holding`, plus dated pending/accepted/declined/deferred
+decisions. For each date through today, it reuses the existing #103 evaluator over the canonical
+source rows; it does not implement new eligibility or recommendation math. Future dates may show a
+planned workout, but Algorithm is `future` with `not_applicable` evidence rather than a forecast.
+
+### Context
+
+Active `adaptive_nutrition_review_contexts` are included only when their bounded subject maps to a
+date in the requested range. Date/range subjects map directly. Entity subjects map through the
+owned nutrition, weight, schedule, session, or check-in row. Context is shown with actor provenance,
+revision, timestamps, and resolution. Free-form context never changes nutrition/weight status or
+algorithm inclusion.
+
+Context rows exist only inside an Adaptive program today. Users without a program still receive
+nutrition, weight, and workout calendar truth, with an empty context list.
+
+## Client contract
+
+- `/data-quality` renders a month grid and an adjacent selected-date audit panel from one response.
+- Each day is a native button with a full accessible name and compact text/icon domain indicators;
+  state is never communicated by color alone.
+- Filters hide/show domains without changing server facts. Summary counts remain clearly labeled by
+  domain rather than collapsing unlike meanings into one score.
+- Previous/next month and a date input request an authoritative bounded range. The selected date is
+  retained when possible and announced politely.
+- Date detail shows source labels, recorded timestamps, reason codes/copy, provenance, related IDs,
+  and links to existing correction/review surfaces. It never provides manual meal-entry controls.
+- Loading uses a status region; errors keep navigation available, explain that source records are
+  safe, and provide Retry.
+- The layout must not overflow at 320, 390, 430, 768, or desktop widths. All interactive targets are
+  at least 44 px and keyboard operable.
+
+## Explicit non-claims
+
+- Absence of a row is not a zero measurement.
+- A complete nutrition status is not automatically algorithm-usable.
+- A context annotation is not proof of causation or exclusion.
+- An `updatedAt` timestamp is not a general-purpose audit ledger.
+- The calendar does not diagnose a weight change, auto-complete nutrition, accept a recommendation,
+  or modify production data.

--- a/docs/specs/data-quality-calendar-v1.md
+++ b/docs/specs/data-quality-calendar-v1.md
@@ -27,7 +27,11 @@ routes. The calendar may link to those actions but does not replace them.
 - Date-only keys are authoritative local calendar dates. Clients must not reinterpret them through
   the browser time zone.
 - The store performs a fixed set of bounded range queries and batched relation queries. Query count
-  must not grow with the number of dates or records.
+  must not grow with the number of dates or records. Program revisions are reduced to the latest
+  revision before the bounded window plus revisions that can become effective inside it. Review
+  projection filters terminal history before hydration. Workouts, contexts, check-ins, and reviews
+  use date-partitioned caps with exact per-date omitted counts so a dense early date cannot starve a
+  later date.
 - The endpoint is read-only. A GET must not change any source, review, action, target, or context row.
 
 ## Composition sources

--- a/docs/specs/data-quality-calendar-v1.md
+++ b/docs/specs/data-quality-calendar-v1.md
@@ -57,6 +57,8 @@ trend estimates stay null.
 `body_weight.updated_at` is a generic row timestamp: a notes-only edit changes it. Pulse has no
 measurement-correction ledger, so Data Quality and Trend Weight report correction history as
 unavailable and do not create a correction marker from that timestamp.
+The calendar therefore exposes only `not_applicable` and `history_unavailable` correction states;
+it does not publish corrected-record summary counters that the source model cannot substantiate.
 
 Pulse currently has no deleted-weight event ledger, so the calendar does not claim to reconstruct a
 deleted measurement. If such a ledger is added later, it may be composed without changing this

--- a/docs/specs/data-quality-calendar-v1.md
+++ b/docs/specs/data-quality-calendar-v1.md
@@ -18,6 +18,9 @@ routes. The calendar may link to those actions but does not replace them.
 
 - JWT and AgentToken callers receive the same strict `data` payload for the same user and query.
 - The range is inclusive and limited to 42 calendar days. `start` must be on or before `end`.
+- Omitting both `start` and `end` is the bootstrap request. The server resolves the authoritative
+  local `today` and returns its complete Monday-through-Sunday month grid. The client must not issue
+  a browser-local month request before this response.
 - An explicitly supplied, `Intl`-supported IANA time zone controls today and completed-day cutoff.
   Otherwise the latest effective Adaptive program time zone is used, followed by the user
   preference and then UTC.
@@ -39,18 +42,21 @@ Algorithm evidence is separate from the recorded status:
 
 - today's record is `pending_cutoff` in a live view;
 - the existing #103 eligibility evaluator classifies current source rows as `usable` or `excluded`
-  for each completed local-date boundary; immutable calculation/review snapshots retain the reason
-  codes and treatment that supported past decisions;
-- a complete low day is `suspected_partial` only when an existing immutable weekly-review
-  data-quality module says so. The calendar does not run a second anomaly heuristic.
+  for each completed local-date boundary;
+- a complete low day is `suspected_partial` only when the current, fingerprint-fresh weekly-review
+  data-quality module says so. A stale immutable review remains visible as historical evidence but
+  never overwrites the current evaluator projection.
 
 ### Weight
 
 `body_weight` is canonical and already contains one selected measurement per user/local date. The
-calendar returns that exact row, its entry unit, recorded/updated timestamps, and a `corrected`
-flag when the retained row was updated after creation. Product Trend Weight and Adaptive snapshots
+calendar returns that exact row, its entry unit, and recorded/updated timestamps. Product Trend Weight and Adaptive snapshots
 supply derived inclusion, suspect, stale, and pending-cutoff facts. Missing measurements and missing
 trend estimates stay null.
+
+`body_weight.updated_at` is a generic row timestamp: a notes-only edit changes it. Pulse has no
+measurement-correction ledger, so Data Quality and Trend Weight report correction history as
+unavailable and do not create a correction marker from that timestamp.
 
 Pulse currently has no deleted-weight event ledger, so the calendar does not claim to reconstruct a
 deleted measurement. If such a ledger is added later, it may be composed without changing this
@@ -59,21 +65,25 @@ source-of-truth rule.
 ### Workout
 
 `scheduled_workouts` and non-deleted `workout_sessions` provide planned, active, paused, completed,
-and cancelled facts. A completed session is `corrected` only when its retained update timestamp is
-later than completion. `schedule_change` or `training_change` context is displayed as context; it is
+and cancelled facts. The calendar never treats a general session update timestamp as correction
+proof. `schedule_change` or `training_change` context is displayed as context; it is
 not treated as proof that a schedule moved.
 
-Pulse currently has no immutable schedule-movement ledger. The calendar therefore uses `moved`
-only when an authoritative future schedule-event source exists; v1 otherwise reports the retained
-plan/session state and any bounded context honestly.
+Pulse currently has no immutable schedule-movement ledger. When a schedule and session retain a
+foreign-key link but have different dates, the calendar exposes both IDs/dates and labels the
+relation `linked_different_date`; `moved` describes that retained relationship, not a reconstructed
+event. The response states this limitation. Original-only and destination-only ranges retain the
+linked counterpart needed to explain the relationship.
 
 ### Algorithm and decisions
 
 Append-only program revisions, immutable check-in calculation snapshots, weekly-review snapshots,
 and review actions provide the algorithm history. The calendar distinguishes `no_program`,
 `pre_program`, `learning`, `updating`, and `holding`, plus dated pending/accepted/declined/deferred
-decisions. For each date through today, it reuses the existing #103 evaluator over the canonical
-source rows; it does not implement new eligibility or recommendation math. Future dates may show a
+decisions. Review state is projected by the authoritative weekly-review store, including current
+fingerprint staleness and its safe refresh route. Historical program state reuses the same check-in
+state primitive as Adaptive analytics plus #103 eligibility; eligibility by itself never implies an
+accepted update. Future dates may show a
 planned workout, but Algorithm is `future` with `not_applicable` evidence rather than a forecast.
 
 ### Context
@@ -89,11 +99,12 @@ nutrition, weight, and workout calendar truth, with an empty context list.
 
 ## Client contract
 
-- `/data-quality` renders a month grid and an adjacent selected-date audit panel from one response.
+- `/data-quality` bootstraps its month from the response `today`, then renders a month grid and an
+  adjacent selected-date audit panel.
 - Each day is a native button with a full accessible name and compact text/icon domain indicators;
   state is never communicated by color alone.
-- Filters hide/show domains without changing server facts. Summary counts remain clearly labeled by
-  domain rather than collapsing unlike meanings into one score.
+- Filters hide/show domains without changing server facts. Summary counts are explicitly labeled
+  for the complete visible calendar grid, including adjacent-month dates.
 - Previous/next month and a date input request an authoritative bounded range. The selected date is
   retained when possible and announced politely.
 - Date detail shows source labels, recorded timestamps, reason codes/copy, provenance, related IDs,

--- a/docs/specs/trend-weight-v1.md
+++ b/docs/specs/trend-weight-v1.md
@@ -13,12 +13,12 @@ the full series before cropping it to the selected display range. A date therefo
 Product Trend Weight in `1M`, `3M`, `6M`, `1Y`, and `All` views.
 
 Persistence allows one authoritative body-weight row per user and local date. A same-date POST
-replaces that row, a PATCH correction recomputes every affected response, and DELETE removes the
+replaces that row, a PATCH edit recomputes every affected response, and DELETE removes the
 observation. Responses fingerprint the strict, rounded response facts (with the fingerprint field
 omitted), so identical user-visible analytics have an identical fingerprint while any visible
 measurement, provenance, state, goal, marker, or explanation change produces a new one. An explicit
 historical `end` excludes later rows; a later-dated write cannot alter that historical response,
-while a correction or deletion inside the historical evidence window intentionally does.
+while a measurement edit or deletion inside the historical evidence window intentionally does.
 
 Historical requests supply an explicit local `end`. Live requests omit `end` and must supply the
 caller's IANA time zone; the server does not derive local “today” from its host time zone. The
@@ -69,7 +69,7 @@ intervals are null with a reason; they are never displayed as zero.
 
 Raw scale observations are discrete dots. Only Product Trend Weight is a connected line, and a gap
 of more than seven days starts a new visible segment. The accessible table is the exact-value
-equivalent of the chart. Goal, revision, check-in, and correction markers use continuous date
+equivalent of the chart. Goal, revision, and check-in markers use continuous date
 coordinates, group same-date labels, and remain available as dated text even when no weigh-in exists
 on the marker date.
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,6 +10,7 @@ export * from './schemas/agent-tokens.js';
 export * from './schemas/common.js';
 export * from './schemas/dashboard-config.js';
 export * from './schemas/dashboard.js';
+export * from './schemas/data-quality-calendar.js';
 export * from './schemas/entity-links.js';
 export * from './schemas/equipment.js';
 export * from './schemas/exercises.js';

--- a/packages/shared/src/schemas/data-quality-calendar.test.ts
+++ b/packages/shared/src/schemas/data-quality-calendar.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   dataQualityCalendarQuerySchema,
   dataQualityCalendarSchema,
+  dataQualityCorrectionStateSchema,
   type DataQualityCalendar,
 } from './data-quality-calendar.js';
 
@@ -70,8 +71,8 @@ const response = (): DataQualityCalendar => ({
   days: [day('2026-03-07'), day('2026-03-08'), day('2026-03-09')],
   summary: {
     nutrition: { complete: 0, partial: 0, unknown: 0, missing: 3, pending: 0, excluded: 0 },
-    weight: { logged: 0, missing: 3, pending: 0, excluded: 0, corrected: 0 },
-    workout: { planned: 0, active: 0, completed: 0, cancelled: 0, corrected: 0 },
+    weight: { logged: 0, missing: 3, pending: 0, excluded: 0 },
+    workout: { planned: 0, active: 0, completed: 0, cancelled: 0 },
     algorithm: { learning: 0, updating: 0, holding: 0, pendingReview: 0 },
     contextDays: 0,
     intervalLabel: 'Visible calendar grid',
@@ -134,6 +135,22 @@ describe('dataQualityCalendarSchema', () => {
 
   it('parses one strict day for every literal local date', () => {
     expect(dataQualityCalendarSchema.parse(response())).toEqual(response());
+  });
+
+  it('rejects correction claims and counters when no correction ledger exists', () => {
+    expect(() => dataQualityCorrectionStateSchema.parse('confirmed')).toThrow();
+    expect(() => dataQualityCorrectionStateSchema.parse('not_corrected')).toThrow();
+
+    const value = response();
+    expect(() =>
+      dataQualityCalendarSchema.parse({
+        ...value,
+        summary: {
+          ...value.summary,
+          weight: { ...value.summary.weight, corrected: 1 },
+        },
+      }),
+    ).toThrow(/Unrecognized key/);
   });
 
   it('rejects fabricated nutrition and partial weight source precision', () => {

--- a/packages/shared/src/schemas/data-quality-calendar.test.ts
+++ b/packages/shared/src/schemas/data-quality-calendar.test.ts
@@ -17,8 +17,15 @@ const day = (date: string): DataQualityCalendar['days'][number] => ({
     totals: null,
     mealCount: null,
     itemCount: null,
+    createdAt: null,
     statusUpdatedAt: null,
     updatedAt: null,
+    provenance: {
+      type: 'not_recorded',
+      label: 'Not recorded',
+      agentTokenId: null,
+      limitation: 'No source.',
+    },
     reasonCodes: [],
     actions: [],
   },
@@ -28,11 +35,17 @@ const day = (date: string): DataQualityCalendar['days'][number] => ({
     weight: null,
     unit: null,
     trendWeight: null,
-    corrected: false,
+    correctionState: 'not_applicable',
     suspect: false,
     stale: false,
     createdAt: null,
     updatedAt: null,
+    provenance: {
+      type: 'not_recorded',
+      label: 'Not recorded',
+      agentTokenId: null,
+      limitation: 'No source.',
+    },
     reasonCodes: [],
     actions: [],
   },
@@ -43,12 +56,16 @@ const day = (date: string): DataQualityCalendar['days'][number] => ({
     weightEvidenceState: 'not_applicable',
     reasonCodes: [],
     events: [],
+    omittedEventCount: 0,
   },
   contexts: [],
+  omittedWorkoutCount: 0,
+  omittedContextCount: 0,
 });
 
 const response = (): DataQualityCalendar => ({
   range: { startDate: '2026-03-07', endDate: '2026-03-09' },
+  today: '2026-03-08',
   timeZone: 'America/Detroit',
   days: [day('2026-03-07'), day('2026-03-08'), day('2026-03-09')],
   summary: {
@@ -57,11 +74,13 @@ const response = (): DataQualityCalendar => ({
     workout: { planned: 0, active: 0, completed: 0, cancelled: 0, corrected: 0 },
     algorithm: { learning: 0, updating: 0, holding: 0, pendingReview: 0 },
     contextDays: 0,
+    intervalLabel: 'Visible calendar grid',
   },
 });
 
 describe('dataQualityCalendarQuerySchema', () => {
   it('accepts a bounded DST-spanning range and supported IANA zone', () => {
+    expect(dataQualityCalendarQuerySchema.parse({})).toEqual({});
     expect(
       dataQualityCalendarQuerySchema.parse({
         start: '2026-03-07',
@@ -148,10 +167,81 @@ describe('dataQualityCalendarSchema', () => {
       totals: { calories: 900, protein: 50, carbs: 90, fat: 20 },
       mealCount: 2,
       itemCount: 4,
+      createdAt: 9,
       updatedAt: 10,
     };
     expect(() => dataQualityCalendarSchema.parse(value)).toThrow(
       /Only an explicitly complete day can be flagged as suspected partial/,
+    );
+  });
+
+  it('requires honest source provenance in every calendar domain', () => {
+    for (const domain of ['nutrition', 'weight'] as const) {
+      const value = response();
+      firstDay(value)[domain].provenance = {
+        type: 'agent_token',
+        label: 'Connected agent',
+        agentTokenId: null,
+        limitation: null,
+      };
+      expect(() => dataQualityCalendarSchema.parse(value)).toThrow(
+        /Only AgentToken provenance may include an agent token ID/,
+      );
+    }
+
+    const withWorkout = response();
+    firstDay(withWorkout).workouts = [
+      {
+        id: 'session-1',
+        kind: 'workout_session',
+        state: 'completed',
+        name: 'Strength',
+        sessionStatus: 'completed',
+        scheduledWorkoutId: null,
+        sessionId: 'session-1',
+        plannedDate: null,
+        sessionDate: '2026-03-07',
+        relation: 'unlinked',
+        relationLimitation: null,
+        correctionState: 'history_unavailable',
+        startedAt: 1,
+        completedAt: 2,
+        createdAt: 1,
+        updatedAt: 2,
+        provenance: {
+          type: 'not_recorded',
+          label: 'Not recorded',
+          agentTokenId: null,
+          limitation: null,
+        },
+        reasonCodes: [],
+        actions: [],
+      },
+    ];
+    expect(() => dataQualityCalendarSchema.parse(withWorkout)).toThrow(
+      /Unrecorded provenance must explain its limitation/,
+    );
+
+    const withAlgorithm = response();
+    firstDay(withAlgorithm).algorithm.events = [
+      {
+        id: 'check-in-1',
+        kind: 'check_in',
+        state: 'accepted',
+        effectiveDate: '2026-03-07',
+        createdAt: 1,
+        reasonCodes: [],
+        provenance: {
+          type: 'system_derived',
+          label: 'Pulse algorithm',
+          agentTokenId: 'token-1',
+          limitation: null,
+        },
+        actions: [],
+      },
+    ];
+    expect(() => dataQualityCalendarSchema.parse(withAlgorithm)).toThrow(
+      /Only AgentToken provenance may include an agent token ID/,
     );
   });
 

--- a/packages/shared/src/schemas/data-quality-calendar.test.ts
+++ b/packages/shared/src/schemas/data-quality-calendar.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  dataQualityCalendarQuerySchema,
+  dataQualityCalendarSchema,
+  type DataQualityCalendar,
+} from './data-quality-calendar.js';
+
+const day = (date: string): DataQualityCalendar['days'][number] => ({
+  date,
+  isToday: false,
+  nutrition: {
+    qualityState: 'no_records',
+    evidenceState: 'missing',
+    logId: null,
+    explicitStatus: null,
+    totals: null,
+    mealCount: null,
+    itemCount: null,
+    statusUpdatedAt: null,
+    updatedAt: null,
+    reasonCodes: [],
+    actions: [],
+  },
+  weight: {
+    evidenceState: 'missing',
+    entryId: null,
+    weight: null,
+    unit: null,
+    trendWeight: null,
+    corrected: false,
+    suspect: false,
+    stale: false,
+    createdAt: null,
+    updatedAt: null,
+    reasonCodes: [],
+    actions: [],
+  },
+  workouts: [],
+  algorithm: {
+    state: 'no_program',
+    nutritionEvidenceState: 'not_applicable',
+    weightEvidenceState: 'not_applicable',
+    reasonCodes: [],
+    events: [],
+  },
+  contexts: [],
+});
+
+const response = (): DataQualityCalendar => ({
+  range: { startDate: '2026-03-07', endDate: '2026-03-09' },
+  timeZone: 'America/Detroit',
+  days: [day('2026-03-07'), day('2026-03-08'), day('2026-03-09')],
+  summary: {
+    nutrition: { complete: 0, partial: 0, unknown: 0, missing: 3, pending: 0, excluded: 0 },
+    weight: { logged: 0, missing: 3, pending: 0, excluded: 0, corrected: 0 },
+    workout: { planned: 0, active: 0, completed: 0, cancelled: 0, corrected: 0 },
+    algorithm: { learning: 0, updating: 0, holding: 0, pendingReview: 0 },
+    contextDays: 0,
+  },
+});
+
+describe('dataQualityCalendarQuerySchema', () => {
+  it('accepts a bounded DST-spanning range and supported IANA zone', () => {
+    expect(
+      dataQualityCalendarQuerySchema.parse({
+        start: '2026-03-07',
+        end: '2026-03-09',
+        timeZone: 'America/Detroit',
+      }),
+    ).toEqual({
+      start: '2026-03-07',
+      end: '2026-03-09',
+      timeZone: 'America/Detroit',
+    });
+    expect(
+      dataQualityCalendarQuerySchema.parse({
+        start: '2026-08-01',
+        end: '2026-08-01',
+        timeZone: 'UTC',
+      }).timeZone,
+    ).toBe('UTC');
+  });
+
+  it('rejects reversed, oversized, invalid-zone, and unknown-field queries', () => {
+    expect(() =>
+      dataQualityCalendarQuerySchema.parse({ start: '2026-08-02', end: '2026-08-01' }),
+    ).toThrow(/start must be on or before end/);
+    expect(() =>
+      dataQualityCalendarQuerySchema.parse({ start: '2026-01-01', end: '2026-02-12' }),
+    ).toThrow(/limited to 42 days/);
+    expect(() =>
+      dataQualityCalendarQuerySchema.parse({
+        start: '2026-08-01',
+        end: '2026-08-02',
+        timeZone: 'Detroit',
+      }),
+    ).toThrow(/valid IANA/);
+    expect(() =>
+      dataQualityCalendarQuerySchema.parse({
+        start: '2026-08-01',
+        end: '2026-08-02',
+        extra: true,
+      }),
+    ).toThrow();
+  });
+});
+
+describe('dataQualityCalendarSchema', () => {
+  const firstDay = (value: ReturnType<typeof response>) => {
+    const day = value.days[0];
+    if (!day) throw new Error('Expected a calendar day fixture');
+    return day;
+  };
+
+  it('parses one strict day for every literal local date', () => {
+    expect(dataQualityCalendarSchema.parse(response())).toEqual(response());
+  });
+
+  it('rejects fabricated nutrition and partial weight source precision', () => {
+    const withMissingCalories = response();
+    firstDay(withMissingCalories).nutrition.totals = {
+      calories: 0,
+      protein: 0,
+      carbs: 0,
+      fat: 0,
+    };
+    expect(() => dataQualityCalendarSchema.parse(withMissingCalories)).toThrow(
+      /missing nutrition day cannot include numeric totals/i,
+    );
+
+    const withPartialWeight = response();
+    firstDay(withPartialWeight).weight.entryId = 'weight-1';
+    expect(() => dataQualityCalendarSchema.parse(withPartialWeight)).toThrow(
+      /Weight source fields must be all present or all absent/,
+    );
+  });
+
+  it('rejects suspected partial without an explicit complete source status', () => {
+    const value = response();
+    const day = firstDay(value);
+    day.nutrition = {
+      ...day.nutrition,
+      qualityState: 'suspected_partial',
+      evidenceState: 'excluded',
+      logId: 'nutrition-1',
+      explicitStatus: 'partial',
+      totals: { calories: 900, protein: 50, carbs: 90, fat: 20 },
+      mealCount: 2,
+      itemCount: 4,
+      updatedAt: 10,
+    };
+    expect(() => dataQualityCalendarSchema.parse(value)).toThrow(
+      /Only an explicitly complete day can be flagged as suspected partial/,
+    );
+  });
+
+  it('rejects duplicate, missing, or out-of-range calendar days', () => {
+    const duplicate = response();
+    duplicate.days[2] = day('2026-03-08');
+    expect(() => dataQualityCalendarSchema.parse(duplicate)).toThrow(/unique and inside/);
+
+    const incomplete = response();
+    incomplete.days.pop();
+    expect(() => dataQualityCalendarSchema.parse(incomplete)).toThrow(/one day for every/);
+  });
+});

--- a/packages/shared/src/schemas/data-quality-calendar.ts
+++ b/packages/shared/src/schemas/data-quality-calendar.ts
@@ -118,12 +118,7 @@ export const dataQualityProvenanceSchema = z
     }
   });
 
-export const dataQualityCorrectionStateSchema = z.enum([
-  'not_applicable',
-  'confirmed',
-  'not_corrected',
-  'history_unavailable',
-]);
+export const dataQualityCorrectionStateSchema = z.enum(['not_applicable', 'history_unavailable']);
 
 export const dataQualityNutritionSchema = z
   .object({
@@ -222,7 +217,6 @@ export const dataQualityWorkoutItemSchema = z
       'paused',
       'completed',
       'cancelled',
-      'corrected',
     ]),
     name: labelSchema,
     sessionStatus: workoutSessionStatusSchema.nullable(),
@@ -340,7 +334,6 @@ export const dataQualityCalendarSchema = z
             missing: z.number().int().nonnegative(),
             pending: z.number().int().nonnegative(),
             excluded: z.number().int().nonnegative(),
-            corrected: z.number().int().nonnegative(),
           })
           .strict(),
         workout: z
@@ -349,7 +342,6 @@ export const dataQualityCalendarSchema = z
             active: z.number().int().nonnegative(),
             completed: z.number().int().nonnegative(),
             cancelled: z.number().int().nonnegative(),
-            corrected: z.number().int().nonnegative(),
           })
           .strict(),
         algorithm: z

--- a/packages/shared/src/schemas/data-quality-calendar.ts
+++ b/packages/shared/src/schemas/data-quality-calendar.ts
@@ -34,12 +34,21 @@ const calendarDaysBetween = (start: string, end: string) => {
 
 export const dataQualityCalendarQuerySchema = z
   .object({
-    start: dateSchema,
-    end: dateSchema,
+    start: dateSchema.optional(),
+    end: dateSchema.optional(),
     timeZone: timeZoneSchema.optional(),
   })
   .strict()
   .superRefine((value, context) => {
+    if ((value.start === undefined) !== (value.end === undefined)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'start and end must be supplied together',
+        path: value.start === undefined ? ['start'] : ['end'],
+      });
+      return;
+    }
+    if (value.start === undefined || value.end === undefined) return;
     if (value.start > value.end) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
@@ -84,6 +93,38 @@ export const dataQualityActionSchema = z
   })
   .strict();
 
+export const dataQualityProvenanceSchema = z
+  .object({
+    type: z.enum(['user', 'agent_token', 'imported', 'system_derived', 'not_recorded']),
+    label: labelSchema,
+    agentTokenId: idSchema.nullable(),
+    limitation: z.string().trim().min(1).max(500).nullable(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if ((value.type === 'agent_token') !== (value.agentTokenId !== null)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Only AgentToken provenance may include an agent token ID',
+        path: ['agentTokenId'],
+      });
+    }
+    if (value.type === 'not_recorded' && value.limitation === null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Unrecorded provenance must explain its limitation',
+        path: ['limitation'],
+      });
+    }
+  });
+
+export const dataQualityCorrectionStateSchema = z.enum([
+  'not_applicable',
+  'confirmed',
+  'not_corrected',
+  'history_unavailable',
+]);
+
 export const dataQualityNutritionSchema = z
   .object({
     qualityState: z.enum(['no_records', 'unknown', 'partial', 'complete', 'suspected_partial']),
@@ -93,8 +134,10 @@ export const dataQualityNutritionSchema = z
     totals: nutritionMacroTotalsSchema.nullable(),
     mealCount: z.number().int().nonnegative().nullable(),
     itemCount: z.number().int().nonnegative().nullable(),
+    createdAt: z.number().int().nonnegative().nullable(),
     statusUpdatedAt: z.number().int().nonnegative().nullable(),
     updatedAt: z.number().int().nonnegative().nullable(),
+    provenance: dataQualityProvenanceSchema,
     reasonCodes: z.array(reasonCodeSchema).max(50),
     actions: z.array(dataQualityActionSchema).max(10),
   })
@@ -132,11 +175,12 @@ export const dataQualityWeightSchema = z
     weight: z.number().positive().finite().nullable(),
     unit: weightUnitSchema.nullable(),
     trendWeight: z.number().positive().finite().nullable(),
-    corrected: z.boolean(),
+    correctionState: dataQualityCorrectionStateSchema,
     suspect: z.boolean(),
     stale: z.boolean(),
     createdAt: z.number().int().nonnegative().nullable(),
     updatedAt: z.number().int().nonnegative().nullable(),
+    provenance: dataQualityProvenanceSchema,
     reasonCodes: z.array(reasonCodeSchema).max(50),
     actions: z.array(dataQualityActionSchema).max(10),
   })
@@ -157,7 +201,7 @@ export const dataQualityWeightSchema = z
         path: ['entryId'],
       });
     }
-    if (sourceCount === 0 && (value.corrected || value.suspect)) {
+    if (sourceCount === 0 && (value.correctionState !== 'not_applicable' || value.suspect)) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'A missing weight cannot be corrected or suspect',
@@ -173,6 +217,7 @@ export const dataQualityWorkoutItemSchema = z
     state: z.enum([
       'planned',
       'moved',
+      'scheduled',
       'in_progress',
       'paused',
       'completed',
@@ -183,10 +228,16 @@ export const dataQualityWorkoutItemSchema = z
     sessionStatus: workoutSessionStatusSchema.nullable(),
     scheduledWorkoutId: idSchema.nullable(),
     sessionId: idSchema.nullable(),
+    plannedDate: dateSchema.nullable(),
+    sessionDate: dateSchema.nullable(),
+    relation: z.enum(['unlinked', 'linked_same_date', 'linked_different_date']),
+    relationLimitation: z.string().trim().min(1).max(500).nullable(),
+    correctionState: dataQualityCorrectionStateSchema,
     startedAt: z.number().int().nonnegative().nullable(),
     completedAt: z.number().int().nonnegative().nullable(),
     createdAt: z.number().int().nonnegative(),
     updatedAt: z.number().int().nonnegative(),
+    provenance: dataQualityProvenanceSchema,
     reasonCodes: z.array(reasonCodeSchema).max(50),
     actions: z.array(dataQualityActionSchema).max(10),
   })
@@ -209,6 +260,7 @@ export const dataQualityAlgorithmEventSchema = z
     effectiveDate: dateSchema,
     createdAt: z.number().int().nonnegative(),
     reasonCodes: z.array(reasonCodeSchema).max(50),
+    provenance: dataQualityProvenanceSchema,
     actions: z.array(dataQualityActionSchema).max(10),
   })
   .strict();
@@ -220,6 +272,7 @@ export const dataQualityAlgorithmSchema = z
     weightEvidenceState: dataQualityEvidenceStateSchema,
     reasonCodes: z.array(reasonCodeSchema).max(100),
     events: z.array(dataQualityAlgorithmEventSchema).max(50),
+    omittedEventCount: z.number().int().nonnegative(),
   })
   .strict();
 
@@ -256,6 +309,8 @@ export const dataQualityCalendarDaySchema = z
     workouts: z.array(dataQualityWorkoutItemSchema).max(50),
     algorithm: dataQualityAlgorithmSchema,
     contexts: z.array(dataQualityContextSchema).max(100),
+    omittedWorkoutCount: z.number().int().nonnegative(),
+    omittedContextCount: z.number().int().nonnegative(),
   })
   .strict();
 
@@ -273,6 +328,7 @@ const countSummarySchema = z
 export const dataQualityCalendarSchema = z
   .object({
     range: z.object({ startDate: dateSchema, endDate: dateSchema }).strict(),
+    today: dateSchema,
     timeZone: timeZoneSchema,
     days: z.array(dataQualityCalendarDaySchema).min(1).max(42),
     summary: z
@@ -305,6 +361,7 @@ export const dataQualityCalendarSchema = z
           })
           .strict(),
         contextDays: z.number().int().nonnegative(),
+        intervalLabel: z.string().trim().min(1).max(100),
       })
       .strict(),
   })

--- a/packages/shared/src/schemas/data-quality-calendar.ts
+++ b/packages/shared/src/schemas/data-quality-calendar.ts
@@ -1,0 +1,349 @@
+import { z } from 'zod';
+
+import {
+  adaptiveReviewActorSchema,
+  adaptiveReviewContextCategorySchema,
+} from './adaptive-weekly-review.js';
+import { dateSchema } from './common.js';
+import { nutritionLogStatusSchema, nutritionMacroTotalsSchema } from './nutrition.js';
+import { weightUnitSchema } from './users.js';
+import { workoutSessionStatusSchema } from './workout-sessions.js';
+
+const idSchema = z.string().trim().min(1);
+const reasonCodeSchema = z.string().trim().min(1).max(100);
+const labelSchema = z.string().trim().min(1).max(255);
+
+const timeZoneSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((value) => {
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone: value }).format(0);
+      return true;
+    } catch {
+      return false;
+    }
+  }, 'Expected a valid IANA time zone');
+
+const calendarDaysBetween = (start: string, end: string) => {
+  const startMs = Date.parse(`${start}T00:00:00.000Z`);
+  const endMs = Date.parse(`${end}T00:00:00.000Z`);
+  return Math.floor((endMs - startMs) / 86_400_000) + 1;
+};
+
+export const dataQualityCalendarQuerySchema = z
+  .object({
+    start: dateSchema,
+    end: dateSchema,
+    timeZone: timeZoneSchema.optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.start > value.end) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'start must be on or before end',
+        path: ['end'],
+      });
+      return;
+    }
+    if (calendarDaysBetween(value.start, value.end) > 42) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Data Quality calendar ranges are limited to 42 days',
+        path: ['end'],
+      });
+    }
+  });
+
+export const dataQualityEvidenceStateSchema = z.enum([
+  'not_applicable',
+  'missing',
+  'logged',
+  'pending_cutoff',
+  'usable',
+  'excluded',
+]);
+
+export const dataQualityActionSchema = z
+  .object({
+    kind: z.enum([
+      'set_nutrition_status',
+      'add_context',
+      'correct_weight',
+      'correct_workout',
+      'view_check_in',
+      'view_review',
+      'refresh_review',
+      'request_agent_review',
+    ]),
+    label: labelSchema,
+    href: z.string().trim().min(1),
+    method: z.enum(['navigate', 'patch', 'post']),
+  })
+  .strict();
+
+export const dataQualityNutritionSchema = z
+  .object({
+    qualityState: z.enum(['no_records', 'unknown', 'partial', 'complete', 'suspected_partial']),
+    evidenceState: dataQualityEvidenceStateSchema,
+    logId: idSchema.nullable(),
+    explicitStatus: nutritionLogStatusSchema.nullable(),
+    totals: nutritionMacroTotalsSchema.nullable(),
+    mealCount: z.number().int().nonnegative().nullable(),
+    itemCount: z.number().int().nonnegative().nullable(),
+    statusUpdatedAt: z.number().int().nonnegative().nullable(),
+    updatedAt: z.number().int().nonnegative().nullable(),
+    reasonCodes: z.array(reasonCodeSchema).max(50),
+    actions: z.array(dataQualityActionSchema).max(10),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const missing = value.qualityState === 'no_records';
+    const hasSource = value.logId !== null && value.explicitStatus !== null;
+    if (missing === hasSource) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Nutrition source identity must match the recorded quality state',
+        path: ['logId'],
+      });
+    }
+    if (missing && value.totals !== null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'A missing nutrition day cannot include numeric totals',
+        path: ['totals'],
+      });
+    }
+    if (value.qualityState === 'suspected_partial' && value.explicitStatus !== 'complete') {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Only an explicitly complete day can be flagged as suspected partial',
+        path: ['qualityState'],
+      });
+    }
+  });
+
+export const dataQualityWeightSchema = z
+  .object({
+    evidenceState: dataQualityEvidenceStateSchema,
+    entryId: idSchema.nullable(),
+    weight: z.number().positive().finite().nullable(),
+    unit: weightUnitSchema.nullable(),
+    trendWeight: z.number().positive().finite().nullable(),
+    corrected: z.boolean(),
+    suspect: z.boolean(),
+    stale: z.boolean(),
+    createdAt: z.number().int().nonnegative().nullable(),
+    updatedAt: z.number().int().nonnegative().nullable(),
+    reasonCodes: z.array(reasonCodeSchema).max(50),
+    actions: z.array(dataQualityActionSchema).max(10),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const sourceValues = [
+      value.entryId,
+      value.weight,
+      value.unit,
+      value.createdAt,
+      value.updatedAt,
+    ];
+    const sourceCount = sourceValues.filter((item) => item !== null).length;
+    if (sourceCount !== 0 && sourceCount !== sourceValues.length) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Weight source fields must be all present or all absent',
+        path: ['entryId'],
+      });
+    }
+    if (sourceCount === 0 && (value.corrected || value.suspect)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'A missing weight cannot be corrected or suspect',
+        path: ['entryId'],
+      });
+    }
+  });
+
+export const dataQualityWorkoutItemSchema = z
+  .object({
+    id: idSchema,
+    kind: z.enum(['scheduled_workout', 'workout_session']),
+    state: z.enum([
+      'planned',
+      'moved',
+      'in_progress',
+      'paused',
+      'completed',
+      'cancelled',
+      'corrected',
+    ]),
+    name: labelSchema,
+    sessionStatus: workoutSessionStatusSchema.nullable(),
+    scheduledWorkoutId: idSchema.nullable(),
+    sessionId: idSchema.nullable(),
+    startedAt: z.number().int().nonnegative().nullable(),
+    completedAt: z.number().int().nonnegative().nullable(),
+    createdAt: z.number().int().nonnegative(),
+    updatedAt: z.number().int().nonnegative(),
+    reasonCodes: z.array(reasonCodeSchema).max(50),
+    actions: z.array(dataQualityActionSchema).max(10),
+  })
+  .strict();
+
+export const dataQualityAlgorithmEventSchema = z
+  .object({
+    id: idSchema,
+    kind: z.enum(['check_in', 'weekly_review']),
+    state: z.enum([
+      'pending',
+      'accepted',
+      'declined',
+      'deferred',
+      'awaiting_clarification',
+      'stale',
+      'held',
+      'superseded',
+    ]),
+    effectiveDate: dateSchema,
+    createdAt: z.number().int().nonnegative(),
+    reasonCodes: z.array(reasonCodeSchema).max(50),
+    actions: z.array(dataQualityActionSchema).max(10),
+  })
+  .strict();
+
+export const dataQualityAlgorithmSchema = z
+  .object({
+    state: z.enum(['no_program', 'pre_program', 'future', 'learning', 'updating', 'holding']),
+    nutritionEvidenceState: dataQualityEvidenceStateSchema,
+    weightEvidenceState: dataQualityEvidenceStateSchema,
+    reasonCodes: z.array(reasonCodeSchema).max(100),
+    events: z.array(dataQualityAlgorithmEventSchema).max(50),
+  })
+  .strict();
+
+export const dataQualityContextSchema = z
+  .object({
+    id: idSchema,
+    category: adaptiveReviewContextCategorySchema,
+    note: z.string().trim().min(1).max(4000),
+    resolution: z.string().trim().min(1).max(4000).nullable(),
+    provenance: adaptiveReviewActorSchema,
+    subjectKind: z.enum([
+      'date',
+      'date_range',
+      'nutrition_log',
+      'weigh_in',
+      'scheduled_workout',
+      'workout_session',
+      'check_in',
+      'upcoming_check_in',
+    ]),
+    revision: z.number().int().positive(),
+    createdAt: z.number().int().nonnegative(),
+    updatedAt: z.number().int().nonnegative(),
+    actions: z.array(dataQualityActionSchema).max(10),
+  })
+  .strict();
+
+export const dataQualityCalendarDaySchema = z
+  .object({
+    date: dateSchema,
+    isToday: z.boolean(),
+    nutrition: dataQualityNutritionSchema,
+    weight: dataQualityWeightSchema,
+    workouts: z.array(dataQualityWorkoutItemSchema).max(50),
+    algorithm: dataQualityAlgorithmSchema,
+    contexts: z.array(dataQualityContextSchema).max(100),
+  })
+  .strict();
+
+const countSummarySchema = z
+  .object({
+    complete: z.number().int().nonnegative(),
+    partial: z.number().int().nonnegative(),
+    unknown: z.number().int().nonnegative(),
+    missing: z.number().int().nonnegative(),
+    pending: z.number().int().nonnegative(),
+    excluded: z.number().int().nonnegative(),
+  })
+  .strict();
+
+export const dataQualityCalendarSchema = z
+  .object({
+    range: z.object({ startDate: dateSchema, endDate: dateSchema }).strict(),
+    timeZone: timeZoneSchema,
+    days: z.array(dataQualityCalendarDaySchema).min(1).max(42),
+    summary: z
+      .object({
+        nutrition: countSummarySchema,
+        weight: z
+          .object({
+            logged: z.number().int().nonnegative(),
+            missing: z.number().int().nonnegative(),
+            pending: z.number().int().nonnegative(),
+            excluded: z.number().int().nonnegative(),
+            corrected: z.number().int().nonnegative(),
+          })
+          .strict(),
+        workout: z
+          .object({
+            planned: z.number().int().nonnegative(),
+            active: z.number().int().nonnegative(),
+            completed: z.number().int().nonnegative(),
+            cancelled: z.number().int().nonnegative(),
+            corrected: z.number().int().nonnegative(),
+          })
+          .strict(),
+        algorithm: z
+          .object({
+            learning: z.number().int().nonnegative(),
+            updating: z.number().int().nonnegative(),
+            holding: z.number().int().nonnegative(),
+            pendingReview: z.number().int().nonnegative(),
+          })
+          .strict(),
+        contextDays: z.number().int().nonnegative(),
+      })
+      .strict(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.range.startDate > value.range.endDate) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'range start must be on or before range end',
+        path: ['range', 'endDate'],
+      });
+      return;
+    }
+    const expectedDays = calendarDaysBetween(value.range.startDate, value.range.endDate);
+    if (value.days.length !== expectedDays) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Calendar response must contain one day for every requested date',
+        path: ['days'],
+      });
+    }
+    const seen = new Set<string>();
+    for (const [index, day] of value.days.entries()) {
+      if (
+        day.date < value.range.startDate ||
+        day.date > value.range.endDate ||
+        seen.has(day.date)
+      ) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Calendar day dates must be unique and inside the response range',
+          path: ['days', index, 'date'],
+        });
+      }
+      seen.add(day.date);
+    }
+  });
+
+export type DataQualityCalendarQuery = z.infer<typeof dataQualityCalendarQuerySchema>;
+export type DataQualityCalendar = z.infer<typeof dataQualityCalendarSchema>;
+export type DataQualityCalendarDay = z.infer<typeof dataQualityCalendarDaySchema>;
+export type DataQualityEvidenceState = z.infer<typeof dataQualityEvidenceStateSchema>;

--- a/packages/shared/src/utils/ewma.ts
+++ b/packages/shared/src/utils/ewma.ts
@@ -166,7 +166,9 @@ export function calculateCanonicalTrendWeightPoint(
     gapFromPreviousDays: previous
       ? trendWeightCalendarDaysBetween(previous.date, latest.date)
       : null,
-    corrected: latest.updatedAt > latest.createdAt,
+    // Body-weight rows retain a generic update timestamp, not a measurement-correction ledger.
+    // Notes-only edits must never be presented as confirmed measurement corrections.
+    corrected: false,
   };
 }
 


### PR DESCRIPTION
Closes #111

## Summary
- add a strict shared Data Quality calendar contract and read-only JWT/AgentToken API
- compose nutrition, weight, workout, Adaptive TDEE, weekly review, and bounded context evidence without duplicating domain algorithms
- add the responsive audit calendar, exact per-day evidence, provenance, accessible filters, and bounded context creation
- add deterministic preview fixtures plus real-SQLite, route, component, invalidation, seeder, and installed-Chrome coverage

## Verification
- git diff --check 4ce2ba0..HEAD
- TURBO_FORCE=true pnpm lint
- TURBO_FORCE=true pnpm typecheck
- TURBO_FORCE=true pnpm test (15 repository-script tests; 2,552 Vitest tests)
- TURBO_FORCE=true pnpm build
- installed Chrome focused: 4/4
- installed Chrome full suite: 83/83, default 5 workers, no exclusions
- SQLite integrity_check: ok; foreign_key_check: no rows

## QA evidence
Responsive screenshots were captured and visually reviewed at 320, 390, 430, 768, and 1280 px under artifacts/issue-111 in the local handoff.

No production deployment was performed.