### PR TITLE
fix(workouts): preserve scheduled snapshot provenance

### DIFF
--- a/apps/api/drizzle/0060_scheduled_session_prescriptions.sql
+++ b/apps/api/drizzle/0060_scheduled_session_prescriptions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `workout_sessions` ADD `exercise_prescriptions` text;

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -421,6 +421,13 @@
       "when": 1788048000000,
       "tag": "0059_first_class_rir",
       "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "6",
+      "when": 1788733000000,
+      "tag": "0060_scheduled_session_prescriptions",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/adaptive-program-revision-causal-migration.test.ts
+++ b/apps/api/src/db/adaptive-program-revision-causal-migration.test.ts
@@ -21,6 +21,11 @@ type MigrationJournal = {
   entries: Array<{ idx: number; version: string; when: number; tag: string; breakpoints: boolean }>;
 };
 
+const currentJournal = JSON.parse(
+  readFileSync(join(sourceMigrationsFolder, 'meta/_journal.json'), 'utf8'),
+) as MigrationJournal;
+const pendingAfter0055 = currentJournal.entries.filter((entry) => entry.idx > 55).length;
+
 const stageMigrationsThrough = (root: string, maximumIndex: number) => {
   const destination = join(root, `through-${maximumIndex}`);
   mkdirSync(join(destination, 'meta'), { recursive: true });
@@ -461,7 +466,7 @@ describe('adaptive program revision causal migration', () => {
       }
 
       expect(migratePulseDatabase(sqlite, { migrationsFolder: sourceMigrationsFolder })).toEqual({
-        applied: 4,
+        applied: pendingAfter0055,
         projectionRevisions: 3,
       });
       expect(
@@ -690,7 +695,7 @@ describe('adaptive program revision causal migration', () => {
       ).toEqual({ createdAt: 1787702400000 });
 
       expect(migratePulseDatabase(sqlite, { migrationsFolder: sourceMigrationsFolder })).toEqual({
-        applied: 4,
+        applied: pendingAfter0055,
         projectionRevisions: 1,
       });
       expect(migratePulseDatabase(sqlite, { migrationsFolder: sourceMigrationsFolder })).toEqual({
@@ -762,7 +767,7 @@ describe('adaptive program revision causal migration', () => {
       });
 
       expect(migratePulseDatabase(sqlite, { migrationsFolder: sourceMigrationsFolder })).toEqual({
-        applied: 4,
+        applied: pendingAfter0055,
         projectionRevisions: 1,
       });
       expectHealthyDatabase(sqlite);
@@ -778,7 +783,7 @@ describe('adaptive program revision causal migration', () => {
     sqlite.pragma('foreign_keys = ON');
     try {
       expect(migratePulseDatabase(sqlite, { migrationsFolder: sourceMigrationsFolder })).toEqual({
-        applied: 60,
+        applied: currentJournal.entries.length,
         projectionRevisions: 0,
       });
       expect(

--- a/apps/api/src/db/scheduled-session-prescriptions-migration.test.ts
+++ b/apps/api/src/db/scheduled-session-prescriptions-migration.test.ts
@@ -1,0 +1,82 @@
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { migratePulseDatabase } from './migrate.js';
+
+const sourceMigrationsFolder = fileURLToPath(new URL('../../drizzle', import.meta.url));
+const temporaryDirectories: string[] = [];
+
+type Journal = {
+  version: string;
+  dialect: string;
+  entries: Array<{ idx: number; version: string; when: number; tag: string; breakpoints: boolean }>;
+};
+
+const sourceJournal = JSON.parse(
+  readFileSync(join(sourceMigrationsFolder, 'meta/_journal.json'), 'utf8'),
+) as Journal;
+
+function stageThrough(root: string, maximumIndex: number) {
+  const destination = join(root, `through-${maximumIndex}`);
+  mkdirSync(join(destination, 'meta'), { recursive: true });
+  const entries = sourceJournal.entries.filter((entry) => entry.idx <= maximumIndex);
+  writeFileSync(
+    join(destination, 'meta/_journal.json'),
+    `${JSON.stringify({ ...sourceJournal, entries }, null, 2)}\n`,
+  );
+  for (const entry of entries) {
+    copyFileSync(
+      join(sourceMigrationsFolder, `${entry.tag}.sql`),
+      join(destination, `${entry.tag}.sql`),
+    );
+  }
+  return destination;
+}
+
+function createDatabase() {
+  const root = mkdtempSync(join(tmpdir(), 'pulse-prescription-migration-'));
+  temporaryDirectories.push(root);
+  const sqlite = new Database(join(root, 'migration.db'));
+  sqlite.pragma('foreign_keys = ON');
+  return { root, sqlite };
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('0060 scheduled session prescriptions', () => {
+  it('upgrades populated legacy sessions without changing history and is idempotent', () => {
+    const { root, sqlite } = createDatabase();
+    try {
+      migrate(drizzle(sqlite), { migrationsFolder: stageThrough(root, 59) });
+      sqlite.exec(
+        "INSERT INTO users (id, username, password_hash) VALUES ('u', 'fictional', 'hash')",
+      );
+      sqlite.exec(
+        "INSERT INTO workout_sessions (id, user_id, name, date, status, started_at, completed_at) VALUES ('legacy', 'u', 'Legacy', '2026-09-06', 'completed', 100, 200)",
+      );
+      const before = sqlite.prepare('SELECT * FROM workout_sessions').get();
+      const result = migratePulseDatabase(sqlite, { migrationsFolder: sourceMigrationsFolder });
+      expect(result).toBeDefined();
+      expect(sqlite.prepare('SELECT * FROM workout_sessions').get()).toEqual({
+        ...(before as object),
+        exercise_prescriptions: null,
+      });
+      migratePulseDatabase(sqlite, { migrationsFolder: sourceMigrationsFolder });
+      expect(sqlite.pragma('foreign_key_check')).toEqual([]);
+      expect(sqlite.pragma('quick_check')).toEqual([{ quick_check: 'ok' }]);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/src/db/schema.test.ts
+++ b/apps/api/src/db/schema.test.ts
@@ -1213,6 +1213,7 @@ describe('workoutSessions schema', () => {
       'exerciseProgrammingNotes',
       'exerciseAgentNotes',
       'exerciseAgentNotesMeta',
+      'exercisePrescriptions',
       'notes',
       'deletedAt',
       'createdAt',

--- a/apps/api/src/db/schema/workout-sessions.ts
+++ b/apps/api/src/db/schema/workout-sessions.ts
@@ -20,6 +20,19 @@ import type { WorkoutTemplateSectionType } from './workout-templates.js';
 import { workoutTemplates } from './workout-templates.js';
 import { users } from './users.js';
 
+export type SessionExercisePrescription = {
+  tempo: string | null;
+  restSeconds: number | null;
+  sourceScheduledExerciseId: string;
+  sourceSetCount: number;
+  exerciseId: string;
+  exerciseName: string;
+  trackingType: ExerciseTrackingType;
+  section: WorkoutTemplateSectionType;
+  orderIndex: number;
+  supersetGroup: string | null;
+};
+
 export type WorkoutSessionStatus =
   | 'scheduled'
   | 'in-progress'
@@ -123,6 +136,10 @@ export const workoutSessions = sqliteTable(
     exerciseAgentNotesMeta: text('exercise_agent_notes_meta', { mode: 'json' }).$type<Record<
       string,
       WorkoutSessionExerciseAgentNotesMeta | null
+    > | null>(),
+    exercisePrescriptions: text('exercise_prescriptions', { mode: 'json' }).$type<Record<
+      string,
+      SessionExercisePrescription
     > | null>(),
     notes: text('notes'),
     deletedAt: text('deleted_at'),

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -3870,7 +3870,7 @@ describe('workout session routes', () => {
     });
   });
 
-  it('links a newly started session to an unclaimed scheduled workout for today', async () => {
+  it('keeps an independent template start separate from an unclaimed scheduled workout', async () => {
     const authToken = context.app.jwt.sign(
       { sub: 'user-1', type: 'session', iss: 'pulse-api' },
       { expiresIn: '7d' },
@@ -3912,9 +3912,15 @@ describe('workout session routes', () => {
       .limit(1)
       .get();
 
-    expect(linkedSchedule).toEqual({
-      sessionId,
-    });
+    expect(linkedSchedule).toEqual({ sessionId: null });
+
+    const persistedSession = context.db
+      .select({ scheduledWorkoutId: workoutSessions.scheduledWorkoutId })
+      .from(workoutSessions)
+      .where(eq(workoutSessions.id, sessionId))
+      .limit(1)
+      .get();
+    expect(persistedSession).toEqual({ scheduledWorkoutId: null });
   });
 
   it('starts a session from scheduled-workout snapshot and propagates programming and agent notes', async () => {
@@ -4049,6 +4055,454 @@ describe('workout session routes', () => {
     expect(persistedSession).toEqual({
       scheduledWorkoutId: 'schedule-snapshot-seed',
     });
+
+    const persistedSets = context.db
+      .select({
+        sourceScheduledSetId: sessionSets.sourceScheduledSetId,
+        targetRepsMin: sessionSets.targetRepsMin,
+        targetRepsMax: sessionSets.targetRepsMax,
+        targetReps: sessionSets.targetReps,
+        targetWeight: sessionSets.targetWeight,
+        targetWeightMin: sessionSets.targetWeightMin,
+        targetWeightMax: sessionSets.targetWeightMax,
+        section: sessionSets.section,
+      })
+      .from(sessionSets)
+      .where(eq(sessionSets.sessionId, payload.data.id))
+      .all()
+      .sort((left, right) =>
+        (left.sourceScheduledSetId ?? '').localeCompare(right.sourceScheduledSetId ?? ''),
+      );
+    expect(persistedSets).toEqual([
+      {
+        sourceScheduledSetId: 'schedule-snapshot-bench-set-1',
+        targetRepsMin: null,
+        targetRepsMax: null,
+        targetReps: 6,
+        targetWeight: 190,
+        targetWeightMin: null,
+        targetWeightMax: null,
+        section: 'main',
+      },
+      {
+        sourceScheduledSetId: 'schedule-snapshot-bench-set-2',
+        targetRepsMin: null,
+        targetRepsMax: null,
+        targetReps: 6,
+        targetWeight: null,
+        targetWeightMin: 190,
+        targetWeightMax: 195,
+        section: 'main',
+      },
+    ]);
+  });
+
+  function seedProvenanceFixture(identical = true) {
+    seedScheduledWorkout({
+      id: 'proof-schedule',
+      userId: 'user-1',
+      templateId: 'template-1',
+      date: '2026-09-07',
+    });
+    const names = identical
+      ? ['Bench', 'Row', 'Curl', 'Dead Bug']
+      : ['Leg Extension', 'Leg Curl', 'Hip Flexion', 'Hip Abduction'];
+    return names.flatMap((name, i) => {
+      const exerciseId = `proof-exercise-${i}`;
+      const snapshotId = `proof-snapshot-${i}`;
+      seedExercise({ id: exerciseId, userId: 'user-1', name });
+      seedTemplateExercise({
+        id: `proof-template-${i}`,
+        templateId: 'template-1',
+        exerciseId,
+        orderIndex: i,
+        sets: 5,
+      });
+      context.db
+        .insert(scheduledWorkoutExercises)
+        .values({
+          id: snapshotId,
+          scheduledWorkoutId: 'proof-schedule',
+          exerciseId,
+          exerciseNameSnapshot: name,
+          trackingTypeSnapshot: 'weight_reps',
+          section: identical || i < 3 ? 'main' : 'cooldown',
+          orderIndex: 3 - i,
+          programmingNotes: i === 0 ? null : `Programming ${i}`,
+          agentNotes: i === 1 ? null : `Recovery gate ${i}`,
+          agentNotesMeta:
+            i === 1
+              ? null
+              : {
+                  author: 'Fictional Coach',
+                  generatedAt: '2026-09-06T22:00:00Z',
+                  scheduledDateAtGeneration: '2026-09-07',
+                  stale: false,
+                },
+          supersetGroup: i < 2 ? 'pair' : null,
+          tempo: i === 0 ? null : '3110',
+          restSeconds: i === 0 ? null : 75,
+        })
+        .run();
+      return Array.from({ length: identical ? 5 : i + 1 }, (_, n) => {
+        const fields = {
+          setNumber: n + 1,
+          reps: n === 0 ? null : 8,
+          repsMin: n === 0 ? 6 : null,
+          repsMax: n === 0 ? 10 : null,
+          targetWeight: n === 1 ? 40 : null,
+          targetWeightMin: n === 2 ? 30 : null,
+          targetWeightMax: n === 2 ? 45 : null,
+          targetSeconds: n === 3 ? 60 : null,
+          targetDistance: n === 3 ? 100 : null,
+          targetZone: n === 3 ? 2 : null,
+        };
+        const id = `proof-set-${i}-${n}`;
+        context.db
+          .insert(scheduledWorkoutExerciseSets)
+          .values({ id, scheduledWorkoutExerciseId: snapshotId, ...fields })
+          .run();
+        return {
+          sourceScheduledSetId: id,
+          exerciseId,
+          exerciseIdSnapshot: exerciseId,
+          exerciseNameSnapshot: name,
+          trackingTypeSnapshot: 'weight_reps',
+          section: identical || i < 3 ? 'main' : 'cooldown',
+          orderIndex: 3 - i,
+          supersetGroup: i < 2 ? 'pair' : null,
+          setNumber: fields.setNumber,
+          targetReps: fields.reps,
+          targetRepsMin: fields.repsMin,
+          targetRepsMax: fields.repsMax,
+          targetWeight: fields.targetWeight,
+          targetWeightMin: fields.targetWeightMin,
+          targetWeightMax: fields.targetWeightMax,
+          targetSeconds: fields.targetSeconds,
+          targetDistance: fields.targetDistance,
+          targetZone: fields.targetZone,
+        };
+      });
+    });
+  }
+
+  const proofHeaders = () =>
+    createAuthorizationHeader(
+      context.app.jwt.sign(
+        { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+        { expiresIn: '7d' },
+      ),
+    );
+  const proofStart = (headers: Record<string, string> = proofHeaders()) =>
+    context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions',
+      headers,
+      payload: {
+        scheduledWorkoutId: 'proof-schedule',
+        date: '2026-09-06',
+        startedAt: Date.parse('2026-09-07T03:59:59Z'),
+      },
+    });
+
+  it.each([true, false])(
+    'preserves full DB/API snapshot provenance, nulls and notes (20-set visible parity=%s)',
+    async (identical) => {
+      const expectedSets = seedProvenanceFixture(identical);
+      if (!identical) {
+        // The later reusable workout contains only a removed exercise, with unrelated targets.
+        context.db
+          .delete(templateExercises)
+          .where(eq(templateExercises.templateId, 'template-1'))
+          .run();
+        seedTemplateExercise({
+          id: 'diverged-template',
+          templateId: 'template-1',
+          exerciseId: 'global-bench-press',
+          orderIndex: 0,
+          sets: 12,
+          notes: 'Do not leak',
+        });
+        context.db
+          .update(exercises)
+          .set({ name: 'Later catalog rename', trackingType: 'duration' })
+          .where(eq(exercises.id, 'proof-exercise-0'))
+          .run();
+      }
+      const response = await proofStart(
+        identical ? proofHeaders() : createAgentTokenHeader(seedAgentToken('user-1')),
+      );
+      expect(response.statusCode, response.body).toBe(201);
+      const session = response.json().data;
+      expect(session.scheduledWorkoutId).toBe('proof-schedule');
+      expect(session.date).toBe('2026-09-07'); // starts before local midnight, retains scheduled date
+      expect(session.sets).toHaveLength(identical ? 20 : 10);
+      const dbSets = context.db
+        .select()
+        .from(sessionSets)
+        .where(eq(sessionSets.sessionId, session.id))
+        .all();
+      for (const expected of expectedSets) {
+        expect(
+          dbSets.find((set) => set.sourceScheduledSetId === expected.sourceScheduledSetId),
+        ).toMatchObject(expected);
+        expect(
+          session.sets.find(
+            (set: { sourceScheduledSetId: string }) =>
+              set.sourceScheduledSetId === expected.sourceScheduledSetId,
+          ),
+        ).toMatchObject(expected);
+      }
+      const dbSession = context.db
+        .select()
+        .from(workoutSessions)
+        .where(eq(workoutSessions.id, session.id))
+        .get();
+      expect(dbSession?.scheduledWorkoutId).toBe('proof-schedule');
+      expect(
+        context.db
+          .select()
+          .from(scheduledWorkouts)
+          .where(eq(scheduledWorkouts.id, 'proof-schedule'))
+          .get()?.sessionId,
+      ).toBe(session.id);
+      const snapshot = context.db.select().from(scheduledWorkoutExercises).all();
+      for (const exercise of snapshot) {
+        const key = `${exercise.section}::${exercise.exerciseId}`;
+        expect(JSON.parse(dbSession?.exerciseProgrammingNotes ?? '{}')[key]).toBe(
+          exercise.programmingNotes,
+        );
+        expect(dbSession?.exerciseAgentNotes?.[key]).toBe(exercise.agentNotes);
+        expect(dbSession?.exerciseAgentNotesMeta?.[key]).toEqual(exercise.agentNotesMeta);
+        expect(dbSession?.exercisePrescriptions?.[key]).toMatchObject({
+          tempo: exercise.tempo,
+          restSeconds: exercise.restSeconds,
+        });
+        expect(
+          session.exercises.find(
+            (row: { exerciseId: string }) => row.exerciseId === exercise.exerciseId,
+          ),
+        ).toMatchObject({
+          exerciseName: exercise.exerciseNameSnapshot,
+          trackingType: exercise.trackingTypeSnapshot,
+          section: exercise.section,
+          orderIndex: exercise.orderIndex,
+          programmingNotes: exercise.programmingNotes,
+          agentNotes: exercise.agentNotes,
+          agentNotesMeta: exercise.agentNotesMeta,
+          tempo: exercise.tempo,
+          restSeconds: exercise.restSeconds,
+          supersetGroup: exercise.supersetGroup,
+        });
+      }
+      const refreshed = await context.app.inject({
+        method: 'GET',
+        url: `/api/v1/workout-sessions/${session.id}`,
+        headers: proofHeaders(),
+      });
+      expect(refreshed.json().data).toEqual(session);
+    },
+  );
+
+  it('retains a source exercise whose scheduled sets have all been removed', async () => {
+    seedProvenanceFixture();
+    context.db
+      .delete(scheduledWorkoutExerciseSets)
+      .where(eq(scheduledWorkoutExerciseSets.scheduledWorkoutExerciseId, 'proof-snapshot-0'))
+      .run();
+    const response = await proofStart();
+    expect(response.statusCode, response.body).toBe(201);
+    expect(response.json().data.sets).toHaveLength(15);
+    expect(response.json().data.exercises).toHaveLength(4);
+    expect(
+      response
+        .json()
+        .data.exercises.find(
+          (exercise: { exerciseId: string }) => exercise.exerciseId === 'proof-exercise-0',
+        ),
+    ).toMatchObject({
+      sourceScheduledExerciseId: 'proof-snapshot-0',
+      exerciseName: 'Bench',
+      sets: [],
+      tempo: null,
+      restSeconds: null,
+      programmingNotes: null,
+    });
+  });
+
+  it.each([
+    { exerciseId: 'missing-exercise', setNumber: 1 },
+    { exerciseId: 'global-bench-press', setNumber: 1, targetWeight: -1 },
+  ])('rejects invalid template materialization without consuming the schedule', async (set) => {
+    seedProvenanceFixture();
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions',
+      headers: proofHeaders(),
+      payload: { templateId: 'template-1', date: '2026-09-06', startedAt: 1, sets: [set] },
+    });
+    expect(response.statusCode).toBe(400);
+    expect(context.db.select().from(workoutSessions).all()).toHaveLength(0);
+    expect(context.db.select().from(sessionSets).all()).toHaveLength(0);
+    expect(
+      context.db
+        .select()
+        .from(scheduledWorkouts)
+        .where(eq(scheduledWorkouts.id, 'proof-schedule'))
+        .get()?.sessionId,
+    ).toBeNull();
+  });
+
+  it('rejects invalid stored snapshot targets before creating or linking any session', async () => {
+    seedProvenanceFixture();
+    context.db
+      .update(scheduledWorkoutExerciseSets)
+      .set({ targetSeconds: 2147483647 })
+      .where(eq(scheduledWorkoutExerciseSets.id, 'proof-set-0-0'))
+      .run();
+    const response = await proofStart();
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error.code).toBe('INVALID_SCHEDULED_SNAPSHOT');
+    expect(context.db.select().from(workoutSessions).all()).toHaveLength(0);
+    expect(context.db.select().from(sessionSets).all()).toHaveLength(0);
+    expect(
+      context.db
+        .select()
+        .from(scheduledWorkouts)
+        .where(eq(scheduledWorkouts.id, 'proof-schedule'))
+        .get()?.sessionId,
+    ).toBeNull();
+  });
+
+  it('allows exactly one concurrent scheduled start and leaves no orphan session or sets', async () => {
+    seedProvenanceFixture();
+    const responses = await Promise.all([proofStart(), proofStart()]);
+    expect(responses.map((response) => response.statusCode).sort()).toEqual([201, 409]);
+    expect(context.db.select().from(workoutSessions).all()).toHaveLength(1);
+    expect(context.db.select().from(sessionSets).all()).toHaveLength(20);
+    const conflict = responses.find((response) => response.statusCode === 409)?.json();
+    expect(['SCHEDULED_WORKOUT_LINK_CONFLICT', 'SCHEDULED_WORKOUT_ALREADY_STARTED']).toContain(
+      conflict.error.code,
+    );
+  });
+
+  it.each(['sets', 'link'])(
+    'rolls back session and set inserts on injected %s failure, retaining cancelled link',
+    async (failure) => {
+      seedProvenanceFixture();
+      seedWorkoutSession({
+        id: 'old-cancelled',
+        userId: 'user-1',
+        templateId: 'template-1',
+        scheduledWorkoutId: 'proof-schedule',
+        name: 'Cancelled',
+        date: '2026-09-07',
+        status: 'cancelled',
+        startedAt: 1,
+      });
+      context.db
+        .update(scheduledWorkouts)
+        .set({ sessionId: 'old-cancelled' })
+        .where(eq(scheduledWorkouts.id, 'proof-schedule'))
+        .run();
+      context.sqlite.exec(
+        failure === 'sets'
+          ? "CREATE TRIGGER fail_proof BEFORE INSERT ON session_sets BEGIN SELECT RAISE(ABORT, 'injected set failure'); END"
+          : 'CREATE TRIGGER fail_proof BEFORE UPDATE OF session_id ON scheduled_workouts BEGIN SELECT RAISE(IGNORE); END',
+      );
+      try {
+        const response = await proofStart();
+        expect(response.statusCode).toBe(failure === 'sets' ? 500 : 409);
+        expect(
+          context.db
+            .select()
+            .from(workoutSessions)
+            .all()
+            .map((row) => row.id),
+        ).toEqual(['old-cancelled']);
+        expect(context.db.select().from(sessionSets).all()).toHaveLength(0);
+        expect(
+          context.db
+            .select()
+            .from(scheduledWorkouts)
+            .where(eq(scheduledWorkouts.id, 'proof-schedule'))
+            .get()?.sessionId,
+        ).toBe('old-cancelled');
+      } finally {
+        context.sqlite.exec('DROP TRIGGER fail_proof');
+      }
+      expect((await proofStart()).statusCode).toBe(201);
+    },
+  );
+
+  it.each(['jwt', 'agent', 'missing', 'malformed'])(
+    'rejects unauthorized or malformed scheduled selector (%s) without writes',
+    async (mode) => {
+      seedProvenanceFixture();
+      const response =
+        mode === 'malformed'
+          ? await context.app.inject({
+              method: 'POST',
+              url: '/api/v1/workout-sessions',
+              headers: proofHeaders(),
+              payload: {
+                scheduledWorkoutId: '',
+                templateId: 'template-1',
+                date: '2026-09-06',
+                startedAt: 1,
+              },
+            })
+          : await proofStart(
+              mode === 'missing'
+                ? {}
+                : mode === 'agent'
+                  ? createAgentTokenHeader(seedAgentToken('user-2'))
+                  : createAuthorizationHeader(
+                      context.app.jwt.sign(
+                        { sub: 'user-2', type: 'session', iss: 'pulse-api' },
+                        { expiresIn: '7d' },
+                      ),
+                    ),
+            );
+      expect(response.statusCode).toBe(mode === 'missing' ? 401 : mode === 'malformed' ? 400 : 404);
+      expect(context.db.select().from(workoutSessions).all()).toHaveLength(0);
+      expect(context.db.select().from(sessionSets).all()).toHaveLength(0);
+      expect(
+        context.db
+          .select()
+          .from(scheduledWorkouts)
+          .where(eq(scheduledWorkouts.id, 'proof-schedule'))
+          .get()?.sessionId,
+      ).toBeNull();
+    },
+  );
+
+  it('fails closed for an unknown scheduled workout id without creating a template session', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+
+    const response = await context.app.inject({
+      method: 'POST',
+      url: '/api/v1/workout-sessions',
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        scheduledWorkoutId: 'missing-scheduled-workout',
+        templateId: null,
+        date: '2026-03-12',
+        startedAt: 1_700_000_400_000,
+      },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({
+      error: {
+        code: 'SCHEDULED_WORKOUT_NOT_FOUND',
+        message: 'Scheduled workout not found',
+      },
+    });
+    expect(context.db.select({ id: workoutSessions.id }).from(workoutSessions).all()).toEqual([]);
   });
 
   it('returns 409 when scheduled workout is already linked to a live session', async () => {

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -51,7 +51,6 @@ import {
   findScheduledWorkoutById,
   findScheduledWorkoutBySessionId,
   unlinkScheduledWorkoutSession,
-  linkTodayScheduledWorkoutToSession,
 } from '../scheduled-workouts/store.js';
 import {
   readSnapshot,
@@ -86,6 +85,7 @@ import {
   SessionSetEffortConflictError,
   SessionSetNotFoundError,
   SessionSetRirUnsupportedError,
+  ScheduledWorkoutLinkConflictError,
   type SessionSetSnapshotFact,
   swapWorkoutSessionExercise,
   updateSessionSet,
@@ -493,6 +493,23 @@ const buildScheduledSnapshotSessionSeed = ({
     agentNotesByExerciseSection,
     agentNotesMetaByExerciseSection,
     setSnapshotFactsByKey,
+    exercisePrescriptions: Object.fromEntries(
+      persistedExercises.map((exercise) => [
+        `${exercise.section ?? 'main'}::${exercise.exerciseId}`,
+        {
+          tempo: exercise.tempo,
+          restSeconds: exercise.restSeconds,
+          sourceScheduledExerciseId: exercise.id,
+          sourceSetCount: exercise.sets.length,
+          exerciseId: exercise.exerciseId,
+          exerciseName: exercise.exerciseNameSnapshot ?? 'Unknown exercise',
+          trackingType: exercise.trackingTypeSnapshot ?? 'reps_only',
+          section: exercise.section,
+          orderIndex: exercise.orderIndex,
+          supersetGroup: exercise.supersetGroup,
+        },
+      ]),
+    ),
   };
 };
 
@@ -646,7 +663,11 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
             NonNullable<ScheduledWorkoutSnapshot['exercises'][number]['agentNotesMeta']> | null
           >
         | undefined;
+      let exercisePrescriptions:
+        | ReturnType<typeof buildScheduledSnapshotSessionSeed>['exercisePrescriptions']
+        | undefined;
       let scheduledWorkoutId: string | undefined;
+      let replaceScheduledWorkoutSessionId: string | null | undefined;
       let setSnapshotFactsByKey: Record<string, SessionSetSnapshotFact> | undefined;
       let linkScheduledWorkoutSession = false;
       let warnings: Array<z.infer<typeof workoutSessionCreateWarningSchema>> | undefined;
@@ -724,7 +745,7 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
             });
           }
 
-          await unlinkScheduledWorkoutSession(schedule.id, request.userId);
+          replaceScheduledWorkoutSessionId = schedule.sessionId;
         }
 
         const snapshot = await readSnapshot(schedule.id);
@@ -772,6 +793,7 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
         agentNotesByExerciseSection = scheduledSeed.agentNotesByExerciseSection;
         agentNotesMetaByExerciseSection = scheduledSeed.agentNotesMetaByExerciseSection;
         setSnapshotFactsByKey = scheduledSeed.setSnapshotFactsByKey;
+        exercisePrescriptions = scheduledSeed.exercisePrescriptions;
         scheduledWorkoutId = schedule.id;
         linkScheduledWorkoutSession = true;
 
@@ -863,6 +885,30 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
         );
       }
 
+      // Persisted snapshots may predate current validation. Reject invalid prescriptions
+      // before the transaction, rather than failing response serialization after commit.
+      if (hasScheduledStart) {
+        const validInput = createWorkoutSessionInputSchema.safeParse(input).success;
+        const validSnapshotSets = input.sets.every((set) => {
+          const key = `${set.section ?? 'main'}::${set.exerciseId}::${set.setNumber}`;
+          const facts = setSnapshotFactsByKey?.[key];
+          return sessionSetSchema.safeParse({
+            ...set,
+            ...facts,
+            id: facts?.sourceScheduledSetId ?? '',
+            createdAt: input.startedAt,
+          }).success;
+        });
+        if (!validInput || !validSnapshotSets) {
+          return sendError(
+            reply,
+            400,
+            'INVALID_SCHEDULED_SNAPSHOT',
+            'Scheduled snapshot contains invalid prescriptions',
+          );
+        }
+      }
+
       let session;
       try {
         session = await createWorkoutSession({
@@ -874,22 +920,18 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
           agentNotesMetaByExerciseSection,
           scheduledWorkoutId,
           linkScheduledWorkoutSession,
+          replaceScheduledWorkoutSessionId,
           setSnapshotFactsByKey,
+          exercisePrescriptions,
         });
       } catch (error) {
         if (error instanceof SessionSetRirUnsupportedError) {
           return sendError(reply, 400, 'RIR_UNSUPPORTED_TRACKING_TYPE', error.message);
         }
+        if (error instanceof ScheduledWorkoutLinkConflictError) {
+          return sendError(reply, 409, 'SCHEDULED_WORKOUT_LINK_CONFLICT', error.message);
+        }
         throw error;
-      }
-
-      if (!hasScheduledStart && input.templateId !== null) {
-        await linkTodayScheduledWorkoutToSession({
-          userId: request.userId,
-          templateId: input.templateId,
-          date: input.date,
-          sessionId: session.id,
-        });
       }
 
       setAgentEnrichmentContext(request, {

--- a/apps/api/src/routes/workout-sessions/store.test.ts
+++ b/apps/api/src/routes/workout-sessions/store.test.ts
@@ -199,6 +199,15 @@ describe('workout session store deleteSessionSet', () => {
     ): SortableSetRecord => ({
       id,
       sessionId: 'session-sort',
+      sourceScheduledSetId: null,
+      exerciseIdSnapshot: null,
+      exerciseNameSnapshot: null,
+      trackingTypeSnapshot: null,
+      targetReps: null,
+      targetRepsMin: null,
+      targetRepsMax: null,
+      targetZone: null,
+
       exerciseId: `${id}-exercise`,
       orderIndex: 0,
       setNumber: 1,

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -1,3 +1,4 @@
+import type { SessionExercisePrescription } from '../../db/schema/workout-sessions.js';
 import { randomUUID } from 'node:crypto';
 
 import {
@@ -58,6 +59,8 @@ export const sectionRank = (section: WorkoutTemplateSectionType | null): number 
   return index === -1 ? SECTION_ORDER.length + 1 : index;
 };
 
+type ExercisePrescriptions = Record<string, SessionExercisePrescription>;
+
 type WorkoutSessionRecord = {
   id: string;
   userId: string;
@@ -74,6 +77,7 @@ type WorkoutSessionRecord = {
   exerciseProgrammingNotes: string | null;
   exerciseAgentNotes: Record<string, string | null> | null;
   exerciseAgentNotesMeta: Record<string, WorkoutSessionExerciseAgentNotesMeta | null> | null;
+  exercisePrescriptions: ExercisePrescriptions | null;
   notes: string | null;
   createdAt: number;
   updatedAt: number;
@@ -84,7 +88,7 @@ type WorkoutSessionAccessRecord = {
   status: WorkoutSession['status'];
 };
 
-type SessionSetRecord = {
+type SessionSetRecord = SessionSetSnapshotFact & {
   id: string;
   sessionId: string;
   exerciseId: string | null;
@@ -155,6 +159,7 @@ const workoutSessionSelection = {
   exerciseProgrammingNotes: workoutSessions.exerciseProgrammingNotes,
   exerciseAgentNotes: workoutSessions.exerciseAgentNotes,
   exerciseAgentNotesMeta: workoutSessions.exerciseAgentNotesMeta,
+  exercisePrescriptions: workoutSessions.exercisePrescriptions,
   notes: workoutSessions.notes,
   createdAt: workoutSessions.createdAt,
   updatedAt: workoutSessions.updatedAt,
@@ -187,6 +192,15 @@ const workoutSessionListSelection = {
 const sessionSetSelection = {
   id: sessionSets.id,
   sessionId: sessionSets.sessionId,
+  sourceScheduledSetId: sessionSets.sourceScheduledSetId,
+  exerciseIdSnapshot: sessionSets.exerciseIdSnapshot,
+  exerciseNameSnapshot: sessionSets.exerciseNameSnapshot,
+  trackingTypeSnapshot: sessionSets.trackingTypeSnapshot,
+  targetReps: sessionSets.targetReps,
+  targetRepsMin: sessionSets.targetRepsMin,
+  targetRepsMax: sessionSets.targetRepsMax,
+  targetZone: sessionSets.targetZone,
+
   exerciseId: sessionSets.exerciseId,
   orderIndex: sessionSets.orderIndex,
   setNumber: sessionSets.setNumber,
@@ -252,6 +266,24 @@ const buildSessionSet = (set: SessionSetRecord): SessionSet => ({
   ...(set.targetWeightMax !== null ? { targetWeightMax: set.targetWeightMax } : {}),
   ...(set.targetSeconds !== null ? { targetSeconds: set.targetSeconds } : {}),
   ...(set.targetDistance !== null ? { targetDistance: set.targetDistance } : {}),
+  ...(set.sourceScheduledSetId
+    ? {
+        sourceScheduledSetId: set.sourceScheduledSetId,
+        exerciseIdSnapshot: set.exerciseIdSnapshot,
+        exerciseNameSnapshot: set.exerciseNameSnapshot,
+        trackingTypeSnapshot: set.trackingTypeSnapshot,
+        targetReps: set.targetReps,
+        targetRepsMin: set.targetRepsMin,
+        targetRepsMax: set.targetRepsMax,
+        targetZone: set.targetZone,
+        targetWeight: set.targetWeight,
+        targetWeightMin: set.targetWeightMin,
+        targetWeightMax: set.targetWeightMax,
+        targetSeconds: set.targetSeconds,
+        targetDistance: set.targetDistance,
+        supersetGroup: set.supersetGroup,
+      }
+    : {}),
   completed: set.completed,
   skipped: set.skipped,
   section: set.section,
@@ -263,7 +295,7 @@ const buildSessionSetGroups = (sets: SessionSetRecord[]): SessionSetGroup[] => {
   const groups = new Map<string, { exerciseId: string | null; sets: SessionSet[] }>();
 
   for (const set of sets.sort(sortSessionSets)) {
-    const groupKey = set.exerciseId ?? `deleted-${set.section ?? 'supplemental'}-${set.orderIndex}`;
+    const groupKey = `${set.section ?? 'main'}::${set.exerciseId ?? `deleted-${set.orderIndex}`}`;
     const existingGroup = groups.get(groupKey);
     const parsedSet = buildSessionSet(set);
 
@@ -313,6 +345,7 @@ const buildWorkoutSession = (
     id: session.id,
     userId: session.userId,
     templateId: session.templateId,
+    ...(session.scheduledWorkoutId ? { scheduledWorkoutId: session.scheduledWorkoutId } : {}),
     name: session.name,
     date: session.date,
     status: session.status,
@@ -329,6 +362,7 @@ const buildWorkoutSession = (
       programmingNotesByExerciseSection,
       agentNotesByExerciseSection,
       agentNotesMetaByExerciseSection,
+      session.exercisePrescriptions ?? {},
     ),
     sets: sets.sort(sortSessionSets).map<SessionSet>(buildSessionSet),
     createdAt: session.createdAt,
@@ -352,6 +386,7 @@ const buildWorkoutSessionExercises = (
   programmingNotesByExerciseSection: Record<string, string | null>,
   agentNotesByExerciseSection: Record<string, string | null>,
   agentNotesMetaByExerciseSection: Record<string, WorkoutSessionExerciseAgentNotesMeta | null>,
+  prescriptions: ExercisePrescriptions,
 ): WorkoutSessionExercise[] => {
   const groupedByExercise = new Map<
     string,
@@ -371,13 +406,14 @@ const buildWorkoutSessionExercises = (
   >();
 
   for (const set of sets.sort(sortSessionSets)) {
-    const groupKey = set.exerciseId ?? `deleted-${set.section ?? 'supplemental'}-${set.orderIndex}`;
+    const groupKey = `${set.section ?? 'main'}::${set.exerciseId ?? `deleted-${set.orderIndex}`}`;
     const existing = groupedByExercise.get(groupKey);
     const parsedSet = buildSessionSet(set);
     const exerciseInfo =
       typeof set.exerciseId === 'string' ? exerciseInfoById.get(set.exerciseId) : undefined;
     const exerciseName =
-      set.exerciseId === null ? 'Deleted exercise' : (exerciseInfo?.name ?? 'Unknown Exercise');
+      set.exerciseNameSnapshot ??
+      (set.exerciseId === null ? 'Deleted exercise' : (exerciseInfo?.name ?? 'Unknown Exercise'));
 
     if (existing) {
       existing.orderIndex = Math.min(existing.orderIndex, set.orderIndex);
@@ -393,7 +429,8 @@ const buildWorkoutSessionExercises = (
       exerciseName,
       deletedAt: exerciseInfo?.deletedAt ?? null,
       supersetGroup: set.supersetGroup,
-      trackingType: (exerciseInfo?.trackingType as ExerciseTrackingType) ?? null,
+      trackingType:
+        set.trackingTypeSnapshot ?? (exerciseInfo?.trackingType as ExerciseTrackingType) ?? null,
       orderIndex: set.orderIndex,
       section: set.section,
       sets: [parsedSet],
@@ -401,6 +438,21 @@ const buildWorkoutSessionExercises = (
       coachingNotes: exerciseInfo?.coachingNotes ?? null,
       instructions: exerciseInfo?.instructions ?? null,
     });
+  }
+
+  // Retain source exercises even when all planned sets were removed.
+  for (const prescription of Object.values(prescriptions)) {
+    const key = `${prescription.section}::${prescription.exerciseId}`;
+    if (prescription.sourceSetCount === 0 && !groupedByExercise.has(key)) {
+      groupedByExercise.set(key, {
+        ...prescription,
+        deletedAt: exerciseInfoById.get(prescription.exerciseId)?.deletedAt ?? null,
+        formCues: [],
+        coachingNotes: null,
+        instructions: null,
+        sets: [],
+      });
+    }
   }
 
   return Array.from(groupedByExercise.values())
@@ -448,6 +500,12 @@ const buildWorkoutSessionExercises = (
           : (agentNotesMetaByExerciseSection[
               `${exercise.section ?? 'main'}::${exercise.exerciseId}`
             ] ?? null),
+      tempo: prescriptions[`${exercise.section ?? 'main'}::${exercise.exerciseId}`]?.tempo,
+      restSeconds:
+        prescriptions[`${exercise.section ?? 'main'}::${exercise.exerciseId}`]?.restSeconds,
+      sourceScheduledExerciseId:
+        prescriptions[`${exercise.section ?? 'main'}::${exercise.exerciseId}`]
+          ?.sourceScheduledExerciseId,
       sets: exercise.sets,
     }));
 };
@@ -533,6 +591,13 @@ export class SessionSetNotFoundError extends Error {
     super(`Session set ${setId} not found`);
     this.name = 'SessionSetNotFoundError';
     this.setId = setId;
+  }
+}
+
+export class ScheduledWorkoutLinkConflictError extends Error {
+  constructor() {
+    super('Scheduled workout is already linked to another session');
+    this.name = 'ScheduledWorkoutLinkConflictError';
   }
 }
 
@@ -1364,6 +1429,8 @@ export const createWorkoutSession = async ({
   agentNotesMetaByExerciseSection,
   scheduledWorkoutId,
   linkScheduledWorkoutSession,
+  replaceScheduledWorkoutSessionId,
+  exercisePrescriptions,
   setSnapshotFactsByKey = {},
 }: {
   id: string;
@@ -1374,6 +1441,8 @@ export const createWorkoutSession = async ({
   agentNotesMetaByExerciseSection?: Record<string, WorkoutSessionExerciseAgentNotesMeta | null>;
   scheduledWorkoutId?: string;
   linkScheduledWorkoutSession?: boolean;
+  replaceScheduledWorkoutSessionId?: string | null;
+  exercisePrescriptions?: ExercisePrescriptions;
   setSnapshotFactsByKey?: Record<string, SessionSetSnapshotFact>;
 }): Promise<WorkoutSession> => {
   const { db } = await import('../../db/index.js');
@@ -1433,6 +1502,7 @@ export const createWorkoutSession = async ({
         ),
         exerciseAgentNotes: agentNotesByExerciseSection ?? null,
         exerciseAgentNotesMeta: agentNotesMetaByExerciseSection ?? null,
+        exercisePrescriptions: exercisePrescriptions ?? null,
         notes: input.notes,
       })
       .run();
@@ -1455,13 +1525,16 @@ export const createWorkoutSession = async ({
           and(
             eq(scheduledWorkouts.id, scheduledWorkoutId),
             eq(scheduledWorkouts.userId, userId),
-            isNull(scheduledWorkouts.sessionId),
+            replaceScheduledWorkoutSessionId === null ||
+              replaceScheduledWorkoutSessionId === undefined
+              ? isNull(scheduledWorkouts.sessionId)
+              : eq(scheduledWorkouts.sessionId, replaceScheduledWorkoutSessionId),
           ),
         )
         .run();
 
       if (linkResult.changes !== 1) {
-        throw new Error('Failed to link scheduled workout to the new session');
+        throw new ScheduledWorkoutLinkConflictError();
       }
     }
   });

--- a/apps/web/e2e/scheduled-provenance.spec.ts
+++ b/apps/web/e2e/scheduled-provenance.spec.ts
@@ -1,0 +1,410 @@
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { expect, test, request, type APIRequestContext } from '@playwright/test';
+import type { ScheduledWorkoutDetail, WorkoutSession } from '@pulse/shared';
+
+const apiURL = process.env.API_BASE_URL ?? '';
+const database = process.env.E2E_DATABASE_URL ?? '';
+const now = '2026-09-07T03:59:00Z'; // Detroit Sep 6; browser and UTC already Sep 7.
+const day = '2026-09-06';
+
+async function call<T>(
+  api: APIRequestContext,
+  method: string,
+  path: string,
+  data?: unknown,
+): Promise<T> {
+  const response = await api.fetch(`/api/v1/${path}`, { method, data });
+  expect(response.ok(), `${method} ${path}: ${await response.text()}`).toBeTruthy();
+  return (await response.json()).data as T;
+}
+
+function readDatabase(scheduleId: string, sessionId: string) {
+  return JSON.parse(
+    execFileSync(
+      'python3',
+      [
+        '-c',
+        `
+import json, sqlite3, sys
+c=sqlite3.connect('file:'+sys.argv[1]+'?mode=ro',uri=True)
+c.row_factory=sqlite3.Row
+queries={
+ 'session': ('select * from workout_sessions where id=?',sys.argv[3]),
+ 'schedule': ('select * from scheduled_workouts where id=?',sys.argv[2]),
+ 'sets': ('select * from session_sets where session_id=? order by source_scheduled_set_id',sys.argv[3]),
+ 'source': ('select s.*, e.exercise_id, e.section, e.order_index, e.superset_group, e.exercise_name_snapshot, e.tracking_type_snapshot from scheduled_workout_exercise_sets s join scheduled_workout_exercises e on e.id=s.scheduled_workout_exercise_id where e.scheduled_workout_id=? order by s.id',sys.argv[2])}
+print(json.dumps({k:[dict(r) for r in c.execute(q,(v,))] for k,(q,v) in queries.items()}))
+`,
+        database,
+        scheduleId,
+        sessionId,
+      ],
+      { encoding: 'utf8' },
+    ),
+  );
+}
+
+for (const scenario of [
+  { surface: 'list', identical: false, early: false, mobile: false },
+  { surface: 'calendar', identical: false, early: false, mobile: false },
+  { surface: 'dashboard', identical: false, early: false, mobile: false },
+  { surface: 'detail', identical: false, early: true, mobile: false },
+  { surface: 'list', identical: true, early: false, mobile: true },
+] as const) {
+  test(`${scenario.surface}: ${scenario.identical ? 'identical visible 20-set' : 'structural divergence'}${scenario.early ? ' early' : ''}${scenario.mobile ? ' mobile' : ''}`, async ({
+    page,
+  }, testInfo) => {
+    const sha = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+    if (process.env.TESTED_CODE_SHA) expect(sha).toBe(process.env.TESTED_CODE_SHA);
+    const unauth = await request.newContext({ baseURL: apiURL });
+    const registered = await call<{ token: string }>(unauth, 'POST', 'auth/register', {
+      username: `p134-${Date.now()}`,
+      password: 'disposable-test-password',
+      timeZone: 'America/Detroit',
+    });
+    await unauth.dispose();
+    const api = await request.newContext({
+      baseURL: apiURL,
+      extraHTTPHeaders: { Authorization: `Bearer ${registered.token}` },
+    });
+    try {
+      const authority = await call<{ localDate: string; timeZone: string }>(
+        api,
+        'GET',
+        'adaptive-nutrition',
+      );
+      expect(authority).toMatchObject({ localDate: day, timeZone: 'America/Detroit' });
+      const ids: string[] = [];
+      for (const name of ['Leg Extension', 'Leg Curl', 'Hip Flexion', 'Dead Bug', 'Removed Row']) {
+        ids.push(
+          (
+            await call<{ id: string }>(api, 'POST', 'exercises', {
+              name,
+              category: 'isolation',
+              muscleGroups: ['legs'],
+              equipment: 'cable',
+              trackingType: 'weight_reps',
+            })
+          ).id,
+        );
+      }
+      const templateName = `Snapshot ${scenario.surface}`;
+      const sections = [
+        {
+          type: 'main',
+          exercises: ids.slice(0, 4).map((exerciseId) => ({
+            exerciseId,
+            sets: 5,
+            repsMin: 8,
+            repsMax: 8,
+            tempo: '2111',
+            restSeconds: 60,
+            cues: [],
+          })),
+        },
+      ];
+      const template = await call<{ id: string }>(api, 'POST', 'workout-templates', {
+        name: templateName,
+        sections,
+        tags: [],
+      });
+      let schedule = await call<ScheduledWorkoutDetail>(api, 'POST', 'scheduled-workouts', {
+        templateId: template.id,
+        date: scenario.early ? '2026-09-07' : day,
+      });
+      if (!scenario.identical) {
+        schedule = await call(api, 'PATCH', `scheduled-workouts/${schedule.id}/exercise-swap`, {
+          fromExerciseId: ids[0],
+          toExerciseId: ids[4],
+          preserveSets: true,
+        });
+        schedule = await call(api, 'PATCH', `scheduled-workouts/${schedule.id}/exercise-swap`, {
+          fromExerciseId: ids[3],
+          toExerciseId: null,
+        });
+        schedule = await call(api, 'PATCH', `scheduled-workouts/${schedule.id}/reorder`, {
+          order: [ids[2], ids[4], ids[1]],
+        });
+        schedule = await call(api, 'PATCH', `scheduled-workouts/${schedule.id}/exercise-sets`, {
+          exerciseId: ids[1],
+          sets: [
+            { setNumber: 5, remove: true },
+            { setNumber: 1, reps: null, repsMin: null, repsMax: null, targetWeight: null },
+            { setNumber: 6, reps: 9, targetWeight: 42 },
+          ],
+        });
+      }
+      schedule = await call(api, 'PATCH', `scheduled-workouts/${schedule.id}/exercises`, {
+        updates: schedule.exercises.map((exercise, i) => ({
+          exerciseId: exercise.exerciseId,
+          programmingNotes: i === 0 ? null : `Programming recovery gate ${i}`,
+          tempo: i === 0 ? null : '3110',
+          restSeconds: i === 0 ? null : 75,
+          supersetGroup: i < 2 ? 'pair-a' : null,
+        })),
+      });
+      const agent = await call<{ token: string }>(api, 'POST', 'agent-tokens', {
+        name: 'Disposable proof',
+      });
+      const agentApi = await request.newContext({
+        baseURL: apiURL,
+        extraHTTPHeaders: { Authorization: `AgentToken ${agent.token}` },
+      });
+      schedule = await call(agentApi, 'PATCH', `scheduled-workouts/${schedule.id}/exercise-notes`, {
+        notes: schedule.exercises.map((exercise, i) => ({
+          exerciseId: exercise.exerciseId,
+          agentNotes: i === 0 ? null : `Fictional coaching ${i}`,
+        })),
+      });
+      await agentApi.dispose();
+      if (!scenario.identical) {
+        await call(api, 'PUT', `workout-templates/${template.id}`, {
+          name: templateName,
+          tags: [],
+          sections: [
+            {
+              type: 'main',
+              exercises: [
+                {
+                  exerciseId: ids[3],
+                  sets: 12,
+                  repsMin: 15,
+                  repsMax: 20,
+                  tempo: '9999',
+                  restSeconds: 180,
+                  cues: [],
+                },
+              ],
+            },
+            {
+              type: 'supplemental',
+              exercises: [{ exerciseId: ids[0], sets: 2, repsMin: 10, repsMax: 10, cues: [] }],
+            },
+          ],
+        });
+      }
+      schedule = await call(api, 'GET', `scheduled-workouts/${schedule.id}`);
+      if (scenario.mobile) await page.setViewportSize({ width: 375, height: 812 });
+      await page.clock.setFixedTime(new Date(now));
+      await page.addInitScript(
+        (token) => localStorage.setItem('pulse-auth-token', token),
+        registered.token,
+      );
+      await page.goto(`/workouts/scheduled/${schedule.id}`);
+      await expect(page.getByRole('button', { name: 'Start workout', exact: true })).toBeVisible();
+      await page.screenshot({ path: testInfo.outputPath('scheduled-detail.png'), fullPage: true });
+      const captured: unknown[] = [];
+      page.on('request', (req) => {
+        if (req.method() === 'POST' && new URL(req.url()).pathname === '/api/v1/workout-sessions')
+          captured.push(req.postDataJSON());
+      });
+      if (scenario.surface === 'list') {
+        await page.goto('/workouts?view=list');
+        await page.getByRole('button', { name: 'Start', exact: true }).click();
+      } else if (scenario.surface === 'calendar') {
+        await page.goto('/workouts?view=calendar');
+        await page.getByRole('button', { name: 'Start', exact: true }).click();
+      } else {
+        if (scenario.surface === 'dashboard') {
+          await page.goto('/');
+          await page.locator(`a[href*="/workouts/scheduled/${schedule.id}"]`).first().click();
+        }
+        await page.getByRole('button', { name: 'Start workout', exact: true }).click();
+        if (scenario.early)
+          await page.getByRole('button', { name: 'Start now', exact: true }).click();
+      }
+      await expect(page).toHaveURL(/sessionId=/);
+      const sessionId = new URL(page.url()).searchParams.get('sessionId') ?? '';
+      const session = await call<WorkoutSession>(api, 'GET', `workout-sessions/${sessionId}`);
+      const linked = await call<ScheduledWorkoutDetail>(
+        api,
+        'GET',
+        `scheduled-workouts/${schedule.id}`,
+      );
+      expect(session.scheduledWorkoutId).toBe(schedule.id);
+      expect(linked.sessionId).toBe(session.id);
+      expect(session.date).toBe(schedule.date);
+      expect(captured).toHaveLength(1);
+      expect(captured[0]).toMatchObject({ scheduledWorkoutId: schedule.id, date: day });
+      expect(captured[0]).not.toHaveProperty('templateId');
+      expect(captured[0]).not.toHaveProperty('sets');
+      expect(session.sets).toHaveLength(
+        schedule.exercises.reduce((n, ex) => n + ex.sets.length, 0),
+      );
+      if (scenario.identical) expect(session.sets).toHaveLength(20);
+      for (const exercise of schedule.exercises) {
+        const actual = session.exercises?.find(
+          (row) => row.exerciseId === exercise.exerciseId && row.section === exercise.section,
+        );
+        expect(actual).toMatchObject({
+          exerciseId: exercise.exerciseId,
+          exerciseName: exercise.exerciseName,
+          section: exercise.section,
+          orderIndex: exercise.orderIndex,
+          programmingNotes: exercise.programmingNotes,
+          agentNotes: exercise.agentNotes,
+          agentNotesMeta: exercise.agentNotesMeta,
+          supersetGroup: exercise.supersetGroup,
+          tempo: exercise.tempo,
+          restSeconds: exercise.restSeconds,
+        });
+        for (const set of exercise.sets) {
+          expect(actual?.sets.find((row) => row.setNumber === set.setNumber)).toMatchObject({
+            targetReps: set.reps,
+            targetRepsMin: set.repsMin,
+            targetRepsMax: set.repsMax,
+            targetWeight: set.targetWeight,
+            targetWeightMin: set.targetWeightMin,
+            targetWeightMax: set.targetWeightMax,
+            targetSeconds: set.targetSeconds,
+            targetDistance: set.targetDistance,
+            targetZone: set.targetZone,
+          });
+        }
+      }
+      const db = readDatabase(schedule.id, session.id);
+      expect(db.session[0].scheduled_workout_id).toBe(schedule.id);
+      expect(db.schedule[0].session_id).toBe(session.id);
+      expect(db.sets).toHaveLength(db.source.length);
+      for (const source of db.source) {
+        const row = db.sets.find(
+          (set: { source_scheduled_set_id: string }) => set.source_scheduled_set_id === source.id,
+        );
+        expect(row).toMatchObject({
+          source_scheduled_set_id: source.id,
+          exercise_id_snapshot: source.exercise_id,
+          exercise_name_snapshot: source.exercise_name_snapshot,
+          tracking_type_snapshot: source.tracking_type_snapshot,
+          set_number: source.set_number,
+          section: source.section,
+          order_index: source.order_index,
+          superset_group: source.superset_group,
+          target_reps: source.reps,
+          target_reps_min: source.reps_min,
+          target_reps_max: source.reps_max,
+          target_weight: source.target_weight,
+          target_weight_min: source.target_weight_min,
+          target_weight_max: source.target_weight_max,
+          target_seconds: source.target_seconds,
+          target_distance: source.target_distance,
+          target_zone: source.target_zone,
+        });
+      }
+      for (const exercise of schedule.exercises) {
+        const key = `${exercise.section}::${exercise.exerciseId}`;
+        expect(JSON.parse(db.session[0].exercise_programming_notes)[key]).toBe(
+          exercise.programmingNotes,
+        );
+        expect(JSON.parse(db.session[0].exercise_agent_notes)[key]).toBe(exercise.agentNotes);
+        expect(JSON.parse(db.session[0].exercise_agent_notes_meta)[key]).toEqual(
+          exercise.agentNotesMeta,
+        );
+        expect(JSON.parse(db.session[0].exercise_prescriptions)[key]).toMatchObject({
+          tempo: exercise.tempo,
+          restSeconds: exercise.restSeconds,
+        });
+        const source = db.source.find(
+          (row: { exercise_id: string }) => row.exercise_id === exercise.exerciseId,
+        );
+        expect(
+          session.exercises?.find((row) => row.exerciseId === exercise.exerciseId)
+            ?.sourceScheduledExerciseId,
+        ).toBe(source.scheduled_workout_exercise_id);
+      }
+      const initialSessions = await call<Array<{ id: string }>>(
+        api,
+        'GET',
+        `workout-sessions?from=${day}&to=2026-09-07`,
+      );
+      expect(initialSessions.map((row) => row.id)).toEqual([session.id]);
+      await page.reload();
+      await expect(page.getByRole('heading', { name: templateName, exact: true })).toBeVisible();
+      expect(await call(api, 'GET', `workout-sessions/${sessionId}`)).toEqual(session);
+      await page.screenshot({ path: testInfo.outputPath('active-refreshed.png'), fullPage: true });
+      expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(
+        true,
+      );
+      const restarts: unknown[] = [];
+      if (scenario.surface === 'list' && !scenario.identical) {
+        let previousSessionId = session.id;
+        const normalize = (value: WorkoutSession) => ({
+          date: value.date,
+          scheduledWorkoutId: value.scheduledWorkoutId,
+          exercises: value.exercises?.map((exercise) => ({
+            ...exercise,
+            sets: exercise.sets.map((set) =>
+              Object.fromEntries(
+                Object.entries(set).filter(([key]) => key !== 'id' && key !== 'createdAt'),
+              ),
+            ),
+          })),
+        });
+        for (const surface of ['calendar', 'dashboard', 'detail']) {
+          await call(api, 'POST', `workout-sessions/${previousSessionId}/cancel`);
+          if (surface === 'calendar') {
+            await page.goto('/workouts?view=calendar');
+            await page.getByRole('button', { name: 'Start', exact: true }).click();
+          } else {
+            if (surface === 'dashboard') {
+              await page.goto('/');
+              await page.locator(`a[href*="/workouts/scheduled/${schedule.id}"]`).first().click();
+            } else await page.goto(`/workouts/scheduled/${schedule.id}`);
+            await page.getByRole('button', { name: 'Start workout', exact: true }).click();
+          }
+          await expect(page).toHaveURL(/sessionId=/);
+          const nextId = new URL(page.url()).searchParams.get('sessionId') ?? '';
+          const next = await call<WorkoutSession>(api, 'GET', `workout-sessions/${nextId}`);
+          expect(normalize(next)).toEqual(normalize(session));
+          const nextDb = readDatabase(schedule.id, nextId);
+          expect(nextDb.schedule[0].session_id).toBe(nextId);
+          expect(nextDb.session[0].scheduled_workout_id).toBe(schedule.id);
+          expect(
+            nextDb.sets.map(
+              (set: { source_scheduled_set_id: string }) => set.source_scheduled_set_id,
+            ),
+          ).toEqual(
+            db.sets.map((set: { source_scheduled_set_id: string }) => set.source_scheduled_set_id),
+          );
+          await page.reload();
+          await page.screenshot({
+            path: testInfo.outputPath(`same-schedule-${surface}.png`),
+            fullPage: true,
+          });
+          restarts.push({ surface, session: next, db: nextDb });
+          previousSessionId = nextId;
+        }
+      }
+      if (scenario.identical) {
+        await call(api, 'POST', `workout-sessions/${session.id}/cancel`);
+        await page.goto(`/workouts/template/${template.id}`);
+        await page.getByRole('button', { name: 'Start Workout', exact: true }).click();
+        await page.getByRole('button', { name: 'Create another anyway', exact: true }).click();
+        await expect(page).toHaveURL(/sessionId=/);
+        const duplicateId = new URL(page.url()).searchParams.get('sessionId') ?? '';
+        const duplicate = await call<WorkoutSession>(api, 'GET', `workout-sessions/${duplicateId}`);
+        expect(duplicate.scheduledWorkoutId ?? null).toBeNull();
+        expect(
+          (await call<ScheduledWorkoutDetail>(api, 'GET', `scheduled-workouts/${schedule.id}`))
+            .sessionId,
+        ).toBeNull();
+        const duplicateDb = readDatabase(schedule.id, duplicateId);
+        expect(duplicateDb.session[0].scheduled_workout_id).toBeNull();
+        expect(duplicateDb.schedule[0].session_id).toBeNull();
+        expect(
+          duplicateDb.sets.every(
+            (set: { source_scheduled_set_id: string | null }) =>
+              set.source_scheduled_set_id === null,
+          ),
+        ).toBe(true);
+        restarts.push({ independentDuplicate: duplicate, db: duplicateDb });
+      }
+      writeFileSync(
+        testInfo.outputPath('readback.json'),
+        JSON.stringify({ sha, scenario, captured, schedule, session, db, restarts }, null, 2),
+      );
+    } finally {
+      await api.dispose();
+    }
+  });
+}

--- a/apps/web/playwright.provenance.config.ts
+++ b/apps/web/playwright.provenance.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Run only against explicitly supplied disposable local services.
+if (!process.env.BASE_URL || !process.env.API_BASE_URL || !process.env.E2E_DATABASE_URL) {
+  throw new Error('Provenance acceptance requires explicit isolated web/API URLs and database');
+}
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: 'scheduled-provenance.spec.ts',
+  workers: 1,
+  retries: 0,
+  timeout: 60_000,
+  outputDir: process.env.PROVENANCE_OUTPUT_DIR ?? '/private/tmp/pulse-pr134-evidence/browser',
+  reporter: [['list']],
+  use: {
+    ...devices['Desktop Chrome'],
+    channel: 'chrome',
+    baseURL: process.env.BASE_URL,
+    timezoneId: 'Pacific/Kiritimati',
+    trace: 'on',
+    screenshot: 'on',
+  },
+});

--- a/apps/web/src/features/workouts/components/scheduled-start-surfaces.test.tsx
+++ b/apps/web/src/features/workouts/components/scheduled-start-surfaces.test.tsx
@@ -1,0 +1,152 @@
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, API_TOKEN_STORAGE_KEY } from '@/lib/api-client';
+import { renderWithQueryClient } from '@/test/render-with-query-client';
+import { jsonResponse } from '@/test/test-utils';
+import { WorkoutList } from './workout-list';
+import { WorkoutCalendar } from './workout-calendar';
+
+const state = vi.hoisted(() => ({
+  date: '2026-09-06' as string | null,
+  start: vi.fn(),
+}));
+vi.mock('../hooks/use-today-key', () => ({
+  useTodayKey: () => ({
+    todayKey: '2026-09-06',
+    dateAuthorityLocked: false,
+    getTodayKeyForMutation: () => state.date,
+  }),
+}));
+vi.mock('@/hooks/use-workout-session', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/hooks/use-workout-session')>()),
+  useStartSession: () => ({ mutateAsync: state.start, isPending: false }),
+}));
+
+beforeEach(() => {
+  state.date = '2026-09-06';
+  state.start.mockReset().mockResolvedValue({ id: 'new-session', templateId: 'template-1' });
+  window.localStorage.setItem(API_TOKEN_STORAGE_KEY, 'test-token');
+});
+
+for (const surface of ['list', 'calendar'] as const) {
+  describe(`${surface} scheduled start`, () => {
+    function renderSurface({ early = false, active = false, deleted = false } = {}) {
+      const schedule = {
+        id: 'scheduled-1',
+        date: early ? '2026-09-07' : '2026-09-06',
+        templateId: deleted ? null : 'template-1',
+        templateName: deleted ? null : 'Snapshot workout',
+        templateTrackingTypes: [],
+        sessionId: null,
+        createdAt: 1,
+      };
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+        const path = new URL(String(input), 'https://pulse.test').pathname;
+        if (path === '/api/v1/workout-sessions')
+          return Promise.resolve(
+            jsonResponse({
+              data: active
+                ? [
+                    {
+                      id: 'active-1',
+                      status: 'in-progress',
+                      name: 'Active workout',
+                      date: '2026-09-06',
+                      templateId: null,
+                      templateName: null,
+                      startedAt: 1,
+                      completedAt: null,
+                      duration: null,
+                      exerciseCount: 1,
+                      createdAt: 1,
+                    },
+                  ]
+                : [],
+            }),
+          );
+        if (path === '/api/v1/scheduled-workouts')
+          return Promise.resolve(jsonResponse({ data: [schedule] }));
+        throw new Error(`Scheduled start must not fetch a template: ${path}`);
+      });
+      renderWithQueryClient(
+        <MemoryRouter>
+          {surface === 'list' ? (
+            <WorkoutList sessions={[]} scheduledWorkouts={[schedule]} />
+          ) : (
+            <WorkoutCalendar />
+          )}
+        </MemoryRouter>,
+      );
+      return fetchSpy;
+    }
+
+    it.each(['normal', 'early', 'active', 'deleted'] as const)(
+      'uses only schedule identity for %s starts without fetching the template',
+      async (mode) => {
+        const fetchSpy = renderSurface({
+          early: mode === 'early',
+          active: mode === 'active',
+          deleted: mode === 'deleted',
+        });
+        const start = await screen.findByRole('button', { name: 'Start' });
+        // Let active-session query resolve before opening its confirmation.
+        await waitFor(() => expect(start).toBeEnabled());
+        fireEvent.click(start);
+        if (mode === 'early' || mode === 'active') {
+          const dialog = await screen.findByRole('alertdialog');
+          fireEvent.click(
+            within(dialog).getByRole('button', {
+              name: mode === 'early' ? 'Start now' : 'Start anyway',
+            }),
+          );
+        }
+        await waitFor(() => expect(state.start).toHaveBeenCalledTimes(1));
+        expect(state.start).toHaveBeenCalledWith({
+          scheduledWorkoutId: 'scheduled-1',
+          date: '2026-09-06',
+          startedAt: expect.any(Number),
+        });
+        expect(
+          fetchSpy.mock.calls.every(([input]) => !String(input).includes('workout-templates')),
+        ).toBe(true);
+      },
+    );
+
+    it('retries stale exercises with the same schedule and explicit force', async () => {
+      state.start.mockRejectedValueOnce(
+        new ApiError(409, 'Stale exercise', 'STALE_SNAPSHOT_EXERCISES'),
+      );
+      renderSurface();
+      const start = await screen.findByRole('button', { name: 'Start' });
+      await waitFor(() => expect(start).toBeEnabled());
+      fireEvent.click(start);
+      const dialog = await screen.findByRole('alertdialog');
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Start anyway' }));
+      await waitFor(() => expect(state.start).toHaveBeenCalledTimes(2));
+      expect(state.start.mock.calls[1][0]).toEqual({
+        scheduledWorkoutId: 'scheduled-1',
+        date: '2026-09-06',
+        startedAt: expect.any(Number),
+        force: true,
+      });
+    });
+
+    it.each([null, '2026-09-07'])(
+      'aborts stale confirmation when authoritative day changes to %s',
+      async (date) => {
+        state.start.mockRejectedValueOnce(
+          new ApiError(409, 'Stale exercise', 'STALE_SNAPSHOT_EXERCISES'),
+        );
+        renderSurface();
+        const start = await screen.findByRole('button', { name: 'Start' });
+        await waitFor(() => expect(start).toBeEnabled());
+        fireEvent.click(start);
+        const dialog = await screen.findByRole('alertdialog');
+        state.date = date;
+        fireEvent.click(within(dialog).getByRole('button', { name: 'Start anyway' }));
+        expect(state.start).toHaveBeenCalledTimes(1);
+      },
+    );
+  });
+}

--- a/apps/web/src/features/workouts/components/scheduled-workout-detail.tsx
+++ b/apps/web/src/features/workouts/components/scheduled-workout-detail.tsx
@@ -1,3 +1,4 @@
+import { buildScheduledStartPayload } from '../lib/scheduled-start';
 import { useMemo, useState, type ReactNode } from 'react';
 import { useNavigate } from 'react-router';
 import {
@@ -260,13 +261,12 @@ export function ScheduledWorkoutDetail({ bannerSlot, id }: ScheduledWorkoutDetai
     const startedAt = Date.now();
 
     try {
-      const session = await startSessionMutation.mutateAsync({
-        date: mutationTodayKey,
-        ...(options?.force ? { force: true } : {}),
-        ...(template?.name ? { name: template.name } : {}),
-        scheduledWorkoutId: scheduledWorkout.id,
-        startedAt,
-      });
+      const session = await startSessionMutation.mutateAsync(
+        buildScheduledStartPayload(scheduledWorkout.id, mutationTodayKey, {
+          startedAt,
+          force: options?.force,
+        }),
+      );
 
       const searchParams = new URLSearchParams({ sessionId: session.id });
       const templateId = session.templateId ?? scheduledWorkout.templateId;

--- a/apps/web/src/features/workouts/components/session-exercise-list.tsx
+++ b/apps/web/src/features/workouts/components/session-exercise-list.tsx
@@ -493,7 +493,7 @@ export function SessionExerciseList({
                         (exercise) => exercise.id === (focusTarget?.exerciseId ?? null),
                       );
                       const sharedRestSeconds = Math.max(
-                        ...item.exercises.map((exercise) => exercise.restSeconds),
+                        ...item.exercises.map((exercise) => exercise.restSeconds ?? 0),
                       );
                       const isGroupCompleted = item.exercises.every(
                         (exercise) => exercise.completedSets >= exercise.targetSets,
@@ -1013,7 +1013,7 @@ function ExerciseCardItem({
               {exercise.tempo ? (
                 <MetadataPill label={`Tempo: ${formatTempo(exercise.tempo)}`} />
               ) : null}
-              {exercise.restSeconds > 0 ? (
+              {exercise.restSeconds != null && exercise.restSeconds > 0 ? (
                 <MetadataPill label={`Rest: ${formatRestDuration(exercise.restSeconds)}`} />
               ) : null}
             </div>

--- a/apps/web/src/features/workouts/components/workout-calendar.tsx
+++ b/apps/web/src/features/workouts/components/workout-calendar.tsx
@@ -28,13 +28,14 @@ import {
   useRescheduleWorkout,
   useScheduledWorkouts,
   useUnscheduleWorkout,
-  useWorkoutTemplate,
   useWorkoutSessions,
 } from '../api/workouts';
 import { ScheduleWorkoutDialog } from './schedule-workout-dialog';
 import { useTodayKey } from '../hooks/use-today-key';
 import { hasAvailableTemplate } from '../lib/workout-filters';
-import { buildInitialSessionSets } from '../lib/workout-session-sets';
+import { buildScheduledStartPayload } from '../lib/scheduled-start';
+import { ApiError } from '@/lib/api-client';
+import { toast } from 'sonner';
 
 const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
 const monthFormatter = new Intl.DateTimeFormat('en-US', {
@@ -441,17 +442,10 @@ function DayWorkoutItemCard({
   const deleteSessionMutation = useDeleteSession(workout.session?.id ?? null);
   const cancelSessionMutation = useCancelAndRevertSession(workout.session?.id ?? null);
   const activeSessionsQuery = useWorkoutSessions({ status: ['in-progress', 'paused'] });
-  const templateId = workout.templateId ?? '';
-  const shouldFetchTemplate = workout.status === 'scheduled' && templateId.trim().length > 0;
-  const templateQuery = useWorkoutTemplate(templateId, { enabled: shouldFetchTemplate });
   const { confirm, dialog } = useConfirmation();
   const [isRescheduleDialogOpen, setIsRescheduleDialogOpen] = useState(false);
   const [rescheduleAuthorityDate, setRescheduleAuthorityDate] = useState<string | null>(null);
-  const canStart =
-    !dateAuthorityLocked &&
-    todayKey !== null &&
-    workout.status === 'scheduled' &&
-    !workout.isUnavailable;
+  const canStart = !dateAuthorityLocked && todayKey !== null && workout.status === 'scheduled';
   const isMutating =
     unscheduleWorkoutMutation.isPending ||
     rescheduleWorkoutMutation.isPending ||
@@ -459,27 +453,38 @@ function DayWorkoutItemCard({
     deleteSessionMutation.isPending ||
     cancelSessionMutation.isPending;
 
-  async function doStart(expectedTodayKey: string) {
+  async function doStart(expectedTodayKey: string, force = false) {
     const mutationTodayKey = getTodayKeyForMutation();
     if (
       mutationTodayKey === null ||
       mutationTodayKey !== expectedTodayKey ||
-      !workout.scheduledWorkout ||
-      !workout.templateId ||
-      !templateQuery.data
+      !workout.scheduledWorkout
     ) {
       return;
     }
 
-    const startedAt = Date.now();
-    const session = await startSessionMutation.mutateAsync({
-      date: mutationTodayKey,
-      name: workout.name,
-      sets: buildInitialSessionSets(templateQuery.data),
-      startedAt,
-      templateId: workout.templateId,
-    });
-    navigate(`/workouts/active?template=${workout.templateId}&sessionId=${session.id}`);
+    try {
+      const session = await startSessionMutation.mutateAsync(
+        buildScheduledStartPayload(workout.scheduledWorkout.id, mutationTodayKey, { force }),
+      );
+      const search = new URLSearchParams({ sessionId: session.id });
+      const templateId = session.templateId ?? workout.templateId;
+      if (templateId) search.set('template', templateId);
+      navigate(`/workouts/active?${search.toString()}`);
+    } catch (error) {
+      if (error instanceof ApiError && error.code === 'STALE_SNAPSHOT_EXERCISES') {
+        confirm({
+          title: 'Some scheduled exercises are unavailable',
+          description: 'Start the scheduled snapshot and skip unavailable exercises?',
+          confirmLabel: 'Start anyway',
+          onConfirm: () => {
+            void doStart(expectedTodayKey, true);
+          },
+        });
+        return;
+      }
+      toast.error(error instanceof Error ? error.message : 'Unable to start workout');
+    }
   }
 
   function handleStart() {
@@ -610,7 +615,7 @@ function DayWorkoutItemCard({
       <div className="mt-3 flex flex-wrap gap-2">
         {workout.status === 'scheduled' ? (
           <Button
-            disabled={isMutating || !canStart || templateQuery.isPending}
+            disabled={isMutating || activeSessionsQuery.isPending || !canStart}
             onClick={() => {
               void handleStart();
             }}

--- a/apps/web/src/features/workouts/components/workout-list.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.test.tsx
@@ -137,7 +137,8 @@ describe('WorkoutList', () => {
       });
   });
 
-  it('shows unavailable state for soft-deleted scheduled templates and hides stale start actions', async () => {
+  it('allows snapshot start when the reusable template is unavailable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ data: [] }));
     const sessions = [
       createSession({
         id: 'session-hidden',
@@ -171,9 +172,11 @@ describe('WorkoutList', () => {
     expect(screen.getByText('Workout unavailable')).toBeInTheDocument();
     const unavailableCard = screen.getByText('Workout unavailable').closest('[data-slot="card"]');
     expect(unavailableCard).not.toBeNull();
-    expect(
-      within(unavailableCard as HTMLElement).getByRole('button', { name: 'Start' }),
-    ).toBeDisabled();
+    await waitFor(() =>
+      expect(
+        within(unavailableCard as HTMLElement).getByRole('button', { name: 'Start' }),
+      ).toBeEnabled(),
+    );
   });
 
   it('shows planned-workout onboarding when no scheduled or active workouts exist', async () => {

--- a/apps/web/src/features/workouts/components/workout-list.tsx
+++ b/apps/web/src/features/workouts/components/workout-list.tsx
@@ -31,12 +31,13 @@ import {
   useRescheduleWorkout,
   useScheduledWorkouts,
   useUnscheduleWorkout,
-  useWorkoutTemplate,
   useWorkoutSessions,
 } from '../api/workouts';
 import { useTodayKey } from '../hooks/use-today-key';
 import { hasAvailableTemplate } from '../lib/workout-filters';
-import { buildInitialSessionSets } from '../lib/workout-session-sets';
+import { buildScheduledStartPayload } from '../lib/scheduled-start';
+import { ApiError } from '@/lib/api-client';
+import { toast } from 'sonner';
 import {
   useCancelAndRevertSession,
   useDeleteSession,
@@ -373,8 +374,6 @@ function ScheduledWorkoutCard({
   const unscheduleWorkoutMutation = useUnscheduleWorkout();
   const startSessionMutation = useStartSession();
   const activeSessionsQuery = useWorkoutSessions({ status: ['in-progress', 'paused'] });
-  const templateId = scheduledWorkout.templateId ?? '';
-  const templateQuery = useWorkoutTemplate(templateId);
 
   const isMutating =
     rescheduleWorkoutMutation.isPending ||
@@ -385,13 +384,9 @@ function ScheduledWorkoutCard({
   );
   const [isRescheduleDialogOpen, setIsRescheduleDialogOpen] = useState(false);
   const [rescheduleAuthorityDate, setRescheduleAuthorityDate] = useState<string | null>(null);
-  const isTemplateAvailable = !scheduledWorkout.isUnavailable && !templateQuery.isError;
+  const isTemplateAvailable = !scheduledWorkout.isUnavailable;
   const isStartDisabled =
-    isMutating ||
-    dateAuthorityLocked ||
-    todayKey === null ||
-    !isTemplateAvailable ||
-    templateQuery.isPending;
+    isMutating || activeSessionsQuery.isPending || dateAuthorityLocked || todayKey === null;
 
   async function handleReschedule(requestedDate: string) {
     const mutationTodayKey = getTodayKeyForMutation();
@@ -424,27 +419,34 @@ function ScheduledWorkoutCard({
     setIsRescheduleDialogOpen(true);
   }
 
-  async function doStart(expectedTodayKey: string) {
+  async function doStart(expectedTodayKey: string, force = false) {
     const mutationTodayKey = getTodayKeyForMutation();
-    if (
-      mutationTodayKey === null ||
-      mutationTodayKey !== expectedTodayKey ||
-      !templateQuery.data ||
-      !scheduledWorkout.templateId ||
-      !scheduledWorkout.templateName
-    ) {
+    if (mutationTodayKey === null || mutationTodayKey !== expectedTodayKey) {
       return;
     }
 
-    const startedAt = Date.now();
-    const session = await startSessionMutation.mutateAsync({
-      date: mutationTodayKey,
-      name: scheduledWorkout.templateName,
-      sets: buildInitialSessionSets(templateQuery.data),
-      startedAt,
-      templateId: scheduledWorkout.templateId,
-    });
-    navigate(`/workouts/active?template=${scheduledWorkout.templateId}&sessionId=${session.id}`);
+    try {
+      const session = await startSessionMutation.mutateAsync(
+        buildScheduledStartPayload(scheduledWorkout.id, mutationTodayKey, { force }),
+      );
+      const search = new URLSearchParams({ sessionId: session.id });
+      const templateId = session.templateId ?? scheduledWorkout.templateId;
+      if (templateId) search.set('template', templateId);
+      navigate(`/workouts/active?${search.toString()}`);
+    } catch (error) {
+      if (error instanceof ApiError && error.code === 'STALE_SNAPSHOT_EXERCISES') {
+        confirm({
+          title: 'Some scheduled exercises are unavailable',
+          description: 'Start the scheduled snapshot and skip unavailable exercises?',
+          confirmLabel: 'Start anyway',
+          onConfirm: () => {
+            void doStart(expectedTodayKey, true);
+          },
+        });
+        return;
+      }
+      toast.error(error instanceof Error ? error.message : 'Unable to start workout');
+    }
   }
 
   function handleStartNow() {

--- a/apps/web/src/features/workouts/lib/active-session.ts
+++ b/apps/web/src/features/workouts/lib/active-session.ts
@@ -110,7 +110,7 @@ export function buildActiveWorkoutSession(
         lastPerformance: sessions
           ? getLastPerformance(templateExercise.exerciseId, sessionStartedAt, sessions)
           : (enhancedExercise?.lastPerformance ?? null),
-        name: enhancedExercise?.name ?? fallbackExerciseName,
+        name: templateExercise.exerciseName ?? enhancedExercise?.name ?? fallbackExerciseName,
         notes: exerciseNotes[templateExercise.exerciseId] ?? '',
         phaseBadge: enhancedExercise?.phaseBadge ?? 'moderate',
         programmingNotes: templateExerciseWithMetadata.programmingNotes ?? null,
@@ -122,7 +122,9 @@ export function buildActiveWorkoutSession(
         sets,
         supersetGroup: hasSupersetOverride
           ? exerciseSupersetOverrides[templateExercise.exerciseId]
-          : (templateExercise.supersetGroup ?? enhancedExercise?.supersetGroup ?? null),
+          : template.scheduledWorkoutId
+            ? (templateExercise.supersetGroup ?? null)
+            : (templateExercise.supersetGroup ?? enhancedExercise?.supersetGroup ?? null),
         tempo: templateExercise.tempo ?? null,
         targetSets: sets.length,
         trackingType,

--- a/apps/web/src/features/workouts/lib/scheduled-start.ts
+++ b/apps/web/src/features/workouts/lib/scheduled-start.ts
@@ -1,0 +1,16 @@
+import { createWorkoutSessionRequestSchema } from '@pulse/shared';
+import type { z } from 'zod';
+
+/** Called at the start/force event. The server retains the scheduled date. */
+export function buildScheduledStartPayload(
+  scheduledWorkoutId: string,
+  date: string,
+  options?: { startedAt?: number; force?: boolean },
+): z.input<typeof createWorkoutSessionRequestSchema> {
+  return {
+    scheduledWorkoutId,
+    date,
+    startedAt: options?.startedAt ?? Date.now(),
+    ...(options?.force ? { force: true } : {}),
+  };
+}

--- a/apps/web/src/features/workouts/lib/time-estimates.ts
+++ b/apps/web/src/features/workouts/lib/time-estimates.ts
@@ -104,7 +104,7 @@ function estimateSingleExerciseTime(exercise: ActiveWorkoutExercise, setCount: n
   const secondsPerRep = estimateSecondsPerRep(exercise.tempo);
   const repTime = secondsPerRep * averageReps;
   const totalWork = repTime * normalizedSetCount;
-  const totalRest = Math.max(normalizedSetCount - 1, 0) * exercise.restSeconds;
+  const totalRest = Math.max(normalizedSetCount - 1, 0) * (exercise.restSeconds ?? 0);
 
   return Math.max(0, Math.round(totalWork + totalRest));
 }
@@ -134,7 +134,7 @@ function estimateSupersetGroupTime(
 
   const totalWork = entries.reduce((total, entry) => total + entry.workPerSet * entry.setCount, 0);
   const roundCount = entries.reduce((max, entry) => Math.max(max, entry.setCount), 0);
-  const trailingRestSeconds = entries[entries.length - 1].exercise.restSeconds;
+  const trailingRestSeconds = entries[entries.length - 1].exercise.restSeconds ?? 0;
   const totalRest = Math.max(roundCount - 1, 0) * trailingRestSeconds;
 
   return Math.max(0, Math.round(totalWork + totalRest));

--- a/apps/web/src/features/workouts/types.ts
+++ b/apps/web/src/features/workouts/types.ts
@@ -36,7 +36,7 @@ export type ActiveWorkoutTemplateExercise = {
   formCues: string[];
   programmingNotes?: string | null;
   reps: string;
-  restSeconds: number;
+  restSeconds: number | null;
   sets: number;
   supersetGroup?: string | null;
   targetDistance?: number | null;
@@ -44,7 +44,7 @@ export type ActiveWorkoutTemplateExercise = {
   targetWeight?: number | null;
   targetWeightMax?: number | null;
   targetWeightMin?: number | null;
-  tempo: string;
+  tempo: string | null;
   templateCues?: string[];
   trackingType?: ExerciseTrackingType;
 };
@@ -56,6 +56,7 @@ export type ActiveWorkoutTemplateSection = {
 };
 
 export type ActiveWorkoutTemplate = {
+  scheduledWorkoutId?: string | null;
   description: string;
   id: string;
   name: string;
@@ -176,7 +177,7 @@ export type ActiveWorkoutExerciseMetadata = {
   prescribedReps: string;
   prescribedSets: number;
   priority: ActiveWorkoutPriority;
-  restSeconds: number;
+  restSeconds: number | null;
   reversePyramid: ActiveWorkoutReversePyramidTarget[];
   supersetGroup: string | null;
   tempo: string | null;

--- a/apps/web/src/hooks/use-workout-session.test.tsx
+++ b/apps/web/src/hooks/use-workout-session.test.tsx
@@ -156,6 +156,10 @@ describe('use-workout-session hooks', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: workoutQueryKeys.scheduledWorkout('scheduled-1'),
     });
+    const body = JSON.parse(String(mockFetch.mock.calls[0]?.[1]?.body));
+    expect(body.scheduledWorkoutId).toBe('scheduled-1');
+    expect(body).not.toHaveProperty('templateId');
+    expect(body).not.toHaveProperty('sets');
   });
 
   it('patches session start time and refreshes the session query', async () => {

--- a/apps/web/src/hooks/use-workout-session.ts
+++ b/apps/web/src/hooks/use-workout-session.ts
@@ -14,9 +14,7 @@ import { toast } from 'sonner';
 import { z } from 'zod';
 
 import { setStoredActiveWorkoutSessionId } from '@/features/workouts/lib/session-persistence';
-import {
-  workoutQueryKeys,
-} from '@/features/workouts/api/workouts';
+import { workoutQueryKeys } from '@/features/workouts/api/workouts';
 import {
   syncSessionMutationCache,
   workoutSessionQueryKeys,
@@ -55,8 +53,12 @@ async function getWorkoutSession(sessionId: string) {
 
 async function startSession(input: CreateWorkoutSessionRequest) {
   const parsedInput = createWorkoutSessionRequestSchema.parse(input);
+  // Schema defaults belong to the server; scheduled requests never seed template sets.
+  const requestBody = parsedInput.scheduledWorkoutId
+    ? { ...parsedInput, templateId: undefined, sets: undefined }
+    : parsedInput;
   const data = await apiRequest<unknown>('/api/v1/workout-sessions', {
-    body: JSON.stringify(parsedInput),
+    body: JSON.stringify(requestBody),
     method: 'POST',
   });
   const payload = workoutSessionResponseSchema.parse({ data });

--- a/apps/web/src/pages/active-workout.test.tsx
+++ b/apps/web/src/pages/active-workout.test.tsx
@@ -2992,6 +2992,29 @@ describe('buildTemplateFromSession', () => {
     ]);
   });
 
+  it('never restores removed supplemental exercises or cleared notes from a scheduled template', () => {
+    const fallbackTemplate = createTemplateForBuildTemplateTests({
+      supplementalExercises: [
+        createTemplateExerciseForBuildTemplateTests({ exerciseId: 'removed' }),
+      ],
+    });
+    fallbackTemplate.sections[0].exercises[0] = {
+      ...fallbackTemplate.sections[0].exercises[0],
+      programmingNotes: 'Later template notes',
+      agentNotes: 'Wrong notes',
+      trackingType: 'duration',
+    };
+    const session = createSessionForBuildTemplateTests({ scheduledWorkoutId: 'schedule-1' });
+    const result = buildTemplateFromSession(session, fallbackTemplate);
+    expect(result.sections.find((section) => section.type === 'supplemental')).toBeUndefined();
+    const exercise = result.sections.find((section) => section.type === 'main')?.exercises[0];
+    expect(exercise?.programmingNotes).toBeNull();
+    expect(exercise?.agentNotes).toBeNull();
+    expect(exercise?.trackingType).toBe('weight_reps');
+    expect(exercise?.tempo).toBeNull();
+    expect(exercise?.restSeconds).toBeNull();
+  });
+
   it('omits supplemental when neither snapshot nor template has supplemental exercises', () => {
     const fallbackTemplate = createTemplateForBuildTemplateTests({
       supplementalExercises: [],

--- a/apps/web/src/pages/active-workout.tsx
+++ b/apps/web/src/pages/active-workout.tsx
@@ -98,7 +98,7 @@ import { buildSessionSetInputs, extractExerciseNotes } from '@/features/workouts
 import { startCase } from '@/features/workouts/lib/start-case';
 import { ApiError, apiRequest } from '@/lib/api-client';
 import { crossFeatureInvalidationMap, invalidateQueryKeys } from '@/lib/query-invalidation';
-import type { ActiveWorkoutExercise, ActiveWorkoutTemplate } from '@/features/workouts/types';
+import type { ActiveWorkoutTemplate } from '@/features/workouts/types';
 
 const sectionTitleByType: Record<WorkoutTemplateSectionType, string> = {
   warmup: 'Warmup',
@@ -1501,6 +1501,13 @@ export function ActiveWorkoutPage() {
       return;
     }
 
+    if (
+      templateExercise.exercise.restSeconds == null ||
+      templateExercise.exercise.restSeconds <= 0
+    ) {
+      setRestTimer(null);
+      return;
+    }
     restTimerTokenRef.current += 1;
     setRestTimer({
       duration: templateExercise.exercise.restSeconds,
@@ -2599,7 +2606,9 @@ export function buildTemplateFromSession(
       continue;
     }
 
-    const fallbackExercise = fallbackExerciseById.get(sessionExercise.exerciseId)?.exercise;
+    const fallbackExercise = activeSession.scheduledWorkoutId
+      ? undefined
+      : fallbackExerciseById.get(sessionExercise.exerciseId)?.exercise;
     const defaultReps = fallbackExercise?.reps ?? inferExerciseRepsFromSets(sessionExercise.sets);
 
     const sessionSetCount = sessionExercise.sets.reduce(
@@ -2618,10 +2627,18 @@ export function buildTemplateFromSession(
         sessionExercise.supersetGroup === undefined
           ? (fallbackExercise?.supersetGroup ?? null)
           : sessionExercise.supersetGroup,
-      sets: sessionSetCount > 0 ? sessionSetCount : (fallbackExercise?.sets ?? 1),
+      sets: activeSession.scheduledWorkoutId
+        ? sessionExercise.sets.length
+        : sessionSetCount > 0
+          ? sessionSetCount
+          : (fallbackExercise?.sets ?? 1),
       reps: defaultReps,
-      tempo: fallbackExercise?.tempo ?? '2111',
-      restSeconds: fallbackExercise?.restSeconds ?? 60,
+      tempo: activeSession.scheduledWorkoutId
+        ? (sessionExercise.tempo ?? null)
+        : (fallbackExercise?.tempo ?? '2111'),
+      restSeconds: activeSession.scheduledWorkoutId
+        ? (sessionExercise.restSeconds ?? null)
+        : (fallbackExercise?.restSeconds ?? 60),
       formCues: fallbackExercise?.formCues ?? [],
       templateCues: fallbackExercise?.templateCues ?? [],
       programmingNotes:
@@ -2633,7 +2650,11 @@ export function buildTemplateFromSession(
   }
 
   const supplementalSection = sectionsByType.get('supplemental');
-  if (supplementalSection && supplementalSection.exercises.length === 0) {
+  if (
+    !activeSession.scheduledWorkoutId &&
+    supplementalSection &&
+    supplementalSection.exercises.length === 0
+  ) {
     const fallbackSupplemental = fallbackTemplate.sections.find(
       (section) => section.type === 'supplemental',
     );
@@ -2660,6 +2681,7 @@ export function buildTemplateFromSession(
   return {
     ...fallbackTemplate,
     id: activeSession.templateId ?? fallbackTemplate.id,
+    scheduledWorkoutId: activeSession.scheduledWorkoutId,
     name: activeSession.name,
     sections: sectionOrder
       .map((type) => sectionsByType.get(type))
@@ -2669,7 +2691,9 @@ export function buildTemplateFromSession(
   };
 }
 
-function buildSessionExercisesFromSets(session: ApiWorkoutSession) {
+function buildSessionExercisesFromSets(
+  session: ApiWorkoutSession,
+): NonNullable<ApiWorkoutSession['exercises']> {
   const namesById = new Map(
     session.sets
       .filter(
@@ -2688,7 +2712,7 @@ function buildSessionExercisesFromSets(session: ApiWorkoutSession) {
       supersetGroup: string | null;
       programmingNotes: string | null;
       agentNotes: string | null;
-      agentNotesMeta: ActiveWorkoutExercise['agentNotesMeta'];
+      agentNotesMeta: NonNullable<ApiWorkoutSession['exercises']>[number]['agentNotesMeta'];
       sets: SessionSet[];
     }
   >();

--- a/docs/conventions/workout-domain.md
+++ b/docs/conventions/workout-domain.md
@@ -71,26 +71,47 @@ Lifecycle rules:
 
 ### Scheduled Start Lifecycle
 
-`POST /api/v1/workout-sessions` supports three start selectors:
+`POST /api/v1/workout-sessions` accepts exactly one source selector:
 
-1. `scheduledWorkoutId` (scheduled snapshot start)
-2. `templateId` or `templateName` (template start)
-3. `name` (ad-hoc start)
+1. `scheduledWorkoutId`: materialize that owned snapshot.
+2. `templateId` or AgentToken `templateName`: create an independent template session.
+3. `name` without either selector: create an independent ad-hoc session.
 
-Scheduled starts seed from `scheduled_workout_exercises` + `scheduled_workout_exercise_sets`, not from live template rows.
+Template and ad-hoc starts never claim a schedule, including the explicit “Create another
+anyway” action. No same-day template matching or post-create auto-link is performed. Missing,
+malformed, foreign and nonexistent scheduled selectors cannot fall through to a template start.
 
-- Session set prescriptions copy snapshot targets (`targetWeight*`, `targetSeconds`, `targetDistance`, and exact `reps` when present).
-- Session exercise note snapshots copy `programmingNotes`, `agentNotes`, and `agentNotesMeta` from the scheduled snapshot.
+List, calendar and scheduled detail use `buildScheduledStartPayload`; dashboard links to scheduled
+detail. Scheduled requests omit `templateId` and `sets`, including after schema validation.
+The date-authority hook supplies the current local day and is rechecked after confirmations.
+The API intentionally retains `schedule.date`; `startedAt` records when the early start occurs.
+If local midnight passes or date authority locks while a confirmation is open, the pending start
+is aborted. Browser timezone is never used to select a schedule.
 
-Scheduled-start idempotency:
+Session creation, all set inserts and reverse schedule linking are one transaction. Both link
+columns must agree. A live linked session returns `409 SCHEDULED_WORKOUT_ALREADY_STARTED`;
+a competing transaction returns `409 SCHEDULED_WORKOUT_LINK_CONFLICT`. A cancelled/deleted
+link is replaced atomically only if it still has the observed value. Failed inserts/links preserve
+that old link and leave no new session or sets. Stored prescriptions are validated before
+creation; invalid targets return `400 INVALID_SCHEDULED_SNAPSHOT` with no writes. Cancellation permits another start of the same
+snapshot without changing its source rows.
 
-- If `scheduled_workouts.sessionId` points to a live session (not cancelled and not soft-deleted), start returns `409 SCHEDULED_WORKOUT_ALREADY_STARTED`.
-- If the linked session is cancelled or deleted, the server clears `scheduled_workouts.sessionId` and allows a fresh start from the same snapshot.
+Scheduled materialization copies exact source set IDs, identity/tracking snapshots, all targets
+(including nulls), section/order/supersets and the three note channels. The session response exposes
+`scheduledWorkoutId`, source exercise/set IDs, immutable facts and nullable targets. Migration
+`0060_scheduled_session_prescriptions` adds nullable exercise prescription JSON for tempo/rest
+and source exercise identity, including exercises with zero source sets. It does not backfill
+historical sessions. Legacy responses remain readable without these optional fields.
 
-Stale snapshot exercises:
+Active rendering uses session snapshot names, tracking, notes, sets and prescriptions. Scheduled
+sessions never union in template supplemental exercises or replace explicit null notes/tempo/rest
+with template values. Null rest disables the automatic rest timer; time estimates count it as zero
+without changing the prescription. Later live changes to set order/supersets remain session data.
 
-- If snapshot exercises reference deleted/unavailable exercises, start returns `409 STALE_SNAPSHOT_EXERCISES` with `staleExercises`.
-- `force: true` allows start to continue by skipping stale snapshot exercises and returns `warnings: [{ code: 'STALE_EXERCISES_SKIPPED', exercises: [...] }]`.
+Stale snapshot exercises return `409 STALE_SNAPSHOT_EXERCISES`. The explicit force confirmation
+reuses the same scheduled selector and skips only stale exercises, returning
+`STALE_EXERCISES_SKIPPED`. Source completeness applies to every non-skipped source set.
+An empty snapshot can start an empty session; it never silently loads a template.
 
 ## Completed Session Detail Surface
 
@@ -152,7 +173,7 @@ A workout session is the user-specific execution record of a template.
 - API response ordering: `GET /api/v1/workout-sessions/:id` must return both `sets[]` and `exercises[]` ordered as `warmup → main → supplemental → cooldown → null-section orphans → unknown`. This is enforced by `sectionRank` in `apps/api/src/routes/workout-sessions/store.ts`.
 - Unknown section values always sort to the end. If a new section type is introduced, add it to `SECTION_ORDER` in `apps/api/src/routes/workout-sessions/store.ts` so it sorts in the intended position.
 - Session snapshot rule: section membership is snapshotted at session creation via `buildInitialSessionSets` in `apps/api/src/routes/workout-sessions/session-set-utils.ts`. Later template edits do not backfill an in-flight session. To modify upcoming workouts, edit the scheduled-workout snapshot endpoints instead of the template source.
-- Supplemental UI fallback: `buildTemplateFromSession` in `apps/web/src/pages/active-workout.tsx` unions in fallback-template supplemental exercises when the session snapshot has zero supplemental rows.
+- Legacy/template-only supplemental UI fallback: `buildTemplateFromSession` in `apps/web/src/pages/active-workout.tsx` unions in fallback-template supplemental exercises when the session snapshot has zero supplemental rows.
 - Logging against a fallback-sourced supplemental exercise writes a real supplemental session-set row through the existing bulk `PATCH /api/v1/workout-sessions/:id` path; once logged, that row is part of the session snapshot.
 - Warmup/main/cooldown are not unioned from fallback templates. If those sections are empty in a session response, treat it as data corruption, not expected product behavior.
 

--- a/docs/implementation/scheduled-snapshot-goal.md
+++ b/docs/implementation/scheduled-snapshot-goal.md
@@ -2,7 +2,7 @@
 
 ## Contract status
 
-**Frozen handoff for Pulse issue #134. Docs-only; implementation is not authorized in this worktree.**
+**Frozen handoff for Pulse issue #134. The handoff commit is docs-only. Upon verified Goal Mode launch, implementation in this isolated worktree is authorized; production deployment/data repair and executor merge remain prohibited.**
 
 - Repository: `/Users/meridian/Projects/pulse-scheduled-snapshot-fix`
 - Upstream repository: `https://github.com/derekbeau/pulse-fitness-app.git`

--- a/docs/implementation/scheduled-snapshot-goal.md
+++ b/docs/implementation/scheduled-snapshot-goal.md
@@ -1,0 +1,346 @@
+# Scheduled Snapshot Provenance: Goal-Mode Implementation Contract
+
+## Contract status
+
+**Frozen handoff for Pulse issue #134. Docs-only; implementation is not authorized in this worktree.**
+
+- Repository: `/Users/meridian/Projects/pulse-scheduled-snapshot-fix`
+- Upstream repository: `https://github.com/derekbeau/pulse-fitness-app.git`
+- Approved implementation baseline: `origin/main` / `85930bd6497286bcc3153b77885e44feb1f31a82` (merged PR #144)
+- Executor branch: `fix/scheduled-snapshot-provenance`
+- Primary implementation model approved by Derek: **GPT-6 Astra, Low reasoning**
+- Review/support model: **GPT-5.6 Luna, Medium reasoning**
+- Execution mode: one fresh Codex App Goal Mode lane, one isolated worktree, no competing editor
+- Scope: one coherent implementation PR for #134; no production launch, deployment, or data repair
+
+The executor must fail before editing if the branch, worktree, starting SHA, required context, or clean/dirty expectation does not match the generated launcher manifest supplied with this handoff.
+
+## Goal
+
+Make a customized scheduled workout snapshot the canonical source for every scheduled-workout start. Starting the same scheduled workout from the Workouts list, calendar, dashboard, or scheduled-workout detail must materialize the same immutable snapshot into the active session. The visible workout and persisted provenance must agree, including when the reusable template happens to look identical.
+
+Complete the contract 100%. Do not stop at a plan, a happy-path test, visible exercise equality, or a status summary. Read the actual implementation, plan, implement, test, adversarially review, repair, run the complete gate, inspect the final diff, commit coherent changes, and retain literal evidence. This file is a frozen implementation contract, not evidence that implementation has occurred.
+
+## Exact live issue snapshot
+
+Captured from GitHub on **2026-09-06** at issue `https://github.com/derekbeau/pulse-fitness-app/issues/134` (state: `open`, updated `2026-09-06T20:03:24Z`, title: **Starting a scheduled workout from the Workouts list ignores its snapshot**). The following issue body is preserved verbatim from the live API snapshot:
+
+> ## Bug
+>
+> Starting a scheduled workout from the Workouts list ignores the customized scheduled-workout snapshot and builds the active session from the reusable template instead.
+>
+> The API then automatically links that template-built session back to the scheduled workout, making the session appear correctly linked while its exercises, sets, targets, order, supersets, and notes are wrong.
+>
+> This has occurred on multiple production workout starts, including the September 2 provenance-only failure documented below; live data repairs did not fix the underlying code path.
+>
+> ## Production evidence
+>
+> ### Reproduction 1: Wednesday, August 26, 2026
+>
+> The scheduled upper workout had been customized and verified before start:
+>
+> - Removed the heavy seated cable row because of temporary posterior-chain tightness
+> - Added Dead Bug
+> - Updated exercise order, support instructions, and recovery gates
+>
+> The active session instead restored template content, including Seated Cable Row and Band Pull-Aparts, while omitting scheduled-snapshot content including Cable Preacher Curl, Face Pulls, and Dead Bug.
+>
+> The user had to split and repair exercises in the live workout after starting.
+>
+> ### Reproduction 2: Thursday, August 27, 2026
+>
+> Scheduled workout `447fd6ee-6fa7-4d17-b689-deb5705a4336` was customized and API-verified with exactly six exercises:
+>
+> 1. Leg Extension Machine
+> 2. Lying Leg Curl Machine
+> 3. Lying Cable Hip Flexion (Ankle Strap)
+> 4. Cable Hip Abduction
+> 5. Cable Hip Adduction
+> 6. Posterior Chain Roll + Hamstring Stretch
+>
+> After start, active session `31e5fb2e-fa9e-477a-bb98-6d33e2247bf3` contained the reusable template instead:
+>
+> - Bodyweight Squat (ATG)
+> - Tib Bar Tibialis Raise
+> - Barbell Hip Thrust
+> - Leg Extension Machine
+> - Lying Leg Curl Machine
+> - Cable Hip Adduction
+> - Spanish Squat
+> - Weighted Calf Stretch
+> - Ankle Rockers
+> - Plantar Fascia Foot Stretch
+> - Posterior Chain Roll + Hamstring Stretch
+>
+> This restored exercises explicitly removed for recovery/toe constraints and omitted hip flexion and abduction. The recovery block survived only because it had also been added to the reusable template, which is strong evidence that active-session construction used the template rather than the scheduled snapshot.
+>
+> ## Root cause
+>
+> The API already has a correct scheduled-start branch.
+>
+> In `apps/api/src/routes/workout-sessions/index.ts` around lines 726–772, requests containing `scheduledWorkoutId`:
+>
+> - read the scheduled snapshot;
+> - build session sets from `snapshot.exercises`;
+> - propagate programming notes, agent notes, metadata, source scheduled-set IDs, and snapshot facts;
+> - link the resulting session to the schedule.
+>
+> The scheduled-workout detail page uses that path correctly:
+>
+> ```ts
+> // apps/web/src/features/workouts/components/scheduled-workout-detail.tsx
+> startSessionMutation.mutateAsync({
+>   scheduledWorkoutId: scheduledWorkout.id,
+>   startedAt,
+>   ...
+> });
+> ```
+>
+> The Workouts-list start action does not:
+>
+> ```ts
+> // apps/web/src/features/workouts/components/workout-list.tsx
+> startSessionMutation.mutateAsync({
+>   date: mutationTodayKey,
+>   name: scheduledWorkout.templateName,
+>   sets: buildInitialSessionSets(templateQuery.data),
+>   startedAt,
+>   templateId: scheduledWorkout.templateId,
+> });
+> ```
+>
+> Because `scheduledWorkoutId` is omitted, the API takes the template-start branch and uses current template sets.
+>
+> It then runs this fallback after creation:
+>
+> ```ts
+> if (!hasScheduledStart && input.templateId !== null) {
+>   await linkTodayScheduledWorkoutToSession(...);
+> }
+> ```
+>
+> That auto-link masks the mistake: the active session receives the scheduled-workout relationship even though it was not materialized from that snapshot.
+>
+> Issue #104 fixed dashboard routing to the scheduled detail page, but the Workouts-list inline Start flow still uses the unsafe template-start payload. This is a distinct downstream bug.
+>
+> ## Required fix
+>
+> ### Web
+>
+> - Change the Workouts-list scheduled-card start action to send `scheduledWorkoutId` and use the same scheduled-start contract as `scheduled-workout-detail.tsx`.
+> - Do not send `templateId` or `buildInitialSessionSets(templateQuery.data)` when starting an existing scheduled workout.
+> - Consolidate scheduled-start payload construction so list, calendar, dashboard, and detail surfaces cannot drift again.
+> - Preserve early-start confirmation, active-session conflict handling, stale-exercise confirmation, navigation, query invalidation, and error behavior.
+>
+> ### API defense in depth
+>
+> Do not silently auto-link a template-built session to a scheduled workout when that would hide snapshot divergence.
+>
+> Implement one explicit, tested behavior:
+>
+> 1. Preferably, resolve an unambiguous matching scheduled workout through the scheduled-snapshot materialization path; or
+> 2. Fail closed with a structured conflict requiring `scheduledWorkoutId`, unless the caller explicitly requested a separate template/ad-hoc session.
+>
+> The server must preserve the intentional “create another anyway” flow without attaching a template-built duplicate to the scheduled card.
+>
+> ## Snapshot integrity invariant
+>
+> When a scheduled workout is started, the active session must be an immutable materialization of the scheduled snapshot at start time.
+>
+> The following must match the scheduled detail exactly:
+>
+> - Exercise IDs and names
+> - Included/removed exercises
+> - Section and order
+> - Set count and set numbers
+> - Repetition, duration, distance, and weight targets
+> - Cleared/null targets
+> - Superset groups
+> - Rest/tempo where represented in the active contract
+> - Programming Notes
+> - Agent Notes and metadata
+> - Source scheduled exercise/set identity
+> - Exercise and tracking-type snapshot facts
+>
+> Later template edits must not change an already scheduled snapshot or its resulting active session.
+>
+> ## Acceptance criteria
+>
+> - [ ] Starting from the Workouts list sends `scheduledWorkoutId` and does not seed from the template.
+> - [ ] Starting from scheduled detail, Workouts list, calendar, and dashboard produces equivalent active-session data.
+> - [ ] Removed scheduled exercises do not reappear.
+> - [ ] Added/swapped scheduled exercises appear in the active session.
+> - [ ] Scheduled set additions/removals, target changes, and explicit null clears survive start exactly.
+> - [ ] Scheduled exercise order and superset groups survive start.
+> - [ ] Programming Notes, Agent Notes, and note metadata survive start.
+> - [ ] Active session links to the correct scheduled workout and the schedule links back to the session.
+> - [ ] Starting early uses the scheduled date/start semantics intentionally and does not lose the snapshot.
+> - [ ] Template changes after scheduling do not leak into the active session.
+> - [ ] Explicit “create another anyway” creates a separate template session without consuming or silently linking the scheduled card.
+> - [ ] A malformed/missing scheduled-start identifier cannot silently fall back to template materialization and auto-link.
+> - [ ] Regression tests cover both production failure shapes above.
+>
+> ## Tests
+>
+> ### Web component/mutation tests
+>
+> - Workouts-list scheduled Start calls the mutation with `scheduledWorkoutId`.
+> - Payload excludes template-generated sets and `templateId` for scheduled starts.
+> - Early-start and active-session confirmation preserve the same payload.
+> - Stale-snapshot conflict can force-start the scheduled snapshot.
+>
+> ### API integration tests
+>
+> Existing API coverage already proves a direct `scheduledWorkoutId` request uses the snapshot. Extend it to verify:
+>
+> - structural exercise removals/additions;
+> - reordered exercises;
+> - set deletion and explicit target clearing;
+> - supersets and notes;
+> - template divergence after snapshot creation;
+> - server behavior when a template start matches an unconsumed scheduled workout;
+> - explicit duplicate/template-start behavior.
+>
+> ### Installed-browser acceptance
+>
+> 1. Create a scheduled workout from a template.
+> 2. Modify its exercise list, order, targets, supersets, and notes.
+> 3. Modify the reusable template differently afterward.
+> 4. Start from each user-facing scheduled-workout entry point.
+> 5. Assert the active session matches the scheduled snapshot, not the template.
+> 6. Refresh/resume and verify persistence.
+> 7. Confirm no duplicate session/card or false auto-link.
+>
+> ## Implementation evidence required
+>
+> - Exact before/after payloads for each start surface
+> - Focused web and API test results
+> - Full uncached lint, typecheck, test, and build
+> - Installed-Chrome screenshots or trace showing scheduled detail and resulting active session
+> - Database/API readback proving schedule/session linkage and snapshot identity
+>
+> ## Related
+>
+> - #104 fixed dashboard routing to scheduled workout details, but did not fix the Workouts-list inline Start payload.
+>
+>
+> ## Acceptance clarification from September 2 production evidence
+>
+> When a scheduled workout is started, acceptance must verify persisted snapshot provenance even when the visible exercise list happens to equal the reusable template:
+>
+> - [ ] The active session contains a symmetric schedule/session link: `workout_sessions.scheduled_workout_id` points to the schedule and the scheduled workout's `session_id` points back to that session.
+> - [ ] Every active-session set carries the exact source scheduled-set ID (`source_scheduled_set_id`) for all source scheduled sets; no source IDs are omitted.
+> - [ ] Scheduled target values, explicit null/cleared targets, set order, sections, and superset groups survive materialization exactly.
+> - [ ] Programming Notes, Agent Notes, and their metadata survive materialization exactly, including when exercise names and visible sets match the template.
+> - [ ] Regression and installed-browser acceptance checks assert these persisted links, IDs, targets/nulls, ordering, supersets, programming notes, and agent notes/metadata—not only visible exercise equality.
+>
+> This clarification promotes the September 2 comment evidence into the body's acceptance criteria; the original comment remains unchanged.
+
+### Exact live issue comment
+
+The only live issue comment at capture time was comment `5517108054`, by `derekbeau`, created `2026-09-02T22:07:41Z`. It is preserved verbatim:
+
+> ### Third production reproduction: September 2, 2026
+>
+> The Workouts-list inline Start path was used again.
+>
+> This time the visible workout happened to remain structurally correct because the reusable `Upper Strength + Back Width` template had been deliberately aligned with the scheduled snapshot immediately before scheduling. The user completed every intended exercise and target load.
+>
+> The hidden provenance still failed exactly as predicted:
+>
+> - `workout_sessions.scheduled_workout_id` was `NULL`.
+> - The scheduled card's `session_id` pointed to the completed session, creating asymmetric linkage.
+> - All 20 `session_sets.source_scheduled_set_id` values were `NULL`.
+> - Scheduled target fields were absent from the session rows.
+> - `exercise_agent_notes` was missing.
+> - `exercise_programming_notes` contained null values rather than the scheduled snapshot notes.
+>
+> This demonstrates that visual equality between template and snapshot can hide the bug while progression/audit provenance is still corrupted.
+>
+> The production data was repaired after completion by mapping all 20 session sets to the exact scheduled exercise/set rows using `(exercise_id, section, set_number)`, restoring targets, order, supersets, Programming Notes, Agent Notes, and the symmetric scheduled-workout link without changing any logged performance.
+>
+> Additional acceptance requirement: tests must assert persisted `scheduled_workout_id`, every `source_scheduled_set_id`, target fields, and note snapshots, not only the visible exercise list.
+
+## Known baseline and inspected implementation surface
+
+The approved base is clean in the isolated worktree at `85930bd6497286bcc3153b77885e44feb1f31a82`, the merged PR #144 head. The original checkout `/Users/meridian/Projects/pulse-fitness-app` has pre-existing untracked artifacts; they are intentionally preserved and not copied, staged, or modified.
+
+Observed baseline behavior and files:
+
+- `apps/web/src/features/workouts/components/workout-list.tsx:357-483`: scheduled-card start fetches the reusable template, calls `buildInitialSessionSets(templateQuery.data)`, and sends `templateId`; it omits `scheduledWorkoutId`.
+- `apps/web/src/features/workouts/components/workout-calendar.tsx:430-509`: scheduled calendar start has the same template-seeding shape.
+- `apps/web/src/features/workouts/components/scheduled-workout-detail.tsx:254-289`: already sends `scheduledWorkoutId`, optional `force`, `startedAt`, and no template-generated sets; stale-snapshot conflict opens force-start recovery.
+- `apps/web/src/hooks/use-workout-session.ts:172-212`: mutation caches the session and invalidates sessions, schedule list, the specific schedule when `variables.scheduledWorkoutId` exists, and cross-feature keys.
+- `apps/api/src/routes/workout-sessions/index.ts:599-879`: request schema supports exactly one scheduled/template/ad-hoc mode. The scheduled branch reads the snapshot, checks ownership, handles an existing live link, stale exercise conflicts, builds snapshot sets/facts/notes, then calls the store with linking enabled. The template branch builds current template sets.
+- `apps/api/src/routes/workout-sessions/store.ts:1358-1475`: creation is transactional; it inserts the session and set rows, then sets `scheduled_workouts.session_id` under owner + null-link predicates. The session foreign key is `scheduledWorkoutId`; set provenance/facts include `sourceScheduledSetId`, target fields, exercise/name/tracking snapshots, section, order, and supersets.
+- `apps/api/src/db/schema/workout-sessions.ts:87-235`: persisted session linkage, note JSON, set target fields, source scheduled-set ID, snapshot facts, section/order, and superset group are present.
+- `apps/api/src/db/schema/scheduled-workouts.ts:17-51`: schedule has `templateVersion`, date, nullable `sessionId`, and user/date/template/session indexes.
+- `packages/shared/src/schemas/workout-sessions.ts:295-547`: session and request schemas preserve nullable targets and enforce exactly one start mode; `force` is a request-only recovery flag.
+- `packages/shared/src/schemas/scheduled-workouts.ts:22-119`: schedule detail schema exposes exercise order, sections, notes, agent metadata, sets, targets, supersets, tempo/rest, drift, and stale-exercise state.
+- Existing tests: `apps/api/src/routes/workout-sessions/index.test.ts` has scheduled snapshot, consumed/restart, stale, force, cancellation, and persistence coverage; `apps/web/src/features/workouts/components/{workout-list,scheduled-workout-detail,workout-calendar}.test.tsx` and `apps/web/src/hooks/use-workout-session.test.tsx` cover current mutations and UI behavior; shared schema tests cover contracts.
+- `docs/DEVELOPMENT-PROCESS.md` is not tracked/present on this approved branch. The applicable Foundry/Goal-Mode contract is the loaded `derek-dev-workflows` reference, recorded here by its required execution rules.
+
+## Fixed product and architecture decisions
+
+1. The scheduled snapshot, not the reusable template, is canonical once a schedule exists.
+2. All scheduled entry points use one shared client payload builder or equivalent single contract. No surface may hand-build template sets for an existing schedule.
+3. A scheduled materialization has symmetric links: session `scheduled_workout_id = schedule.id` and schedule `session_id = session.id`.
+4. Every source snapshot set carries its exact `source_scheduled_set_id`, including when visible values equal the template. No provenance inference after creation.
+5. Snapshot values are copied exactly: exercise identity/name, section, order, set numbers/count, all target fields including explicit nulls, supersets, tempo/rest where active, programming notes, agent notes, metadata, and tracking facts.
+6. “Start anyway” for an existing active session and “force” for stale exercises remain explicit flows; neither may change the source of truth.
+7. “Create another anyway” is an explicit template/ad-hoc start. It creates an independent session and never consumes, links, or silently repairs the schedule.
+8. Prefer a deterministic server-side scheduled path. Any ambiguous implicit matching must fail closed with a structured conflict rather than auto-linking a template-built session.
+
+## Complete implementation surface
+
+### Web entry paths
+
+Audit and normalize every path that can start a scheduled workout: Workouts list inline Start, calendar scheduled-card Start, dashboard/snapshot links and actions, scheduled-workout detail, and any shared/template/session resume or duplicate actions. Detail already demonstrates the target contract. Preserve navigation query parameters, loading/disabled states, early-start confirmation, active-session conflict confirmation, stale-exercise recovery, toast/error behavior, and query invalidation. Do not require template detail data to start an existing schedule.
+
+The shared scheduled-start payload must carry only schedule identity plus intentional start-time/session fields (`scheduledWorkoutId`, authoritative current date semantics, `startedAt`, optional `force`, and optional display name if the API allows it). It must not carry `templateId` or template-generated `sets` for an existing schedule. The duplicate/template path remains separate and may carry `templateId` and generated sets.
+
+### API, persistence, and atomicity
+
+Keep one validated start-mode discriminator. A request with `scheduledWorkoutId` must be owned by the authenticated user, read the immutable snapshot, and never fall through to template construction. A missing, malformed, foreign, deleted, or nonexistent schedule ID must return a structured 4xx/409 outcome without creating or linking a session. A template/ad-hoc request must not opportunistically attach itself to a same-day schedule; remove, guard, or redesign the fallback auto-link so no template-built session can masquerade as a scheduled materialization. Preserve explicit duplicate creation.
+
+Create session row, all set rows, and the reverse schedule link in one transaction. On any insert/link conflict, roll back all rows and leave the schedule link unchanged. Make retry behavior explicit: a live linked session returns the existing-session conflict; after cancellation/unlink, a new scheduled start may materialize again; concurrent starts cannot create two linked sessions. Verify both link columns after creation.
+
+### Canonical snapshot mapping
+
+Map each snapshot exercise in stored `orderIndex` order and section. For each source set map source ID, set number, all reps min/max/exact, weight min/max/exact, seconds, distance, zone, section/order, superset group, and the session's mutable performance defaults. Copy exercise ID/name/tracking-type snapshot facts and programming/agent notes + metadata. Preserve null versus omitted semantics through Zod, JSON serialization, Drizzle, API response, and UI. Do not reconstruct provenance later from `(exercise_id, section, set_number)`; that tuple is only a diagnostic fallback for historical repair, never the implementation path.
+
+### Authorization, dates, timezone, and idempotency
+
+Every schedule/session/read/write query remains scoped to authenticated `userId` for both JWT and AgentToken paths. Agent conveniences must remain middleware-based and must not bypass schedule ownership. Use the existing authoritative local-day/date authority hook; early starts begin now but materialize the schedule snapshot and intentionally retain the scheduled date semantics defined by the existing API contract. Document and test the timezone boundary around local midnight and stale date authority. Do not use browser/template date guesses to select a schedule.
+
+### Backwards compatibility
+
+Preserve existing template starts, ad-hoc starts, AgentToken `templateName` convenience, direct scheduled starts, cancellation/unlink/resume behavior, soft-deleted/missing exercise stale handling, existing response envelopes and error codes, OpenAPI generation, legacy sessions with null provenance, and read paths that tolerate nullable historical fields. No production repair, migration, backfill execution, deployment, or launch is part of this PR. If a schema change is genuinely required, include only the migration and compatibility tests needed for new code; do not mutate canonical/production data.
+
+## Acceptance matrix
+
+1. **Structural divergence:** create a schedule, remove template exercises, add/swap scheduled exercises, reorder, alter sections/supersets, add/remove sets, and diverge the reusable template afterward. Start from every scheduled entry path. Assert exact active structure and no template leakage.
+2. **Targets and nulls:** cover reps, weight range/exact, seconds, distance, zone, and explicit null clears. Assert persisted DB rows and API response, not only rendered text.
+3. **Provenance:** assert `workout_sessions.scheduled_workout_id`, schedule `session_id`, every non-null `session_sets.source_scheduled_set_id`, set IDs, exercise/name/tracking snapshots, order/section/set number, and note/meta JSON. Include the identical-visible-template / 20-set-shaped regression described by the live comment.
+4. **Notes and metadata:** programming notes, agent notes, author/generatedAt/scheduledDateAtGeneration/stale metadata survive exactly, including null values.
+5. **Entry-point equivalence:** list, calendar, dashboard, and detail submit the same scheduled contract and yield equivalent materialization. Use populated UI inputs and production-shaped legacy fixtures.
+6. **Early start/time authority:** confirm early-start UX, local-day semantics, midnight/date authority changes, and persistence after refresh/resume.
+7. **Conflict and idempotency:** active linked schedule returns the existing-session conflict; stale exercises require confirmation then force-start uses the same snapshot minus explicitly skipped stale exercises; concurrent/repeated submission cannot create duplicate linked sessions; cancelled/unlinked restart behavior remains intentional.
+8. **Isolation/auth:** JWT and AgentToken authorized paths work as intended; unauthenticated and cross-user schedule IDs return the existing safe errors and create no rows; template/ad-hoc starts never attach to a schedule.
+9. **Atomicity/failure:** inject/cover duplicate link, invalid exercise, invalid target, and transaction failure. Assert no partial session/sets/link remain.
+10. **UI quality:** loading, unavailable/deleted template, stale conflict, active-session confirmation, errors, responsive mobile layout, keyboard/accessibility states, and navigation are covered without requiring a template fetch for canonical scheduled start.
+11. **Repository gate:** run focused shared-schema, API route/store, web mutation/component tests; then one full **uncached** lint, typecheck, test, and build at final implementation HEAD. Do not claim this gate in this docs-only handoff.
+12. **Installed browser:** once implementation is final, use isolated real Chrome flows for create/customize/diverge/start from each path/refresh-resume. Retain raw command logs, API/database readbacks, and screenshot/trace paths. Record the exact tested code SHA. Evidence must be generated after the final code commit and must not be committed into the code/evidence commit itself.
+13. **Git hygiene:** one implementation lane, no unrelated files, no secrets, clean final worktree, no merge by executor. A draft PR may be pushed/opened only with explicit authorization; production data repair/deploy/launch remain separate approval gates.
+
+## Required executor completion report
+
+Return `COMPLETE` or `BLOCKED`, exact branch and full SHA, commits/files, requirement-to-evidence mapping, all reviewer assignments/findings/dispositions, literal focused and full gate results, raw log/screenshot/trace paths, browser/API/DB readbacks, tested code SHA, remaining blockers, prohibited-action confirmation, and `git status --porcelain`. Do not use a self-referential evidence commit: evidence must identify the exact code/docs commit it tests, and any generated manifest/logs/screenshots remain outside the implementation commit unless separately approved.
+
+## Explicit non-goals and approval boundaries
+
+- Do not implement production code, migrations, schema changes, or tests in this docs-only preparation lane.
+- Do not start tests, launch the UI, run browser flows, deploy, merge, repair production/canonical data, or touch Foundry.
+- Do not assume the September production repair is a substitute for code correctness.
+- Do not silently reinterpret template duplicate behavior as scheduled start.
+- Push/open a **draft** PR only if the parent agent explicitly authorizes it after review; the executor must not merge.

--- a/packages/shared/src/schemas/workout-sessions.ts
+++ b/packages/shared/src/schemas/workout-sessions.ts
@@ -310,6 +310,15 @@ export const sessionSetSchema = z
     targetWeightMax: z.number().min(0).nullable().optional(),
     targetSeconds: z.number().int().min(0).max(MAX_DURATION_SECONDS).nullable().optional(),
     targetDistance: z.number().min(0).nullable().optional(),
+    sourceScheduledSetId: requiredStringSchema.nullable().optional(),
+    exerciseIdSnapshot: requiredStringSchema.nullable().optional(),
+    exerciseNameSnapshot: requiredStringSchema.nullable().optional(),
+    trackingTypeSnapshot: exerciseTrackingTypeSchema.nullable().optional(),
+    targetReps: nullableIntegerSchema.optional(),
+    targetRepsMin: nullableIntegerSchema.optional(),
+    targetRepsMax: nullableIntegerSchema.optional(),
+    targetZone: nullableZoneSchema.optional(),
+    supersetGroup: nullableShortStringSchema.optional(),
     completed: z.boolean(),
     skipped: z.boolean(),
     section: workoutTemplateSectionTypeSchema.nullable(),
@@ -327,6 +336,7 @@ export const sessionSetSchema = z
   .superRefine(validateMutuallyExclusiveWorkoutEffort);
 
 export const workoutSessionExerciseSchema = z.object({
+  sourceScheduledExerciseId: requiredStringSchema.nullable().optional(),
   exerciseId: requiredStringSchema.nullable(),
   exerciseName: requiredStringSchema,
   deletedAt: z.string().nullable().optional(),
@@ -341,6 +351,8 @@ export const workoutSessionExerciseSchema = z.object({
     .optional(),
   orderIndex: z.number().int().min(0),
   section: workoutTemplateSectionTypeSchema.nullable(),
+  tempo: z.string().nullable().optional(),
+  restSeconds: z.number().int().nonnegative().nullable().optional(),
   programmingNotes: nullableLongStringSchema.default(null),
   agentNotes: nullableLongStringSchema.default(null),
   agentNotesMeta: z
@@ -360,6 +372,7 @@ export const workoutSessionSchema = z
     id: z.string(),
     userId: z.string(),
     templateId: z.string().nullable(),
+    scheduledWorkoutId: requiredStringSchema.nullable().optional(),
     name: requiredStringSchema,
     date: dateSchema,
     status: workoutSessionStatusSchema,


### PR DESCRIPTION
## Outcome
Scheduled workout starts now materialize the scheduled snapshot rather than reusable template contents, preserving source identities, targets including explicit nulls, order/supersets, notes/metadata and symmetric atomic links. Shared payload construction covers start surfaces; implicit template auto-linking removed. Includes migration 0060 and regression coverage.

Fixes #134

## Independent acceptance
Approved exact SHA `587764e568b9ef8ce4ca165c827ab351db3715df` by independent Luna review. Focused API 125/125, shared 47/47, web 73/73. Independent uncached lint/typecheck/full tests/build and diff check passed. Exact-SHA browser evidence audited: 5/5 scenarios with traces, screenshots, and API/DB readbacks. No remaining findings.

Retained reports: `/tmp/pulse134-independent-review.md`, `/tmp/pulse134-independent-full-gate.log`, `/tmp/pulse-pr134-evidence/verified-final/`.

Production has NOT been deployed or repaired. Claude workflows disabled by owner because subscription cancelled; normal CI required before integration.
