### PR TITLE
fix(workouts): restore legacy progression previews and bound retries

### DIFF
--- a/apps/api/src/routes/scheduled-workouts/index.test.ts
+++ b/apps/api/src/routes/scheduled-workouts/index.test.ts
@@ -893,8 +893,8 @@ describe('scheduled workout routes', () => {
             sets: [
               {
                 setNumber: 1,
-                repsMin: 5,
-                repsMax: 5,
+                repsMin: null,
+                repsMax: null,
                 reps: 5,
                 targetWeight: 95,
                 targetWeightMin: null,
@@ -905,8 +905,8 @@ describe('scheduled workout routes', () => {
               },
               {
                 setNumber: 2,
-                repsMin: 5,
-                repsMax: 5,
+                repsMin: null,
+                repsMax: null,
                 reps: 5,
                 targetWeight: 105,
                 targetWeightMin: null,
@@ -2333,6 +2333,49 @@ describe('scheduled workout routes', () => {
       },
     });
     expect(noAuthResponse.statusCode).toBe(401);
+  });
+
+  it('canonicalizes equivalent exact rep redundancy and rejects conflicting writes', async () => {
+    const authToken = context.app.jwt.sign(
+      { sub: 'user-1', type: 'session', iss: 'pulse-api' },
+      { expiresIn: '7d' },
+    );
+    seedStructuralSnapshotTemplate();
+    const scheduledWorkoutId = await createScheduledWorkoutFromTemplate({ authToken });
+
+    const equivalentResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-sets`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        exerciseId: STRUCTURAL_EXERCISE_IDS.first,
+        sets: [{ setNumber: 1, reps: 8, repsMin: 8, repsMax: 8 }],
+      },
+    });
+    expect(equivalentResponse.statusCode).toBe(200);
+    const equivalentSet = equivalentResponse
+      .json()
+      .data.exercises.find(
+        (exercise: { exerciseId: string }) => exercise.exerciseId === STRUCTURAL_EXERCISE_IDS.first,
+      )?.sets[0];
+    expect(equivalentSet).toMatchObject({ reps: 8, repsMin: null, repsMax: null });
+
+    const conflictResponse = await context.app.inject({
+      method: 'PATCH',
+      url: `/api/v1/scheduled-workouts/${scheduledWorkoutId}/exercise-sets`,
+      headers: createAuthorizationHeader(authToken),
+      payload: {
+        exerciseId: STRUCTURAL_EXERCISE_IDS.first,
+        sets: [{ setNumber: 1, reps: 8, repsMin: 7 }],
+      },
+    });
+    expect(conflictResponse.statusCode).toBe(400);
+    expect(conflictResponse.json()).toEqual({
+      error: {
+        code: 'INVALID_REP_TARGET',
+        message: 'Rep targets must use an exact value or a valid range without conflicting fields',
+      },
+    });
   });
 
   it('returns validation and unknown-exercise errors for scheduled-workout exercise-set updates', async () => {

--- a/apps/api/src/routes/scheduled-workouts/index.ts
+++ b/apps/api/src/routes/scheduled-workouts/index.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import {
   apiDataResponseSchema,
+  canonicalizeWorkoutRepTarget,
   createScheduledWorkoutInputSchema,
   reorderScheduledWorkoutInputSchema,
   scheduledWorkoutDetailSchema,
@@ -66,6 +67,7 @@ import {
   updateScheduledWorkoutExerciseSets,
   updateScheduledWorkoutExercises,
   updateScheduledWorkout,
+  SCHEDULED_WORKOUT_INVALID_REP_TARGET,
 } from './store.js';
 
 const SCHEDULED_WORKOUT_NOT_FOUND_RESPONSE = {
@@ -162,14 +164,6 @@ const shouldMarkAgentNoteStale = ({
   newDate: string;
 }) => Math.abs(toUtcDay(newDate) - toUtcDay(scheduledDateAtGeneration)) > 2;
 
-const toExactReps = (repsMin: number | null, repsMax: number | null): number | null => {
-  if (repsMin === null || repsMax === null) {
-    return null;
-  }
-
-  return repsMin === repsMax ? repsMin : null;
-};
-
 const toSnapshotSetDrafts = ({
   sets,
   repsMin,
@@ -184,14 +178,18 @@ const toSnapshotSetDrafts = ({
   const sortedTargets = [...(setTargets ?? [])].sort(
     (left, right) => left.setNumber - right.setNumber,
   );
-  const reps = toExactReps(repsMin, repsMax);
+  const canonicalReps = canonicalizeWorkoutRepTarget({
+    reps: repsMin !== null && repsMin === repsMax ? repsMin : null,
+    repsMin,
+    repsMax,
+  });
 
   if (sortedTargets.length > 0) {
     return sortedTargets.map((target) => ({
       setNumber: target.setNumber,
-      repsMin,
-      repsMax,
-      reps,
+      repsMin: canonicalReps.repsMin ?? null,
+      repsMax: canonicalReps.repsMax ?? null,
+      reps: canonicalReps.reps ?? null,
       targetWeight: target.targetWeight ?? null,
       targetWeightMin: target.targetWeightMin ?? null,
       targetWeightMax: target.targetWeightMax ?? null,
@@ -203,9 +201,9 @@ const toSnapshotSetDrafts = ({
   const setCount = Math.max(1, sets ?? 1);
   return Array.from({ length: setCount }, (_, index) => ({
     setNumber: index + 1,
-    repsMin,
-    repsMax,
-    reps,
+    repsMin: canonicalReps.repsMin ?? null,
+    repsMax: canonicalReps.repsMax ?? null,
+    reps: canonicalReps.reps ?? null,
     targetWeight: null,
     targetWeightMin: null,
     targetWeightMax: null,
@@ -992,6 +990,14 @@ export const scheduledWorkoutRoutes: FastifyPluginAsync = async (app) => {
       }
 
       if ('error' in updated) {
+        if (updated.error === SCHEDULED_WORKOUT_INVALID_REP_TARGET) {
+          return sendError(
+            reply,
+            400,
+            'INVALID_REP_TARGET',
+            'Rep targets must use an exact value or a valid range without conflicting fields',
+          );
+        }
         return sendError(
           reply,
           400,

--- a/apps/api/src/routes/scheduled-workouts/snapshot-store.test.ts
+++ b/apps/api/src/routes/scheduled-workouts/snapshot-store.test.ts
@@ -231,6 +231,8 @@ describe('scheduled workout snapshot store', () => {
       expect(readResult.exercises[1]?.sets[0]).toMatchObject({
         targetWeight: 55,
         reps: 8,
+        repsMin: null,
+        repsMax: null,
       });
       expect(readResult.exercises[1]?.sets[1]).toMatchObject({
         targetWeight: 62.5,

--- a/apps/api/src/routes/scheduled-workouts/snapshot-store.ts
+++ b/apps/api/src/routes/scheduled-workouts/snapshot-store.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto';
 
 import { eq, inArray } from 'drizzle-orm';
+import { canonicalizeWorkoutRepTarget } from '@pulse/shared';
 
 import type {
   TemplateExerciseSetTarget,
@@ -183,14 +184,6 @@ const compareTemplateExercisesByRank =
 const compareTemplateExercises = compareTemplateExercisesByRank(SECTION_RANK);
 const compareLegacyTemplateExercises = compareTemplateExercisesByRank(LEGACY_SECTION_RANK);
 
-const toExactReps = (repsMin: number | null, repsMax: number | null): number | null => {
-  if (repsMin === null || repsMax === null) {
-    return null;
-  }
-
-  return repsMin === repsMax ? repsMin : null;
-};
-
 type SnapshotSetDraft = {
   setNumber: number;
   repsMin: number | null;
@@ -207,14 +200,18 @@ const toSnapshotSetDrafts = (row: TemplateExerciseSnapshotRow): SnapshotSetDraft
   const targets = [...(row.setTargets ?? [])].sort(
     (left, right) => left.setNumber - right.setNumber,
   );
-  const reps = toExactReps(row.repsMin, row.repsMax);
+  const canonicalReps = canonicalizeWorkoutRepTarget({
+    reps: row.repsMin !== null && row.repsMin === row.repsMax ? row.repsMin : null,
+    repsMin: row.repsMin,
+    repsMax: row.repsMax,
+  });
 
   if (targets.length > 0) {
     return targets.map((target) => ({
       setNumber: target.setNumber,
-      repsMin: row.repsMin,
-      repsMax: row.repsMax,
-      reps,
+      repsMin: canonicalReps.repsMin ?? null,
+      repsMax: canonicalReps.repsMax ?? null,
+      reps: canonicalReps.reps ?? null,
       targetWeight: target.targetWeight ?? null,
       targetWeightMin: target.targetWeightMin ?? null,
       targetWeightMax: target.targetWeightMax ?? null,
@@ -226,9 +223,9 @@ const toSnapshotSetDrafts = (row: TemplateExerciseSnapshotRow): SnapshotSetDraft
   const setCount = Math.max(1, row.sets ?? 1);
   return Array.from({ length: setCount }, (_, index) => ({
     setNumber: index + 1,
-    repsMin: row.repsMin,
-    repsMax: row.repsMax,
-    reps,
+    repsMin: canonicalReps.repsMin ?? null,
+    repsMax: canonicalReps.repsMax ?? null,
+    reps: canonicalReps.reps ?? null,
     targetWeight: null,
     targetWeightMin: null,
     targetWeightMax: null,

--- a/apps/api/src/routes/scheduled-workouts/store.ts
+++ b/apps/api/src/routes/scheduled-workouts/store.ts
@@ -1,18 +1,18 @@
 import { randomUUID } from 'node:crypto';
 
 import { and, asc, eq, gte, inArray, isNull, lte, or } from 'drizzle-orm';
-import type {
-  CreateScheduledWorkoutInput,
-  ExerciseTrackingType,
-  ReorderScheduledWorkoutInput,
-  ScheduledWorkoutDetail,
-  ScheduledWorkout,
-  ScheduledWorkoutListItem,
-  UpdateScheduledWorkoutExercisesInput,
-  UpdateScheduledWorkoutExerciseSetsInput,
-  UpdateScheduledWorkoutInput,
+import {
+  canonicalizeWorkoutRepTarget,
+  type CreateScheduledWorkoutInput,
+  type ExerciseTrackingType,
+  type ReorderScheduledWorkoutInput,
+  type ScheduledWorkoutDetail,
+  type ScheduledWorkout,
+  type ScheduledWorkoutListItem,
+  type UpdateScheduledWorkoutExercisesInput,
+  type UpdateScheduledWorkoutExerciseSetsInput,
+  type UpdateScheduledWorkoutInput,
 } from '@pulse/shared';
-
 import {
   exercises,
   type WorkoutTemplateSectionType,
@@ -341,6 +341,12 @@ const buildSetUpdatePayload = (
     >
   > = {};
 
+  const canonicalReps = canonicalizeWorkoutRepTarget({
+    reps: input.reps !== undefined ? input.reps : current.reps,
+    repsMin: input.repsMin !== undefined ? input.repsMin : current.repsMin,
+    repsMax: input.repsMax !== undefined ? input.repsMax : current.repsMax,
+  });
+
   if (input.targetWeight !== undefined && input.targetWeight !== current.targetWeight) {
     payload.targetWeight = input.targetWeight;
   }
@@ -359,14 +365,14 @@ const buildSetUpdatePayload = (
   if (input.targetZone !== undefined && input.targetZone !== current.targetZone) {
     payload.targetZone = input.targetZone;
   }
-  if (input.repsMin !== undefined && input.repsMin !== current.repsMin) {
-    payload.repsMin = input.repsMin;
+  if (canonicalReps.repsMin !== current.repsMin) {
+    payload.repsMin = canonicalReps.repsMin ?? null;
   }
-  if (input.repsMax !== undefined && input.repsMax !== current.repsMax) {
-    payload.repsMax = input.repsMax;
+  if (canonicalReps.repsMax !== current.repsMax) {
+    payload.repsMax = canonicalReps.repsMax ?? null;
   }
-  if (input.reps !== undefined && input.reps !== current.reps) {
-    payload.reps = input.reps;
+  if (canonicalReps.reps !== current.reps) {
+    payload.reps = canonicalReps.reps ?? null;
   }
 
   return payload;
@@ -374,6 +380,7 @@ const buildSetUpdatePayload = (
 
 export const SCHEDULED_WORKOUT_REORDER_INVALID_ORDER = 'invalid-order' as const;
 export const SCHEDULED_WORKOUT_UNKNOWN_EXERCISE = 'unknown-exercise' as const;
+export const SCHEDULED_WORKOUT_INVALID_REP_TARGET = 'invalid-rep-target' as const;
 
 export type ReorderScheduledWorkoutExercisesValidationError = {
   error: typeof SCHEDULED_WORKOUT_REORDER_INVALID_ORDER;
@@ -383,7 +390,7 @@ export type ReorderScheduledWorkoutExercisesValidationError = {
 };
 
 export type UpdateScheduledWorkoutExercisesValidationError = {
-  error: typeof SCHEDULED_WORKOUT_UNKNOWN_EXERCISE;
+  error: typeof SCHEDULED_WORKOUT_UNKNOWN_EXERCISE | typeof SCHEDULED_WORKOUT_INVALID_REP_TARGET;
   exerciseId: string;
 };
 
@@ -889,119 +896,138 @@ export const updateScheduledWorkoutExerciseSets = async ({
     };
   }
 
-  db.transaction((tx) => {
-    let mutated = false;
+  try {
+    db.transaction((tx) => {
+      let mutated = false;
 
-    let persistedRows = tx
-      .select(scheduledWorkoutExerciseSetMutationSelection)
-      .from(scheduledWorkoutExerciseSets)
-      .where(eq(scheduledWorkoutExerciseSets.scheduledWorkoutExerciseId, snapshotExercise.id))
-      .all()
-      .sort(sortSnapshotSets);
+      let persistedRows = tx
+        .select(scheduledWorkoutExerciseSetMutationSelection)
+        .from(scheduledWorkoutExerciseSets)
+        .where(eq(scheduledWorkoutExerciseSets.scheduledWorkoutExerciseId, snapshotExercise.id))
+        .all()
+        .sort(sortSnapshotSets);
 
-    const persistedBySetNumber = new Map(persistedRows.map((row) => [row.setNumber, row]));
+      const persistedBySetNumber = new Map(persistedRows.map((row) => [row.setNumber, row]));
 
-    for (const setUpdate of sets) {
-      const existing = persistedBySetNumber.get(setUpdate.setNumber);
-      if (setUpdate.remove === true) {
-        if (!existing) {
+      for (const setUpdate of sets) {
+        const existing = persistedBySetNumber.get(setUpdate.setNumber);
+        if (setUpdate.remove === true) {
+          if (!existing) {
+            continue;
+          }
+
+          tx.delete(scheduledWorkoutExerciseSets)
+            .where(eq(scheduledWorkoutExerciseSets.id, existing.id))
+            .run();
+          persistedBySetNumber.delete(setUpdate.setNumber);
+          mutated = true;
           continue;
         }
 
-        tx.delete(scheduledWorkoutExerciseSets)
-          .where(eq(scheduledWorkoutExerciseSets.id, existing.id))
-          .run();
-        persistedBySetNumber.delete(setUpdate.setNumber);
-        mutated = true;
-        continue;
-      }
+        if (existing) {
+          const payload = buildSetUpdatePayload(existing, setUpdate);
+          if (Object.keys(payload).length === 0) {
+            continue;
+          }
 
-      if (existing) {
-        const payload = buildSetUpdatePayload(existing, setUpdate);
-        if (Object.keys(payload).length === 0) {
+          tx.update(scheduledWorkoutExerciseSets)
+            .set(payload)
+            .where(eq(scheduledWorkoutExerciseSets.id, existing.id))
+            .run();
+
+          persistedBySetNumber.set(setUpdate.setNumber, {
+            ...existing,
+            ...payload,
+          });
+          mutated = true;
           continue;
         }
 
-        tx.update(scheduledWorkoutExerciseSets)
-          .set(payload)
-          .where(eq(scheduledWorkoutExerciseSets.id, existing.id))
-          .run();
-
-        persistedBySetNumber.set(setUpdate.setNumber, {
-          ...existing,
-          ...payload,
-        });
-        mutated = true;
-        continue;
-      }
-
-      tx.insert(scheduledWorkoutExerciseSets)
-        .values({
-          id: randomUUID(),
-          scheduledWorkoutExerciseId: snapshotExercise.id,
-          setNumber: setUpdate.setNumber,
-          targetWeight: setUpdate.targetWeight ?? null,
-          targetWeightMin: setUpdate.targetWeightMin ?? null,
-          targetWeightMax: setUpdate.targetWeightMax ?? null,
-          targetSeconds: setUpdate.targetSeconds ?? null,
-          targetDistance: setUpdate.targetDistance ?? null,
-          targetZone: setUpdate.targetZone ?? null,
+        const canonicalReps = canonicalizeWorkoutRepTarget({
+          reps: setUpdate.reps ?? null,
           repsMin: setUpdate.repsMin ?? null,
           repsMax: setUpdate.repsMax ?? null,
-          reps: setUpdate.reps ?? null,
-        })
-        .run();
-      mutated = true;
-    }
+        });
 
-    persistedRows = tx
-      .select(scheduledWorkoutExerciseSetMutationSelection)
-      .from(scheduledWorkoutExerciseSets)
-      .where(eq(scheduledWorkoutExerciseSets.scheduledWorkoutExerciseId, snapshotExercise.id))
-      .all()
-      .sort(sortSnapshotSets);
+        tx.insert(scheduledWorkoutExerciseSets)
+          .values({
+            id: randomUUID(),
+            scheduledWorkoutExerciseId: snapshotExercise.id,
+            setNumber: setUpdate.setNumber,
+            targetWeight: setUpdate.targetWeight ?? null,
+            targetWeightMin: setUpdate.targetWeightMin ?? null,
+            targetWeightMax: setUpdate.targetWeightMax ?? null,
+            targetSeconds: setUpdate.targetSeconds ?? null,
+            targetDistance: setUpdate.targetDistance ?? null,
+            targetZone: setUpdate.targetZone ?? null,
+            repsMin: canonicalReps.repsMin ?? null,
+            repsMax: canonicalReps.repsMax ?? null,
+            reps: canonicalReps.reps ?? null,
+          })
+          .run();
+        mutated = true;
+      }
 
-    const renumberUpdates = persistedRows
-      .map((row, index) => ({
-        id: row.id,
-        currentSetNumber: row.setNumber,
-        nextSetNumber: index + 1,
-      }))
-      .filter((row) => row.currentSetNumber !== row.nextSetNumber);
+      persistedRows = tx
+        .select(scheduledWorkoutExerciseSetMutationSelection)
+        .from(scheduledWorkoutExerciseSets)
+        .where(eq(scheduledWorkoutExerciseSets.scheduledWorkoutExerciseId, snapshotExercise.id))
+        .all()
+        .sort(sortSnapshotSets);
 
-    if (renumberUpdates.length > 0) {
-      const maxPersistedSetNumber = persistedRows.reduce(
-        (maxValue, row) => Math.max(maxValue, row.setNumber),
-        0,
-      );
-      const tempOffset = maxPersistedSetNumber + persistedRows.length + 1_000;
+      const renumberUpdates = persistedRows
+        .map((row, index) => ({
+          id: row.id,
+          currentSetNumber: row.setNumber,
+          nextSetNumber: index + 1,
+        }))
+        .filter((row) => row.currentSetNumber !== row.nextSetNumber);
 
-      for (const update of renumberUpdates) {
-        tx.update(scheduledWorkoutExerciseSets)
-          .set({ setNumber: update.nextSetNumber + tempOffset })
-          .where(eq(scheduledWorkoutExerciseSets.id, update.id))
+      if (renumberUpdates.length > 0) {
+        const maxPersistedSetNumber = persistedRows.reduce(
+          (maxValue, row) => Math.max(maxValue, row.setNumber),
+          0,
+        );
+        const tempOffset = maxPersistedSetNumber + persistedRows.length + 1_000;
+
+        for (const update of renumberUpdates) {
+          tx.update(scheduledWorkoutExerciseSets)
+            .set({ setNumber: update.nextSetNumber + tempOffset })
+            .where(eq(scheduledWorkoutExerciseSets.id, update.id))
+            .run();
+        }
+
+        for (const update of renumberUpdates) {
+          tx.update(scheduledWorkoutExerciseSets)
+            .set({ setNumber: update.nextSetNumber })
+            .where(eq(scheduledWorkoutExerciseSets.id, update.id))
+            .run();
+        }
+
+        mutated = true;
+      }
+
+      if (mutated) {
+        tx.update(scheduledWorkouts)
+          .set({ updatedAt: Date.now() })
+          .where(eq(scheduledWorkouts.id, scheduledWorkoutId))
           .run();
       }
 
-      for (const update of renumberUpdates) {
-        tx.update(scheduledWorkoutExerciseSets)
-          .set({ setNumber: update.nextSetNumber })
-          .where(eq(scheduledWorkoutExerciseSets.id, update.id))
-          .run();
-      }
-
-      mutated = true;
+      return mutated;
+    });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error.message === 'INVALID_REP_TARGET' || error.message === 'CONFLICTING_REP_TARGET')
+    ) {
+      return {
+        error: SCHEDULED_WORKOUT_INVALID_REP_TARGET,
+        exerciseId,
+      };
     }
-
-    if (mutated) {
-      tx.update(scheduledWorkouts)
-        .set({ updatedAt: Date.now() })
-        .where(eq(scheduledWorkouts.id, scheduledWorkoutId))
-        .run();
-    }
-
-    return mutated;
-  });
+    throw error;
+  }
 
   const detail = await buildScheduledWorkoutDetail({
     scheduledWorkoutId,

--- a/apps/api/src/routes/workout-progression/index.test.ts
+++ b/apps/api/src/routes/workout-progression/index.test.ts
@@ -222,6 +222,47 @@ describe('workout progression routes', () => {
     }
   });
 
+  it('returns 200 partial invalid evidence with source diagnostics identically for both actors', async () => {
+    const invalid: WorkoutProgressionRecommendation = {
+      ...recommendation,
+      id: 'invalid-recommendation',
+      confidence: 'unavailable',
+      decision: 'hold',
+      reasonCodes: ['INVALID_CURRENT_TARGET'],
+      recommendedTargets: [],
+      evidence: {
+        ...recommendation.evidence,
+        scheduledWorkoutExerciseId: 'invalid-exercise',
+        priorTargets: [],
+        diagnostics: [
+          {
+            reason: 'INVALID_CURRENT_TARGET',
+            source: 'current_scheduled_target',
+            setId: 'bad-set',
+            setNumber: 1,
+            raw: { reps: 8, repsMin: 6, repsMax: 8 },
+          },
+        ],
+      },
+    };
+    vi.mocked(previewWorkoutProgression).mockResolvedValue([recommendation, invalid]);
+    const { app, jwt } = await withAuth();
+    try {
+      for (const authorization of [`Bearer ${jwt}`, 'AgentToken agent-secret']) {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/v1/workout-progression/preview',
+          headers: { authorization },
+          payload: { scheduledWorkoutId: 'scheduled-1' },
+        });
+        expect(response.statusCode).toBe(200);
+        expect(response.json().data.recommendations).toEqual([recommendation, invalid]);
+      }
+    } finally {
+      await app.close();
+    }
+  });
+
   it('passes authenticated AgentToken provenance and idempotency input to the action store', async () => {
     vi.mocked(applyWorkoutProgressionAction).mockResolvedValue(action);
     const { app } = await withAuth();

--- a/apps/api/src/routes/workout-progression/store.integration.test.ts
+++ b/apps/api/src/routes/workout-progression/store.integration.test.ts
@@ -170,6 +170,214 @@ afterEach(async () => {
 });
 
 describe('workout progression store', () => {
+  it.each([
+    { action: 'accept', both: false },
+    { action: 'edit', both: false },
+    { action: 'accept', both: true },
+    { action: 'edit', both: true },
+  ] as const)(
+    'keeps a legacy recommendation %j after material canonicalization',
+    async ({ action, both }) => {
+      const file = prepareDatabase();
+      const sql = new Database(file);
+      sql.exec('UPDATE scheduled_workout_exercise_sets SET reps=8, reps_min=8, reps_max=8');
+      if (both) {
+        sql.exec('UPDATE session_sets SET target_reps=8, target_reps_min=8, target_reps_max=8');
+        sql.exec(
+          "UPDATE workout_progression_configurations SET revision=revision+1, snapshot=json_set(snapshot, '$.revision', 2, '$.policy.family', 'strength_load', '$.policy.loadIncreasePercent', 25)",
+        );
+      }
+      const store = await loadStore();
+      const input = { scheduledWorkoutId: 'scheduled-1', userId: 'user-1', generatedAt: 500 };
+      const preview = (await store.previewWorkoutProgression(input))?.[0];
+      if (!preview) throw new Error('Missing preview');
+      expect(preview.confidence).toBe('supported');
+      await store.applyWorkoutProgressionAction({
+        actor: { id: 'user-1', label: 'You', type: 'user' },
+        userId: 'user-1',
+        recommendationId: preview.id,
+        input: {
+          action,
+          expectedFingerprint: preview.sourceFingerprint,
+          idempotencyKey: `legacy-${action}`,
+          editedTargets:
+            action === 'edit'
+              ? preview.recommendedTargets.map((target) => ({ ...target, weight: 22.5 }))
+              : null,
+          reason: null,
+        },
+      });
+      expect(await store.getWorkoutProgressionRecommendation('user-1', preview.id)).toMatchObject({
+        state: action === 'accept' ? 'accepted' : 'edited',
+        staleAt: null,
+        evidence: preview.evidence,
+      });
+      expect((await store.previewWorkoutProgression(input))?.[0]?.id).toBe(preview.id);
+      expect(
+        sql.prepare('SELECT reps, reps_min, reps_max FROM scheduled_workout_exercise_sets').all(),
+      ).toEqual([
+        { reps: 8, reps_min: null, reps_max: null },
+        { reps: 8, reps_min: null, reps_max: null },
+      ]);
+      sql.close();
+    },
+  );
+
+  it.each(['current', 'historical'] as const)(
+    'normalizes persisted equal redundancy in %s evidence without rewriting rows',
+    async (source) => {
+      const file = prepareDatabase();
+      const sql = new Database(file);
+      if (source === 'current')
+        sql.exec('UPDATE scheduled_workout_exercise_sets SET reps=8, reps_min=8, reps_max=8');
+      else sql.exec('UPDATE session_sets SET target_reps=8, target_reps_min=8, target_reps_max=8');
+      const before = sql
+        .prepare(
+          source === 'current'
+            ? 'SELECT * FROM scheduled_workout_exercise_sets'
+            : 'SELECT * FROM session_sets',
+        )
+        .all();
+      const store = await loadStore();
+      const input = { scheduledWorkoutId: 'scheduled-1', userId: 'user-1', generatedAt: 500 };
+      const first = (await store.previewWorkoutProgression(input))?.[0];
+      if (!first) throw new Error('Missing preview');
+      expect(first.evidence.diagnostics).toHaveLength(2);
+      expect(first.evidence.diagnostics?.every((d) => d.reason === 'REDUNDANT_EXACT_REPS')).toBe(
+        true,
+      );
+      const canonical =
+        source === 'current'
+          ? first.evidence.priorTargets
+          : first.evidence.performance.map((set) => set.prescribed);
+      expect(
+        canonical.every((set) => set.reps === 8 && set.repsMin === null && set.repsMax === null),
+      ).toBe(true);
+      expect((await store.previewWorkoutProgression(input))?.[0]).toEqual(first);
+      expect(
+        sql
+          .prepare(
+            source === 'current'
+              ? 'SELECT * FROM scheduled_workout_exercise_sets'
+              : 'SELECT * FROM session_sets',
+          )
+          .all(),
+      ).toEqual(before);
+      sql.close();
+    },
+  );
+
+  it.each(['current', 'historical'] as const)(
+    'isolates conflicting %s evidence and blocks material actions',
+    async (source) => {
+      const file = prepareDatabase();
+      const sql = new Database(file);
+      sql.exec(
+        "INSERT INTO scheduled_workout_exercises (id, scheduled_workout_id, exercise_id, exercise_name_snapshot, tracking_type_snapshot, section, order_index, created_at, updated_at) VALUES ('valid-exercise', 'scheduled-1', 'exercise-1', 'Valid exercise', 'weight_reps', 'main', 1, 200, 200)",
+      );
+      sql.exec(
+        "INSERT INTO scheduled_workout_exercise_sets (id, scheduled_workout_exercise_id, set_number, reps_min, reps_max, target_weight, created_at) VALUES ('valid-set', 'valid-exercise', 1, 8, 10, 20, 200)",
+      );
+      if (source === 'current')
+        sql.exec(
+          "UPDATE scheduled_workout_exercise_sets SET reps=8, reps_min=6, reps_max=8 WHERE scheduled_workout_exercise_id='scheduled-exercise-1'",
+        );
+      else sql.exec('UPDATE session_sets SET target_reps=8, target_reps_min=6, target_reps_max=8');
+      const config = sql
+        .prepare(
+          "SELECT snapshot FROM workout_progression_configurations WHERE id='configuration-1'",
+        )
+        .get() as { snapshot: string };
+      const validConfig = {
+        ...JSON.parse(config.snapshot),
+        id: 'valid-configuration',
+        scheduledWorkoutExerciseId: 'valid-exercise',
+      };
+      sql
+        .prepare(
+          "INSERT INTO workout_progression_configurations (id,user_id,scheduled_workout_id,scheduled_workout_exercise_id,revision,snapshot,actor_type,actor_label,updated_at) VALUES ('valid-configuration','user-1','scheduled-1','valid-exercise',1,?,'user','You',450)",
+        )
+        .run(JSON.stringify(validConfig));
+      const before = sql.prepare('SELECT * FROM scheduled_workout_exercise_sets').all();
+      const store = await loadStore();
+      const results = await store.previewWorkoutProgression({
+        scheduledWorkoutId: 'scheduled-1',
+        userId: 'user-1',
+        generatedAt: 500,
+      });
+      expect(results).toHaveLength(2);
+      const invalid = results?.[0];
+      const valid = results?.[1];
+      if (!invalid || !valid) throw new Error('Missing exercise result');
+      expect(invalid).toMatchObject({
+        confidence: 'unavailable',
+        decision: 'hold',
+        reasonCodes: [
+          source === 'current' ? 'INVALID_CURRENT_TARGET' : 'INVALID_HISTORICAL_PRESCRIPTION',
+        ],
+      });
+      expect(invalid.evidence.diagnostics?.[0]?.raw).toMatchObject({
+        reps: 8,
+        repsMin: 6,
+        repsMax: 8,
+      });
+      if (source === 'current')
+        expect(valid).toMatchObject({ confidence: 'supported', decision: 'increase' });
+      for (const action of ['accept', 'edit'] as const) {
+        await expect(
+          store.applyWorkoutProgressionAction({
+            actor: { id: 'user-1', label: 'You', type: 'user' },
+            userId: 'user-1',
+            recommendationId: invalid.id,
+            input: {
+              action,
+              expectedFingerprint: invalid.sourceFingerprint,
+              idempotencyKey: `invalid-${action}`,
+              editedTargets: action === 'edit' ? valid.evidence.priorTargets : null,
+              reason: null,
+            },
+          }),
+        ).rejects.toBeInstanceOf(store.WorkoutProgressionInvalidEditError);
+      }
+      expect(sql.prepare('SELECT * FROM scheduled_workout_exercise_sets').all()).toEqual(before);
+      const held = await store.applyWorkoutProgressionAction({
+        actor: { id: 'user-1', label: 'You', type: 'user' },
+        userId: 'user-1',
+        recommendationId: invalid.id,
+        input: {
+          action: 'hold',
+          expectedFingerprint: invalid.sourceFingerprint,
+          idempotencyKey: 'invalid-hold',
+          editedTargets: null,
+          reason: 'Review source prescription',
+        },
+      });
+      expect(held.action).toBe('hold');
+      expect(sql.prepare('SELECT * FROM scheduled_workout_exercise_sets').all()).toEqual(before);
+      sql.close();
+    },
+  );
+
+  it('distinguishes no completed history from missing policy and malformed prescriptions', async () => {
+    const file = prepareDatabase();
+    const sql = new Database(file);
+    sql.exec('DELETE FROM session_sets');
+    sql.close();
+    const store = await loadStore();
+    const result = (
+      await store.previewWorkoutProgression({ scheduledWorkoutId: 'scheduled-1', userId: 'user-1' })
+    )?.[0];
+    expect(result).toMatchObject({
+      confidence: 'unavailable',
+      reasonCodes: ['NO_COMPLETED_HISTORY'],
+      evidence: {
+        policySource: { type: 'programming_config' },
+        performance: [],
+        sourceSessionId: null,
+      },
+    });
+  });
+
   it('fails closed without an explicit programming policy and blocks target application', async () => {
     const databaseUrl = prepareDatabase();
     const lifecycleDb = new Database(databaseUrl);

--- a/apps/api/src/routes/workout-progression/store.ts
+++ b/apps/api/src/routes/workout-progression/store.ts
@@ -5,6 +5,10 @@ import {
   configureWorkoutProgressionInputSchema,
   evaluateWorkoutProgression,
   sha256Hex,
+  validateWorkoutProgressionTarget,
+  workoutProgressionPerformanceSetSchema,
+  type WorkoutProgressionDiagnostic,
+  type WorkoutProgressionPerformanceSet,
   workoutProgressionActionSchema,
   workoutProgressionEvidenceSchema,
   workoutProgressionConfigurationSchema,
@@ -268,10 +272,10 @@ function buildEvidenceForScheduledWorkout(
   const evidence: WorkoutProgressionEvidence[] = [];
   for (const exerciseRow of exerciseRows) {
     if (exerciseRow.exerciseName === null || exerciseRow.trackingType === null) continue;
-    const priorTargets = orderedTargets(
+    const rawPriorTargets = orderedTargets(
       targetsByScheduledExercise.get(exerciseRow.scheduledWorkoutExerciseId) ?? [],
     );
-    if (priorTargets.length === 0) {
+    if (rawPriorTargets.length === 0) {
       continue;
     }
 
@@ -300,7 +304,7 @@ function buildEvidenceForScheduledWorkout(
       .limit(1)
       .get();
 
-    const performance = latestSession
+    const rawPerformance = latestSession
       ? client
           .select({
             completed: sessionSets.completed,
@@ -365,6 +369,66 @@ function buildEvidenceForScheduledWorkout(
           }))
       : [];
 
+    const diagnostics: WorkoutProgressionDiagnostic[] = [];
+    const priorTargets: WorkoutProgressionTarget[] = [];
+    for (const raw of rawPriorTargets) {
+      const result = validateWorkoutProgressionTarget(raw, 'current_scheduled_target');
+      if (result.diagnostic) diagnostics.push(result.diagnostic);
+      if (result.target) priorTargets.push(result.target);
+    }
+    const performance: WorkoutProgressionPerformanceSet[] = [];
+    for (const raw of rawPerformance) {
+      const result = validateWorkoutProgressionTarget(
+        raw.prescribed,
+        'historical_prescribed_target',
+      );
+      if (result.diagnostic)
+        diagnostics.push({
+          ...result.diagnostic,
+          ...(!result.target
+            ? {
+                observed: Object.fromEntries(
+                  Object.entries(raw)
+                    .filter(([key]) => key !== 'prescribed')
+                    .map(([key, value]) => [
+                      key,
+                      typeof value === 'number' && Number.isFinite(value)
+                        ? value
+                        : value === null
+                          ? null
+                          : String(value),
+                    ]),
+                ),
+              }
+            : {}),
+        });
+      if (!result.target) continue;
+      const parsed = workoutProgressionPerformanceSetSchema.safeParse({
+        ...raw,
+        prescribed: result.target,
+      });
+      if (parsed.success) performance.push(parsed.data);
+      else
+        diagnostics.push({
+          reason: 'INVALID_HISTORICAL_PRESCRIPTION',
+          source: 'historical_prescribed_target',
+          setId: raw.setId,
+          setNumber: Number.isFinite(raw.setNumber) ? raw.setNumber : null,
+          raw: Object.fromEntries(
+            Object.entries(raw)
+              .filter(([key]) => key !== 'prescribed')
+              .map(([key, value]) => [
+                key,
+                typeof value === 'number' && Number.isFinite(value)
+                  ? value
+                  : value === null
+                    ? null
+                    : String(value),
+              ]),
+          ),
+        });
+    }
+
     const configurationRow = client
       .select({ snapshot: workoutProgressionConfigurations.snapshot })
       .from(workoutProgressionConfigurations)
@@ -409,6 +473,7 @@ function buildEvidenceForScheduledWorkout(
 
     evidence.push(
       workoutProgressionEvidenceSchema.parse({
+        ...(diagnostics.length ? { diagnostics } : {}),
         exerciseId: exerciseRow.exerciseId,
         exerciseName: exerciseRow.exerciseName,
         performance,
@@ -598,6 +663,18 @@ function evidenceMatchesDecision(
     current.trackingType === snapshot.evidence.trackingType &&
     current.sourceSessionId === snapshot.evidence.sourceSessionId &&
     current.sourceSessionDate === snapshot.evidence.sourceSessionDate &&
+    stableJson(
+      (current.diagnostics ?? []).filter(
+        (item) =>
+          !(item.source === 'current_scheduled_target' && item.reason === 'REDUNDANT_EXACT_REPS'),
+      ),
+    ) ===
+      stableJson(
+        (snapshot.evidence.diagnostics ?? []).filter(
+          (item) =>
+            !(item.source === 'current_scheduled_target' && item.reason === 'REDUNDANT_EXACT_REPS'),
+        ),
+      ) &&
     stableJson(current.performance) === stableJson(snapshot.evidence.performance) &&
     stableJson(current.priorTargets) === stableJson(expectedTargets) &&
     stableJson(current.context) === stableJson(snapshot.evidence.context) &&

--- a/apps/api/src/routes/workout-sessions/index.test.ts
+++ b/apps/api/src/routes/workout-sessions/index.test.ts
@@ -4353,26 +4353,67 @@ describe('workout session routes', () => {
     ).toBeNull();
   });
 
-  it('rejects invalid stored snapshot targets before creating or linking any session', async () => {
+  it('copies redundant legacy scheduled reps canonically while retaining source identity and source rows', async () => {
     seedProvenanceFixture();
     context.db
       .update(scheduledWorkoutExerciseSets)
-      .set({ targetSeconds: 2147483647 })
+      .set({ reps: 8, repsMin: 8, repsMax: 8 })
       .where(eq(scheduledWorkoutExerciseSets.id, 'proof-set-0-0'))
       .run();
     const response = await proofStart();
-    expect(response.statusCode).toBe(400);
-    expect(response.json().error.code).toBe('INVALID_SCHEDULED_SNAPSHOT');
-    expect(context.db.select().from(workoutSessions).all()).toHaveLength(0);
-    expect(context.db.select().from(sessionSets).all()).toHaveLength(0);
+    expect(response.statusCode, response.body).toBe(201);
     expect(
       context.db
         .select()
-        .from(scheduledWorkouts)
-        .where(eq(scheduledWorkouts.id, 'proof-schedule'))
-        .get()?.sessionId,
-    ).toBeNull();
+        .from(sessionSets)
+        .where(eq(sessionSets.sourceScheduledSetId, 'proof-set-0-0'))
+        .get(),
+    ).toMatchObject({
+      targetReps: 8,
+      targetRepsMin: null,
+      targetRepsMax: null,
+      sourceScheduledSetId: 'proof-set-0-0',
+    });
+    expect(
+      context.db
+        .select()
+        .from(scheduledWorkoutExerciseSets)
+        .where(eq(scheduledWorkoutExerciseSets.id, 'proof-set-0-0'))
+        .get(),
+    ).toMatchObject({ reps: 8, repsMin: 8, repsMax: 8 });
   });
+
+  it.each([
+    { targetSeconds: 2147483647 },
+    { reps: 8, repsMin: 6, repsMax: 8 },
+    { reps: 8, repsMin: 8, repsMax: 10 },
+    { reps: null, repsMin: 10, repsMax: 6 },
+  ])(
+    'rejects invalid stored snapshot targets %j before creating or linking any session',
+    async (targets) => {
+      seedProvenanceFixture();
+      // Test-only corruption fixture: exercise the legacy read boundary, beyond new-write CHECKs.
+      context.sqlite.pragma('ignore_check_constraints = ON');
+      context.db
+        .update(scheduledWorkoutExerciseSets)
+        .set(targets)
+        .where(eq(scheduledWorkoutExerciseSets.id, 'proof-set-0-0'))
+        .run();
+      context.sqlite.pragma('ignore_check_constraints = OFF');
+      const response = await proofStart();
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.code).toBe('INVALID_SCHEDULED_SNAPSHOT');
+      expect(context.db.select().from(workoutSessions).all()).toHaveLength(0);
+      expect(context.db.select().from(sessionSets).all()).toHaveLength(0);
+      expect(
+        context.db
+          .select()
+          .from(scheduledWorkouts)
+          .where(eq(scheduledWorkouts.id, 'proof-schedule'))
+          .get()?.sessionId,
+      ).toBeNull();
+    },
+  );
 
   it('allows exactly one concurrent scheduled start and leaves no orphan session or sets', async () => {
     seedProvenanceFixture();

--- a/apps/api/src/routes/workout-sessions/index.ts
+++ b/apps/api/src/routes/workout-sessions/index.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import {
   apiDataResponseSchema,
+  canonicalizeWorkoutRepTarget,
   batchUpsertSetsSchema,
   createSetSchema,
   createWorkoutSessionInputSchema,
@@ -892,6 +893,15 @@ export const workoutSessionRoutes: FastifyPluginAsync = async (app) => {
         const validSnapshotSets = input.sets.every((set) => {
           const key = `${set.section ?? 'main'}::${set.exerciseId}::${set.setNumber}`;
           const facts = setSnapshotFactsByKey?.[key];
+          try {
+            canonicalizeWorkoutRepTarget({
+              reps: facts?.targetReps,
+              repsMin: facts?.targetRepsMin,
+              repsMax: facts?.targetRepsMax,
+            });
+          } catch {
+            return false;
+          }
           return sessionSetSchema.safeParse({
             ...set,
             ...facts,

--- a/apps/api/src/routes/workout-sessions/store.ts
+++ b/apps/api/src/routes/workout-sessions/store.ts
@@ -14,7 +14,7 @@ import {
   sql,
   type SQL,
 } from 'drizzle-orm';
-import { supportsRirTrackingType } from '@pulse/shared';
+import { canonicalizeWorkoutRepTarget, supportsRirTrackingType } from '@pulse/shared';
 import type {
   BatchUpsertSetsInput,
   CreateSetInput,
@@ -519,6 +519,11 @@ const buildSessionSetRows = (
   sets.map((set) => {
     const key = `${set.section ?? 'main'}::${set.exerciseId}::${set.setNumber}`;
     const fact = factsByKey[key];
+    const canonicalTarget = canonicalizeWorkoutRepTarget({
+      reps: fact?.targetReps ?? null,
+      repsMin: fact?.targetRepsMin ?? null,
+      repsMax: fact?.targetRepsMax ?? null,
+    });
     return {
       id: idsByKey[key] ?? randomUUID(),
       sessionId,
@@ -537,9 +542,9 @@ const buildSessionSetRows = (
       targetWeightMax: fact ? fact.targetWeightMax : (set.targetWeightMax ?? null),
       targetSeconds: fact ? fact.targetSeconds : (set.targetSeconds ?? null),
       targetDistance: fact ? fact.targetDistance : (set.targetDistance ?? null),
-      targetRepsMin: fact?.targetRepsMin ?? null,
-      targetRepsMax: fact?.targetRepsMax ?? null,
-      targetReps: fact?.targetReps ?? null,
+      targetRepsMin: canonicalTarget.repsMin ?? null,
+      targetRepsMax: canonicalTarget.repsMax ?? null,
+      targetReps: canonicalTarget.reps ?? null,
       targetZone: fact?.targetZone ?? null,
       sourceScheduledSetId: fact?.sourceScheduledSetId ?? null,
       exerciseIdSnapshot: fact ? fact.exerciseIdSnapshot : set.exerciseId,

--- a/apps/web/e2e/progression-preview-compatibility.spec.ts
+++ b/apps/web/e2e/progression-preview-compatibility.spec.ts
@@ -1,0 +1,406 @@
+import { execFileSync } from 'node:child_process';
+import { lstatSync, realpathSync, mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { expect, request, test, type APIRequestContext, type Page } from '@playwright/test';
+
+import { setAuthenticatedSession } from './auth-session';
+import { apiBaseURL } from './test-env';
+
+test.use({ timezoneId: 'America/Detroit' });
+
+const username = 'adaptive-preview-wp-accept';
+const password = 'adaptive-preview-only';
+const scheduledDate = '2026-08-24';
+const repoRoot = resolve(__dirname, '../../..');
+const artifactDirectory = resolve(repoRoot, 'logs/progression-preview/chrome');
+
+type Target = {
+  setId: string;
+  setNumber: number;
+  reps: number | null;
+  repsMin: number | null;
+  repsMax: number | null;
+  [key: string]: unknown;
+};
+
+type Performance = {
+  setId: string;
+  setNumber: number;
+  prescribed: Target;
+  [key: string]: unknown;
+};
+
+type Recommendation = {
+  evidence: {
+    priorTargets: Target[];
+    performance: Performance[];
+    policy: Record<string, unknown>;
+    policySource: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+  recommendedTargets: Target[];
+  [key: string]: unknown;
+};
+
+type PreviewPayload = { recommendations: Recommendation[] };
+
+let api: APIRequestContext;
+let token: string;
+let scheduledWorkoutId: string;
+
+function gitMetadata() {
+  return {
+    commitSha: execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(),
+    branch: execFileSync('git', ['branch', '--show-current'], { encoding: 'utf8' }).trim(),
+    workingTreeDirty:
+      execFileSync('git', ['status', '--porcelain'], { encoding: 'utf8' }).trim().length > 0,
+  };
+}
+
+async function writeScreenshot(page: Page, name: string, viewport: number, phase: string) {
+  mkdirSync(artifactDirectory, { recursive: true });
+  const filename = `${name}-${viewport}.png`;
+  await page.screenshot({ fullPage: true, path: resolve(artifactDirectory, filename) });
+  writeFileSync(
+    resolve(artifactDirectory, `${name}-${viewport}.json`),
+    `${JSON.stringify(
+      {
+        ...gitMetadata(),
+        fixture: 'adaptive-preview-wp-accept plus isolated browser response scenario',
+        scenario: name,
+        viewport: { width: viewport, height: 1000 },
+        phase,
+        screenshot: filename,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+async function loginAndFindWorkout() {
+  const login = await api.post('/api/v1/auth/login', { data: { username, password } });
+  expect(login.ok(), await login.text()).toBeTruthy();
+  token = ((await login.json()) as { data: { token: string } }).data.token;
+  const workouts = await api.get(
+    `/api/v1/scheduled-workouts?from=${scheduledDate}&to=${scheduledDate}`,
+    { headers: { authorization: `Bearer ${token}` } },
+  );
+  expect(workouts.ok(), await workouts.text()).toBeTruthy();
+  const data = (await workouts.json()) as { data: Array<{ id: string }> };
+  expect(data.data).toHaveLength(1);
+  scheduledWorkoutId = data.data[0]?.id ?? '';
+  expect(scheduledWorkoutId).toBeTruthy();
+}
+
+function injectPersistedLegacyTargets(repsMin: 6 | 8 = 8) {
+  const configuredDatabase = process.env.E2E_DATABASE_URL;
+  if (!configuredDatabase) throw new Error('Explicit isolated E2E_DATABASE_URL required');
+  const database = resolve(process.cwd(), configuredDatabase);
+  const allowedNames = new Set(['pulse-tdee-dev.db', 'pulse-e2e.db', 'pulse-progression-e2e.db']);
+  if (
+    !allowedNames.has(database.split('/').pop() ?? '') ||
+    !database.startsWith(`${repoRoot}/`) ||
+    lstatSync(database).isSymbolicLink() ||
+    realpathSync(database) !== database
+  ) {
+    throw new Error(
+      `Refusing legacy fixture injection outside an isolated E2E database: ${database}`,
+    );
+  }
+  const sql = `
+    UPDATE scheduled_workout_exercise_sets
+    SET reps = 8, reps_min = ${repsMin}, reps_max = 8
+    WHERE scheduled_workout_exercise_id IN (
+      SELECT swe.id
+      FROM scheduled_workout_exercises swe
+      JOIN scheduled_workouts sw ON sw.id = swe.scheduled_workout_id
+      JOIN users u ON u.id = sw.user_id
+      WHERE u.username = '${username}' AND sw.date = '${scheduledDate}'
+    );
+    UPDATE session_sets
+    SET target_reps = 8, target_reps_min = 8, target_reps_max = 8
+    WHERE session_id IN (
+      SELECT ws.id
+      FROM workout_sessions ws
+      JOIN users u ON u.id = ws.user_id
+      WHERE u.username = '${username}'
+    );
+  `;
+  execFileSync('sqlite3', [database, sql], { encoding: 'utf8' });
+}
+
+async function scheduledTargets() {
+  const response = await api.get(`/api/v1/scheduled-workouts/${scheduledWorkoutId}`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  expect(response.ok(), await response.text()).toBeTruthy();
+  const payload = (await response.json()) as {
+    data: { exercises: Array<{ sets: Array<Record<string, unknown>> }> };
+  };
+  return payload.data.exercises.flatMap((exercise) => exercise.sets);
+}
+
+async function openReview(page: Page, width: number) {
+  await page.setViewportSize({ width, height: 1000 });
+  await setAuthenticatedSession(page, token);
+  await page.goto(`/workouts/scheduled/${scheduledWorkoutId}`, { waitUntil: 'domcontentloaded' });
+  await expect(page.getByRole('heading', { name: 'Progression review' })).toBeVisible();
+}
+
+async function basePreviewWithScenario(
+  page: Page,
+  scenario: (payload: PreviewPayload) => PreviewPayload,
+) {
+  await page.route('**/api/v1/workout-progression/preview', async (route) => {
+    const response = await route.fetch();
+    const payload = (await response.json()) as { data: PreviewPayload };
+    await route.fulfill({
+      response,
+      body: JSON.stringify({ data: scenario(payload.data) }),
+      contentType: 'application/json',
+    });
+  });
+}
+
+function noPolicyResponse(payload: PreviewPayload): PreviewPayload {
+  const recommendation = payload.recommendations[0];
+  if (!recommendation) throw new Error('Progression fixture has no recommendation');
+  return {
+    recommendations: [
+      {
+        ...recommendation,
+        decision: 'hold',
+        confidence: 'unavailable',
+        reasonCodes: ['MISSING_POLICY'],
+        facts: ['No progression policy is configured for this exercise.'],
+        evidence: {
+          ...recommendation.evidence,
+          policy: {
+            family: 'unsupported',
+            version: 1,
+            loadIncrement: null,
+            loadIncreasePercent: null,
+            repRangeMin: null,
+            repRangeMax: null,
+            effortCeiling: null,
+            lowEffortThreshold: null,
+            secondsStep: null,
+            distanceStep: null,
+            zoneCeiling: null,
+            allowReduction: false,
+            contextRequired: false,
+          },
+          policySource: {
+            type: 'none',
+            configurationId: null,
+            revision: 0,
+            configuredAt: null,
+            actorType: null,
+            actorId: null,
+            actorLabel: null,
+          },
+        },
+        recommendedTargets: recommendation.evidence.priorTargets,
+      },
+    ],
+  };
+}
+
+test.describe.serial('installed Chrome progression preview compatibility', () => {
+  test.beforeAll(async () => {
+    api = await request.newContext({ baseURL: apiBaseURL });
+    injectPersistedLegacyTargets();
+    await loginAndFindWorkout();
+  });
+
+  test.afterAll(async () => {
+    await api.dispose();
+  });
+
+  test('serves a persisted legacy exact plus equal bounds fixture without a 500', async () => {
+    const response = await api.post('/api/v1/workout-progression/preview', {
+      data: { scheduledWorkoutId },
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(response.status(), await response.text()).toBe(200);
+    const payload = (await response.json()) as { data: PreviewPayload };
+    const recommendation = payload.data.recommendations[0];
+    expect(recommendation).toBeDefined();
+    expect(recommendation?.evidence.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          reason: 'REDUNDANT_EXACT_REPS',
+          source: 'current_scheduled_target',
+        }),
+        expect.objectContaining({
+          reason: 'REDUNDANT_EXACT_REPS',
+          source: 'historical_prescribed_target',
+        }),
+      ]),
+    );
+  });
+
+  test('renders legacy exact plus redundant bounds at mobile and desktop widths without changing the plan', async ({
+    page,
+  }) => {
+    const before = await scheduledTargets();
+
+    for (const width of [320, 1280]) {
+      await openReview(page, width);
+      await expect(page.getByText(/Legacy exact-reps bounds were normalized/u)).toHaveCount(4);
+      await expect(page.getByRole('button', { name: 'Accept targets' })).toBeVisible();
+      await expect(page.getByText(/Nothing changes until you choose an action/u)).toBeVisible();
+      expect(
+        await page.evaluate(
+          () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+        ),
+      ).toBe(true);
+      for (const button of await page
+        .getByRole('button', { name: /^(Accept targets|Edit|Keep current|Hold with reason)$/u })
+        .all()) {
+        expect((await button.boundingBox())?.height).toBeGreaterThanOrEqual(44);
+      }
+      await writeScreenshot(page, 'legacy-success-pre-action', width, 'pre-action');
+      if (width === 320) {
+        await page.getByRole('region', { name: /comparison scroll area/u }).evaluate((node) => {
+          node.scrollLeft = node.scrollWidth;
+        });
+        await writeScreenshot(page, 'legacy-comparison-right-pre-action', width, 'pre-action');
+      }
+      await page.reload({ waitUntil: 'domcontentloaded' });
+    }
+    expect(await scheduledTargets()).toEqual(before);
+  });
+
+  test('reopening the same plan within the app reuses the preview without a new POST', async ({
+    page,
+  }) => {
+    let requests = 0;
+    page.on('request', (requestValue) => {
+      if (requestValue.url().endsWith('/workout-progression/preview')) requests += 1;
+    });
+    const before = await scheduledTargets();
+    await openReview(page, 1280);
+    await expect(page.getByRole('button', { name: 'Accept targets' })).toBeVisible();
+    expect(requests).toBe(1);
+    await page.getByRole('link', { name: 'Workouts', exact: true }).first().click();
+    await page.goBack();
+    await expect(page.getByRole('button', { name: 'Accept targets' })).toBeVisible();
+    await page.waitForLoadState('networkidle');
+    expect(requests).toBe(1);
+    expect(await scheduledTargets()).toEqual(before);
+    console.log(
+      JSON.stringify({
+        ...gitMetadata(),
+        scenario: 'SPA-reopen',
+        viewport: 1280,
+        phase: 'pre-action',
+        requests,
+        targetsUnchanged: true,
+      }),
+    );
+  });
+
+  test('announces loading while the first preview is pending without changing targets', async ({
+    page,
+  }) => {
+    const before = await scheduledTargets();
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolveGate) => {
+      release = resolveGate;
+    });
+    await page.route('**/api/v1/workout-progression/preview', async (route) => {
+      await gate;
+      await route.continue();
+    });
+    await openReview(page, 320);
+    await expect(
+      page.getByRole('status').filter({ hasText: 'Checking prior performance' }),
+    ).toBeVisible();
+    await writeScreenshot(page, 'loading-pre-action', 320, 'pre-action');
+    await page.setViewportSize({ width: 1280, height: 1000 });
+    await writeScreenshot(page, 'loading-pre-action', 1280, 'pre-action');
+    release?.();
+    await expect(page.getByRole('button', { name: 'Accept targets' })).toBeVisible();
+    expect(await scheduledTargets()).toEqual(before);
+  });
+
+  test('renders no-policy as an unavailable hold with the plan unchanged', async ({ page }) => {
+    const before = await scheduledTargets();
+    await basePreviewWithScenario(page, noPolicyResponse);
+    await openReview(page, 1280);
+    await expect(
+      page.getByRole('status').filter({ hasText: 'No progression policy' }),
+    ).toContainText('No progression policy is configured for this exercise');
+    await expect(page.getByRole('button', { name: 'Accept targets' })).toBeDisabled();
+    await expect(page.getByText(/The current plan has not changed/u).first()).toBeVisible();
+    await writeScreenshot(page, 'missing-policy-unavailable-pre-action', 1280, 'pre-action');
+    await page.setViewportSize({ width: 320, height: 1000 });
+    await writeScreenshot(page, 'missing-policy-unavailable-pre-action', 320, 'pre-action');
+    expect(await scheduledTargets()).toEqual(before);
+  });
+
+  test('renders a conflicting legacy target as an unavailable inline diagnostic', async ({
+    page,
+  }) => {
+    injectPersistedLegacyTargets(6);
+    const before = await scheduledTargets();
+    await openReview(page, 320);
+    await expect(page.getByText(/Invalid current scheduled target at set/u).first()).toBeVisible();
+    await expect(page.getByText(/Raw values:.*repsMin=6/u).first()).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Accept targets' })).toBeDisabled();
+    await expect(page.getByText(/The current plan has not changed/u).first()).toBeVisible();
+    await writeScreenshot(page, 'conflicting-target-unavailable-pre-action', 320, 'pre-action');
+    await page.setViewportSize({ width: 1280, height: 1000 });
+    await writeScreenshot(page, 'conflicting-target-unavailable-pre-action', 1280, 'pre-action');
+    expect(await scheduledTargets()).toEqual(before);
+    injectPersistedLegacyTargets();
+  });
+
+  test('makes one server request, shows inline retry, and succeeds after explicit retry', async ({
+    page,
+  }) => {
+    let requestCount = 0;
+    await page.route('**/api/v1/workout-progression/preview', async (route) => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        await route.fulfill({
+          status: 503,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            error: { code: 'PREVIEW_UNAVAILABLE', message: 'fixture failure' },
+          }),
+        });
+        return;
+      }
+      const response = await route.fetch();
+      await route.fulfill({ response });
+    });
+    await openReview(page, 1280);
+    await expect(page.getByRole('alert')).toContainText('Your plan has not changed');
+    await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+    expect(requestCount).toBe(1);
+    await writeScreenshot(page, 'server-error-pre-retry', 1280, 'pre-retry');
+    await page.setViewportSize({ width: 320, height: 1000 });
+    await writeScreenshot(page, 'server-error-pre-retry', 320, 'pre-retry');
+    await page.setViewportSize({ width: 1280, height: 1000 });
+    await page.getByRole('button', { name: 'Retry' }).focus();
+    await page.keyboard.press('Enter');
+    await expect(page.getByRole('heading', { name: 'Progression review' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Accept targets' })).toBeVisible();
+    expect(requestCount).toBe(2);
+    console.log(
+      JSON.stringify({
+        ...gitMetadata(),
+        scenario: 'explicit-retry',
+        viewport: 1280,
+        phase: 'post-retry-pre-action',
+        requestCount,
+        assertion: 'one initial failed request plus one explicit retry',
+      }),
+    );
+    await writeScreenshot(page, 'server-error-explicit-retry-post-retry', 1280, 'post-retry');
+  });
+});

--- a/apps/web/e2e/workout-progression.spec.ts
+++ b/apps/web/e2e/workout-progression.spec.ts
@@ -1,4 +1,5 @@
-import { mkdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { expect, request, test, type APIRequestContext, type Page } from '@playwright/test';
@@ -82,9 +83,26 @@ function monitorPage(page: Page) {
 }
 
 async function capture(page: Page, filename: string) {
-  const directory = resolve(process.cwd(), '../../artifacts/issue-112');
+  const directory = resolve(process.cwd(), '../../logs/progression-preview/existing-chrome');
   mkdirSync(directory, { recursive: true });
   await page.screenshot({ fullPage: true, path: resolve(directory, filename) });
+  writeFileSync(
+    resolve(directory, `${filename}.json`),
+    JSON.stringify(
+      {
+        commitSha: execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(),
+        branch: execFileSync('git', ['branch', '--show-current'], { encoding: 'utf8' }).trim(),
+        workingTreeDirty:
+          execFileSync('git', ['status', '--porcelain'], { encoding: 'utf8' }).trim().length > 0,
+        fixture: 'adaptive-preview progression and muscle fixtures',
+        scenario: filename,
+        viewport: page.viewportSize(),
+        phase: filename.includes('accepted') ? 'post-action' : 'pre-action',
+      },
+      null,
+      2,
+    ),
+  );
 }
 
 async function expectNoOverflow(page: Page, width: number) {

--- a/apps/web/src/features/workouts/api/progression.test.tsx
+++ b/apps/web/src/features/workouts/api/progression.test.tsx
@@ -1,0 +1,45 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import {
+  QueryClient,
+  QueryClientProvider,
+  focusManager,
+  onlineManager,
+} from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { apiRequest } from '@/lib/api-client';
+import { useWorkoutProgressionPreview } from './progression';
+vi.mock('@/lib/api-client', () => ({ apiRequest: vi.fn() }));
+describe('progression POST request budget', () => {
+  it.each([false, true])(
+    'remount/focus/reconnect does not repeat a preview (failure=%s)',
+    async (failure) => {
+      vi.mocked(apiRequest).mockReset();
+      if (failure) vi.mocked(apiRequest).mockRejectedValue(new Error('Server failure'));
+      else vi.mocked(apiRequest).mockResolvedValue({ recommendations: [] });
+      const client = new QueryClient();
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      );
+      const first = renderHook(() => useWorkoutProgressionPreview('schedule-1'), { wrapper });
+      await waitFor(() => expect(first.result.current.fetchStatus).toBe('idle'));
+      expect(apiRequest).toHaveBeenCalledTimes(1);
+      first.unmount();
+      const second = renderHook(() => useWorkoutProgressionPreview('schedule-1'), { wrapper });
+      await act(async () => {
+        focusManager.setFocused(false);
+        focusManager.setFocused(true);
+        onlineManager.setOnline(false);
+        onlineManager.setOnline(true);
+      });
+      expect(apiRequest).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        await second.result.current.refetch();
+      });
+      expect(apiRequest).toHaveBeenCalledTimes(2);
+      second.unmount();
+      client.clear();
+      focusManager.setFocused(undefined);
+    },
+  );
+});

--- a/apps/web/src/features/workouts/api/progression.ts
+++ b/apps/web/src/features/workouts/api/progression.ts
@@ -31,6 +31,14 @@ export function useWorkoutProgressionPreview(scheduledWorkoutId: string, enabled
         }),
       ),
     queryKey: workoutProgressionQueryKeys.preview(scheduledWorkoutId),
+    meta: { suppressGlobalErrorToast: true },
+    refetchOnMount: false,
+    retryOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    retry: false,
+    staleTime: Infinity,
+    gcTime: Infinity,
   });
 }
 
@@ -60,6 +68,7 @@ export function useApplyWorkoutProgressionAction(scheduledWorkoutId: string) {
         }),
       ]);
     },
+    meta: { suppressGlobalErrorToast: true },
   });
 }
 

--- a/apps/web/src/features/workouts/components/workout-progression-review.test.tsx
+++ b/apps/web/src/features/workouts/components/workout-progression-review.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import type { WorkoutProgressionRecommendation } from '@pulse/shared';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -160,7 +160,7 @@ describe('WorkoutProgressionReview', () => {
       within(comparison).getByRole('columnheader', { name: 'Proposed target' }),
     ).toBeInTheDocument();
     expect(within(comparison).getByRole('row', { name: /Set 1/ })).toHaveTextContent(
-      'Set 120 lbs · 8–10 reps20 lbs · 10 reps · RPE 820 lbs · 8–10 reps25 lbs · 8–10 reps',
+      'Set 120 lbs · 8–10 repsSource session set: source-set-1; scheduled source: source-scheduled-set-120 lbs · 10 reps · RPE 820 lbs · 8–10 repsCurrent scheduled set: scheduled-set-125 lbs · 8–10 reps',
     );
     expect(screen.getByText('Every required set reached 10 reps.')).toBeInTheDocument();
     expect(screen.getByText(/completed session 2026-08-20/)).toBeInTheDocument();
@@ -168,6 +168,28 @@ describe('WorkoutProgressionReview', () => {
       'You · revision 1 · priority exercise',
     );
     expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it('shows compatibility provenance and raw values for legacy evidence', () => {
+    setup({
+      ...recommendation,
+      evidence: {
+        ...recommendation.evidence,
+        diagnostics: [
+          {
+            reason: 'REDUNDANT_EXACT_REPS',
+            raw: { reps: 8, repsMin: 8, repsMax: 8 },
+            setId: 'scheduled-set-1',
+            setNumber: 1,
+            source: 'current_scheduled_target',
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByLabelText('Incline press evidence diagnostics')).toHaveTextContent(
+      'Legacy exact-reps bounds were normalized for evaluation in the current scheduled target (set 1).',
+    );
   });
 
   it('requires an explicit accept and preserves the server fingerprint', async () => {
@@ -259,6 +281,129 @@ describe('WorkoutProgressionReview', () => {
     expect(screen.getByRole('button', { name: 'Edit' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Keep current' })).toBeEnabled();
     expect(screen.getByRole('button', { name: 'Hold with reason' })).toBeEnabled();
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'No progression policy is configured for this exercise. The current plan has not changed.',
+    );
+  });
+
+  it('shows no-history and server failures inline without a global retry loop', () => {
+    vi.mocked(useWorkoutProgressionPreview).mockReturnValue({
+      data: {
+        recommendations: [
+          {
+            ...recommendation,
+            confidence: 'unavailable',
+            decision: 'hold',
+            reasonCodes: ['NO_COMPLETED_HISTORY'],
+            facts: ['No completed performance exists for this exercise.'],
+          },
+        ],
+      },
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useWorkoutProgressionPreview>);
+    vi.mocked(useApplyWorkoutProgressionAction).mockReturnValue({
+      error: null,
+      isError: false,
+      isPending: false,
+      mutateAsync: vi.fn(),
+    } as unknown as ReturnType<typeof useApplyWorkoutProgressionAction>);
+    const { unmount } = render(
+      <WorkoutProgressionReview locked={false} scheduledWorkoutId="scheduled-1" />,
+    );
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'No completed matching history is available yet. The current plan has not changed.',
+    );
+    unmount();
+
+    const retry = vi.fn();
+    vi.mocked(useWorkoutProgressionPreview).mockReturnValue({
+      data: undefined,
+      isError: true,
+      isFetching: false,
+      isLoading: false,
+      refetch: retry,
+    } as unknown as ReturnType<typeof useWorkoutProgressionPreview>);
+    render(<WorkoutProgressionReview locked={false} scheduledWorkoutId="scheduled-1" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Your plan has not changed.');
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(retry).toHaveBeenCalledOnce();
+  });
+
+  it('retains invalid historical prescription and completed observations in the comparison', () => {
+    setup();
+    cleanup();
+    vi.mocked(useWorkoutProgressionPreview).mockReturnValue({
+      data: {
+        recommendations: [
+          {
+            ...recommendation,
+            confidence: 'unavailable',
+            decision: 'hold',
+            reasonCodes: ['INVALID_HISTORICAL_PRESCRIPTION'],
+            evidence: {
+              ...recommendation.evidence,
+              performance: [],
+              diagnostics: [
+                {
+                  reason: 'INVALID_HISTORICAL_PRESCRIPTION',
+                  source: 'historical_prescribed_target',
+                  setId: 'source-set-1',
+                  setNumber: 1,
+                  raw: { reps: 8, repsMin: 6, repsMax: 8 },
+                  observed: { weight: 20, reps: 10, completed: 'true' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useWorkoutProgressionPreview>);
+    render(<WorkoutProgressionReview locked={false} scheduledWorkoutId="scheduled-1" />);
+    const table = screen.getByRole('table');
+    expect(within(table).getByText(/Invalid historical prescribed target/)).toHaveTextContent(
+      'repsMin=6',
+    );
+    expect(within(table).getByText(/weight=20/)).toHaveTextContent('reps=10');
+    expect(screen.getByRole('button', { name: 'Accept targets' })).toBeDisabled();
+  });
+
+  it('shows exactly one disabled retry while a retry is pending', () => {
+    setup();
+    cleanup();
+    const refetch = vi.fn();
+    vi.mocked(useWorkoutProgressionPreview).mockReturnValue({
+      data: undefined,
+      isError: true,
+      isFetching: true,
+      isLoading: false,
+      refetch,
+    } as unknown as ReturnType<typeof useWorkoutProgressionPreview>);
+    render(<WorkoutProgressionReview locked={false} scheduledWorkoutId="scheduled-1" />);
+    expect(
+      screen.queryByRole('button', { name: 'Recompute workout progression' }),
+    ).not.toBeInTheDocument();
+    const button = screen.getByRole('button', { name: 'Retrying…' });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it('preserves previous and current source identities in same-number comparisons', () => {
+    setup();
+    expect(
+      screen.getByText(
+        'Source session set: source-set-1; scheduled source: source-scheduled-set-1',
+      ),
+    ).toBeVisible();
+    expect(screen.getByText('Current scheduled set: scheduled-set-1')).toBeVisible();
   });
 
   it('submits bounded edited targets while retaining the immutable recommendation', async () => {

--- a/apps/web/src/features/workouts/components/workout-progression-review.tsx
+++ b/apps/web/src/features/workouts/components/workout-progression-review.tsx
@@ -68,6 +68,35 @@ function completedText(
   return parts.join(' · ') || 'No measured completion';
 }
 
+function availabilityMessage(recommendation: WorkoutProgressionRecommendation) {
+  if (recommendation.reasonCodes.includes('MISSING_POLICY')) {
+    return 'No progression policy is configured for this exercise. The current plan has not changed.';
+  }
+  if (recommendation.reasonCodes.includes('NO_COMPLETED_HISTORY')) {
+    return 'No completed matching history is available yet. The current plan has not changed.';
+  }
+  if (recommendation.confidence === 'unavailable') {
+    return 'This recommendation is unavailable because its evidence could not support a safe change. The current plan has not changed.';
+  }
+  return null;
+}
+
+function diagnosticMessage(
+  diagnostic: NonNullable<WorkoutProgressionRecommendation['evidence']['diagnostics']>[number],
+) {
+  const source =
+    diagnostic.source === 'current_scheduled_target'
+      ? 'current scheduled target'
+      : 'historical prescribed target';
+  const raw = Object.entries(diagnostic.raw)
+    .map(([key, value]) => `${key}=${value === null ? 'null' : String(value)}`)
+    .join(', ');
+  if (diagnostic.reason === 'REDUNDANT_EXACT_REPS') {
+    return `Legacy exact-reps bounds were normalized for evaluation in the ${source} (set ${diagnostic.setNumber ?? 'unknown'}).`;
+  }
+  return `Invalid ${source} at set ${diagnostic.setNumber ?? 'unknown'}: ${diagnostic.reason}. Raw values: ${raw}.`;
+}
+
 export function WorkoutProgressionReview({
   locked,
   scheduledWorkoutId,
@@ -124,17 +153,19 @@ export function WorkoutProgressionReview({
             Nothing changes until you choose an action.
           </p>
         </div>
-        <Button
-          aria-label="Recompute workout progression"
-          className="min-h-11"
-          disabled={preview.isFetching}
-          onClick={() => void preview.refetch()}
-          type="button"
-          variant="outline"
-        >
-          <RefreshCw aria-hidden="true" className="size-4" />
-          {preview.isFetching ? 'Checking…' : 'Recompute'}
-        </Button>
+        {!preview.isError ? (
+          <Button
+            aria-label="Recompute workout progression"
+            className="min-h-11"
+            disabled={preview.isFetching}
+            onClick={() => void preview.refetch()}
+            type="button"
+            variant="outline"
+          >
+            <RefreshCw aria-hidden="true" className="size-4" />
+            {preview.isFetching ? 'Checking…' : 'Recompute'}
+          </Button>
+        ) : null}
       </div>
 
       {preview.isLoading ? (
@@ -147,8 +178,13 @@ export function WorkoutProgressionReview({
         <Card className="border-destructive/40" role="alert">
           <CardContent className="space-y-3 py-6">
             <p>Progression recommendations could not be loaded. Your plan has not changed.</p>
-            <Button className="min-h-11" onClick={() => void preview.refetch()} variant="outline">
-              Retry
+            <Button
+              className="min-h-11"
+              disabled={preview.isFetching}
+              onClick={() => void preview.refetch({ cancelRefetch: false })}
+              variant="outline"
+            >
+              {preview.isFetching ? 'Retrying…' : 'Retry'}
             </Button>
           </CardContent>
         </Card>
@@ -159,7 +195,7 @@ export function WorkoutProgressionReview({
           </CardContent>
         </Card>
       ) : (
-        <div className="grid min-w-0 gap-3 xl:grid-cols-2">
+        <div className="grid min-w-0 gap-3">
           {preview.data?.recommendations.map((recommendation) => {
             const meta = decisionMeta[recommendation.decision];
             const Icon = meta.icon;
@@ -169,6 +205,9 @@ export function WorkoutProgressionReview({
               ...new Set([
                 ...recommendation.evidence.priorTargets.map((target) => target.setNumber),
                 ...recommendation.evidence.performance.map((set) => set.setNumber),
+                ...(recommendation.evidence.diagnostics ?? []).flatMap((item) =>
+                  item.setNumber !== null ? [item.setNumber] : [],
+                ),
               ]),
             ].sort((left, right) => left - right);
             return (
@@ -208,7 +247,39 @@ export function WorkoutProgressionReview({
                     </p>
                   ) : null}
 
-                  <div className="overflow-x-auto rounded-xl border border-border/70">
+                  {availabilityMessage(recommendation) ? (
+                    <p
+                      className="rounded-xl border border-warning/40 bg-warning/10 p-3 text-sm"
+                      role="status"
+                    >
+                      {availabilityMessage(recommendation)}
+                    </p>
+                  ) : null}
+
+                  {recommendation.evidence.diagnostics?.length ? (
+                    <div
+                      aria-label={`${recommendation.evidence.exerciseName} evidence diagnostics`}
+                      className="rounded-xl border border-border/70 bg-secondary/30 p-3 text-sm"
+                    >
+                      <p className="font-medium">Evidence compatibility</p>
+                      <ul className="mt-2 list-disc space-y-1 break-words pl-5 text-muted-foreground">
+                        {recommendation.evidence.diagnostics.map((diagnostic, index) => (
+                          <li
+                            key={`${diagnostic.reason}-${diagnostic.source}-${diagnostic.setId}-${index}`}
+                          >
+                            {diagnosticMessage(diagnostic)}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null}
+
+                  <div
+                    className="overflow-x-auto rounded-xl border border-border/70"
+                    role="region"
+                    aria-label={`${recommendation.evidence.exerciseName} comparison scroll area`}
+                    tabIndex={0}
+                  >
                     <table
                       aria-label={`${recommendation.evidence.exerciseName} exact progression comparison`}
                       className="w-full min-w-[42rem] text-left text-sm"
@@ -240,6 +311,18 @@ export function WorkoutProgressionReview({
                           const performance = recommendation.evidence.performance.find(
                             (set) => set.setNumber === setNumber,
                           );
+                          const currentDiagnostic = recommendation.evidence.diagnostics?.find(
+                            (item) =>
+                              item.source === 'current_scheduled_target' &&
+                              item.setNumber === setNumber &&
+                              item.reason !== 'REDUNDANT_EXACT_REPS',
+                          );
+                          const historicalDiagnostic = recommendation.evidence.diagnostics?.find(
+                            (item) =>
+                              item.source === 'historical_prescribed_target' &&
+                              item.setNumber === setNumber &&
+                              item.reason !== 'REDUNDANT_EXACT_REPS',
+                          );
                           const proposed = current
                             ? recommendation.recommendedTargets.find(
                                 (target) => target.setId === current.setId,
@@ -256,13 +339,36 @@ export function WorkoutProgressionReview({
                               <td className="px-3 py-3 text-muted-foreground">
                                 {performance
                                   ? targetText(performance.prescribed, weightUnit)
-                                  : 'No matching source set'}
+                                  : historicalDiagnostic
+                                    ? diagnosticMessage(historicalDiagnostic)
+                                    : 'No matching source set'}
+                                {performance ? (
+                                  <span className="mt-1 block break-all text-xs">
+                                    Source session set: {performance.setId}; scheduled source:{' '}
+                                    {performance.sourceScheduledSetId ?? 'unavailable'}
+                                  </span>
+                                ) : null}
                               </td>
                               <td className="px-3 py-3 text-muted-foreground">
-                                {completedText(performance, weightUnit)}
+                                {performance
+                                  ? completedText(performance, weightUnit)
+                                  : historicalDiagnostic?.observed
+                                    ? Object.entries(historicalDiagnostic.observed)
+                                        .map(([key, value]) => `${key}=${value ?? 'null'}`)
+                                        .join(' · ')
+                                    : 'Not recorded'}
                               </td>
                               <td className="px-3 py-3">
-                                {current ? targetText(current, weightUnit) : 'No current set'}
+                                {current
+                                  ? targetText(current, weightUnit)
+                                  : currentDiagnostic
+                                    ? diagnosticMessage(currentDiagnostic)
+                                    : 'No current set'}
+                                {current ? (
+                                  <span className="mt-1 block break-all text-xs">
+                                    Current scheduled set: {current.setId}
+                                  </span>
+                                ) : null}
                               </td>
                               <td className="px-3 py-3 font-medium">
                                 {proposed ? targetText(proposed, weightUnit) : 'Not available'}

--- a/apps/web/src/lib/query-client.test.ts
+++ b/apps/web/src/lib/query-client.test.ts
@@ -57,6 +57,16 @@ describe('query-client', () => {
     expect(toastErrorMock).toHaveBeenCalledWith('Network error. Check your connection.');
   });
 
+  it('skips the global query toast for feature-scoped errors', () => {
+    const queryOnError = createAppQueryClient().getQueryCache().config.onError;
+
+    queryOnError?.(new ApiError(500, 'Preview failed', 'INTERNAL_ERROR'), {
+      meta: { suppressGlobalErrorToast: true },
+    } as never);
+
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
   it('skips the global mutation toast when the mutation handles its own error feedback', () => {
     const mutationOnError = createAppQueryClient().getMutationCache().config.onError;
 

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -63,8 +63,10 @@ export function createAppQueryClient(): QueryClient {
       },
     }),
     queryCache: new QueryCache({
-      onError: (error) => {
-        handleGlobalError(error);
+      onError: (error, query) => {
+        handleGlobalError(error, {
+          skipToast: query.meta?.suppressGlobalErrorToast === true,
+        });
       },
     }),
     defaultOptions: {

--- a/docs/implementation/progression-preview-evidence.md
+++ b/docs/implementation/progression-preview-evidence.md
@@ -1,0 +1,135 @@
+# Progression preview compatibility — execution evidence
+
+## Scope and execution plan
+
+Worktree: `/Users/meridian/Projects/pulse-progression-preview-fix`.
+Branch: `fix/progression-preview-compatibility`.
+Verified clean starting HEAD: `ad3d78706ca8f2dc399ec1726dbe27a05cdbaa3d`.
+Its parent is the approved base `4f9574e607be99fee2396a673154e41699853a31`.
+
+1. Read AGENTS, progression v1 specification, and the absolute goal contract; verify isolated checkout.
+2. Implement shared lossless compatibility, per-exercise invalid evidence, and writer protection.
+3. Bound preview request behavior and preserve inline source-aware comparisons.
+4. Add persisted legacy, route, lifecycle, writer, UI, and installed-Chrome checks.
+5. Run four distinct Luna-medium adversarial reviews, consolidate concrete findings, repair and verify.
+6. Commit coherent source and evidence; run uncached gates and Chrome again from clean final HEAD.
+
+## Behavior and boundaries
+
+The strict canonical target schema still rejects mixed exact/range representations. The shared
+compatibility helper alone recognizes equivalent equal rep bounds, retains exact reps, and records
+`REDUNDANT_EXACT_REPS`. Conflicts retain schema-safe raw fields with current/historical source,
+set ID and number; invalid historical prescriptions also retain completed observations. Invalid
+sets never become fabricated canonical targets. Their exercise holds unavailable; other exercises
+are evaluated independently. Empty canonical target arrays are allowed only with invalid-current
+evidence, and material actions cannot apply unavailable evidence or empty action targets.
+
+Existing immutable snapshots and action audit records are retained. Current redundant diagnostics
+are non-semantic only when projecting an already decided recommendation: an explicit material
+action may have canonicalized that current row. Historical diagnostics remain compared exactly.
+Preview never updates scheduled targets. Keep/hold remain no-change actions.
+
+Writers audited: scheduled template snapshot creation/replacement, scheduled route snapshot
+construction, merged existing-set patches and added sets, scheduled-to-session materialization,
+session set recreation preserving snapshot facts, and explicit progression accept/edit. Session
+corrections update completed values without rewriting prescriptions. Agent/import callers share
+these routes; no auth or enrichment branching was added. Session-start validation rejects conflicts
+before creating a session, sets, or schedule link.
+
+## Adversarial reviews and consolidated dispositions
+
+All four requested distinct review agents were explicitly launched as `gpt-5.6-luna`, medium.
+Reviews were read-only. Implementer validation below is separate from reviewer observations;
+reviewer test attempts were blocked by their sandbox or command invocation, not counted as passes.
+
+| Review                   | Finding                                                                        | Disposition                                                                                                                                                                                                                                                                                                                                                         |
+| ------------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A schemas/evidence       | P1: accepting current legacy redundancy makes decided recommendation stale     | Repaired: ignore only current redundant diagnostic provenance during decided projection. Accept/edit/reopen regressions cover current-only and both current/historical redundancy.                                                                                                                                                                                  |
+| A schemas/evidence       | P1: exercise-set conflict mapped to unknown exercise                           | Repaired: correct route emits 400 `INVALID_REP_TARGET`; route regression passes.                                                                                                                                                                                                                                                                                    |
+| B auth/isolation/writers | No consequential defect found                                                  | Auth, ownership, actor-bound idempotency, transactional action protection, and scheduled source identity retained.                                                                                                                                                                                                                                                  |
+| C UI/query               | P1: Retry remains enabled while fetching                                       | Repaired: disabled pending Retry, pending label, non-cancelling refetch; pending activation test.                                                                                                                                                                                                                                                                   |
+| C UI/query               | P2: both Retry and Recompute shown on error                                    | Repaired: hide Recompute on error, leaving one explicit retry.                                                                                                                                                                                                                                                                                                      |
+| C UI/query               | P1/P2: number-based previous/current comparison may imply same source identity | Numeric rows intentionally compare different workout prescriptions: previous scheduled source IDs normally differ from the future schedule. Replacing this with ID matching would lose normal comparisons. Added explicit historical session-set/scheduled-source and current scheduled-set identities, with regression; no identity-based fulfillment is inferred. |
+| D tests/evidence         | Claimed dual-source redundancy still stales after action                       | Not reproduced after A repair: historical diagnostics remain unchanged on both sides. Added dual-source accept/edit/reopen regressions using a material strength policy; both pass.                                                                                                                                                                                 |
+| D tests/evidence         | Browser legacy success used synthetic payload                                  | Repaired: browser renders the real API response from current and historical persisted redundant rows. Conflict browser flow also uses persisted malformed current rows.                                                                                                                                                                                             |
+| D tests/evidence         | Missing browser reopen request counts                                          | Repaired: SPA navigation away/back asserts exactly one POST and unchanged targets. Full page loads start a new query client and naturally make one initial POST.                                                                                                                                                                                                    |
+| D tests/evidence         | Session-start conflict atomicity insufficiently tested                         | Repaired implementation and coverage: canonicalization checked before session transaction; conflict directions/range order return 400 with zero new sessions/sets/links; equivalent copying keeps source IDs and leaves source rows untouched.                                                                                                                      |
+
+## Requirements to evidence
+
+| Contract items                                                             | Evidence                                                                                                                                                                    |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1–6 target forms, domain rejection, source-aware normalization             | `packages/shared/src/schemas/workout-progression-compatibility.test.ts`; strict original schema tests; evaluator tests                                                      |
+| 3–9 persisted legacy, current/historical isolation, missing policy/history | `apps/api/src/routes/workout-progression/store.integration.test.ts` with populated isolated SQLite fixtures                                                                 |
+| 10 writers/copy/update                                                     | scheduled snapshot tests, scheduled route tests, session route tests; rollback and unchanged source assertions                                                              |
+| 11 JWT/AgentToken, cross-user 404, idempotency                             | progression route tests plus store actor/resource/body replay and ownership tests                                                                                           |
+| 12 request counts/unchanged targets                                        | real TanStack hook tests (success and failure remount/focus/reconnect/retry), installed-Chrome SPA reopen and retry counts, persisted row assertions                        |
+| 13 actions/stale/locks                                                     | existing and added progression store tests, scheduled/session route coverage, existing progression Chrome acceptance/edit/stale flows                                       |
+| 14 UI/loading/unavailable/history/error/stale/accessibility                | progression review and query-client tests; keyboard-focusable horizontal comparison; 44px controls                                                                          |
+| 15 installed Chrome                                                        | `apps/web/e2e/progression-preview-compatibility.spec.ts` and existing `workout-progression.spec.ts`; PNGs and JSON sidecars under ignored `logs/progression-preview/chrome` |
+| 16 clean final uncached gates                                              | final raw logs and manifest under ignored `logs/progression-preview/final-<SHA>/`; exact outputs include command, branch, SHA, status, and exit code                        |
+
+## Browser fixture and evidence policy
+
+Only `/Users/meridian/Projects/pulse-progression-preview-fix/apps/api/data/pulse-tdee-dev.db`
+is seeded, using fictional `adaptive-preview-*` users, anchored at 2026-08-23. API port 3191,
+frontend 5291, installed channel `chrome`, one worker, zero Playwright retries. A fixture-only
+`.env` contains no real credentials. No production environment or database is read or copied.
+Legacy injection rejects absent, non-local, or symlink database paths. Successful legacy and
+conflict previews use real persisted rows. No-policy response and intentional transport failure
+are browser-controlled UI scenarios; API missing-policy behavior is separately tested with real rows.
+PNG metadata records branch, full SHA, dirty/clean state, fixture, viewport, and action phase.
+Working-tree logs/screenshots are explicitly pre-commit evidence, not final-HEAD receipts.
+
+Mobile and desktop PNGs were inspected visually, including the horizontally scrollable comparison.
+Final verification regenerates screenshots on the clean committed implementation.
+
+## Execution metadata limitation
+
+The contract requests the exact visible model/effort UI label. The Computer Use attempt to read
+Codex was refused: `Computer Use is not allowed to use the app 'com.openai.codex' for safety reasons.`
+No label-to-effort mapping or visible label is asserted. User clarification was requested while
+implementation continued. This restriction does not affect repository or browser verification.
+
+## Prohibited actions
+
+No merge, push, deployment, production access/repair, migration creation/execution against canonical
+data, external message, or changes to the original dirty checkout. Disposable fixture migrations
+are test setup only. No known in-scope implementation finding is left unresolved.
+
+## Literal pre-commit receipts
+
+These are working-tree receipts at base `ad3d78706ca8f2dc399ec1726dbe27a05cdbaa3d`,
+not final-HEAD evidence. Full unmodified output is retained in
+`logs/progression-preview/consolidated-gates.log`.
+
+```text
+COMMAND: pnpm lint --force
+EXIT CODE: 0
+COMMAND: pnpm typecheck --force
+EXIT CODE: 0
+COMMAND: pnpm test --force
+@pulse/shared:test:  Test Files  47 passed (47)
+@pulse/shared:test:       Tests  671 passed (671)
+@pulse/api:test:  Test Files  85 passed (85)
+@pulse/api:test:       Tests  1071 passed (1071)
+@pulse/web:test:  Test Files  184 passed (184)
+@pulse/web:test:       Tests  1260 passed (1260)
+EXIT CODE: 0
+COMMAND: pnpm build --force
+EXIT CODE: 0
+```
+
+The repository script tests are also included in `pnpm test`; every Turbo gate reports zero
+cache hits. Existing frontend refresh-export warnings and the Vite chunk-size advisory remain
+warnings, not gate failures. Working installed-Chrome receipts: seven compatibility tests and
+five existing progression/muscle tests passed; their final committed versions are rerun below
+through the final evidence harness.
+
+## Reproduce final verification
+
+Use the final `logs/progression-preview/final-<SHA>/manifest.json` for exact command arrays,
+exit codes, branch/SHA and clean-status assertions. Each gate uses `--force` to bypass Turbo cache.
+Browser commands use the environment described above and `--workers=1 --retries=0`; fixture seeding
+runs before each browser suite so the explicit-accept suite cannot contaminate the compatibility
+suite. Final PNGs are copied into that SHA-specific directory with their JSON metadata.

--- a/docs/implementation/progression-preview-evidence.md
+++ b/docs/implementation/progression-preview-evidence.md
@@ -84,18 +84,27 @@ Working-tree logs/screenshots are explicitly pre-commit evidence, not final-HEAD
 Mobile and desktop PNGs were inspected visually, including the horizontally scrollable comparison.
 Final verification regenerates screenshots on the clean committed implementation.
 
-## Execution metadata limitation
+## Launcher-owned execution evidence
 
-The contract requests the exact visible model/effort UI label. The Computer Use attempt to read
-Codex was refused: `Computer Use is not allowed to use the app 'com.openai.codex' for safety reasons.`
-No label-to-effort mapping or visible label is asserted. User clarification was requested while
-implementation continued. This restriction does not affect repository or browser verification.
+The launcher verified the exact UI label **GPT-6 Astra Light**. This is launcher-owned evidence,
+not an executor observation or a label-to-effort mapping. The user explicitly waived executor
+verification of the model/effort UI and confirmed that it is not a coding acceptance gate.
+The earlier Computer Use refusal is therefore no longer a blocker.
 
-## Prohibited actions
+## Publication authorization and boundaries
 
-No merge, push, deployment, production access/repair, migration creation/execution against canonical
-data, external message, or changes to the original dirty checkout. Disposable fixture migrations
-are test setup only. No known in-scope implementation finding is left unresolved.
+The user subsequently authorized committing, pushing this branch, and publishing a draft PR.
+No merge, deployment, production access/repair, migration creation/execution against canonical
+data, or changes to the original dirty checkout are authorized or performed. Disposable fixture
+migrations are test setup only. No known in-scope implementation finding is left unresolved.
+
+## Completed implementation-head verification
+
+The clean implementation commit `e1afd10551ea53c21c31f472bdbc8ca9c8c76f9e` passed all four
+uncached repository gates (each exit 0), 3,017 tests including repository scripts, and both
+installed-Chrome suites (5 existing flows and 7 compatibility flows, each exit 0). All 44
+artifacts in its exact-SHA manifest were hash-verified. The only subsequent tracked change is
+this evidence clarification; the final publication HEAD is verified again using the same harness.
 
 ## Literal pre-commit receipts
 

--- a/docs/implementation/progression-preview-goal.md
+++ b/docs/implementation/progression-preview-goal.md
@@ -1,0 +1,121 @@
+# Pulse #141: Progression preview compatibility and bounded error UX
+
+## Goal
+
+Complete this contract 100%. Restore scheduled-workout progression preview for persisted legacy prescription shapes without weakening strict validation, provenance, authorization, or action safety. Continue until implementation, tests, adversarial review, final verification, clean commit(s), and literal evidence are complete. Do not stop at a plan, a happy-path test, or a status summary.
+
+This is the executor's implementation contract. The preparation commit that contains this file is docs-only; after the verified Goal Mode launch, the executor is authorized to implement the complete in-scope behavior below. Do not deploy, repair production data, or merge.
+
+## Exact execution context
+
+- Repository: `/Users/meridian/Projects/pulse-progression-preview-fix`
+- Approved base: `origin/main` / `4f9574e607be99fee2396a673154e41699853a31` (PR #145 merge, scheduled-session provenance)
+- Working branch: `fix/progression-preview-compatibility`
+- Required first reads: `AGENTS.md`, `docs/specs/workout-progression-v1.md`, this file
+- Related issue: GitHub #141, “Fix progression preview crashes on legacy rep targets and repeated error toasts”
+- Related prior work: #112/#128 progression and muscle analytics; #134/#145 scheduled snapshot provenance. Do not regress #134's source-session prescription identity.
+- Pre-existing state: the original checkout `/Users/meridian/Projects/pulse-fitness-app` is intentionally dirty with unrelated untracked `CODEX-ISSUE-*` files and artifact directories. Do not edit, stage, delete, or copy those artifacts. Work only in this isolated worktree.
+
+Fail before editing if the worktree is not the named branch at the approved base, or if unrelated files appear in this worktree.
+
+## Confirmed current behavior and evidence
+
+At the approved base, a real persisted shape can contain `reps: 6, repsMin: 6, repsMax: 6` (also 8/8/8 and 5/5/5). The shared `workoutProgressionTargetSchema` currently rejects any exact reps combined with either range field, so `buildEvidenceForScheduledWorkout` in `apps/api/src/routes/workout-progression/store.ts` throws while constructing `priorTargets` or historical `performance[].prescribed`. The exception escapes `POST /api/v1/workout-progression/preview` in `apps/api/src/routes/workout-progression/index.ts` rather than becoming a recoverable domain result.
+
+Relevant paths inspected:
+
+- `packages/shared/src/schemas/workout-progression.ts`: strict target/evidence/recommendation/action schemas and lifecycle invariants.
+- `apps/api/src/routes/workout-progression/store.ts`: scheduled target writer/read, historical `session_sets` prescription read, evidence construction, evaluation, fingerprinting, persistence, stale/idempotent action application.
+- `apps/api/src/routes/scheduled-workouts/store.ts`, `snapshot-store.ts`, and `index.ts`: scheduled-set construction/update and snapshot writers.
+- `apps/api/src/routes/workout-sessions/store.ts` and `index.ts`: copying scheduled prescriptions into live session sets and completed-session correction/history paths.
+- `apps/web/src/features/workouts/api/progression.ts`: preview query and action mutation.
+- `apps/web/src/features/workouts/components/workout-progression-review.tsx`: comparison, empty/error/retry UI, explicit actions, stale/unavailable rendering.
+- `apps/web/src/lib/query-client.ts`: global query error toast and one default retry; unrelated auth handling must remain unchanged.
+- `apps/api/src/routes/workout-progression/*.test.ts`, shared progression tests, `apps/web/src/features/workouts/components/workout-progression-review.test.tsx`, and `apps/web/e2e/workout-progression.spec.ts`: existing contract and regression surface.
+
+The preview is a POST and may persist recommendations. Therefore retries/remounts must be bounded and safe; do not describe this as polling or assume a toast per HTTP retry without testing.
+
+## Frozen product and compatibility decisions
+
+1. **Target meaning is field-preserving and deterministic.** For each target independently, exact-only means `reps != null` and both `repsMin`/`repsMax` null; range-only means `reps == null` with a valid range (both bounds for a complete range, or the existing explicitly supported partial-bound semantics); no rep target means all three null.
+2. **Lossless legacy redundancy rule.** If exact reps is present and every non-null rep-range bound equals that exact value (`repsMin === reps` and/or `repsMax === reps`), treat it as equivalent redundant legacy encoding. Normalize only at the validation boundary to the canonical exact representation (`reps` retained; redundant equal range fields become null), and record deterministic compatibility provenance/reason/source in evidence or diagnostics. Do not mutate the scheduled row or historical row.
+3. **Conflicts fail closed.** Any exact/range mismatch (including `reps=8, repsMin=6, repsMax=8`, `reps=8, repsMin=8, repsMax=10`, invalid bound order, or non-finite/out-of-domain values) is not silently selected, clipped, or fabricated. It must produce structured source-aware invalid evidence and an unavailable/hold outcome for that exercise. The original raw persisted values remain readable in diagnostics/evidence where schema-safe.
+4. Apply the same compatibility/conflict handling to both current `priorTargets` and historical `performance[].prescribed`; never normalize current while leaving historical contradictory or vice versa.
+5. **Safe isolation.** One malformed exercise must not abort valid exercises in the same scheduled workout. The valid exercise can produce a normal recommendation. The malformed exercise must be unavailable/hold, with stable machine-readable reason and source (`current scheduled target` versus `historical prescribed target`, set identity/number), and must not enable target application.
+6. Missing policy is a distinct valid unavailable state (`MISSING_POLICY`), not a target-compatibility crash. Missing history is also informative and non-crashing. Preserve policy provenance and clearly distinguish no policy, no completed history, invalid current evidence, and invalid historical evidence.
+7. New writers must prevent recreating equivalent/conflicting shapes. At every scheduled and session prescription writer/copy/update boundary, validate or canonicalize equivalent redundancy and reject conflicts fail-closed. Do not rewrite existing production rows and do not add a migration unless absolutely necessary; if a migration is proposed, stop for approval rather than silently adding it. Prefer shared helpers so all writers use one rule.
+8. Preview never changes scheduled targets merely by opening, remounting, retrying, or recomputing. Only explicit `accept`/bounded `edit` may update targets, and only after existing stale, ownership, editability, transaction, and idempotency checks. `keep`/`hold` remain no-change actions. Preserve recommendation snapshots and action audit history.
+9. JWT and `AgentToken` use the same schemas and behavior. Keep every query and action scoped to authenticated `userId`; cross-user resources remain indistinguishable from not-found. AgentToken idempotency remains actor-bound. Do not weaken auth or enrichment middleware.
+10. UI errors are scoped inline to the progression panel with one explicit retry. Avoid repeated global toast noise for this persistent preview failure, without globally suppressing unrelated query errors or changing unauthorized logout/redirect behavior. Show loading, success, unavailable/no-policy, no-history, error/retry, and stale states with useful text and accessible roles; preserve the exact previous/current/proposed comparison when evidence is available.
+
+These are deterministic compatibility/safety semantics. Do not ask for product clarification unless the repository makes them impossible or reveals a consequential contradiction (for example, an existing public contract that requires preserving both redundant forms in a schema where they are currently forbidden). Escalate such a contradiction with exact file/test evidence; do not guess.
+
+## Implementation surface
+
+### Shared compatibility and diagnostics
+
+- Add a shared, typed target compatibility/validation helper (or the smallest equivalent abstraction) used before strict target parsing.
+- Keep valid exact-only and range-only targets lossless.
+- Define stable reason/source discriminants for redundant-equivalent normalization, current invalid target, historical invalid prescription, malformed set identity, and other necessary fail-closed evidence conditions.
+- Ensure normalized values used for evaluation/fingerprinting are deterministic; never include nondeterministic error ordering.
+- Preserve strict schemas for accepted canonical targets and recommendation/action invariants.
+
+### API evidence and preview
+
+- Refactor evidence construction so each exercise is isolated and parse failures become structured unavailable/hold recommendations or an equivalent response contract, rather than an unhandled 500.
+- Ensure invalid evidence cannot be accepted or edited and cannot cause another exercise's recommendation to change.
+- Verify recommendation persistence/query projection, stale fingerprinting, and action application remain coherent for normalized evidence.
+- Preserve no-policy (`MISSING_POLICY`), no-history, unsupported tracking, and historical-source explanations.
+- Add/retain explicit route tests for 200 partial results, stable invalid reasons, 404 ownership, JWT/AgentToken parity, and cross-user isolation.
+
+### Writers and historical provenance
+
+Audit and cover every writer identified in the inspected paths: scheduled template/snapshot creation and edits; scheduled-to-session copying; session correction/read projection; any agent/import writer that sets target reps fields. New writes must canonicalize equal redundancy or reject contradictions before persistence. Do not repair existing data.
+
+### UI/query behavior
+
+- Keep TanStack Query request count bounded: no automatic retry loop, no repeated preview POST caused by render/remount, and explicit retry only.
+- Scope suppression to this preview query/mutation using existing mechanisms or a feature-specific error policy; do not alter global auth behavior or silence unrelated errors.
+- Render informative inline unavailable/error states, including retry affordance and “plan has not changed”; distinguish missing policy/no history from transport/server failure.
+- Preserve comparison rows and exact source/provenance text for valid and partially invalid exercises. Ensure keyboard operation, 44px controls, responsive 320px+ layout, and accessible loading/alert/status semantics.
+
+## Invariants and non-goals
+
+- No production deployment, production DB access/repair, historical rewrite, migration execution against canonical data, merge, or executor auto-merge.
+- No target changes until explicit accepted/edited action passes stale and idempotency checks.
+- No cross-user evidence, recommendation, configuration, or action access.
+- No silent discard of conflicting fields, no fabricated target, no global toast-policy regression.
+- Existing #134 scheduled snapshot provenance and completed-session correction semantics remain intact.
+
+## Acceptance matrix
+
+Add focused tests with populated, isolated legacy-shaped fixtures (not only freshly normalized schedules):
+
+1. exact-only reps;
+2. range-only reps;
+3. exact plus equal min/max redundancy, including historical `performance.prescribed`;
+4. exact plus one equal bound;
+5. exact/range conflicts in each direction and invalid range ordering;
+6. missing/no measurable reps target where otherwise valid;
+7. malformed current exercise alongside valid exercise, proving per-exercise isolation;
+8. malformed historical prescription alongside valid current target;
+9. missing policy (`MISSING_POLICY`) and no completed history as separate informative outcomes;
+10. writer/copy/update canonicalization or rejection, with no persisted contradictory new row;
+11. JWT and AgentToken parity, user scoping, cross-user 404, and agent idempotency;
+12. preview reopen/remount/explicit retry request counts and no target mutation;
+13. accept/edit/keep/hold, stale recommendation, stale schedule, idempotency replay/conflict, and schedule-lock behavior;
+14. UI tests for loading, success, unavailable/no-policy, no-history, server error + inline retry, bounded retry, unchanged targets, stale and accessible responsive content;
+15. installed Chrome meaningful flows at mobile and desktop widths: loading, successful legacy compatibility preview, unavailable/no-policy, malformed/conflict error, explicit retry, and proof scheduled target values are unchanged before accept;
+16. full uncached repository gates from clean final head: `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build` (with exact outputs and exit codes). Run relevant installed-Chrome command(s) with exact output; if unavailable, report the concrete blocker and do not substitute a screenshot claim.
+
+For evidence, save raw exact-SHA logs, request-count/assertion output, and screenshots under a repo-contained or explicitly reported ignored evidence path. Every artifact must identify commit SHA, branch, fixture/scenario, viewport, and whether it is pre/post action. Do not treat empty screenshots or DOM-only value assertions as visual usability proof.
+
+## Required executor completion loop
+
+Read all required context and inspect actual code first. Write a bounded plan. Implement the full contract. Run focused checks, then the complete uncached matrix. Spawn distinct internal Luna-medium adversarial reviews for: (a) schemas/evidence/provenance/failure atomicity, (b) auth/isolation/idempotency/writers, (c) UI/query retry/accessibility/Chrome, and (d) tests/evidence/git hygiene. Consolidate all concrete findings once, repair every in-scope finding, rerun affected and full gates, inspect final diff, commit coherent implementation and literal evidence. Do not hand back known defects.
+
+Use GPT-6 Astra at the lowest visible effort setting for primary implementation; report the exact UI label observed without asserting a label-to-effort mapping. Review/support agents remain GPT-5.6 Luna at medium effort.
+
+## Final report contract
+
+Return `COMPLETE` or `BLOCKED`, exact branch and full SHA, commits/files, requirements-to-evidence mapping, every adversarial finding/disposition, exact commands/results, Chrome evidence, remaining blockers, prohibited-actions confirmation, and final `git status --porcelain`.

--- a/packages/shared/src/schemas/workout-progression-compatibility.test.ts
+++ b/packages/shared/src/schemas/workout-progression-compatibility.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canonicalizeWorkoutRepTarget,
+  validateWorkoutProgressionTarget,
+  workoutProgressionTargetSchema,
+  type WorkoutProgressionTarget,
+} from './workout-progression.js';
+const target: WorkoutProgressionTarget = {
+  setId: 'set-1',
+  setNumber: 1,
+  weight: 20,
+  weightMin: null,
+  weightMax: null,
+  reps: null,
+  repsMin: null,
+  repsMax: null,
+  seconds: null,
+  distance: null,
+  zone: null,
+};
+describe('persisted target compatibility', () => {
+  it.each([{ reps: 6 }, { repsMin: 6, repsMax: 8 }, { repsMin: 6 }, { repsMax: 8 }, {}])(
+    'preserves canonical fields %j',
+    (fields) => {
+      const raw = { ...target, ...fields };
+      expect(validateWorkoutProgressionTarget(raw, 'current_scheduled_target')).toEqual({
+        target: raw,
+        diagnostic: null,
+      });
+    },
+  );
+  it.each([
+    { reps: 6, repsMin: 6, repsMax: 6 },
+    { reps: 8, repsMin: 8 },
+    { reps: 5, repsMax: 5 },
+  ])('normalizes only equivalent redundancy %j', (fields) => {
+    const raw = { ...target, ...fields };
+    const before = { ...raw };
+    for (const source of ['current_scheduled_target', 'historical_prescribed_target'] as const) {
+      expect(validateWorkoutProgressionTarget(raw, source)).toEqual({
+        target: { ...raw, repsMin: null, repsMax: null },
+        diagnostic: { reason: 'REDUNDANT_EXACT_REPS', source, setId: raw.setId, setNumber: 1, raw },
+      });
+    }
+    expect(raw).toEqual(before);
+    expect(workoutProgressionTargetSchema.safeParse(raw).success).toBe(false);
+  });
+  it.each([
+    { reps: 8, repsMin: 6, repsMax: 8 },
+    { reps: 8, repsMin: 8, repsMax: 10 },
+    { repsMin: 10, repsMax: 6 },
+    { reps: 0 },
+    { reps: 1001 },
+    { reps: Infinity },
+    { repsMin: NaN },
+    { reps: 1.5 },
+    { setNumber: 0 },
+    { setId: '' },
+  ])('fails closed without fabrication %j', (fields) => {
+    for (const source of ['current_scheduled_target', 'historical_prescribed_target'] as const) {
+      const result = validateWorkoutProgressionTarget({ ...target, ...fields }, source);
+      expect(result.target).toBeNull();
+      expect(result.diagnostic?.source).toBe(source);
+      expect(result.diagnostic?.reason).not.toBe('REDUNDANT_EXACT_REPS');
+    }
+  });
+  it('rejects contradictory writer input', () => {
+    expect(() => canonicalizeWorkoutRepTarget({ reps: 8, repsMin: 6 })).toThrow(
+      'CONFLICTING_REP_TARGET',
+    );
+  });
+});

--- a/packages/shared/src/schemas/workout-progression.ts
+++ b/packages/shared/src/schemas/workout-progression.ts
@@ -34,6 +34,9 @@ export const workoutProgressionStateSchema = z.enum([
 ]);
 
 export const workoutProgressionReasonCodeSchema = z.enum([
+  'INVALID_CURRENT_TARGET',
+  'INVALID_HISTORICAL_PRESCRIPTION',
+  'MALFORMED_SET_IDENTITY',
   'ALL_SETS_AT_RANGE_TOP',
   'ALL_TARGETS_COMPLETED',
   'BELOW_RANGE_TOP',
@@ -129,6 +132,88 @@ export const workoutProgressionTargetSchema = z
     message: 'Exact reps cannot be combined with a rep range',
     path: ['reps'],
   });
+
+/** Canonicalize only lossless redundant legacy rep bounds. Never chooses a conflicting field. */
+export function canonicalizeWorkoutRepTarget<
+  T extends { reps?: number | null; repsMin?: number | null; repsMax?: number | null },
+>(value: T): T {
+  for (const metric of [value.reps, value.repsMin, value.repsMax]) {
+    if (metric != null && (!Number.isInteger(metric) || metric <= 0 || metric > 1000)) {
+      throw new Error('INVALID_REP_TARGET');
+    }
+  }
+  if (value.repsMin != null && value.repsMax != null && value.repsMin > value.repsMax) {
+    throw new Error('INVALID_REP_TARGET');
+  }
+  if (value.reps == null) return { ...value };
+  if ([value.repsMin, value.repsMax].some((bound) => bound != null && bound !== value.reps)) {
+    throw new Error('CONFLICTING_REP_TARGET');
+  }
+  return {
+    ...value,
+    ...(value.repsMin != null ? { repsMin: null } : {}),
+    ...(value.repsMax != null ? { repsMax: null } : {}),
+  };
+}
+
+export const workoutProgressionDiagnosticSchema = z
+  .object({
+    reason: z.enum([
+      'REDUNDANT_EXACT_REPS',
+      'INVALID_CURRENT_TARGET',
+      'INVALID_HISTORICAL_PRESCRIPTION',
+      'MALFORMED_SET_IDENTITY',
+    ]),
+    source: z.enum(['current_scheduled_target', 'historical_prescribed_target']),
+    setId: z.string(),
+    setNumber: z.number().finite().nullable(),
+    raw: z.record(z.string(), z.union([z.string(), z.number().finite(), z.null()])),
+    observed: z.record(z.string(), z.union([z.string(), z.number().finite(), z.null()])).optional(),
+  })
+  .strict();
+export type WorkoutProgressionDiagnostic = z.infer<typeof workoutProgressionDiagnosticSchema>;
+
+export function validateWorkoutProgressionTarget(
+  raw: WorkoutProgressionTarget,
+  source: WorkoutProgressionDiagnostic['source'],
+): { target: WorkoutProgressionTarget | null; diagnostic: WorkoutProgressionDiagnostic | null } {
+  let canonical = raw;
+  try {
+    canonical = canonicalizeWorkoutRepTarget(raw);
+  } catch {
+    /* Strict parsing below still rejects conflicts; invalid metrics also fail. */
+  }
+  const parsed = workoutProgressionTargetSchema.safeParse(canonical);
+  const invalidIdentity =
+    !idSchema.safeParse(raw.setId).success ||
+    !z.number().int().positive().safeParse(raw.setNumber).success;
+  const normalized =
+    raw.reps != null && (raw.repsMin != null || raw.repsMax != null) && parsed.success;
+  return {
+    target: parsed.success ? parsed.data : null,
+    diagnostic:
+      !parsed.success || normalized
+        ? {
+            reason: !parsed.success
+              ? invalidIdentity
+                ? 'MALFORMED_SET_IDENTITY'
+                : source === 'current_scheduled_target'
+                  ? 'INVALID_CURRENT_TARGET'
+                  : 'INVALID_HISTORICAL_PRESCRIPTION'
+              : 'REDUNDANT_EXACT_REPS',
+            source,
+            setId: String(raw.setId),
+            setNumber: Number.isFinite(raw.setNumber) ? raw.setNumber : null,
+            raw: Object.fromEntries(
+              Object.entries(raw).map(([key, value]) => [
+                key,
+                typeof value === 'number' && !Number.isFinite(value) ? String(value) : value,
+              ]),
+            ),
+          }
+        : null,
+  };
+}
 
 export const workoutProgressionPerformanceSetSchema = z
   .object({
@@ -279,14 +364,27 @@ export const workoutProgressionEvidenceSchema = z
     trackingType: exerciseTrackingTypeSchema,
     sourceSessionId: idSchema.nullable(),
     sourceSessionDate: dateSchema.nullable(),
-    priorTargets: z.array(workoutProgressionTargetSchema).min(1).max(100),
+    priorTargets: z.array(workoutProgressionTargetSchema).max(100),
+    diagnostics: z.array(workoutProgressionDiagnosticSchema).optional(),
     performance: z.array(workoutProgressionPerformanceSetSchema).max(100),
     policy: workoutProgressionPolicySchema,
     policySource: workoutProgressionPolicySourceSchema,
     priority: z.boolean().nullable(),
     context: workoutProgressionContextSchema,
   })
-  .strict();
+  .strict()
+  .refine(
+    (value) =>
+      value.priorTargets.length > 0 ||
+      value.diagnostics?.some(
+        (item) =>
+          item.source === 'current_scheduled_target' && item.reason !== 'REDUNDANT_EXACT_REPS',
+      ),
+    {
+      message: 'Current targets are required unless invalid current evidence is recorded',
+      path: ['priorTargets'],
+    },
+  );
 
 export const workoutProgressionRecommendationSchema = z
   .object({
@@ -298,7 +396,7 @@ export const workoutProgressionRecommendationSchema = z
     decision: workoutProgressionDecisionSchema,
     confidence: workoutProgressionConfidenceSchema,
     reasonCodes: z.array(workoutProgressionReasonCodeSchema).min(1),
-    recommendedTargets: z.array(workoutProgressionTargetSchema).min(1).max(100),
+    recommendedTargets: z.array(workoutProgressionTargetSchema).max(100),
     facts: z.array(z.string().trim().min(1).max(500)).min(1).max(12),
     generatedAt: z.number().int().positive(),
     effectiveDate: dateSchema,
@@ -306,6 +404,19 @@ export const workoutProgressionRecommendationSchema = z
   })
   .strict()
   .superRefine((value, ctx) => {
+    const invalid = value.evidence.diagnostics?.some(
+      (item) => item.reason !== 'REDUNDANT_EXACT_REPS',
+    );
+    if (
+      (!invalid && value.evidence.priorTargets.length === 0) ||
+      (invalid && (value.confidence !== 'unavailable' || value.decision !== 'hold'))
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Invalid evidence must be unavailable; valid evidence requires targets',
+        path: ['evidence'],
+      });
+    }
     if (value.recommendedTargets.length !== value.evidence.priorTargets.length) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -367,14 +478,19 @@ export const workoutProgressionActionSchema = z
     recommendationId: idSchema,
     sequence: z.number().int().positive(),
     action: workoutProgressionActionTypeSchema,
-    appliedTargets: z.array(workoutProgressionTargetSchema).min(1).max(100),
+    appliedTargets: z.array(workoutProgressionTargetSchema).max(100),
     reason: z.string().trim().min(1).max(1000).nullable(),
     actorType: z.enum(['user', 'agent']),
     actorId: idSchema,
     idempotencyKey: z.string().trim().min(8).max(255),
     createdAt: z.number().int().positive(),
   })
-  .strict();
+  .strict()
+  .refine(
+    (value) =>
+      value.appliedTargets.length > 0 || value.action === 'keep' || value.action === 'hold',
+    { message: 'Material actions require targets', path: ['appliedTargets'] },
+  );
 
 export const workoutProgressionPreviewResponseSchema = z
   .object({ recommendations: z.array(workoutProgressionRecommendationSchema).max(200) })

--- a/packages/shared/src/utils/workout-progression.ts
+++ b/packages/shared/src/utils/workout-progression.ts
@@ -147,6 +147,25 @@ export function evaluateWorkoutProgression(
   evidence: WorkoutProgressionEvidence,
 ): WorkoutProgressionEvaluation {
   const { performance, policy, priorTargets } = evidence;
+  const invalid =
+    evidence.diagnostics?.filter((item) => item.reason !== 'REDUNDANT_EXACT_REPS') ?? [];
+  if (invalid.length > 0) {
+    return hold(
+      evidence,
+      'unavailable',
+      [...new Set(invalid.map((item) => item.reason))].filter(
+        (reason): reason is Exclude<typeof reason, 'REDUNDANT_EXACT_REPS'> =>
+          reason !== 'REDUNDANT_EXACT_REPS',
+      ),
+      invalid
+        .slice(0, 10)
+        .map(
+          (item) =>
+            `${item.source === 'current_scheduled_target' ? 'Current scheduled target' : 'Historical prescribed target'}, set ${item.setNumber ?? item.setId}: ${item.reason}. The plan has not changed.`,
+        ),
+    );
+  }
+
   if (policy.family === 'unsupported' || evidence.policySource.type === 'none') {
     return hold(
       evidence,


### PR DESCRIPTION
Persisted progression prescriptions such as `reps: 8, repsMin: 8, repsMax: 8` could crash preview. Normalize only equivalent redundancy at validation boundaries, retain source diagnostics, and isolate contradictory current or historical targets as unavailable holds without aborting other exercises. New prescription writers reject conflicts, and preview errors now use one bounded inline retry while preserving auth handling and explicit-action safety.

Fixes #141.

Validation at `279c97f182ba92dcf03a6830d0375d47948941df`:

- Uncached `pnpm lint --force`, `pnpm typecheck --force`, `pnpm test --force --concurrency=1 -- --maxWorkers=1`, and `pnpm build --force`: exit 0; 3,017 tests including repository scripts.
- The initial concurrent test run timed out in the unrelated adaptive-preview seed test; the raw failure is retained. The full serial rerun keeps all assertions and original timeout limits.
- Installed Chrome: 12 passing tests across existing progression flows and persisted legacy compatibility, loading, unavailable, conflict, reopen, and retry scenarios at mobile/desktop widths. SPA reopen stays at one preview POST; explicit retry produces two total requests; targets remain unchanged before action.
- Four distinct Luna-medium adversarial reviews consolidated; every concrete in-scope finding repaired or dispositioned with regression evidence.
- [Requirements mapping, writer audit, review dispositions, and evidence instructions](https://github.com/derekbeau/pulse-fitness-app/blob/279c97f182ba92dcf03a6830d0375d47948941df/docs/implementation/progression-preview-evidence.md). Exact-SHA raw logs and PNG metadata are retained locally under the ignored `logs/progression-preview/final-279c97f182ba92dcf03a6830d0375d47948941df/` directory.

Launcher-owned UI evidence is `GPT-6 Astra Light`; executor UI verification was waived by the launcher. No merge, deployment, production data access/repair, or changes to the original dirty checkout.
